### PR TITLE
fix(ediscovery): remove display names to avoid out of memory errors

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/transforms.js
@@ -205,11 +205,6 @@ class Transforms {
           activity.spaceName = '';
         }
 
-        if (space.participantDisplayNames) {
-          // Remove sender from list of participants as they will appear in the 'To' field
-          activity.participantDisplayNames = space.participantDisplayNames.filter((value) => value !== activity.actorDisplayName).toString();
-        }
-
         // only post and share activities have content which needs to be decrypted
         if (!['post', 'share'].includes(activity.verb)) {
           return Promise.resolve(object);

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/test/unit/spec/transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/test/unit/spec/transforms.js
@@ -172,18 +172,6 @@ describe('EDiscovery Transform Tests', () => {
         return result;
       });
 
-      it('Removes sender from participantDisplayNames', () => {
-        const result = Transforms.decryptReportContent(ctx, object, reportId)
-          .then(() => {
-            assert.callCount(ctx.webex.internal.encryption.decryptText, 1);
-            assert.equal(activity.objectDisplayName, decryptedText);
-            // as the sender, user1 should be removed
-            assert.equal(activity.participantDisplayNames, 'user2,user3');
-          });
-
-        return result;
-      });
-
       it('Does not call any decrypt functions when transforming add activities', () => {
         object.body.verb = 'add';
         // object display name for add activity is a uuid


### PR DESCRIPTION
# Pull Request Template

## Description

Fix for an out of memory issue. In a real world test the ediscovery downloader process was dying. Through profiling we were able to identify the root cause. The download in question was arriving at a set of activities for a large space. i.e. With ~3,300 participants. As the downloader was retrieving 3,500 activities at a time this translated to 

3,300 participants * 3,500 activities * 50 bytes (e.g. Leia Vitali <teamcloudniners+leia@gmail.com>) = 577500000 bytes or 577.5 MBs of RAM. Eventually that caused RAM to run out.

Fixes # (issue)

[SPARK-87426 - Downloader Hang at offset 743800 for report c4d5cc0f-e5d8-4e1c-aa63-59bf3d51920f](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-87426)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Original reporter will validate with a friendly build.

Before and after memory usage by the app. i.e. Fix introduced after 16:00.

![image](https://user-images.githubusercontent.com/47003715/63532239-1f76da00-c502-11e9-99ad-0f143b3b1e2b.png)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
