### PR TITLE
test(internal-plugin-team): remove skip clause from testing suite

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-team/test/integration/spec/get.js
+++ b/packages/node_modules/@webex/internal-plugin-team/test/integration/spec/get.js
@@ -161,8 +161,7 @@ describe('plugin-team', () => {
       }));
   });
 
-  // Skipping until SPARK-92569
-  describe.skip('#list()', () => {
+  describe('#list()', () => {
     it('retrieves a list of teams', () => kirk.webex.internal.team.list()
       .then((teams) => {
         assert.equal(teams.length, 2);


### PR DESCRIPTION
# **Test** [*internal-plugin-team*] - Remove the Skip Clause from the Intergration Testing Suite

## Description

Remove the unnecessary 'skip' clause from the testing suite
now that all tests for the specified clause are passing.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] test fix

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] project test scripts for package

**Test Configuration**:
* Node/Browser Version v8.16.0
* NPM Version v6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
