### PR TITLE
feat(reactions): add decrypt-transforms for reaction objects

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/decryption-transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/decryption-transforms.js
@@ -46,6 +46,56 @@ export const transforms = toArray('inbound', {
     return ctx.transform(`decrypt${capitalize(object.objectType)}`, key, object);
   },
 
+
+  /**
+   * Decrypt an individual reaction2Summary activity (object.objectType === 'reaction2Summary')
+   * @param   {Object} ctx      An object containg a webex instance and a transform
+   * @param   {String} key      KMS key
+   * @param   {Object} object An instance of a Webex Teams reaction2Summary object
+   * these objects are returned by various conversation APIs and over mercury
+   * represents an aggregated summary of all reactions to a specific activity
+   * @returns {Promise}         Returns a ctx.transform promise
+   */
+  decryptReaction2summary(ctx, key, object) {
+    if (!object.reactions) {
+      return Promise.resolve();
+    }
+
+    return Promise.all(object.reactions.map((reaction) => ctx.transform('decryptPropDisplayName', key, reaction)));
+  },
+
+  /**
+   * Decrypt an individual reaction2SelfSummary activity (object.objectType === 'reaction2SelfSummary')
+   * @param   {Object} ctx      An object containg a webex instance and a transform
+   * @param   {String} key      KMS key
+   * @param   {Object} object An instance of a Webex Teams reaction2SelfSummary object
+   * these objects are returned by various conversation APIs and NOT over mercury
+   * they are ONLY received by the self user
+   * they represent ONLY the self user's reactions and are used for enforcing
+   * limit of times they can react to a specific activity
+   * @returns {Promise}         Returns a ctx.transform promise
+   */
+  decryptReaction2selfsummary(ctx, key, object) {
+    if (!object.reactions) {
+      return Promise.resolve();
+    }
+
+    return Promise.all(object.reactions.map((reaction) => ctx.transform('decryptPropDisplayName', key, reaction)));
+  },
+
+  /**
+   * Decrypt an individual reaction2 activity (object.objectType === 'reaction2')
+   * @param   {Object} ctx      An object containg a webex instance and a transform
+   * @param   {String} key      KMS key
+   * @param   {Object} object An instance of a Webex Teams reaction2 object
+   * these objects are returned by various conversation APIs and over mercury
+   * ONLY self users receive these objects
+   * @returns {Promise}         Returns a ctx.transform promise
+   */
+  decryptReaction2(ctx, key, object) {
+    return ctx.transform('decryptPropDisplayName', key, object);
+  },
+
   /**
    * Decrypts a given conversation and it's activites by building an array of promises that call
    * decryptObject, which may then call other decrypt functions
@@ -94,7 +144,16 @@ export const transforms = toArray('inbound', {
 
     const keyUrl = activity.encryptionKeyUrl || activity.object.encryptionKeyUrl || key;
 
-    return ctx.transform('decryptObject', keyUrl, activity.object);
+    let promises = [];
+
+    // iterate and recursively decrypt over children objects
+    if (activity.children && Array.isArray(activity.children)) {
+      promises = activity.children.map((child) => ctx.transform('decryptObject', keyUrl, child.activity));
+    }
+
+    promises.push(ctx.transform('decryptObject', keyUrl, activity.object));
+
+    return Promise.all(promises);
   },
 
   /**

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/decrypt-transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/decrypt-transforms.js
@@ -65,6 +65,138 @@ describe('plugin-conversation', () => {
       });
     });
 
+    describe('reactions', () => {
+      it('calls the correct method if a reaction2Summary object is passed in', () => {
+        const transform = transforms.find((t) => t.name === 'decryptObject');
+        const transformStub = sinon.stub();
+
+        const ctx = {
+          transform: transformStub
+        };
+        const key = null;
+        const activity = {
+          objectType: 'reaction2Summary'
+        };
+
+        transform.fn(ctx, key, activity);
+
+        assert.equal(transformStub.lastCall.args[0], 'decryptReaction2summary');
+      });
+
+      it('decrypts the activity object and its children and its reactions', () => {
+        const transform = transforms.find((t) => t.name === 'decryptActivity');
+        const transformStub = sinon.spy();
+
+        const ctx = {
+          transform: transformStub
+        };
+        const key = null;
+        const activity = {
+          objectType: 'activity',
+          verb: 'post',
+          encryptionKeyUrl: 'keyUrl1',
+          object: {
+            objectType: 'comment'
+          },
+          children: [
+            {
+              verb: 'add',
+              objectType: 'activity',
+              encryptionKeyUrl: 'keyUrl1',
+              object: {
+                objectType: 'reaction2Summary',
+                reactions: [
+                  {displayName: 'reaction1'},
+                  {displayName: 'reaction2'}
+                ]
+              }
+            },
+            {
+              verb: 'add',
+              objectType: 'activity',
+              encryptionKeyUrl: 'keyUrl1',
+              object: {
+                objectType: 'reaction2Summary',
+                reactions: [
+                  {displayName: 'reaction1'},
+                  {displayName: 'reaction2'}
+                ]
+              }
+            }
+
+          ]
+
+        };
+
+        return transform.fn(ctx, key, activity)
+          .then(() => {
+            assert.equal(transformStub.callCount, 3); // once for the parents object and then once for each child
+            assert.equal(transformStub.getCall(0).args[0], 'decryptObject');
+            assert.equal(transformStub.getCall(1).args[0], 'decryptObject');
+            assert.equal(transformStub.getCall(2).args[0], 'decryptObject');
+          });
+      });
+
+      it('decrypts the reaction2Summary object and the reactions', () => {
+        const transform = transforms.find((t) => t.name === 'decryptReaction2summary');
+        const transformStub = sinon.spy();
+
+        const ctx = {
+          transform: transformStub
+        };
+        const key = null;
+        const activity = {
+          objectType: 'reaction2Summary',
+          reactions: [
+            {displayName: 'reaction1'},
+            {displayName: 'reaction2'}
+          ]
+
+        };
+
+        return transform.fn(ctx, key, activity)
+          .then(() => {
+            assert.equal(transformStub.callCount, 2);
+            assert.equal(transformStub.getCall(0).args[0], 'decryptPropDisplayName');
+            assert.equal(transformStub.getCall(1).args[0], 'decryptPropDisplayName');
+          });
+      });
+
+      it('calls the correct method if a reaction2SelfSummary object is passed in', () => {
+        const transform = transforms.find((t) => t.name === 'decryptObject');
+        const transformStub = sinon.stub();
+
+        const ctx = {
+          transform: transformStub
+        };
+        const key = null;
+        const activity = {
+          objectType: 'reaction2SelfSummary'
+        };
+
+        transform.fn(ctx, key, activity);
+
+        assert.equal(transformStub.lastCall.args[0], 'decryptReaction2selfsummary');
+      });
+
+      it('calls the correct method if a reaction2 object is passed in', () => {
+        const transform = transforms.find((t) => t.name === 'decryptObject');
+        const transformStub = sinon.stub();
+
+        const ctx = {
+          transform: transformStub
+        };
+        const key = null;
+        const activity = {
+          objectType: 'reaction2'
+        };
+
+        transform.fn(ctx, key, activity);
+
+        assert.equal(transformStub.lastCall.args[0], 'decryptReaction2');
+      });
+    });
+
     describe('link activity', () => {
       it('calls the correct method if a content object is passed in', () => {
         const transform = transforms.find((t) => t.name === 'decryptObject');


### PR DESCRIPTION
# Pull Request Template

## Description
Added functions to decrypt-transform to decrypt reaction activity objects.
see https://confluence-eng-gpk2.cisco.com/conf/display/CUERVOS/Reactions+-+Crawl for reference of what these objects look like.

## Type of Change
Feature/added functionality

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Test Coverage
I used this code to develop the feature in the Webex Teams web client. this [PR](https://sqbu-github.cisco.com/WebExSquared/webex-web-client/pull/362) allows consuming reactions in the Webex Teams web client.
I also added tests to `packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/decrypt-transforms.js`

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version: v1.80.63
* Node/Browser Version: Node v10.16.2/Chrome: 79.0.3945.74
* NPM Version: 6.9.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
