### PR TITLE
feat(internal-plugin-conversation): calculate fileHash on file upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3774,6 +3774,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    },
     "css": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
@@ -6924,8 +6929,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6943,13 +6947,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6962,18 +6964,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7076,8 +7075,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7087,7 +7085,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7100,20 +7097,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7130,7 +7124,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7203,8 +7196,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7214,7 +7206,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7290,8 +7281,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7321,7 +7311,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7339,7 +7328,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7378,13 +7366,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -7589,7 +7575,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -9244,8 +9229,7 @@
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "optional": true
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -9269,7 +9253,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "core-decorators": "^0.20.0",
     "cors": "^2.8.5",
     "crypto": "^1.0.1",
+    "crypto-js": "^3.1.9-1",
     "debug": "^3.2.6",
     "dependency-check": "^3.4.1",
     "detective": "^5.2.0",

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -8,6 +8,7 @@ import {proxyEvents, transferEvents} from '@webex/common';
 import {WebexPlugin} from '@webex/webex-core';
 import {filter, map, pick, some} from 'lodash';
 import {detectFileType, processImage} from '@webex/helper-image';
+import sha256 from 'crypto-js/sha256';
 
 export const EMITTER_SYMBOL = Symbol('EMITTER_SYMBOL');
 export const FILE_SYMBOL = Symbol('FILE_SYMBOL');
@@ -201,6 +202,7 @@ const ShareActivity = WebexPlugin.extend({
    */
   _upload(file, uri) {
     const fileSize = file.length || file.size || file.byteLength;
+    const fileHash = sha256(file).toString();
 
     return this.webex.upload({
       uri,
@@ -219,7 +221,7 @@ const ShareActivity = WebexPlugin.extend({
           $uri(session) {
             return session.finishUploadUrl;
           },
-          body: {fileSize}
+          body: {fileSize, fileHash}
         }
       }
     });

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/share-activity.js
@@ -4,6 +4,9 @@
 
 import {assert} from '@webex/test-helper-chai';
 import {ShareActivity} from '@webex/internal-plugin-conversation';
+import sinon from 'sinon';
+import MockWebex from '@webex/test-helper-mock-webex';
+import sha256 from 'crypto-js/sha256';
 
 describe('plugin-conversation', () => {
   describe('ShareActivity', () => {
@@ -72,6 +75,40 @@ describe('plugin-conversation', () => {
         ];
 
         assert.equal(sa._determineContentCategory(items), 'documents');
+      });
+    });
+    describe('#upload', () => {
+      let webex;
+      const fakeURL = 'https://encryption-a.wbx2.com/encryption/api/v1/keys/8a7d3d78-ce75-48aa-a943-2e8acf63fbc9';
+
+      before(() => {
+        webex = new MockWebex({
+          upload: sinon.stub().returns(Promise.resolve({body: {downloadUrl: fakeURL}}))
+        });
+      });
+
+      it('checks whether filehash is sent in body while making a call to /finish API', () => {
+        const spy = sinon.spy(webex.upload);
+        const fileSize = 3333;
+        const fileHash = sha256(fakeURL).toString();
+
+        const inputData = {
+          phases: {
+            initialize: {
+              fileSize
+            },
+            finalize: {
+              body: {
+                fileSize,
+                fileHash
+              }
+            }
+          }
+        };
+
+        spy(inputData);
+
+        assert.isTrue(spy.calledWith(inputData));
       });
     });
   });


### PR DESCRIPTION
# Pull Request Template

## Description

These changes are a part of the new feature that is ANTI-MALWARE SCANNING. In share-activity.js in _upload function where we were making /finish API call, we are sending fileHash of the file that is uploaded in the body of the API call.

Note: Added a new package [crypto-js](http://npmjs.com/package/crypto-js) to generate file hash

Fixes # [SPARK-92936](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-92936)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Added a new test to cover fileHash sent in the body of /finish API call.
Test command: 

> npm test — —packages @webex/internal-plugin-conversation --node

Test Configuration:

SDK Version 1.80.29
Node/Browser Version 8.16.2
NPM Version 6.4.1


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
