### PR TITLE
feat(plugin-search): added breadcrumbs

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-search/src/search.js
+++ b/packages/node_modules/@webex/internal-plugin-search/src/search.js
@@ -59,7 +59,14 @@ const Search = WebexPlugin.extend({
           searchEncryptionKeyUrl: this.webex.internal.device.searchEncryptionKeyUrl
         })
       }))
-      .then((res) => get(res, 'body.activities.items') || []);
+      .then((res) => {
+        const resActivities = get(res, 'body.activities.items', []);
+
+        return (options.breadcrumbsEnabled ? {
+          activities: resActivities,
+          breadcrumbs: get(res, 'body.breadcrumbs', {})
+        } : resActivities);
+      });
   }
 
 });

--- a/packages/node_modules/@webex/internal-plugin-search/test/integration/spec/search.js
+++ b/packages/node_modules/@webex/internal-plugin-search/test/integration/spec/search.js
@@ -14,6 +14,7 @@ import '@webex/internal-plugin-wdm';
 
 import {map, countBy} from 'lodash';
 import uuid from 'uuid';
+
 import util from 'util';
 
 describe('plugin-search', () => {
@@ -503,6 +504,39 @@ describe('plugin-search', () => {
               expected.results.forEach((expectedResults) => {
                 assert.equal(counts[expectedResults.name], expectedResults.count);
               });
+            });
+        }));
+
+        // TODO: modify tests when breadcrumbs are complete with real data
+        // Currently the breadcrumb is {}
+        it(message, () => retry(() => {
+          let params;
+
+          if (given.query) {
+            params = {
+              query: given.query,
+              limit: given.size,
+              breadcrumbsEnabled: true
+            };
+          }
+          else {
+            params = {
+              sharedIn: spockConversation.id,
+              type: given.type
+            };
+          }
+
+          return party[given.user].webex.internal.search.search(params)
+            .then((results) => {
+              assert.isDefined(results);
+
+              if (given.query) {
+                assert.isDefined(results.activities);
+                assert.isDefined(results.breadcrumbs);
+                assert.lengthOf(results.activities, expected.resultsCount);
+                assert.isTrue(typeof results.breadcrumbs === 'object');
+                assert.isTrue(results.breadcrumbs.constructor === Object);
+              }
             });
         }));
       });


### PR DESCRIPTION
# Pull Request Template

## Description

Updated `search.js` to return a response object with breadcrumbs instead of just returning list of activities.

Fixes # (issue)

## Type of Change
Refactor: adding breadcrumbs to search requests
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage
Currently not tested by automated testing, tests are failing before changes currently.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `Breadcrumb` is not **undefined**
- [x] `Activities` is not **undefined**
- [x] `Breadcrumb` is an Object
- [x] **Old Tests:** not passing `breadcrumbsEnabled: true` --> into **options** lets developers opt-out of the feature until breadcrumbs are fully implemented
- [x] Passing `breadcrumbsEnabled: true` --> into **options** for search function enables developers to opt-in to breadcrumbs

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules