### PR TITLE
feat(meetings): use device refresh during register

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -324,7 +324,7 @@ export default class Meetings extends WebexPlugin {
         return Promise.resolve();
       }
 
-      return this.webex.internal.device.register()
+      return this.webex.internal.device.refresh()
         .then(() => this.webex.internal.mercury.connect())
         .then(() => {
           this.listenForEvents();

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -64,6 +64,7 @@ skipInBrowser(describe)('plugin-meetings', () => {
       Object.assign(webex.internal, {
         device: {
           deviceType: 'FAKE_DEVICE',
+          refresh: sinon.stub().returns(Promise.resolve()),
           register: sinon.stub().returns(Promise.resolve()),
           unregister: sinon.stub().returns(Promise.resolve())
         },


### PR DESCRIPTION
# Pull Request Template

## Description

Since `device.refresh` will register the device if it isn't already registered, switching to that method will give us the benefit of not doing unnecessary device registrations.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] plugin-meetings

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
