### PR TITLE
feat(plugin-meetings): add #register method

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/README.md
+++ b/packages/node_modules/@webex/plugin-meetings/README.md
@@ -30,11 +30,11 @@ See https://github.com/webex/webex-js-sdk/tree/master/packages/node_modules/samp
 
 #### Device Registration
 
-With the meetings plugin, device registration and websocket connection need to be manually handled:
+The meetings plugin requires some setup actions which are handled with the `register` function.
+This function registers the device, connects web sockets, and listens for meeting events.
 
 ```js
-webex.internal.device.register()
-  .then(() => webex.internal.mercury.connect());
+webex.meetings.register()
 ```
 
 #### Creating a basic meeting

--- a/packages/node_modules/@webex/plugin-meetings/UPGRADING.md
+++ b/packages/node_modules/@webex/plugin-meetings/UPGRADING.md
@@ -20,13 +20,12 @@ This method is no longer provided and if the functionality is needed, we suggest
 Meeting data is received via websockets from the Webex Teams servers.
 In order for the client to receive these websocket events, it must register with the websocket servers.
 
-When using the phone plugin, this was handled automatically for you via `Webex.phone.register()`.
+When using the phone plugin, this was handled automatically for you via `webex.phone.register()`.
 
-With the meetings plugin, device registration and websocket connection need to be manually handled:
+With the meetings plugin, we provide the same method:
 
 ```js
-webex.internal.device.register()
-  .then(() => webex.internal.mercury.connect());
+webex.meetings.register()
 ```
 
 ## Dialing

--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -296,6 +296,7 @@ export const DELTAEVENT = {
 // TODO: do we want to scope by meeting, members when they come off those objects themselves?
 export const EVENT_TRIGGERS = {
   MEETINGS_READY: 'meetings:ready',
+  MEETINGS_REGISTERED: 'meetings:registered',
   MEDIA_READY: 'media:ready',
   MEDIA_STOPPED: 'media:stopped',
   MEDIA_UPDATE: 'media:update',

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -50,6 +50,14 @@ import MeetingsUtil from './util';
    */
 
 /**
+ * Meetings Registered Event
+ * Emitted when the meetings instance has been registered and listening
+ * @event meetings:registered
+ * @instance
+ * @memberof Meetings
+ */
+
+/**
     * Meeting Removed Event
     * Emitted when a meeting was removed from the cache of meetings
     * @event meeting:removed
@@ -121,6 +129,16 @@ export default class Meetings extends WebexPlugin {
        * @memberof Meetings
        */
       this.reachability = null;
+
+      /**
+       * If the meetings plugin has been registered and listening via {@link Meetings#register}
+       * @instance
+       * @type {Boolean}
+       * @public
+       * @memberof Meetings
+       */
+      this.registered = false;
+
       this.onReady();
       Metrics.initialSetup(this.meetingCollection, this.webex.version);
     }
@@ -263,19 +281,57 @@ export default class Meetings extends WebexPlugin {
         StaticConfig.set(this.config);
         LoggerConfig.set(this.config.logging);
         LoggerProxy.set(this.webex.logger);
-        if (this.webex.canAuthorize) {
+        Trigger.trigger(
+          this,
+          {
+            file: 'meetings',
+            function: 'onReady'
+          },
+          EVENT_TRIGGERS.MEETINGS_READY
+        );
+      });
+    }
+
+    /**
+     * Explicitly sets up the meetings plugin by registering
+     * the device, connecting to mercury, and listening for locus events.
+     *
+     * @returns {Promise}
+     * @public
+     * @memberof Meetings
+     */
+    register() {
+      if (!this.webex.canAuthorize) {
+        LoggerProxy.logger.error('meetings->register#ERROR, Unable to register, SDK cannot authorize');
+
+        return Promise.reject(new Error('SDK cannot authorize'));
+      }
+
+      if (this.registered) {
+        LoggerProxy.logger.info('meetings->register#INFO, Meetings plugin already registered');
+
+        return Promise.resolve();
+      }
+
+      return this.webex.internal.device.register()
+        .then(() => this.webex.internal.mercury.connect())
+        .then(() => {
           this.listenForEvents();
-          // this.listenInternal();
           Trigger.trigger(
             this,
             {
               file: 'meetings',
-              function: 'onReady'
+              function: 'register'
             },
-            EVENT_TRIGGERS.MEETINGS_READY
+            EVENT_TRIGGERS.MEETINGS_REGISTERED
           );
-        }
-      });
+          this.registered = true;
+        })
+        .catch((error) => {
+          LoggerProxy.logger.error(`meetings->register#ERROR, Unable to register, ${error.message}`);
+
+          return Promise.reject(error);
+        });
     }
 
     /**

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -11,463 +11,465 @@ const webexTestUsers = require('./webex-test-users');
 let userSet, alice, bob, chris;
 // TODO: Merge all the test it sections into one
 
-skipInNode(describe)('plugin-meeting', () => {
-  before(() => webexTestUsers.generateTestUsers({count: 3})
-    .then((users) => {
-      userSet = users;
-      alice = userSet[0];
-      bob = userSet[1];
-      chris = userSet[2];
-      alice.name = 'alice';
-      bob.name = 'bob';
-      chris.name = 'chris';
-      alice.webex.meetings.name = 'alice';
-      bob.webex.meetings.name = 'bob';
-      chris.webex.meetings.name = 'chris';
-    })
-    .then(() => Promise.all([testUtils.syncAndEndMeeting(alice),
-      testUtils.syncAndEndMeeting(bob)]))
-    .catch((error) => {
-      console.log(error);
-    }));
+skipInNode(describe)('plugin-meetings', () => {
+  describe('journey', () => {
+    before(() => webexTestUsers.generateTestUsers({count: 3})
+      .then((users) => {
+        userSet = users;
+        alice = userSet[0];
+        bob = userSet[1];
+        chris = userSet[2];
+        alice.name = 'alice';
+        bob.name = 'bob';
+        chris.name = 'chris';
+        alice.webex.meetings.name = 'alice';
+        bob.webex.meetings.name = 'bob';
+        chris.webex.meetings.name = 'chris';
+      })
+      .then(() => Promise.all([testUtils.syncAndEndMeeting(alice),
+        testUtils.syncAndEndMeeting(bob)]))
+      .catch((error) => {
+        console.log(error);
+      }));
 
-  after(() => {
-    const promise = [];
-
-    userSet.forEach((user) => {
-      promise.push(user.webex.internal.mercury.disconnect());
-    });
-
-    return Promise.all(promise)
-      .then(() => webexTestUsers.remove(userSet));
-    // TODO: end is not a function on browser object
-  });
-
-  // Alice calls bob and bob rejects it
-  describe('End outgoing Call', () => {
     after(() => {
-      alice.meeting = null;
-      bob.meeting = null;
+      const promise = [];
+
+      userSet.forEach((user) => {
+        promise.push(user.webex.internal.mercury.disconnect());
+      });
+
+      return Promise.all(promise)
+        .then(() => webexTestUsers.remove(userSet));
+      // TODO: end is not a function on browser object
     });
 
-    it('Alice Ends a outgoing meeting', () => Promise.all([
-      testUtils.delayedPromise(alice.webex.meetings.create(bob.emailAddress)),
-      testUtils.waitForEvents([{scope: alice.webex.meetings, event: 'meeting:added', user: alice}])
-    ])
-      .then(() => Promise.all([
-        testUtils.delayedPromise(alice.meeting.join()),
-        testUtils.waitForEvents([{scope: bob.webex.meetings, event: 'meeting:added', user: bob}])
-      ]))
-      .then(() => {
-        // bob and alice have meeting object
-        bob.meeting.acknowledge('INCOMING');
-        assert.equal(bob.meeting.sipUri, alice.emailAddress);
-        assert.equal(alice.meeting.sipUri, bob.emailAddress);
-        assert.equal(bob.meeting.state, 'IDLE');
-        assert.equal(alice.meeting.state, 'JOINED');
-      })
-      .then(function aliceLeavesMeetingAndBobGetsMeetingRemoved() {
-        return Promise.all([
-          testUtils.delayedPromise(alice.meeting.leave()),
-          testUtils.waitForEvents([{scope: bob.webex.meetings, event: 'meeting:removed', user: bob}])
-        ]);
-      })
-      .then(() => testUtils.waitForStateChange(alice.meeting, 'LEFT'))
-      .then(() => Promise.all([
-        testUtils.waitForCallEnded(alice, bob.emailAddress),
-        testUtils.waitForCallEnded(bob, alice.emailAddress)
-      ]))
-      .then(() => {
-        assert.equal(alice.webex.meetings.getMeetingByType('sipUri', bob.emailAddress), null);
-        assert.equal(bob.webex.meetings.getMeetingByType('sipUri', alice.emailAddress), null);
-      })
-      .catch((err) => {
-        console.log('ERROR JOIN ', err);
-        throw err;
-      }));
-  });
+    // Alice calls bob and bob rejects it
+    describe('End outgoing Call', () => {
+      after(() => {
+        alice.meeting = null;
+        bob.meeting = null;
+      });
 
-  // The event was coming but incomplete
-  // 1) Test user doesnt have locus tag information
-
-  // Alice calls bob and bob rejects it
-  describe('reject Incoming Call', () => {
-    it('alice dials bob and bob receives meeting added', () => Promise.all([
-      testUtils.delayedPromise(alice.webex.meetings.create(bob.emailAddress)),
-      testUtils.waitForEvents([{scope: alice.webex.meetings, event: 'meeting:added', user: alice}])
-    ])
-      .then(() => Promise.all([
-        testUtils.delayedPromise(alice.meeting.join()),
-        testUtils.waitForEvents([{scope: bob.webex.meetings, event: 'meeting:added', user: bob}])
-      ]))
-      .then(function alicebobJoined() {
-        assert.exists(bob.meeting);
-        assert.exists(alice.meeting);
-        assert.equal(bob.meeting.sipUri, alice.emailAddress);
-        assert.equal(alice.meeting.sipUri, bob.emailAddress);
-        assert.exists(bob.meeting.partner);
-        assert.exists(alice.meeting.partner);
-      })
-      .then(function bobState() {
-        testUtils.waitForStateChange(bob.meeting, 'IDLE');
-      })
-      .then(function aliceState() {
-        testUtils.waitForStateChange(alice.meeting, 'JOINED');
-      })
-      .then(function bobDeclinedCall() {
-        return bob.meeting.acknowledge('INCOMING')
-          .then(() => bob.meeting.decline('BUSY'))
-          .then(() => testUtils.waitForStateChange(bob.meeting, 'DECLINED'))
-          .catch((e) => { console.error('Bob decline call not successful', e); throw e; });
-      })
-      .then(function aliceLeaveMeeting() {
-        assert.equal(alice.meeting.state, 'JOINED');
-
-        return alice.meeting.leave()
-          .then(() => testUtils.waitForStateChange(alice.meeting, 'LEFT'))
-          .then(() => testUtils.waitForStateChange(bob.meeting, 'DECLINED'))
-          .catch((e) => { console.error('alice was not able to leave the meeting', e); throw e; });
-      })
-      .then(function WaitForMeetingEnd() {
-        return Promise.all([
-          testUtils.waitForCallEnded(alice, bob.emailAddress),
-          testUtils.waitForCallEnded(bob, alice.emailAddress)
-        ])
-          .then(() => {
-            assert.equal(alice.webex.meetings.getMeetingByType('sipUri', bob.emailAddress), null);
-            assert.equal(bob.webex.meetings.getMeetingByType('sipUri', alice.emailAddress), null);
-          })
-          .catch((e) => { console.error('Alice bob meeting is deleted', e); throw e; });
-      }));
-  });
-
-  // Alice calls bob and bob rejects it
-  describe('Successful 1:1 meeting (including Guest)', function () {
-    this.timeout(80000);
-    it('No previous Call', () => {
-      assert.equal(Object.keys(bob.webex.meetings.getAllMeetings()), 0);
-      assert.equal(Object.keys(alice.webex.meetings.getAllMeetings()), 0);
-
-      return alice.webex.internal.conversation.create({participants: [bob]})
-        .then((conversation) => {
-          console.log('CONVERSATION CREATED ', JSON.stringify(conversation));
-
-          return alice.webex.internal.conversation.post(conversation, {displayName: 'hello world how are you '});
-        });
-    });
-
-    it('alice dials bob and adds media', () => Promise.all([
-      testUtils.delayedPromise(alice.webex.meetings.create(bob.emailAddress)),
-      testUtils.waitForEvents([{scope: alice.webex.meetings, event: 'meeting:added', user: alice}])
-    ])
-      .then(function aliceJoinsMeeting() {
-        return Promise.all([
+      it('Alice Ends a outgoing meeting', () => Promise.all([
+        testUtils.delayedPromise(alice.webex.meetings.create(bob.emailAddress)),
+        testUtils.waitForEvents([{scope: alice.webex.meetings, event: 'meeting:added', user: alice}])
+      ])
+        .then(() => Promise.all([
           testUtils.delayedPromise(alice.meeting.join()),
           testUtils.waitForEvents([{scope: bob.webex.meetings, event: 'meeting:added', user: bob}])
-        ]);
-      })
-      .then(() => assert.equal(bob.meeting.partner.state, 'JOINED'))
-      .then(() => testUtils.addMedia(alice)));
-
-    it('bob joins the meeting', () => {
-      bob.meeting.acknowledge('INCOMING');
-
-      return Promise.all([
-        testUtils.delayedPromise(bob.meeting.join()),
-        testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update', user: alice}])
-          .then((response) => {
-            const bobParticipant = response[0].result.delta.updated.find((member) => bob.meeting.members.selfId === member.id);
-
-            assert.equal(bobParticipant.status, 'IN_MEETING');
-          })
-      ])
-        .then(() => testUtils.addMedia(bob))
+        ]))
         .then(() => {
+          // bob and alice have meeting object
+          bob.meeting.acknowledge('INCOMING');
           assert.equal(bob.meeting.sipUri, alice.emailAddress);
           assert.equal(alice.meeting.sipUri, bob.emailAddress);
-          assert.exists(alice.meeting.members.locusUrl);
-          assert.equal(alice.meeting.type, 'CALL');
-          assert.equal(bob.meeting.type, 'CALL');
+          assert.equal(bob.meeting.state, 'IDLE');
+          assert.equal(alice.meeting.state, 'JOINED');
+        })
+        .then(function aliceLeavesMeetingAndBobGetsMeetingRemoved() {
+          return Promise.all([
+            testUtils.delayedPromise(alice.meeting.leave()),
+            testUtils.waitForEvents([{scope: bob.webex.meetings, event: 'meeting:removed', user: bob}])
+          ]);
+        })
+        .then(() => testUtils.waitForStateChange(alice.meeting, 'LEFT'))
+        .then(() => Promise.all([
+          testUtils.waitForCallEnded(alice, bob.emailAddress),
+          testUtils.waitForCallEnded(bob, alice.emailAddress)
+        ]))
+        .then(() => {
+          assert.equal(alice.webex.meetings.getMeetingByType('sipUri', bob.emailAddress), null);
+          assert.equal(bob.webex.meetings.getMeetingByType('sipUri', alice.emailAddress), null);
+        })
+        .catch((err) => {
+          console.log('ERROR JOIN ', err);
+          throw err;
+        }));
+    });
+
+    // The event was coming but incomplete
+    // 1) Test user doesnt have locus tag information
+
+    // Alice calls bob and bob rejects it
+    describe('reject Incoming Call', () => {
+      it('alice dials bob and bob receives meeting added', () => Promise.all([
+        testUtils.delayedPromise(alice.webex.meetings.create(bob.emailAddress)),
+        testUtils.waitForEvents([{scope: alice.webex.meetings, event: 'meeting:added', user: alice}])
+      ])
+        .then(() => Promise.all([
+          testUtils.delayedPromise(alice.meeting.join()),
+          testUtils.waitForEvents([{scope: bob.webex.meetings, event: 'meeting:added', user: bob}])
+        ]))
+        .then(function alicebobJoined() {
+          assert.exists(bob.meeting);
+          assert.exists(alice.meeting);
+          assert.equal(bob.meeting.sipUri, alice.emailAddress);
+          assert.equal(alice.meeting.sipUri, bob.emailAddress);
+          assert.exists(bob.meeting.partner);
+          assert.exists(alice.meeting.partner);
         })
         .then(function bobState() {
-          testUtils.waitForStateChange(bob.meeting, 'JOINED');
+          testUtils.waitForStateChange(bob.meeting, 'IDLE');
         })
         .then(function aliceState() {
           testUtils.waitForStateChange(alice.meeting, 'JOINED');
         })
-        .catch((e) => console.log('Error joining one_on_one', e));
+        .then(function bobDeclinedCall() {
+          return bob.meeting.acknowledge('INCOMING')
+            .then(() => bob.meeting.decline('BUSY'))
+            .then(() => testUtils.waitForStateChange(bob.meeting, 'DECLINED'))
+            .catch((e) => { console.error('Bob decline call not successful', e); throw e; });
+        })
+        .then(function aliceLeaveMeeting() {
+          assert.equal(alice.meeting.state, 'JOINED');
+
+          return alice.meeting.leave()
+            .then(() => testUtils.waitForStateChange(alice.meeting, 'LEFT'))
+            .then(() => testUtils.waitForStateChange(bob.meeting, 'DECLINED'))
+            .catch((e) => { console.error('alice was not able to leave the meeting', e); throw e; });
+        })
+        .then(function WaitForMeetingEnd() {
+          return Promise.all([
+            testUtils.waitForCallEnded(alice, bob.emailAddress),
+            testUtils.waitForCallEnded(bob, alice.emailAddress)
+          ])
+            .then(() => {
+              assert.equal(alice.webex.meetings.getMeetingByType('sipUri', bob.emailAddress), null);
+              assert.equal(bob.webex.meetings.getMeetingByType('sipUri', alice.emailAddress), null);
+            })
+            .catch((e) => { console.error('Alice bob meeting is deleted', e); throw e; });
+        }));
     });
 
-    it('check for meeting properties', () => {
-      assert.exists(alice.meeting.userId, 'userId not present');
-      assert.exists(alice.meeting.deviceUrl, 'deviceUrl not present');
-      assert.exists(alice.meeting.partner, 'partner not present');
-      assert.exists(alice.meeting.type, 'type not present');
-      assert.exists(alice.meeting.state, 'state not present');
-      assert.exists(alice.meeting.guest, 'guest not present');
-      assert.exists(alice.meeting.mediaProperties, 'mediaProperties not Present');
-      assert.exists(alice.meeting.mediaProperties.mediaDirection, 'mediaDirection not present');
-      // assert.exists(alice.meeting.joinedWith);
-      assert.exists(alice.meeting.members.selfId, 'selfId not present');
-    });
+    // Alice calls bob and bob rejects it
+    describe('Successful 1:1 meeting (including Guest)', function () {
+      this.timeout(80000);
+      it('No previous Call', () => {
+        assert.equal(Object.keys(bob.webex.meetings.getAllMeetings()), 0);
+        assert.equal(Object.keys(alice.webex.meetings.getAllMeetings()), 0);
 
-    it('check for getStats', () => {
-      const options = {
-        useConfig: true,
-        senders: [
-          {
-            id: 'audioSend',
-            history: true,
-            correlate: 'audio', // NECESSARY KEY
-            onData: (k) => { console.log('audioSend stats data cb', k); }
-          }
-        ],
-        receivers: [
-          {
-            id: 'audioRecv',
-            history: true,
-            correlate: 'audio', // NECESSARY KEY
-            onData: (k) => { console.log('audioRecv stats data cb', k); }
-          }
-        ]
-      };
+        return alice.webex.internal.conversation.create({participants: [bob]})
+          .then((conversation) => {
+            console.log('CONVERSATION CREATED ', JSON.stringify(conversation));
 
-      alice.meeting.getStats(options, true);
-      bob.meeting.getStats(options, true);
+            return alice.webex.internal.conversation.post(conversation, {displayName: 'hello world how are you '});
+          });
+      });
 
-      assert.exists(alice.meeting.getStats());
-      assert.exists(bob.meeting.getStats());
-
-      assert.exists(alice.meeting.getStats().getSender('audioSend'));
-      assert.exists(alice.meeting.getStats().getReceiver('audioRecv'));
-      assert.exists(bob.meeting.getStats().getSender('audioSend'));
-      assert.exists(bob.meeting.getStats().getReceiver('audioRecv'));
-
-      return testUtils.waitUntil(7000);
-    });
-
-    it('check populated get stats data', () => {
-      assert.ok(alice.meeting.getStats().getSender('audioSend').getHistory().get().length);
-      assert.ok(alice.meeting.getStats().getReceiver('audioRecv').getHistory().get().length);
-      assert.ok(bob.meeting.getStats().getSender('audioSend').getHistory().get().length);
-      assert.ok(bob.meeting.getStats().getReceiver('audioRecv').getHistory().get().length);
-    });
-
-    it('analyze getStats data', () => {
-      const aliceThirtySecondsData1 = alice.meeting.getStats().getSender('audioSend').getHistory().getSlice(5);
-      const analysis1 = alice.webex.meetings.getAnalyzer().analyze(aliceThirtySecondsData1, {analysisKeys: [{key: 'bytesSent', check: 'increasing'}]});
-      const aliceThirtySecondsData2 = alice.meeting.getStats().getReceiver('audioRecv').getHistory().getSlice(5);
-      const analysis2 = alice.webex.meetings.getAnalyzer().analyze(aliceThirtySecondsData2, {analysisKeys: [{key: 'bytesReceived', check: 'increasing'}]});
-
-      const bobThirtySecondsData3 = bob.meeting.getStats().getSender('audioSend').getHistory().getSlice(5);
-      const analysis3 = alice.webex.meetings.getAnalyzer().analyze(bobThirtySecondsData3, {analysisKeys: [{key: 'bytesSent', check: 'increasing'}]});
-      const bobThirtySecondsData4 = bob.meeting.getStats().getReceiver('audioRecv').getHistory().getSlice(5);
-      const analysis4 = alice.webex.meetings.getAnalyzer().analyze(bobThirtySecondsData4, {analysisKeys: [{key: 'bytesReceived', check: 'increasing'}]});
-
-      assert.equal(analysis1.valid, true);
-      assert.equal(analysis2.valid, true);
-      assert.equal(analysis3.valid, true);
-      assert.equal(analysis4.valid, true);
-    });
-
-    it('alice Audio Mute ', () => Promise.all([
-      testUtils.delayedPromise(alice.meeting.muteAudio()),
-      testUtils.waitForEvents([{scope: bob.meeting.members, event: 'members:update'}])
-        .then((response) => {
-          const aliceParticipant = response[0].result.delta.updated.find((member) => alice.meeting.members.selfId === member.id);
-
-          console.log('Alice participant', JSON.stringify(aliceParticipant));
-          console.log('SELF STATE ', JSON.stringify(alice.meeting.locusInfo.participants));
-          assert.equal(aliceParticipant.isAudioMuted, true);
+      it('alice dials bob and adds media', () => Promise.all([
+        testUtils.delayedPromise(alice.webex.meetings.create(bob.emailAddress)),
+        testUtils.waitForEvents([{scope: alice.webex.meetings, event: 'meeting:added', user: alice}])
+      ])
+        .then(function aliceJoinsMeeting() {
+          return Promise.all([
+            testUtils.delayedPromise(alice.meeting.join()),
+            testUtils.waitForEvents([{scope: bob.webex.meetings, event: 'meeting:added', user: bob}])
+          ]);
         })
-    ])
-      .then(() => {
-        assert.equal(alice.meeting.audio.muted, true);
+        .then(() => assert.equal(bob.meeting.partner.state, 'JOINED'))
+        .then(() => testUtils.addMedia(alice)));
 
-        return testUtils.waitUntil(4000);
-      }));
-
-    it('alice Audio unMute ', () => Promise.all([
-      testUtils.delayedPromise(alice.meeting.unmuteAudio()),
-      testUtils.waitForEvents([{scope: bob.meeting.members, event: 'members:update'}])
-        .then((response) => {
-          const aliceParticipant = response[0].result.delta.updated.find((member) => alice.meeting.members.selfId === member.id);
-
-          assert.equal(aliceParticipant.isAudioMuted, false);
-        })
-    ])
-      .then(() => {
-        assert.equal(alice.meeting.audio.muted, false);
-      }));
-
-    it('alice Video Mute', () => Promise.all([
-      testUtils.delayedPromise(alice.meeting.muteVideo()),
-      testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update'}])
-        .then((response) => {
-          const aliceParticipant = response[0].result.delta.updated.find((member) => alice.meeting.members.selfId === member.id);
-
-          assert.equal(aliceParticipant.isVideoMuted, true);
-        })
-    ])
-      .then(() => {
-        assert.equal(alice.meeting.video.muted, true);
-      }));
-
-    it('alice video unMute', () => Promise.all([
-      testUtils.delayedPromise(alice.meeting.unmuteVideo()),
-      testUtils.waitForEvents([{scope: bob.meeting.members, event: 'members:update'}])
-        .then((response) => {
-          const aliceParticipant = response[0].result.delta.updated.find((member) => alice.meeting.members.selfId === member.id);
-
-          assert.equal(aliceParticipant.isVideoMuted, false);
-        })
-    ])
-      .then(() => {
-        assert.equal(alice.meeting.video.muted, false);
-      }));
-
-    it('alice update Audio', () => alice.meeting.getMediaStreams({sendAudio: true})
-      .then((response) => Promise.all([
-        testUtils.delayedPromise(alice.meeting.updateAudio({
-          sendAudio: true,
-          receiveAudio: true,
-          stream: response[0]
-        })
-          .then(() => {
-            console.log('AUDIO ', alice.meeting.mediaProperties.peerConnection.audioTransceiver.sender.track);
-            assert.equal(alice.meeting.mediaProperties.audioTrack.id, response[0].getAudioTracks()[0].id);
-          })),
-        testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
-          .then((response) => {
-            console.log('MEDIA:READY event ', response[0].result);
-            assert.equal(response[0].result.type === 'local', true);
-          })
-      ])));
-
-    it('alice update video', () => alice.meeting.getMediaStreams({sendVideo: true})
-      .then((response) => Promise.all([
-        testUtils.delayedPromise(alice.meeting.updateVideo({
-          sendVideo: true,
-          receiveVideo: true,
-          stream: response[0]
-        })
-          .then(() => {
-            assert.equal(alice.meeting.mediaProperties.videoTrack.id, response[0].getVideoTracks()[0].id);
-          })),
-        testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
-          .then((response) => {
-            console.log('MEDIA:READY event ', response[0].result);
-            assert.equal(response[0].result.type === 'local', true);
-          })
-      ])));
-
-    it('alice shares the screen', () => alice.meeting.getMediaStreams({
-      sendShare: true
-    })
-      .then((response) => Promise.all([
-        testUtils.delayedPromise(alice.meeting.updateShare({
-          sendShare: true,
-          receiveShare: true,
-          stream: response[1]
-        })),
-        testUtils.waitForEvents([{scope: alice.meeting, event: 'meeting:startedSharingLocal'}]),
-        testUtils.waitForEvents([{scope: bob.meeting.members, event: 'members:update'}])
-          .then((response) => {
-            console.log('SCREEN SHARE RESPONSE ', JSON.stringify(response));
-          }),
-        testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
-          .then((response) => {
-            console.log('MEDIA:READY event ', response[0].result);
-            assert.equal(response[0].result.type === 'localShare', true);
-          })
-      ]))
-      .then(() => {
-        assert.equal(alice.meeting.isSharing, true);
-        console.log('SCREEN SHARE PARTICIPANTS ', JSON.stringify(alice.meeting.locusInfo.participants));
-
-        return testUtils.waitUntil(4000);
-      }));
-
-    it('alice stops sharing ', () => Promise.all([
-      testUtils.delayedPromise(alice.meeting.updateShare({
-        sendShare: false,
-        receiveShare: true
-      })),
-      testUtils.waitForEvents([{scope: alice.meeting, event: 'meeting:stoppedSharingLocal'}])
-    ])
-      .then(() => {
-        assert.equal(alice.meeting.isSharing, false);
-      }));
-
-    it.skip('alice adds chris as guest to 1:1 meeting', () => Promise.all([
-      testUtils.delayedPromise(alice.meeting.invite({emailAddress: chris.emailAddress})),
-      testUtils.waitForEvents([{scope: chris.webex.meetings, event: 'meeting:added', user: chris}]),
-      testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update'}])
-        .then((response) => {
-          const chrisParticipant = response[0].result.delta.added.find((member) => chris.emailAddress === member.email);
-
-          assert.equal(chrisParticipant.status, 'NOT_IN_MEETING');
-        })
-    ])
-      .catch((e) => { console.error('Error adding chris as guest ', e); throw e; })
-      .then(function memberUpdated() {
-        assert.exists(chris.meeting);
+      it('bob joins the meeting', () => {
+        bob.meeting.acknowledge('INCOMING');
 
         return Promise.all([
-          testUtils.delayedPromise(chris.meeting.join()),
-          testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update'}])
+          testUtils.delayedPromise(bob.meeting.join()),
+          testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update', user: alice}])
             .then((response) => {
-              const chrisParticipant = response[0].result.delta.updated.find((member) => chris.meeting.members.selfId === member.id);
+              const bobParticipant = response[0].result.delta.updated.find((member) => bob.meeting.members.selfId === member.id);
 
-              assert.equal(chrisParticipant.status, 'IN_LOBBY');
-
-              return alice.meeting.admit(chrisParticipant.id);
+              assert.equal(bobParticipant.status, 'IN_MEETING');
             })
         ])
+          .then(() => testUtils.addMedia(bob))
           .then(() => {
-            assert.equal(alice.meeting.members.membersCollection.get(chris.meeting.members.selfId).participant.state, 'JOINED');
+            assert.equal(bob.meeting.sipUri, alice.emailAddress);
+            assert.equal(alice.meeting.sipUri, bob.emailAddress);
+            assert.exists(alice.meeting.members.locusUrl);
+            assert.equal(alice.meeting.type, 'CALL');
+            assert.equal(bob.meeting.type, 'CALL');
           })
-          .then(() => testUtils.waitForStateChange(chris.meeting, 'JOINED'))
-          .then(() => testUtils.addMedia(chris));
-      })
-      .then(() => Promise.all([
-        testUtils.delayedPromise(chris.meeting.leave()),
+          .then(function bobState() {
+            testUtils.waitForStateChange(bob.meeting, 'JOINED');
+          })
+          .then(function aliceState() {
+            testUtils.waitForStateChange(alice.meeting, 'JOINED');
+          })
+          .catch((e) => console.log('Error joining one_on_one', e));
+      });
+
+      it('check for meeting properties', () => {
+        assert.exists(alice.meeting.userId, 'userId not present');
+        assert.exists(alice.meeting.deviceUrl, 'deviceUrl not present');
+        assert.exists(alice.meeting.partner, 'partner not present');
+        assert.exists(alice.meeting.type, 'type not present');
+        assert.exists(alice.meeting.state, 'state not present');
+        assert.exists(alice.meeting.guest, 'guest not present');
+        assert.exists(alice.meeting.mediaProperties, 'mediaProperties not Present');
+        assert.exists(alice.meeting.mediaProperties.mediaDirection, 'mediaDirection not present');
+        // assert.exists(alice.meeting.joinedWith);
+        assert.exists(alice.meeting.members.selfId, 'selfId not present');
+      });
+
+      it('check for getStats', () => {
+        const options = {
+          useConfig: true,
+          senders: [
+            {
+              id: 'audioSend',
+              history: true,
+              correlate: 'audio', // NECESSARY KEY
+              onData: (k) => { console.log('audioSend stats data cb', k); }
+            }
+          ],
+          receivers: [
+            {
+              id: 'audioRecv',
+              history: true,
+              correlate: 'audio', // NECESSARY KEY
+              onData: (k) => { console.log('audioRecv stats data cb', k); }
+            }
+          ]
+        };
+
+        alice.meeting.getStats(options, true);
+        bob.meeting.getStats(options, true);
+
+        assert.exists(alice.meeting.getStats());
+        assert.exists(bob.meeting.getStats());
+
+        assert.exists(alice.meeting.getStats().getSender('audioSend'));
+        assert.exists(alice.meeting.getStats().getReceiver('audioRecv'));
+        assert.exists(bob.meeting.getStats().getSender('audioSend'));
+        assert.exists(bob.meeting.getStats().getReceiver('audioRecv'));
+
+        return testUtils.waitUntil(7000);
+      });
+
+      it('check populated get stats data', () => {
+        assert.ok(alice.meeting.getStats().getSender('audioSend').getHistory().get().length);
+        assert.ok(alice.meeting.getStats().getReceiver('audioRecv').getHistory().get().length);
+        assert.ok(bob.meeting.getStats().getSender('audioSend').getHistory().get().length);
+        assert.ok(bob.meeting.getStats().getReceiver('audioRecv').getHistory().get().length);
+      });
+
+      it('analyze getStats data', () => {
+        const aliceThirtySecondsData1 = alice.meeting.getStats().getSender('audioSend').getHistory().getSlice(5);
+        const analysis1 = alice.webex.meetings.getAnalyzer().analyze(aliceThirtySecondsData1, {analysisKeys: [{key: 'bytesSent', check: 'increasing'}]});
+        const aliceThirtySecondsData2 = alice.meeting.getStats().getReceiver('audioRecv').getHistory().getSlice(5);
+        const analysis2 = alice.webex.meetings.getAnalyzer().analyze(aliceThirtySecondsData2, {analysisKeys: [{key: 'bytesReceived', check: 'increasing'}]});
+
+        const bobThirtySecondsData3 = bob.meeting.getStats().getSender('audioSend').getHistory().getSlice(5);
+        const analysis3 = alice.webex.meetings.getAnalyzer().analyze(bobThirtySecondsData3, {analysisKeys: [{key: 'bytesSent', check: 'increasing'}]});
+        const bobThirtySecondsData4 = bob.meeting.getStats().getReceiver('audioRecv').getHistory().getSlice(5);
+        const analysis4 = alice.webex.meetings.getAnalyzer().analyze(bobThirtySecondsData4, {analysisKeys: [{key: 'bytesReceived', check: 'increasing'}]});
+
+        assert.equal(analysis1.valid, true);
+        assert.equal(analysis2.valid, true);
+        assert.equal(analysis3.valid, true);
+        assert.equal(analysis4.valid, true);
+      });
+
+      it('alice Audio Mute ', () => Promise.all([
+        testUtils.delayedPromise(alice.meeting.muteAudio()),
+        testUtils.waitForEvents([{scope: bob.meeting.members, event: 'members:update'}])
+          .then((response) => {
+            const aliceParticipant = response[0].result.delta.updated.find((member) => alice.meeting.members.selfId === member.id);
+
+            console.log('Alice participant', JSON.stringify(aliceParticipant));
+            console.log('SELF STATE ', JSON.stringify(alice.meeting.locusInfo.participants));
+            assert.equal(aliceParticipant.isAudioMuted, true);
+          })
+      ])
+        .then(() => {
+          assert.equal(alice.meeting.audio.muted, true);
+
+          return testUtils.waitUntil(4000);
+        }));
+
+      it('alice Audio unMute ', () => Promise.all([
+        testUtils.delayedPromise(alice.meeting.unmuteAudio()),
+        testUtils.waitForEvents([{scope: bob.meeting.members, event: 'members:update'}])
+          .then((response) => {
+            const aliceParticipant = response[0].result.delta.updated.find((member) => alice.meeting.members.selfId === member.id);
+
+            assert.equal(aliceParticipant.isAudioMuted, false);
+          })
+      ])
+        .then(() => {
+          assert.equal(alice.meeting.audio.muted, false);
+        }));
+
+      it('alice Video Mute', () => Promise.all([
+        testUtils.delayedPromise(alice.meeting.muteVideo()),
         testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update'}])
           .then((response) => {
-            console.log('CHRIS RESPONSE ', response[0]);
-            const chrisParticipant = response[0].result.delta.updated.find((member) => chris.meeting.members.selfId === member.id);
+            const aliceParticipant = response[0].result.delta.updated.find((member) => alice.meeting.members.selfId === member.id);
+
+            assert.equal(aliceParticipant.isVideoMuted, true);
+          })
+      ])
+        .then(() => {
+          assert.equal(alice.meeting.video.muted, true);
+        }));
+
+      it('alice video unMute', () => Promise.all([
+        testUtils.delayedPromise(alice.meeting.unmuteVideo()),
+        testUtils.waitForEvents([{scope: bob.meeting.members, event: 'members:update'}])
+          .then((response) => {
+            const aliceParticipant = response[0].result.delta.updated.find((member) => alice.meeting.members.selfId === member.id);
+
+            assert.equal(aliceParticipant.isVideoMuted, false);
+          })
+      ])
+        .then(() => {
+          assert.equal(alice.meeting.video.muted, false);
+        }));
+
+      it('alice update Audio', () => alice.meeting.getMediaStreams({sendAudio: true})
+        .then((response) => Promise.all([
+          testUtils.delayedPromise(alice.meeting.updateAudio({
+            sendAudio: true,
+            receiveAudio: true,
+            stream: response[0]
+          })
+            .then(() => {
+              console.log('AUDIO ', alice.meeting.mediaProperties.peerConnection.audioTransceiver.sender.track);
+              assert.equal(alice.meeting.mediaProperties.audioTrack.id, response[0].getAudioTracks()[0].id);
+            })),
+          testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
+            .then((response) => {
+              console.log('MEDIA:READY event ', response[0].result);
+              assert.equal(response[0].result.type === 'local', true);
+            })
+        ])));
+
+      it('alice update video', () => alice.meeting.getMediaStreams({sendVideo: true})
+        .then((response) => Promise.all([
+          testUtils.delayedPromise(alice.meeting.updateVideo({
+            sendVideo: true,
+            receiveVideo: true,
+            stream: response[0]
+          })
+            .then(() => {
+              assert.equal(alice.meeting.mediaProperties.videoTrack.id, response[0].getVideoTracks()[0].id);
+            })),
+          testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
+            .then((response) => {
+              console.log('MEDIA:READY event ', response[0].result);
+              assert.equal(response[0].result.type === 'local', true);
+            })
+        ])));
+
+      it('alice shares the screen', () => alice.meeting.getMediaStreams({
+        sendShare: true
+      })
+        .then((response) => Promise.all([
+          testUtils.delayedPromise(alice.meeting.updateShare({
+            sendShare: true,
+            receiveShare: true,
+            stream: response[1]
+          })),
+          testUtils.waitForEvents([{scope: alice.meeting, event: 'meeting:startedSharingLocal'}]),
+          testUtils.waitForEvents([{scope: bob.meeting.members, event: 'members:update'}])
+            .then((response) => {
+              console.log('SCREEN SHARE RESPONSE ', JSON.stringify(response));
+            }),
+          testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
+            .then((response) => {
+              console.log('MEDIA:READY event ', response[0].result);
+              assert.equal(response[0].result.type === 'localShare', true);
+            })
+        ]))
+        .then(() => {
+          assert.equal(alice.meeting.isSharing, true);
+          console.log('SCREEN SHARE PARTICIPANTS ', JSON.stringify(alice.meeting.locusInfo.participants));
+
+          return testUtils.waitUntil(4000);
+        }));
+
+      it('alice stops sharing ', () => Promise.all([
+        testUtils.delayedPromise(alice.meeting.updateShare({
+          sendShare: false,
+          receiveShare: true
+        })),
+        testUtils.waitForEvents([{scope: alice.meeting, event: 'meeting:stoppedSharingLocal'}])
+      ])
+        .then(() => {
+          assert.equal(alice.meeting.isSharing, false);
+        }));
+
+      it.skip('alice adds chris as guest to 1:1 meeting', () => Promise.all([
+        testUtils.delayedPromise(alice.meeting.invite({emailAddress: chris.emailAddress})),
+        testUtils.waitForEvents([{scope: chris.webex.meetings, event: 'meeting:added', user: chris}]),
+        testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update'}])
+          .then((response) => {
+            const chrisParticipant = response[0].result.delta.added.find((member) => chris.emailAddress === member.email);
 
             assert.equal(chrisParticipant.status, 'NOT_IN_MEETING');
           })
-      ]))
-      .catch((e) => { console.error('Error chris joining the meeting ', e); throw e; }));
-
-    it('shut down get stats', () => {
-      alice.meeting.stopStats();
-      bob.meeting.stopStats();
-      assert.ok(!alice.meeting.stats);
-      assert.ok(!bob.meeting.stats);
-    });
-
-    it('leave on the meeting object', () => Promise.all([
-      testUtils.delayedPromise(bob.meeting.leave()),
-      testUtils.waitForEvents([
-        {scope: alice.meeting.members, event: 'members:update', user: alice},
-        {scope: bob.webex.meetings, event: 'meeting:removed', user: bob},
-        {scope: alice.webex.meetings, event: 'meeting:removed', user: alice}
       ])
-    ])
-      .then((response) => {
-        assert.equal(bob.meeting, null);
-        assert.equal(alice.meeting, null);
+        .catch((e) => { console.error('Error adding chris as guest ', e); throw e; })
+        .then(function memberUpdated() {
+          assert.exists(chris.meeting);
 
-        console.log('RESPONSE ALL ', response);
-      })
-      .then(() => testUtils.waitForCallEnded(bob, alice.emailAddress))
-      .then(() => testUtils.waitForCallEnded(alice, bob.emailAddress))
-      .then(() => {
-        assert.equal(alice.webex.meetings.getMeetingByType('sipUri', bob.emailAddress), null);
-        assert.equal(bob.webex.meetings.getMeetingByType('sipUri', alice.emailAddress), null);
-      }));
+          return Promise.all([
+            testUtils.delayedPromise(chris.meeting.join()),
+            testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update'}])
+              .then((response) => {
+                const chrisParticipant = response[0].result.delta.updated.find((member) => chris.meeting.members.selfId === member.id);
+
+                assert.equal(chrisParticipant.status, 'IN_LOBBY');
+
+                return alice.meeting.admit(chrisParticipant.id);
+              })
+          ])
+            .then(() => {
+              assert.equal(alice.meeting.members.membersCollection.get(chris.meeting.members.selfId).participant.state, 'JOINED');
+            })
+            .then(() => testUtils.waitForStateChange(chris.meeting, 'JOINED'))
+            .then(() => testUtils.addMedia(chris));
+        })
+        .then(() => Promise.all([
+          testUtils.delayedPromise(chris.meeting.leave()),
+          testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update'}])
+            .then((response) => {
+              console.log('CHRIS RESPONSE ', response[0]);
+              const chrisParticipant = response[0].result.delta.updated.find((member) => chris.meeting.members.selfId === member.id);
+
+              assert.equal(chrisParticipant.status, 'NOT_IN_MEETING');
+            })
+        ]))
+        .catch((e) => { console.error('Error chris joining the meeting ', e); throw e; }));
+
+      it('shut down get stats', () => {
+        alice.meeting.stopStats();
+        bob.meeting.stopStats();
+        assert.ok(!alice.meeting.stats);
+        assert.ok(!bob.meeting.stats);
+      });
+
+      it('leave on the meeting object', () => Promise.all([
+        testUtils.delayedPromise(bob.meeting.leave()),
+        testUtils.waitForEvents([
+          {scope: alice.meeting.members, event: 'members:update', user: alice},
+          {scope: bob.webex.meetings, event: 'meeting:removed', user: bob},
+          {scope: alice.webex.meetings, event: 'meeting:removed', user: alice}
+        ])
+      ])
+        .then((response) => {
+          assert.equal(bob.meeting, null);
+          assert.equal(alice.meeting, null);
+
+          console.log('RESPONSE ALL ', response);
+        })
+        .then(() => testUtils.waitForCallEnded(bob, alice.emailAddress))
+        .then(() => testUtils.waitForCallEnded(alice, bob.emailAddress))
+        .then(() => {
+          assert.equal(alice.webex.meetings.getMeetingByType('sipUri', bob.emailAddress), null);
+          assert.equal(bob.webex.meetings.getMeetingByType('sipUri', alice.emailAddress), null);
+        }));
+    });
   });
 });

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
@@ -11,8 +11,10 @@ const webexTestUsers = require('./webex-test-users.js');
 
 let userSet, alice, bob, chris, guest;
 
-skipInNode(describe)('plugin-meetings-automation', () => {
-  describe('plugin-meeting-space-meeting', () => {
+skipInNode(describe)('plugin-meetings', () => {
+  describe('space-meeting', () => {
+    let space = null;
+
     before(() => webexTestUsers.generateTestUsers({count: 4})
       .then((users) => {
         userSet = users;
@@ -43,78 +45,75 @@ skipInNode(describe)('plugin-meetings-automation', () => {
       // TODO: end is not a function on browser object
     });
 
-    describe('Space meeting', () => {
-      let space = null;
 
-      it('Alice starts a space meeting', () =>
-        alice.webex.internal.conversation.create({participants: [bob, chris]})
-          .then((conversation) => {
-            assert.lengthOf(conversation.participants.items, 3);
-            assert.lengthOf(conversation.activities.items, 1);
-            console.log('CONVERSATION', conversation);
-            space = conversation;
-          })
-          .then(function aliceStartsMeeting() {
-            return Promise.all([
-              testUtils.delayedPromise(alice.webex.meetings.create(space.id)),
-              testUtils.waitForEvents([{scope: alice.webex.meetings, event: 'meeting:added', user: alice}])
-            ]);
-          })
-          .then(() => Promise.all([
-            testUtils.delayedPromise(alice.meeting.join()),
-            testUtils.waitForEvents([
-              {scope: bob.webex.meetings, event: 'meeting:added', user: bob},
-              {scope: chris.webex.meetings, event: 'meeting:added', user: chris}])
-          ])));
+    it('Alice starts a space meeting', () =>
+      alice.webex.internal.conversation.create({participants: [bob, chris]})
+        .then((conversation) => {
+          assert.lengthOf(conversation.participants.items, 3);
+          assert.lengthOf(conversation.activities.items, 1);
+          console.log('CONVERSATION', conversation);
+          space = conversation;
+        })
+        .then(function aliceStartsMeeting() {
+          return Promise.all([
+            testUtils.delayedPromise(alice.webex.meetings.create(space.id)),
+            testUtils.waitForEvents([{scope: alice.webex.meetings, event: 'meeting:added', user: alice}])
+          ]);
+        })
+        .then(() => Promise.all([
+          testUtils.delayedPromise(alice.meeting.join()),
+          testUtils.waitForEvents([
+            {scope: bob.webex.meetings, event: 'meeting:added', user: bob},
+            {scope: chris.webex.meetings, event: 'meeting:added', user: chris}])
+        ])));
 
-      it('Bob and chris joins space meeting', () => testUtils.waitForStateChange(alice.meeting, 'JOINED')
-        .then(() => testUtils.waitForStateChange(bob.meeting, 'IDLE'))
-        .then(() => testUtils.waitForStateChange(chris.meeting, 'IDLE'))
-        .then(() => bob.meeting.join())
-        .then(() => chris.meeting.join())
-      // add .then checks for alice response, should see bob and chris member status to isInMeeting = true
-        .then(() => testUtils.waitForStateChange(bob.meeting, 'JOINED'))
-        .then(() => testUtils.waitForStateChange(chris.meeting, 'JOINED')));
+    it('Bob and chris joins space meeting', () => testUtils.waitForStateChange(alice.meeting, 'JOINED')
+      .then(() => testUtils.waitForStateChange(bob.meeting, 'IDLE'))
+      .then(() => testUtils.waitForStateChange(chris.meeting, 'IDLE'))
+      .then(() => bob.meeting.join())
+      .then(() => chris.meeting.join())
+    // add .then checks for alice response, should see bob and chris member status to isInMeeting = true
+      .then(() => testUtils.waitForStateChange(bob.meeting, 'JOINED'))
+      .then(() => testUtils.waitForStateChange(chris.meeting, 'JOINED')));
 
-      it('Bob and Chris addsMedia', () => testUtils.addMedia(bob)
-        .then(() => testUtils.addMedia(alice)));
+    it('Bob and Chris addsMedia', () => testUtils.addMedia(bob)
+      .then(() => testUtils.addMedia(alice)));
 
-      it('alice Leaves the meeting', () =>
-        Promise.all([
-          testUtils.delayedPromise(alice.meeting.leave()),
-          testUtils.waitForEvents([{scope: chris.meeting.members, event: 'members:update'}])
-            .then((response) => {
-              const aliceParticipant = response[0].result.delta.updated.find((member) => alice.meeting.members.selfId === member.id);
-
-              assert.equal(aliceParticipant.status, 'NOT_IN_MEETING');
-            })
-        ]).then(() => testUtils.waitForStateChange(alice.meeting, 'LEFT')));
-
-      it('bob and chris leave meeting', () => Promise.all([
-        testUtils.delayedPromise(bob.meeting.leave()),
+    it('alice Leaves the meeting', () =>
+      Promise.all([
+        testUtils.delayedPromise(alice.meeting.leave()),
         testUtils.waitForEvents([{scope: chris.meeting.members, event: 'members:update'}])
           .then((response) => {
-            const bobParticipant = response[0].result.delta.updated.find((member) => bob.meeting.members.selfId === member.id);
+            const aliceParticipant = response[0].result.delta.updated.find((member) => alice.meeting.members.selfId === member.id);
 
-            assert.equal(bobParticipant.status, 'NOT_IN_MEETING');
+            assert.equal(aliceParticipant.status, 'NOT_IN_MEETING');
           })
-      ]).then(() => testUtils.waitForStateChange(bob.meeting, 'LEFT'))
-        .then(() => {
-          console.log('CHRIS MEETING', chris.meeting.locusInfo);
+      ]).then(() => testUtils.waitForStateChange(alice.meeting, 'LEFT')));
 
-          return chris.meeting.leave();
+    it('bob and chris leave meeting', () => Promise.all([
+      testUtils.delayedPromise(bob.meeting.leave()),
+      testUtils.waitForEvents([{scope: chris.meeting.members, event: 'members:update'}])
+        .then((response) => {
+          const bobParticipant = response[0].result.delta.updated.find((member) => bob.meeting.members.selfId === member.id);
+
+          assert.equal(bobParticipant.status, 'NOT_IN_MEETING');
         })
-        .then(() => testUtils.waitUntil(4000)));
+    ]).then(() => testUtils.waitForStateChange(bob.meeting, 'LEFT'))
+      .then(() => {
+        console.log('CHRIS MEETING', chris.meeting.locusInfo);
+
+        return chris.meeting.leave();
+      })
+      .then(() => testUtils.waitUntil(4000)));
 
 
-      it('check for meeting cleanup', () => {
-        console.log('Alice ', alice.webex.meetings.getAllMeetings());
-        console.log('Bob ', bob.webex.meetings.getAllMeetings());
-        console.log('Chris ', chris.webex.meetings.getAllMeetings());
-        assert.notExists(alice.webex.meetings.getMeetingByType('correlationId', alice.meeting.correlationId), 'alice meeting exists');
-        assert.notExists(bob.webex.meetings.getMeetingByType('correlationId', bob.meeting.correlationId), 'bob meeting exists');
-        assert.notExists(chris.webex.meetings.getMeetingByType('correlationId', chris.meeting.correlationId), 'chris meeting exists');
-      });
+    it('check for meeting cleanup', () => {
+      console.log('Alice ', alice.webex.meetings.getAllMeetings());
+      console.log('Bob ', bob.webex.meetings.getAllMeetings());
+      console.log('Chris ', chris.webex.meetings.getAllMeetings());
+      assert.notExists(alice.webex.meetings.getMeetingByType('correlationId', alice.meeting.correlationId), 'alice meeting exists');
+      assert.notExists(bob.webex.meetings.getMeetingByType('correlationId', bob.meeting.correlationId), 'bob meeting exists');
+      assert.notExists(chris.webex.meetings.getMeetingByType('correlationId', chris.meeting.correlationId), 'chris meeting exists');
     });
   });
 

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/webex-test-users.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/webex-test-users.js
@@ -13,10 +13,13 @@ require('@webex/internal-plugin-conversation');
 require('@webex/plugin-meetings');
 
 const generateTestUsers = (options) => testUser.create({count: options.count})
-  .then((userSet) => {
+  .then(async (userSet) => {
     if (userSet.length !== options.count) {
       return Promise.reject(new Error('Test users not created'));
     }
+
+    // Pause for 5 seconds for CI
+    await new Promise((done) => setTimeout(done, 5000));
 
     const userRegisterPromises = [];
 
@@ -31,16 +34,12 @@ const generateTestUsers = (options) => testUser.create({count: options.count})
 
       userRegisterPromises.push(user.webex.meetings.register());
     });
-    console.log({userSet});
 
     return Promise.all(userRegisterPromises)
-      .then(() => userSet)
-      .catch((error) => {
-        console.log(error);
-      });
+      .then(() => userSet);
   })
   .catch((error) => {
-    console.log('ERROR', error);
+    console.error('#generateTestUsers=>ERROR', error);
   });
 
 const remove = (userSet) => testUser.remove(userSet);

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/webex-test-users.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/webex-test-users.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 
 const testUser = require('@webex/test-helper-test-users');
 const WebexCore = require('@webex/webex-core').default;
@@ -13,14 +14,14 @@ require('@webex/plugin-meetings');
 
 const generateTestUsers = (options) => testUser.create({count: options.count})
   .then((userSet) => {
-    const mercuryPromise = [];
-    const devicePromise = [];
-
-    if (userSet.length === 0) {
-      return Promise.reject(new Error('Test user not created'));
+    if (userSet.length !== options.count) {
+      return Promise.reject(new Error('Test users not created'));
     }
 
+    const userRegisterPromises = [];
+
     userSet.forEach((user) => {
+      // eslint-disable-next-line no-param-reassign
       user.webex = new WebexCore({
         config: config.webex,
         credentials: {
@@ -28,13 +29,11 @@ const generateTestUsers = (options) => testUser.create({count: options.count})
         }
       });
 
-      console.log(user.webex);
-      mercuryPromise.push(user.webex.internal.mercury.connect());
-      devicePromise.push(user.webex.internal.device.register());
+      userRegisterPromises.push(user.webex.meetings.register());
     });
+    console.log({userSet});
 
-    return Promise.all(mercuryPromise)
-      .then(() => Promise.all(devicePromise))
+    return Promise.all(userRegisterPromises)
       .then(() => userSet)
       .catch((error) => {
         console.log(error);

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -60,7 +60,19 @@ skipInBrowser(describe)('plugin-meetings', () => {
           meetings: Meetings
         }
       });
+
+      Object.assign(webex.internal, {
+        device: {
+          deviceType: 'FAKE_DEVICE',
+          register: sinon.stub().returns(Promise.resolve())
+        },
+        mercury: {
+          connect: sinon.stub().returns(Promise.resolve()),
+          on: () => {}
+        }
+      });
     });
+
     it('has a webex instance with a meetings property', () => {
       assert.exists(webex, 'webex was initialized with children');
       assert.exists(webex.meetings, 'meetings child was set up on the webex instance');
@@ -72,6 +84,45 @@ skipInBrowser(describe)('plugin-meetings', () => {
     });
 
     describe('Public API Contracts', () => {
+      describe('#register', () => {
+        it('emits an event and resolves when register succeeds', (done) => {
+          webex.canAuthorize = true;
+          webex.meetings.register().then(() => {
+            assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meetings), {file: 'meetings', function: 'register'}, 'meetings:registered');
+            assert.isTrue(webex.meetings.registered);
+            done();
+          });
+        });
+
+        it('rejects when SDK canAuthorize is false', () => {
+          webex.canAuthorize = false;
+          assert.isRejected(webex.meetings.register());
+        });
+
+        it('rejects when device.register fails', () => {
+          webex.canAuthorize = true;
+          webex.internal.device.register = sinon.stub().returns(Promise.reject());
+          assert.isRejected(webex.meetings.register());
+        });
+
+        it('rejects when mercury.connect fails', () => {
+          webex.canAuthorize = true;
+          webex.internal.mercury.connect = sinon.stub().returns(Promise.reject());
+          assert.isRejected(webex.meetings.register());
+        });
+
+        it('resolves immediately if already registered', (done) => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = true;
+          webex.meetings.register().then(() => {
+            assert.notCalled(webex.internal.device.register);
+            assert.notCalled(webex.internal.mercury.connect);
+            assert.isTrue(webex.meetings.registered);
+            done();
+          });
+        });
+      });
+
       describe('gets', () => {
         describe('#getReachability', () => {
           it('should have #getReachability', () => {

--- a/packages/node_modules/samples/browser-call-with-screenshare/app.js
+++ b/packages/node_modules/samples/browser-call-with-screenshare/app.js
@@ -67,11 +67,8 @@ function connect() {
     });
 
     // Register our device with Webex cloud
-    if (!webex.internal.device.registered) {
-      webex.internal.device
-        .register()
-        // Connect to websockets after registering device
-        .then(() => webex.internal.mercury.connect())
+    if (!webex.meetings.registered) {
+      webex.meetings.register()
         // Sync our meetings with existing meetings on the server
         .then(() => webex.meetings.syncMeetings())
         .then(() => {

--- a/packages/node_modules/samples/browser-multi-party-call/app.js
+++ b/packages/node_modules/samples/browser-multi-party-call/app.js
@@ -68,11 +68,8 @@ function connect() {
     });
 
     // Register our device with Webex cloud
-    if (!webex.internal.device.registered) {
-      webex.internal.device
-        .register()
-        // Connect to websockets after registering device
-        .then(() => webex.internal.mercury.connect())
+    if (!webex.meetings.registered) {
+      webex.meetings.register()
         // Sync our meetings with existing meetings on the server
         .then(() => webex.meetings.syncMeetings())
         .then(() => {

--- a/packages/node_modules/samples/browser-plugin-meetings/app.js
+++ b/packages/node_modules/samples/browser-plugin-meetings/app.js
@@ -46,17 +46,14 @@ function connect() {
     });
   }
 
-  if (!webex.internal.device.registered) {
-    webex.internal.device
-      .register()
+  // Register our device with Webex cloud
+  if (!webex.meetings.registered) {
+    webex.meetings.register()
       .then(() => {
         // This is just a little helper for our selenium tests and doesn't
         // really matter for the example
         document.body.classList.add('listening');
         document.getElementById('connection-status').innerHTML = 'connected';
-
-        // return this.webex.internal.device.register()
-        return webex.internal.mercury.connect();
       })
       // This is a terrible way to handle errors, but anything more specific is
       // going to depend a lot on your app

--- a/packages/node_modules/samples/browser-single-party-call-with-mute/app.js
+++ b/packages/node_modules/samples/browser-single-party-call-with-mute/app.js
@@ -68,11 +68,8 @@ function connect() {
     });
 
     // Register our device with Webex cloud
-    if (!webex.internal.device.registered) {
-      webex.internal.device
-        .register()
-        // Connect to websockets after registering device
-        .then(() => webex.internal.mercury.connect())
+    if (!webex.meetings.registered) {
+      webex.meetings.register()
         // Sync our meetings with existing meetings on the server
         .then(() => webex.meetings.syncMeetings())
         .then(() => {

--- a/packages/node_modules/samples/browser-single-party-call/app.js
+++ b/packages/node_modules/samples/browser-single-party-call/app.js
@@ -67,11 +67,8 @@ function connect() {
     });
 
     // Register our device with Webex cloud
-    if (!webex.internal.device.registered) {
-      webex.internal.device
-        .register()
-        // Connect to websockets after registering device
-        .then(() => webex.internal.mercury.connect())
+    if (!webex.meetings.registered) {
+      webex.meetings.register()
         // Sync our meetings with existing meetings on the server
         .then(() => webex.meetings.syncMeetings())
         .then(() => {


### PR DESCRIPTION
# Pull Request Template

## Description

Adds `meetings.register` method to do the device registration, websocket connect, and locus event listening. 

BREAKING CHANGE: No longer automatically listens to locus events upon initialization.

Fixes # SPARK-86902

## Type of Change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Plugin-meetings
- [X] Samples

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
