### PR TITLE
serve samples from root

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
+const path = require('path');
+
 const dotenv = require('dotenv');
 const glob = require('glob');
-const path = require('path');
 const {EnvironmentPlugin} = require('webpack');
 
 dotenv.config();
@@ -19,7 +20,8 @@ module.exports = {
   devServer: {
     https: true,
     disableHostCheck: true,
-    port: 8000
+    port: 8000,
+    contentBase: './packages/node_modules/samples'
   },
   resolve: {
     alias: glob
@@ -29,7 +31,10 @@ module.exports = {
         // Always use src as the entry point for local files so that we have the
         // best opportunity for treeshaking; also makes developing easier since
         // we don't need to manually rebuild after changing code.
-        alias[`./packages/node_modules/${packageName}`] = path.resolve(__dirname, `./packages/node_modules/${packageName}/src/index.js`);
+        alias[`./packages/node_modules/${packageName}`] = path.resolve(
+          __dirname,
+          `./packages/node_modules/${packageName}/src/index.js`
+        );
         alias[`${packageName}`] = path.resolve(__dirname, `./packages/node_modules/${packageName}/src/index.js`);
         return alias;
       }, {})
@@ -53,7 +58,10 @@ module.exports = {
       // The follow environment variables are specific to our continuous
       // integration process and should not be used in general
       // Also, yes, CONVERSATION_SERVICE does not end in URL
-      CONVERSATION_SERVICE: process.env.CONVERSATION_SERVICE || process.env.CONVERSATION_SERVICE_URL || 'https://conv-a.wbx2.com/conversation/api/v1',
+      CONVERSATION_SERVICE:
+        process.env.CONVERSATION_SERVICE
+        || process.env.CONVERSATION_SERVICE_URL
+        || 'https://conv-a.wbx2.com/conversation/api/v1',
       WDM_SERVICE_URL: process.env.WDM_SERVICE_URL || 'https://wdm-a.wbx2.com/wdm/api/v1',
       HYDRA_SERVICE_URL: process.env.HYDRA_SERVICE_URL || 'https://api.ciscospark.com/v1',
       ATLAS_SERVICE_URL: process.env.ATLAS_SERVICE_URL || 'https://atlas-a.wbx2.com/admin/api/v1'


### PR DESCRIPTION
# Pull Request Template
Adds a webpack config for the samples directory. This way we can `npm run samples:serve` and the output will be served at localhost:8000/ instead of the file path `packages/node_modules/etc`. 

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
