### PR TITLE
test(ediscovery): remove getServiceUrl stubs

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-ediscovery/test/unit/spec/content.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/test/unit/spec/content.js
@@ -7,7 +7,6 @@ import config from '@webex/internal-plugin-ediscovery/src/config';
 /* eslint-disable max-len */
 describe('EDiscovery Content API Tests', () => {
   let webex;
-  const url = 'https://ediscovery-test.wbx2.com/ediscovery';
   const uuid = 'cc06f622-46ab-45b9-b3a6-5d70bad1d70a';
   const defaultTimeout = 30000;
 
@@ -18,7 +17,6 @@ describe('EDiscovery Content API Tests', () => {
       }
     });
     webex.config.ediscovery = config.ediscovery;
-    webex.internal.device.getServiceUrl = sinon.stub().returns(Promise.resolve(url));
   });
 
   describe('GetContent Tests', () => {

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/test/unit/spec/report.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/test/unit/spec/report.js
@@ -11,7 +11,6 @@ import config from '@webex/internal-plugin-ediscovery/src/config';
 /* eslint-disable max-len */
 describe('EDiscovery Report API Tests', () => {
   let webex;
-  const url = 'https://ediscovery-test.wbx2.com/ediscovery';
   const uuid = 'cc06f622-46ab-45b9-b3a6-5d70bad1d70a';
   const defaultTimeout = 30000;
   const reportRequest = new ReportRequest();
@@ -25,7 +24,6 @@ describe('EDiscovery Report API Tests', () => {
       }
     });
     webex.config.ediscovery = config.ediscovery;
-    webex.internal.device.getServiceUrl = sinon.stub().returns(Promise.resolve(url));
   });
 
   describe('CreateReport Tests', () => {


### PR DESCRIPTION
# Pull Request Template

## Description

Removes the `getServiceUrl` stubs from the unit tests which were unused.

Fixes # (issue)
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-106011


## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] `npm run test -- --packages @webex/internal-plugin-ediscovery`


