### PR TITLE
Add max timeout for renegotiating ECDH keys

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/create.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/create.js
@@ -109,20 +109,24 @@ describe('plugin-conversation', function () {
         it('returns the preexisting conversation and posts a comment', () => webex.internal.conversation.create({participants: [checkov], comment: 'hi'})
           .then((conversation) => webex.internal.conversation.create({participants: [checkov]})
             .then((conversation2) => {
-              assert.equal(conversation2.url, conversation.url);
-              assert.lengthOf(conversation.activities.items, 1);
-              assert.equal(conversation.activities.items[0].verb, 'post');
-              assert.equal(conversation.activities.items[0].object.displayName, 'hi');
+              assert.equal(conversation2.id, conversation.id);
+              // the first activity is "create"; get the "post"
+              const activity = conversation.activities.items.pop();
+
+              assert.equal(activity.verb, 'post');
+              assert.equal(activity.object.displayName, 'hi');
             })));
 
         it('returns the preexisting conversation and posts a comment with html', () => webex.internal.conversation.create({participants: [checkov], comment: '**hi**', html: '<strong>hi</strong>'})
           .then((conversation) => webex.internal.conversation.create({participants: [checkov]})
             .then((conversation2) => {
-              assert.equal(conversation2.url, conversation.url);
-              assert.lengthOf(conversation.activities.items, 1);
-              assert.equal(conversation.activities.items[0].verb, 'post');
-              assert.equal(conversation.activities.items[0].object.displayName, '**hi**');
-              assert.equal(conversation.activities.items[0].object.content, '<strong>hi</strong>');
+              assert.equal(conversation2.id, conversation.id);
+              // the first activity is "create"; get the "post"
+              const activity = conversation.activities.items.pop();
+
+              assert.equal(activity.verb, 'post');
+              assert.equal(activity.object.displayName, '**hi**');
+              assert.equal(activity.object.content, '<strong>hi</strong>');
             })));
       });
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
@@ -232,7 +232,7 @@ describe('plugin-conversation', function () {
         .then(() => webex.internal.conversation.listLeft())
         .then((c) => {
           assert.lengthOf(c, 1);
-          assert.equal(c[0].url, conversation.url);
+          assert.equal(c[0].id, conversation.id);
         }));
     });
 

--- a/packages/node_modules/@webex/internal-plugin-encryption/src/config.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/src/config.js
@@ -10,9 +10,24 @@ export default {
       protect: '*'
     },
 
+    /**
+     * Initial timeout before contacting KMS with a new request
+     * @type {Number}
+     */
     kmsInitialTimeout: 6000,
 
+    /**
+     * Maximum timeout before negotiating a new ECDH key
+     * and contacting KMS with a new request
+     * @type {Number}
+     */
     kmsMaxTimeout: 32000,
+
+    /**
+     * Maximum timeout after negotiating several ECDH keys
+     * @type {Number}
+     */
+    ecdhMaxTimeout: 32000 * 3,
 
     /**
      * Debounce wait before sending a kms request

--- a/packages/node_modules/@webex/internal-plugin-encryption/src/kms.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/src/kms.js
@@ -455,7 +455,11 @@ const KMS = WebexPlugin.extend({
             return Promise.reject(reason);
           }
 
-          if (timeout >= this.config.kmsMaxTimeout) {
+          // Peek ahead to make sure we don't reset the timeout if the next timeout
+          // will exceed the maximum timeout for renegotiating ECDH keys.
+          const nextTimeout = timeout * 2;
+
+          if (timeout >= this.config.kmsMaxTimeout && nextTimeout < this.config.ecdhMaxTimeout) {
             this.logger.info('kms: exceeded maximum KMS request retries; negotiating new ecdh key');
 
             /* istanbul ignore else */

--- a/packages/node_modules/@webex/internal-plugin-encryption/src/kms.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/src/kms.js
@@ -18,6 +18,8 @@ const contexts = new WeakMap();
 const kmsDetails = new WeakMap();
 const partialContexts = new WeakMap();
 
+const consoleDebug = require('debug')('kms');
+
 /**
  * @class
  */
@@ -444,7 +446,14 @@ const KMS = WebexPlugin.extend({
             this.logger.info('kms: request error', reason.stack || reason);
           }
 
+          consoleDebug(`timeout ${timeout}`);
           timeout *= 2;
+
+          if (timeout >= this.config.ecdhMaxTimeout) {
+            this.logger.info('kms: exceeded maximum KMS request retries');
+
+            return Promise.reject(reason);
+          }
 
           if (timeout >= this.config.kmsMaxTimeout) {
             this.logger.info('kms: exceeded maximum KMS request retries; negotiating new ecdh key');

--- a/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/kms.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/kms.js
@@ -10,6 +10,8 @@ import WebexCore from '@webex/webex-core';
 import testUsers from '@webex/test-helper-test-users';
 import uuid from 'uuid';
 
+const debug = require('debug')('kms');
+
 describe('Encryption', function () {
   this.timeout(30000);
   describe('KMS', () => {
@@ -39,6 +41,23 @@ describe('Encryption', function () {
       }));
 
     after(() => webex && webex.internal.mercury.disconnect());
+
+    let expiredUser;
+
+    it('errs using an invalid token', () => testUsers.create({count: 1})
+      .then((users) => {
+        [expiredUser] = users;
+        expiredUser.webex = new WebexCore({
+          credentials: {
+            authorization: 'invalidToken'
+          }
+        });
+        expiredUser.webex.internal.device.register();
+      })
+      .then(() => expiredUser.webex.internal.encryption.kms.createUnboundKeys({count: 1}))
+      .catch((err) => {
+        assert.equal(err.statusCode, 401);
+      }));
 
     describe('#createResource()', () => {
       it('creates a kms resource object', () => webex.internal.encryption.kms.createUnboundKeys({count: 1})
@@ -438,8 +457,28 @@ describe('Encryption', function () {
           // 1 for the initial ping message
           // 1 when the ecdh key gets renegotiated
           // 1 when the pings gets sent again
+          debug(`ecdhe: spy call count: ${spy.callCount}`);
           assert.isAbove(spy.callCount, 2, 'If this test fails, we\'ve made previously-assumed-to-be-impossible performance gains in cloudapps; please update this test accordingly.');
         }));
+
+      describe('when ecdhe is renegotiated', () => {
+        let ecdhMaxTimeout;
+
+        before('alter config', () => {
+          ecdhMaxTimeout = webex2.config.encryption.ecdhMaxTimeout;
+          webex2.config.encryption.ecdhMaxTimeout = 500;
+        });
+
+        after(() => {
+          webex2.config.encryption.ecdhMaxTimeout = ecdhMaxTimeout;
+        });
+
+        it('limits the number of retries', () => webex2.internal.encryption.kms.ping()
+          .then(() => {
+            debug(`retry: spy call count: ${spy.callCount}`);
+            assert.isBelow(spy.callCount, 4);
+          }));
+      });
     });
 
     describe('when the kms is in another org', () => {

--- a/packages/node_modules/@webex/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@webex/plugin-memberships/src/memberships.js
@@ -440,7 +440,7 @@ const Memberships = WebexPlugin.extend({
           roomType: getHydraRoomType(ack.target.tags),
           isRoomHidden: false, // any activity unhides a space.
           isMonitor: false, // deprecated, returned for back compat
-          created: ack.object.published
+          created: ack.published
         })));
   },
 

--- a/packages/node_modules/@webex/plugin-memberships/test/integration/spec/memberships.js
+++ b/packages/node_modules/@webex/plugin-memberships/test/integration/spec/memberships.js
@@ -702,4 +702,3 @@ function validateMembershipEvent(event, membership, actor, creator = actor) {
   }
   debug(`membership:${event.event} event validated`);
 }
-


### PR DESCRIPTION
# Pull Request 

## Description

Add a max timeout for renegotiating ECDH keys so we don't end up in a loop getting new keys. 

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-84651

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

`npm run test -- --package @webex/internal-plugin-encryption --node`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
