### PR TITLE
fix(encryption): re-supporting roles when creating test users

### DIFF
--- a/packages/node_modules/@webex/test-users/src/index.js
+++ b/packages/node_modules/@webex/test-users/src/index.js
@@ -123,7 +123,9 @@ function requestWithAuth(options) {
  * @property {string} [emailAddress]
  * @property {Array.<string>} entitlements
  * @property {string} [scope] defaults to WEBEX_SCOPE
+ * @property {string} [roles] defaults to []
  * @property {boolean} authCodeOnly generates auth_code
+ * @property {string} orgId defaults to undefined
  */
 
 /**
@@ -187,7 +189,9 @@ export function createTestUser(options = {}) {
       'webExSquared'
     ],
     scopes: options.scope || process.env.WEBEX_SCOPE,
-    authCodeOnly: options.authCodeOnly
+    roles: options.roles || [],
+    authCodeOnly: options.authCodeOnly,
+    orgId: options.orgId
   };
 
   return requestWithAuth({


### PR DESCRIPTION
# Pull Request Template

## Description

Looks like a recent move away from the test-legacy-user module for creating test users broke these tests as the new approach lacked support for **roles** and **orgId**.

https://github.com/webex/webex-js-sdk/commit/58dd59738fcbf4f46ff50e45ca55f5b457b98c62

Since the above commit these tests would have failed. I'm not familiar enough with the system to know why they did not block commits, etc.

Fixes # (issue)

      5 failing

      1) Encryption
           #onBehalfOf
             getKey:
         KmsError: Request id eb75e621-5467-4b0b-be7d-ed32de4d9e29 user 917e4c88-38a1-4688-9881-517bcc6ccd74 doesn't have permission to do operation on behalf of another user bc5c370b-071d-421b-8490-b791b1f3dd63
    KMS_RESPONSE_STATUS: 403
    KMS_REQUEST_ID: 8a834c47-473c-48e9-9b7e-c36310d360ee

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Fixing some tests that were reported as broken. The following test is still being reported as failing but it is unrelated to this area as far as I know.

      39 passing (2m)
      2 failing

      1) Encryption
           KMS
             when ecdhe negotiation times out
               when ecdhe is renegotiated
                 limits the number of retries:
         KmsTimeoutError: The KMS did not respond within 400 milliseconds
    KMS_REQUEST: update /ping
    KMS_REQUEST_ID: 5470ada7-197f-4973-b93a-161664564e9c
        at KmsTimeoutError.ExtendableBuiltin (packages/node_modules/@webex/common/dist/exception.js:52:44)
        at KmsTimeoutError.Exception (packages/node_modules/@webex/common/dist/exception.js:99:142)
        at KmsTimeoutError.KmsError (packages/node_modules/@webex/internal-plugin-encryption/dist/kms-errors.js:56:123)
        at new KmsTimeoutError (packages/node_modules/@webex/internal-plugin-encryption/dist/kms-errors.js:115:137)
        at Timeout.<anonymous> (packages/node_modules/@webex/internal-plugin-encryption/dist/kms-batcher.js:78:40)

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
