### PR TITLE
chore(eslint): disable underscore dangle rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -37,7 +37,7 @@ rules:
   no-multi-assign: warn
   no-param-reassign: warn
   no-shadow: warn
-  no-underscore-dangle: warn
+  no-underscore-dangle: off
   import/first: warn
   import/order: warn
   prefer-destructuring:


### PR DESCRIPTION
The plugins use the underscored function names to
indicate private functions. This is a highly debated
pattern, but is consistent across the sdk.
