### PR TITLE
feat: pass through default device headers

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
@@ -537,7 +537,7 @@ const Device = WebexPlugin.extend({
       return this.refresh();
     }
 
-    const body = this.config.defaults;
+    const body = omit(this.config.defaults, 'headers');
 
     if (this.config.ephemeral) {
       body.ttl = this.config.ephemeralDeviceTTL;

--- a/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
@@ -2,14 +2,16 @@
  * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
  */
 
+import util from 'util';
+import Url from 'url';
+
 import {oneFlight} from '@webex/common';
 import {safeSetTimeout} from '@webex/common-timers';
 import {omit, find} from 'lodash';
-import util from 'util';
+import {persist, waitForValue, WebexPlugin} from '@webex/webex-core';
+
 import FeaturesModel from './features-model';
 import ServiceCollection from './service-collection';
-import {persist, waitForValue, WebexPlugin} from '@webex/webex-core';
-import Url from 'url';
 
 
 /**
@@ -481,6 +483,8 @@ const Device = WebexPlugin.extend({
 @oneFlight
 @waitForValue('@')
   refresh() {
+    let headers;
+
     this.logger.info('device: refreshing');
 
     if (!this.registered) {
@@ -495,10 +499,15 @@ const Device = WebexPlugin.extend({
       body.ttl = this.config.ephemeralDeviceTTL;
     }
 
+    if (this.config.defaults && this.config.defaults.headers) {
+      headers = this.config.defaults.headers;
+    }
+
     return this.request({
       method: 'PUT',
       uri: this.url,
-      body
+      body,
+      headers
     })
       .then((res) => this._processRegistrationSuccess(res))
       .catch((reason) => {
@@ -518,9 +527,10 @@ const Device = WebexPlugin.extend({
 @oneFlight
 @waitForValue('@')
   register() {
-  /* eslint no-invalid-this: [0] */
-    this.logger.info('device: registering');
+    let headers;
 
+    /* eslint no-invalid-this: [0] */
+    this.logger.info('device: registering');
     if (this.registered) {
       this.logger.info('device: device already registered, refreshing');
 
@@ -533,11 +543,16 @@ const Device = WebexPlugin.extend({
       body.ttl = this.config.ephemeralDeviceTTL;
     }
 
+    if (this.config.defaults && this.config.defaults.headers) {
+      headers = this.config.defaults.headers;
+    }
+
     return this.request({
       method: 'POST',
       service: 'wdm',
       resource: 'devices',
-      body
+      body,
+      headers
     })
       .then((res) => this._processRegistrationSuccess(res));
   },

--- a/packages/node_modules/@webex/internal-plugin-wdm/test/unit/spec/device.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/test/unit/spec/device.js
@@ -3,7 +3,7 @@
  */
 
 import {assert} from '@webex/test-helper-chai';
-import {cloneDeep} from 'lodash';
+import {cloneDeep, assign} from 'lodash';
 import MockWebex from '@webex/test-helper-mock-webex';
 import sinon from 'sinon';
 import Device from '@webex/internal-plugin-wdm';
@@ -399,6 +399,34 @@ describe('plugin-wdm', () => {
 
             return device.refresh()
               .then(() => assert.calledOnce(device.register));
+          });
+
+          it('registers the device with custom headers', () => {
+            const {request} = device.webex;
+
+
+            sinon.spy(device, 'register');
+            device.unset('url');
+            device.config.defaults = assign(device.config.defaults, {
+              headers: {
+                'my-custom-header': true
+              }
+            });
+
+            assert.notCalled(device.register);
+
+            return device.refresh()
+              .then(() => {
+                assert.calledOnce(device.register);
+                assert.calledWithMatch(request, {
+                  headers: {
+                    'my-custom-header': true
+                  },
+                  method: 'POST',
+                  resource: 'devices',
+                  service: 'wdm'
+                });
+              });
           });
         });
 


### PR DESCRIPTION
# Pull Request Template

## Description

This change allows us to pass additional default headers for the device registration and refresh. This is required by WDM for EU users as they will not return the correct serviceHostMap via WDM as they expect everyone to be using u2c going forward. 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage
I ran `npm test -- --packages @webex/internal-plugin-wdm` and the unit tests passed. 

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
