### PR TITLE
feat(mercury): expand which options can be passed down

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js
@@ -3,10 +3,12 @@
  */
 
 import url from 'url';
+
 import {WebexPlugin} from '@webex/webex-core';
 import {deprecated, oneFlight} from '@webex/common';
 import {camelCase, get, set} from 'lodash';
 import backoff from 'backoff';
+
 import Socket from './socket';
 import {
   BadRequest,
@@ -167,7 +169,7 @@ const Mercury = WebexPlugin.extend({
       .then(([webSocketUrl, token]) => {
         attemptWSUrl = webSocketUrl;
 
-        const options = {
+        let options = {
           forceCloseDelay: this.config.forceCloseDelay,
           pingInterval: this.config.pingInterval,
           pongTimeout: this.config.pongTimeout,
@@ -176,10 +178,10 @@ const Mercury = WebexPlugin.extend({
           logger: this.logger
         };
 
-        // if a proxy agent has been configured we will add it here to successfully open a websocket
-        if (this.webex.config.defaultMercuryOptions && this.webex.config.defaultMercuryOptions.agent) {
-          this.logger.info('mercury: setup proxy agent');
-          options.agent = this.webex.config.defaultMercuryOptions.agent;
+        // if the consumer has supplied request options use them
+        if (this.webex.config.defaultMercuryOptions) {
+          this.logger.info('mercury: setting custom options');
+          options = {...options, ...this.webex.config.defaultMercuryOptions};
         }
 
         return socket.open(webSocketUrl, options);


### PR DESCRIPTION
# Pull Request Template

## Description

To support setting a `user-agent` on the mercury websocket I'm expanding which options can be passed down to mercury via the `init`. This'll allow us to support corporate proxies which can direct traffic based on `user-agent`.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
