### PR TITLE
feat(meetings): use service plugin methods

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js
@@ -190,9 +190,10 @@ MeetingInfoUtil.generateOptions = async (from) => {
   }
   else if (hydraId.room) {
     options.type = _CONVERSATION_URL_;
-    // TODO: cleanup after hydra is federated :::SPARK-91986:::
-    // do not build conversation URLs in federation!
-    options.destination = `${webex.internal.device.services.conversationServiceUrl}/${CONVERSATIONS}/${hydraId.destination}`;
+    await webex.internal.services.waitForCatalog('postauth');
+    const convoUrl = `${webex.internal.services.get('conversation')}/${CONVERSATIONS}/${hydraId.destination}`;
+
+    options.destination = convoUrl;
   }
   else {
     throw new ParameterError('MeetingInfo is fetched with meeting link, sip uri, phone number, hydra room id, hydra people id, or a conversation url.');

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
@@ -31,7 +31,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
    * @param {String} options.correlationId
    * @returns {Promise}
    */
-  joinMeeting(options) {
+  async joinMeeting(options) {
     const {
       sipUri, deviceUrl, locusUrl, resourceId, correlationId, ensureConversation, moderator, hostPin, moveToResource, roapMessage
     } = options;
@@ -64,9 +64,8 @@ export default class MeetingRequest extends StatelessWebexPlugin {
       url = `${locusUrl}/${PARTICIPANT}`;
     }
     else if (sipUri) {
-      // eslint-lin-disable-next-line no-warning-comments
-      // TODO switch to use the locus object and look into federation?
-      url = `${this.webex.internal.device.services.locusServiceUrl}/${LOCI}/${CALL}`;
+      await this.webex.internal.services.waitForCatalog('postauth');
+      url = `${this.webex.internal.services.get('locus')}/${LOCI}/${CALL}`;
       body.invitee = {
         address: sipUri
       };

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/request.js
@@ -49,7 +49,7 @@ export default class RoapRequest extends StatelessWebexPlugin {
     LoggerProxy.logger.info('RoapRequest->joinMeetingWithRoap#Join locus with roap');
     LoggerProxy.logger.info(`RoapRequest->joinMeetingWithRoap#Clocal SDP: ${options.roapMessage}`);
 
-    return Promise.resolve().then(() => {
+    return Promise.resolve().then(async () => {
       const deviceUrl = this.webex.internal.device.url;
       let url = '';
 
@@ -72,7 +72,8 @@ export default class RoapRequest extends StatelessWebexPlugin {
         url = `${options.locusUrl}/${PARTICIPANT}`;
       }
       else if (options.sipUrl) {
-        url = `${this.webex.internal.device.services.locusServiceUrl}/${LOCI}/${CALL}`;
+        await this.webex.internal.services.waitForCatalog('postauth');
+        url = `${this.webex.internal.services.get('locus')}/${LOCI}/${CALL}`;
         body.invitee = {
           address: options.sipTarget
         };


### PR DESCRIPTION
# Pull Request Template

## Description

Switches the meetings plugin to use non-deprecated service catalog methods.

Fixes # (issue)
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-106016

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
