### PR TITLE
fix(meetings): add close remote stream on cleanup

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -148,6 +148,7 @@ MeetingUtil.joinMeeting = (meeting, options) => {
 
 MeetingUtil.cleanUp = (meeting) => meeting.closeLocalStream()
   .then(() => meeting.closeLocalShare())
+  .then(() => meeting.closeRemoteStream())
   .then(() => meeting.closePeerConnections())
   .then(() => {
     meeting.unsetLocalVideoTrack();


### PR DESCRIPTION
# Pull Request Template

Meetings plugin remote stream fix.

## Description

Remote stream was not being closed during meeting cleanup, causing the media stopped events to not trigger.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)


