### PR TITLE
feat(meetings): add unregister method

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/README.md
+++ b/packages/node_modules/@webex/plugin-meetings/README.md
@@ -30,11 +30,23 @@ See https://github.com/webex/webex-js-sdk/tree/master/packages/node_modules/samp
 
 #### Device Registration
 
-The meetings plugin requires some setup actions which are handled with the `register` function.
+The meetings plugin relies on websocket data to function. The user's device needs to register and connect to the web socket server.
+
+These setup actions are handled with the `register` function.
+
 This function registers the device, connects web sockets, and listens for meeting events.
 
 ```js
 webex.meetings.register()
+```
+
+#### Device Unregistration
+
+The inverse of the `register()` function is available as well.
+This function stops listening for meeting events, disconnects from web sockets and unregisters the device.
+
+```js
+webex.meetings.unregister()
 ```
 
 #### Creating a basic meeting
@@ -1053,6 +1065,9 @@ meeting.on(...)
 
 | Event Name | Description |
 |---|---|
+| `meetings:ready` | Fired when the meetings plugin has been successfully initialized |
+| `meetings:registered` | Fired when the meetings plugin has registered the device and is listening to websocket events |
+| `meetings:unregistered` | Fired when the meetings plugin has been disconnected from websockets and unregistered as a device |
 | `media:ready` | Fired when remote or local media has been acquired |
 | `media:stopped` | Fired when remote or local media has been torn down |
 | `meeting:alerted` | Fired when locus was notified that user received meeting |
@@ -1070,6 +1085,12 @@ meeting.on(...)
 | `meeting:locked` | Fired when the meeting was locked by the host, for webex type meetings only |
 | `meeting:actionsUpdate` | Fired when the user has new actions they can take, such as lock, unlock, transferHost |
 |---|---|
+
+`meetings:ready` does not have a payload
+
+`meetings:registered` does not have a payload
+
+`meetings:unregistered` does not have a payload
 
 `media:ready` has the following payload
 ```javascript

--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -297,6 +297,7 @@ export const DELTAEVENT = {
 export const EVENT_TRIGGERS = {
   MEETINGS_READY: 'meetings:ready',
   MEETINGS_REGISTERED: 'meetings:registered',
+  MEETINGS_UNREGISTERED: 'meetings:unregistered',
   MEDIA_READY: 'media:ready',
   MEDIA_STOPPED: 'media:stopped',
   MEDIA_UPDATE: 'media:update',

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -272,6 +272,17 @@ export default class Meetings extends WebexPlugin {
     }
 
     /**
+     * stops listening for locus and roap mercury events
+     * @returns {undefined}
+     * @private
+     * @memberof Meetings
+     */
+    stopListeningForEvents() {
+      this.webex.internal.mercury.off(LOCUSEVENT.LOCUS_MERCURY);
+      this.webex.internal.mercury.off(ROAP.ROAP_MERCURY);
+    }
+
+    /**
      * @returns {undefined}
      * @private
      * @memberof Meetings
@@ -331,6 +342,38 @@ export default class Meetings extends WebexPlugin {
           LoggerProxy.logger.error(`meetings->register#ERROR, Unable to register, ${error.message}`);
 
           return Promise.reject(error);
+        });
+    }
+
+    /**
+     * Explicitly tears down the meetings plugin by deregistering
+     * the device, disconnecting from mercury, and stops listening to locus events
+     *
+     * @returns {Promise}
+     * @public
+     * @memberof Meetings
+     */
+    unregister() {
+      if (!this.registered) {
+        LoggerProxy.logger.info('meetings->unregister#INFO, Meetings plugin already unregistered');
+
+        return Promise.resolve();
+      }
+
+      this.stopListeningForEvents();
+
+      return this.webex.internal.mercury.disconnect()
+        .then(() => this.webex.internal.device.unregister())
+        .then(() => {
+          Trigger.trigger(
+            this,
+            {
+              file: 'meetings',
+              function: 'unregister'
+            },
+            EVENT_TRIGGERS.MEETINGS_UNREGISTERED
+          );
+          this.registered = false;
         });
     }
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -64,11 +64,14 @@ skipInBrowser(describe)('plugin-meetings', () => {
       Object.assign(webex.internal, {
         device: {
           deviceType: 'FAKE_DEVICE',
-          register: sinon.stub().returns(Promise.resolve())
+          register: sinon.stub().returns(Promise.resolve()),
+          unregister: sinon.stub().returns(Promise.resolve())
         },
         mercury: {
           connect: sinon.stub().returns(Promise.resolve()),
-          on: () => {}
+          disconnect: sinon.stub().returns(Promise.resolve()),
+          on: () => {},
+          off: () => {}
         }
       });
     });
@@ -118,6 +121,39 @@ skipInBrowser(describe)('plugin-meetings', () => {
             assert.notCalled(webex.internal.device.register);
             assert.notCalled(webex.internal.mercury.connect);
             assert.isTrue(webex.meetings.registered);
+            done();
+          });
+        });
+      });
+
+      describe('#unregister', () => {
+        it('emits an event and resolves when unregister succeeds', (done) => {
+          webex.meetings.registered = true;
+          webex.meetings.unregister().then(() => {
+            assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meetings), {file: 'meetings', function: 'unregister'}, 'meetings:unregistered');
+            assert.isFalse(webex.meetings.registered);
+            done();
+          });
+        });
+
+        it('rejects when device.unregister fails', () => {
+          webex.meetings.registered = true;
+          webex.internal.device.unregister = sinon.stub().returns(Promise.reject());
+          assert.isRejected(webex.meetings.unregister());
+        });
+
+        it('rejects when mercury.disconnect fails', () => {
+          webex.meetings.registered = true;
+          webex.internal.mercury.disconnect = sinon.stub().returns(Promise.reject());
+          assert.isRejected(webex.meetings.unregister());
+        });
+
+        it('resolves immediately if already registered', (done) => {
+          webex.meetings.registered = false;
+          webex.meetings.unregister().then(() => {
+            assert.notCalled(webex.internal.device.register);
+            assert.notCalled(webex.internal.mercury.connect);
+            assert.isFalse(webex.meetings.registered);
             done();
           });
         });


### PR DESCRIPTION
# Pull Request Template

## Description

Adds public `unregister` method to balance out the `register` method.
Tests and documentation added as well.

Fixes #1367 

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

- [x] `npm run test -- --packages @webex/plugin-meetings --unit`

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
