### PR TITLE
feat(internal-plugin-wdm): add support for navigationBarColor

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
@@ -75,6 +75,7 @@ const Device = WebexPlugin.extend({
       default: () => []
     },
     modificationTime: 'string',
+    navigationBarColor: 'string',
     partnerCompanyName: 'string',
     partnerLogoUrl: 'string',
     peopleInsightsEnabled: 'boolean',

--- a/packages/node_modules/@webex/internal-plugin-wdm/test/integration/spec/device.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/test/integration/spec/device.js
@@ -38,6 +38,7 @@ describe('plugin-wdm', function () {
           assert.property(webex.internal.device, 'supportProviderLogoUrl');
 
           assert.property(webex.internal.device, 'modificationTime');
+          assert.property(webex.internal.device, 'navigationBarColor');
           assert.property(webex.internal.device, 'services');
           assert.property(webex.internal.device, 'url');
           assert.property(webex.internal.device, 'userId');

--- a/packages/node_modules/@webex/internal-plugin-wdm/test/unit/lib/device-fixture.json
+++ b/packages/node_modules/@webex/internal-plugin-wdm/test/unit/lib/device-fixture.json
@@ -106,6 +106,7 @@
   "customerCompanyName": "Example Customer",
   "customerLogoUrl": "www.example.com/customer-logo",
   "helpUrl": "www.example.com/help",
+  "navigationBarColor": "#000000",
   "partnerCompanyName": "Example Partners",
   "partnerLogoUrl": "www.example.com/partner-logo",
   "peopleInsightsEnabled": false,


### PR DESCRIPTION
## Description 
Add the `navigationBarColor` parameter, which is used the customize the colour of the Navigation Bar



## Type of Change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
