### PR TITLE
fix(meetings): mutedByOthers empty param

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js
@@ -160,7 +160,7 @@ selfUtils.isAdmittedGuest = (oldSelf, changedSelf) => {
   return selfUtils.isLocusGuestUnadmitted(oldSelf) && selfUtils.isLocusGuestAdmitted(changedSelf);
 };
 
-selfUtils.mutedByOthers = (oldSelf, changedSelf) => {
+selfUtils.mutedByOthers = (oldSelf = {}, changedSelf) => {
   if (!changedSelf) {
     throw new ParameterError('New self must be defined to determine if self was muted by others.');
   }


### PR DESCRIPTION
If "mute on join" is set, there will be no
"oldSelf" object to compare against.
