### PR TITLE
fix(plugin-webhooks): fix get and list webhooks return types

### DIFF
--- a/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js
+++ b/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js
@@ -66,7 +66,7 @@ const Webhooks = WebexPlugin.extend({
    * @instance
    * @memberof Webhooks
    * @param {Webhook|string} webhook
-   * @returns {Promise<Array<Webhook>>}
+   * @returns {Promise<Webhook>}
    * @example
    * var webhook;
    * webex.rooms.create({title: 'Get Webhook Example'})
@@ -106,7 +106,7 @@ const Webhooks = WebexPlugin.extend({
    * @memberof Webhooks
    * @param {Object} options
    * @param {integer} options.max Limit the maximum number of webhooks in the response.
-   * @returns {Promise<Webhook>}
+   * @returns {Promise<Array<Webhook>>}
    * @example
    * var room, webhook;
    * webex.rooms.create({title: 'List Webhooks Example'})


### PR DESCRIPTION
Documentation at https://webex.github.io/webex-js-sdk/api/#webhooks is wrong, in particular, the return types for get webhook and list webhooks, they seem to have been mixed up. From that link clicked through to the source code and found the mistake. I assume docs are auto generated so this change should hopefully propogate through to the docs.

No tests ran as it is a simple documentation change
