### PR TITLE
Add proxy support for mercury web socket connections

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-mercury/README.md
+++ b/packages/node_modules/@webex/internal-plugin-mercury/README.md
@@ -31,6 +31,28 @@ webex.internal.mercury.WHATEVER
 
 ```
 
+## Using A Proxy Agent To Open A Websocket Connection
+
+For consumers who are not using the SDK via the browser it may be necessary to configure a proxy agent in order to connect with Mercury and open a Websocket in a proxy environment.
+
+This can be done by configuring an agent as part of a DefaultMercuryOptions config object as shown below. The agent object will then be injected into the SDK and used in the Mercury plugin during WebSocket construction as an option property, allowing a connection to be established via the specified proxy url.
+
+```js
+const webex = require(`webex`);
+const HttpsProxyAgent = require('https-proxy-agent');
+
+let httpsProxyAgent = new HttpsProxyAgent(url.parse(proxyUrl));
+
+webex.init({
+	config: {
+	  defaultMercuryOptions: {
+		agent: httpsProxyAgent
+	  },
+	 ...
+	}
+});
+```
+
 ## Maintainers
 
 This package is maintained by [Cisco Webex for Developers](https://developer.webex.com/).

--- a/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js
@@ -104,7 +104,7 @@ const Mercury = WebexPlugin.extend({
   },
 
   _applyOverrides(event) {
-    if (!event.headers) {
+    if (!event || !event.headers) {
       return;
     }
     const headerKeys = Object.keys(event.headers);
@@ -167,14 +167,22 @@ const Mercury = WebexPlugin.extend({
       .then(([webSocketUrl, token]) => {
         attemptWSUrl = webSocketUrl;
 
-        return socket.open(webSocketUrl, {
+        const options = {
           forceCloseDelay: this.config.forceCloseDelay,
           pingInterval: this.config.pingInterval,
           pongTimeout: this.config.pongTimeout,
           token: token.toString(),
           trackingId: `${this.webex.sessionId}_${Date.now()}`,
           logger: this.logger
-        });
+        };
+
+        // if a proxy agent has been configured we will add it here to successfully open a websocket
+        if (this.webex.config.defaultMercuryOptions && this.webex.config.defaultMercuryOptions.agent) {
+          this.logger.info('mercury: setup proxy agent');
+          options.agent = this.webex.config.defaultMercuryOptions.agent;
+        }
+
+        return socket.open(webSocketUrl, options);
       })
       .then(() => {
         this.socket = socket;

--- a/packages/node_modules/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -193,7 +193,7 @@ export default class Socket extends EventEmitter {
       const WebSocket = Socket.getWebSocketConstructor();
 
       this.logger.info('socket: creating WebSocket');
-      const socket = new WebSocket(url);
+      const socket = new WebSocket(url, [], options);
 
       socket.binaryType = 'arraybuffer';
       socket.onmessage = this.onmessage;

--- a/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/mercury-events.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/mercury-events.js
@@ -166,8 +166,12 @@ describe('plugin-mercury', () => {
               assert.isFalse(mercury.connected, 'Mercury has not yet connected');
               assert.notCalled(onlineSpy);
               assert.lengthOf(spy.args, 0, 'The client has not yet sent the auth message');
+              // set websocket readystate to 1 to allow a successful send message
+              mockWebSocket.readyState = 1;
+              mockWebSocket.emit('open');
               mockWebSocket.emit('message', {
                 data: JSON.stringify({
+                  id: uuid.v4(),
                   data: {
                     eventType: 'mercury.buffer_state'
                   }
@@ -428,13 +432,19 @@ describe('plugin-mercury', () => {
               mockWebSocket.emit('message', {
                 data: JSON.stringify({
                   sequenceNumber: 2,
-                  id: 'mockid'
+                  id: 'mockid',
+                  data: {
+                    eventType: 'mercury.buffer_state'
+                  }
                 })
               });
               mockWebSocket.emit('message', {
                 data: JSON.stringify({
                   sequenceNumber: 4,
-                  id: 'mockid'
+                  id: 'mockid',
+                  data: {
+                    eventType: 'mercury.buffer_state'
+                  }
                 })
               });
               assert.called(spy);

--- a/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -402,6 +402,46 @@ describe('plugin-mercury', () => {
       });
     });
 
+    describe('Websocket proxy agent', () => {
+      afterEach(() => {
+        delete webex.config.defaultMercuryOptions;
+      });
+
+      it('connects to Mercury using proxy agent', () => {
+        const testProxyUrl = 'http://proxyurl.com:80';
+
+        webex.config.defaultMercuryOptions = {agent: {proxy: {href: testProxyUrl}}};
+        const promise = mercury.connect();
+
+        assert.isFalse(mercury.connected, 'Mercury is not connected');
+        assert.isTrue(mercury.connecting, 'Mercury is connecting');
+        mockWebSocket.open();
+
+        return promise
+          .then(() => {
+            assert.isTrue(mercury.connected, 'Mercury is connected');
+            assert.isFalse(mercury.connecting, 'Mercury is not connecting');
+            assert.calledWith(socketOpenStub, sinon.match(/ws:\/\/example.com/), sinon.match.has('agent',
+              sinon.match.has('proxy', sinon.match.has('href', testProxyUrl))));
+          });
+      });
+
+      it('connects to Mercury without proxy agent', () => {
+        const promise = mercury.connect();
+
+        assert.isFalse(mercury.connected, 'Mercury is not connected');
+        assert.isTrue(mercury.connecting, 'Mercury is connecting');
+        mockWebSocket.open();
+
+        return promise
+          .then(() => {
+            assert.isTrue(mercury.connected, 'Mercury is connected');
+            assert.isFalse(mercury.connecting, 'Mercury is not connecting');
+            assert.calledWith(socketOpenStub, sinon.match(/ws:\/\/example.com/), sinon.match({agent: undefined}));
+          });
+      });
+    });
+
     describe('#disconnect()', () => {
       it('disconnects the WebSocket', () => mercury.connect()
         .then(() => {
@@ -433,6 +473,8 @@ describe('plugin-mercury', () => {
             assert.isFalse(mercury.connecting, 'Mercury is not connecting');
 
             assert.notCalled(spy);
+            mockWebSocket.readyState = 1;
+            mockWebSocket.emit('open');
             mockWebSocket.emit('message', {data: statusStartTypingMessage});
           })
           .then(() => {
@@ -440,6 +482,8 @@ describe('plugin-mercury', () => {
 
             const promise = mercury.disconnect();
 
+            mockWebSocket.readyState = 1;
+            mockWebSocket.emit('open');
             mockWebSocket.emit('message', {data: statusStartTypingMessage});
             mockWebSocket.emit('close', {
               code: 1000,
@@ -451,6 +495,8 @@ describe('plugin-mercury', () => {
           })
 
           .then(() => {
+            mockWebSocket.readyState = 1;
+            mockWebSocket.emit('open');
             mockWebSocket.emit('message', {data: statusStartTypingMessage});
             assert.calledOnce(spy);
           });

--- a/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/socket.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/socket.js
@@ -128,6 +128,7 @@ describe('plugin-mercury', () => {
 
         mockWebSocket.emit('message', {
           data: JSON.stringify({
+            id: uuid.v4(),
             data: {
               eventType: 'mercury.buffer_state'
             }
@@ -387,6 +388,7 @@ describe('plugin-mercury', () => {
           mockWebSocket.emit('open');
           mockWebSocket.emit('message', {
             data: JSON.stringify({
+              id: uuid.v4(),
               data: {
                 eventType: 'mercury.buffer_state'
               }
@@ -405,6 +407,7 @@ describe('plugin-mercury', () => {
           mockWebSocket.emit('open');
           mockWebSocket.emit('message', {
             data: JSON.stringify({
+              id: uuid.v4(),
               data: {
                 eventType: 'mercury.registration_status'
               }
@@ -449,6 +452,7 @@ describe('plugin-mercury', () => {
         mockWebSocket.emit('open');
         mockWebSocket.emit('message', {
           data: JSON.stringify({
+            id: uuid.v4(),
             data: {
               eventType: 'mercury.buffer_state'
             }

--- a/packages/node_modules/@webex/test-helper-mock-web-socket/src/index.js
+++ b/packages/node_modules/@webex/test-helper-mock-web-socket/src/index.js
@@ -33,7 +33,7 @@ function noop() {}
   * @returns {MockWebSocket}
   */
 export default class MockWebSocket extends EventEmitter {
-  constructor(url, protocol = [], option = {}) {
+  constructor(url, protocol = [], options = {}) {
     super();
     this.url = url;
     this.protocol = protocol;

--- a/packages/node_modules/@webex/test-helper-mock-web-socket/src/index.js
+++ b/packages/node_modules/@webex/test-helper-mock-web-socket/src/index.js
@@ -33,9 +33,11 @@ function noop() {}
   * @returns {MockWebSocket}
   */
 export default class MockWebSocket extends EventEmitter {
-  constructor(url) {
+  constructor(url, protocol = [], option = {}) {
     super();
     this.url = url;
+    this.protocol = protocol;
+    this.options = options;
 
     sinon.spy(this, 'send');
     sinon.spy(this, 'close');
@@ -94,6 +96,7 @@ export default class MockWebSocket extends EventEmitter {
     process.nextTick(() => {
       this.emit('message', {
         data: JSON.stringify({
+          id: 'mockid',
           data: {
             eventType: 'mercury.buffer_state'
           }


### PR DESCRIPTION
# Pull Request Template

## Description

When testing our ediscovery downloader client on a dedicated proxy test environment we found that we could not establish a connection to mercury to open a web socket. In order to fix this we had to add a https proxy agent, configure it with the proxy url (which we have set as HTTPS_PROXY to enable proxy support in the http request module) and pass it as an option to the WS websocket constructor.

Fixes # (issue)

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-96966

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

All mercury tests were run (npm test — —packages @webex/internal-plugin-Mercury) and 4 new tests were added to cover the http(s) proxy agent 

**Test Configuration**:
* SDK Version 1.80.25
* Node/Browser Version 10.13.0
* NPM Version 6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules