### PR TITLE
Add attachments to message event when sending adpative card

### DIFF
--- a/packages/node_modules/@webex/common/src/constants.js
+++ b/packages/node_modules/@webex/common/src/constants.js
@@ -50,6 +50,9 @@ export const SDK_EVENT = {
       MEMBERSHIPS: 'memberships',
       MESSAGES: 'messages',
       ROOMS: 'rooms'
+    },
+    ATTACHMENTS: {
+      CARD_CONTENT_TYPE: 'application/vnd.microsoft.card.adaptive'
     }
   }
 };

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -363,7 +363,7 @@ const Messages = WebexPlugin.extend({
         activity.actor.emailAddress || activity.actor.entryEmail;
 
       if (event !== SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED) {
-        const {content, displayName} = activity.object;
+        const {content, displayName, cards} = activity.object;
         const text = content || displayName;
         const files = getHydraFiles(activity);
 
@@ -376,6 +376,17 @@ const Messages = WebexPlugin.extend({
         }
         if (files.length) {
           sdkEvent.data.files = files;
+        }
+        if (cards) {
+          if ((typeof cards === 'object') && (cards.length)) {
+            sdkEvent.data.attachments = [];
+            for (const card of cards) {
+              sdkEvent.data.attachments.push({
+                contentType: SDK_EVENT.EXTERNAL.ATTACHMENTS.CARD_CONTENT_TYPE,
+                content: JSON.parse(card)
+              });
+            }
+          }
         }
       }
       else {

--- a/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
@@ -207,6 +207,63 @@ describe('plugin-messages', function () {
               validateMessageEvent(event, message, actor);
             }));
       });
+
+      it('posts a message to a card to a room validates the event', () => {
+        const created = new Promise((resolve) => {
+          webex.messages.on('created', (event) => {
+            debug('message created event called');
+            resolve(event);
+          });
+        });
+        const attachment = {
+          contentType: 'application/vnd.microsoft.card.adaptive',
+          content: {
+            type: 'AdaptiveCard',
+            version: '1.0',
+            body: [
+              {
+                type: 'TextBlock',
+                text: 'Here is an image'
+              },
+              {
+                type: 'Image',
+                url: KNOWN_HOSTED_IMAGE_URL,
+                size: 'small'
+              }
+            ]
+          }
+        };
+
+        return webex.messages.listen()
+          .then(() => webex.messages.create({
+            roomId: room.id,
+            text,
+            attachments: [attachment]
+          })
+            .then(async (message) => {
+              // // Assert that the message shape is valid and contains attachment data.
+              validateMessage(message, text, 0, attachment);
+              let event = await created;
+
+              // When using this method to attach a file to
+              // a message, sometimes, the first event does not
+              // include all the data included in the message.
+              // kms then triggers a second event that includes
+              // all of the data in the message object.
+              if (event.data.id !== message.id) {
+                const createdCombined = new Promise((resolve) => {
+                  webex.messages.on('created', (e) => {
+                    debug('message created event called');
+                    resolve(e);
+                  });
+                });
+
+                event = await createdCombined;
+              }
+
+              validateMessageEvent(event, message, actor);
+            }));
+      });
     });
 
     describe('#remove()', () => {
@@ -329,13 +386,17 @@ describe('plugin-messages', function () {
  * @param {Object} message
  * @param {String} text -- optional message text to check
  * @param {Boolean} numFiles
+ * @param {Object} attachment
  * @returns {void}
  */
-function validateMessage(message, text = '', numFiles = 0) {
+function validateMessage(message, text = '', numFiles = 0, attachment = null) {
   assert.isDefined(message);
   assert.isMessage(message);
   if (text) {
     assert.equal(message.text, text);
+  }
+  if (attachment) {
+    validateAdaptiveCard(message, attachment);
   }
   if (numFiles) {
     assert.property(message, 'files');
@@ -344,6 +405,38 @@ function validateMessage(message, text = '', numFiles = 0) {
     assert.lengthOf(message.files, numFiles);
   }
   debug('message validated');
+}
+
+/**
+ * Validate a Attachment Action.
+ * @param {Object} message -- message returned from the API
+ * @param {Object} attachment - adaptive card object that was sent to the API
+ * @returns {void}
+ */
+function validateAdaptiveCard(message, attachment) {
+  assert.isArray(message.attachments);
+  assert.isDefined(message.attachments.length);
+  const card = message.attachments[0];
+
+  // Cannot do a deepEqual compare because the image URLs are remapped
+  // Validate some aspects of the card data
+
+  assert.isDefined(card.contentType);
+  assert.isDefined(attachment.contentType);
+  assert.equal(card.contentType, attachment.contentType);
+  assert.isDefined(card.content);
+  assert.isDefined(attachment.content);
+  assert.equal(card.content.type, attachment.content.type);
+  assert.equal(card.content.version, attachment.content.version);
+  assert.isDefined(card.content.body);
+  assert.isArray(attachment.content.body);
+  assert.isDefined(card.content.body.length);
+  assert.equal(card.content.body.length, attachment.content.body.length);
+  for (let i = 0; i < card.content.body.length; i += 1) {
+    if (card.content.body[i].type.toLowerCase() === 'textblock') {
+      assert.deepEqual(card.content.body[i], attachment.content.body[i]);
+    }
+  }
 }
 
 /**
@@ -396,5 +489,10 @@ function validateMessageEvent(event, message, actor) {
         message.files[i].substr(message.files[i].lastIndexOf('/') + 1),
         'event/message file urls do not match');
     }
+  }
+  if (message.attachments) {
+    assert.isArray(event.data.attachments);
+    assert.isDefined(event.data.attachments.length);
+    validateAdaptiveCard(message, event.data.attachments[0]);
   }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Add the attachments element the message:created event when the message included an adaptive card.

Fixes # (issue)
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-116380

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

- [ ] Add a new test in plugin-messages to send a test message with a card
- [ ] Added a new validateAttachmentAction method to plugin-messages/test/src/messages.js

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation   - N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules - N/A
