### PR TITLE
Spark 102791/append additional cluster info

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/lib/services/service-catalog.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/service-catalog.js
@@ -15,8 +15,8 @@ const ServiceCatalog = AmpState.extend({
     serviceGroups: ['object', true, (() => ({
       discovery: [],
       preauth: [],
-      postauth: [],
-      signin: []
+      signin: [],
+      postauth: []
     }))],
     status: ['object', true, (() => ({
       discovery: {
@@ -57,6 +57,21 @@ const ServiceCatalog = AmpState.extend({
       ];
 
     return serviceUrls.find((serviceUrl) => serviceUrl.name === name);
+  },
+
+  /**
+   * @private
+   * Generate an array of `ServiceUrl`s that is organized from highest auth
+   * level to lowest auth level.
+   * @returns {Array<ServiceUrl>} - array of `ServiceUrl`s
+   */
+  _listServiceUrls() {
+    return [
+      ...this.serviceGroups.postauth,
+      ...this.serviceGroups.signin,
+      ...this.serviceGroups.preauth,
+      ...this.serviceGroups.discovery
+    ];
   },
 
   /**
@@ -120,14 +135,14 @@ const ServiceCatalog = AmpState.extend({
       for (const service of this.serviceGroups[key]) {
         serviceUrlObj = Url.parse(service.defaultUrl);
 
-        if (serviceUrlObj.host === incomingUrlObj.host &&
+        if (serviceUrlObj.hostname === incomingUrlObj.hostname &&
           service.hosts.length > 0) {
           clusterId = service.hosts[0].id;
           break;
         }
 
         for (const host of service.hosts) {
-          if (incomingUrlObj.host === host.host && host.id) {
+          if (incomingUrlObj.hostname === host.host && host.id) {
             clusterId = host.id;
             break;
           }
@@ -150,7 +165,7 @@ const ServiceCatalog = AmpState.extend({
    * Services plugin methods.
    * @param {object} params
    * @param {string} params.clusterId - clusterId of found service
-   * @param {boolean} [params.priorityHost] - returns priority host url if true
+   * @param {boolean} [params.priorityHost = true] - returns priority host url if true
    * @param {string} [params.serviceGroup] - specify service group
    * @returns {object} service
    * @returns {string} service.name
@@ -158,12 +173,11 @@ const ServiceCatalog = AmpState.extend({
    */
   findServiceFromClusterId({clusterId, priorityHost = true, serviceGroup} = {}) {
     const serviceUrls = (typeof serviceGroup === 'string') ?
-      this.serviceGroups[serviceGroup] || [] :
-      [
-        ...this.serviceGroups.discovery,
-        ...this.serviceGroups.preauth,
+      this.serviceGroups[serviceGroup] || [] : [
+        ...this.serviceGroups.postauth,
         ...this.serviceGroups.signin,
-        ...this.serviceGroups.postauth
+        ...this.serviceGroups.preauth,
+        ...this.serviceGroups.discovery
       ];
 
     const identifiedServiceUrl = serviceUrls.find(
@@ -198,11 +212,12 @@ const ServiceCatalog = AmpState.extend({
 
     return serviceUrls.find(
       (serviceUrl) => {
-        if (incomingUrlObj.host === Url.parse(serviceUrl.defaultUrl).host) {
+        if (incomingUrlObj.hostname ===
+          Url.parse(serviceUrl.defaultUrl).hostname) {
           return true;
         }
 
-        if (serviceUrl.hosts.find((host) => host.host === incomingUrlObj.host)) {
+        if (serviceUrl.hosts.find((host) => host.host === incomingUrlObj.hostname)) {
           return true;
         }
 

--- a/packages/node_modules/@webex/webex-core/src/lib/services/service-url.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/service-url.js
@@ -24,7 +24,9 @@ const ServiceUrl = AmpState.extend({
   _generateHostUrl(hostUri) {
     const url = Url.parse(this.defaultUrl);
 
-    url.host = hostUri;
+    // setting url.hostname will not apply during Url.format(), set host via
+    // a string literal instead.
+    url.host = `${hostUri}${url.port ? `:${url.port}` : ''}`;
 
     return Url.format(url);
   },
@@ -52,7 +54,8 @@ const ServiceUrl = AmpState.extend({
     }
 
     return this._generateHostUrl(this.hosts.reduce((previous, current) => (
-      previous.priority > current.priority ? current : previous
+      (previous.priority > current.priority || !previous.homeCluster) ?
+        current : previous
     )).host);
   },
 
@@ -70,8 +73,8 @@ const ServiceUrl = AmpState.extend({
       return true;
     }
 
-    const {host} = Url.parse(url);
-    const foundHost = this.hosts.find((hostObj) => hostObj.host === host);
+    const {hostname} = Url.parse(url);
+    const foundHost = this.hosts.find((hostObj) => hostObj.host === hostname);
 
     this.hosts.splice(this.hosts.indexOf(foundHost), 1);
 

--- a/packages/node_modules/@webex/webex-core/src/lib/services/services.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/services.js
@@ -327,20 +327,68 @@ const Services = WebexPlugin.extend({
    * @returns {object}
    */
   _formatReceivedHostmap(serviceHostmap) {
-    const output = [];
-    let item = {};
+    // map the host catalog items to a formatted hostmap
+    const formattedHostmap = Object.keys(serviceHostmap.hostCatalog).reduce(
+      (accumulator, key) => {
+        if (serviceHostmap.hostCatalog[key].length === 0) {
+          return accumulator;
+        }
 
+        const serviceName = serviceHostmap.hostCatalog[key][0].id.split(':')[3];
+        const defaultUrl = serviceHostmap.serviceLinks[serviceName];
+
+        let serviceItem = accumulator.find(
+          (item) => item.name === serviceName
+        );
+
+        if (!serviceItem) {
+          serviceItem = {
+            name: serviceName,
+            defaultUrl,
+            defaultHost: Url.parse(defaultUrl).hostname,
+            hosts: []
+          };
+
+          accumulator.push(serviceItem);
+        }
+
+        serviceItem.hosts.push(
+          // map the default key as a low priority default for cluster matching
+          {
+            host: key,
+            ttl: -1,
+            priority: 10,
+            id: serviceHostmap.hostCatalog[key][0].id,
+            homeCluster: serviceItem.defaultHost === key
+          },
+          // map the rest of the hosts in their proper locations
+          ...serviceHostmap.hostCatalog[key].map(
+            (host) => ({
+              ...host,
+              homeCluster: serviceItem.defaultHost === key
+            })
+          )
+        );
+
+        return accumulator;
+      }, []
+    );
+
+    // append service links that do not exist in the host catalog
     Object.keys(serviceHostmap.serviceLinks).forEach((key) => {
-      item = {};
+      const service = formattedHostmap.find((item) => item.name === key);
 
-      item.name = key;
-      item.defaultUrl = serviceHostmap.serviceLinks[key];
-      item.hosts = serviceHostmap.hostCatalog[Url.parse(item.defaultUrl).host];
-
-      output.push(item);
+      if (!service) {
+        formattedHostmap.push({
+          name: key,
+          defaultUrl: serviceHostmap.serviceLinks[key],
+          defaultHost: Url.parse(serviceHostmap.serviceLinks[key]).hostname,
+          hosts: []
+        });
+      }
     });
 
-    return output;
+    return formattedHostmap;
   },
 
   /**

--- a/packages/node_modules/@webex/webex-core/test/integration/spec/services/service-catalog.js
+++ b/packages/node_modules/@webex/webex-core/test/integration/spec/services/service-catalog.js
@@ -21,7 +21,7 @@ describe('webex-core', () => {
       .then(([user]) => new Promise((resolve) => {
         setTimeout(() => {
           webexUser = user;
-          webex = new WebexCore({credentials: {supertoken: user.token}});
+          webex = new WebexCore({credentials: user.token});
           services = webex.internal.services;
           catalog = services._getCatalog();
           resolve();
@@ -95,16 +95,18 @@ describe('webex-core', () => {
               host: 'www.example-p5.com',
               ttl: -1,
               priority: 5,
-              id: 'exampleClusterId'
+              homeCluster: true,
+              id: '0:0:0:exampleClusterIdFind'
             },
             {
               host: 'www.example-p3.com',
               ttl: -1,
               priority: 3,
-              id: 'exampleClusterId'
+              homeCluster: true,
+              id: '0:0:0:exampleClusterIdFind'
             }
           ],
-          name: 'exampleValid'
+          name: 'exampleClusterIdFind'
         };
         testUrl = new ServiceUrl({...testUrlTemplate});
         catalog._loadServiceUrls('preauth', [testUrl]);
@@ -150,16 +152,16 @@ describe('webex-core', () => {
               host: 'www.example-p5.com',
               ttl: -1,
               priority: 5,
-              id: 'exampleClusterId'
+              id: '0:0:0:example-test'
             },
             {
               host: 'www.example-p3.com',
               ttl: -1,
               priority: 3,
-              id: 'exampleClusterId'
+              id: '0:0:0:example-test'
             }
           ],
-          name: 'exampleValid'
+          name: 'example-test'
         };
         testUrl = new ServiceUrl({...testUrlTemplate});
         catalog._loadServiceUrls('preauth', [testUrl]);
@@ -186,7 +188,7 @@ describe('webex-core', () => {
         });
 
         assert.equal(serviceFound.name, testUrl.name);
-        assert.equal(serviceFound.url, catalog.get('exampleValid', true));
+        assert.equal(serviceFound.url, catalog.get(testUrl.name, true));
       });
 
       it('finds a valid service when a service group is defined', () => {
@@ -383,12 +385,16 @@ describe('webex-core', () => {
             {
               host: 'www.example-p5.com',
               ttl: -1,
-              priority: 5
+              priority: 5,
+              id: '0:0:0:exampleValid',
+              homeCluster: true
             },
             {
               host: 'www.example-p3.com',
               ttl: -1,
-              priority: 3
+              priority: 3,
+              id: '0:0:0:exampleValid',
+              homeCluster: true
             }
           ],
           name: 'exampleValid'
@@ -544,19 +550,64 @@ describe('webex-core', () => {
           },
           hostCatalog: {
             'example-a.com': [
-              {host: 'example-a-1.com', ttl: -1, priority: 5},
-              {host: 'example-a-2.com', ttl: -1, priority: 3},
-              {host: 'example-a-3.com', ttl: -1, priority: 1}
+              {
+                host: 'example-a-1.com',
+                ttl: -1,
+                priority: 5,
+                id: '0:0:0:example-a'
+              },
+              {
+                host: 'example-a-2.com',
+                ttl: -1,
+                priority: 3,
+                id: '0:0:0:example-a'
+              },
+              {
+                host: 'example-a-3.com',
+                ttl: -1,
+                priority: 1,
+                id: '0:0:0:example-a'
+              }
             ],
             'example-b.com': [
-              {host: 'example-b-1.com', ttl: -1, priority: 5},
-              {host: 'example-b-2.com', ttl: -1, priority: 3},
-              {host: 'example-b-3.com', ttl: -1, priority: 1}
+              {
+                host: 'example-b-1.com',
+                ttl: -1,
+                priority: 5,
+                id: '0:0:0:example-b'
+              },
+              {
+                host: 'example-b-2.com',
+                ttl: -1,
+                priority: 3,
+                id: '0:0:0:example-b'
+              },
+              {
+                host: 'example-b-3.com',
+                ttl: -1,
+                priority: 1,
+                id: '0:0:0:example-b'
+              }
             ],
             'example-c.com': [
-              {host: 'example-c-1.com', ttl: -1, priority: 5},
-              {host: 'example-c-2.com', ttl: -1, priority: 3},
-              {host: 'example-c-3.com', ttl: -1, priority: 1}
+              {
+                host: 'example-c-1.com',
+                ttl: -1,
+                priority: 5,
+                id: '0:0:0:example-c'
+              },
+              {
+                host: 'example-c-2.com',
+                ttl: -1,
+                priority: 3,
+                id: '0:0:0:example-c'
+              },
+              {
+                host: 'example-c-3.com',
+                ttl: -1,
+                priority: 1,
+                id: '0:0:0:example-c'
+              }
             ]
           },
           format: 'hostmap'
@@ -600,19 +651,37 @@ describe('webex-core', () => {
           },
           hostCatalog: {
             'example-a.com': [
-              {host: 'example-a-1.com', ttl: -1, priority: 5},
-              {host: 'example-a-2.com', ttl: -1, priority: 3},
-              {host: 'example-a-3.com', ttl: -1, priority: 1}
+              {
+                host: 'example-a-1.com', ttl: -1, priority: 5, id: '0:0:0:example-a'
+              },
+              {
+                host: 'example-a-2.com', ttl: -1, priority: 3, id: '0:0:0:example-a'
+              },
+              {
+                host: 'example-a-3.com', ttl: -1, priority: 1, id: '0:0:0:example-a'
+              }
             ],
             'example-b.com': [
-              {host: 'example-b-1.com', ttl: -1, priority: 5},
-              {host: 'example-b-2.com', ttl: -1, priority: 3},
-              {host: 'example-b-3.com', ttl: -1, priority: 1}
+              {
+                host: 'example-b-1.com', ttl: -1, priority: 5, id: '0:0:0:example-b'
+              },
+              {
+                host: 'example-b-2.com', ttl: -1, priority: 3, id: '0:0:0:example-b'
+              },
+              {
+                host: 'example-b-3.com', ttl: -1, priority: 1, id: '0:0:0:example-b'
+              }
             ],
             'example-c.com': [
-              {host: 'example-c-1.com', ttl: -1, priority: 5},
-              {host: 'example-c-2.com', ttl: -1, priority: 3},
-              {host: 'example-c-3.com', ttl: -1, priority: 1}
+              {
+                host: 'example-c-1.com', ttl: -1, priority: 5, id: '0:0:0:example-c'
+              },
+              {
+                host: 'example-c-2.com', ttl: -1, priority: 3, id: '0:0:0:example-c'
+              },
+              {
+                host: 'example-c-3.com', ttl: -1, priority: 1, id: '0:0:0:example-c'
+              }
             ]
           },
           format: 'hostmap'
@@ -637,14 +706,18 @@ describe('webex-core', () => {
       });
 
       it('updates any existing ServiceUrls', () => {
-        const newServiceHM = {...serviceHostmap};
-
-        newServiceHM.serviceLinks['example-a'] = 'https://e-a.com/api/v1';
-        newServiceHM.serviceLinks['example-b'] = 'https://e-b.com/api/v1';
-        newServiceHM.serviceLinks['example-c'] = 'https://e-c.com/api/v1';
-        newServiceHM.hostCatalog['example-a'] = [];
-        newServiceHM.hostCatalog['example-b'] = [];
-        newServiceHM.hostCatalog['example-c'] = [];
+        const newServiceHM = {
+          serviceLinks: {
+            'example-a': 'https://e-a.com/api/v1',
+            'example-b': 'https://e-b.com/api/v1',
+            'example-c': 'https://e-c.com/api/v1'
+          },
+          hostCatalog: {
+            'e-a.com': [],
+            'e-b.com': [],
+            'e-c.com': []
+          }
+        };
 
         const newFormattedHM = services._formatReceivedHostmap(newServiceHM);
 
@@ -685,14 +758,18 @@ describe('webex-core', () => {
       });
 
       it('creates an array with matching host data', () => {
-        let foundFormatted;
-
         Object.keys(serviceHostmap.hostCatalog).forEach((key) => {
-          foundFormatted = formattedHM.find(
-            (entry) => entry.defaultUrl.includes(key)
+          const hostGroup = serviceHostmap.hostCatalog[key];
+
+          const foundMatch = hostGroup.every(
+            (inboundHost) => formattedHM.find(
+              (formattedService) => formattedService.hosts.find(
+                (formattedHost) => formattedHost.host === inboundHost.host
+              )
+            )
           );
 
-          assert.equal(foundFormatted.hosts, serviceHostmap.hostCatalog[key]);
+          assert.isTrue(foundMatch, `did not find matching host data for the \`${key}\` host group.`);
         });
       });
 

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/service-url.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/service-url.js
@@ -21,11 +21,41 @@ describe('webex-core', () => {
       template = {
         defaultUrl: 'https://example.com/api/v1',
         hosts: [
-          {host: 'example-host-p1.com', priority: 1, ttl: -1},
-          {host: 'example-host-p2.com', priority: 2, ttl: -1},
-          {host: 'example-host-p3.com', priority: 3, ttl: -1},
-          {host: 'example-host-p4.com', priority: 4, ttl: -1},
-          {host: 'example-host-p5.com', priority: 5, ttl: -1}
+          {
+            host: 'example-host-p1.com',
+            priority: 1,
+            ttl: -1,
+            id: '1',
+            homeCluster: false
+          },
+          {
+            host: 'example-host-p2.com',
+            priority: 2,
+            ttl: -1,
+            id: '2',
+            homeCluster: false
+          },
+          {
+            host: 'example-host-p3.com',
+            priority: 3,
+            ttl: -1,
+            id: '3',
+            homeCluster: true
+          },
+          {
+            host: 'example-host-p4.com',
+            priority: 4,
+            ttl: -1,
+            id: '4',
+            homeCluster: true
+          },
+          {
+            host: 'example-host-p5.com',
+            priority: 5,
+            ttl: -1,
+            id: '5',
+            homeCluster: true
+          }
         ],
         name: 'example'
       };
@@ -98,14 +128,18 @@ describe('webex-core', () => {
     });
 
     describe('#_getPriorityHostUrl()', () => {
-      it('gets the highest priority url from hosts', () => {
-        const hph = serviceUrl._generateHostUrl(
+      let highPriorityHost;
+
+      before('get a high priority host manually', () => {
+        highPriorityHost = serviceUrl._generateHostUrl(
           serviceUrl.hosts.reduce((o, c) => (
-            o.priority > c.priority ? c : o
+            o.priority > c.priority || !o.homeCluster ? c : o
           )).host
         );
+      });
 
-        assert.equal(serviceUrl._getPriorityHostUrl(), hph);
+      it('validates that the retrieved high priority host matches the manually retrieved high priority host', () => {
+        assert.equal(serviceUrl._getPriorityHostUrl(), highPriorityHost);
       });
     });
 

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/services.js
@@ -61,60 +61,117 @@ describe('webex-core', () => {
           serviceLinks: {
             'example-a': 'https://example-a.com/api/v1',
             'example-b': 'https://example-b.com/api/v1',
-            'example-c': 'https://example-c.com/api/v1'
+            'example-c': 'https://example-c.com/api/v1',
+            'example-d': 'https://example-d.com/api/v1'
           },
           hostCatalog: {
             'example-a.com': [
-              {host: 'example-a-1.com', ttl: -1, priority: 5},
-              {host: 'example-a-2.com', ttl: -1, priority: 3},
-              {host: 'example-a-3.com', ttl: -1, priority: 1}
+              {
+                host: 'example-a-1.com', ttl: -1, priority: 5, id: '0:0:0:example-a'
+              },
+              {
+                host: 'example-a-2.com', ttl: -1, priority: 3, id: '0:0:0:example-a'
+              },
+              {
+                host: 'example-a-3.com', ttl: -1, priority: 1, id: '0:0:0:example-a-x'
+              }
             ],
             'example-b.com': [
-              {host: 'example-b-1.com', ttl: -1, priority: 5},
-              {host: 'example-b-2.com', ttl: -1, priority: 3},
-              {host: 'example-b-3.com', ttl: -1, priority: 1}
+              {
+                host: 'example-b-1.com', ttl: -1, priority: 5, id: '0:0:0:example-b'
+              },
+              {
+                host: 'example-b-2.com', ttl: -1, priority: 3, id: '0:0:0:example-b'
+              },
+              {
+                host: 'example-b-3.com', ttl: -1, priority: 1, id: '0:0:0:example-b-x'
+              }
             ],
             'example-c.com': [
-              {host: 'example-c-1.com', ttl: -1, priority: 5},
-              {host: 'example-c-2.com', ttl: -1, priority: 3},
-              {host: 'example-c-3.com', ttl: -1, priority: 1}
+              {
+                host: 'example-c-1.com', ttl: -1, priority: 5, id: '0:0:0:example-c'
+              },
+              {
+                host: 'example-c-2.com', ttl: -1, priority: 3, id: '0:0:0:example-c'
+              },
+              {
+                host: 'example-c-3.com', ttl: -1, priority: 1, id: '0:0:0:example-c-x'
+              }
+            ],
+            'example-d.com': [
+              {
+                host: 'example-c-1.com', ttl: -1, priority: 5, id: '0:0:0:example-d'
+              },
+              {
+                host: 'example-c-2.com', ttl: -1, priority: 3, id: '0:0:0:example-d'
+              },
+              {
+                host: 'example-c-3.com', ttl: -1, priority: 1, id: '0:0:0:example-d-x'
+              }
             ]
           },
           format: 'hostmap'
         };
+      });
+
+      it('creates a formmatted host map that contains the same amount of entries as the original received hostmap', () => {
         formattedHM = services._formatReceivedHostmap(serviceHostmap);
+
+        assert(Object.keys(serviceHostmap.serviceLinks).length >=
+          formattedHM.length, 'length is not equal or less than');
       });
 
-      it('creates an array of equal length of serviceLinks', () => {
-        assert.equal(Object.keys(serviceHostmap.serviceLinks).length,
-          formattedHM.length);
-      });
+      it.skip('creates an array of equal or less length of hostMap', () => {
+        formattedHM = services._formatReceivedHostmap(serviceHostmap);
 
-      it('creates an array of equal length of hostMap', () => {
-        assert.equal(Object.keys(serviceHostmap.hostCatalog).length,
-          formattedHM.length);
+        assert(Object.keys(serviceHostmap.hostCatalog).length >=
+          formattedHM.length, 'length is not equal or less than');
       });
 
       it('creates an array with matching url data', () => {
+        formattedHM = services._formatReceivedHostmap(serviceHostmap);
+
         formattedHM.forEach((entry) => {
           assert.equal(serviceHostmap.serviceLinks[entry.name],
             entry.defaultUrl);
         });
       });
 
-      it('creates an array with matching host data', () => {
-        let foundFormatted;
+      it('has all keys in host map hosts', () => {
+        formattedHM = services._formatReceivedHostmap(serviceHostmap);
 
-        Object.keys(serviceHostmap.hostCatalog).forEach((key) => {
-          foundFormatted = formattedHM.find(
-            (entry) => entry.defaultUrl.includes(key)
-          );
+        formattedHM.forEach((service) => {
+          service.hosts.forEach((host) => {
+            assert.hasAllKeys(host,
+              ['homeCluster', 'host', 'id', 'priority', 'ttl'], `${service.name} has an invalid host shape`);
+          });
+        });
+      });
 
-          assert.equal(foundFormatted.hosts, serviceHostmap.hostCatalog[key]);
+      it('creates a formmated host map containing all received host map service entries', () => {
+        formattedHM = services._formatReceivedHostmap(serviceHostmap);
+
+        formattedHM.forEach((service) => {
+          const foundServiceKey = Object.keys(serviceHostmap.serviceLinks)
+            .find((key) => service.name === key);
+
+          assert.isDefined(foundServiceKey);
+        });
+      });
+
+      it('creates a formmated host map containing all received host map host entries', () => {
+        formattedHM = services._formatReceivedHostmap(serviceHostmap);
+
+        formattedHM.forEach((service) => {
+          const foundHosts = serviceHostmap.hostCatalog[service.defaultHost];
+
+          assert.isDefined(foundHosts);
         });
       });
 
       it('creates an array with matching names', () => {
+        formattedHM = services._formatReceivedHostmap(serviceHostmap);
+
         assert.hasAllKeys(serviceHostmap.serviceLinks,
           formattedHM.map((item) => item.name));
       });


### PR DESCRIPTION
# Pull Request

## Description

A recent change has appended new clusters to the U2C service host map that aren't being mapped to any specific service. The current methods used to map the services only map hosts with the same root host address as the key. In order to map the additional hosts, the hostIds from the host catalog must be analyzed against the service names in the serviceLinks section.

Fixes # SPARK-102783

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Modified and appended tests to the current plugin's test suite
- [x] Ran plugin test suite to confirm changes worked
- [x] Ran live usability tests to confirm that the changes function as expected

**Test Configuration**:
* Node/Browser Version v8.16.0
* NPM Version v6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
