### PR TITLE
test(meetings): fix to FF 71

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/browsers.js
+++ b/packages/node_modules/@webex/plugin-meetings/browsers.js
@@ -41,7 +41,7 @@ module.exports = function createBrowsers() {
         base: 'SauceLabs',
         platform: 'OS X 10.13',
         browserName: 'firefox',
-        version: 'latest',
+        version: '71',
         extendedDebugging: true,
         'moz:firefoxOptions': {
           args: [

--- a/packages/node_modules/@webex/plugin-meetings/src/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/index.js
@@ -1,6 +1,4 @@
 /* eslint-env browser */
-// Any references to 'webex' should be removed once this becomes an actual plugin
-
 import {registerPlugin} from '@webex/webex-core';
 
 import Meetings from './meetings';


### PR DESCRIPTION
Ok team, I have confirmed that the screen share issue is due to Firefox 72. According to their [changelog](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/72):

> The MediaDevices.getDisplayMedia() method can now only be called in response to a user gesture such as a click event 

This means we can’t do the tests without some sort of webdriver. 

I have placed a workaround in to stick the sauce labs version of FF to 71.