### PR TITLE
Update calling guide with plugin-meetings

### DIFF
--- a/docs/_posts/guides/9999-01-03-calling.md
+++ b/docs/_posts/guides/9999-01-03-calling.md
@@ -7,6 +7,16 @@ redirect_from:
   - /example/calling/
 ---
 
+# Upgrade to webex.meetings
+
+`webex.phone` is no longer the default, though you can use it with SDK versions 1.6x or by creating a custom build.
+
+`webex.meetings` delivers a better meeting (call) experience with tighter integrations across Webex products and devices. Follow our [upgrade guide](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/%40webex/plugin-meetings/UPGRADING.md) and look at our [samples](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/samples/browser-multi-party-call/app.js) to include it in your application.
+
+---
+
+# webex.phone
+
 First, authenticate according to [Browsers]({{ site.baseurl }}{% post_url /guides/9999-01-02-browsers %}). From there, you'll need to register with our cloud and start listening for incoming calls.
 
 ```javascript


### PR DESCRIPTION
# Pull Request 

## Description

https://webex.github.io/webex-js-sdk/guides/calling/ is outdated. Added a description and links to the meetings upgrade guide and samples. 

## Type of Change

- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
