### PR TITLE
feat(internal-plugin-metrics): add support to business metric payload

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-metrics/src/metrics.js
+++ b/packages/node_modules/@webex/internal-plugin-metrics/src/metrics.js
@@ -50,6 +50,10 @@ const Metrics = WebexPlugin.extend({
       payload.context = props.context;
     }
 
+    if (props.eventPayload) {
+      payload.eventPayload = props.eventPayload;
+    }
+
     payload.timestamp = Date.now();
 
     if (preLoginId) {

--- a/packages/node_modules/@webex/internal-plugin-metrics/test/unit/spec/metrics.js
+++ b/packages/node_modules/@webex/internal-plugin-metrics/test/unit/spec/metrics.js
@@ -35,7 +35,8 @@ describe('plugin-metrics', () => {
       },
       metricName: eventName,
       test: 'this field should not be included in final payload',
-      type: 'behavioral'
+      type: 'behavioral',
+      eventPayload: {value: 'splunk business metric payload'}
     };
     const transformedProps = {
       fields: {
@@ -136,12 +137,14 @@ describe('plugin-metrics', () => {
               assert.property(metric, 'fields');
               assert.property(metric, 'timestamp');
               assert.property(metric, 'type');
+              assert.property(metric, 'eventPayload');
 
               assert.equal(metric.timestamp, date);
               assert.equal(metric.metricName, 'test_event');
               assert.equal(metric.type, 'behavioral');
               assert.equal(metric.fields.testField, 123);
               assert.equal(metric.tags.testTag, 'tag value');
+              assert.equal(metric.eventPayload.value, 'splunk business metric payload');
             });
         });
       });
@@ -150,7 +153,8 @@ describe('plugin-metrics', () => {
           const testPayload = {
             tags: {success: true},
             fields: {perceivedDurationInMillis: 314},
-            context: {}
+            context: {},
+            eventPayload: {value: 'splunk business metric payload'}
           };
           const date = Date.now();
           const promise = metrics.submitClientMetrics('test', testPayload);
@@ -168,11 +172,13 @@ describe('plugin-metrics', () => {
               assert.property(metric, 'fields');
               assert.property(metric, 'timestamp');
               assert.property(metric, 'context');
+              assert.property(metric, 'eventPayload');
 
               assert.equal(metric.timestamp, date);
               assert.equal(metric.metricName, 'test');
               assert.equal(metric.tags.success, true);
               assert.equal(metric.fields.perceivedDurationInMillis, 314);
+              assert.equal(metric.eventPayload.value, 'splunk business metric payload');
             });
         });
       });


### PR DESCRIPTION
# Pull Request Template

## Description

/clientmetrics api requires a new property 'eventPayload' to submit [business](https://wiki.cisco.com/display/WX2/Splunk+-+Business+Metrics) metrics to splunk. This pull request adds support for this property in method 'submitClientMetrics'. This will be an optional property like tags, fields e.t.c. This makes sdk able to send business metrics to splunk. 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

ran test for package internal-plugin-metric

**Test Configuration**:
* SDK Version - 0.5.349
* Node/Browser Version - node 8.16.0
* NPM Version - 6.4.1

## Checklist:

- 

- [ x] My code follows the style guidelines of this project

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
