### PR TITLE
fix(plugin-conversation): Add option argument to download encrypted file

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -216,7 +216,7 @@ const Conversation = WebexPlugin.extend({
     let promise;
 
     if (isEncrypted) {
-      promise = this.webex.internal.encryption.download(item.scr);
+      promise = this.webex.internal.encryption.download(item.scr, item.options);
     }
     else if (item.scr && item.scr.loc) {
       promise = this._downloadUnencryptedFile(item.scr.loc, options);

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
@@ -52,6 +52,19 @@ describe('plugin-conversation', function () {
 
       afterEach(() => conversationRequestSpy.restore());
 
+      it('rejects for invalid options argument', () => webex.internal.conversation.share(conversation, [sampleImageSmallOnePng])
+        .then((activity) => {
+          const item = activity.object.files.items[0];
+
+          item.options = {
+            params: {
+              allow: 'invalidOption'
+            }
+          };
+
+          assert.isRejected(webex.internal.conversation.download(item));
+        }));
+
       it('downloads and decrypts an encrypted file', () => webex.internal.conversation.share(conversation, [sampleImageSmallOnePng])
         .then((activity) => webex.internal.conversation.download(activity.object.files.items[0]))
         .then((f) => fh.isMatchingFile(f, sampleImageSmallOnePng)

--- a/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/encryption.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/encryption.js
@@ -154,6 +154,29 @@ describe('Encryption', function () {
       .then((f) => file.isMatchingFile(f, FILE)
         .then((result) => assert.deepEqual(result, true))));
 
+    it('downloads and decrypts an encrypted file with options param', () => webex.internal.encryption.encryptBinary(FILE)
+      .then(({scr, cdata}) => webex.request({
+        method: 'POST',
+        uri: makeLocalUrl('/files/upload'),
+        body: cdata
+      })
+        .then((res) => {
+          scr.loc = makeLocalUrl(res.body.loc, {full: true});
+
+          return webex.internal.encryption.encryptScr(key, scr);
+        }))
+      .then((cipherScr) => webex.internal.encryption.decryptScr(key, cipherScr))
+      .then((scr) => {
+        const options = {
+          params: {
+            allow: 'none'
+          }
+        };
+
+        return webex.internal.encryption.download(scr, options);
+      })
+      .then((f) => assert.isTrue(file.isMatchingFile(f, FILE))));
+
     it('emits progress events', () => {
       const spy = sinon.spy();
 


### PR DESCRIPTION
# Pull Request Template

## Description
This PR is a continuation of this PR: #1401 
From conversation package, we are making a call to encryption package for scanning and downloading a file. I and Meesha, had added a new options argument for allowing unchecked files to get downloaded upon end-user request.

Fixes #SPARK-99531

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

This PR doesn't need a new test cases.

**Test Configuration**:
* SDK Version: 1.80.29
* Node/Browser Version: 1.80.29
* NPM Version: 6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
