### PR TITLE
Adding retry handling for rate limiting and timeouts to ediscovery plugin

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/ediscovery.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/ediscovery.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
  */
 import {InvalidEmailAddressError} from './ediscovery-error';
+import {requestWithRetries} from './retry';
 import {waitForValue, WebexPlugin} from '@webex/webex-core';
 import {oneFlight, base64} from '@webex/common';
 
@@ -223,6 +224,25 @@ const EDiscovery = WebexPlugin.extend({
 
   @waitForValue('@')
   /**
+   * Retrieves user information from CI based on a query filter
+   * @param {UUID} orgId - Id of the organisation for which users are being requested
+   * @param {String} filter - Query containing information to match users on (id, username, displayName etc.)
+   * @returns {Promise<ResponseEntity<Resources>>} Http response containing the user information
+   */
+  getUsers(orgId, filter = '') {
+    if (!orgId) {
+      throw Error('Organisation Id is required in order to retrieve users');
+    }
+
+    return this.request({
+      method: 'GET',
+      service: 'hydra',
+      resource: `scim/${orgId}/Users?filter=${filter}`
+    });
+  },
+
+  @waitForValue('@')
+  /**
    * Converts an array of email addresses to their corresponding user ids in CI
    * @param {Array<String>} emails - Array of email addresses
    * @returns {Array<UUID>} User ids for the email addresses being requested
@@ -273,11 +293,7 @@ const EDiscovery = WebexPlugin.extend({
           // certain characters must first be encoded for the request to work successfully
           filter = encodeURIComponent(filter);
 
-          const promise = this.request({
-            method: 'GET',
-            service: 'hydra',
-            resource: `scim/${orgId}/Users?filter=${filter}`
-          })
+          const promise = requestWithRetries(this, this.getUsers, [orgId, filter])
             .then((res) => {
               for (const resource of res.body.Resources) {
                 // User id is base64 encoded and of the format Y2lzY29zcGFyazovL3VzL1BFT1BMRS81ZDU5Yjc5NS02ZmEyLTQ2NTQtOGVjMi03NjlkYjE1YzBkOWU

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/index.js
@@ -9,6 +9,7 @@ import {registerInternalPlugin} from '@webex/webex-core';
 import {has} from 'lodash';
 
 import EDiscovery from './ediscovery';
+import {requestWithRetries} from './retry';
 
 registerInternalPlugin('ediscovery', EDiscovery, {
   payloadTransformer: {
@@ -263,9 +264,17 @@ registerInternalPlugin('ediscovery', EDiscovery, {
                 return object;
               }
 
+              if (spaceSummary.error) {
+                // add error property to activity - this error will be recorded in the downloader
+                activity.error = spaceSummary.error;
+              }
+
               // set space name and participants on activity
               if (spaceSummary.spaceName) {
                 activity.spaceName = spaceSummary.spaceName;
+              }
+              else {
+                activity.spaceName = '';
               }
 
               if (spaceSummary.participantDisplayNames) {
@@ -293,7 +302,8 @@ registerInternalPlugin('ediscovery', EDiscovery, {
               // Decrypt activity message if present
               // For 'add' activities the objectDisplayName is a user id which does not need to be decrypted
               if (activity.verb !== 'add' && activity.objectDisplayName && activity.encryptionKeyUrl) {
-                promises.push(ctx.webex.internal.encryption.decryptText(activity.encryptionKeyUrl, activity.objectDisplayName, {onBehalfOf: spaceParticipantId})
+                promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
+                  [activity.encryptionKeyUrl, activity.objectDisplayName, {onBehalfOf: spaceParticipantId}])
                   .then((decryptedMessage) => {
                     activity.objectDisplayName = decryptedMessage;
                   })
@@ -319,53 +329,50 @@ registerInternalPlugin('ediscovery', EDiscovery, {
                 // Ignore the unencrypted 'NoName' display name the ED service sets in error situations
 
                 if (share.displayName && (!activity.whiteboards || !activity.whiteboards.includes(share)) && share.displayName !== 'NoName') {
-                  promises.push(
-                    ctx.webex.internal.encryption.decryptText(activity.encryptionKeyUrl, share.displayName, {onBehalfOf: spaceParticipantId})
-                      .then((decryptedDisplayName) => {
-                        share.displayName = decryptedDisplayName;
-                      })
-                      .catch((reason) => {
-                        ctx.webex.logger.error(`Decrypt DisplayName error for activity ${activity.activityId} in space ${activity.targetId} for share type: ${share.mimeType}, size: ${share.fileSize}, and url: ${share.url} due to error: ${reason}`);
-                        // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
-                        activity.error = reason;
+                  promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
+                    [activity.encryptionKeyUrl, share.displayName, {onBehalfOf: spaceParticipantId}])
+                    .then((decryptedDisplayName) => {
+                      share.displayName = decryptedDisplayName;
+                    })
+                    .catch((reason) => {
+                      ctx.webex.logger.error(`Decrypt DisplayName error for activity ${activity.activityId} in space ${activity.targetId} for share type: ${share.mimeType}, size: ${share.fileSize}, and url: ${share.url} due to error: ${reason}`);
+                      // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+                      activity.error = reason;
 
-                        return object;
-                      })
-                  );
+                      return object;
+                    }));
                 }
 
                 // Shared Links can have additional decryption fields
                 if (share.microsoftSharedLinkInfo) {
                   if (share.microsoftSharedLinkInfo.driveId) {
-                    promises.push(
-                      ctx.webex.internal.encryption.decryptText(activity.encryptionKeyUrl, share.microsoftSharedLinkInfo.driveId, {onBehalfOf: spaceParticipantId})
-                        .then((decryptedDriveId) => {
-                          share.microsoftSharedLinkInfo.driveId = decryptedDriveId;
-                        })
-                        .catch((reason) => {
-                          ctx.webex.logger.error(`Decrypt share.microsoftSharedLinkInfo.driveId error for activity ${activity.activityId} in space ${activity.targetId} for share type: ${share.mimeType}, size: ${share.fileSize}, and url: ${share.url} due to error: ${reason}`);
-                          // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
-                          activity.error = reason;
+                    promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
+                      [activity.encryptionKeyUrl, share.microsoftSharedLinkInfo.driveId, {onBehalfOf: spaceParticipantId}])
+                      .then((decryptedDriveId) => {
+                        share.microsoftSharedLinkInfo.driveId = decryptedDriveId;
+                      })
+                      .catch((reason) => {
+                        ctx.webex.logger.error(`Decrypt share.microsoftSharedLinkInfo.driveId error for activity ${activity.activityId} in space ${activity.targetId} for share type: ${share.mimeType}, size: ${share.fileSize}, and url: ${share.url} due to error: ${reason}`);
+                        // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+                        activity.error = reason;
 
-                          return object;
-                        })
-                    );
+                        return object;
+                      }));
                   }
 
                   if (share.microsoftSharedLinkInfo.itemId) {
-                    promises.push(
-                      ctx.webex.internal.encryption.decryptText(activity.encryptionKeyUrl, share.microsoftSharedLinkInfo.itemId, {onBehalfOf: spaceParticipantId})
-                        .then((decryptedItemId) => {
-                          share.microsoftSharedLinkInfo.itemId = decryptedItemId;
-                        })
-                        .catch((reason) => {
-                          ctx.webex.logger.error(`Decrypt share.microsoftSharedLinkInfo.itemId error for activity ${activity.activityId} in space ${activity.targetId} for share type: ${share.mimeType}, size: ${share.fileSize}, and url: ${share.url} due to error: ${reason}`);
-                          // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
-                          activity.error = reason;
+                    promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
+                      [activity.encryptionKeyUrl, share.microsoftSharedLinkInfo.itemId, {onBehalfOf: spaceParticipantId}])
+                      .then((decryptedItemId) => {
+                        share.microsoftSharedLinkInfo.itemId = decryptedItemId;
+                      })
+                      .catch((reason) => {
+                        ctx.webex.logger.error(`Decrypt share.microsoftSharedLinkInfo.itemId error for activity ${activity.activityId} in space ${activity.targetId} for share type: ${share.mimeType}, size: ${share.fileSize}, and url: ${share.url} due to error: ${reason}`);
+                        // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+                        activity.error = reason;
 
-                          return object;
-                        })
-                    );
+                        return object;
+                      }));
                   }
                 }
 
@@ -373,24 +380,23 @@ registerInternalPlugin('ediscovery', EDiscovery, {
                 // Unlike a scr the sslr contains only a loc. But decryptScr(...) is flexible and
                 // leaves the tag, auth, IV, etc fields on the SCR object as undefined.
                 if (share.scr || share.sslr) {
-                  promises.push(
-                    ctx.webex.internal.encryption.decryptScr(activity.encryptionKeyUrl, share.scr || share.sslr, {onBehalfOf: spaceParticipantId})
-                      .then((decryptedSCR) => {
-                        if (share.scr) {
-                          share.scr = decryptedSCR;
-                        }
-                        else {
-                          share.sslr = decryptedSCR.loc;
-                        }
-                      })
-                      .catch((reason) => {
-                        ctx.webex.logger.error(`Decrypt file scr or sslr error for activity ${activity.activityId} in space ${activity.targetId} for share type: ${share.mimeType}, size: ${share.fileSize}, and url: ${share.url} due to error: ${reason}`);
-                        // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
-                        activity.error = reason;
+                  promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptScr,
+                    [activity.encryptionKeyUrl, share.scr || share.sslr, {onBehalfOf: spaceParticipantId}])
+                    .then((decryptedSCR) => {
+                      if (share.scr) {
+                        share.scr = decryptedSCR;
+                      }
+                      else {
+                        share.sslr = decryptedSCR.loc;
+                      }
+                    })
+                    .catch((reason) => {
+                      ctx.webex.logger.error(`Decrypt file scr or sslr error for activity ${activity.activityId} in space ${activity.targetId} for share type: ${share.mimeType}, size: ${share.fileSize}, and url: ${share.url} due to error: ${reason}`);
+                      // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+                      activity.error = reason;
 
-                        return object;
-                      })
-                  );
+                      return object;
+                    }));
                 }
               }
 
@@ -428,7 +434,12 @@ registerInternalPlugin('ediscovery', EDiscovery, {
           }
           const spaceSummary = object.body;
 
-          return ctx.webex.internal.encryption.decryptText(spaceSummary.encryptionKeyUrl, spaceSummary.spaceName, {onBehalfOf: spaceSummary.participants[0]})
+          if (!spaceSummary.spaceName) {
+            return object;
+          }
+
+          return requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
+            [spaceSummary.encryptionKeyUrl, spaceSummary.spaceName, {onBehalfOf: spaceSummary.participants[0]}])
             .then((decryptedSpaceName) => {
               spaceSummary.spaceName = decryptedSpaceName;
             })

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/retry.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/retry.js
@@ -1,0 +1,34 @@
+const retryErrors = [429, 502, 503, 504];
+
+async function requestWithRetries(ctx, func, args, retryCount = 0, retryIntervalInSeconds = 0, maxRetries = 3) {
+  await timeout(retryIntervalInSeconds);
+
+  return func.apply(ctx, args)
+    .catch((reason) => {
+      if (retryErrors.includes(reason.statusCode) && retryCount < maxRetries) {
+        retryCount += 1;
+        let retryIntervalInSeconds = (retryCount + 1) ** 2; // 4, 9 and 16 second delays as default
+
+        if (reason.headers && reason.headers['retry-after']) {
+          retryIntervalInSeconds = reason.headers['retry-after'];
+        }
+        console.error(`Request #${retryCount} error: ${reason.statusCode}. Attempting retry #${retryCount} in ${retryIntervalInSeconds} seconds`);
+
+        return requestWithRetries(ctx, func, args, retryCount, retryIntervalInSeconds, maxRetries);
+      }
+
+      return Promise.reject(reason);
+    });
+}
+
+function timeout(sec) {
+  // return immediately if timeout is zero or undefined
+  if (!sec) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => setTimeout(resolve, sec * 1000));
+}
+
+module.exports.requestWithRetries = requestWithRetries;
+module.exports.timeout = timeout;

--- a/packages/node_modules/samples/browser-read-status/app.js
+++ b/packages/node_modules/samples/browser-read-status/app.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 
-/* global ciscospark */ // from bundle.js
+/* global Webex */ // from bundle.js
 
 /* eslint-disable no-console */
 /* eslint-disable require-jsdoc */
@@ -27,7 +27,7 @@ let haveFetchedAll = false;
 
 // Connect to Webex Teams and listen for message events.
 function authorize() {
-  webex = ciscospark.init({
+  webex = Webex.init({
     config: {
 
     },


### PR DESCRIPTION
## Description

Adding retry handling for rate limiting and timeouts to ediscovery plugin. The retry behaviour can be configured, but by default it will attempt 3 retries, with exponentially increasing delays of 4, 9 and 16 seconds.

Fixes # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-71491

## Type of Change

New feature (non-breaking change which adds functionality)

## Test Coverage

Manual testing required simulation of errors that trigger retry mechanism

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules