### PR TITLE
feat(webex-core): adding support for a custom user-agent

### DIFF
--- a/packages/node_modules/@webex/http-core/src/request/index.js
+++ b/packages/node_modules/@webex/http-core/src/request/index.js
@@ -2,9 +2,9 @@
  * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
  */
 
-import _request from './request';
-import {inBrowser} from '@webex/common';
 import {EventEmitter} from 'events';
+
+import _request from './request';
 
 /**
  * @param {Object} options
@@ -17,10 +17,6 @@ export default function request(options) {
   }
 
   options.headers = options.headers || {};
-  if (!inBrowser && !options.headers['user-agent']) {
-    options.headers['user-agent'] = '@webex/http-core';
-  }
-
 
   options.download = new EventEmitter();
   options.upload = new EventEmitter();

--- a/packages/node_modules/@webex/webex-core/src/index.js
+++ b/packages/node_modules/@webex/webex-core/src/index.js
@@ -41,6 +41,7 @@ export {default as ResponseLoggerInterceptor} from './interceptors/response-logg
 export {default as RequestEventInterceptor} from './interceptors/request-event';
 export {default as RequestLoggerInterceptor} from './interceptors/request-logger';
 export {default as RequestTimingInterceptor} from './interceptors/request-timing';
+export {default as UserAgentInterceptor} from './interceptors/user-agent';
 export {default as WebexTrackingIdInterceptor} from './interceptors/webex-tracking-id';
 export {default as WebexUserAgentInterceptor} from './interceptors/webex-user-agent';
 export {default as RateLimitInterceptor} from './interceptors/rate-limit';

--- a/packages/node_modules/@webex/webex-core/src/interceptors/user-agent.js
+++ b/packages/node_modules/@webex/webex-core/src/interceptors/user-agent.js
@@ -1,0 +1,72 @@
+/*!
+ * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {Interceptor} from '@webex/http-core';
+import {get} from 'lodash';
+
+const strings = new WeakMap();
+
+/**
+ * Sets a 'user-agent' header on all requests if one is not present.
+ * Defaults to '@webex/http-core' though a custom user-agent can be set
+ * using the appName and appVersion configuration. e.g.
+ *
+ *   webex = WebexSdk.init({
+ *     credentials: {
+ *       supertoken: superToken
+ *     },
+ *     config: {
+ *       credentials: {
+ *         client_id,
+ *         client_secret
+ *       },
+ *       appName: 'custom-user-agent',
+ *       appVersion: '1.0',
+ *     }
+ *   });
+ */
+export default class UserAgentInterceptor extends Interceptor {
+  /**
+   * @param {Object} [options={}]
+   * @param {WebexCore} [options.webex]
+   * @private
+   * @returns {UserAgentInterceptor}
+   */
+  constructor(options = {}) {
+    const appName = get(options, 'webex.config.appName');
+    const appVersion = get(options, 'webex.config.appVersion') || '0.0';
+
+    super(options);
+    if (appName) {
+      strings.set(this, `${appName}/${appVersion}`);
+    }
+    else {
+      strings.set(this, '@webex/http-core'); // Using the traditional default from http-core
+    }
+  }
+
+  /**
+   * @returns {UserAgentInterceptor}
+   */
+  static create() {
+    return new UserAgentInterceptor({webex: this});
+  }
+
+  /**
+   * @see Interceptor#onRequest
+   * @param {Object} options
+   * @returns {Object}
+   */
+  onRequest(options) {
+    options.headers = options.headers || {};
+
+    if ('user-agent' in options.headers && options.headers['spark-user-agent']) {
+      return options;
+    }
+
+    options.headers['user-agent'] = strings.get(this);
+
+    return options;
+  }
+}

--- a/packages/node_modules/@webex/webex-core/src/webex-core.js
+++ b/packages/node_modules/@webex/webex-core/src/webex-core.js
@@ -20,6 +20,7 @@ import RequestLoggerInterceptor from './interceptors/request-logger';
 import RequestTimingInterceptor from './interceptors/request-timing';
 import ResponseLoggerInterceptor from './interceptors/response-logger';
 import WebexHttpError from './lib/webex-http-error';
+import UserAgentInterceptor from './interceptors/user-agent';
 import WebexTrackingIdInterceptor from './interceptors/webex-tracking-id';
 import WebexUserAgentInterceptor from './interceptors/webex-user-agent';
 import RateLimitInterceptor from './interceptors/rate-limit';
@@ -42,6 +43,7 @@ const interceptors = {
   /* eslint-enable no-extra-parens */
   RequestTimingInterceptor: RequestTimingInterceptor.create,
   UrlInterceptor: undefined,
+  UserAgentInterceptor: UserAgentInterceptor.create,
   WebexUserAgentInterceptor: WebexUserAgentInterceptor.create,
   AuthInterceptor: AuthInterceptor.create,
   KmsDryErrorInterceptor: undefined,

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/interceptors/user-agent.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/interceptors/user-agent.js
@@ -1,0 +1,62 @@
+/*!
+ * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {assert} from '@webex/test-helper-chai';
+import {UserAgentInterceptor} from '@webex/webex-core';
+
+import pkg from '../../../../package';
+
+describe('webex-core', () => {
+  describe('Interceptors', () => {
+    describe('UserAgentInterceptor', () => {
+      describe('#onRequest', () => {
+        it('default user-agent header', () => {
+          const interceptor = Reflect.apply(UserAgentInterceptor.create, {
+            version: pkg.version
+          }, []);
+          const options = {headers: {}};
+
+          interceptor.onRequest(options);
+
+          assert.property(options, 'headers');
+          assert.property(options.headers, 'user-agent');
+          assert.equal(options.headers['user-agent'], '@webex/http-core');
+        });
+
+        it('custom user-agent header', () => {
+          const interceptor = Reflect.apply(UserAgentInterceptor.create, {
+            version: pkg.version,
+            config: {
+              appName: 'sample',
+              appVersion: '1.0.0'
+            }
+          }, []);
+          const options = {headers: {}};
+
+          interceptor.onRequest(options);
+
+          assert.property(options, 'headers');
+          assert.property(options.headers, 'user-agent');
+          assert.equal(options.headers['user-agent'], 'sample/1.0.0');
+        });
+
+        it('custom user-agent header when there is no appVersion', () => {
+          const interceptor = Reflect.apply(UserAgentInterceptor.create, {
+            version: pkg.version,
+            config: {
+              appName: 'sample'
+            }
+          }, []);
+          const options = {headers: {}};
+
+          interceptor.onRequest(options);
+
+          assert.property(options, 'headers');
+          assert.property(options.headers, 'user-agent');
+          assert.equal(options.headers['user-agent'], 'sample/0.0'); // defaults to 0.0
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request Template

## Description

Adding support for an app to set a custom `user-agent` header on all requests. The app can control this by setting the **appName** and **appVersion** configuration during init. e.g.

    webex = WebexSdk.init({
      credentials: {
        supertoken: superToken
      },
      config: {
        credentials: {
          client_id,
          client_secret
        },
        appName: 'custom-user-agent',
        appVersion: '1.0.0',
      }
    });

By allowing for custom `user-agents` it'll be easier to identify where metrics are coming from.

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [?] This change requires a documentation update

If an existing app already sets the **appName** / **appVersion** and expects a `user-agent` of `@webex/http-core` this could  break it. I'm not sure how likely that is and would defer to the reviewers expertise.

I'm not sure if this needs documentation but it sounds like a good idea. Where would something like this be documented?

## Test Coverage

Added unit tests to cover this scenario. They can be run with

> npm test -- --packages @webex/webex-core --node

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [?] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
