### PR TITLE
add default connection timeout to http-core

### DIFF
--- a/packages/node_modules/@webex/http-core/src/index.js
+++ b/packages/node_modules/@webex/http-core/src/index.js
@@ -3,6 +3,7 @@
  */
 
 import {assign, curry, defaults as lodashDefaults, isString} from 'lodash';
+
 import HttpStatusInterceptor from './interceptors/http-status';
 import _request from './request';
 
@@ -38,6 +39,10 @@ const protorequest = curry(function protorequest(defaultOptions, options) {
 
   if (!options.json) {
     Reflect.deleteProperty(options, 'json');
+  }
+
+  if (!options.timeout) {
+    options.timeout = 60000; // default 60 second timeout
   }
 
   options.logger = options.logger || console;

--- a/packages/node_modules/@webex/http-core/test/integration/spec/request.js
+++ b/packages/node_modules/@webex/http-core/test/integration/spec/request.js
@@ -46,6 +46,16 @@ describe('http-core', function () {
           assert.deepEqual(res.body, {isObject: true});
         }));
 
+      it('ensure default connection timeout is set', () => request({uri: makeLocalUrl('/')})
+        .then((res) => {
+          assert.equal(res.options.timeout, 60000);
+        }));
+
+      it('ensure default connection timeout can be overwritten', () => request({uri: makeLocalUrl('/'), timeout: 5000})
+        .then((res) => {
+          assert.equal(res.options.timeout, 5000);
+        }));
+
       it('emits download progress events', () => {
         const options = {uri: makeLocalUrl('/sample-image-small-one.png')};
         const promise = request(options);


### PR DESCRIPTION
# Pull Request Template

## Description

adding a default http timeout of 60 seconds on requests in the js-sdk. The timeout is for connection to the server and first byte of response received.


Fixes # (issue)

SPARK-83465 - ETIMEDOUT and then next download hung

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

added 2 new tests to `request.js` in `http-core/test/integration/spec` : 
- "ensure default connection timeout is set"
- "ensure default connection timeout can be overwritten"

ran new and existing tests using command `npm test -- --packages @webex/http-core --node`

**Test Configuration**:
* SDK Version - v1.74.5
* Node/Browser Version - v10.15.3
* NPM Version - 6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
