### PR TITLE
Add a sleep to some test suites in board, conversation, feature, mercury, and room integration tests

### DIFF
--- a/packages/node_modules/@webex/bin-sauce-connect/package.json
+++ b/packages/node_modules/@webex/bin-sauce-connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/bin-sauce-connect",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "bin": {

--- a/packages/node_modules/@webex/common-evented/package.json
+++ b/packages/node_modules/@webex/common-evented/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/common-evented",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "Class property decorator the adds change events to properties",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/common-timers/package.json
+++ b/packages/node_modules/@webex/common-timers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/common-timers",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "Timer wrappers to prevent wedging a process open",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/common/package.json
+++ b/packages/node_modules/@webex/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/common",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "Common utilities for Cisco Webex",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/helper-html/package.json
+++ b/packages/node_modules/@webex/helper-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/helper-html",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "HTML Utiltities",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/helper-image/package.json
+++ b/packages/node_modules/@webex/helper-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/helper-image",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Saurabh Jain <saurjai3@cisco.com>",

--- a/packages/node_modules/@webex/http-core/package.json
+++ b/packages/node_modules/@webex/http-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/http-core",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "Core HTTP library for the Cisco Webex",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/internal-plugin-board/package.json
+++ b/packages/node_modules/@webex/internal-plugin-board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-board",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Greg Hewett <ghewett@cisco.com>",

--- a/packages/node_modules/@webex/internal-plugin-board/test/integration/spec/realtime.js
+++ b/packages/node_modules/@webex/internal-plugin-board/test/integration/spec/realtime.js
@@ -19,8 +19,11 @@ describe('plugin-board', () => {
     let mccoyRealtimeChannel, spockRealtimeChannel;
 
     before('create users', () => testUsers.create({count: 2})
-      .then((users) => {
+      .then(async (users) => {
         participants = [spock, mccoy] = users;
+
+        // Pause for 5 seconds for CI
+        await new Promise((done) => setTimeout(done, 5000));
 
         return Promise.all(map(participants, (participant) => {
           participant.webex = new WebexCore({

--- a/packages/node_modules/@webex/internal-plugin-calendar/package.json
+++ b/packages/node_modules/@webex/internal-plugin-calendar/package.json
@@ -15,5 +15,5 @@
       "envify"
     ]
   },
-  "version": "1.73.1"
+  "version": "1.73.2"
 }

--- a/packages/node_modules/@webex/internal-plugin-conversation/package.json
+++ b/packages/node_modules/@webex/internal-plugin-conversation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-conversation",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/create.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/create.js
@@ -17,9 +17,12 @@ describe('plugin-conversation', function () {
     let checkov, kirk, mccoy, participants, webex, spock;
 
     before(() => testUsers.create({count: 4})
-      .then((users) => {
+      .then(async (users) => {
         [spock, mccoy, checkov, kirk] = users;
         participants = [spock, mccoy, checkov];
+
+        // Pause for 5 seconds for CI
+        await new Promise((done) => setTimeout(done, 5000));
 
         webex = new WebexCore({
           credentials: {

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/share.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/share.js
@@ -12,7 +12,7 @@ import {assert} from '@webex/test-helper-chai';
 import testUsers from '@webex/test-helper-test-users';
 import {find} from 'lodash';
 import uuid from 'uuid';
-import {skipInNode} from '@webex/test-helper-mocha';
+import {flaky, skipInNode} from '@webex/test-helper-mocha';
 
 /**
  * Resolves with the first argument passed in, after applying `fn()` on that
@@ -31,9 +31,12 @@ describe('plugin-conversation', function () {
     let mccoy, participants, webex, spock;
 
     before(() => testUsers.create({count: 3})
-      .then((users) => {
+      .then(async (users) => {
         participants = users;
         [spock, mccoy] = participants;
+
+        // Pause for 5 seconds for CI
+        await new Promise((done) => setTimeout(done, 5000));
 
         webex = new WebexCore({
           credentials: {
@@ -286,7 +289,7 @@ describe('plugin-conversation', function () {
     describe('#makeShare', () => {
       // http-core doesn't current do upload progress events in node, so this
       // test is browser-only for now
-      skipInNode(it)('provides an interface for file upload events', () => {
+      skipInNode(flaky(it, process.env.SKIP_FLAKY_TESTS))('provides an interface for file upload events', () => {
         const spy = sinon.spy();
         const share = webex.internal.conversation.makeShare(conversation);
         const emitter = share.add(sampleImageSmallOnePng);

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/verbs.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/verbs.js
@@ -20,8 +20,11 @@ describe('plugin-conversation', function () {
     let checkov, mccoy, participants, webex, spock;
 
     before(() => testUsers.create({count: 3})
-      .then((users) => {
+      .then(async (users) => {
         [spock, mccoy, checkov] = participants = users;
+
+        // Pause for 5 seconds for CI
+        await new Promise((done) => setTimeout(done, 5000));
 
         webex = new WebexCore({
           credentials: {

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/package.json
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-ediscovery",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/node_modules/@webex/internal-plugin-encryption/package.json
+++ b/packages/node_modules/@webex/internal-plugin-encryption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-encryption",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/internal-plugin-feature/package.json
+++ b/packages/node_modules/@webex/internal-plugin-feature/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-feature",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Aimee <aimma@cisco.com>",

--- a/packages/node_modules/@webex/internal-plugin-feature/test/integration/spec/feature.js
+++ b/packages/node_modules/@webex/internal-plugin-feature/test/integration/spec/feature.js
@@ -7,7 +7,7 @@ import '@webex/internal-plugin-feature';
 import {assert} from '@webex/test-helper-chai';
 import WebexCore from '@webex/webex-core';
 import testUsers from '@webex/test-helper-test-users';
-import {expectEvent} from '@webex/test-helper-mocha';
+import {expectEvent, flaky} from '@webex/test-helper-mocha';
 import sinon from '@webex/test-helper-sinon';
 
 describe('plugin-feature', function () {
@@ -16,8 +16,12 @@ describe('plugin-feature', function () {
 
   describe('#setFeature()', () => {
     before(() => testUsers.create({count: 1})
-      .then((users) => {
+      .then(async (users) => {
         spock = users[0];
+
+        // Pause for 5 seconds for CI
+        await new Promise((done) => setTimeout(done, 5000));
+
         webex = new WebexCore({
           credentials: {
             authorization: spock.token
@@ -85,8 +89,12 @@ describe('plugin-feature', function () {
 
   describe('when feature toggle update event is received', () => {
     before(() => testUsers.create({count: 1})
-      .then((users) => {
+      .then(async (users) => {
         spock = users[0];
+
+        // Pause for 5 seconds for CI
+        await new Promise((done) => setTimeout(done, 5000));
+
         webex = new WebexCore({
           credentials: {
             authorization: spock.token
@@ -101,7 +109,7 @@ describe('plugin-feature', function () {
 
     after(() => webex.internal.mercury.disconnect());
 
-    it('updates the feature toggle', () => {
+    flaky(it, process.env.SKIP_FLAKY_TESTS)('updates the feature toggle', () => {
       const featureUpdateArray = [{
         key: 'mention-notifications',
         val: false,

--- a/packages/node_modules/@webex/internal-plugin-locus/package.json
+++ b/packages/node_modules/@webex/internal-plugin-locus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-locus",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/internal-plugin-lyra/package.json
+++ b/packages/node_modules/@webex/internal-plugin-lyra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-lyra",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Tran Tu <tratu@cisco.com>",

--- a/packages/node_modules/@webex/internal-plugin-mercury/package.json
+++ b/packages/node_modules/@webex/internal-plugin-mercury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-mercury",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/internal-plugin-mercury/test/integration/spec/mercury.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/test/integration/spec/mercury.js
@@ -5,6 +5,7 @@
 import '@webex/internal-plugin-mercury';
 
 import {assert} from '@webex/test-helper-chai';
+import {flaky} from '@webex/test-helper-mocha';
 import sinon from '@webex/test-helper-sinon';
 import WebexCore from '@webex/webex-core';
 import testUsers from '@webex/test-helper-test-users';
@@ -69,7 +70,7 @@ describe('plugin-mercury', function () {
       });
 
       describe('when web-high-availability is enabled', () => {
-        it('connects to mercury using service catalog url', () => {
+        flaky(it, process.env.SKIP_FLAKY_TESTS)('connects to mercury using service catalog url', () => {
           let defaultWebSocketUrl;
 
           // we need to ensure the feature is set for user before "registering"

--- a/packages/node_modules/@webex/internal-plugin-mercury/test/integration/spec/webex.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/test/integration/spec/webex.js
@@ -15,7 +15,10 @@ describe('plugin-mercury', function () {
   let webex;
 
   beforeEach('create users', () => testUsers.create({count: 1})
-    .then((users) => {
+    .then(async (users) => {
+      // Pause for 5 seconds for CI
+      await new Promise((done) => setTimeout(done, 5000));
+
       webex = new WebexCore({
         credentials: {
           supertoken: users[0].token

--- a/packages/node_modules/@webex/internal-plugin-search/package.json
+++ b/packages/node_modules/@webex/internal-plugin-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-search",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Michael Wegman <mwegman@cisco.com>",

--- a/packages/node_modules/@webex/internal-plugin-team/package.json
+++ b/packages/node_modules/@webex/internal-plugin-team/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-team",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Josh Dykstra <jodykstr@cisco.com>",

--- a/packages/node_modules/@webex/jsdoctrinetest/package.json
+++ b/packages/node_modules/@webex/jsdoctrinetest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/jsdoctrinetest",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/node_modules/@webex/media-engine-webrtc/package.json
+++ b/packages/node_modules/@webex/media-engine-webrtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/media-engine-webrtc",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/plugin-attachment-actions/package.json
+++ b/packages/node_modules/@webex/plugin-attachment-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-attachment-actions",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/node_modules/@webex/plugin-authorization-browser-first-party/package.json
+++ b/packages/node_modules/@webex/plugin-authorization-browser-first-party/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-authorization-browser-first-party",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/plugin-device-manager/package.json
+++ b/packages/node_modules/@webex/plugin-device-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-device-manager",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/node_modules/@webex/plugin-logger/package.json
+++ b/packages/node_modules/@webex/plugin-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-logger",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/plugin-meetings/package.json
+++ b/packages/node_modules/@webex/plugin-meetings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-meetings",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/node_modules/@webex/plugin-memberships/package.json
+++ b/packages/node_modules/@webex/plugin-memberships/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-memberships",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/plugin-messages/package.json
+++ b/packages/node_modules/@webex/plugin-messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-messages",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/plugin-people/package.json
+++ b/packages/node_modules/@webex/plugin-people/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-people",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Adam Weeks <adweeks@cisco.com>",

--- a/packages/node_modules/@webex/plugin-phone/package.json
+++ b/packages/node_modules/@webex/plugin-phone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-phone",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/plugin-rooms/package.json
+++ b/packages/node_modules/@webex/plugin-rooms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-rooms",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/plugin-rooms/test/integration/spec/rooms.js
+++ b/packages/node_modules/@webex/plugin-rooms/test/integration/spec/rooms.js
@@ -25,7 +25,10 @@ describe('plugin-rooms', function () {
   let webex, actor;
 
   before(() => testUsers.create({count: 1})
-    .then(([user]) => {
+    .then(async ([user]) => {
+      // Pause for 5 seconds for CI
+      await new Promise((done) => setTimeout(done, 5000));
+
       webex = new WebexCore({credentials: user.token});
 
       return webex.people.get('me')
@@ -81,7 +84,10 @@ describe('plugin-rooms', function () {
       let user1, room;
 
       before(() => testUsers.create({count: 1})
-        .then((users) => {
+        .then(async (users) => {
+          // Pause for 5 seconds for CI
+          await new Promise((done) => setTimeout(done, 5000));
+
           user1 = users[0];
           debug('Test User for One-on-One room:');
           debug(`- name: ${user1.displayName}`);
@@ -202,7 +208,10 @@ describe('plugin-rooms', function () {
       let room1, user2;
 
       before(() => testUsers.create({count: 1})
-        .then(([user]) => {
+        .then(async ([user]) => {
+          // Pause for 5 seconds for CI
+          await new Promise((done) => setTimeout(done, 5000));
+
           user2 = user;
           user2.webex = new WebexCore({credentials: user2.token});
         }));
@@ -247,7 +256,10 @@ describe('plugin-rooms', function () {
       let room1, room2, user2;
 
       before(() => testUsers.create({count: 1})
-        .then(([user]) => {
+        .then(async ([user]) => {
+          // Pause for 5 seconds for CI
+          await new Promise((done) => setTimeout(done, 5000));
+
           user2 = user;
           user2.webex = new WebexCore({credentials: user2.token});
         }));

--- a/packages/node_modules/@webex/plugin-team-memberships/package.json
+++ b/packages/node_modules/@webex/plugin-team-memberships/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-team-memberships",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/plugin-teams/package.json
+++ b/packages/node_modules/@webex/plugin-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-teams",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/plugin-webhooks/package.json
+++ b/packages/node_modules/@webex/plugin-webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-webhooks",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/recipe-private-web-client/package.json
+++ b/packages/node_modules/@webex/recipe-private-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/recipe-private-web-client",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "This is a plugin recipe for the Cisco Webex JS SDK. This recipe uses internal APIs to provide the features needed by the Cisco Webex Teams Client. There is no guarantee of non-breaking changes. Non-Cisco engineers should stick to the `webex` package.",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/storage-adapter-local-forage/package.json
+++ b/packages/node_modules/@webex/storage-adapter-local-forage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/storage-adapter-local-forage",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Matt Norris <matthew.g.norris@gmail.com>",

--- a/packages/node_modules/@webex/storage-adapter-local-storage/package.json
+++ b/packages/node_modules/@webex/storage-adapter-local-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/storage-adapter-local-storage",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/storage-adapter-session-storage/package.json
+++ b/packages/node_modules/@webex/storage-adapter-session-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/storage-adapter-session-storage",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Andrew Holsted <holsted@cisco.com>",

--- a/packages/node_modules/@webex/storage-adapter-spec/package.json
+++ b/packages/node_modules/@webex/storage-adapter-spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/storage-adapter-spec",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/test-helper-appid/package.json
+++ b/packages/node_modules/@webex/test-helper-appid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-appid",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/test-helper-automation/package.json
+++ b/packages/node_modules/@webex/test-helper-automation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-automation",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-chai/package.json
+++ b/packages/node_modules/@webex/test-helper-chai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-chai",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "chai extended with webex specific assertions",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-file/package.json
+++ b/packages/node_modules/@webex/test-helper-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-file",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "File helpers for writing isomorphicish mocha tests",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-make-local-url/package.json
+++ b/packages/node_modules/@webex/test-helper-make-local-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-make-local-url",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-mocha/package.json
+++ b/packages/node_modules/@webex/test-helper-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-mocha",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "Helpers for controlling where tests run",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-mock-web-socket/package.json
+++ b/packages/node_modules/@webex/test-helper-mock-web-socket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-mock-web-socket",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-mock-webex/package.json
+++ b/packages/node_modules/@webex/test-helper-mock-webex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-mock-webex",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-refresh-callback/package.json
+++ b/packages/node_modules/@webex/test-helper-refresh-callback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-refresh-callback",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-retry/package.json
+++ b/packages/node_modules/@webex/test-helper-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-retry",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-server/package.json
+++ b/packages/node_modules/@webex/test-helper-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-server",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-sinon/package.json
+++ b/packages/node_modules/@webex/test-helper-sinon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-sinon",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/@webex/test-helper-test-users/package.json
+++ b/packages/node_modules/@webex/test-helper-test-users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-test-users",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/@webex/webex-core/package.json
+++ b/packages/node_modules/@webex/webex-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/webex-core",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "Plugin handling for Cisco Webex",
   "license": "MIT",
   "contributors": [

--- a/packages/node_modules/@webex/webex-server/package.json
+++ b/packages/node_modules/@webex/webex-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/webex-server",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": ".",
   "license": "MIT",
   "contributors": [

--- a/packages/node_modules/@webex/webrtc/package.json
+++ b/packages/node_modules/@webex/webrtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/webrtc",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/node_modules/@webex/xunit-with-logs/package.json
+++ b/packages/node_modules/@webex/xunit-with-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/xunit-with-logs",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/node_modules/samples/package.json
+++ b/packages/node_modules/samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samples",
-  "version": "1.72.6",
+  "version": "1.73.2",
   "description": "Sample apps for the Webex JavaScript SDK",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/node_modules/webex/package.json
+++ b/packages/node_modules/webex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex",
-  "version": "1.73.1",
+  "version": "1.73.2",
   "description": "SDK for Cisco Webex",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
## Description

Add a `sleep` to conversation, feature, and mercury integration tests where user creation is causing tests to fail

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
