### PR TITLE
Creation of "devices" plugin to replace WDM service methods

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-devices/README.md
+++ b/packages/node_modules/@webex/internal-plugin-devices/README.md
@@ -26,7 +26,32 @@ import '@webex/internal-plugin-devices';
 import WebexCore from '@webex/webex-core';
 
 const webex = new WebexCore();
+
+// Namespace.
 webex.internal.devices
+
+// Register the device.
+webex.internal.devices.register()
+  .then(() => {}) // On successful registration.
+  .catch(() => {}); // On failed registration.
+
+// Refresh the device.
+webex.internal.devices.refresh()
+  .then(() => {}) // On successful refresh.
+  .catch(() => {}); // On failed refresh.
+
+// Unregister the device.
+webex.internal.devices.unregister()
+  .then(() => {}) // On successful unregistration.
+  .catch(() => {}); // On failed unregistration.
+
+// Common properties to reference.
+webex.internal.devices.url; // Stores the device's url once registered.
+webex.internal.devices.userId; // Stores the registered device's user uuid.
+webex.internal.devices.registered; // Determines if the device is registered.
+
+// Common methods to reference
+webex.internal.devices.getWebSocketUrl(); // Resolves to the web socket url.
 ```
 
 ## Maintainers

--- a/packages/node_modules/@webex/internal-plugin-devices/README.md
+++ b/packages/node_modules/@webex/internal-plugin-devices/README.md
@@ -1,0 +1,42 @@
+# @webex/internal-plugin-devices
+
+[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+> Plugin for device management
+
+This is an internal Cisco Webex plugin. As such, it does not strictly adhere to semantic versioning. Use at your own risk. If you're not working on one of our first party clients, please look at our [developer api](https://developer.webex.com/getting-started.html) and stick to our public plugins.
+
+- [Install](#install)
+- [Usage](#usage)
+- [Contribute](#contribute)
+- [Maintainers](#maintainers)
+- [License](#license)
+
+## Install
+
+```bash
+npm install --save @webex/internal-plugin-devices
+```
+
+## Usage
+
+```js
+import '@webex/internal-plugin-devices';
+
+import WebexCore from '@webex/webex-core';
+
+const webex = new WebexCore();
+webex.internal.devices
+```
+
+## Maintainers
+
+This package is maintained by [Cisco Webex for Developers](https://developer.webex.com/).
+
+## Contribute
+
+Pull requests welcome. Please see [CONTRIBUTING.md](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md) for more details.
+
+## License
+
+© 2016-2019 Cisco and/or its affiliates. All Rights Reserved.

--- a/packages/node_modules/@webex/internal-plugin-devices/package.json
+++ b/packages/node_modules/@webex/internal-plugin-devices/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@webex/internal-plugin-devices",
+  "version": "1.80.41",
+  "description": "",
+  "license": "MIT",
+  "author": "Timothy Scheuering <timsch@cisco.com>",
+  "main": "dist/index.js",
+  "devMain": "src/index.js",
+  "repository": "https://github.com/webex/webex-js-sdk/tree/master/packages/node_modules/@webex/internal-plugin-devices",
+  "engines": {
+    "node": ">=4"
+  },
+  "browserify": {
+    "transform": [
+      "babelify",
+      "envify"
+    ]
+  }
+}

--- a/packages/node_modules/@webex/internal-plugin-devices/src/config.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/config.js
@@ -1,0 +1,61 @@
+import {inBrowser} from '@webex/common';
+
+export default {
+  devices: {
+
+    /**
+     * The duration to wait for the catalog to populate in seconds.
+     *
+     * @type {number}
+     */
+    canRegisterWaitDuration: 10,
+
+    /**
+     * The default configuration group when sending registration requests.
+     *
+     * @type {Object}
+     */
+    defaults: {
+
+      /**
+       * The default body configuration of registration requests.
+       *
+       * @type {Object}
+       */
+      body: {
+        name: (typeof process.title === 'string' ?
+          process.title.trim() : undefined) ||
+          inBrowser && 'browser' || 'javascript',
+        deviceType: 'WEB',
+        model: 'web-js-sdk',
+        localizedModel: 'webex-js-sdk',
+        systemName: 'WEBEX_JS_SDK',
+        systemVersion: '1.0.0'
+      }
+    },
+
+    /**
+     * When true, the **wdm** service will enforce an inactivity duration.
+     *
+     * @type {boolean}
+     */
+    enableInactivityEnforcement: false,
+
+    /**
+     * When true, the device registration will include a ttl value of
+     * {@link config.devices.ephemeralDeviceTTL} and refresh on an interval of
+     * {@link config.devices.ephemeralDeviceTTL} / 2 + 60 seconds.
+     *
+     * @type {boolean}
+     */
+    ephemeral: false,
+
+    /**
+     * The ttl value to include in device registration if
+     * {@link config.device.ephemeral} is true. Measured in seconds.
+     *
+     * @type {boolean}
+     */
+    ephemeralDeviceTTL: 30 * 60
+  }
+};

--- a/packages/node_modules/@webex/internal-plugin-devices/src/devices.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/devices.js
@@ -447,7 +447,7 @@ const Devices = WebexPlugin.extend({
           .then((response) => this.processRegistrationSuccess(response));
       })
       .catch((error) => {
-        this.logger.warn(
+        this.logger.error(
           'devices: registration failed, `wdm` service url is not available'
         );
 
@@ -489,7 +489,7 @@ const Devices = WebexPlugin.extend({
    * the `services` plugin to confirm if the appropriate service urls are
    * available for device registration.
    *
-   * @param {boolean} [wait] - Willing to wait on registration.
+   * @param {boolean} [wait=false] - Willing to wait on registration.
    * @returns {Promise<void, Error>}
    */
   canRegister(wait = false) {
@@ -581,7 +581,7 @@ const Devices = WebexPlugin.extend({
   /**
    * Get the current websocket url with the appropriate priority host.
    *
-   * @param {boolean} [wait] - Willing to wait on a valid url.
+   * @param {boolean} [wait=false] - Willing to wait on a valid url.
    * @returns {Promise<string, Error>} - The priority-mapped web socket url.
    */
   getWebSocketUrl(wait = false) {
@@ -589,22 +589,11 @@ const Devices = WebexPlugin.extend({
 
     // Destructure the services plugin for ease of reference.
     const {services} = this.webex.internal;
-    let url;
 
     // Validate if the method should wait for registration.
     if (wait) {
       return this.waitForRegistration()
-        .then(() => {
-          // Attempt to collect the priority-mapped url.
-          try {
-            url = services.convertUrlToPriorityHostUrl(this.webSocketUrl);
-          }
-          catch (error) {
-            return Promise.reject(error);
-          }
-
-          return url;
-        })
+        .then(() => services.convertUrlToPriorityHostUrl(this.webSocketUrl))
         .catch((error) => {
           this.logger.warn(error.message);
 
@@ -621,15 +610,8 @@ const Devices = WebexPlugin.extend({
       ));
     }
 
-    // Attempt to collect the priority-mapped url.
-    try {
-      url = services.convertUrlToPriorityHostUrl(this.webSocketUrl);
-    }
-    catch (error) {
-      return Promise.reject(error);
-    }
-
-    return Promise.resolve(url);
+    return Promise.resolve()
+      .then(() => services.convertUrlToPriorityHostUrl(this.webSocketUrl));
   },
 
   /**

--- a/packages/node_modules/@webex/internal-plugin-devices/src/devices.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/devices.js
@@ -433,7 +433,7 @@ const Devices = WebexPlugin.extend({
         // Merge header configurations, overriding defaults.
         const headers = {
           ...(this.config.defaults.headers ? this.config.defaults.headers : {}),
-          ...(this.config.headers ? this.config.defaults.headers : {})
+          ...(this.config.headers ? this.config.headers : {})
         };
 
         // This will be replaced by a `create()` method.
@@ -482,19 +482,20 @@ const Devices = WebexPlugin.extend({
       .then(() => this.clear());
   },
 
-  // Registration helper method members.
+  // Helper method members.
 
   /**
    * Determine if registration methods can be performed. This method utilizes
    * the `services` plugin to confirm if the appropriate service urls are
    * available for device registration.
    *
-   * @param {boolean} wait - Willing to wait on registration.
+   * @param {boolean} [wait] - Willing to wait on registration.
    * @returns {Promise<void, Error>}
    */
-  canRegister(wait) {
+  canRegister(wait = false) {
     this.logger.info('devices: validating if registration can occur');
 
+    // Destructure the services plugin for ease of reference.
     const {services} = this.webex.internal;
 
     // Validate if the service url exists in the service catalog.
@@ -558,6 +559,8 @@ const Devices = WebexPlugin.extend({
         this.logger.info('devices: did not reach ping endpoint');
         this.logger.info('devices: triggering off-network timer');
 
+        this.isInNetwork = false;
+
         return Promise.resolve(this.resetLogoutTimer());
       });
   },
@@ -576,6 +579,60 @@ const Devices = WebexPlugin.extend({
   },
 
   /**
+   * Get the current websocket url with the appropriate priority host.
+   *
+   * @param {boolean} [wait] - Willing to wait on a valid url.
+   * @returns {Promise<string, Error>} - The priority-mapped web socket url.
+   */
+  getWebSocketUrl(wait = false) {
+    this.logger.info('devices: getting the current websocket url');
+
+    // Destructure the services plugin for ease of reference.
+    const {services} = this.webex.internal;
+    let url;
+
+    // Validate if the method should wait for registration.
+    if (wait) {
+      return this.waitForRegistration()
+        .then(() => {
+          // Attempt to collect the priority-mapped url.
+          try {
+            url = services.convertUrlToPriorityHostUrl(this.webSocketUrl);
+          }
+          catch (error) {
+            return Promise.reject(error);
+          }
+
+          return url;
+        })
+        .catch((error) => {
+          this.logger.warn(error.message);
+
+          return Promise.reject(new Error(
+            'devices: failed to get the current websocket url'
+          ));
+        });
+    }
+
+    // Validate if the device is registered.
+    if (!this.registered) {
+      return Promise.reject(new Error(
+        'devices: cannot get websocket url, device is not registered'
+      ));
+    }
+
+    // Attempt to collect the priority-mapped url.
+    try {
+      url = services.convertUrlToPriorityHostUrl(this.webSocketUrl);
+    }
+    catch (error) {
+      return Promise.reject(error);
+    }
+
+    return Promise.resolve(url);
+  },
+
+  /**
    * Process a successful device registration.
    *
    * @param {Object} response - response object from registration success.
@@ -584,6 +641,7 @@ const Devices = WebexPlugin.extend({
   processRegistrationSuccess(response) {
     this.logger.info('devices: received registration payload');
 
+    // Assign the recieved DTO from **WDM** to this device.
     this.set(response.body);
 
     // Validate if device is ephemeral and setup refresh timer.
@@ -594,6 +652,9 @@ const Devices = WebexPlugin.extend({
 
       this.refreshTimer = safeSetTimeout(() => this.refresh(), delay);
     }
+
+    // Emit the registration:success event.
+    this.trigger('registration:success', this);
   },
 
   /**
@@ -647,6 +708,31 @@ const Devices = WebexPlugin.extend({
     this.logoutTimer = safeSetTimeout(() => {
       this.webex.logout();
     }, duration * 1000);
+  },
+
+  /**
+   * Wait for the device to be registered.
+   *
+   * @param {number} [timeout] - The maximum duration to wait, in seconds.
+   * @returns {Promise<void, Error>}
+   */
+  waitForRegistration(timeout = 10) {
+    this.logger.info('devices: waiting for registration');
+
+    return new Promise((resolve, reject) => {
+      if (this.registered) {
+        resolve();
+      }
+
+      const timeoutTimer = safeSetTimeout(() => reject(
+        new Error('devices: timeout occured while waiting for registration')
+      ), timeout * 1000);
+
+      this.once('registration:success', () => {
+        clearTimeout(timeoutTimer);
+        resolve();
+      });
+    });
   },
 
   // Ampersand method members.

--- a/packages/node_modules/@webex/internal-plugin-devices/src/devices.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/devices.js
@@ -1,0 +1,709 @@
+// Internal dependencies.
+import {WebexPlugin} from '@webex/webex-core';
+import {safeSetTimeout} from '@webex/common-timers';
+
+import FeaturesModel from './features-model';
+
+/**
+ * Devices plugin.
+ *
+ * @description
+ * This plugin is used to maintain and manage a device within the local Webex
+ * JS SDK instance based on the DTO received from the **WDM** service.
+ *
+ * @todo
+ * This plugin is used as a prototyped replacement plugin for the previous
+ * device plugin `internal-plugin-wdm`. After this plugin is fully implemented,
+ * other plugins will likely need to be modified to consume this one over
+ * `internal-plugin-wdm` [ **device** ].
+ */
+const Devices = WebexPlugin.extend({
+
+  // Ampersand property members.
+
+  namespace: 'Devices',
+
+  // Allow for extra properties to prevent the plugin from failing due to
+  // **WDM** service DTO changes.
+  extraProperties: 'allow',
+
+  children: {
+    /**
+     * The class object that contains all of the feature collections.
+     *
+     * @type {FeaturesModel}
+     */
+    features: FeaturesModel
+  },
+
+  props: {
+    /**
+     * This property determines whether or not giphy support is enabled.
+     *
+     * @type {'ALLOW' | 'BLOCK'}
+     */
+    clientMessagingGiphy: 'string',
+
+    /**
+     * This property should store the company name.
+     *
+     * @type {string}
+     */
+    customerCompanyName: 'string',
+
+    /**
+     * This property should store the logo url.
+     *
+     * @type {string}
+     */
+    customerLogoUrl: 'string',
+
+    /**
+     * This property doesn't have any real values, but is sent during device
+     * refresh to prevent the **wdm** service from falling back to an iOS device
+     * type.
+     *
+     * @type {string}
+     */
+    deviceType: 'string',
+
+    /**
+     * This property should store the help url.
+     *
+     * @type {string}
+     */
+    helpUrl: 'string',
+
+    /**
+     * This property should store the intranet inactivity timer duration.
+     *
+     * @type {number}
+     */
+    intranetInactivityDuration: 'number',
+
+    /**
+     * This property stores the url required to validate if the device is able
+     * to actively reach the intranet network.
+     *
+     * @type {string}
+     */
+    intranetInactivityCheckUrl: 'string',
+
+    /**
+     * This property stores the inactivity timer duration, and could possibly
+     * deprecate the `intranetInactivityDuration` property.
+     *
+     * @type {number}
+     */
+    inNetworkInactivityDuration: 'number',
+
+    /**
+     * This property stores the ECM (external content management) enabled value
+     * for the whole organization.
+     *
+     * @type {boolean}
+     */
+    ecmEnabledForAllUsers: ['boolean', false, false],
+
+    /**
+     * This property stores an array of ECM (external content management)
+     * providers that are currently available.
+     *
+     * @returns {Array<string>}
+     */
+    ecmSupportedStorageProviders: ['array', false, (() => [])],
+
+    /**
+     * This property stores the modification time value retrieved from the
+     * **WDM** endpoint formatted as ISO 8601.
+     *
+     * @type {string}
+     */
+    modificationTime: 'string',
+
+    /**
+     * This property stores the navigation bar color.
+     *
+     * @type {string}
+     */
+    navigationBarColor: 'string',
+
+    /**
+     * This property stores the partner company's name when available.
+     *
+     * @type {string}
+     */
+    partnerCompanyName: 'string',
+
+    /**
+     * This property stores the partner company's logo when available.
+     *
+     * @type {string}
+     */
+    partnerLogoUrl: 'string',
+
+    /**
+     * This property stores the availability of people data from the **WDM**
+     * service.
+     *
+     * @type {boolean}
+     */
+    peopleInsightsEnabled: 'boolean',
+
+    /**
+     * This property stores the reporting site's description when available.
+     *
+     * @type {string}
+     */
+    reportingSiteDesc: 'string',
+
+    /**
+     * This property stores the reporting site's access url when available.
+     *
+     * @type {string}
+     */
+    reportingSiteUrl: 'string',
+
+    /**
+     * This property stores the encryption key url when available.
+     *
+     * @type {string}
+     */
+    searchEncryptionKeyUrl: 'string',
+
+    /**
+     * This property stores the availability of support-provided text from the
+     * **WDM** service.
+     *
+     * @type {boolean}
+     */
+    showSupportText: 'boolean',
+
+    /**
+     * This property stores the support provider's company name when available.
+     *
+     * @type {string}
+     */
+    supportProviderCompanyName: 'string',
+
+    /**
+     * This property stores the support provider's logo url when available.
+     *
+     * @type {string}
+     */
+    supportProviderLogoUrl: 'string',
+
+    /**
+     * This property stores the device's url retrieved from a registration
+     * request. This property gets set via the initial registration process by a
+     * `this.set()` method.
+     *
+     * @type {string}
+     */
+    url: 'string',
+
+    /**
+     * This property stores the device's userId uuid value, which can also be
+     * derived from the device's registerd user's userId retrieved from
+     * the **Hydra** service.
+     *
+     * @type {string}
+     */
+    userId: 'string',
+
+    /**
+     * This property stores whether or not file sharing is enabled
+     *
+     * @type {'BLOCK_BOTH' | 'BLOCK_UPLOAD'}
+     */
+    webFileShareControl: 'string',
+
+    /**
+     * This property stores the current web socket url used by the registered
+     * device.
+     *
+     * @type {string}
+     */
+    webSocketUrl: 'string',
+
+    /**
+     * This property stores the value indicating whether or not white board file
+     * sharing is enabled for the current device.
+     *
+     * @type {'ALLOW' | 'BLOCK'}
+     */
+    whiteboardFileShareControl: 'string'
+  },
+
+  derived: {
+    /**
+     * This property determines if the current device is registered.
+     *
+     * @type {boolean}
+     */
+    registered: {
+      deps: ['url'],
+
+      /**
+       * Checks if the device is registered by validating that the url exists.
+       *
+       * @returns {boolean}
+       */
+      fn() {
+        return !!(this.url);
+      }
+    }
+  },
+
+  /**
+   * Stores timer data as well as other state details.
+   *
+   * @type {Object}
+   */
+  session: {
+
+    /**
+     * This property stores the logout timer object
+     *
+     * @type {any}
+     */
+    logoutTimer: 'any',
+
+    /**
+     * This property stores the date for the last activity the user made
+     * with the current device.
+     *
+     * @type {number}
+     */
+    lastUserActivityDate: 'number',
+
+    /**
+     * This property stores whether or not the reachability check has been
+     * performed to prevent the reachability check from performing its
+     * operation more than once after a successful check.
+     *
+     * @returns {boolean}
+     */
+    isReachabilityChecked: ['boolean', false, false],
+
+    /**
+     * This property stores whether or not the current device is in a meeting
+     * to prevent an unneeded timeout of a meeting due to inactivity.
+     *
+     * @type {boolean}
+     */
+    isInMeeting: 'boolean',
+
+    /**
+     * This property identifies if the device is currently in network to prevent
+     * the `resetLogoutTimer()` method from being called repeatedly once its
+     * known client is connected to the organization's internal network.
+     *
+     * @type {boolean}
+     */
+    isInNetwork: 'boolean'
+  },
+
+  // Event method members.
+
+  /**
+   * Trigger meeting started event for webex instance. Used by web-client team.
+   *
+   * @returns {void}
+   */
+  meetingStarted() {
+    this.webex.trigger('meeting started');
+  },
+
+  /**
+   * Trigger meeting ended event for webex instance. Used by web-client team.
+   *
+   * @returns {void}
+   */
+  meetingEnded() {
+    this.webex.trigger('meeting ended');
+  },
+
+  // Registration method members.
+
+  /**
+   * Refresh the current registered device if able.
+   *
+   * @todo
+   * This method contains some logic that could be moved to an `update()` method
+   * at a later time.
+   *
+   * @returns {Promise<void, Error>}
+   */
+  refresh() {
+    this.logger.info('devices: refreshing');
+
+    // Validate that the device can be registered.
+    return this.canRegister(true)
+      .then(() => {
+        // Validate if the device is not registered and register instead.
+        if (!this.registered) {
+          this.logger.info('devices: device not registered, registering');
+
+          return this.register();
+        }
+
+        // Merge body configurations, overriding defaults.
+        const body = {
+          ...(this.serialize()),
+          ...(this.config.body ? this.config.body : {})
+        };
+
+        // Remove unneeded properties from the body object.
+        delete body.features;
+        delete body.mediaCluster;
+
+        // Append a ttl value if the device is marked as ephemeral.
+        if (this.config.ephemeral) {
+          body.ttl = this.config.ephemeralDeviceTTL;
+        }
+
+        // Merge header configurations, overriding defaults.
+        const headers = {
+          ...(this.config.defaults.headers ? this.config.defaults.headers : {}),
+          ...(this.config.headers ? this.config.headers : {})
+        };
+
+        return this.request({
+          method: 'PUT',
+          uri: this.url,
+          body,
+          headers
+        })
+          .then((response) => this.processRegistrationSuccess(response))
+          .catch((reason) => {
+            // Handle a 404 error, which indicates that the device is no longer
+            // valid and needs to be registered as a new device.
+            if (reason.statusCode === 404) {
+              this.logger.info('devices: refresh failed, device is not valid');
+              this.logger.info('devices: attempting to register a new device');
+
+              this.clear();
+
+              return this.register();
+            }
+
+            return Promise.reject(reason);
+          });
+      })
+      .catch((error) => {
+        this.logger.warn(
+          'devices: refresh failed, `wdm` service url is not available'
+        );
+
+        return Promise.reject(error);
+      });
+  },
+
+  /**
+   * Register or refresh a device depending on the current device state. Device
+   * registration utilizes the services plugin to send the request to the
+   * **WDM** service.
+   *
+   * @todo
+   * This method contains some logic that could be moved to a `create()` method
+   * at a later time.
+   *
+   * @returns {Promise<void, Error>}
+   */
+  register() {
+    this.logger.info('devices: registering');
+
+    // Validate that the device can be registered.
+    return this.canRegister(true)
+      .then(() => {
+        // Validate if the device is already registered and refresh instead.
+        if (this.registered) {
+          this.logger.info('devices: device already registered, refreshing');
+
+          return this.refresh();
+        }
+
+        // Merge body configurations, overriding defaults.
+        const body = {
+          ...(this.config.defaults.body ? this.config.defaults.body : {}),
+          ...(this.config.body ? this.config.body : {})
+        };
+
+        // Merge header configurations, overriding defaults.
+        const headers = {
+          ...(this.config.defaults.headers ? this.config.defaults.headers : {}),
+          ...(this.config.headers ? this.config.defaults.headers : {})
+        };
+
+        // This will be replaced by a `create()` method.
+        return this.request({
+          method: 'POST',
+          service: 'wdm',
+          resource: 'devices',
+          body,
+          headers
+        })
+          .then((response) => this.processRegistrationSuccess(response));
+      })
+      .catch((error) => {
+        this.logger.warn(
+          'devices: registration failed, `wdm` service url is not available'
+        );
+
+        return Promise.reject(error);
+      });
+  },
+
+  /**
+   * Unregister the current registered device if available. Unregistering a
+   * device utilizes the services plugin to send the request to the **WDM**
+   * service.
+   *
+   * @todo
+   * This method contains some logic that could be moved to a `remove()` method
+   * at a later time.
+   *
+   * @returns {Promise<void, Error>}
+   */
+  unregister() {
+    this.logger.info('devices: unregistering');
+
+    if (!this.registered) {
+      this.logger.warn('devices: not registered');
+
+      return Promise.resolve();
+    }
+
+    return this.request({
+      uri: this.url,
+      method: 'DELETE'
+    })
+      .then(() => this.clear());
+  },
+
+  // Registration helper method members.
+
+  /**
+   * Determine if registration methods can be performed. This method utilizes
+   * the `services` plugin to confirm if the appropriate service urls are
+   * available for device registration.
+   *
+   * @param {boolean} wait - Willing to wait on registration.
+   * @returns {Promise<void, Error>}
+   */
+  canRegister(wait) {
+    this.logger.info('devices: validating if registration can occur');
+
+    const {services} = this.webex.internal;
+
+    // Validate if the service url exists in the service catalog.
+    if (services.get('wdm')) {
+      return Promise.resolve();
+    }
+
+    // If wait is true, wait for the catalog to populate.
+    if (wait) {
+      return services.waitForCatalog('postauth',
+        this.config.canRegisterWaitDuration);
+    }
+
+    // Reject if the service url is not available.
+    return Promise.reject(new Error(
+      '`wdm` service is not currently available'
+    ));
+  },
+
+  /**
+   * Check if the device can currently reach the inactivity check url.
+   *
+   * @returns {Promise<void, Error>}
+   */
+  checkNetworkReachability() {
+    this.logger.info('devices: checking network reachability');
+
+    // Validate if the device has been checked and reset the logout timer.
+    if (this.isReachabilityChecked) {
+      return Promise.resolve(this.resetLogoutTimer());
+    }
+
+    // Validate if the device has a intranet checking url.
+    if (!this.intranetInactivityCheckUrl) {
+      this.isInNetwork = false;
+
+      return Promise.resolve(this.resetLogoutTimer());
+    }
+
+    this.isReachabilityChecked = true;
+
+    // Clear unnecessary headers for reachability request.
+    const headers = {
+      'cisco-no-http-redirect': null,
+      'spark-user-agent': null,
+      trackingid: null
+    };
+
+    // Send the network reachability request.
+    return this.webex.request({
+      headers,
+      method: 'GET',
+      uri: this.intranetInactivityCheckUrl
+    })
+      .then(() => {
+        this.isInNetwork = true;
+
+        return Promise.resolve(this.resetLogoutTimer());
+      })
+      .catch(() => {
+        this.logger.info('devices: did not reach ping endpoint');
+        this.logger.info('devices: triggering off-network timer');
+
+        return Promise.resolve(this.resetLogoutTimer());
+      });
+  },
+
+  /**
+   * Clears the registration ttl value if available.
+   *
+   * @param {Object} options - Values to be cleared.
+   * @returns {void}
+   */
+  clear(...args) {
+    this.logger.info('devices: clearing registered device');
+
+    // Prototype the extended class in order to preserve the parent member.
+    Reflect.apply(WebexPlugin.prototype.clear, this, args);
+  },
+
+  /**
+   * Process a successful device registration.
+   *
+   * @param {Object} response - response object from registration success.
+   * @returns {void}
+   */
+  processRegistrationSuccess(response) {
+    this.logger.info('devices: received registration payload');
+
+    this.set(response.body);
+
+    // Validate if device is ephemeral and setup refresh timer.
+    if (this.config.ephemeral) {
+      this.logger.info('devices: enqueuing device refresh');
+
+      const delay = (this.config.ephemeralDeviceTTL / 2 + 60) * 1000;
+
+      this.refreshTimer = safeSetTimeout(() => this.refresh(), delay);
+    }
+  },
+
+  /**
+   * Reset the current local logout timer for the registered device if
+   * registered.
+   *
+   * @returns {void}
+   */
+  resetLogoutTimer() {
+    this.logger.info('devices: resetting logout timer');
+
+    // Clear current logout timer.
+    clearTimeout(this.logoutTimer);
+
+    // Remove last activity date event listener.
+    this.off('change:lastUserActivityDate');
+
+    // Remove the logout timer.
+    this.unset('logoutTimer');
+
+    // Validate if the device is currently in a meeting and is configured to
+    // required inactivity enforcement.
+    if (!this.isInMeeting && this.config.enableInactivityEnforcement &&
+      this.isReachabilityChecked) {
+      if (this.isInNetwork) {
+        this.setLogoutTimer(this.inNetworkInactivityDuration);
+      }
+      else {
+        this.setLogoutTimer(this.intranetInactivityDuration);
+      }
+    }
+  },
+
+  /**
+   * Set the value of the logout timer for the current registered device.
+   *
+   * @param {number} duration - Value in seconds of the new logout timer.
+   * @returns {void}
+   */
+  setLogoutTimer(duration) {
+    this.logger.info('devices: setting logout timer');
+
+    if (!duration || duration <= 0) {
+      return;
+    }
+
+    // Setup user activity date event listener.
+    this.on('change:lastUserActivityDate', () => { this.resetLogoutTimer(); });
+
+    // Initialize a new timer.
+    this.logoutTimer = safeSetTimeout(() => {
+      this.webex.logout();
+    }, duration * 1000);
+  },
+
+  // Ampersand method members.
+
+  /**
+   * Initializer method for the devices plugin.
+   *
+   * @override
+   * @returns {void}
+   */
+  initialize(...args) {
+    // Prototype the extended class in order to preserve the parent member.
+    Reflect.apply(WebexPlugin.prototype.initialize, this, args);
+
+    // Declare the feature collection group names.
+    const featureCollectionNames = ['developer', 'entitlement', 'user'];
+
+    // Initialize feature events and listeners.
+    featureCollectionNames.forEach((collectionName) => {
+      this.features.on(`change:${collectionName}`, (model, value, options) => {
+        this.trigger('change', this, options);
+        this.trigger('change:features', this, this.features, options);
+      });
+    });
+
+    // Initialize network reachability checking event for url change.
+    this.on('change:intranetInactivityCheckUrl', () => {
+      this.checkNetworkReachability();
+    });
+
+    // Initialize network reachability checking event for duration change.
+    this.on('change:intranetInactivityDuration', () => {
+      this.checkNetworkReachability();
+    });
+
+    // Initialize network reachability checking event for duration change.
+    this.on('change:inNetworkInactivityDuration', () => {
+      this.checkNetworkReachability();
+    });
+
+    // Initialize listener for activity checking.
+    this.listenTo(this.webex, 'user-activity', () => {
+      this.lastUserActivityDate = Date.now();
+    });
+
+    // Initialize listener for meeting started event.
+    this.listenTo(this.webex, 'meeting started', () => {
+      this.isInMeeting = true;
+      this.resetLogoutTimer();
+    });
+
+    // Initialize listener for meeting ended event.
+    this.listenTo(this.webex, 'meeting ended', () => {
+      this.isInMeeting = false;
+      this.resetLogoutTimer();
+    });
+  }
+});
+
+export default Devices;

--- a/packages/node_modules/@webex/internal-plugin-devices/src/devices.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/devices.js
@@ -545,7 +545,7 @@ const Devices = WebexPlugin.extend({
     };
 
     // Send the network reachability request.
-    return this.webex.request({
+    return this.request({
       headers,
       method: 'GET',
       uri: this.intranetInactivityCheckUrl

--- a/packages/node_modules/@webex/internal-plugin-devices/src/feature-collection.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/feature-collection.js
@@ -1,0 +1,30 @@
+// External dependencies.
+import AmpCollection from 'ampersand-collection';
+
+// Internal dependencies.
+import FeatureModel from './feature-model';
+
+/**
+ * Feature collection model.
+ *
+ * @description
+ * This model contains a collection of features under a specific collection
+ * group.
+ */
+const FeatureCollection = AmpCollection.extend({
+  /**
+   * The unique identifier for the models in this collection.
+   *
+   * @type {string}
+   */
+  mainIndex: 'key',
+
+  /**
+   * The type of model this collection can contain.
+   *
+   * @type {Class}
+   */
+  model: FeatureModel
+});
+
+export default FeatureCollection;

--- a/packages/node_modules/@webex/internal-plugin-devices/src/feature-model.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/feature-model.js
@@ -1,0 +1,139 @@
+// External dependencies.
+import AmpState from 'ampersand-state';
+import {defaults, isObject} from 'lodash';
+
+/**
+ * Feature model.
+ *
+ * @description
+ * This model contains details on a single feature and is received from the
+ * **WDM** service upon registration.
+ */
+const FeatureModel = AmpState.extend({
+
+  // Ampersand property members.
+
+  props: {
+    /**
+     * Contains the unique identifier for this feature to be addressed by.
+     *
+     * @type {string}
+     */
+    key: 'string',
+
+    /**
+     * This property contains the date in which this feature was last modified.
+     *
+     * @type {date}
+     */
+    lastModified: 'date',
+
+    /**
+     * This property defines whether or not the feature is mutable.
+     *
+     * @type {boolean}
+     */
+    mutable: 'boolean',
+
+    /**
+     * This property contains the data type the string value should be
+     * interpreted as.
+     *
+     * @type {string}
+     */
+    type: 'string',
+
+    /**
+     * This property contains the string value of this feature.
+     *
+     * @type {string}
+     */
+    val: 'string',
+
+    /**
+     * This property contains the interpreted value of this feature.
+     *
+     * @type {any}
+     */
+    value: 'any'
+  },
+
+  /**
+   * Class object constructor. This method safely initializes the class object
+   * prior to it fully loading to allow data to be accessed and modified
+   * immediately after construction instead of initialization.
+   *
+   * @override
+   * @param {any} attrs
+   * @param {any} options
+   */
+  constructor(attrs, options = {}) {
+    defaults(options, {parse: true});
+
+    return Reflect.apply(
+      AmpState.prototype.constructor,
+      this,
+      [attrs, options]
+    );
+  },
+
+  // Ampsersand method members.
+
+  /**
+   * Serialize the feature using the parent ampersand method with its date as an
+   * instance of a `Date`.
+   *
+   * @override
+   * @param  {...any} args
+   * @returns {Object}
+   */
+  serialize(...args) {
+    // Call the overloaded class member.
+    const attrs = Reflect.apply(AmpState.prototype.serialize, this, args);
+
+    // Validate that the overloaded class member returned an object with the
+    // `lastModified` key-value pair and instance it as a date.
+    if (attrs.lastModified) {
+      attrs.lastModified = (new Date(attrs.lastModified).toISOString());
+    }
+
+    return attrs;
+  },
+
+  /**
+   * Set a property of this object to a specific value. This method utilizes
+   * code that exists within the `ampersand-state` dependency to handle
+   * scenarios in which `key = {"key": "value"}` or
+   * `key = "key", value = "value"`. Since the snippet is pulled directly from
+   * `ampersand-state`, there is no need to test both scenarios.
+   *
+   * @override
+   * @param {object | string} key - The key value, or object to be set.
+   * @param {any} value - The key value or object to set the keyed pair to.
+   * @param {any} options - The object to set the keyed pair to.
+   * @returns {any} - The changed property.
+   */
+  set(key, value, options) {
+    // Declare formatted output variables for properly setting the targetted
+    // property for this method.
+    let attrs;
+    let optns;
+
+    // Validate if the key is an instance of any object or not.
+    if (isObject(key) || key === null) {
+      attrs = key;
+      optns = value;
+    }
+    else {
+      attrs = {};
+      attrs[key] = value;
+      optns = options;
+    }
+
+    attrs = this.parse(attrs, optns);
+
+    return Reflect.apply(AmpState.prototype.set, this, [attrs, optns]);
+  }
+});
+
+export default FeatureModel;

--- a/packages/node_modules/@webex/internal-plugin-devices/src/features-model.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/features-model.js
@@ -1,0 +1,101 @@
+// External dependencies.
+import AmpState from 'ampersand-state';
+
+import FeatureCollection from './feature-collection';
+
+/**
+ * Feature collection parent container.
+ *
+ * @description
+ * This class contains all of the feature
+ * collection class objects to help organize the data retrieved from the **wdm**
+ * service upon device registration.
+ */
+const FeaturesModel = AmpState.extend({
+
+  // Ampersand property members.
+
+  collections: {
+    /**
+     * This collection contains the developer feature collection.
+     *
+     * @type {FeatureCollection}
+     */
+    developer: FeatureCollection,
+
+    /**
+     * This collection contains the entitlement feature collection.
+     *
+     * @type {FeatureCollection}
+     */
+    entitlement: FeatureCollection,
+
+    /**
+     * This collection contains the user feature collection.
+     *
+     * @type {FeatureCollection}
+     */
+    user: FeatureCollection
+  },
+
+  // Helper method members.
+
+  /**
+   * Recursively clear attributes, children, and collections.
+   *
+   * @param {Object} options - Attribute options to unset.
+   * @returns {this}
+   */
+  clear(options) {
+    // Clear the ampersand attributes safely.
+    Object.keys(this.attributes).forEach((key) => {
+      this.unset(key, options);
+    });
+
+    // Clear the ampersand children safely.
+    /* eslint-disable-next-line no-underscore-dangle */
+    Object.keys(this._children).forEach((key) => {
+      this[key].clear();
+    });
+
+    // Clear the ampersand collections safely.
+    /* eslint-disable-next-line no-underscore-dangle */
+    Object.keys(this._collections).forEach((key) => {
+      this[key].reset();
+    });
+
+    return this;
+  },
+
+  // Ampersand method members.
+
+  /**
+   * Initializer method for FeatureModel class object.
+   *
+   * @override
+   * @returns {void}
+   */
+  initialize() {
+    // Declare the collection event names.
+    const eventNames = ['change:value', 'add', 'remove'];
+
+    // Declare the collection names.
+    const collectionNames = ['developer', 'entitlement', 'user'];
+
+    // Initialize collection event listeners.
+    eventNames.forEach((eventName) => {
+      collectionNames.forEach((collectionName) => {
+        this[collectionName].on(eventName, (model, options) => {
+          this.trigger(
+            `change:${collectionName}`,
+            this,
+            this[collectionName],
+            options
+          );
+        });
+      });
+    });
+  }
+});
+
+export default FeaturesModel;

--- a/packages/node_modules/@webex/internal-plugin-devices/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/index.js
@@ -1,0 +1,10 @@
+import {registerInternalPlugin} from '@webex/webex-core';
+
+import Devices from './devices';
+import config from './config';
+
+registerInternalPlugin('devices', Devices, {
+  config
+});
+
+export default Devices;

--- a/packages/node_modules/@webex/internal-plugin-devices/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/index.js
@@ -7,4 +7,5 @@ registerInternalPlugin('devices', Devices, {
   config
 });
 
-export default Devices;
+export {default} from './devices';
+export {default as Devices} from './devices';

--- a/packages/node_modules/@webex/internal-plugin-devices/test/integration/spec/devices.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/test/integration/spec/devices.js
@@ -1,0 +1,955 @@
+import '@webex/internal-plugin-devices';
+
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import testUsers from '@webex/test-helper-test-users';
+import WebexCore, {WebexHttpError} from '@webex/webex-core';
+
+
+describe('plugin-wdm', () => {
+  describe('Devices', () => {
+    let webex;
+    let devices;
+    let user;
+
+    beforeEach('create users', () => testUsers.create({count: 1})
+      .then(([definedUser]) => {
+        user = definedUser;
+        webex = new WebexCore({
+          credentials: user.token
+        });
+
+        devices = webex.internal.devices;
+      }));
+
+    afterEach('remove users', () => testUsers.remove([user]));
+
+    describe('#canRegister()', () => {
+      describe('when wait is truthy', () => {
+        let wait;
+
+        beforeEach('set wait', () => {
+          wait = true;
+        });
+
+        describe('when the `wdm` service is available', () => {
+          let services;
+
+          beforeEach('destructure services plugin', () => {
+            services = webex.internal.services;
+
+            return services.waitForCatalog('postauth');
+          });
+
+          it('returns a resolved promise', () => {
+            assert.isDefined(services.get('wdm'));
+
+            return devices.canRegister(wait)
+              .then(() => assert.isTrue(true, 'resolved the promise'));
+          });
+        });
+
+        describe('when the service catalog is not ready', () => {
+          let services;
+
+          beforeEach('setup catalog to be not ready', () => {
+            services = webex.internal.services;
+
+            services.updateServices();
+          });
+
+          it('waits for the catalog then returns a resolved promise', () => {
+            /* eslint-disable-next-line no-underscore-dangle */
+            assert.isTrue(services._getCatalog().status.postauth.collecting);
+
+            return devices.canRegister(wait)
+              .then(() => assert.isTrue(true, 'resolved the promise'));
+          });
+        });
+
+        describe('when the `wdm` service is not available', () => {
+          let catalog;
+          let services;
+
+          beforeEach('remove wdm service', () => {
+            services = webex.internal.services;
+            /* eslint-disable-next-line no-underscore-dangle */
+            catalog = services._getCatalog();
+
+            catalog.serviceGroups.postauth = [];
+          });
+
+          it('returns a rejected promise', () => {
+            assert.isUndefined(services.get('wdm'));
+
+            return devices.canRegister(wait)
+              .then(() => assert.isTrue(false, 'resolved the promise'))
+              .catch(() => assert.isTrue(true, 'rejected the promise'));
+          });
+        });
+      });
+
+      describe('when wait is falsy', () => {
+        let wait;
+
+        beforeEach('set wait', () => {
+          wait = false;
+        });
+
+        describe('when the `wdm` service is available', () => {
+          let services;
+
+          beforeEach('destructure services plugin', () => {
+            services = webex.internal.services;
+
+            return services.updateServices();
+          });
+
+          it('returns a resolved promise', () => {
+            assert.isDefined(services.get('wdm'));
+
+            return devices.canRegister(wait)
+              .then(() => assert.isTrue(true, 'resolved the promise'));
+          });
+        });
+
+        describe('when the service catalog is not ready', () => {
+          let catalog;
+          let services;
+
+          beforeEach('setup catalog to be not ready', () => {
+            services = webex.internal.services;
+            /* eslint-disable-next-line no-underscore-dangle */
+            catalog = services._getCatalog();
+
+            catalog.serviceGroups.postauth = [];
+
+            services.updateServices();
+          });
+
+          it('returns a rejected promise', () => {
+            /* eslint-disable-next-line no-underscore-dangle */
+            assert.isTrue(services._getCatalog().status.postauth.collecting);
+
+            return devices.canRegister(wait)
+              .then(() => assert.isTrue(false, 'resolved the promise'))
+              .catch(() => assert.isTrue(true, 'rejected the promise'));
+          });
+        });
+
+        describe('when the `wdm` service is not available', () => {
+          let catalog;
+          let services;
+
+          beforeEach('setup catalog to be not ready', () => {
+            services = webex.internal.services;
+            /* eslint-disable-next-line no-underscore-dangle */
+            catalog = services._getCatalog();
+
+            catalog.serviceGroups.postauth = [];
+          });
+
+          it('returns a rejected promise', () => {
+            assert.isUndefined(services.get('wdm'));
+
+            return devices.canRegister(wait)
+              .then(() => assert.isTrue(false, 'resolved the promise'))
+              .catch(() => assert.isTrue(true, 'rejected the promise'));
+          });
+        });
+      });
+    });
+
+    describe('#checkNetworkReachability()', () => {
+      describe('when the reachability check has already been completed', () => {
+        beforeEach('set reachability checked to true', () => {
+          devices.isReachabilityChecked = true;
+        });
+
+        it('returns a resolved promise', () => {
+          assert.isTrue(devices.isReachabilityChecked);
+
+          return devices.checkNetworkReachability()
+            .then(() => assert.isTrue(true, 'resolved the promise'));
+        });
+      });
+
+      describe('when there is no intranet inactivity check url', () => {
+        beforeEach('setup devices properties', () => {
+          devices.intranetInactivityCheckUrl = undefined;
+          devices.isReachabilityChecked = false;
+        });
+
+        it('sets the in-network property to false', () => {
+          assert.isUndefined(devices.intranetInactivityCheckUrl);
+
+          return devices.checkNetworkReachability()
+            .then(() => {
+              assert.isFalse(devices.isInNetwork);
+            });
+        });
+
+        it('returns a resolved promise', () => {
+          assert.isUndefined(devices.intranetInactivityCheckUrl);
+
+          return devices.checkNetworkReachability()
+            .then(() => assert.isTrue(true, 'resolved the promise'));
+        });
+
+        describe('when the device has inactivity enforcement', () => {
+          let logoutTimer;
+
+          beforeEach('set device to enforce inactivity timers', () => {
+            devices.config.enableInactivityEnforcement = true;
+            logoutTimer = devices.logoutTimer;
+          });
+
+          it('does not reset the logout timer', () => {
+            assert.isUndefined(devices.intranetInactivityCheckUrl);
+
+            return devices.checkNetworkReachability()
+              .then(() => assert.equal(devices.logoutTimer, logoutTimer));
+          });
+        });
+      });
+
+      describe('when the rechability is performable', () => {
+        beforeEach('setup for reachability check', () => {
+          // Due to property overriding, `isReachabilityChecked` must be set
+          // within each `it` statement.
+          devices.isInNetwork = false;
+        });
+
+        describe('when the network is reachabable', () => {
+          beforeEach('set inactivity check url and stubs', () => {
+            devices.intranetInactivityCheckUrl =
+              'https://myspark.cisco.com/spark_session_check.json';
+
+            devices.resetLogoutTimer = sinon.spy();
+
+            devices.request = sinon.stub().resolves({});
+          });
+
+          it('utilizes \'resetLogoutTimer()\'', () => {
+            devices.isReachabilityChecked = false;
+
+            assert.isFalse(devices.isReachabilityChecked);
+
+            return devices.checkNetworkReachability()
+              .then(() => assert.called(devices.resetLogoutTimer));
+          });
+
+          it('sets the reachability check to true', () => {
+            devices.isReachabilityChecked = false;
+
+            assert.isFalse(devices.isReachabilityChecked);
+
+            return devices.checkNetworkReachability()
+              .then(() => assert.isTrue(devices.isReachabilityChecked));
+          });
+
+          it('sets the in-network property to true', () => {
+            devices.isReachabilityChecked = false;
+
+            assert.isFalse(devices.isInNetwork);
+
+            return devices.checkNetworkReachability()
+              .then(() => assert.isTrue(devices.isInNetwork));
+          });
+
+          it('returns a resolved promise',
+            () => devices.checkNetworkReachability()
+              .then(() => assert.isTrue(true, 'resolved the promise')));
+        });
+
+        describe('when the network is not reachable', () => {
+          beforeEach('unset inactivity check url', () => {
+            devices.intranetInactivityCheckUrl =
+              'https://myspark.cisco.com/bad-spark_session_check.json';
+          });
+
+          it('sets the reachability check to true', () => {
+            devices.isReachabilityChecked = false;
+
+            assert.isFalse(devices.isReachabilityChecked);
+
+            return devices.checkNetworkReachability()
+              .then(() => assert.isTrue(false, 'resolved the promise'))
+              .catch(() => assert.isTrue(devices.isReachabilityChecked));
+          });
+
+          it('sets the in-network property to false',
+            () => devices.checkNetworkReachability()
+              .then(() => assert.isTrue(false, 'resolved the promise'))
+              .catch(() => assert.isFalse(devices.isInNetwork)));
+
+          it('returns a rejected promise',
+            () => devices.checkNetworkReachability()
+              .then(() => assert.isTrue(false, 'resolved the promise'))
+              .catch(() => assert.isTrue(true, 'rejected the promise')));
+        });
+      });
+    });
+
+    describe('#getWebSocketUrl()', () => {
+      let services;
+
+      beforeEach('destructure services', () => {
+        services = webex.internal.services;
+      });
+
+      describe('when wait is truthy', () => {
+        let wait;
+
+        beforeEach('set wait', () => {
+          wait = true;
+        });
+
+        describe('when the device is registered', () => {
+          beforeEach('register the device', () => devices.register());
+
+          it('returns a resolved promise with the websocket url',
+            () => devices.getWebSocketUrl(wait)
+              .then((url) => {
+                assert.isDefined(url);
+                assert.isTrue(services.isServiceUrl(url));
+                assert.include(url, 'mercury');
+              }));
+        });
+
+        describe('when the device is not registered', () => {
+          describe('when the device successfully registers', () => {
+            beforeEach(() => {
+              // This needs to not be returned, as it must be pending during the
+              // it clause.
+              devices.register();
+            });
+
+            it('returns a resolved promise with the websocket url', () => {
+              assert.isFalse(devices.registered);
+
+              return devices.getWebSocketUrl(wait)
+                .then((url) => {
+                  assert.isDefined(url);
+                  assert.isTrue(services.isServiceUrl(url));
+                  assert.include(url, 'mercury');
+                });
+            });
+          });
+
+          describe('when the device never registers', () => {
+            it('returns a rejected promise', () => {
+              assert.isFalse(devices.registered);
+
+              return devices.getWebSocketUrl(wait)
+                .then(() => assert.isTrue(false, 'resolved the promise'))
+                .catch(() => assert.isTrue(true, 'rejected the promise'));
+            });
+          });
+        });
+      });
+
+      describe('when wait is falsy', () => {
+        let wait;
+
+        beforeEach('set wait', () => {
+          wait = false;
+        });
+
+        describe('when the device is registered', () => {
+          beforeEach('register the device', () => devices.register());
+
+          describe('when the priority host can be mapped', () => {
+            it('returns a resolved promise with the websocket url', () => {
+              assert.isDefined(services.get('wdm'));
+              assert.isTrue(devices.registered);
+
+              return devices.getWebSocketUrl(wait)
+                .then((url) => {
+                  assert.isDefined(url);
+                  assert.isTrue(services.isServiceUrl(url));
+                  assert.include(url, 'mercury');
+                });
+            });
+          });
+
+          describe('when the priority host cannot be mapped', () => {
+            beforeEach('remove postauth services', () => {
+              /* eslint-disable-next-line no-underscore-dangle */
+              services._getCatalog().serviceGroups.postauth = [];
+            });
+
+            it('returns a rejected promise',
+              () => devices.getWebSocketUrl(wait)
+                .then(() => assert.isTrue(false, 'resolved the promise'))
+                .catch(() => assert.isTrue(true, 'rejected the promise')));
+          });
+        });
+
+        describe('when the device is not registered', () => {
+          it('returns a rejected promise', () => {
+            assert.isFalse(devices.registered);
+
+            return devices.getWebSocketUrl(wait)
+              .then(() => assert.isTrue(false, 'resolved the promise'))
+              .catch(() => assert.isTrue(true, 'rejected the promise'));
+          });
+        });
+      });
+    });
+
+    describe('#meetingStarted()', () => {
+      let spyFunction;
+
+      beforeEach('setup instance function', () => {
+        spyFunction = sinon.spy();
+      });
+
+      it('triggers a \'meeting started\' event', () => {
+        webex.on('meeting started', spyFunction);
+        devices.meetingStarted();
+        assert.called(spyFunction);
+      });
+    });
+
+    describe('#meetingEnded()', () => {
+      let spyFunction;
+
+      beforeEach('setup instance function', () => {
+        spyFunction = sinon.spy();
+      });
+
+      it('triggers a \'meeting ended\' event', () => {
+        webex.on('meeting ended', spyFunction);
+        devices.meetingEnded();
+        assert.called(spyFunction);
+      });
+    });
+
+    describe('#processRegistrationSuccess()', () => {
+      let customResponse;
+      let spyFunction;
+
+      beforeEach('setup parameters', () => {
+        customResponse = {
+          body: {
+            exampleKey: 'exampleValue'
+          }
+        };
+
+        spyFunction = sinon.spy();
+      });
+
+      it('sets the device properties to the values within the response', () => {
+        devices.processRegistrationSuccess(customResponse);
+        assert.equal(devices.exampleKey, customResponse.body.exampleKey);
+      });
+
+      it('triggers a \'registration:success\' event', () => {
+        devices.on('registration:success', spyFunction);
+        devices.processRegistrationSuccess(customResponse);
+        assert.called(spyFunction);
+      });
+
+      describe('when the device is ephemeral', () => {
+        beforeEach('set the device to ephemeral', () => {
+          devices.config.ephemeral = true;
+        });
+
+        it('creates a refresh timer', () => {
+          const {refreshTimer} = devices;
+
+          devices.processRegistrationSuccess(customResponse);
+          assert.notEqual(devices.refreshTimer, refreshTimer);
+        });
+      });
+    });
+
+    describe('#refresh()', () => {
+      describe('when the device can register', () => {
+        describe('when the device is not registered', () => {
+          beforeEach('setup spy function', () => {
+            devices.register = sinon.spy();
+          });
+
+          it('attempts to register', () => {
+            assert.isFalse(devices.registered);
+
+            return devices.refresh()
+              .then(() => assert.called(devices.register));
+          });
+        });
+
+        describe('when the device is registered', () => {
+          let exampleResponse;
+
+          beforeEach('register the device', () => {
+            exampleResponse = {
+              body: {
+                exampleKey: 'example response value'
+              }
+            };
+
+            return devices.register()
+              .then(() => {
+                devices.request = sinon.stub().returns(Promise.resolve(
+                  {...exampleResponse}
+                ));
+              });
+          });
+
+          describe('when the device is ephemeral', () => {
+            beforeEach('set device to ephemeral', () => {
+              devices.config.ephemeral = true;
+            });
+
+            it('sets the ttl property to the config values',
+              () => devices.refresh()
+                .then(() =>
+                  assert.calledWith(devices.request, sinon.match.hasNested(
+                    'body.ttl', devices.config.ephemeralDeviceTTL
+                  ))));
+          });
+
+          describe('when the refresh request is sent', () => {
+            let customHeaders;
+            let customBody;
+
+            beforeEach('configure devices plugin', () => {
+              customHeaders = {
+                testHeader: 'example header value'
+              };
+
+              customBody = {
+                testBody: 'example body value'
+              };
+            });
+
+            it('allows for custom header key:values', () => {
+              assert.isTrue(devices.registered);
+
+              devices.config.headers = {...customHeaders};
+
+              return devices.refresh()
+                .then(() =>
+                  assert.calledWith(devices.request, sinon.match.hasNested(
+                    'headers.testHeader', customHeaders.testHeader
+                  )));
+            });
+
+            it('allows for custom body key:values', () => {
+              assert.isTrue(devices.registered);
+
+              devices.config.body = {...customBody};
+
+              return devices.refresh()
+                .then(() =>
+                  assert.calledWith(devices.request, sinon.match.hasNested(
+                    'body.testBody', customBody.testBody
+                  )));
+            });
+
+            it('uses the device\'s url property', () => {
+              assert.isTrue(devices.registered);
+
+              devices.config.body = {...customBody};
+
+              return devices.refresh()
+                .then(() =>
+                  assert.calledWith(devices.request, sinon.match.has(
+                    'uri', devices.url
+                  )));
+            });
+
+            it('sends a PUT request', () => {
+              assert.isTrue(devices.registered);
+
+              devices.config.body = {...customBody};
+
+              return devices.refresh()
+                .then(() =>
+                  assert.calledWith(devices.request, sinon.match.has(
+                    'method', 'PUT'
+                  )));
+            });
+          });
+
+          describe('when the device is successfully refreshes', () => {
+            beforeEach('setup stubs', () => {
+              devices.processRegistrationSuccess = sinon.stub();
+            });
+
+            it('returns a resolved promise', () => devices.refresh()
+              .then(() => assert.isTrue(true, 'resolved the promise')));
+
+            it('calls \'processRegistrationSuccess()\'', () => devices.refresh()
+              .then(() => assert.called(devices.processRegistrationSuccess)));
+          });
+
+          describe('when the device fails to refresh', () => {
+            beforeEach('setup \'register()\' stub', () => {
+              devices.register = sinon.spy();
+            });
+
+            describe('when the device is not found', () => {
+              beforeEach('setup request stub to 404', () => {
+                devices.request = sinon.stub().rejects(
+                  new WebexHttpError({
+                    statusCode: 404,
+                    options: {
+                      url: devices.url,
+                      headers: {
+                        trackingId: 'tid'
+                      }
+                    }
+                  })
+                );
+              });
+
+              it('clears the current device', () => devices.refresh()
+                .then(() => assert.isUndefined(devices.url)));
+
+              it('attempts to register a new device', () => devices.refresh()
+                .then(() => assert.called(devices.register)));
+            });
+
+            describe('when the device was found', () => {
+              beforeEach('setup request stub to 503', () => {
+                devices.request = sinon.stub().rejects(
+                  new WebexHttpError({
+                    statusCode: 503,
+                    options: {
+                      url: devices.url,
+                      headers: {
+                        trackingId: 'tid'
+                      }
+                    }
+                  })
+                );
+              });
+
+              it('returns a rejected promise', () => devices.refresh()
+                .then(() => assert.isTrue(false, 'resolved the promise'))
+                .catch(() => assert.isTrue(true, 'rejected the promise')));
+            });
+          });
+        });
+      });
+
+      describe('when the device cannot register', () => {
+        beforeEach('setup \'canRegister()\' stub', () => {
+          devices.canRegister = sinon.stub().rejects(
+            new Error()
+          );
+        });
+
+        it('returns a rejected promise', () => devices.refresh()
+          .then(() => assert.isTrue(false, 'resolved the promise'))
+          .catch(() => assert.isTrue(true, 'rejected the promise')));
+      });
+    });
+
+    describe('#register()', () => {
+      describe('when the device can register', () => {
+        describe('when the device is already registered', () => {
+          beforeEach('setup \'register()\' spy and register', () => {
+            devices.refresh = sinon.spy();
+
+            return devices.register();
+          });
+
+          it('attempts to refresh', () => {
+            assert.isTrue(devices.registered);
+
+            return devices.register()
+              .then(() => assert.called(devices.refresh));
+          });
+        });
+
+        describe('when the device is not already registered', () => {
+          let exampleResponse;
+
+          beforeEach('setup stubs and scoped variables', () => {
+            exampleResponse = {
+              body: {
+                exampleKey: 'example response value'
+              }
+            };
+
+            devices.request = sinon.stub().returns(Promise.resolve(
+              {...exampleResponse}
+            ));
+          });
+
+          describe('when the registration request is sent', () => {
+            let customHeaders;
+            let customBody;
+
+            beforeEach('configure devices plugin', () => {
+              customHeaders = {
+                testHeader: 'example header value'
+              };
+
+              customBody = {
+                testBody: 'example body value'
+              };
+            });
+
+            it('allows for custom header key:values', () => {
+              assert.isFalse(devices.registered);
+
+              devices.config.headers = {...customHeaders};
+
+              return devices.register()
+                .then(() =>
+                  assert.calledWith(devices.request, sinon.match.hasNested(
+                    'headers.testHeader', customHeaders.testHeader
+                  )));
+            });
+
+            it('allows for custom body key:values', () => {
+              assert.isFalse(devices.registered);
+
+              devices.config.body = {...customBody};
+
+              return devices.register()
+                .then(() =>
+                  assert.calledWith(devices.request, sinon.match.hasNested(
+                    'body.testBody', customBody.testBody
+                  )));
+            });
+
+            it('uses the \'wdm\' service', () => {
+              assert.isFalse(devices.registered);
+
+              devices.config.body = {...customBody};
+
+              return devices.register()
+                .then(() =>
+                  assert.calledWith(devices.request, sinon.match.has(
+                    'service', 'wdm'
+                  )));
+            });
+
+            it('uses the \'devices\' resource', () => {
+              assert.isFalse(devices.registered);
+
+              devices.config.body = {...customBody};
+
+              return devices.register()
+                .then(() =>
+                  assert.calledWith(devices.request, sinon.match.has(
+                    'resource', 'devices'
+                  )));
+            });
+
+            it('sends a POST request', () => {
+              assert.isFalse(devices.registered);
+
+              devices.config.body = {...customBody};
+
+              return devices.register()
+                .then(() =>
+                  assert.calledWith(devices.request, sinon.match.has(
+                    'method', 'POST'
+                  )));
+            });
+          });
+
+          describe('when the device is successfully registers', () => {
+            beforeEach('setup stubs', () => {
+              devices.processRegistrationSuccess = sinon.stub();
+            });
+
+            it('returns a resolved promise', () => devices.register()
+              .then(() => assert.isTrue(true, 'resolved the promise')));
+
+            it('calls \'processRegistrationSuccess()\'',
+              () => devices.register()
+                .then(() => assert.called(devices.processRegistrationSuccess)));
+          });
+
+          describe('when the device fails to register', () => {
+            beforeEach('setup request stub to 503', () => {
+              devices.request = sinon.stub().rejects(
+                new WebexHttpError({
+                  statusCode: 503,
+                  options: {
+                    url: 'http://not-a-url.com/resource',
+                    headers: {
+                      trackingId: 'tid'
+                    }
+                  }
+                })
+              );
+            });
+
+            it('returns a rejected promise', () => devices.register()
+              .then(() => assert.isTrue(false, 'resolved the promise'))
+              .catch(() => assert.isTrue(true, 'rejected the promise')));
+          });
+        });
+      });
+
+      describe('when the device cannot register', () => {
+        beforeEach('setup \'canRegister()\' stub', () => {
+          devices.canRegister = sinon.stub().rejects(
+            new Error()
+          );
+        });
+
+        it('returns a rejected promise', () => devices.register()
+          .then(() => assert.isTrue(false, 'resolved the promise'))
+          .catch(() => assert.isTrue(true, 'rejected the promise')));
+      });
+    });
+
+    describe('#resetLogoutTimer()', () => {
+      describe('when inactivty enforcement is enabled', () => {
+        beforeEach('set inactity enforcement and reachability checked', () => {
+          devices.config.enableInactivityEnforcement = true;
+          devices.isReachabilityChecked = true;
+        });
+
+        describe('when the user is in a meeting', () => {
+          beforeEach('set user to be in a meeting', () => {
+            devices.isInMeeting = true;
+          });
+
+          it('it does not set the logout timer', () => {
+            devices.resetLogoutTimer();
+
+            assert.isUndefined(devices.logoutTimer);
+          });
+        });
+
+        describe('when the user is not in a meeting', () => {
+          beforeEach('setup the \'setLogoutTimer()\' spy', () => {
+            devices.setLogoutTimer = sinon.stub();
+          });
+
+          describe('when the user is in network', () => {
+            beforeEach('set user to be in network', () => {
+              devices.isInNetwork = true;
+            });
+
+            it('sets the logout timer to the in-network duration', () => {
+              devices.resetLogoutTimer();
+
+              assert.calledWith(
+                devices.setLogoutTimer,
+                devices.intranetInactivityCheckUrl
+              );
+            });
+          });
+
+          describe('when the user is not in network', () => {
+            it('sets the logout timer to the intranet duration', () => {
+              devices.resetLogoutTimer();
+
+              assert.calledWith(
+                devices.setLogoutTimer,
+                devices.intranetInactivityDuration
+              );
+            });
+          });
+        });
+      });
+    });
+
+    describe('#unregister()', () => {
+      describe('when the device is registered', () => {
+        beforeEach('register the device', () => devices.register());
+
+        describe('when the unregistration request is sent', () => {
+          let url;
+
+          beforeEach('setup the \'request()\' stub', () => {
+            devices.request = sinon.stub().resolves();
+            url = devices.url;
+          });
+
+          it('uses the device\'s url property', () => {
+            assert.isTrue(devices.registered);
+
+            return devices.unregister()
+              .then(() =>
+                assert.calledWith(devices.request, sinon.match.has(
+                  'uri', url
+                )));
+          });
+
+          it('sends a DELETE request', () => {
+            assert.isTrue(devices.registered);
+
+            return devices.unregister()
+              .then(() =>
+                assert.calledWith(devices.request, sinon.match.has(
+                  'method', 'DELETE'
+                )));
+          });
+        });
+
+        describe('when the device unregistration request is successful', () => {
+          it('clears the device properties', () => devices.unregister()
+            .then(() => assert.isUndefined(devices.url)));
+        });
+
+        describe('when the device unregistration request fails', () => {
+          beforeEach('setup the \'request\' stub', () => {
+            devices.request = sinon.stub().rejects(
+              new WebexHttpError({
+                statusCode: 404,
+                options: {
+                  url: devices.url,
+                  headers: {
+                    trackingId: 'tid'
+                  }
+                }
+              })
+            );
+          });
+
+          it('returns a rejected promise', () => devices.unregister()
+            .then(() => assert.isTrue(false, 'resolved the promise'))
+            .catch(() => assert.isTrue(true, 'rejected the promise')));
+        });
+      });
+
+      describe('when the device is not registered', () => {
+        it('returns a resolved promise', () => devices.unregister()
+          .then(() => assert.isTrue(true, 'resolved the promise')));
+      });
+    });
+
+    describe('#waitForRegistration()', () => {
+      describe('when the device is registered', () => {
+        beforeEach('register the device', () => devices.register());
+
+        it('returns a resolved promise', () => devices.waitForRegistration()
+          .then(() => assert.isTrue(true, 'resolved the promise')));
+      });
+
+      describe('when the device is not registered', () => {
+        describe('when the device registers', () => {
+          beforeEach('trigger a pending device registration', () => {
+            devices.register();
+          });
+
+          it('returns a resolved promise once registered', () => {
+            assert.isFalse(devices.registered);
+
+            return devices.waitForRegistration()
+              .then(() => assert.isTrue(devices.registered));
+          });
+        });
+
+        describe('when the device does not register', () => {
+          it('returns a rejected promise', () => devices.waitForRegistration()
+            .then(() => assert.isTrue(false, 'resolved the promise'))
+            .catch(() => assert.isTrue(true, 'rejected the promise')));
+        });
+      });
+    });
+  });
+});

--- a/packages/node_modules/@webex/internal-plugin-devices/test/integration/spec/devices.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/test/integration/spec/devices.js
@@ -6,23 +6,30 @@ import testUsers from '@webex/test-helper-test-users';
 import WebexCore, {WebexHttpError} from '@webex/webex-core';
 
 
-describe('plugin-wdm', () => {
+describe('plugin-devices', () => {
   describe('Devices', () => {
     let webex;
     let devices;
     let user;
 
-    beforeEach('create users', () => testUsers.create({count: 1})
+    before('create users', () => testUsers.create({count: 1})
       .then(([definedUser]) => {
         user = definedUser;
-        webex = new WebexCore({
-          credentials: user.token
-        });
-
-        devices = webex.internal.devices;
       }));
 
-    afterEach('remove users', () => testUsers.remove([user]));
+    beforeEach('create webex instance', () => {
+      webex = new WebexCore({
+        credentials: user.token
+      });
+
+      devices = webex.internal.devices;
+    });
+
+    // Do nothing on error, as some methods utilize sinon for `unregister()`.
+    afterEach('attempt to unregister the device', () => devices.unregister()
+      .catch(() => {}));
+
+    after('remove users', () => testUsers.remove([user]));
 
     describe('#canRegister()', () => {
       describe('when wait is truthy', () => {

--- a/packages/node_modules/@webex/internal-plugin-devices/test/unit/spec/device-fixture.json
+++ b/packages/node_modules/@webex/internal-plugin-devices/test/unit/spec/device-fixture.json
@@ -1,0 +1,120 @@
+{
+  "url": "https://locus-a.wbx2.com/locus/api/v1/devices/88888888-4444-4444-4444-CCCCCCCCCCCC",
+  "sessionUrl": "https://locus-a.wbx2.com/locus/api/v1/sessions/SESSIONID",
+  "webSocketUrl": "wss://mercury-connection-a.wbx2.com/v1/apps/wx2/registrations/WEBSOCKETID/messages",
+  "services": {
+    "atlasServiceUrl": "https://atlas-a.wbx2.com/admin/api/v1",
+    "avatarServiceUrl": "https://avatar-a.wbx2.com/avatar/api/v1",
+    "conversationServiceUrl": "https://conv-a.wbx2.com/conversation/api/v1",
+    "encryptionServiceUrl": "https://encryption-a.wbx2.com/encryption/api/v1",
+    "filesServiceUrl": "https://beta.webex.com/files/api/v1",
+    "locusServiceUrl": "https://locus-a.wbx2.com/locus/api/v1",
+    "metricsServiceUrl": "https://metrics-a.wbx2.com/metrics/api/v1",
+    "mercuryConnectionServiceUrl": "https://mercury-connection-a.wbx2.com/v1",
+    "squaredFilesServiceUrl": "https://files-api-a.wbx2.com/v1"
+  },
+  "deviceType": "DESKTOP",
+  "name": "DESKTOP",
+  "model": "DESKTOP",
+  "localizedModel": "DESKTOP",
+  "systemName": "DESKTOP",
+  "systemVersion": "42",
+  "capabilities": {
+    "groupCallSupported": false,
+    "sdpSupported": false
+  },
+  "serviceHostMap": {
+    "serviceLinks": {
+      "atlas": "https://atlas-a.wbx2.com/admin/api/v1",
+      "avatar": "https://avatar-a.wbx2.com/avatar/api/v1",
+      "conversation": "https://conv-a.wbx2.com/conversation/api/v1",
+      "encryption": "https://encryption-a.wbx2.com/encryption/api/v1",
+      "files": "https://beta.webex.com/files/api/v1",
+      "locus": "https://locus-a.wbx2.com/locus/api/v1",
+      "metrics": "https://metrics-a.wbx2.com/metrics/api/v1",
+      "mercuryConnection": "https://mercury-connection-a.wbx2.com/v1",
+      "squaredFiles": "https://files-api-a.wbx2.com/v1"
+    },
+    "hostCatalog": {
+        "mercury-connection-a.wbx2.com": [
+          {
+            "host": "mercury-connection-a4.wbx2.com",
+            "ttl": -1,
+            "priority": 7
+          },
+          {
+            "host": "mercury-connection-a5.wbx2.com",
+            "ttl": -1,
+            "priority": 6
+          },
+          {
+            "host": "mercury-connection.a6.ciscospark.com",
+             "ttl": -1,
+             "priority": 5
+          }
+        ],
+        "conv-a.wbx2.com": [
+          {
+            "host": "conv-a5.wbx2.com",
+            "ttl": -1,
+            "priority": 5
+          },
+          {
+            "host": "conv-a4.wbx2.com",
+            "ttl": -1,
+            "priority": 4
+          }
+        ]
+    }
+  },
+  "features": {
+    "developer": [
+      {
+        "key": "console",
+        "val": "true",
+        "value": true,
+        "mutable": true,
+        "lastModified": "2015-06-29T20:02:48.033Z"
+      },
+      {
+        "key": "another-feature",
+        "val": "true",
+        "value": false,
+        "mutable": false
+      }
+    ],
+    "entitlement": [
+      {
+        "key": "call-initiation",
+        "val": "true",
+        "value": true,
+        "mutable": false
+      }
+    ],
+    "user": [
+      {
+        "key": "location-sharing",
+        "val": "false",
+        "value": false,
+        "mutable": true
+      }
+    ]
+  },
+  "userId": "USERID",
+  "isWx2TeamMember": true,
+  "clientMessagingGiphy": "ALLOW",
+  "customerCompanyName": "Example Customer",
+  "customerLogoUrl": "www.example.com/customer-logo",
+  "helpUrl": "www.example.com/help",
+  "navigationBarColor": "#000000",
+  "partnerCompanyName": "Example Partners",
+  "partnerLogoUrl": "www.example.com/partner-logo",
+  "peopleInsightsEnabled": false,
+  "reportingSiteDesc": "Example Description",
+  "reportingSiteUrl": "www.example.com/report",
+  "showSupportText": false,
+  "supportProviderCompanyName": "Example Support Provider",
+  "supportProviderLogoUrl": "www.example.com/support-provider-logo",
+  "ecmEnabledForAllUsers": true,
+  "ecmSupportedStorageProviders": ["TEAMS_STORAGE", "MICROSOFT_STORAGE"]
+}

--- a/packages/node_modules/@webex/internal-plugin-devices/test/unit/spec/devices.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/test/unit/spec/devices.js
@@ -1,0 +1,81 @@
+import {assert} from '@webex/test-helper-chai';
+import {cloneDeep} from 'lodash';
+import Devices from '@webex/internal-plugin-devices';
+import MockWebex from '@webex/test-helper-mock-webex';
+
+import deviceFixture from './device-fixture';
+
+describe('plugin-devices', () => {
+  describe('Devices', () => {
+    let webex;
+    let devices;
+
+    beforeEach('initialize webex', () => {
+      webex = new MockWebex({
+        children: {
+          devices: Devices
+        }
+      });
+
+      const deviceConfig = cloneDeep(deviceFixture);
+
+      webex.internal.devices.set(deviceConfig);
+
+      devices = webex.internal.devices;
+    });
+
+    describe('#clear()', () => {
+      it('clears all features', () => {
+        assert.isAbove(devices.features.developer.length, 0);
+        devices.clear();
+        assert.lengthOf(devices.features.developer, 0);
+      });
+
+      it('does not clear the logger', () => {
+        assert.property(devices, 'logger');
+        assert.isDefined(devices.logger);
+        devices.clear();
+        assert.property(devices, 'logger');
+        assert.isDefined(devices.logger);
+      });
+    });
+
+    describe('#setLogoutTimer()', () => {
+      describe('when the duration is not valid', () => {
+        it('returns when it is not set', () => {
+          const {logoutTimer} = devices;
+
+          devices.setLogoutTimer();
+          assert.equal(devices.logoutTimer, logoutTimer);
+        });
+
+        it('returns when it\'s less than or equal to zero', () => {
+          const {logoutTimer} = devices;
+
+          devices.setLogoutTimer(-1);
+          assert.equal(devices.logoutTimer, logoutTimer);
+        });
+      });
+
+      describe('when the duration is valid', () => {
+        it('sets up a \'change:lastUserActivityDate\' event listener', () => {
+          assert(true);
+        });
+
+        it('sets the logout timer', () => {
+          const {logoutTimer} = devices;
+
+          devices.setLogoutTimer(60000);
+          assert.notEqual(devices.logoutTimer, logoutTimer);
+        });
+      });
+    });
+
+    describe('#serialize()', () => {
+      it('serializes feature toggles in a format compatible with wdm', () => {
+        assert.deepEqual(devices.serialize().features, deviceFixture.features);
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
# Deprecate WDM Service Methods

## Description

This is a draft pull request for the new Devices plugin that will deprecate the original WDM plugin and its service methods. This is being presented as a draft pull request to allow for gated validation points along the way. Ultimately, this added plugin could either stay unique, leaving legacy support for WDM, or, replace WDM and it's a namespace.

Fixes # spark-102183

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Generated a testing suite [TODO]

**Test Configuration**:
* Node/Browser Version v8.16.0
* NPM Version v6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
