### PR TITLE
chore(circle-ci): fix unit test failure not reporting in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,9 @@ jobs:
             echo Failures $FAILURES
             echo Errors $ERRORS
 
-            if [[ "$FAILURES" -ne *0* ]] || [[ "$ERRORS" -ne *0* ]]; then
+            if [[ $FAILURES =~ "^[0 ]*$" ]] && [[ $ERRORS =~ "^[0 ]*$" ]]; then
+              echo 'Unit tests succeeded'
+            else
               echo 'Unit tests failed'
               exit 1
             fi
@@ -225,8 +227,10 @@ jobs:
             echo Failures $FAILURES
             echo Errors $ERRORS
 
-            if [[ "$FAILURES" -ne *0* ]] || [[ "$ERRORS" -ne *0* ]]; then
-              echo 'Unit tests failed'
+            if [[ $FAILURES =~ "^[0 ]*$" ]] && [[ $ERRORS =~ "^[0 ]*$" ]]; then
+              echo 'Integration tests succeeded'
+            else
+              echo 'Integration tests failed'
               exit 1
             fi
       - store_test_results:


### PR DESCRIPTION
# Pull Request

## Description

Add multi-line error handing to test runners within the CircleCi config files in order to address an issue occurring in which when an error is thrown in a test, it doesn't report errors in CircleCI

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Testing against CircleCI

**Test Configuration**:
* SDK Version
* Node/Browser Version v8.16.0
* NPM Version v6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
