### PR TITLE
Skip flaky tests

### DIFF
--- a/packages/node_modules/@webex/media-engine-webrtc/test/unit/spec/engine.js
+++ b/packages/node_modules/@webex/media-engine-webrtc/test/unit/spec/engine.js
@@ -71,7 +71,10 @@ browserOnly(describe)('media-engine-webrtc', function () {
       });
     });
 
-    describe('renegotiation', () => {
+    // NOTE: Media Engine will be deprecated for plugin-meetings.
+    // Skipping these tests because they do not pass or fail consistently,
+    // thus they provide no confidence.
+    describe.skip('renegotiation', () => {
       const audioStartStates = [
         'inactive',
         'recvonly',
@@ -758,7 +761,10 @@ browserOnly(describe)('media-engine-webrtc', function () {
       });
     });
 
-    firefoxOnly(describe)('screensharing', () => {
+    // NOTE: Media Engine will be deprecated for plugin-meetings.
+    // Skipping these tests because they do not pass or fail consistently,
+    // thus they provide no confidence.
+    firefoxOnly(describe.skip)('screensharing', () => {
       let engine;
 
       before('create a audio-video session', () => handleErrorEvent(new WebRTCMediaEngine(), (e) => {

--- a/packages/node_modules/@webex/plugin-device-manager/sample/index.html
+++ b/packages/node_modules/@webex/plugin-device-manager/sample/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Sample: Device Manager Kitchen Sink</title>
+  <title>Sample: Device Manager</title>
 </head>
 
 <body>
@@ -9,7 +9,7 @@
     <div id='notifications' style="float:right; text-align: right; font-size: 20px;">
     </div>
     <div style="float:inherit;">
-      <h1>Device Manager Kitchen Sink</h1>
+      <h1>Device Manager</h1>
       <p>This is the start of the "kitchen sink" demo app for plugin-device-manager.</p>
 
       <h2>Connect first:</h2>

--- a/packages/node_modules/@webex/plugin-phone/test/integration/spec/screenshare.js
+++ b/packages/node_modules/@webex/plugin-phone/test/integration/spec/screenshare.js
@@ -92,7 +92,10 @@ browserOnly(describe)('plugin-phone', function () {
   this.timeout(60000);
 
   describe('Call', () => {
-    firefoxOnly(describe)('mid-call screen and application sharing', () => {
+    // NOTE: plugin-phone will be deprecated for plugin-meetings.
+    // Skipping these tests because they do not pass or fail consistently,
+    // thus they provide no confidence.
+    firefoxOnly(describe.skip)('mid-call screen and application sharing', () => {
       let mccoy, spock;
       const users = {
         mccoy: null,

--- a/packages/node_modules/samples/browser-plugin-meetings/index.html
+++ b/packages/node_modules/samples/browser-plugin-meetings/index.html
@@ -17,11 +17,11 @@
         cursor: pointer;
       }
     </style>
-    <title>Sample: Meetings Kitchen Sink</title>
+    <title>Sample: Meetings</title>
   </head>
 
   <body>
-    <h1>Meetings Kitchen Sink</h1>
+    <h1>Meetings</h1>
     <p>This is the start of the "kitchen sink" demo app for plugin-meetings.</p>
 
     <h2>Connect first:</h2>

--- a/packages/node_modules/samples/browser-plugin-meetings/index.html
+++ b/packages/node_modules/samples/browser-plugin-meetings/index.html
@@ -25,11 +25,6 @@
     <p>This is the start of the "kitchen sink" demo app for plugin-meetings.</p>
 
     <h2>Connect first:</h2>
-    <fieldset id="incomingsection" style="display:none">
-      <legend>Incoming Call</legend>
-      <button id="answer">answer</button>
-      <button id="reject">reject</button>
-    </fieldset>
     <form id="credentials">
       <fieldset>
         <legend>Credentials</legend>
@@ -38,7 +33,6 @@
         <p id="connection-status">disconnected</p>
       </fieldset>
     </form>
-
     <form id="disconnect">
       <fieldset>
         <legend>Unregister</legend>
@@ -46,6 +40,12 @@
       </fieldset>
     </form>
 
+    <!-- Incoming meeting notification -->
+    <fieldset id="incomingsection" style="display:none">
+      <legend>Incoming Call</legend>
+      <button id="answer">answer</button>
+      <button id="reject">reject</button>
+    </fieldset>
 
     <button id="device" name="device" title="Device" type="button">DEVICE</button>
     <div id='devices' style="display:none">

--- a/packages/node_modules/samples/browser-plugin-meetings/test/wdio/spec/mediatest.js
+++ b/packages/node_modules/samples/browser-plugin-meetings/test/wdio/spec/mediatest.js
@@ -1,5 +1,6 @@
 /* globals browser */
 import {expect} from 'chai';
+import {flaky} from '@webex/test-helper-mocha';
 import testUsers from '@webex/test-helper-test-users';
 
 describe('samples', () => {
@@ -13,7 +14,6 @@ describe('samples', () => {
       before('create test users', () => testUsers.create({count: 2})
         .then((users) => {
           [mccoy, spock] = users;
-          console.log('ACCESS TOKEN ', users);
         }));
 
       before('reload browser', () => {
@@ -21,12 +21,12 @@ describe('samples', () => {
       });
 
       it('loads the app', () => {
-        browser.url('/');
+        browser.url('/browser-plugin-meetings');
         browser.waitForExist('#access-token', 1500);
       });
 
       it('connects spock\'s browser', () => {
-        expect(browserMccoy.getTitle()).to.equal('Sample: Meetings Kitchen Sink');
+        expect(browserMccoy.getTitle()).to.equal('Sample: Meetings');
         browserMccoy.setValue('#access-token', spock.token.access_token);
         browserMccoy.pause(10000);
         browserMccoy.click('#connect');
@@ -42,7 +42,7 @@ describe('samples', () => {
       });
 
       it('connects mccoy\'s browser', () => {
-        expect(browserSpock.getTitle()).to.equal('Sample: Meetings Kitchen Sink');
+        expect(browserSpock.getTitle()).to.equal('Sample: Meetings');
         browserSpock.setValue('#access-token', mccoy.token.access_token);
         browserSpock.pause(10000);
         browserSpock.click('#connect');
@@ -65,7 +65,7 @@ describe('samples', () => {
         browserSpock.click('#addMedia');
       });
 
-      it('spock answers the call', () => {
+      flaky(it, process.env.SKIP_FLAKY_TESTS)('spock answers the call', () => {
         browserMccoy.pause(5000);
         browserMccoy.waitForVisible('#answer', 20000);
         browserMccoy.click('#answer');

--- a/packages/node_modules/samples/browser-plugin-meetings/test/wdio/spec/mediatest.js
+++ b/packages/node_modules/samples/browser-plugin-meetings/test/wdio/spec/mediatest.js
@@ -1,6 +1,5 @@
 /* globals browser */
 import {expect} from 'chai';
-import {flaky} from '@webex/test-helper-mocha';
 import testUsers from '@webex/test-helper-test-users';
 
 describe('samples', () => {
@@ -57,7 +56,7 @@ describe('samples', () => {
       });
 
       it('places call from spock to mccoy', () => {
-        browserSpock.setValue('#invitee', spock.emailAddress);
+        browserSpock.setValue('#invitee', mccoy.emailAddress);
         browserSpock.click('[title="create"]');
         browserSpock.pause(5000);
         browserSpock.click('#join');
@@ -65,7 +64,7 @@ describe('samples', () => {
         browserSpock.click('#addMedia');
       });
 
-      flaky(it, process.env.SKIP_FLAKY_TESTS)('spock answers the call', () => {
+      it('mccoy answers the call', () => {
         browserMccoy.pause(5000);
         browserMccoy.waitForVisible('#answer', 20000);
         browserMccoy.click('#answer');


### PR DESCRIPTION
# Pull Request 

## Description

- Skip inconsistent tests with Media Engine. They no longer provide confidence and will be deprecated for `plugin-meetings` shortly. 
- Fix kitchen sink sample tests.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
