### PR TITLE
WIP : feat(internal-plugin-encryption): add support for multi-cluster file download

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-encryption/src/encryption.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/src/encryption.js
@@ -3,6 +3,7 @@
  */
 
 import {EventEmitter} from 'events';
+import url from 'url';
 
 import {WebexPlugin} from '@webex/webex-core';
 import {proxyEvents, tap, transferEvents} from '@webex/common';
@@ -120,11 +121,15 @@ const Encryption = WebexPlugin.extend({
     const inputBody = {
       endpoints: [scr.loc]
     };
+    const endpointUrl = url.parse(scr.loc);
+
+    // hardcode the url to use 'https' and the file service '/v1/download/endpoints' api
+    endpointUrl.protocol = 'https';
+    endpointUrl.pathname = '/v1/download/endpoints';
 
     return this.request({
       method: 'POST',
-      service: 'files',
-      resource: 'download/endpoints',
+      uri: url.format(endpointUrl),
       body: options ? {
         ...inputBody,
         allow: options.params.allow

--- a/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/encryption.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/encryption.js
@@ -175,7 +175,8 @@ describe('Encryption', function () {
 
         return webex.internal.encryption.download(scr, options);
       })
-      .then((f) => assert.isTrue(file.isMatchingFile(f, FILE))));
+      .then((f) => file.isMatchingFile(f, FILE))
+      .then((result) => assert.deepEqual(result, true)));
 
     it('emits progress events', () => {
       const spy = sinon.spy();

--- a/packages/node_modules/@webex/internal-plugin-encryption/test/unit/spec/encryption.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/test/unit/spec/encryption.js
@@ -1,0 +1,79 @@
+/*!
+ * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
+ */
+/* eslint-disable no-underscore-dangle */
+import Url from 'url';
+
+import {assert} from '@webex/test-helper-chai';
+import MockWebex from '@webex/test-helper-mock-webex';
+import sinon from 'sinon';
+import Encryption from '@webex/internal-plugin-encryption';
+
+describe('internal-plugin-encryption', () => {
+  describe('download', () => {
+    let webex;
+
+    beforeEach(() => {
+      webex = new MockWebex({
+        children: {
+          encryption: Encryption
+        }
+      });
+    });
+
+    describe('check _fetchDownloadUrl()', () => {
+      const scrArray = [
+        {
+          loc: 'https://files-api-intb1.ciscospark.com/v1/spaces/a0cba376-fc05-4b88-af4b-cfffa7465f9a/contents/1d3931e7-9e31-46bc-8084-d766a8f72c99/versions/5fa9caf87a98410aae49e0173856a974/bytes'
+        },
+        {
+          loc: 'https://files-api-intb2.ciscospark.com/v1/spaces/a0cba376-fc05-4b88-af4b-cfffa7465f9a/contents/1d3931e7-9e31-46bc-8084-d766a8f72c99/versions/5fa9caf87a98410aae49e0173856a974/bytes'
+        },
+        {
+          loc: 'https://www.test-api.com/v1/spaces/test-path-name-space/contents/test-path-name-contents/versions/test-version/bytes'
+        },
+        {
+          loc: 'http://www.test-api.com/v1/spaces/test-path-name-space/contents/test-path-name-contents/versions/test-version/bytes'
+        }
+
+      ];
+      const options = undefined;
+      let spyStub;
+
+      beforeEach(() => {
+        const returnStub = (obj) => Promise.resolve(obj);
+
+        spyStub = sinon.stub(webex.internal.encryption, 'request').callsFake(returnStub);
+
+        scrArray.forEach(
+          (scr) => webex.internal.encryption._fetchDownloadUrl(scr, options)
+        );
+      });
+
+      it('verifying file service uris', () => {
+        assert.equal(spyStub.args[0][0].uri, 'https://files-api-intb1.ciscospark.com/v1/download/endpoints');
+        assert.equal(spyStub.args[1][0].uri, 'https://files-api-intb2.ciscospark.com/v1/download/endpoints');
+        assert.equal(spyStub.args[2][0].uri, 'https://www.test-api.com/v1/download/endpoints');
+        assert.equal(spyStub.args[3][0].uri, 'https://www.test-api.com/v1/download/endpoints');
+      });
+
+      it('verifying https', () => {
+        assert.equal(Url.parse(spyStub.args[0][0].uri).protocol, 'https:');
+        assert.equal(Url.parse(spyStub.args[1][0].uri).protocol, 'https:');
+        assert.equal(Url.parse(spyStub.args[2][0].uri).protocol, 'https:');
+        assert.equal(Url.parse(spyStub.args[3][0].uri).protocol, 'https:');
+      });
+
+      it('verifying endpoints', () => {
+        assert.equal(spyStub.args[0][0].body.endpoints[0], scrArray[0].loc);
+        assert.equal(spyStub.args[1][0].body.endpoints[0], scrArray[1].loc);
+        assert.equal(spyStub.args[2][0].body.endpoints[0], scrArray[2].loc);
+        assert.equal(spyStub.args[3][0].body.endpoints[0], scrArray[3].loc);
+      });
+
+      afterEach(() => {
+        spyStub.resetHistory();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR adds support for multi-cluster file download. Before this PR, files are downloaded from the files-service tied to the `internal.device._values -> serviceHostMap`.  
In some use cases (i.e. federation) the file location may be stored on different file services. The PR points the file service to the one received in the endpoint URL.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
