### PR TITLE
Breaking Change: meetings | federation convoId -> convoUrl

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/README.md
+++ b/packages/node_modules/@webex/plugin-meetings/README.md
@@ -39,11 +39,11 @@ webex.meetings.register()
 
 #### Creating a basic meeting
 
-##### Via conversation ID
+##### Via conversation url
 
 ```javascript
-let convoId = `ObiwanAnnouncementsConversationUUID`;
-return webex.meetings.create(convoId).then((meeting) ==> {...});
+let convoUrl = `https://conv-a.wbx2.com/conversation/api/v1/ObiwanAnnouncementsConversationUUID`;
+return webex.meetings.create(convoUrl).then((meeting) ==> {...});
 ```
 
 ##### Via SIP URI

--- a/packages/node_modules/@webex/plugin-meetings/UPGRADING.md
+++ b/packages/node_modules/@webex/plugin-meetings/UPGRADING.md
@@ -68,9 +68,9 @@ await myMeeting.join();
 ### Joining a group meeting
 
 ```js
-let convoId = `ObiwanAnnouncementsConversationUUID`;
+let convoUrl = `https://conv-a.wbx2.com/conversation/api/v1/ObiwanAnnouncementsConversationUUID`;
 
-const myMeeting = await webex.meetings.create(convoId);
+const myMeeting = await webex.meetings.create(convoUrl);
 
 await myMeeting.join();
 

--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -133,6 +133,8 @@ export const WWW_DOT = 'www.';
 
 export const WEBEX_DOT_COM = 'webex.com';
 
+export const CONVERSATION_SERVICE = 'identityLookup';
+
 // ******************* ARRAYS ********************
 // Please alphabetize
 export const DEFAULT_EXCLUDED_STATS = ['timestamp', 'ssrc', 'priority'];

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js
@@ -95,7 +95,7 @@ export default class MeetingInfo extends StatelessWebexPlugin {
     return MeetingInfoUtil.generateOptions({
       destination,
       type,
-      conversationServiceUrl: this.webex.internal.device.services.conversationServiceUrl
+      webex: this.webex
     });
   }
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js
@@ -2,13 +2,13 @@ import url from 'url';
 
 import btoa from 'btoa';
 
+import ParameterError from '../common/errors/parameter';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {
   _SIP_URI_,
   _PERSONAL_ROOM_,
   _MEETING_ID_,
   _CONVERSATION_URL_,
-  CONVERSATIONS,
   _LOCUS_ID_,
   _MEETING_LINK_,
   HTTP_VERBS,
@@ -19,6 +19,7 @@ import {
   ALTERNATE_REDIRECT_TRUE,
   DIALER_REGEX,
   WEBEX_DOT_COM,
+  CONVERSATION_SERVICE,
   WWW_DOT,
   JOIN,
   MEET,
@@ -61,6 +62,8 @@ MeetingInfoUtil.isMeetingLink = (value) => {
 
   return hostNameBool && pathNameBool;
 };
+
+MeetingInfoUtil.isConversationUrl = (value, webex) => webex.internal.services.getClusterId(value).endsWith(CONVERSATION_SERVICE);
 
 MeetingInfoUtil.convertLinkToSip = (value) => {
   const parsedUrl = MeetingInfoUtil.getParsedUrl(value);
@@ -108,7 +111,7 @@ MeetingInfoUtil.isPhoneNumber = (phoneNumber) => {
 };
 
 MeetingInfoUtil.generateOptions = (from) => {
-  const {destination, type, conversationServiceUrl} = from;
+  const {destination, type, webex} = from;
 
   if (type) {
     return {
@@ -130,9 +133,12 @@ MeetingInfoUtil.generateOptions = (from) => {
     options.type = _SIP_URI_;
     options.destination = destination;
   }
-  else {
+  else if (MeetingInfoUtil.isConversationUrl(destination, webex)) {
     options.type = _CONVERSATION_URL_;
-    options.destination = `${conversationServiceUrl}/${CONVERSATIONS}/${destination}`;
+    options.destination = destination;
+  }
+  else {
+    throw new ParameterError('MeetingInfo is fetched with meeting link, sip uri, phone number, or a conversation url.');
   }
 
   return options;

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js
@@ -1,6 +1,9 @@
 import url from 'url';
 
 import btoa from 'btoa';
+import {
+  deconstructHydraId
+} from '@webex/common';
 
 import ParameterError from '../common/errors/parameter';
 import LoggerProxy from '../common/logs/logger-proxy';
@@ -24,7 +27,9 @@ import {
   JOIN,
   MEET,
   MEET_M,
-  HTTPS_PROTOCOL
+  HTTPS_PROTOCOL,
+  CONVERSATIONS,
+  UUID_REG
 } from '../constants';
 
 const MeetingInfoUtil = {};
@@ -63,7 +68,15 @@ MeetingInfoUtil.isMeetingLink = (value) => {
   return hostNameBool && pathNameBool;
 };
 
-MeetingInfoUtil.isConversationUrl = (value, webex) => webex.internal.services.getClusterId(value).endsWith(CONVERSATION_SERVICE);
+MeetingInfoUtil.isConversationUrl = (value, webex) => {
+  const clusterId = webex.internal.services.getClusterId(value);
+
+  if (clusterId) {
+    return clusterId.endsWith(CONVERSATION_SERVICE);
+  }
+
+  return false;
+};
 
 MeetingInfoUtil.convertLinkToSip = (value) => {
   const parsedUrl = MeetingInfoUtil.getParsedUrl(value);
@@ -110,6 +123,16 @@ MeetingInfoUtil.isPhoneNumber = (phoneNumber) => {
   return isValidNumber;
 };
 
+MeetingInfoUtil.getHydraId = (destination) => {
+  const decodedDestination = deconstructHydraId(destination).id;
+
+  if (UUID_REG.test(decodedDestination)) {
+    return decodedDestination;
+  }
+
+  return null;
+};
+
 MeetingInfoUtil.generateOptions = (from) => {
   const {destination, type, webex} = from;
 
@@ -120,6 +143,7 @@ MeetingInfoUtil.generateOptions = (from) => {
     };
   }
   const options = {};
+  const hydraId = MeetingInfoUtil.getHydraId(destination);
 
   if (MeetingInfoUtil.isMeetingLink(destination)) {
     options.type = _MEETING_LINK_;
@@ -137,8 +161,14 @@ MeetingInfoUtil.generateOptions = (from) => {
     options.type = _CONVERSATION_URL_;
     options.destination = destination;
   }
+  else if (hydraId) {
+    options.type = _CONVERSATION_URL_;
+    // TODO: cleanup after hydra is federated :::SPARK-91986:::
+    // do not build conversation URLs in federation!
+    options.destination = `${webex.internal.device.services.conversationServiceUrl}/${CONVERSATIONS}/${hydraId}`;
+  }
   else {
-    throw new ParameterError('MeetingInfo is fetched with meeting link, sip uri, phone number, or a conversation url.');
+    throw new ParameterError('MeetingInfo is fetched with meeting link, sip uri, phone number, hydra room id, or a conversation url.');
   }
 
   return options;

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -389,7 +389,7 @@ export default class Meeting extends StatelessWebexPlugin {
      * @public
      * @memberof Meeting
      */
-    this.convoId = null;
+    this.convoUrl = null;
     /**
      * @instance
      * @type {String}
@@ -1072,10 +1072,11 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * Sets the meeting info on the class instance
    * @param {Object} meetingInfo
-   * @param {String} meetingInfo.convoId
-   * @param {String} meetingInfo.locusUrl
-   * @param {String} meetingInfo.sipUri
-   * @param {Object} meetingInfo.owner
+   * @param {Object} meetingInfo.body
+   * @param {String} meetingInfo.body.conversationUrl
+   * @param {String} meetingInfo.body.locusUrl
+   * @param {String} meetingInfo.body.sipUri
+   * @param {Object} meetingInfo.body.owner
    * @returns {undefined}
    * @private
    * @memberof Meeting
@@ -1083,7 +1084,7 @@ export default class Meeting extends StatelessWebexPlugin {
   parseMeetingInfo(meetingInfo) {
     // MeetingInfo will be undefined for 1:1 calls
     if (meetingInfo && meetingInfo.body && !(meetingInfo.errors && meetingInfo.errors.length > 0)) {
-      this.convoId = meetingInfo.body.convoId || this.convoId;
+      this.convoUrl = meetingInfo.body.conversationUrl || this.convoUrl;
       this.locusUrl = meetingInfo.body.locusUrl || this.locusUrl;
       this.setSipUri(meetingInfo.body.sipMeetingUri || this.sipUri);
       this.owner = meetingInfo.body.owner || this.owner;
@@ -1726,7 +1727,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * Scenario B: Joining other's claimed personal meeting room, do pass hostPin (if desired to join as host, or nullify), do pass moderator
    * Scenario C: Joining an unclaimed personal meeting room, -do not- pass hostPin or moderator on first try, -do- pass hostPin and moderator
    *             if joining as host on second loop, -do not- pass hostPin do pass moderator if joining as guest on second loop
-   * Scenario D: Joining any other way (sip, pstn, convoId, link just need to specify resourceId)
+   * Scenario D: Joining any other way (sip, pstn, convoUrl, link just need to specify resourceId)
    */
   join(options = {}) {
     // If Move or PSTN try merging into one

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js
@@ -1,14 +1,9 @@
 import {
-  deconstructHydraId
-} from '@webex/common';
-
-import {
   _LOCUS_ID_,
   _INCOMING_,
   _CREATED_,
   LOCUSEVENT,
-  CORRELATION_ID,
-  UUID_REG
+  CORRELATION_ID
 } from '../constants';
 import ParameterError from '../common/errors/parameter';
 
@@ -26,15 +21,7 @@ MeetingsUtil.extractDestination = (destination, type) => {
     dest = temp[temp.length - 1];
   }
 
-  // If the destination is a UUID, assume it is an internal conversation ID.
-  if (UUID_REG.test(dest)) {
-    return dest;
-  }
-
-  // Next, assume it is a valid Hydra room ID.
-  // If decoding fails, it is a SIP or other destination.
-  // if the id is not present we will use the default destination
-  return deconstructHydraId(dest).id || dest;
+  return dest;
 };
 
 MeetingsUtil.getMeetingAddedType = (type) => (type === _LOCUS_ID_ ? _INCOMING_ : _CREATED_);

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -104,7 +104,7 @@ skipInBrowser(describe)('plugin-meetings', () => {
           assert.isNull(meeting.video);
           assert.instanceOf(meeting.meetingFiniteStateMachine, StateMachine);
           assert.isNull(meeting.stats);
-          assert.isNull(meeting.convoId);
+          assert.isNull(meeting.convoUrl);
           assert.equal(meeting.locusUrl, url1);
           assert.isNull(meeting.sipUri);
           assert.isNull(meeting.partner);
@@ -805,13 +805,13 @@ skipInBrowser(describe)('plugin-meetings', () => {
         it('should parse meeting info, set values, and return null', () => {
           meeting.parseMeetingInfo({
             body: {
-              convoId: uuid1,
+              conversationUrl: uuid1,
               locusUrl: url1,
               sipMeetingUri: test1,
               owner: test2
             }
           });
-          assert.equal(meeting.convoId, uuid1);
+          assert.equal(meeting.convoUrl, uuid1);
           assert.equal(meeting.locusUrl, url1);
           assert.equal(meeting.sipUri, test1);
           assert.equal(meeting.owner, test2);

--- a/packages/node_modules/samples/browser-plugin-meetings/index.html
+++ b/packages/node_modules/samples/browser-plugin-meetings/index.html
@@ -216,11 +216,11 @@
         <p>
           sip uri example: 126707703@alpha.webex.com
           pstn number example: +18885550123
-          convo id example: b7ab0370-911c-11e8-b40c-e117f23f1f95
+          convo url example: https://conv-a.wbx2.com/conversation/api/v1/b7ab0370-911c-11e8-b40c-e117f23f1f95
           meeting link example: https://alpha.webex.com/m/585b8b8f-5e73-4536-9147-f86cb70c8d81
         </p>
         <input id="invitee" name="invitee" value="" type="text" />
-        <label>sip uri, pstn number, convo id, or meeting link</label>
+        <label>sip uri, pstn number, convo url, or meeting link</label>
       </br>
         <input id="hostPin-join" title="hostPin" value="" type="text"/>
         <label>host pin</label>

--- a/packages/node_modules/samples/browser-plugin-meetings/index.html
+++ b/packages/node_modules/samples/browser-plugin-meetings/index.html
@@ -218,9 +218,10 @@
           pstn number example: +18885550123
           convo url example: https://conv-a.wbx2.com/conversation/api/v1/b7ab0370-911c-11e8-b40c-e117f23f1f95
           meeting link example: https://alpha.webex.com/m/585b8b8f-5e73-4536-9147-f86cb70c8d81
+          hydra room id example: Y2lzY29zcGFyazovL3VzL1JPT00vNWZhMWUzODAtZTkzZS0xMWU5LTgyZTEtOGRmYTg5ZTgzMjJm
         </p>
         <input id="invitee" name="invitee" value="" type="text" />
-        <label>sip uri, pstn number, convo url, or meeting link</label>
+        <label>sip uri, pstn number, convo url, hydra room id, or meeting link</label>
       </br>
         <input id="hostPin-join" title="hostPin" value="" type="text"/>
         <label>host pin</label>


### PR DESCRIPTION
The above is being added because currently, convoId will not work at all. We have to do some testing and documentation changes, as with federation/fedramp convoId is no longer present (and no longer uniquely identified a conversation)
