### PR TITLE
feat(plugin-conversation): bulkActivitiesFetch function

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -250,6 +250,43 @@ const Conversation = WebexPlugin.extend({
   },
 
   /**
+  * Gets an array of activities with an array of activity URLS
+  * @param {Array} activities
+  * @param {String} cluster
+  * @returns {Promise<Object>} Resolves with the activities
+  * TODO: add cluster functionality when clusters are ready
+  */
+  bulkActivitiesFetch(activities, cluster) {
+    if (!cluster) {
+      const params = {
+        method: 'POST',
+        api: 'conversation',
+        resource: 'bulk_activities_fetch',
+        body: {
+          activities
+        }
+      };
+
+      return this.webex.request(params)
+        .then((res) => {
+          const activitiesArr = [];
+
+          if (res.body.multistatus) {
+            res.body.multistatus.forEach((statusData) => {
+              if (statusData.status === '200' && statusData.data && statusData.data.activity) {
+                activitiesArr.push(statusData.data.activity);
+              }
+            });
+          }
+
+          return activitiesArr;
+        });
+    }
+
+    return [];
+  },
+
+  /**
    * Fetches a single conversation
    * @param {Object} conversation
    * @param {Object} options

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
@@ -293,5 +293,115 @@ describe('plugin-conversation', function () {
             assert.equal(mentions[0].url, activity.url);
           })));
     });
+
+    // TODO: add testing for bulk_activities_fetch() with clusters later
+    describe('#bulkActivitiesFetch()', () => {
+      let jenny, maria, dan, convo1, convo2;
+      let webex3;
+
+      before('create tests users and connect one to mercury', () => testUsers.create({count: 4})
+        .then((users) => {
+          [jenny, maria, dan] = users;
+
+          webex3 = new WebexCore({
+            credentials: {
+              authorization: jenny.token
+            }
+          });
+
+          return webex3.internal.mercury.connect();
+        }));
+
+      after(() => webex3 && webex3.internal.mercury.disconnect());
+
+      before('create conversation 1', () => webex3.internal.conversation.create({participants: [jenny, maria]})
+        .then((c1) => { convo1 = c1; }));
+
+      before('create conversation 2', () => webex3.internal.conversation.create({participants: [jenny, dan]})
+        .then((c2) => { convo2 = c2; }));
+
+      it('add comments to convo1, and check post requests successfully went through', () =>
+        webex3.internal.conversation.post(convo1, {displayName: 'BAGELS (O)'})
+          .then((c1) => {
+            assert.equal(c1.object.displayName, 'BAGELS (O)');
+
+            return webex3.internal.conversation.post(convo1, {displayName: 'Cream Cheese'});
+          })
+          .then((c2) => { assert.equal(c2.object.displayName, 'Cream Cheese'); }));
+
+      it('add comments to convo2, and check post requests successfully went through', () =>
+        webex3.internal.conversation.post(convo2, {displayName: 'Want to head to lunch soon?'})
+          .then((c1) => {
+            assert.equal(c1.object.displayName, 'Want to head to lunch soon?');
+
+            return webex3.internal.conversation.post(convo2, {displayName: 'Sure :)'});
+          })
+          .then((c2) => {
+            assert.equal(c2.object.displayName, 'Sure :)');
+
+            return webex3.internal.conversation.post(convo2, {displayName: 'where?'});
+          })
+          .then((c3) => {
+            assert.equal(c3.object.displayName, 'where?');
+
+            return webex3.internal.conversation.post(convo2, {displayName: 'Meekong Bar!'});
+          })
+          .then((c4) => { assert.equal(c4.object.displayName, 'Meekong Bar!'); }));
+
+      it('retrieves activities from a single conversation', () =>
+        webex3.internal.conversation.listActivities({conversationId: convo1.id})
+          .then((convoActivities) => {
+            const activityURLs = [];
+
+            convoActivities.map((a) => {
+              if (a.verb === 'post') {
+                activityURLs.push(a.url);
+              }
+
+              return activityURLs;
+            });
+            webex3.internal.conversation.bulkActivitiesFetch(activityURLs)
+              .then((bulkFetchedActivities) => {
+                assert.equal(bulkFetchedActivities, convoActivities);
+              });
+          }));
+
+      it('retrieves activities from multiple conversations', () =>
+        webex3.internal.conversation.listActivities({conversationId: convo1.id})
+          .then((convo1Activities) => {
+            const activityURLs = [];
+
+            // gets all post activty urls from convo1
+            convo1Activities.map((a1) => {
+              if (a1.verb === 'post') {
+                activityURLs.push(a1.url);
+              }
+
+              return activityURLs;
+            });
+            // gets activity urls of only comment 3 and 4 from convo2
+            webex3.internal.conversation.listActivities({conversationId: convo2.id})
+              .then((convo2Activities) => {
+                [3, 4].map((i) => activityURLs.push(convo2Activities[i.url]));
+              });
+            webex3.internal.conversation.bulkActivitiesFetch(activityURLs)
+              .then((bulkFetchedActivities) => {
+                const expectedActivities = convo1Activities;
+
+                expectedActivities.push(convo1Activities[3]);
+                expectedActivities.push(convo1Activities[4]);
+                assert.equal(bulkFetchedActivities, expectedActivities);
+              });
+          }));
+
+      it('given a activity url that does not exist, should return []', () => {
+        const mockURL = 'https://conversation-intb.ciscospark.com/conversation/api/v1/activities/6d8c7c90-a770-11e9-bcfb-6616ead99ac3';
+
+        webex3.internal.conversation.bulkActivitiesFetch([mockURL])
+          .then((bulkFetchedActivities) => {
+            assert.equal(bulkFetchedActivities, []);
+          });
+      });
+    });
   });
 });


### PR DESCRIPTION
# Pull Request Template

## Description
Bulk fetch of activities using a list of URLs and cluster url. For future breadcrumb support so that we can bulk fetch activities based on a specific cluster

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] added 2 comments to conversation 1: confirm they were added
- [x] added 4 comments to conversation 2: confirm they were added
- bulk fetch all **post** activities in conversation 1
 - [x] assert they equal the result of listActivities
- bulk fetch all **post** activities in conversation 1 and comments 3 and 4 from conversation 2
 - [x] assert they equal the result of listActivities on conversation 1 and comment 3 + 4 in conversation 2
- [x] bulk fetch a activity URL that doesn't exist ---> [] 

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
 - **Currently failing 11 local tests that have to do with sharing, verbs, and download**
- [ ] Any dependent changes have been merged and published in downstream modules
