### PR TITLE
fix(plugin-messages): update message created event handling

### DIFF
--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -54,6 +54,11 @@ const Messages = WebexPlugin.extend({
    * This is an alternate approach to registering for messages webhooks.
    * The events passed to any registered handlers will be similar to the webhook JSON,
    * but will omit webhook specific fields such as name, secret, url, etc.
+   * The messages.listen() event objects can also include additional fields not
+   * available in webhook JSON. These fields are text, markdown, and files.
+   * These fields are available when their details are included in the WebSocket's
+   * activity object. Retrieving other fields, such as the html field,
+   * will require a manual request to get the corresponding message object.
    * See the <a href="https://js.samples.s4d.io/browser-socket/">Sample App</a>
    * for more details.
    * @instance
@@ -351,10 +356,16 @@ const Messages = WebexPlugin.extend({
         activity.actor.emailAddress || activity.actor.entryEmail;
 
       if (event !== SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED) {
+        const {content, displayName} = activity.object;
         const files = getHydraFiles(activity);
 
         sdkEvent.data.id = constructHydraId(hydraTypes.MESSAGE, activity.id);
-        sdkEvent.data.text = activity.object.displayName;
+        if (content || displayName) {
+          sdkEvent.data.text = content || displayName;
+        }
+        if (displayName && displayName !== sdkEvent.data.text) {
+          sdkEvent.data.markdown = displayName;
+        }
         if (files.length) {
           sdkEvent.data.files = files;
         }

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -55,9 +55,9 @@ const Messages = WebexPlugin.extend({
    * The events passed to any registered handlers will be similar to the webhook JSON,
    * but will omit webhook specific fields such as name, secret, url, etc.
    * The messages.listen() event objects can also include additional fields not
-   * available in webhook JSON. These fields are text, markdown, and files.
-   * These fields are available when their details are included in the WebSocket's
-   * activity object. Retrieving other fields, such as the html field,
+   * available in the webhook's JSON payload: `text`, `markdown`, and `files`.
+   * These fields are available when their details are included in the web socket's
+   * `activity` object. Retrieving other fields, such as the `html` field,
    * will require a manual request to get the corresponding message object.
    * See the <a href="https://js.samples.s4d.io/browser-socket/">Sample App</a>
    * for more details.
@@ -357,11 +357,12 @@ const Messages = WebexPlugin.extend({
 
       if (event !== SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED) {
         const {content, displayName} = activity.object;
+        const text = content || displayName;
         const files = getHydraFiles(activity);
 
         sdkEvent.data.id = constructHydraId(hydraTypes.MESSAGE, activity.id);
-        if (content || displayName) {
-          sdkEvent.data.text = content || displayName;
+        if (text) {
+          sdkEvent.data.text = text;
         }
         if (displayName && displayName !== sdkEvent.data.text) {
           sdkEvent.data.markdown = displayName;

--- a/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
@@ -104,7 +104,7 @@ describe('plugin-messages', function () {
         return webex.messages.listen()
           .then(() => webex.messages.create({
             roomId: room.id,
-            file: KNOWN_HOSTED_IMAGE_URL
+            files: [KNOWN_HOSTED_IMAGE_URL]
           })
             .then(async (message) => {
               validateMessage(message);
@@ -149,7 +149,7 @@ describe('plugin-messages', function () {
         return webex.messages.listen()
           .then(() => webex.messages.create({
             roomId: room.id,
-            file: blob,
+            files: [blob],
             text
           })
             .then(async (message) => {
@@ -164,7 +164,7 @@ describe('plugin-messages', function () {
       // mostly adequate coverage via blob upload
       flaky(it, process.env.SKIP_FLAKY_TESTS)('posts a file to a room by directly supplying its buffer and validates the event', () => webex.messages.create({
         roomId: room.id,
-        file: buffer
+        files: [buffer]
       })
         .then((message) => {
           validateMessage(message, '', 1);
@@ -181,12 +181,28 @@ describe('plugin-messages', function () {
         return webex.messages.listen()
           .then(() => webex.messages.create({
             roomId: room.id,
-            file: KNOWN_HOSTED_IMAGE_URL,
+            files: [KNOWN_HOSTED_IMAGE_URL],
             text
           })
             .then(async (message) => {
               validateMessage(message);
-              const event = await created;
+              let event = await created;
+
+              // When using this method to attach a file to
+              // a message, sometimes, the first event does not
+              // include all the data included in the message.
+              // kms then triggers a second event that includes
+              // all of the data in the message object.
+              if (event.data.id !== message.id) {
+                const createdCombined = new Promise((resolve) => {
+                  webex.messages.on('created', (e) => {
+                    debug('message created event called');
+                    resolve(e);
+                  });
+                });
+
+                event = await createdCombined;
+              }
 
               validateMessageEvent(event, message, actor);
             }));
@@ -382,4 +398,3 @@ function validateMessageEvent(event, message, actor) {
     }
   }
 }
-


### PR DESCRIPTION
# Pull Request

## Description

Update how message:created events are shaped so that they properly
populate the text, markdown, and files fields. Clean up testing
so that it handles this properly, and adjust testing statements
to utilize the proper 'files' field instead of 'file'. Update
documentation for messages.listen() to identify how to retrieve
the html field data to satisfy the related internal case.

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-78472

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Utilized repository testing suite on the associated module and project.

**Test Configuration**:
* Node/Browser Version v8.16.0
* NPM Version v6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
