### PR TITLE
feat(wdm): SPARK-11787 Web client idle timeout

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
@@ -265,6 +265,7 @@ const Device = WebexPlugin.extend({
 
     this.listenToAndRun(this, 'change:intranetInactivityCheckUrl', () => { this._resetLogoutTimer(); this._inNetworkResetLogoutTimer(); });
     this.listenToAndRun(this, 'change:intranetInactivityDuration', () => { this._resetLogoutTimer(); this._inNetworkResetLogoutTimer(); });
+    this.listenToAndRun(this, 'change:inNetworkInactivityDuration', () => { this._resetLogoutTimer(); this._inNetworkResetLogoutTimer(); });
     this.listenTo(this.webex, 'user-activity', () => { 
       this.lastUserActivityDate = Date.now();
       this.lastInNetworkUserActivityDate = Date.now();

--- a/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
@@ -52,6 +52,7 @@ const Device = WebexPlugin.extend({
     helpUrl: 'string',
     intranetInactivityDuration: 'number',
     intranetInactivityCheckUrl: 'string',
+    inNetworkInactivityDuration: 'number',
     /**
      * Is ECM (external content management) enabled for the whole org
      * @instance
@@ -139,7 +140,11 @@ const Device = WebexPlugin.extend({
     // Fun Fact: setTimeout returns a Timer object instead of a Number in Node 6
     // or later
     logoutTimer: 'any',
-    lastUserActivityDate: 'number'
+    inNetworkLogoutTimer: 'any',
+    lastUserActivityDate: 'number',
+    lastInNetworkUserActivityDate: 'number', //This is needed for inNetworkInactivityLogoutTimer
+    isInMeeting: 'boolean',
+    isInNetwork: 'boolean'
   },
 
   @waitForValue('@')
@@ -255,11 +260,25 @@ const Device = WebexPlugin.extend({
       });
     });
 
+    this.isInNetwork = false;
     this.on('change:serviceHostMap', this._updateServiceCatalog);
 
-    this.listenToAndRun(this, 'change:intranetInactivityCheckUrl', () => this._resetLogoutTimer());
-    this.listenToAndRun(this, 'change:intranetInactivityDuration', () => this._resetLogoutTimer());
-    this.listenTo(this.webex, 'user-activity', () => { this.lastUserActivityDate = Date.now(); });
+    this.listenToAndRun(this, 'change:intranetInactivityCheckUrl', () => { this._resetLogoutTimer(); this._inNetworkResetLogoutTimer(); });
+    this.listenToAndRun(this, 'change:intranetInactivityDuration', () => { this._resetLogoutTimer(); this._inNetworkResetLogoutTimer(); });
+    this.listenTo(this.webex, 'user-activity', () => { 
+      this.lastUserActivityDate = Date.now();
+      this.lastInNetworkUserActivityDate = Date.now();
+    });
+    this.listenTo(this.webex, 'meeting-started', () => {
+      this.isInMeeting = true;
+      this._resetLogoutTimer();
+      this._inNetworkResetLogoutTimer(); 
+    });
+    this.listenTo(this.webex, 'meeting-ended', () => {
+      this.isInMeeting = false;
+      this._resetLogoutTimer();
+      this._inNetworkResetLogoutTimer(); 
+    });
   },
 
   /**
@@ -524,18 +543,59 @@ const Device = WebexPlugin.extend({
     clearTimeout(this.logoutTimer);
     this.off('change:lastUserActivityDate'); // removes previous event listener
     this.unset('logoutTimer');
-    if (this.config.enableInactivityEnforcement && this.intranetInactivityCheckUrl && this.intranetInactivityDuration) {
-      this.on('change:lastUserActivityDate', () => this._resetLogoutTimer());
-      const timer = safeSetTimeout(() => {
-        this.webex.request({
-          headers: {
-            'cisco-no-http-redirect': null,
-            'spark-user-agent': null,
-            trackingid: null
-          },
-          method: 'GET',
-          uri: this.intranetInactivityCheckUrl
-        })
+    if (!this.isInMeeting) {
+      if (this.config.enableInactivityEnforcement && this.intranetInactivityCheckUrl && this.intranetInactivityDuration && !this.isInNetwork && this.intranetInactivityDuration !== -1) {
+        this.on('change:lastUserActivityDate', () => { this._resetLogoutTimer(); });
+        const timer = safeSetTimeout(() => {
+          this.webex.request({
+            headers: {
+              'cisco-no-http-redirect': null,
+              'spark-user-agent': null,
+              trackingid: null
+            },
+            method: 'GET',
+            uri: this.intranetInactivityCheckUrl
+          })
+            .then(()=>{
+              this.isInNetwork = true;
+              return;
+            })
+            .catch(() => {
+              this.logger.info('device: did not reach internal ping endpoint; logging out after inactivity on a public network');
+
+              return this.webex.logout();
+            })
+            .catch((reason) => {
+              this.logger.warn('device: logout failed', reason);
+              return;
+            });
+        }, this.intranetInactivityDuration * 1000);
+
+        this.logoutTimer = timer;
+      }
+    }
+  },
+
+  _inNetworkResetLogoutTimer() {
+    clearTimeout(this.inNetworkLogoutTimer);
+    this.off('change:lastInNetworkUserActivityDate'); // removes previous event listener
+    this.unset('inNetworkLogoutTimer');
+    if (!this.isInMeeting) {
+      if (this.config.enableInactivityEnforcement && this.intranetInactivityCheckUrl && this.inNetworkInactivityDuration && this.intranetInactivityDuration !== -1) {
+        this.on('change:lastInNetworkUserActivityDate', () => {this._inNetworkResetLogoutTimer();});
+        var inNetworkTimer = safeSetTimeout(() => {
+          this.webex.request({
+            headers: {
+              'cisco-no-http-redirect': null,
+              'spark-user-agent': null,
+              trackingid: null
+            },
+            method: 'GET',
+            uri: this.intranetInactivityCheckUrl
+          })
+          .then(()=>{
+            return this.webex.logout();
+          })
           .catch(() => {
             this.logger.info('device: did not reach internal ping endpoint; logging out after inactivity on a public network');
 
@@ -543,10 +603,12 @@ const Device = WebexPlugin.extend({
           })
           .catch((reason) => {
             this.logger.warn('device: logout failed', reason);
+            return;
           });
-      }, this.intranetInactivityDuration * 1000);
-
-      this.logoutTimer = timer;
+        }, this.inNetworkInactivityDuration * 1000);
+  
+        this.inNetworkLogoutTimer = inNetworkTimer;
+      }
     }
   }
 });

--- a/packages/node_modules/@webex/internal-plugin-wdm/test/unit/spec/policy.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/test/unit/spec/policy.js
@@ -211,7 +211,7 @@ describe('plugin-wdm', () => {
         });
 
         describe('when there is user activity', () => {
-          it.only('resets the logout timer', () => {
+          it('resets the logout timer', () => {
             webex.internal.device.set({
               intranetInactivityDuration: 8 * 60 * 60,
               intranetInactivityCheckUrl: 'http://ping.example.com/ping'

--- a/packages/node_modules/@webex/internal-plugin-wdm/test/unit/spec/policy.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/test/unit/spec/policy.js
@@ -8,7 +8,7 @@ import sinon from '@webex/test-helper-sinon';
 import Device from '@webex/internal-plugin-wdm';
 import deviceFixture from '../lib/device-fixture';
 import lolex from 'lolex';
-import {cloneDeep} from 'lodash';
+import { cloneDeep } from 'lodash';
 
 describe('plugin-wdm', () => {
   describe('Device', () => {
@@ -21,7 +21,9 @@ describe('plugin-wdm', () => {
         },
         config: {
           device: {
-            enableInactivityEnforcement: true
+            enableInactivityEnforcement: true,
+            isInMeeting: false,
+            isInNetwork: false,
           }
         }
       });
@@ -33,7 +35,7 @@ describe('plugin-wdm', () => {
     let clock;
 
     beforeEach(() => {
-      clock = lolex.install({now: Date.now()});
+      clock = lolex.install({ now: Date.now() });
     });
 
     afterEach(() => {
@@ -44,15 +46,20 @@ describe('plugin-wdm', () => {
       describe('when some or all of the policy configuration is unspecified', () => {
         it('stays dormant', () => {
           assert.isUndefined(webex.internal.device.logoutTimer);
+          assert.isUndefined(webex.internal.device.inNetworkLogoutTimer);
 
           webex.internal.device.intranetInactivityCheckUrl = 'http://ping.example.com/ping';
           assert.isUndefined(webex.internal.device.logoutTimer);
+          assert.isUndefined(webex.internal.device.inNetworkLogoutTimer);
 
           webex.internal.device.intranetInactivityDuration = 2;
+          webex.internal.device.inNetworkInactivityDuration = 2;
           assert.isDefined(webex.internal.device.logoutTimer);
+          assert.isUndefined(webex.internal.device.inNetworkLogoutTimer);
 
           webex.internal.device.unset('intranetInactivityCheckUrl');
           assert.isUndefined(webex.internal.device.logoutTimer);
+          assert.isUndefined(webex.internal.device.inNetworkLogoutTimer);
         });
       });
 
@@ -61,28 +68,37 @@ describe('plugin-wdm', () => {
           webex.config.device.enableInactivityEnforcement = false;
           webex.internal.device.set({
             intranetInactivityDuration: 8 * 60 * 60,
-            intranetInactivityCheckUrl: 'http://ping.example.com/ping'
+            intranetInactivityCheckUrl: 'http://ping.example.com/ping',
+            inNetworkInactivityDuration: 8 * 60 * 60,
           });
           assert.isUndefined(webex.internal.device.logoutTimer);
+          assert.isUndefined(webex.internal.device.inNetworkLogoutTimer);
 
           webex.internal.device.intranetInactivityCheckUrl = 'http://ping.example.com/ping';
           assert.isUndefined(webex.internal.device.logoutTimer);
+          assert.isUndefined(webex.internal.device.inNetworkLogoutTimer);
 
           webex.internal.device.intranetInactivityDuration = 2;
+          webex.internal.device.inNetworkInactivityDuration = 2;
           assert.isUndefined(webex.internal.device.logoutTimer);
+          assert.isUndefined(webex.internal.device.inNetworkLogoutTimer);
 
           webex.internal.device.unset('intranetInactivityCheckUrl');
           assert.isUndefined(webex.internal.device.logoutTimer);
+          assert.isUndefined(webex.internal.device.inNetworkLogoutTimer);
         });
       });
 
       describe('when the policy configuration is specified', () => {
-        it('logs the user out according to the policy configuration', () => {
+        // Off Networ Inactivity Timer
+        it('logs the user out according to the policy configuration when ping url can\'t be reached', () => {
           webex.request.returns(Promise.reject());
 
           webex.internal.device.set({
             intranetInactivityDuration: 8 * 60 * 60,
-            intranetInactivityCheckUrl: 'http://ping.example.com/ping'
+            intranetInactivityCheckUrl: 'http://ping.example.com/ping',
+            isInMeeting: false,
+            isInNetwork: false,
           });
           assert.isDefined(webex.internal.device.logoutTimer);
 
@@ -99,7 +115,34 @@ describe('plugin-wdm', () => {
           });
 
           return Promise.resolve()
-            .then(() => assert.calledOnce(webex.logout));
+            .catch(() => assert.calledOnce(webex.logout));
+        });
+
+        // In Network Inactivity Timer
+        it('logs the user out according to the policy configuration when ping url can\'t be reached even when in network', () => {
+          webex.request.returns(Promise.reject());
+
+          webex.internal.device.set({
+            inNetworkInactivityDuration: 8 * 60 * 60,
+            intranetInactivityCheckUrl: 'http://ping.example.com/ping',
+            isInMeeting: false,
+          });
+          assert.isDefined(webex.internal.device.inNetworkLogoutTimer);
+
+          clock.tick(8 * 60 * 60 * 1000);
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            headers: {
+              'cisco-no-http-redirect': null,
+              'spark-user-agent': null,
+              trackingid: null
+            },
+            method: 'GET',
+            uri: 'http://ping.example.com/ping'
+          });
+
+          return Promise.resolve()
+            .catch(() => assert.calledOnce(webex.logout));
         });
 
         describe('when the ping url can be reached', () => {
@@ -110,7 +153,9 @@ describe('plugin-wdm', () => {
 
             webex.internal.device.set({
               intranetInactivityDuration: 8 * 60 * 60,
-              intranetInactivityCheckUrl: 'http://ping.example.com/ping'
+              intranetInactivityCheckUrl: 'http://ping.example.com/ping',
+              isInMeeting: false,
+              isInNetwork: false,
             });
             assert.isDefined(webex.internal.device.logoutTimer);
 
@@ -127,12 +172,46 @@ describe('plugin-wdm', () => {
             });
 
             return Promise.resolve()
-              .then(() => assert.notCalled(webex.logout));
+              .then(() => {
+                assert.notCalled(webex.logout);
+                assert.isTrue(webex.internal.device.isInNetwork);
+              });
+          });
+          // In Network Timer
+          it('logs the user out', () => {
+            webex.request.returns(Promise.resolve({
+              statusCode: 200
+            }));
+
+            webex.internal.device.set({
+              inNetworkInactivityDuration: 8 * 60 * 60,
+              intranetInactivityCheckUrl: 'http://ping.example.com/ping',
+              isInMeeting: false,
+              isInNetwork: false,
+            });
+            assert.isDefined(webex.internal.device.inNetworkLogoutTimer);
+
+            clock.tick(8 * 60 * 60 * 1000);
+            assert.calledOnce(webex.request);
+            assert.calledWith(webex.request, {
+              headers: {
+                'cisco-no-http-redirect': null,
+                'spark-user-agent': null,
+                trackingid: null
+              },
+              method: 'GET',
+              uri: 'http://ping.example.com/ping'
+            });
+
+            return Promise.resolve()
+              .then(() => {
+                assert.calledOnce(webex.logout);
+              });
           });
         });
 
         describe('when there is user activity', () => {
-          it('resets the logout timer', () => {
+          it.only('resets the logout timer', () => {
             webex.internal.device.set({
               intranetInactivityDuration: 8 * 60 * 60,
               intranetInactivityCheckUrl: 'http://ping.example.com/ping'
@@ -159,13 +238,47 @@ describe('plugin-wdm', () => {
             });
 
             return Promise.resolve()
-              .then(() => assert.notCalled(webex.logout));
+              .catch(() => assert.notCalled(webex.logout));
+          });
+
+          //In Network Timer
+          it('resets the in network logout timer', () => {
+            webex.internal.device.set({
+              inNetworkInactivityDuration: 8 * 60 * 60,
+              intranetInactivityCheckUrl: 'http://ping.example.com/ping',
+              isInMeeting: false,
+            });
+
+            clock.tick(1 * 60 * 60 * 1000);
+            webex.emit('user-activity');
+
+            clock.tick(7 * 60 * 60 * 1000);
+            assert.neverCalledWith(webex.request, {
+              method: 'GET',
+              uri: 'http://ping.example.com/ping'
+            });
+
+            clock.tick(1 * 60 * 60 * 1000);
+            assert.calledWith(webex.request, {
+              headers: {
+                'cisco-no-http-redirect': null,
+                'spark-user-agent': null,
+                trackingid: null
+              },
+              method: 'GET',
+              uri: 'http://ping.example.com/ping'
+            });
+
+            return Promise.resolve()
+              .catch(() => assert.notCalled(webex.logout));
           });
 
           it('does not call _resetLogoutTimer in arithmetic progression with every post', () => {
             webex.internal.device.set({
               intranetInactivityDuration: 8 * 60 * 60,
-              intranetInactivityCheckUrl: 'http://ping.example.com/ping'
+              intranetInactivityCheckUrl: 'http://ping.example.com/ping',
+              isInMeeting: false,
+              isInNetwork: false,
             });
 
             const resetLogoutTimerSpy = sinon.spy(webex.internal.device, '_resetLogoutTimer');
@@ -189,6 +302,37 @@ describe('plugin-wdm', () => {
             clock.tick(1 * 60 * 60 * 1000);
             assert.equal(resetLogoutTimerSpy.callCount, 1);
             resetLogoutTimerSpy.reset();
+          });
+
+          it('does not call _inNetworkResetLogoutTimer in arithmetic progression with every post', () => {
+            webex.internal.device.set({
+              inNetworkInactivityDuration: 8 * 60 * 60,
+              intranetInactivityCheckUrl: 'http://ping.example.com/ping',
+              isInMeeting: false,
+              isInNetwork: false,
+            });
+
+            const inNetworkResetLogoutTimerSpy = sinon.spy(webex.internal.device, '_inNetworkResetLogoutTimer');
+
+            webex.emit('user-activity');
+            clock.tick(1 * 60 * 60 * 1000);
+            assert.equal(inNetworkResetLogoutTimerSpy.callCount, 1);
+            inNetworkResetLogoutTimerSpy.reset();
+
+            webex.emit('user-activity');
+            clock.tick(1 * 60 * 60 * 1000);
+            assert.equal(inNetworkResetLogoutTimerSpy.callCount, 1);
+            inNetworkResetLogoutTimerSpy.reset();
+
+            webex.emit('user-activity');
+            clock.tick(1 * 60 * 60 * 1000);
+            assert.equal(inNetworkResetLogoutTimerSpy.callCount, 1);
+            inNetworkResetLogoutTimerSpy.reset();
+
+            webex.emit('user-activity');
+            clock.tick(1 * 60 * 60 * 1000);
+            assert.equal(inNetworkResetLogoutTimerSpy.callCount, 1);
+            inNetworkResetLogoutTimerSpy.reset();
           });
         });
       });


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Added new logout timer for inNetworkInactivity
- Added a new duration for inNetworkInactivityTimer
- Added listeners for meeting started and meeting ended which helps in pausing the logout timer while 
  client is in meeting
- Added booleans for isInMeeting and isInNetwork which is used to prevent logout while in meeting 
   and prevent calling _resetLogoutTimer over and over again when meeting ended triggers 
  _resetLogoutTimer.
- Added a check for duration value = -1 which is currently set as the default for None as a duration 
  value
- Added necessary unit tests for the above changes.



Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
