### PR TITLE
fix(ediscovery): file name decrypt errors should be warnings not errors

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/index.js
@@ -335,11 +335,9 @@ registerInternalPlugin('ediscovery', EDiscovery, {
                       share.displayName = decryptedDisplayName;
                     })
                     .catch((reason) => {
-                      ctx.webex.logger.error(`Decrypt DisplayName error for activity ${activity.activityId} in space ${activity.targetId} for share type: ${share.mimeType}, size: ${share.fileSize}, and url: ${share.url} due to error: ${reason}`);
-                      // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
-                      activity.error = reason;
-
-                      return object;
+                      ctx.webex.logger.warn(`Decrypt DisplayName error for activity ${activity.activityId} in space ${activity.targetId} for share type: ${share.mimeType}, size: ${share.fileSize}, and url: ${share.url} due to error: ${reason}`);
+                      // add warning property to activity - this will present an indication that there was data loss on the downloader
+                      activity.warning = reason;
                     }));
                 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Converting file display name decryption errors over to warnings.

Noticed that Whiteboard snapshots created by the Web Client are setting the uploaded file's display name to the activity's id in plaintext. This causes the decryption to fail. Whilst the unencrypted display name seems like a bug we think a display name failure should not omitted the entire activity.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Local test of the change in the eDiscovery downloader.

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
