### PR TITLE
feat(calendar): handle /calendar API not returning meeting notes and participants

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-calendar/src/calendar.js
+++ b/packages/node_modules/@webex/internal-plugin-calendar/src/calendar.js
@@ -42,6 +42,7 @@
  * @memberof Calendar
  */
 
+import btoa from 'btoa';
 import {WebexPlugin} from '@webex/webex-core';
 
 import CalendarCollection from './collection';
@@ -237,6 +238,32 @@ const Calendar = WebexPlugin.extend({
   },
 
   /**
+   * Retrieves an array of meeting participants for the meeting id
+   * @param {String} id
+   * @returns {Promise} Resolves with an object of meeting participants
+   */
+  getParticipants(id) {
+    return this.request({
+      method: 'GET',
+      service: 'calendar',
+      resource: `calendarEvents/${btoa(id)}/participants`
+    });
+  },
+
+  /**
+   * Retrieves a collection of meetings based on the request parameters
+   * @param {String} id
+   * @returns {Promise} Resolves with an object of meeting notes
+   */
+  getNotes(id) {
+    return this.request({
+      method: 'GET',
+      service: 'calendar',
+      resource: `calendarEvents/${btoa(id)}/notes`
+    });
+  },
+
+  /**
    * Retrieves a collection of meetings based on the request parameters
    * @param {Object} options
    * @param {Date} options.fromDate the start of the time range
@@ -252,7 +279,33 @@ const Calendar = WebexPlugin.extend({
       resource: 'calendarEvents',
       qs: options
     })
-      .then((res) => res.body.items);
+      .then((res) => {
+        const meetingObjects = res.body.items;
+        const promises = [];
+
+        meetingObjects.forEach((meeting) => {
+          if (!meeting.encryptedNotes) {
+            promises.push(
+              this.getNotes(meeting.id)
+                .then((notesResponse) => {
+                  meeting.encryptedNotes = notesResponse.body.encryptedNotes;
+                })
+            );
+          }
+
+          if (!meeting.encryptedParticipants) {
+            promises.push(
+              this.getParticipants(meeting.id)
+                .then((notesResponse) => {
+                  meeting.encryptedParticipants = notesResponse.body.encryptedParticipants;
+                })
+            );
+          }
+        });
+
+        return Promise.all(promises)
+          .then(() => meetingObjects);
+      });
   }
 });
 

--- a/packages/node_modules/@webex/internal-plugin-calendar/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-calendar/src/index.js
@@ -17,6 +17,26 @@ registerInternalPlugin('calendar', Calendar, {
   payloadTransformer: {
     predicates: [
       {
+        name: 'transformMeetingNotes',
+        direction: 'inbound',
+        test(ctx, response) {
+          return Promise.resolve(has(response, 'body.encryptedNotes'));
+        },
+        extract(response) {
+          return Promise.resolve(response.body);
+        }
+      },
+      {
+        name: 'transformMeetingParticipants',
+        direction: 'inbound',
+        test(ctx, response) {
+          return Promise.resolve(has(response, 'body.encryptedParticipants'));
+        },
+        extract(response) {
+          return Promise.resolve(response.body);
+        }
+      },
+      {
         name: 'transformMeetingArray',
         direction: 'inbound',
         test(ctx, response) {
@@ -66,11 +86,11 @@ registerInternalPlugin('calendar', Calendar, {
             return Promise.resolve();
           }
 
-          // Decrypt participant properties
-          const decryptedParticipants = object.encryptedParticipants.map((participant) => Promise.all([
+          // Decrypt participant properties if meeting object contains participants
+          const decryptedParticipants = object.encryptedParticipants ? object.encryptedParticipants.map((participant) => Promise.all([
             ctx.transform('decryptTextProp', 'encryptedEmailAddress', object.encryptionKeyUrl, participant),
             ctx.transform('decryptTextProp', 'encryptedName', object.encryptionKeyUrl, participant)
-          ]));
+          ])) : [];
 
           return Promise.all([
             ctx.transform('decryptTextProp', 'encryptedSubject', object.encryptionKeyUrl, object),
@@ -82,6 +102,44 @@ registerInternalPlugin('calendar', Calendar, {
             ctx.transform('decryptTextProp', 'spaceURI', object.encryptionKeyUrl, object),
             ctx.transform('decryptTextProp', 'spaceURL', object.encryptionKeyUrl, object)
           ].concat(decryptedParticipants));
+        }
+      },
+      {
+        name: 'transformMeetingNotes',
+        direction: 'inbound',
+        fn(ctx, object) {
+          if (!object) {
+            return Promise.resolve();
+          }
+
+          if (!object.encryptionKeyUrl) {
+            return Promise.resolve();
+          }
+
+          return Promise.all([
+            ctx.transform('decryptTextProp', 'encryptedNotes', object.encryptionKeyUrl, object)
+          ]);
+        }
+      },
+      {
+        name: 'transformMeetingParticipants',
+        direction: 'inbound',
+        fn(ctx, object) {
+          if (!object) {
+            return Promise.resolve();
+          }
+
+          if (!object.encryptionKeyUrl || !object.encryptedParticipants) {
+            return Promise.resolve();
+          }
+
+          // Decrypt participant properties
+          const decryptedParticipants = object.encryptedParticipants.map((participant) => Promise.all([
+            ctx.transform('decryptTextProp', 'encryptedEmailAddress', object.encryptionKeyUrl, participant),
+            ctx.transform('decryptTextProp', 'encryptedName', object.encryptionKeyUrl, participant)
+          ]));
+
+          return Promise.all(decryptedParticipants);
         }
       }
     ]

--- a/packages/node_modules/@webex/internal-plugin-calendar/test/integration/spec/calendar.js
+++ b/packages/node_modules/@webex/internal-plugin-calendar/test/integration/spec/calendar.js
@@ -65,6 +65,67 @@ function makeMockMeetingPayload(params) {
   return payload;
 }
 
+/**
+ * produces a mock notes object
+ * @param {Object} params
+ * @returns {Notes}
+ */
+function makeMockNotesPayload(params) {
+  const payload = {
+    id: params.meetingId,
+    seriesId: params.seriesId,
+    links: [
+      {
+        href: `https://calendar-example.com/calendar/api/v1/${params.locusId}`,
+        rel: 'self'
+      }
+    ],
+    encryptedNotes: params.meetingNotes
+  };
+
+  return payload;
+}
+
+/**
+ * produces a mock participants object
+ * @param {Object} params
+ * @returns {Participants}
+ */
+function makeMockParticipantsPayload(params) {
+  const payload = {
+    id: params.meetingId,
+    seriesId: params.seriesId,
+    links: [
+      {
+        href: `https://calendar-example.com/calendar/api/v1/${params.locusId}`,
+        rel: 'self'
+      }
+    ],
+    encryptedParticipants: [
+      {
+        id: params.participants.participant1.id,
+        type: 'PERSON',
+        responseType: 'NO_RESPONSE',
+        participantType: 'OPTIONAL',
+        orgId: params.participants.participant1.orgId,
+        encryptedEmailAddress: params.participants.participant1.emailAddress,
+        encryptedName: params.participants.participant1.name
+      },
+      {
+        id: params.participants.participant2.id,
+        type: 'PERSON',
+        responseType: 'UNKNOWN_RESPONSE',
+        participantType: 'REQUIRED',
+        orgId: params.participants.participant2.orgId,
+        encryptedEmailAddress: params.participants.participant2.emailAddress,
+        encryptedName: params.participants.participant2.name
+      }
+    ]
+  };
+
+  return payload;
+}
+
 function postToWhistler(webex, type, payload) {
   return retry(() => webex.request({
     method: 'POST',
@@ -87,6 +148,32 @@ function postToWhistler(webex, type, payload) {
 
       return res;
     }));
+}
+
+function postNotesToWhistler(webex, type, payload) {
+  return retry(() => webex.request({
+    method: 'POST',
+    uri: `${process.env.WHISTLER_API_SERVICE_URL}/calendarEvent`,
+    body: payload,
+    qs: {
+      changeType: type,
+      useProduction: typeof process.env.WDM_SERVICE_URL === 'undefined' || process.env.WDM_SERVICE_URL.includes('wdm-a.wbx2.com')
+    }
+  })
+    .then((res) => res.body));
+}
+
+function postParticipantsToWhistler(webex, type, payload) {
+  return retry(() => webex.request({
+    method: 'POST',
+    uri: `${process.env.WHISTLER_API_SERVICE_URL}/calendarEvent`,
+    body: payload,
+    qs: {
+      changeType: type,
+      useProduction: typeof process.env.WDM_SERVICE_URL === 'undefined' || process.env.WDM_SERVICE_URL.includes('wdm-a.wbx2.com')
+    }
+  })
+    .then((res) => res.body));
 }
 
 describe.skip('plugin-calendar', () => {
@@ -278,6 +365,143 @@ describe.skip('plugin-calendar', () => {
                 assert.equal(meetingParams.participants.participant2.name, encryptedParticipant2.encryptedName);
               });
           });
+      });
+    });
+
+    describe('#getNotes()', () => {
+      let creator, webex;
+
+      before('create test users', () => testUsers.create({
+        count: 3,
+        config: {
+          entitlements: [
+            'sparkCompliance',
+            'sparkAdmin',
+            'spark',
+            'squaredCallInitiation',
+            'squaredRoomModeration',
+            'squaredInviter',
+            'webExSquared',
+            'squaredFusionCal'
+          ]
+        }
+      })
+        .then((users) => {
+          [creator] = users;
+
+          webex = new WebexCore({
+            credentials: {
+              authorization: creator.token
+            },
+            config: {
+              services: {
+                discovery: {
+                  whistlerServiceUrl: process.env.WHISTLER_API_SERVICE_URL || 'https://calendar-whistler.onint.ciscospark.com:8084/api/v1'
+                }
+              }
+            }
+          });
+        }));
+
+      before('register to wdm, set features, and connect to mercury', () => webex.internal.device.register()
+        .then(() => webex.internal.feature.setFeature('developer', 'calsvc_calendar_view', true))
+        .then(() => webex.internal.mercury.connect()));
+
+      after(() => webex && webex.internal.mercury.disconnect());
+
+      it('retrieves the meeting notes for the given meetingId', () => {
+        const meetingNotes = 'Dummy meeting notes';
+        const meetingID = uuid.v4();
+        const locusID = uuid.v4();
+        const seriesID = uuid.v4();
+
+        const meetingParams = {
+          meetingId: meetingID,
+          seriesId: seriesID,
+          locusId: locusID,
+          meetingNotes
+        };
+
+        return postNotesToWhistler(webex, 'CREATE', makeMockNotesPayload(meetingParams))
+          .then((createdMeeting) => webex.internal.calendar.getNotes(meetingID)
+            .then((response) => {
+              assert.equal(createdMeeting.meeting.meetingSeriesId, response.seriesId);
+              assert.equal(meetingParams.meetingNotes, response.encryptedNotes);
+            }));
+      });
+    });
+
+    describe('#getParticipants()', () => {
+      let creator, mccoy, webex, spock;
+
+      before('create test users', () => testUsers.create({
+        count: 3,
+        config: {
+          entitlements: [
+            'sparkCompliance',
+            'sparkAdmin',
+            'spark',
+            'squaredCallInitiation',
+            'squaredRoomModeration',
+            'squaredInviter',
+            'webExSquared',
+            'squaredFusionCal'
+          ]
+        }
+      })
+        .then((users) => {
+          [creator, spock, mccoy] = users;
+
+          webex = new WebexCore({
+            credentials: {
+              authorization: creator.token
+            },
+            config: {
+              services: {
+                discovery: {
+                  whistlerServiceUrl: process.env.WHISTLER_API_SERVICE_URL || 'https://calendar-whistler.onint.ciscospark.com:8084/api/v1'
+                }
+              }
+            }
+          });
+        }));
+
+      before('register to wdm, set features, and connect to mercury', () => webex.internal.device.register()
+        .then(() => webex.internal.feature.setFeature('developer', 'calsvc_calendar_view', true))
+        .then(() => webex.internal.mercury.connect()));
+
+      after(() => webex && webex.internal.mercury.disconnect());
+
+      it('retrieves the meeting participants for the given meetingId', () => {
+        const meetingID = uuid.v4();
+        const locusID = uuid.v4();
+        const seriesID = uuid.v4();
+
+        const meetingParams = {
+          meetingId: meetingID,
+          seriesId: seriesID,
+          locusId: locusID,
+          participants: {
+            participant1: mccoy,
+            participant2: spock
+          }
+        };
+
+        return postParticipantsToWhistler(webex, 'CREATE', makeMockParticipantsPayload(meetingParams))
+          .then((createdMeeting) => webex.internal.calendar.getParticipants(meetingID)
+            .then((response) => {
+              assert.equal(createdMeeting.meeting.meetingSeriesId, response.seriesId);
+
+              const encryptedParticipant1 = response.encryptedParticipants
+                .find((participant) => participant.id === meetingParams.participants.participant1.id);
+              const encryptedParticipant2 = response.encryptedParticipants
+                .find((participant) => participant.id === meetingParams.participants.participant2.id);
+
+              assert.equal(meetingParams.participants.participant1.emailAddress, encryptedParticipant1.encryptedEmailAddress);
+              assert.equal(meetingParams.participants.participant1.name, encryptedParticipant1.encryptedName);
+              assert.equal(meetingParams.participants.participant2.emailAddress, encryptedParticipant2.encryptedEmailAddress);
+              assert.equal(meetingParams.participants.participant2.name, encryptedParticipant2.encryptedName);
+            }));
       });
     });
   });

--- a/packages/node_modules/@webex/internal-plugin-calendar/test/unit/spec/calendar.js
+++ b/packages/node_modules/@webex/internal-plugin-calendar/test/unit/spec/calendar.js
@@ -5,6 +5,7 @@
 import {assert} from '@webex/test-helper-chai';
 import Calendar from '@webex/internal-plugin-calendar';
 import MockWebex from '@webex/test-helper-mock-webex';
+import btoa from 'btoa';
 import sinon from 'sinon';
 
 import {CALENDAR_REGISTERED, CALENDAR_UPDATED, CALENDAR_DELETE, CALENDAR_CREATE, CALENDAR_UNREGISTERED} from '../../../src/constants';
@@ -107,7 +108,16 @@ describe('internal-plugin-calendar', () => {
 
       describe('#syncCalendar()', () => {
         it('should sync from calendar service', async () => {
-          webex.request = sinon.stub().returns(Promise.resolve({body: {items: [{id: 'calendar1'}, {id: 'calendar2'}]}}));
+          webex.request = sinon.stub().returns(Promise.resolve({body: {items: [{id: 'calendar1'}, {id: 'calendar2'}]}})); webex.request = sinon.stub().returns(
+            Promise.resolve({
+              body: {
+                items: [
+                  {id: 'calendar1', encryptedNotes: 'notes1', encryptedParticipants: ['participant1']},
+                  {id: 'calendar2', encryptedNotes: 'notes2', encryptedParticipants: ['participant2']}
+                ]
+              }
+            })
+          );
           await webex.internal.calendar.syncCalendar({fromDate: 'xx-xx', toDate: 'xx-nn'});
           assert.calledWith(webex.request, {
             method: 'GET',
@@ -122,16 +132,70 @@ describe('internal-plugin-calendar', () => {
 
       describe('#list()', () => {
         it('should fetch the calendar list', async () => {
-          webex.request = sinon.stub().returns(Promise.resolve({body: {items: [{id: 'calendar1'}, {id: 'calendar2'}]}}));
-          await webex.internal.calendar.list({fromDate: 'xx-xx', toDate: 'xx-nn'})
-            .then((res) => {
-              assert.equal(res.length, 2);
-            });
+          webex.request = sinon.stub().returns(
+            Promise.resolve({
+              body: {
+                items: [
+                  {id: 'calendar1', encryptedNotes: 'notes1', encryptedParticipants: ['participant1']},
+                  {id: 'calendar2', encryptedNotes: 'notes2', encryptedParticipants: ['participant2']}
+                ]
+              }
+            })
+          );
+          const res = await webex.internal.calendar.list({fromDate: 'xx-xx', toDate: 'xx-nn'});
+
+          assert.equal(res.length, 2);
           assert.calledWith(webex.request, {
             method: 'GET',
             service: 'calendar',
             resource: 'calendarEvents',
             qs: {fromDate: 'xx-xx', toDate: 'xx-nn'}
+          });
+        });
+      });
+
+      describe('#getNotes()', () => {
+        it('should fetch the meeting notes', async () => {
+          const id = 'meetingId123';
+
+          webex.request = sinon.stub().returns(
+            Promise.resolve({
+              body: {
+                encryptedNotes: 'notes1'
+              }
+            })
+          );
+
+          const res = await webex.internal.calendar.getNotes(id);
+
+          assert.equal(res.body.encryptedNotes, 'notes1');
+          assert.calledWith(webex.request, {
+            method: 'GET',
+            service: 'calendar',
+            resource: `calendarEvents/${btoa(id)}/notes`
+          });
+        });
+      });
+
+      describe('#getParticipants()', () => {
+        const id = 'meetingId123';
+
+        it('should fetch the meeting participants', async () => {
+          webex.request = sinon.stub().returns(
+            Promise.resolve({
+              body: {
+                encryptedParticipants: ['participant1']
+              }
+            })
+          );
+
+          const res = await webex.internal.calendar.getParticipants(id);
+
+          assert.equal(res.body.encryptedParticipants.length, 1);
+          assert.calledWith(webex.request, {
+            method: 'GET',
+            service: 'calendar',
+            resource: `calendarEvents/${btoa(id)}/participants`
           });
         });
       });


### PR DESCRIPTION
## Description

Calendar will soon stop sending encrypted notes and participant lists that exceed 20k length from the currently used /calendar API. They'll instead be `null`, and 2 new APIs have been provided to fetch notes and participants with meeting id, which will have to be used in those cases.

Fixes # (issue)
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-100549

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
