### PR TITLE
Filter out lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "lint": "npm run --silent lint:js && npm run --silent lint:jenkinsfile && npm run --silent lint:package-names",
     "lint:ci": "npm run --silent lint:js:ci && npm run --silent lint:jenkinsfile && npm run --silent lint:package-names",
     "lint:commitmsg": "commitlint -e $GIT_PARAMS",
+    "lint:errors": "npm run lint | grep --color -e '\\serror\\s' || true",
     "lint:eslint": "eslint --ignore-pattern 'packages/node_modules/generator-ciscospark/generators/*/templates/**' --ignore-pattern 'packages/node_modules/**/umd/**' --ignore-pattern 'docs/**' --ignore-path .gitignore",
     "lint:eslint:ci-reporter": "bash -c '[[ -n \"${JENKINS}\" ]]' && echo \"-f checkstyle -o reports/style/eslint.xml\" || echo ''",
     "lint:jenkinsfile": "node --eval \"fs.readFileSync('Jenkinsfile').includes('.status') ? console.log('Found \".status\" in Jenkinsfile. You meant \".result\"') && process.exit(1) : process.exit(0)\"",


### PR DESCRIPTION
# Pull Request 

## Description

Add npm script to report only lint *errors*, filtering out *warnings*. 

```sh
npm run lint:errors
```

There are many warnings throughout the codebase, making it tedious to find why a commit hook is failing. Until these are cleaned up, this command will show you only the errors.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
