### PR TITLE
fix(i-p-search): return message search results from remote clusters

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -307,17 +307,17 @@ const Conversation = WebexPlugin.extend({
 
   /**
   * Gets an array of activities with an array of activity URLS
-  * @param {Array} activities
+  * @param {Array} activityUrls
   * @param {String} [cluster] cluster where the activities are located
   * @returns {Promise<Object>} Resolves with the activities
   * TODO: add cluster functionality when clusters are ready
   */
-  bulkActivitiesFetch(activities, cluster) {
+  bulkActivitiesFetch(activityUrls, cluster) {
     const resource = 'bulk_activities_fetch';
     const params = {
       method: 'POST',
       body: {
-        activities
+        activityUrls
       }
     };
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/index.js
@@ -8,10 +8,10 @@ import '@webex/internal-plugin-user';
 import {patterns} from '@webex/common';
 import {filter as htmlFilter, filterEscape as htmlFilterEscape} from '@webex/helper-html';
 import {registerInternalPlugin} from '@webex/webex-core';
-import Conversation from './conversation';
-import config from './config';
 import {capitalize, get, has} from 'lodash';
 
+import Conversation from './conversation';
+import config from './config';
 import {transforms as encryptionTransforms} from './encryption-transforms';
 import {transforms as decryptionTransforms} from './decryption-transforms';
 
@@ -35,6 +35,16 @@ registerInternalPlugin('conversation', Conversation, {
         },
         extract(event) {
           return Promise.resolve(event.activity);
+        }
+      },
+      {
+        name: 'transformObjectArray',
+        direction: 'inbound',
+        test(ctx, response) {
+          return Promise.resolve(has(response, 'body.multistatus'));
+        },
+        extract(response) {
+          return Promise.resolve(response.body.multistatus.map((item) => item && item.data && item.data.activity));
         }
       },
       {

--- a/packages/node_modules/@webex/internal-plugin-flag/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-flag/src/index.js
@@ -3,26 +3,16 @@
  */
 
 import {registerInternalPlugin} from '@webex/webex-core';
+
+import '@webex/internal-plugin-conversation';
+import '@webex/internal-plugin-wdm';
 import Flag from './flag';
 import config from './config';
-import '@webex/internal-plugin-wdm';
-import {has} from 'lodash';
 
 registerInternalPlugin('flag', Flag, {
   config,
   payloadTransformer: {
-    predicates: [
-      {
-        name: 'transformObjectArray',
-        direction: 'inbound',
-        test(ctx, response) {
-          return Promise.resolve(has(response, 'body.multistatus'));
-        },
-        extract(response) {
-          return Promise.resolve(response.body.multistatus.map((item) => item && item.data && item.data.activity));
-        }
-      }
-    ],
+    predicates: [],
     transforms: []
   }
 });

--- a/packages/node_modules/@webex/internal-plugin-search/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-search/src/index.js
@@ -8,6 +8,7 @@ import {has} from 'lodash';
 import Search from './search';
 import config from './config';
 
+import '@webex/internal-plugin-conversation';
 import '@webex/internal-plugin-encryption';
 
 registerInternalPlugin('search', Search, {

--- a/packages/node_modules/@webex/internal-plugin-search/src/search.js
+++ b/packages/node_modules/@webex/internal-plugin-search/src/search.js
@@ -40,6 +40,13 @@ const Search = WebexPlugin.extend({
         .then(() => this.webex.internal.device.set('searchEncryptionKeyUrl', key.uri)));
   },
 
+  /**
+  * Fetches search result activities
+  * @param {Object} options
+  * @param {boolean} options.includeRemoteClusterReferences when true,
+  * includes search results from remote clusters
+  * @returns {Promise<Array>} Resolves with the activities
+  */
   search(options) {
     /* eslint max-nested-callbacks: [0] */
     options = options || {};
@@ -62,10 +69,43 @@ const Search = WebexPlugin.extend({
       .then((res) => {
         const resActivities = get(res, 'body.activities.items', []);
 
-        return (options.breadcrumbsEnabled ? {
-          activities: resActivities,
-          breadcrumbs: get(res, 'body.breadcrumbs', {})
-        } : resActivities);
+        if (options.includeRemoteClusterReferences && res.body.breadcrumbs) {
+          const {breadcrumbs} = res.body;
+          const promises = [];
+
+          Object.keys(breadcrumbs).forEach((cluster) => {
+            // Map activity URLs to their cluster
+            const editedCluster = `${cluster}:identityLookup`;
+            const clusterActivityUrls = breadcrumbs[cluster].items.map(
+              (activity) => activity.activityUrl
+            );
+
+            // Find activities per cluster
+            const bulkActivitiesPromise = this.webex.internal.conversation.bulkActivitiesFetch(
+              clusterActivityUrls,
+              editedCluster
+            )
+              .catch((err) => {
+                this.logger.warn(
+                  'search: error fetching from remote clusters',
+                  err
+                );
+
+                return Promise.resolve([]);
+              });
+
+            promises.push(bulkActivitiesPromise);
+          });
+
+          return Promise.all(promises).then(
+            (clusterResults) => clusterResults.reduce(
+              (accumulator, clusterResult) => accumulator.concat(clusterResult),
+              resActivities
+            )
+          );
+        }
+
+        return resActivities;
       });
   }
 

--- a/packages/node_modules/@webex/internal-plugin-search/test/integration/spec/search.js
+++ b/packages/node_modules/@webex/internal-plugin-search/test/integration/spec/search.js
@@ -4,18 +4,16 @@
 
 import '@webex/internal-plugin-search';
 
+import util from 'util';
+
 import WebexCore from '@webex/webex-core';
 import {assert} from '@webex/test-helper-chai';
 import testUsers from '@webex/test-helper-test-users';
 import retry from '@webex/test-helper-retry';
-
 import '@webex/internal-plugin-conversation';
 import '@webex/internal-plugin-wdm';
-
 import {map, countBy} from 'lodash';
 import uuid from 'uuid';
-
-import util from 'util';
 
 describe('plugin-search', () => {
   describe('#people', () => {
@@ -32,7 +30,12 @@ describe('plugin-search', () => {
         });
       }));
 
-    before('connect to mercury', () => webex.internal.mercury.connect());
+    before('connect to mercury', () => webex.internal.services.updateServices({
+      from: 'limited',
+      query: {email: checkov.email}
+    })
+      .then(() => webex.internal.services.waitForCatalog('postauth'))
+      .then(() => webex.internal.mercury.connect()));
 
     before('create bot', function () {
       this.timeout(retry.timeout(20000));
@@ -78,13 +81,19 @@ describe('plugin-search', () => {
   });
 
   describe('#search', () => {
-    let checkov, mccoy, spock;
+    let checkov, mccoy, spock, kirkEU;
     let party;
 
-    before('create 3 test users and connect them to mercury', () => testUsers.create({count: 3})
-      .then((users) => {
+    before('create 4 test users and connect them to mercury', () => Promise.all([
+      testUsers.create({count: 3}),
+      testUsers.create({count: 1, config: {orgId: process.env.EU_PRIMARY_ORG_ID}})
+    ])
+      .then(([users, usersEU]) => {
         [checkov, mccoy, spock] = users;
-        party = {checkov, mccoy, spock};
+        [kirkEU] = usersEU;
+        party = {
+          checkov, mccoy, spock, kirkEU
+        };
 
         checkov.webex = new WebexCore({
           credentials: {
@@ -104,11 +113,23 @@ describe('plugin-search', () => {
           }
         });
 
+        kirkEU.webex = new WebexCore({
+          credentials: {
+            authorization: kirkEU.token
+          }
+        });
+
         return Promise.all([
           checkov,
           mccoy,
-          spock
-        ].map((user) => user.webex.internal.mercury.connect()));
+          spock,
+          kirkEU
+        ].map((user) => user.webex.internal.services.updateServices({
+          from: 'limited',
+          query: {email: user.email}
+        })
+          .then(() => user.webex.internal.services.waitForCatalog('postauth'))
+          .then(() => user.webex.internal.mercury.connect())));
       })
       .then(() => {
         if (!process.env.PIPELINE) {
@@ -118,7 +139,7 @@ describe('plugin-search', () => {
         return Promise.resolve();
       }));
 
-    let mccoyConversation, spockConversation;
+    let mccoyConversation, spockConversation, kirkEUConversation;
 
     before('create a room for spock', () => spockConversation || spock.webex.internal.conversation.create({
       displayName: 'Spock Room',
@@ -127,6 +148,15 @@ describe('plugin-search', () => {
       .then((conversation) => {
         spockConversation = conversation;
         assert.lengthOf(spockConversation.participants.items, 3);
+      }));
+
+    before('create a room for kirkEU', () => kirkEUConversation || kirkEU.webex.internal.conversation.create({
+      displayName: 'Kirk EU Room',
+      participants: map([mccoy, spock, kirkEU], 'id')
+    }, {forceGrouped: true})
+      .then((conversation) => {
+        kirkEUConversation = conversation;
+        assert.lengthOf(kirkEUConversation.participants.items, 3);
       }));
 
     before('create a room for mccoy', () => mccoyConversation || mccoy.webex.internal.conversation.create({
@@ -138,7 +168,7 @@ describe('plugin-search', () => {
         assert.lengthOf(mccoyConversation.participants.items, 2);
       }));
 
-    after(() => Promise.all([checkov, mccoy, spock].map((user) => user.webex.internal.mercury.disconnect.bind(user))));
+    after(() => Promise.all([checkov, mccoy, spock, kirkEU].map((user) => user.webex.internal.mercury.disconnect.bind(user))));
 
     function populateConversation(conversation) {
       const spockConvo = spock.webex.internal.conversation;
@@ -196,6 +226,25 @@ describe('plugin-search', () => {
         assert.equal(comments[3], 'The captain wishes to board.');
       }));
 
+    before('prepare and verify conversation for kirkEU', () => populateConversation(kirkEUConversation)
+      .then(() => {
+        assert.isDefined(kirkEUConversation);
+
+        return kirkEU.webex.internal.conversation.get({url: kirkEUConversation.url}, {activitiesLimit: 10});
+      })
+      .then((conversation) => {
+        kirkEUConversation = conversation;
+
+        kirkEUConversation.activities.items.shift();
+        const comments = map(kirkEUConversation.activities.items, 'object.displayName');
+
+        assert.lengthOf(comments, 4);
+        assert.equal(comments[0], 'Hello, Spock.');
+        assert.equal(comments[1], 'Hello, Doctor.');
+        assert.equal(comments[2], 'What did Jim say?');
+        assert.equal(comments[3], 'The captain wishes to board.');
+      }));
+
     const testData = [
       // Single word
       // Asserts comments
@@ -214,12 +263,48 @@ describe('plugin-search', () => {
         }
       },
       // Single word
+      // Asserts comments
+      // Includes remote clusters
+      {
+        given: {
+          user: 'spock',
+          query: 'hElLo',
+          includeRemoteClusterReferences: true
+        },
+        expected: {
+          path: 'object.displayName',
+          results: [
+            {name: 'Hello, Spock.', count: 3},
+            {name: 'Hello, Doctor.', count: 3}
+          ],
+          resultsCount: 6
+        }
+      },
+      // Single word
       // Single result
       // Asserts comments
       {
         given: {
           user: 'checkov',
           query: 'JiM'
+        },
+        expected: {
+          path: 'object.displayName',
+          results: [
+            {name: 'What did Jim say?', count: 1}
+          ],
+          resultsCount: 1
+        }
+      },
+      // Single word
+      // Single result
+      // Asserts comments
+      // Includes remote clusters but no results
+      {
+        given: {
+          user: 'checkov',
+          query: 'JiM',
+          includeRemoteClusterReferences: true
         },
         expected: {
           path: 'object.displayName',
@@ -406,6 +491,23 @@ describe('plugin-search', () => {
         given: {
           user: 'spock',
           query: 'hElLo',
+          size: 0,
+          includeRemoteClusterReferences: true
+        },
+        expected: {
+          path: 'object.displayName',
+          results: [
+            {name: 'Hello, Spock.', count: 3},
+            {name: 'Hello, Doctor.', count: 3}
+          ],
+          // Server treats 0 limit as default limit of 20
+          resultsCount: 6
+        }
+      },
+      {
+        given: {
+          user: 'spock',
+          query: 'hElLo',
           size: 1
         },
         expected: {
@@ -475,8 +577,9 @@ describe('plugin-search', () => {
         const {given, expected} = data;
         const conversationLimit = given.sharedIn ? given.sharedIn.length : 'all';
         const resultLimit = given.size ? `a result limit of ${given.size}` : 'no result limit';
-        const queryString = given.query ? `for "${given.query} "` : '';
-        const message = util.format(`${given.user} searches ${conversationLimit} conversation(s) ${queryString}with ${resultLimit}. Verifies ${expected.path}.`);
+        const queryString = given.query ? `for "${given.query}" ` : '';
+        const remoteClusterString = given.includeRemoteClusterReferences ? ' and remote cluster enabled' : '';
+        const message = util.format(`${given.user} searches ${conversationLimit} conversation(s) ${queryString}with ${resultLimit}${remoteClusterString}. Verifies ${expected.path}.`);
 
         it(message, () => retry(() => {
           let params;
@@ -484,7 +587,8 @@ describe('plugin-search', () => {
           if (given.query) {
             params = {
               query: given.query,
-              limit: given.size
+              limit: given.size,
+              includeRemoteClusterReferences: given.includeRemoteClusterReferences
             };
           }
           else {
@@ -504,39 +608,6 @@ describe('plugin-search', () => {
               expected.results.forEach((expectedResults) => {
                 assert.equal(counts[expectedResults.name], expectedResults.count);
               });
-            });
-        }));
-
-        // TODO: modify tests when breadcrumbs are complete with real data
-        // Currently the breadcrumb is {}
-        it(message, () => retry(() => {
-          let params;
-
-          if (given.query) {
-            params = {
-              query: given.query,
-              limit: given.size,
-              breadcrumbsEnabled: true
-            };
-          }
-          else {
-            params = {
-              sharedIn: spockConversation.id,
-              type: given.type
-            };
-          }
-
-          return party[given.user].webex.internal.search.search(params)
-            .then((results) => {
-              assert.isDefined(results);
-
-              if (given.query) {
-                assert.isDefined(results.activities);
-                assert.isDefined(results.breadcrumbs);
-                assert.lengthOf(results.activities, expected.resultsCount);
-                assert.isTrue(typeof results.breadcrumbs === 'object');
-                assert.isTrue(results.breadcrumbs.constructor === Object);
-              }
             });
         }));
       });

--- a/packages/node_modules/@webex/test-helper-retry/src/index.js
+++ b/packages/node_modules/@webex/test-helper-retry/src/index.js
@@ -17,7 +17,11 @@ const backoffPattern = [0, 1000, 2000, 4000, 8000, 16000, 32000, 32000, 32000];
  * @returns {Object}
  */
 function retry(fn) {
-  return backoffPattern.reduce((promise, delay) => promise.catch(() => new Promise((resolve) => {
+  return backoffPattern.reduce((promise, delay) => promise.catch((err) => new Promise((resolve) => {
+    if (err) {
+      console.error(`###Test error: ${err}. Retrying test in ${delay} seconds`);
+    }
+
     setTimeout(() => {
       resolve(fn());
     }, delay);


### PR DESCRIPTION
# Pull Request Template

## Description

Moved federation search into sdk. search can now return results from remote clusters

Fixes # (issue)
fixes incorrect call to bulk_activities_fetch endpoint

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] create convo with eu user B and invite user A and send a message, user A should be able to search for results from that convo

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
