### PR TITLE
fix(meetings): remove error log for meeting info failure

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -395,8 +395,9 @@ export default class Meetings extends WebexPlugin {
           return meeting;
         })
         .catch((err) => {
-          LoggerProxy.logger.error(`Meetings->createMeeting#Error ${err} fetching /meetingInfo for creation, continuing.`);
           // if there is no meeting info we assume its a 1:1 call or wireless share
+          LoggerProxy.logger.info(`Meetings->createMeeting#Error ${err} fetching /meetingInfo for creation.`);
+          LoggerProxy.logger.info('Meetings->createMeeting#Info assuming this destination is a 1:1 or wireless share');
           // We need to save this info for future reference
           meeting.destination = destination;
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -24,6 +24,7 @@ import {skipInBrowser} from '@webex/test-helper-mocha';
 skipInBrowser(describe)('plugin-meetings', () => {
   const logger = {
     log: () => {},
+    info: () => {},
     error: () => {},
     warn: () => {},
     trace: () => {},


### PR DESCRIPTION
This is an expected failure and is handled by the SDK.
Having the console error print out was causing user confusion.

# Pull Request Template

## Description

When a meeting is created with a 1:1 email, we are unable to fetch the meeting info since it doesn't exist. The error is handled appropriately and the meeting gets created properly. No need to spam the console with an error.

Fixes # (issue) SPARK-85535