### PR TITLE
Force all packages to version bump

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -443,7 +443,7 @@ ansiColor('xterm') {
                   // build docs here since they need to be added with `git add`
                   sh 'npm run build:docs'
 
-                  sh "npm run tooling -- version set ${version} --last-log"
+                  sh "npm run tooling -- version set ${version} --all"
 
                   sh 'git add packages/node_modules/*/package.json packages/node_modules/@ciscospark/*/README.md packages/node_modules/@webex/*/package.json docs/ packages/node_modules/webex/umd/*.js'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,7 +155,7 @@ ansiColor('xterm') {
           // Set the description to blank so we can use +=
           currentBuild.description = ''
 
-          env.CONCURRENCY = 4
+          env.CONCURRENCY = 5
           env.ENABLE_VERBOSE_NETWORK_LOGGING = true
           env.SDK_ROOT_DIR=pwd
 


### PR DESCRIPTION
## Description

Currently, some packages are getting version bumped which is causing issues when it comes to unit testing to `webex` package that does a version check. That version is dependent on `webex-core`, and since `webex-core` isn't forced to bump on all PR/merges a version mismatch failure is most likely to happen.
Instead of just adding `webex-core` to bump, bump everything.

Also, bump test concurrency to 5 to speed up testing on Jenkins

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
