### PR TITLE
Feat/add config to services

### DIFF
--- a/packages/node_modules/@webex/webex-core/README.md
+++ b/packages/node_modules/@webex/webex-core/README.md
@@ -20,6 +20,34 @@ npm install --save @webex/webex-core
 
 ## Usage
 
+### Client Scope Requirements
+
+To utilize the basic functionality of the `services` plugin that is bound to the `webex-core` plugin upon initialization, the following scopes must be present in the provided client's scopes:
+
+- `spark:all`
+
+### Environment Variables
+
+The following environment variables are used by this plugin:
+
+- `U2C_SERVICE_URL` - stores the service catalog collecting url, typically the **U2C** service
+
+### Configuration
+
+The `services` plugin that is bound to the `webex-core` plugin upon initialization supports the ability to inject discovery urls via the constructor:
+
+```js
+const webex = new Webex({
+  config: {
+    services: {
+      hydra: 'https://api.ciscospark.com/v1'
+    }
+  }
+});
+```
+
+The default configuration includes the **U2C** url as defined by environment variable `U2C_SERVICE_URL` or the default `https://u2c.wbx2.com/u2c/api/v1`
+
 ## Maintainers
 
 This package is maintained by [Cisco Webex for Developers](https://developer.webex.com/).

--- a/packages/node_modules/@webex/webex-core/src/config.js
+++ b/packages/node_modules/@webex/webex-core/src/config.js
@@ -18,6 +18,9 @@ export default {
   trackingIdSuffix: '',
   AlternateLogger: undefined,
   credentials: new CredentialsConfig(),
+  services: {
+    u2c: process.env.U2C_SERVICE_URL || 'https://u2c.wbx2.com/u2c/api/v1'
+  },
   device: {
     preDiscoveryServices: {
       hydra: process.env.HYDRA_SERVICE_URL || 'https://api.ciscospark.com/v1',

--- a/packages/node_modules/@webex/webex-core/src/lib/services/service-catalog.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/service-catalog.js
@@ -13,19 +13,16 @@ const ServiceCatalog = AmpState.extend({
 
   props: {
     serviceGroups: ['object', true, (() => ({
-      discovery: [
-        new ServiceUrl({
-          name: 'u2c',
-          defaultUrl: process.env.U2C_SERVICE_URL ||
-            'https://u2c.wbx2.com/u2c/api/v1',
-          hosts: []
-        })
-      ],
+      discovery: [],
       preauth: [],
       postauth: [],
       signin: []
     }))],
     status: ['object', true, (() => ({
+      discovery: {
+        ready: false,
+        collecting: false
+      },
       preauth: {
         ready: false,
         collecting: false
@@ -305,7 +302,7 @@ const ServiceCatalog = AmpState.extend({
 
       if (service) {
         service.defaultUrl = serviceObj.defaultUrl;
-        service.hosts = serviceObj.hosts;
+        service.hosts = serviceObj.hosts || [];
       }
       else {
         this._loadServiceUrls(serviceGroup, [new ServiceUrl({

--- a/packages/node_modules/@webex/webex-core/src/lib/services/services.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/services.js
@@ -421,14 +421,31 @@ const Services = WebexPlugin.extend({
    * @returns {Services}
    */
   initialize() {
-    this._catalogs.set(this.webex, new ServiceCatalog());
+    const catalog = new ServiceCatalog();
 
+    this._catalogs.set(this.webex, catalog);
+
+    // once config has changed, begin initialization
+    this.listenToOnce(this.webex, 'change:config', () => {
+      // format services config object into an array
+      const mappedServices = Object.keys(this.webex.config.services)
+        .map((key) => ({
+          name: key,
+          defaultUrl: this.webex.config.services[key]
+        }));
+
+      // inject formatted services into services catalog
+      catalog.updateServiceUrls('discovery', mappedServices);
+    });
+
+    // wait for webex instance to be ready before attempting
+    // to update the service catalogs
     this.listenToOnce(this.webex, 'ready', () => {
       /* eslint-disable camelcase */
       if (this.webex.credentials.canAuthorize) {
         this.updateServices()
-          // this catch prevents crashing in unique situations found
-          // primarily in unit testing with the karma suite.
+        // this catch prevents crashing in unique situations found
+        // primarily in unit testing with the karma suite.
           .catch(
             () => this.logger.warn('services: catalog retrieval failed w/auth')
           );

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/service-catalog.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/service-catalog.js
@@ -13,7 +13,7 @@ describe('webex-core', () => {
     let services;
     let catalog;
 
-    beforeEach('initialize webex', () => {
+    before('initialize webex', () => {
       webex = new MockWebex();
       services = new Services(undefined, {parent: webex});
       catalog = services._getCatalog();
@@ -31,10 +31,6 @@ describe('webex-core', () => {
           ['discovery', 'preauth', 'signin', 'postauth']);
       });
 
-      it('contains at least one discovery item', () => {
-        assert.isAbove(catalog.serviceGroups.discovery.length, 0);
-      });
-
       it('contains values that are arrays', () => {
         Object.keys(catalog.serviceGroups).forEach((key) => {
           assert.typeOf(catalog.serviceGroups[key], 'array');
@@ -45,7 +41,7 @@ describe('webex-core', () => {
     describe('#status()', () => {
       it('has all the required keys', () => {
         assert.hasAllKeys(catalog.status,
-          ['preauth', 'postauth', 'signin']);
+          ['discovery', 'preauth', 'postauth', 'signin']);
       });
 
       it('has valid key value types', () => {

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/services.js
@@ -12,7 +12,7 @@ describe('webex-core', () => {
     let webex;
     let services;
 
-    beforeEach('initialize webex', () => {
+    before('initialize webex', () => {
       webex = new MockWebex({
         children: {
           services: Services


### PR DESCRIPTION
## Description

Add the ability to pass in a config object into the services plugin to specify the prediscovery service urls. This will give users the ability to specify what urls are available via the initial `new Webex({ ... });` constructor.

Fixes # SPARK-100862

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated and utilized the package testing suite

**Test Configuration**:
* SDK Version
* Node/Browser Version v8.16.0
* NPM Version v6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
