### PR TITLE
Spark 106010/remove device service references

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -1099,6 +1099,36 @@ const Conversation = WebexPlugin.extend({
   },
 
   /**
+   * Get the current conversation url.
+   *
+   * @returns {Promise<string>} - conversation url
+   */
+  getConversationUrl() {
+    this.logger.info('conversation: getting the conversation service url');
+
+    const convoUrl = this.webex.internal.services.get('conversation');
+
+    // Validate if the conversation url exists in the services plugin and
+    // resolve with its value.
+    if (convoUrl) {
+      return Promise.resolve(convoUrl);
+    }
+
+    // Wait for the postauth catalog to update and then try to retrieve the
+    // conversation service url again.
+    return this.webex.internal.waitForCatalog('postauth')
+      .then(() => this.webex.internal.services.get('conversation'))
+      .catch((error) => {
+        this.logger.warn(
+          'conversation: unable to get conversation url',
+          error.message
+        );
+
+        return Promise.reject(error);
+      });
+  },
+
+  /**
    * @param {Object} conversation
    * @private
    * @returns {Promise}
@@ -1110,15 +1140,23 @@ const Conversation = WebexPlugin.extend({
           if (haMessagingEnabled) {
             // recompute conversation URL each time as the host may have changed
             // since last usage
-            return this.webex.internal.device.getServiceUrl('conversation')
+            return this.getConversationUrl()
               .then((url) => {
                 conversation.url = `${url}/conversations/${conversation.id}`;
 
                 return conversation;
+              })
+              // throw an error if conversation url is not found
+              .catch((error) => {
+                this.logger.warn(
+                  'conversation: conversation url not found', error.message
+                );
+
+                return Promise.reject(error);
               });
           }
           if (!conversation.url) {
-            return this.webex.internal.device.getServiceUrl('conversation')
+            return this.getConversationUrl()
               .then((url) => {
                 conversation.url = `${url}/conversations/${conversation.id}`;
                 /* istanbul ignore else */
@@ -1127,7 +1165,11 @@ const Conversation = WebexPlugin.extend({
                 }
 
                 return conversation;
-              });
+              })
+              // throw an error if conversation url is not found
+              .catch((error) => this.logger.warn(
+                'conversation: conversation url not found', error.message
+              ));
           }
 
           return Promise.resolve(conversation);

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -20,7 +20,8 @@ describe('plugin-conversation', () => {
         }
       });
 
-      webex.internal.device.getServiceUrl = sinon.stub().returns(Promise.resolve(convoUrl));
+      webex.internal.services = {};
+      webex.internal.services.get = sinon.stub().returns(Promise.resolve(convoUrl));
     });
 
     describe('#_inferConversationUrl', () => {
@@ -29,7 +30,7 @@ describe('plugin-conversation', () => {
       it('Returns given convo if no id', () => webex.internal.conversation._inferConversationUrl(testConvo)
         .then((convo) => {
           assert.notCalled(webex.internal.feature.getFeature);
-          assert.notCalled(webex.internal.device.getServiceUrl);
+          assert.notCalled(webex.internal.services.get);
           assert.equal(convo.test, 'convo');
         }));
 
@@ -44,7 +45,7 @@ describe('plugin-conversation', () => {
           return webex.internal.conversation._inferConversationUrl(testConvo)
             .then((convo) => {
               assert.called(webex.internal.feature.getFeature);
-              assert.notCalled(webex.internal.device.getServiceUrl);
+              assert.notCalled(webex.internal.services.get);
               assert.equal(convo.url, 'http://example.com');
             });
         });
@@ -54,7 +55,7 @@ describe('plugin-conversation', () => {
           return webex.internal.conversation._inferConversationUrl(testConvo)
             .then((convo) => {
               assert.called(webex.internal.feature.getFeature);
-              assert.called(webex.internal.device.getServiceUrl);
+              assert.called(webex.internal.services.get);
               assert.equal(convo.url, `${convoUrl}/conversations/id1`);
             });
         });
@@ -70,7 +71,7 @@ describe('plugin-conversation', () => {
           return webex.internal.conversation._inferConversationUrl(testConvo)
             .then((convo) => {
               assert.called(webex.internal.feature.getFeature);
-              assert.called(webex.internal.device.getServiceUrl);
+              assert.called(webex.internal.services.get);
               assert.equal(convo.url, `${convoUrl}/conversations/id1`);
             });
         });
@@ -80,7 +81,7 @@ describe('plugin-conversation', () => {
           return webex.internal.conversation._inferConversationUrl(testConvo)
             .then((convo) => {
               assert.called(webex.internal.feature.getFeature);
-              assert.called(webex.internal.device.getServiceUrl);
+              assert.called(webex.internal.services.get);
               assert.equal(convo.url, `${convoUrl}/conversations/id1`);
             });
         });


### PR DESCRIPTION
# Pull Request

## Description

Remove all references for the service catalog nested under the devices plugin and replace them with appropriate methods from the services plugin.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran `npm test -- --packages @webex/internal-plugin-team`

**Test Configuration**:
* Node/Browser Version v8.16.0
* NPM Version v6.4.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
