### PR TITLE
Samples test features and styling

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2178,7 +2178,7 @@ export default class Meeting extends StatelessWebexPlugin {
           return Promise.resolve();
         }))
       .then(() => {
-        this.mediaProperties.setLocalShareTrack(track);
+        this.setLocalShareTrack(stream);
         this.mediaProperties.mediaDirection.sendShare = sendShare;
         this.mediaProperties.mediaDirection.receiveShare = receiveShare;
       });
@@ -2328,6 +2328,8 @@ export default class Meeting extends StatelessWebexPlugin {
             EVENT_TRIGGERS.MEETING_STARTED_SHARING_LOCAL,
           );
           Metrics.postEvent({event: eventType.LOCAL_SHARE_FLOOR_GRANTED, meeting: this});
+
+          return Promise.resolve();
         })
         .catch((e) => {
           LoggerProxy.logger.error('Meeting/index->share#Error ', e);

--- a/packages/node_modules/samples/browser-call-with-screenshare/app.js
+++ b/packages/node_modules/samples/browser-call-with-screenshare/app.js
@@ -114,6 +114,7 @@ function bindMeetingEvents(meeting) {
     if (!media) {
       return;
     }
+    console.log(`MEDIA:READY type:${media.type}`);
     if (media.type === 'local') {
       document.getElementById('self-view').srcObject = media.stream;
     }
@@ -122,6 +123,14 @@ function bindMeetingEvents(meeting) {
     }
     if (media.type === 'remoteAudio') {
       document.getElementById('remote-view-audio').srcObject = media.stream;
+    }
+    if (media.type === 'remoteShare') {
+      document.getElementById('remote-screen').srcObject = media.stream;
+      document.getElementById('screenshare-tracks-remote').innerHTML = '1';
+    }
+    if (media.type === 'localShare') {
+      document.getElementById('self-screen').srcObject = media.stream;
+      document.getElementById('screenshare-tracks').innerHTML = '1';
     }
   });
 
@@ -137,6 +146,35 @@ function bindMeetingEvents(meeting) {
     if (media.type === 'remoteAudio') {
       document.getElementById('remote-view-audio').srcObject = null;
     }
+    if (media.type === 'remoteShare') {
+      document.getElementById('remote-screen').srcObject = null;
+      document.getElementById('screenshare-tracks-remote').innerHTML = '0';
+    }
+    if (media.type === 'localShare') {
+      document.getElementById('self-screen').srcObject = null;
+      document.getElementById('screenshare-tracks').innerHTML = '0';
+    }
+  });
+
+  // Update participant info
+  meeting.members.on('members:update', (delta) => {
+    const {full: membersData} = delta;
+    const memberIDs = Object.keys(membersData);
+
+    memberIDs.forEach((memberID) => {
+      const memberObject = membersData[memberID];
+
+      // Devices are listed in the memberships object.
+      // We are not concerned with them in this demo
+      if (memberObject.isUser) {
+        if (memberObject.isSelf) {
+          document.getElementById('call-status-local').innerHTML = memberObject.status;
+        }
+        else {
+          document.getElementById('call-status-remote').innerHTML = memberObject.status;
+        }
+      }
+    });
   });
 
   // Of course, we'd also like to be able to end the call:
@@ -201,7 +239,6 @@ document.getElementById('share-screen').addEventListener('click', () => {
       })
       .then(() => {
         console.info('SHARE-SCREEN: Screen successfully added to meeting.');
-        document.getElementById('screenshare-tracks').innerHTML = '1';
       })
       .catch((e) => {
         console.error('SHARE-SCREEN: Unable to share screen, error:');

--- a/packages/node_modules/samples/browser-call-with-screenshare/index.html
+++ b/packages/node_modules/samples/browser-call-with-screenshare/index.html
@@ -2,61 +2,118 @@
 <html>
   <head>
     <title>Sample: Local Screensharing</title>
+    <link rel="stylesheet" href="https://downloads.momentum-ui.com/@momentum-ui/core/css/momentum-ui.css">
+    <style>
+      main {
+        padding: 10px;
+      }
+      table {
+        border-collapse: collapse;
+        padding: 10px;
+        margin: 10px;
+      }
+      table, th, td {
+        border: 1px solid black;
+      }
+      thead th {
+        font-weight: bold;
+      }
+      tbody td {
+        min-width: 150px;
+      }
+    </style>
   </head>
   <body>
-    <h1>Local Screensharing</h1>
-    <p>This sample demonstrates sharing your local screen</p>
-    <form id="credentials">
-      <fieldset>
-        <legend>Credentials</legend>
-        <input
-          id="access-token"
-          name="accessToken"
-          placeholder="Your access token"
-          type="text">
-        <input id="connect" title="connect" type="submit" value="connect">
-        <p id="connection-status">disconnected</p>
-      </fieldset>
-    </form>
+      <header class="md-top-bar md-top-bar--dark" role="navigation">
+        <div class="md-top-bar__container row">
+          <div class="md-top-bar__brand">
+            <a class="md-brand" href="#">
+              <div class="md-brand__logo">
+                <i class="icon icon-cisco-logo"></i>
+              </div>
+              <div class="md-brand__title">Webex JS SDK Samples</div>
+            </a>
+          </div>
+          <nav class="md-top-bar__nav ">
+            <div class="md-list md-list--horizontal" role="list">
 
-    <form id="dialer">
-      <fieldset>
-        <legend>Dialer</legend>
-        <input
-          id="invitee"
-          name="invitee"
-          placeholder="Person ID or Email Address or SIP URI or Room ID"
-          size="60"
-          type="text">
-          <input title="dial" type="submit" value="dial">
-      </fieldset>
-    </form>
+            </div>
+          </nav>
+        </div>
+      </header>
+      <main>
+        <h1>Local Screensharing</h1>
+        <p>This sample demonstrates sharing your local screen</p>
+        <form id="credentials">
+          <fieldset>
+            <legend>Credentials</legend>
+            <input
+              id="access-token"
+              name="accessToken"
+              placeholder="Your access token"
+              type="text">
+            <input id="connect" title="connect" type="submit" value="connect">
+            <p id="connection-status">disconnected</p>
+          </fieldset>
+        </form>
 
-    <form id="call-controls">
-      <fieldset>
-        <legend>Call Controls</legend>
-        <button id="hangup" title="hangup" type="button">cancel/hangup</button>
+        <form id="dialer">
+          <fieldset>
+            <legend>Dialer</legend>
+            <input
+              id="invitee"
+              name="invitee"
+              placeholder="Person ID or Email Address or SIP URI or Room ID"
+              size="60"
+              type="text">
+              <input title="dial" type="submit" value="dial">
+          </fieldset>
+        </form>
 
-        <button id="share-screen" title="share screen" type="button">share screen</button>
-        <button id="stop-screen-share" title="stop screen share" type="button">stop screen share</button>
-      </fieldset>
-    </form>
+        <form id="call-controls">
+          <fieldset>
+            <legend>Call Controls</legend>
+            <button id="hangup" title="hangup" type="button">cancel/hangup</button>
 
-    <div style="align-items: flex-start; display: flex; max-width: 100%">
-      <div id="screenshare-tracks">0</div>
-      <div style="flex: 1 1 auto; width:30%">
-        <video style="width: 100%" id="self-view" muted autoplay></video>
-        <video style="width: 100%" id="remote-view-video" autoplay></video>
-        <audio id="remote-view-audio" autoplay></audio>
-      </div>
-      <div style="flex: 1 1 auto; width:60%" >
-        <video style="width: 100%;" id="self-screen" muted autoplay></video>
-      </div>
-      <div style="flex: 1 1 auto; height: 400px;  width: 20%;">
-        <h3>Events</h3>
-        <pre id="event-list" style="overflow-y: auto; height: 100%;"></pre>
-      </div>
-    </div>
+            <button id="share-screen" title="share screen" type="button">share screen</button>
+            <button id="stop-screen-share" title="stop screen share" type="button">stop screen share</button>
+          </fieldset>
+        </form>
+
+        <table id="call-status">
+          <thead>
+              <tr>
+                  <th></th>
+                  <th>Call Status</th>
+                  <th>Screenshare Tracks</th>
+              </tr>
+          </thead>
+          <tbody>
+              <tr>
+                  <td>Local Participant</td>
+                  <td id="call-status-local"></td>
+                  <td id="screenshare-tracks"></td>
+              </tr>
+              <tr>
+                <td>Remote Participant</td>
+                <td id="call-status-remote"></td>
+                <td id="screenshare-tracks-remote"></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div style="align-items: flex-start; display: flex; max-width: 100%">
+          <div style="flex: 1 1 auto; width:30%">
+            <video style="width: 100%" id="self-view" muted autoplay></video>
+            <video style="width: 100%" id="remote-view-video" autoplay></video>
+            <audio id="remote-view-audio" autoplay></audio>
+          </div>
+          <div style="flex: 1 1 auto; width:60%" >
+            <video style="width: 100%;" id="self-screen" muted autoplay></video>
+            <video style="width: 100%;" id="remote-screen" muted autoplay></video>
+          </div>
+        </div>
+      </main>
 
     <!-- /bundle.js is the bundled Webex JavaScript SDK -->
     <script src="/bundle.js"></script>

--- a/packages/node_modules/samples/browser-call-with-screenshare/test/wdio/spec/normal-dialing.js
+++ b/packages/node_modules/samples/browser-call-with-screenshare/test/wdio/spec/normal-dialing.js
@@ -40,16 +40,29 @@ describe('samples', () => {
       });
 
       it('places call from spock to mccoy', () => {
-        browserSpock.setValue('#invitee', mccoy.emailAddress);
+        browserSpock.setValue('[placeholder="Person ID or Email Address or SIP URI or Room ID"]', mccoy.emailAddress);
         browserSpock.click('[title="dial"]');
 
-        browserMccoy.pause(2500);
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-local') === 'IN_MEETING'), 10000, 'Timed-out waiting for local user to connect to meeting');
+      });
+
+      it('joins the call on mccoy', () => {
+        browserMccoy.waitUntil(() => {
+          try {
+            const alerttext = browserMccoy.alertText();
+
+            return alerttext === 'Answer incoming call';
+          }
+          catch (error) {
+            // Error is thrown when alert isn't open which is fine
+            return false;
+          }
+        }, 10000, 'Timed out waiting for incoming call alert');
         browserMccoy.alertAccept();
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-remote') === 'IN_MEETING'), 10000, 'Timed-out waiting for remote user to connect to meeting');
       });
 
       it('starts screensharing', () => {
-        // Wait for meeting to establish before sharing screen
-        browser.pause(10000);
         browserSpock.click('button[title="share screen"]');
 
         browserSpock.waitUntil(() => (browserSpock.getText('#screenshare-tracks') === '1'), 10000, 'Timed-out waiting for screenshare tracks to chage');
@@ -62,8 +75,8 @@ describe('samples', () => {
       });
 
       it('ends the call', () => {
-        browser.pause(2500);
-        browserMccoy.click('[title="hangup"]');
+        browserSpock.click('[title="hangup"]');
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-local') === 'NOT_IN_MEETING'), 10000, 'Timed-out waiting for local user to disconnect from meeting');
       });
     });
   });

--- a/packages/node_modules/samples/browser-multi-party-call/app.js
+++ b/packages/node_modules/samples/browser-multi-party-call/app.js
@@ -139,6 +139,32 @@ function bindMeetingEvents(meeting) {
     }
   });
 
+  // Update participant info
+  meeting.members.on('members:update', (delta) => {
+    const {full: membersData} = delta;
+    const memberIDs = Object.keys(membersData);
+    let memberTableHTML = '';
+
+    memberIDs.forEach((memberID) => {
+      const memberObject = membersData[memberID];
+
+      // Devices are listed in the memberships object.
+      // We are not concerned with them in this demo
+      if (memberObject.isUser) {
+        const personId = memberObject.participant.person.id;
+        const memberTableRowHTML = `<tr id="member-${personId}">
+        <td id="member-name-${personId}">${memberObject.name}</td>
+        <td id="member-status-${personId}">${memberObject.status}</td>
+        <td id="member-isSelf-${personId}">${memberObject.isSelf}</td>
+        </tr>`;
+
+        memberTableHTML = memberTableHTML.concat(memberTableRowHTML);
+      }
+    });
+
+    document.getElementById('call-members').innerHTML = memberTableHTML;
+  });
+
   // Of course, we'd also like to be able to leave the meeting:
   document.getElementById('hangup').addEventListener('click', () => {
     meeting.leave();

--- a/packages/node_modules/samples/browser-multi-party-call/index.html
+++ b/packages/node_modules/samples/browser-multi-party-call/index.html
@@ -2,50 +2,100 @@
 <html>
   <head>
     <title>Sample: Multi Party Calling</title>
+    <link rel="stylesheet" href="https://downloads.momentum-ui.com/@momentum-ui/core/css/momentum-ui.css">
+    <style>
+      main {
+        padding: 10px;
+      }
+      table {
+        border-collapse: collapse;
+        padding: 10px;
+        margin: 10px;
+      }
+      table, th, td {
+        border: 1px solid black;
+      }
+      thead th {
+        font-weight: bold;
+      }
+      tbody td, th {
+        min-width: 150px;
+      }
+    </style>
   </head>
   <body>
-    <h1>Multi Party Calling</h1>
-    <p>This sample demonstrates group calling.</p>
-    <p>With the new <em>meetings plugin</em>, there is no setup difference between a single party cal and a multi party call.</p>
-    <form id="credentials">
-      <fieldset>
-        <legend>Credentials</legend>
-        <input
-          id="access-token"
-          name="accessToken"
-          placeholder="Your access token"
-          type="text">
-        <input id="connect" title="connect" type="submit" value="connect">
-        <p id="connection-status">disconnected</p>
-      </fieldset>
-    </form>
+    <header class="md-top-bar md-top-bar--dark" role="navigation">
+      <div class="md-top-bar__container row">
+        <div class="md-top-bar__brand">
+          <a class="md-brand" href="#">
+            <div class="md-brand__logo">
+              <i class="icon icon-cisco-logo"></i>
+            </div>
+            <div class="md-brand__title">Webex JS SDK Samples</div>
+          </a>
+        </div>
+        <nav class="md-top-bar__nav ">
+          <div class="md-list md-list--horizontal" role="list">
 
-    <form id="dialer">
-      <fieldset>
-        <legend>Dialer</legend>
-        <input
-          id="invitee"
-          name="invitee"
-          placeholder="Room ID or SIP URI"
-          type="text">
-          <input title="dial" type="submit" value="dial">
-      </fieldset>
-    </form>
-
-    <form id="call-controls">
-      <fieldset>
-        <legend>Call Controls</legend>
-        <button id="hangup" title="hangup" type="button">cancel/hangup</button>
-      </fieldset>
-    </form>
-
-    <div style="display: flex">
-      <video style="width:50%" id="self-view" muted autoplay></video>
-      <div style="width:50%">
-        <audio id="remote-view-audio" autoplay></audio>
-        <video id="remote-view-video" autoplay></video>
+          </div>
+        </nav>
       </div>
-    </div>
+    </header>
+    <main>
+      <h1>Multi Party Calling</h1>
+      <form id="credentials">
+        <fieldset>
+          <legend>Credentials</legend>
+          <input
+            id="access-token"
+            name="accessToken"
+            placeholder="Your access token"
+            type="text">
+          <input id="connect" title="connect" type="submit" value="connect">
+          <p id="connection-status">disconnected</p>
+        </fieldset>
+      </form>
+
+      <form id="dialer">
+        <fieldset>
+          <legend>Dialer</legend>
+          <input
+            id="invitee"
+            name="invitee"
+            placeholder="Room ID or SIP URI"
+            type="text">
+            <input title="dial" type="submit" value="dial">
+        </fieldset>
+      </form>
+
+      <form id="call-controls">
+        <fieldset>
+          <legend>Call Controls</legend>
+          <button id="hangup" title="hangup" type="button">cancel/hangup</button>
+        </fieldset>
+      </form>
+
+      <table id="call-status">
+          <thead>
+              <tr><th colspan="3">Call Membership Status</th></tr>
+              <tr>
+                <th>User</th>
+                <th>Call status</th>
+                <th>Is Local?</th>
+              </tr>
+          </thead>
+          <tbody id="call-members">
+          </tbody>
+        </table>
+
+      <div style="display: flex">
+        <video style="width:50%" id="self-view" muted autoplay></video>
+        <div style="width:50%">
+          <audio id="remote-view-audio" autoplay></audio>
+          <video id="remote-view-video" autoplay></video>
+        </div>
+      </div>
+    </main>
 
     <!-- /bundle.js is the bundled Webex JavaScript SDK -->
     <script src="/bundle.js"></script>

--- a/packages/node_modules/samples/browser-multi-party-call/test/wdio/spec/dial-and-reject.js
+++ b/packages/node_modules/samples/browser-multi-party-call/test/wdio/spec/dial-and-reject.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-warning-comments */
 
-import '@webex/plugin-phone';
+import '@webex/internal-plugin-wdm';
 
 import WebexCore from '@webex/webex-core';
 import testUsers from '@webex/test-helper-test-users';
@@ -31,7 +31,7 @@ describe('sample', () => {
             }
           });
 
-          return spock.webex.phone.register();
+          return spock.webex.internal.device.register();
         }));
 
       before('create test room and add members to room', () => spock.webex.request({
@@ -57,7 +57,7 @@ describe('sample', () => {
             }
           });
         })
-        .then(() => spock.webex.phone.deregister()));
+        .then(() => spock.webex.internal.device.unregister()));
 
       it('loads the app', () => {
         browser.url('/browser-multi-party-call/');
@@ -77,13 +77,32 @@ describe('sample', () => {
         browserSpock.waitForExist('.listening');
       });
 
-      it('spock places call to room, mccoy rejects', () => {
+      it('places call from spock to shared room', () => {
         browserSpock.setValue('[placeholder="Room ID or SIP URI"]', roomId);
         browserSpock.click('[title="dial"]');
+        browserSpock.waitForExist(`#member-status-${spock.id}`, 5000);
+        browserSpock.waitUntil(() => (browserSpock.getText(`#member-status-${spock.id}`) === 'IN_MEETING'), 10000, `Timed-out waiting for local user (${spock.id}) to connect to meeting`);
+      });
 
-        browserMccoy.pause(2500);
+      it('rejects the call on mccoy', () => {
+        browserMccoy.waitUntil(() => {
+          try {
+            const alerttext = browserMccoy.alertText();
+
+            return alerttext === 'Answer incoming call';
+          }
+          catch (error) {
+            // Error is thrown when alert isn't open which is fine
+            return false;
+          }
+        }, 10000, 'Timed out waiting for incoming call alert');
         browserMccoy.alertDismiss();
+      });
+
+      it('ends the call', () => {
         browserSpock.click('[title="hangup"]');
+        browserSpock.waitUntil(() => (browserSpock.getText(`#member-status-${spock.id}`) === 'NOT_IN_MEETING'), 10000, 'Timed-out waiting for local user to disconnect from meeting');
+        browser.refresh();
       });
     });
   });

--- a/packages/node_modules/samples/browser-multi-party-call/test/wdio/spec/dial-before-connect.js
+++ b/packages/node_modules/samples/browser-multi-party-call/test/wdio/spec/dial-before-connect.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-warning-comments */
 
-import '@webex/plugin-phone';
+import '@webex/internal-plugin-wdm';
 
 import WebexCore from '@webex/webex-core';
 import testUsers from '@webex/test-helper-test-users';
@@ -13,6 +13,10 @@ describe('sample', () => {
 
       const browserSpock = browser.select('browserSpock');
       const browserMccoy = browser.select('browserMccoy');
+
+      before('reload browser', () => {
+        browser.refresh();
+      });
 
       before('create test users', () => testUsers.create({count: 2})
         .then((users) => {
@@ -27,7 +31,7 @@ describe('sample', () => {
             }
           });
 
-          return spock.webex.phone.register();
+          return spock.webex.internal.device.register();
         }));
 
       before('create test room and add members to room', () => spock.webex.request({
@@ -53,42 +57,49 @@ describe('sample', () => {
             }
           });
         })
-        .then(() => spock.webex.phone.deregister()));
-
-      before('reload browser', () => {
-        browser.refresh();
-      });
+        .then(() => spock.webex.internal.device.unregister()));
 
       it('loads the app', () => {
         browser.url('/browser-multi-party-call/');
       });
 
-      it('places call from mccoy to spock', () => {
-        expect(browserMccoy.getTitle()).to.equal('Sample: Multi Party Calling');
-        browserMccoy.setValue('[placeholder="Your access token"]', spock.token.access_token);
-        browserMccoy.setValue('[name="invitee"]', roomId);
-        browserMccoy.click('[title="dial"]');
-
-        browserMccoy.waitForExist('.listening');
-        // Add some delay to let the call establish
-        browserMccoy.pause(2500);
-      });
-
       it('connects spock\'s browser', () => {
         expect(browserSpock.getTitle()).to.equal('Sample: Multi Party Calling');
-        browserSpock.setValue('[placeholder="Your access token"]', mccoy.token.access_token);
+        browserSpock.setValue('[placeholder="Your access token"]', spock.token.access_token);
         browserSpock.click('[title="connect"]');
-        browserMccoy.waitForExist('.listening');
+        browserSpock.waitForExist('.listening');
+      });
 
-        browserSpock.pause(2500);
-        browserSpock.alertAccept();
+      it('places call from spock to shared room', () => {
+        browserSpock.setValue('[placeholder="Room ID or SIP URI"]', roomId);
+        browserSpock.click('[title="dial"]');
+        browserSpock.waitForExist(`#member-status-${spock.id}`, 5000);
+        browserSpock.waitUntil(() => (browserSpock.getText(`#member-status-${spock.id}`) === 'IN_MEETING'), 10000, `Timed-out waiting for local user (${spock.id}) to connect to meeting`);
+      });
+
+      it('connects mccoy\'s browser after call has started and answers', () => {
+        expect(browserMccoy.getTitle()).to.equal('Sample: Multi Party Calling');
+        browserMccoy.setValue('[placeholder="Your access token"]', mccoy.token.access_token);
+        browserMccoy.click('[title="connect"]');
+        browserMccoy.waitUntil(() => {
+          try {
+            const alerttext = browserMccoy.alertText();
+
+            return alerttext === 'Answer incoming call';
+          }
+          catch (error) {
+            // Error is thrown when alert isn't open which is fine
+            return false;
+          }
+        }, 10000, 'Timed out waiting for incoming call alert');
+        browserMccoy.alertAccept();
       });
 
       it('ends the call', () => {
-        browser.pause(5000);
-        // TODO add assertions around streams
-
-        browser.click('[title="hangup"]');
+        browserSpock.waitUntil(() => (browserSpock.getText(`#member-status-${mccoy.id}`) === 'IN_MEETING'), 10000, 'Timed-out waiting for remote user to connect to meeting');
+        browserSpock.click('[title="hangup"]');
+        browserSpock.waitUntil(() => (browserSpock.getText(`#member-status-${spock.id}`) === 'NOT_IN_MEETING'), 10000, 'Timed-out waiting for local user to disconnect from meeting');
+        browser.refresh();
       });
     });
   });

--- a/packages/node_modules/samples/browser-multi-party-call/test/wdio/spec/normal-dialing.js
+++ b/packages/node_modules/samples/browser-multi-party-call/test/wdio/spec/normal-dialing.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-warning-comments */
 
-import '@webex/plugin-phone';
+import '@webex/internal-plugin-wdm';
 
 import WebexCore from '@webex/webex-core';
 import testUsers from '@webex/test-helper-test-users';
@@ -31,7 +31,7 @@ describe('sample', () => {
             }
           });
 
-          return spock.webex.phone.register();
+          return spock.webex.internal.device.register();
         }));
 
       before('create test room and add members to room', () => spock.webex.request({
@@ -57,7 +57,7 @@ describe('sample', () => {
             }
           });
         })
-        .then(() => spock.webex.phone.deregister()));
+        .then(() => spock.webex.internal.device.unregister()));
 
       it('loads the app', () => {
         browser.url('/browser-multi-party-call/');
@@ -66,8 +66,6 @@ describe('sample', () => {
       it('connects mccoy\'s browser', () => {
         expect(browserMccoy.getTitle()).to.equal('Sample: Multi Party Calling');
         browserMccoy.setValue('[placeholder="Your access token"]', mccoy.token.access_token);
-        // Debouncing before connecting reduces flakiness
-        browserSpock.pause(500);
         browserMccoy.click('[title="connect"]');
         browserMccoy.waitForExist('.listening');
       });
@@ -79,20 +77,32 @@ describe('sample', () => {
         browserSpock.waitForExist('.listening');
       });
 
-      it('places call from spock to mccoy', () => {
+      it('places call from spock to shared room', () => {
         browserSpock.setValue('[placeholder="Room ID or SIP URI"]', roomId);
         browserSpock.click('[title="dial"]');
+        browserSpock.waitForExist(`#member-status-${spock.id}`, 5000);
+        browserSpock.waitUntil(() => (browserSpock.getText(`#member-status-${spock.id}`) === 'IN_MEETING'), 10000, `Timed-out waiting for local user (${spock.id}) to connect to meeting`);
+      });
 
-        browserMccoy.pause(2500);
+      it('joins the call on mccoy', () => {
+        browserMccoy.waitUntil(() => {
+          try {
+            const alerttext = browserMccoy.alertText();
+
+            return alerttext === 'Answer incoming call';
+          }
+          catch (error) {
+            // Error is thrown when alert isn't open which is fine
+            return false;
+          }
+        }, 10000, 'Timed out waiting for incoming call alert');
         browserMccoy.alertAccept();
       });
 
       it('ends the call', () => {
-        browser.pause(5000);
-        // TODO add assertions around streams
-
+        browserSpock.waitUntil(() => (browserSpock.getText(`#member-status-${mccoy.id}`) === 'IN_MEETING'), 10000, 'Timed-out waiting for remote user to connect to meeting');
         browserSpock.click('[title="hangup"]');
-        browserMccoy.click('[title="hangup"]');
+        browserSpock.waitUntil(() => (browserSpock.getText(`#member-status-${spock.id}`) === 'NOT_IN_MEETING'), 10000, 'Timed-out waiting for local user to disconnect from meeting');
       });
     });
   });

--- a/packages/node_modules/samples/browser-single-party-call-with-mute/app.js
+++ b/packages/node_modules/samples/browser-single-party-call-with-mute/app.js
@@ -116,12 +116,16 @@ function bindMeetingEvents(meeting) {
     }
     if (media.type === 'local') {
       document.getElementById('self-view').srcObject = media.stream;
+      document.getElementById('microphone-state').innerHTML = 'on';
+      document.getElementById('camera-state').innerHTML = 'on';
     }
     if (media.type === 'remoteVideo') {
       document.getElementById('remote-view-video').srcObject = media.stream;
+      document.getElementById('camera-state-remote').innerHTML = 'on';
     }
     if (media.type === 'remoteAudio') {
       document.getElementById('remote-view-audio').srcObject = media.stream;
+      document.getElementById('microphone-state-remote').innerHTML = 'on';
     }
   });
 
@@ -130,13 +134,38 @@ function bindMeetingEvents(meeting) {
     // Remove media streams
     if (media.type === 'local') {
       document.getElementById('self-view').srcObject = null;
+      document.getElementById('microphone-state').innerHTML = 'off';
+      document.getElementById('camera-state').innerHTML = 'off';
     }
     if (media.type === 'remoteVideo') {
       document.getElementById('remote-view-video').srcObject = null;
+      document.getElementById('camera-state-remote').innerHTML = 'off';
     }
     if (media.type === 'remoteAudio') {
       document.getElementById('remote-view-audio').srcObject = null;
+      document.getElementById('microphone-state-remote').innerHTML = 'off';
     }
+  });
+
+  // Update participant info
+  meeting.members.on('members:update', (delta) => {
+    const {full: membersData} = delta;
+    const memberIDs = Object.keys(membersData);
+
+    memberIDs.forEach((memberID) => {
+      const memberObject = membersData[memberID];
+
+      // Devices are listed in the memberships object.
+      // We are not concerned with them in this demo
+      if (memberObject.isUser) {
+        if (memberObject.isSelf) {
+          document.getElementById('call-status-local').innerHTML = memberObject.status;
+        }
+        else {
+          document.getElementById('call-status-remote').innerHTML = memberObject.status;
+        }
+      }
+    });
   });
 
   // Of course, we'd also like to be able to end the call:
@@ -168,11 +197,6 @@ function joinMeeting(meeting) {
         localShare,
         localStream,
         mediaSettings
-      }).then(() => {
-        document.getElementById('microphone-state').innerHTML = 'on';
-        document.getElementById('microphone-state-remote').innerHTML = 'on';
-        document.getElementById('camera-state').innerHTML = 'on';
-        document.getElementById('camera-state-remote').innerHTML = 'on';
       });
     });
   });

--- a/packages/node_modules/samples/browser-single-party-call-with-mute/index.html
+++ b/packages/node_modules/samples/browser-single-party-call-with-mute/index.html
@@ -2,104 +2,131 @@
 <html>
   <head>
     <title>Sample: Local Mute/Unmute</title>
+    <link rel="stylesheet" href="https://downloads.momentum-ui.com/@momentum-ui/core/css/momentum-ui.css">
     <style>
+      main {
+        padding: 10px;
+      }
       table {
-          border-collapse: collapse;
+        border-collapse: collapse;
+        padding: 10px;
+        margin: 10px;
       }
-
       table, th, td {
-          border: 1px solid black;
+        border: 1px solid black;
       }
-
-      th, td {
-        padding: 15px;
-        text-align: left;
+      thead th {
+        font-weight: bold;
+      }
+      tbody td {
+        min-width: 150px;
       }
     </style>
   </head>
   <body>
-    <h1>Local Mute/Unmute</h1>
-    <p>This sample demonstrates local mute and unmute</p>
-    <form id="credentials">
-      <fieldset>
-        <legend>Credentials</legend>
-        <input
-          id="access-token"
-          name="accessToken"
-          placeholder="Your access token"
-          type="text">
-        <input id="connect" title="connect" type="submit" value="connect">
-        <p id="connection-status">disconnected</p>
-      </fieldset>
-    </form>
+    <header class="md-top-bar md-top-bar--dark" role="navigation">
+      <div class="md-top-bar__container row">
+        <div class="md-top-bar__brand">
+          <a class="md-brand" href="#">
+            <div class="md-brand__logo">
+              <i class="icon icon-cisco-logo"></i>
+            </div>
+            <div class="md-brand__title">Webex JS SDK Samples</div>
+          </a>
+        </div>
+        <nav class="md-top-bar__nav ">
+            <div class="md-list md-list--horizontal" role="list">
 
-    <form id="dialer">
-      <fieldset>
-        <legend>Dialer</legend>
-        <input
-          id="invitee"
-          name="invitee"
-          placeholder="Person ID or Email Address or SIP URI or Room ID"
-          type="text">
-          <input title="dial" type="submit" value="dial">
-      </fieldset>
-    </form>
-
-    <form id="call-controls">
-      <fieldset>
-        <legend>Call Controls</legend>
-        <button id="hangup" title="hangup" type="button">cancel/hangup</button>
-
-        <button id="stop-sending-audio" title="stop sending audio" type="button">stop sending audio</button>
-        <button id="start-sending-audio" title="start sending audio" type="button">start sending audio</button>
-
-        <button id="stop-sending-video" title="stop sending video" type="button">stop sending video</button>
-        <button id="start-sending-video" title="start sending video" type="button">start sending video</button>
-
-        <br />
-
-        <button id="stop-receiving-audio" title="stop receiving audio" type="button">stop receiving audio</button>
-        <button id="start-receiving-audio" title="start receiving audio" type="button">start receiving audio</button>
-
-        <button id="stop-receiving-video" title="stop receiving video" type="button">stop receiving video</button>
-        <button id="start-receiving-video" title="start receiving video" type="button">start receiving video</button>
-
-        <br />
-      </fieldset>
-    </form>
-
-    <div style="align-items: flex-start; display: flex; max-width: 100%">
-      <div style="flex: 1 1 auto">
-        <video style="width:50%" id="self-view" muted autoplay></video>
+            </div>
+          </nav>
       </div>
-      <div style="flex: 1 1 auto; width:50%" >
-        <audio id="remote-view-audio" autoplay></audio>
-        <video id="remote-view-video" autoplay></video>
+    </header>
+    <main>
+      <h1>Local Mute/Unmute</h1>
+      <p>This sample demonstrates local mute and unmute</p>
+      <form id="credentials">
+        <fieldset>
+          <legend>Credentials</legend>
+          <input
+            id="access-token"
+            name="accessToken"
+            placeholder="Your access token"
+            type="text">
+          <input id="connect" title="connect" type="submit" value="connect">
+          <p id="connection-status">disconnected</p>
+        </fieldset>
+      </form>
+
+      <form id="dialer">
+        <fieldset>
+          <legend>Dialer</legend>
+          <input
+            id="invitee"
+            name="invitee"
+            placeholder="Person ID or Email Address or SIP URI or Room ID"
+            type="text">
+            <input title="dial" type="submit" value="dial">
+        </fieldset>
+      </form>
+
+      <form id="call-controls">
+        <fieldset>
+          <legend>Call Controls</legend>
+          <button id="hangup" title="hangup" type="button">cancel/hangup</button>
+
+          <button id="stop-sending-audio" title="stop sending audio" type="button">stop sending audio</button>
+          <button id="start-sending-audio" title="start sending audio" type="button">start sending audio</button>
+
+          <button id="stop-sending-video" title="stop sending video" type="button">stop sending video</button>
+          <button id="start-sending-video" title="start sending video" type="button">start sending video</button>
+
+          <br />
+
+          <button id="stop-receiving-audio" title="stop receiving audio" type="button">stop receiving audio</button>
+          <button id="start-receiving-audio" title="start receiving audio" type="button">start receiving audio</button>
+
+          <button id="stop-receiving-video" title="stop receiving video" type="button">stop receiving video</button>
+          <button id="start-receiving-video" title="start receiving video" type="button">start receiving video</button>
+
+          <br />
+        </fieldset>
+      </form>
+
+      <div style="align-items: flex-start; display: flex; max-width: 100%">
+        <div style="flex: 1 1 auto">
+          <video style="width:50%" id="self-view" muted autoplay></video>
+        </div>
+        <div style="flex: 1 1 auto; width:50%" >
+          <audio id="remote-view-audio" autoplay></audio>
+          <video id="remote-view-video" autoplay></video>
+        </div>
       </div>
-    </div>
 
-    <table>
-      <thead>
-        <tr>
-          <td></td>
-          <td>Local State</td>
-          <td>Remote State</td>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>camera state</td>
-          <td id="camera-state"></td>
-          <td id="camera-state-remote"></td>
-        </tr>
-        <tr>
-          <td>microphone state</td>
-          <td id="microphone-state"></td>
-          <td id="microphone-state-remote"></td>
-        </tr>
-      </tbody>
-    </table>
-
+      <table id="call-status">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Call Status</th>
+                <th>Video</th>
+                <th>Audio</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Local Participant</td>
+                <td id="call-status-local"></td>
+                <td id="camera-state"></td>
+                <td id="microphone-state"></td>
+            </tr>
+            <tr>
+              <td>Remote Participant</td>
+              <td id="call-status-remote"></td>
+              <td id="camera-state-remote"></td>
+              <td id="microphone-state-remote"></td>
+          </tr>
+        </tbody>
+      </table>
+    </main>
 
     <!-- /bundle.js is the bundled Webex JavaScript SDK -->
     <script src="/bundle.js"></script>

--- a/packages/node_modules/samples/browser-single-party-call-with-mute/test/wdio/spec/normal-dialing.js
+++ b/packages/node_modules/samples/browser-single-party-call-with-mute/test/wdio/spec/normal-dialing.js
@@ -39,15 +39,26 @@ describe('samples', () => {
       });
 
       it('places call from spock to mccoy', () => {
-        expect(browserMccoy.getValue('[placeholder="Your access token"]')).to.equal(mccoy.token.access_token);
-        expect(browserSpock.getValue('[placeholder="Your access token"]')).to.equal(spock.token.access_token);
         browserSpock.setValue('[placeholder="Person ID or Email Address or SIP URI or Room ID"]', mccoy.emailAddress);
         browserSpock.click('[title="dial"]');
 
-        browserMccoy.pause(2500);
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-local') === 'IN_MEETING'), 10000, 'Timed-out waiting for local user to connect to meeting');
+      });
+
+      it('joins the call on mccoy', () => {
+        browserMccoy.waitUntil(() => {
+          try {
+            const alerttext = browserMccoy.alertText();
+
+            return alerttext === 'Answer incoming call';
+          }
+          catch (error) {
+            // Error is thrown when alert isn't open which is fine
+            return false;
+          }
+        }, 10000, 'Timed out waiting for incoming call alert');
         browserMccoy.alertAccept();
-        // Wait for call to establish
-        browserSpock.pause(2500);
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-remote') === 'IN_MEETING'), 10000, 'Timed-out waiting for remote user to connect to meeting');
       });
 
       it('turns the local camera off', () => {
@@ -75,10 +86,8 @@ describe('samples', () => {
       });
 
       it('ends the call', () => {
-        browser.pause(5000);
-        // TODO add assertions around streams
-
         browserSpock.click('[title="hangup"]');
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-local') === 'NOT_IN_MEETING'), 10000, 'Timed-out waiting for local user to disconnect from meeting');
       });
     });
   });

--- a/packages/node_modules/samples/browser-single-party-call/app.js
+++ b/packages/node_modules/samples/browser-single-party-call/app.js
@@ -138,6 +138,27 @@ function bindMeetingEvents(meeting) {
     }
   });
 
+  // Update participant info
+  meeting.members.on('members:update', (delta) => {
+    const {full: membersData} = delta;
+    const memberIDs = Object.keys(membersData);
+
+    memberIDs.forEach((memberID) => {
+      const memberObject = membersData[memberID];
+
+      // Devices are listed in the memberships object.
+      // We are not concerned with them in this demo
+      if (memberObject.isUser) {
+        if (memberObject.isSelf) {
+          document.getElementById('call-status-local').innerHTML = memberObject.status;
+        }
+        else {
+          document.getElementById('call-status-remote').innerHTML = memberObject.status;
+        }
+      }
+    });
+  });
+
   // Of course, we'd also like to be able to end the call:
   document.getElementById('hangup').addEventListener('click', () => {
     meeting.leave();

--- a/packages/node_modules/samples/browser-single-party-call/index.html
+++ b/packages/node_modules/samples/browser-single-party-call/index.html
@@ -2,59 +2,116 @@
 <html>
   <head>
     <title>Sample: Single Party Calling</title>
+    <link rel="stylesheet" href="https://downloads.momentum-ui.com/@momentum-ui/core/css/momentum-ui.css">
+    <style>
+      main {
+        padding: 10px;
+      }
+      table {
+        border-collapse: collapse;
+        padding: 10px;
+        margin: 10px;
+      }
+      table, th, td {
+        border: 1px solid black;
+      }
+      thead th {
+        font-weight: bold;
+      }
+      tbody td {
+        min-width: 150px;
+      }
+    </style>
   </head>
   <body>
-    <h1>Single Party Calling</h1>
-    <p>This sample demonstrates 1:1 calling.</p>
-    <form id="credentials">
-      <fieldset>
-        <legend>Credentials</legend>
-        <input
-          id="access-token"
-          name="accessToken"
-          placeholder="Your access token"
-          type="text">
-        <input id="connect" title="connect" type="submit" value="connect">
-        <p id="connection-status">disconnected</p>
-      </fieldset>
-    </form>
+    <header class="md-top-bar md-top-bar--dark" role="navigation">
+      <div class="md-top-bar__container row">
+        <div class="md-top-bar__brand">
+          <a class="md-brand" href="#">
+            <div class="md-brand__logo">
+              <i class="icon icon-cisco-logo"></i>
+            </div>
+            <div class="md-brand__title">Webex JS SDK Samples</div>
+          </a>
+        </div>
+        <nav class="md-top-bar__nav ">
+            <div class="md-list md-list--horizontal" role="list">
 
-    <form id="dialer">
-      <fieldset>
-        <legend>Dialer</legend>
-        <input
-          id="invitee"
-          name="invitee"
-          placeholder="Person ID or Email Address or SIP URI or Room ID"
-          type="text">
-          <input title="dial" type="submit" value="dial">
-      </fieldset>
-    </form>
-
-    <form id="constraints">
-      <fieldset>
-        <legend>Constraints</legend>
-        <input id="constraints-audio" title="audio" type="checkbox" checked>
-        <label for="constraints-audio">Audio</label>
-        <input id="constraints-video" title="video" type="checkbox" checked>
-        <label for="constraints-video">Video</label>
-      </fieldset>
-    </form>
-
-    <form id="call-controls">
-      <fieldset>
-        <legend>Call Controls</legend>
-        <button id="hangup" title="hangup" type="button">cancel/hangup</button>
-      </fieldset>
-    </form>
-
-    <div style="display: flex">
-      <video style="width:50%" id="self-view" muted autoplay></video>
-      <div style="width:50%">
-        <audio id="remote-view-audio" autoplay></audio>
-        <video id="remote-view-video" autoplay></video>
+            </div>
+          </nav>
       </div>
-    </div>
+    </header>
+    <main>
+      <h1>Single Party Calling</h1>
+      <p>This sample demonstrates 1:1 calling.</p>
+      <form id="credentials">
+        <fieldset>
+          <legend>Credentials</legend>
+          <input
+            id="access-token"
+            name="accessToken"
+            placeholder="Your access token"
+            type="text">
+          <input id="connect" title="connect" type="submit" value="connect">
+          <p id="connection-status">disconnected</p>
+        </fieldset>
+      </form>
+
+      <form id="dialer">
+        <fieldset>
+          <legend>Dialer</legend>
+          <input
+            id="invitee"
+            name="invitee"
+            placeholder="Person ID or Email Address or SIP URI or Room ID"
+            type="text">
+            <input title="dial" type="submit" value="dial">
+        </fieldset>
+      </form>
+
+      <form id="constraints">
+        <fieldset>
+          <legend>Constraints</legend>
+          <input id="constraints-audio" title="audio" type="checkbox" checked>
+          <label for="constraints-audio">Audio</label>
+          <input id="constraints-video" title="video" type="checkbox" checked>
+          <label for="constraints-video">Video</label>
+        </fieldset>
+      </form>
+
+      <form id="call-controls">
+        <fieldset>
+          <legend>Call Controls</legend>
+          <button id="hangup" title="hangup" type="button">cancel/hangup</button>
+        </fieldset>
+      </form>
+
+      <table id="call-status">
+        <thead>
+            <tr>
+                <th colspan="2">Call Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Local Participant</td>
+                <td id="call-status-local"></td>
+            </tr>
+            <tr>
+              <td>Remote Participant</td>
+              <td id="call-status-remote"></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div style="display: flex">
+        <video style="width:50%" id="self-view" muted autoplay></video>
+        <div style="width:50%">
+          <audio id="remote-view-audio" autoplay></audio>
+          <video id="remote-view-video" autoplay></video>
+        </div>
+      </div>
+    </main>
 
     <!-- /bundle.js is the bundled Webex JavaScript SDK -->
     <script src="/bundle.js"></script>

--- a/packages/node_modules/samples/browser-single-party-call/test/wdio/spec/dial-and-reject.js
+++ b/packages/node_modules/samples/browser-single-party-call/test/wdio/spec/dial-and-reject.js
@@ -43,8 +43,27 @@ describe('samples', () => {
         browserSpock.setValue('[placeholder="Person ID or Email Address or SIP URI or Room ID"]', mccoy.emailAddress);
         browserSpock.click('[title="dial"]');
 
-        browserMccoy.pause(3500);
-        browserMccoy.alertAccept();
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-local') === 'IN_MEETING'), 10000, 'Timed-out waiting for local user to connect to meeting');
+      });
+
+      it('rejects the call on mccoy', () => {
+        browserMccoy.waitUntil(() => {
+          try {
+            const alerttext = browserMccoy.alertText();
+
+            return alerttext === 'Answer incoming call';
+          }
+          catch (error) {
+            // Error is thrown when alert isn't open which is fine
+            return false;
+          }
+        }, 10000, 'Timed out waiting for incoming call alert');
+        browserMccoy.alertDismiss();
+      });
+
+      it('ends the call', () => {
+        browserSpock.click('[title="hangup"]');
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-local') === 'NOT_IN_MEETING'), 10000, 'Timed-out waiting for local user to disconnect from meeting');
       });
     });
   });

--- a/packages/node_modules/samples/browser-single-party-call/test/wdio/spec/dial-before-connect.js
+++ b/packages/node_modules/samples/browser-single-party-call/test/wdio/spec/dial-before-connect.js
@@ -25,34 +25,46 @@ describe('samples', () => {
         browser.url('/browser-single-party-call');
       });
 
-      it('places call from mccoy to spock', () => {
-        expect(browserMccoy.getTitle()).to.equal('Sample: Single Party Calling');
-        browserMccoy.setValue('[placeholder="Your access token"]', spock.token.access_token);
-
-        browserMccoy.setValue('[placeholder="Person ID or Email Address or SIP URI or Room ID"]', mccoy.emailAddress);
-
-        browserMccoy.click('[title="dial"]');
-        browserMccoy.waitForExist('.listening');
-        // Add some delay to let the call establish
-        browserMccoy.pause(2500);
-      });
-
       it('connects spock\'s browser', () => {
         expect(browserSpock.getTitle()).to.equal('Sample: Single Party Calling');
-        browserSpock.setValue('[placeholder="Your access token"]', mccoy.token.access_token);
-
+        browserSpock.setValue('[placeholder="Your access token"]', spock.token.access_token);
         browserSpock.click('[title="connect"]');
         browserSpock.waitForExist('.listening');
+      });
 
-        browserSpock.pause(2500);
-        browserSpock.alertAccept();
+      it('places call from spock to mccoy', () => {
+        browserSpock.setValue('[placeholder="Person ID or Email Address or SIP URI or Room ID"]', mccoy.emailAddress);
+        browserSpock.click('[title="dial"]');
+
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-local') === 'IN_MEETING'), 10000, 'Timed-out waiting for local user to connect to meeting');
+      });
+
+      it('connects mccoy\'s browser', () => {
+        expect(browserMccoy.getTitle()).to.equal('Sample: Single Party Calling');
+        browserMccoy.setValue('[placeholder="Your access token"]', mccoy.token.access_token);
+        browserMccoy.click('[title="connect"]');
+        browserMccoy.waitForExist('.listening');
+      });
+
+      it('joins the call on mccoy', () => {
+        browserMccoy.waitUntil(() => {
+          try {
+            const alerttext = browserMccoy.alertText();
+
+            return alerttext === 'Answer incoming call';
+          }
+          catch (error) {
+            // Error is thrown when alert isn't open which is fine
+            return false;
+          }
+        }, 10000, 'Timed out waiting for incoming call alert');
+        browserMccoy.alertAccept();
       });
 
       it('ends the call', () => {
-        browser.pause(5000);
-        // TODO add assertions around streams
-
-        browserMccoy.click('[title="hangup"]');
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-remote') === 'IN_MEETING'), 10000, 'Timed-out waiting for remote user to connect to meeting');
+        browserSpock.click('[title="hangup"]');
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-local') === 'NOT_IN_MEETING'), 10000, 'Timed-out waiting for local user to disconnect from meeting');
       });
     });
   });

--- a/packages/node_modules/samples/browser-single-party-call/test/wdio/spec/normal-dialing.js
+++ b/packages/node_modules/samples/browser-single-party-call/test/wdio/spec/normal-dialing.js
@@ -43,15 +43,28 @@ describe('samples', () => {
         browserSpock.setValue('[placeholder="Person ID or Email Address or SIP URI or Room ID"]', mccoy.emailAddress);
         browserSpock.click('[title="dial"]');
 
-        browserMccoy.pause(2500);
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-local') === 'IN_MEETING'), 10000, 'Timed-out waiting for local user to connect to meeting');
+      });
+
+      it('joins the call on mccoy', () => {
+        browserMccoy.waitUntil(() => {
+          try {
+            const alerttext = browserMccoy.alertText();
+
+            return alerttext === 'Answer incoming call';
+          }
+          catch (error) {
+            // Error is thrown when alert isn't open which is fine
+            return false;
+          }
+        }, 10000, 'Timed out waiting for incoming call alert');
         browserMccoy.alertAccept();
       });
 
       it('ends the call', () => {
-        browser.pause(5000);
-        // TODO add assertions around streams
-
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-remote') === 'IN_MEETING'), 10000, 'Timed-out waiting for remote user to connect to meeting');
         browserSpock.click('[title="hangup"]');
+        browserSpock.waitUntil(() => (browserSpock.getText('#call-status-local') === 'NOT_IN_MEETING'), 10000, 'Timed-out waiting for local user to disconnect from meeting');
       });
     });
   });


### PR DESCRIPTION
Adds a call status table to the samples and uses those tables for testing. This makes the tests more specific and less flaky due to timing issues being removed.

This also includes a fix to the screen sharing code to allow for local screen share to be displayed.