### PR TITLE
feat(encryption): add blocking qualifiers in client on file download

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-encryption/src/encryption.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/src/encryption.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
  */
 
+import {EventEmitter} from 'events';
+
 import {WebexPlugin} from '@webex/webex-core';
 import {proxyEvents, tap, transferEvents} from '@webex/common';
-import {EventEmitter} from 'events';
 import jose from 'node-jose';
 import SCR from 'node-scr';
-import ensureBuffer from './ensure-buffer';
 
+import ensureBuffer from './ensure-buffer';
 import KMS from './kms';
 
 const Encryption = WebexPlugin.extend({
@@ -65,14 +66,21 @@ const Encryption = WebexPlugin.extend({
         .then((result) => result.plaintext.toString()));
   },
 
-  download(scr) {
+  /**
+   * Validate and initiate a Download request for requested file
+   *
+   * @param {Object} scr - Plaintext
+   * @param {Object} options - optional paramaters to download a file
+   * @returns {promise}
+   */
+  download(scr, options) {
     /* istanbul ignore if */
     if (!scr.loc) {
       return Promise.reject(new Error('`scr.loc` is required'));
     }
 
     const shunt = new EventEmitter();
-    const promise = this._fetchDownloadUrl(scr)
+    const promise = this._fetchDownloadUrl(scr, options)
       .then((uri) => {
         const options = {
           method: 'GET',
@@ -93,7 +101,14 @@ const Encryption = WebexPlugin.extend({
     return promise;
   },
 
-  _fetchDownloadUrl(scr) {
+  /**
+   * Fetch Download URL for the requested file
+   *
+   * @param {Object} scr - Plaintext
+   * @param {Object} options - optional paramaters to download a file
+   * @returns {promise} url of the downloadable file
+   */
+  _fetchDownloadUrl(scr, options) {
     this.logger.info('encryption: retrieving download url for encrypted file');
 
     if (process.env.NODE_ENV !== 'production' && scr.loc.includes('localhost')) {
@@ -102,15 +117,18 @@ const Encryption = WebexPlugin.extend({
       return Promise.resolve(scr.loc);
     }
 
+    const inputBody = {
+      endpoints: [scr.loc]
+    };
+
     return this.request({
       method: 'POST',
       service: 'files',
       resource: 'download/endpoints',
-      body: {
-        endpoints: [
-          scr.loc
-        ]
-      }
+      body: options ? {
+        ...inputBody,
+        allow: options.params.allow
+      } : inputBody
     })
       .then((res) => {
         const url = res.body.endpoints[scr.loc];

--- a/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/encryption.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/encryption.js
@@ -173,6 +173,53 @@ describe('Encryption', function () {
           .on('progress', spy))
         .then(() => assert.called(spy));
     });
+
+    it('checks body of the API call /downloads/endpoints', () => webex.internal.encryption.encryptBinary(FILE)
+      .then(({scr, cdata}) => webex.request({
+        method: 'POST',
+        uri: makeLocalUrl('/files/upload'),
+        body: cdata
+      })
+        .then((res) => {
+          scr.loc = makeLocalUrl(res.body.loc, {full: true});
+
+          return webex.internal.encryption.encryptScr(key, scr);
+        }))
+      .then((cipherScr) => webex.internal.encryption.decryptScr(key, cipherScr))
+      .then((scr) => {
+        const options = {
+          params: {
+            allow: ['unchecked', 'evaluating']
+          }
+        };
+
+        return webex.internal.encryption.download(scr, options);
+      })
+      .then((f) => file.isMatchingFile(f, FILE))
+      .then((result) => assert.deepEqual(result, true)));
+
+    it('checks _fetchDownloadUrl()', () => webex.internal.encryption.encryptBinary(FILE)
+      .then(({scr, cdata}) => webex.request({
+        method: 'POST',
+        uri: makeLocalUrl('/files/upload'),
+        body: cdata
+      })
+        .then((res) => {
+          scr.loc = makeLocalUrl(res.body.loc, {full: true});
+
+          return webex.internal.encryption.encryptScr(key, scr);
+        }))
+      .then((cipherScr) => webex.internal.encryption.decryptScr(key, cipherScr))
+      .then((scr) => {
+        const options = {
+          params: {
+            allow: ['unchecked', 'evaluating']
+          }
+        };
+
+        return webex.internal.encryption._fetchDownloadUrl(scr, options);
+      })
+      .then((result) => assert.isString(result)));
   });
 
   describe('#encryptBinary()', () => {


### PR DESCRIPTION
# Pull Request Template

## Description

For POST /download/endpoints the parameter with allow=unchecked should be put into the request body as an array. This will allow unscanned files to be downloaded without a warning, but files currently being scanned or already determined to be infected will evoke 423 or 410 responses.

If the client is using the Files APIs to download thumbnails or preview pages, then need to add "allow=unchecked, evaluating" in the new field in the POST body accordingly.

Fixes #SPARK-99531

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Wrote two new test cases to test download for a file. One test case is written for download function where as another for the _fetchDownloadUrl() function.

**Test Configuration**:
* SDK Version: 1.80.29
* Node/Browser Version: 1.80.29
* NPM Version: 6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
