### PR TITLE
Refactor/improve host removal

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/index.js
+++ b/packages/node_modules/@webex/webex-core/src/index.js
@@ -22,9 +22,11 @@ export {
 } from './lib/credentials';
 
 export {
+  constants as serviceConstants,
   ServiceInterceptor,
   ServerErrorInterceptor,
   Services,
+  ServiceHost,
   ServiceUrl,
   ServiceCatalog
 } from './lib/services';

--- a/packages/node_modules/@webex/webex-core/src/lib/services/constants.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/constants.js
@@ -1,0 +1,14 @@
+const NAMESPACE = 'services';
+
+const SERVICE_CATALOGS = [
+  'discovery',
+  'limited',
+  'signin',
+  'postauth',
+  'custom'
+];
+
+export {
+  NAMESPACE,
+  SERVICE_CATALOGS
+};

--- a/packages/node_modules/@webex/webex-core/src/lib/services/index.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/index.js
@@ -3,6 +3,7 @@
  */
 import {registerInternalPlugin} from '../../webex-core';
 
+import * as constants from './constants';
 import Services from './services';
 import ServerErrorInterceptor from './interceptors/server-error';
 import ServiceInterceptor from './interceptors/service';
@@ -14,8 +15,10 @@ registerInternalPlugin('services', Services, {
   }
 });
 
+export {constants};
 export {default as ServiceInterceptor} from './interceptors/service';
 export {default as ServerErrorInterceptor} from './interceptors/server-error';
 export {default as Services} from './services';
 export {default as ServiceCatalog} from './service-catalog';
+export {default as ServiceHost} from './service-host';
 export {default as ServiceUrl} from './service-url';

--- a/packages/node_modules/@webex/webex-core/src/lib/services/service-host.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/service-host.js
@@ -1,0 +1,274 @@
+import Url from 'url';
+
+import {SERVICE_CATALOGS} from './constants';
+
+/**
+ * The parameter transfer object for {@link ServiceHost#constructor}.
+ *
+ * @typedef {Object} ServiceHostConstructorPTO
+ * @property {string} ServiceHostConstructorPTO.catalog - The host's catalog.
+ * @property {string} ServiceHostConstructorPTO.defaultUri - The host's default.
+ * @property {string} ServiceHostConstructorPTO.hostGroup - The host's group.
+ * @property {string} ServiceHostConstructorPTO.id - The host's clusterId.
+ * @property {number} ServiceHostConstructorPTO.priority - The host's priority.
+ * @property {string} ServiceHostConstructorPTO.uri - The host's uri.
+ */
+
+/**
+ * The parameter transfer object for {@link ServiceHost#polyGenerate}.
+ *
+ * @typedef {Object} ServiceHostPolyGeneratePTO
+ * @property {string} ServiceHostPolyGeneratePTO.catalog - The target catalog.
+ * @property {string} ServiceHostPolyGeneratePTO.name - The service name.
+ * @property {string} ServiceHostPolyGeneratePTO.url - The service url.
+ */
+
+/**
+ * @class
+ * @classdesc - Manages a single service host and its associated data.
+ */
+export default class ServiceHost {
+  /**
+   * Generate a new {@link ServiceHost}.
+   *
+   * @public
+   * @constructor
+   * @memberof ServiceHost
+   * @param {ServiceHostConstructorPTO} pto
+   */
+  constructor(pto) {
+    // Validate the parameter transfer object.
+    ServiceHost.validate(pto);
+
+    // Map the parameter transfer object to the class object.
+    /**
+     * The catalog name that the {@link ServiceHost} is associated with.
+     *
+     * @instance
+     * @type {string}
+     * @public
+     * @memberof ServiceHost
+     */
+    this.catalog = pto.catalog;
+
+    /**
+     * The default URI for the {@link ServiceHost}.
+     *
+     * @instance
+     * @type {string}
+     * @public
+     * @memberof ServiceHost
+     */
+    this.default = pto.defaultUri;
+
+    /**
+     * The host group that the {@link ServiceHost} is associated with.
+     *
+     * @instance
+     * @type {string}
+     * @public
+     * @memberof ServiceHost
+     */
+    this.hostGroup = pto.hostGroup;
+
+    /**
+     * The cluster ID of the {@link ServiceHost}.
+     *
+     * @instance
+     * @type {string}
+     * @public
+     * @memberof ServiceHost
+     */
+    this.id = pto.id;
+
+    /**
+     * The priority value of the {@link ServiceHost}. The lower the number, the
+     * higher the priority.
+     *
+     * @instance
+     * @type {number}
+     * @public
+     * @memberof ServiceHost
+     */
+    this.priority = pto.priority;
+
+    /**
+     * The host uri of the {@link ServiceHost}.
+     *
+     * @instance
+     * @type {string}
+     * @public
+     * @memberof ServiceHost
+     */
+    this.uri = pto.uri;
+
+    // Generate flags.
+    /**
+     * If the {@link ServiceHost} is marked as failed.
+     *
+     * @instance
+     * @type {boolean}
+     * @protected
+     * @memberof ServiceHost
+     */
+    this.failed = false;
+
+    /**
+     * If the {@link ServiceHost} is marked as replaced.
+     *
+     * @instance
+     * @type {boolean}
+     * @protected
+     * @memberof ServiceHost
+     */
+    this.replaced = false;
+  }
+
+  /**
+   * If the {@link ServiceHost} is in an active state.
+   *
+   * @public
+   * @memberof ServiceHost
+   * @type {boolean} - `true` if the service is active and usable.
+   */
+  get active() {
+    // Validate that the `ServiceHost` was not marked as failed or replaced.
+    return (!this.failed && !this.replaced);
+  }
+
+  /**
+   * If the host is local to the user's cluster.
+   *
+   * @public
+   * @memberof ServiceHost
+   * @type {boolean} - If the host is local.
+   */
+  get local() {
+    return this.default.includes(this.hostGroup);
+  }
+
+  /**
+   * The service value.
+   *
+   * @public
+   * @memberof ServiceHost
+   * @type {string} - The service value.
+   */
+  get service() {
+    return this.id.split(':')[3];
+  }
+
+  /**
+   * The formatted url for the host.
+   *
+   * @public
+   * @memberof ServiceHost
+   * @type {string} - The service url.
+   */
+  get url() {
+    // Generate a url object from the default url.
+    const urlObj = Url.parse(this.default);
+
+    // Format the host of the generated url object.
+    urlObj.host = `${this.uri}${urlObj.port ? `:${urlObj.port}` : ''}`;
+
+    // Assign the formatted url to this.
+    return Url.format(urlObj);
+  }
+
+  /**
+   * Set one or more of the status properties of the class object.
+   *
+   * @public
+   * @memberof ServiceHost
+   * @param {Object} pto - The parameter transfer object.
+   * @property {boolean} [pto.failed] - The failed status to set.
+   * @property {boolean} [pto.replaced] - the replaced status to set.
+   * @returns {this}
+   */
+  setStatus({failed, replaced}) {
+    if (failed !== undefined) {
+      this.failed = failed;
+    }
+
+    if (replaced !== undefined) {
+      this.replaced = replaced;
+    }
+
+    return this;
+  }
+
+  /**
+   * Generate a service host using only a catalog, name, and URL.
+   *
+   * @public
+   * @static
+   * @memberof ServiceHost
+   * @param {ServiceHostPolyGeneratePTO} pto
+   * @returns {ServiceHost} - The generated service host.
+   */
+  static polyGenerate({catalog, name, url}) {
+    return new ServiceHost({
+      catalog,
+      defaultUri: url,
+      hostGroup: Url.parse(url).host,
+      id: (name) ? `poly-head:poly-group:poly-cluster:${name}` : undefined,
+      priority: 1,
+      uri: Url.parse(url).host
+    });
+  }
+
+  /**
+   * Validate that a constructor parameter transfer object is valid.
+   *
+   * @public
+   * @static
+   * @memberof ServiceHost
+   * @param {ServiceHostConstructorPTO} pto
+   * @throws - If the parameter transfer object is not valid.
+   * @returns {undefined}
+   */
+  static validate({
+    catalog,
+    defaultUri,
+    hostGroup,
+    id,
+    priority,
+    uri
+  }) {
+    // Generate error-throwing method.
+    const throwError = (msg) => {
+      throw new Error(`service-host: invalid constructor parameters, ${msg}`);
+    };
+
+    // Validate the catalog property.
+    if (!SERVICE_CATALOGS.includes(catalog)) {
+      throwError('\'catalog\' must be a string');
+    }
+
+    // Validate the `defaultUri` property.
+    if (typeof defaultUri !== 'string') {
+      throwError('\'defaultUri\' must be a string');
+    }
+
+    // Validate the `hostGroup` property.
+    if (typeof hostGroup !== 'string') {
+      throwError('\'hostGroup\' must be a string');
+    }
+
+    // Validate the `id` property.
+    if (typeof id !== 'string' || id.split(':').length !== 4) {
+      throwError('\'id\' must be a string that contains 3 \':\' characters');
+    }
+
+    // Validate the `priority` property.
+    if (typeof priority !== 'number') {
+      throwError('\'priority\' must be a number');
+    }
+
+    // Validate the `uri` property.
+    if (typeof uri !== 'string') {
+      throwError('\'uri\' must be a string');
+    }
+  }
+}

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/service-host.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/service-host.js
@@ -1,0 +1,257 @@
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import {ServiceHost} from '@webex/webex-core';
+
+describe('webex-core', () => {
+  describe('ServiceHost', () => {
+    let defaultHostGroup;
+    let fixture;
+    let serviceHost;
+
+    before('generate fixture', () => {
+      fixture = {
+        catalog: 'discovery',
+        defaultUri: 'https://example-default.com/',
+        hostGroup: 'example-host-group.com',
+        id: 'example-head:example-group:example-cluster:example-name',
+        priority: 1,
+        uri: 'example-uri.com'
+      };
+
+      defaultHostGroup = 'example-default.com';
+    });
+
+    describe('#constructor()', () => {
+      it('should attempt to validate services', () => {
+        sinon.spy(ServiceHost, 'validate');
+
+        serviceHost = new ServiceHost(fixture);
+
+        assert.called(ServiceHost.validate);
+      });
+    });
+
+    describe('class members', () => {
+      beforeEach('generate service host', () => {
+        serviceHost = new ServiceHost(fixture);
+      });
+
+      describe('#active', () => {
+        it('should return false when the host has failed', () => {
+          serviceHost.failed = true;
+          assert.isFalse(serviceHost.active);
+        });
+
+        it('should return false when the host has been replaced', () => {
+          serviceHost.replaced = true;
+          assert.isFalse(serviceHost.active);
+        });
+
+        it('should return true when the host is active', () => {
+          serviceHost.replaced = false;
+          serviceHost.replaced = false;
+          assert.isTrue(serviceHost.active);
+        });
+      });
+
+      describe('#catalog', () => {
+        it('should match the parameter value', () => {
+          assert.equal(serviceHost.catalog, fixture.catalog);
+        });
+      });
+
+      describe('#defaultUri', () => {
+        it('should match the parameter value', () => {
+          assert.equal(serviceHost.default, fixture.defaultUri);
+        });
+      });
+
+      describe('#failed', () => {
+        it('should automatically set the value to false', () => {
+          assert.isFalse(serviceHost.failed);
+        });
+      });
+
+      describe('#hostGroup', () => {
+        it('should match the parameter value', () => {
+          assert.equal(serviceHost.hostGroup, fixture.hostGroup);
+        });
+      });
+
+      describe('#id', () => {
+        it('should match the parameter value', () => {
+          assert.equal(serviceHost.id, fixture.id);
+        });
+      });
+
+      describe('#local', () => {
+        it('should return true when the uri includes the host group', () => {
+          serviceHost.hostGroup = defaultHostGroup;
+          assert.isTrue(serviceHost.local);
+        });
+
+        it('should return true when the uri excludes the host group', () => {
+          serviceHost.hostGroup = fixture.hostGroup;
+          assert.isFalse(serviceHost.local);
+        });
+      });
+
+      describe('#priority', () => {
+        it('should match the parameter value', () => {
+          assert.equal(serviceHost.priority, fixture.priority);
+        });
+      });
+
+      describe('#replaced', () => {
+        it('should automatically set the value to false', () => {
+          assert.isFalse(serviceHost.replaced);
+        });
+      });
+
+      describe('#service', () => {
+        it('should return the service', () => {
+          assert.equal(serviceHost.service, fixture.id.split(':')[3]);
+        });
+      });
+
+      describe('#uri', () => {
+        it('should match the parameter value', () => {
+          assert.equal(serviceHost.uri, fixture.uri);
+        });
+      });
+
+      describe('#url', () => {
+        it('should return a host-mapped url', () => {
+          assert.isTrue(serviceHost.url.includes(serviceHost.uri));
+        });
+      });
+    });
+
+    describe('#setStatus()', () => {
+      it('should set the property failed to true', () => {
+        assert.isTrue(serviceHost.setStatus({failed: true}).failed);
+      });
+
+
+      it('should set the property failed to false', () => {
+        assert.isFalse(serviceHost.setStatus({failed: false}).failed);
+      });
+
+      it('should set the property replaced to true', () => {
+        assert.isTrue(serviceHost.setStatus({replaced: true}).replaced);
+      });
+
+
+      it('should set the property replaced to false', () => {
+        assert.isFalse(serviceHost.setStatus({replaced: false}).replaced);
+      });
+
+      it('should set the property replaced and failed to true', () => {
+        assert.isTrue(serviceHost.setStatus({
+          failed: true,
+          replaced: true
+        }).failed);
+
+        assert.isTrue(serviceHost.setStatus({
+          failed: true,
+          replaced: true
+        }).replaced);
+      });
+
+      it('should set the property replaced and failed to false', () => {
+        assert.isFalse(serviceHost.setStatus({
+          failed: false,
+          replaced: false
+        }).failed);
+
+        assert.isFalse(serviceHost.setStatus({
+          failed: false,
+          replaced: false
+        }).replaced);
+      });
+
+      describe('static methods', () => {
+        describe('#polyGenerate()', () => {
+          let polyFixture;
+
+          beforeEach('set the poly fixture', () => {
+            polyFixture = {
+              catalog: fixture.catalog,
+              name: fixture.id.split(':')[3],
+              url: fixture.defaultUri
+            };
+          });
+
+          it('should generate a new ServiceHost', () => {
+            assert.instanceOf(
+              ServiceHost.polyGenerate(polyFixture),
+              ServiceHost
+            );
+          });
+        });
+
+        describe('#validate()', () => {
+          it('should throw an error when catalog is missing', () => {
+            delete fixture.catalog;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when defaultUri is missing', () => {
+            delete fixture.defaultUri;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when hostGroup is missing', () => {
+            delete fixture.hostGroup;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when id is missing', () => {
+            delete fixture.id;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when priority is missing', () => {
+            delete fixture.priority;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when uri is missing', () => {
+            delete fixture.uri;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when catalog is invalid', () => {
+            fixture.catalog = 1234;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when defaultUri is invalid', () => {
+            fixture.defaultUri = 1234;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when hostGroup is invalid', () => {
+            fixture.hostGroup = 1234;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when id is invalid', () => {
+            fixture.id = 1234;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when priority is invalid', () => {
+            fixture.priority = 'test-string';
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+
+          it('should throw an error when uri is invalid', () => {
+            fixture.uri = 1234;
+            assert.throws(() => ServiceHost.validate(fixture));
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

This change includes a new `ServiceHost` class that will ultimately replace the `ServiceUrl` class. After full review of the requirements for federation and the data that is received from the `U2C` service, there is a more efficient way to handle and manage service information in a way that properly allows for deleting/creating service links.

This new class is mounted, but not coupled to anything in this pull request.

Fixes # SPARK-118010

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Generate new tests for the new `ServiceHost` class.
- [x] Ran `webex-core` package tests, all pass locally.

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
