### PR TITLE
fix: recursively default upload options

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/webex-core.js
+++ b/packages/node_modules/@webex/webex-core/src/webex-core.js
@@ -7,7 +7,7 @@ import util from 'util';
 
 import {proxyEvents, retry, transferEvents} from '@webex/common';
 import {HttpStatusInterceptor, defaults as requestDefaults} from '@webex/http-core';
-import {defaults, get, isFunction, isString, last, merge, omit, set, unset} from 'lodash';
+import {defaultsDeep, get, isFunction, isString, last, merge, omit, set, unset} from 'lodash';
 import AmpState from 'ampersand-state';
 import uuid from 'uuid';
 
@@ -509,14 +509,14 @@ const WebexCore = AmpState.extend({
     options.phases.upload = options.phases.upload || {};
     options.phases.finalize = options.phases.finalize || {};
 
-    defaults(options.phases.initialize, {
+    defaultsDeep(options.phases.initialize, {
       method: 'POST',
       body: {
         uploadProtocol: s3UploadsSupported ? 'content-length' : null
       }
     }, omit(options, 'file', 'phases'));
 
-    defaults(options.phases.upload, {
+    defaultsDeep(options.phases.upload, {
       method: 'PUT',
       json: false,
       withCredentials: false,
@@ -527,7 +527,7 @@ const WebexCore = AmpState.extend({
       }
     });
 
-    defaults(options.phases.finalize, {
+    defaultsDeep(options.phases.finalize, {
       method: 'POST'
     }, omit(options, 'file', 'phases'));
 


### PR DESCRIPTION
# Pull Request Template

## Description

When uploading logs to the new client logs service `defaults()` didn't recurse and so the uploadProtocol was being omitted unintentionally. 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
