### PR TITLE
test(meetings): use space url instead of id

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
@@ -56,7 +56,7 @@ skipInNode(describe)('plugin-meetings', () => {
         })
         .then(function aliceStartsMeeting() {
           return Promise.all([
-            testUtils.delayedPromise(alice.webex.meetings.create(space.id)),
+            testUtils.delayedPromise(alice.webex.meetings.create(space.url)),
             testUtils.waitForEvents([{scope: alice.webex.meetings, event: 'meeting:added', user: alice}])
           ]);
         })


### PR DESCRIPTION
# Pull Request Template

## Description

Uses the space url instead of id since locus no longer supports id it seems.

Fixes # (issue)

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-107156


