### PR TITLE
Fix/add logout trigger

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-devices/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/index.js
@@ -12,6 +12,14 @@ registerInternalPlugin('devices', Devices, {
   config,
   interceptors: {
     DeviceUrlInterceptor: DeviceUrlInterceptor.create
+  },
+  /**
+   * Unregister the device in the case that the webex instance has logged out.
+   *
+   * @returns {Promise<undefined>}
+   */
+  onBeforeLogout() {
+    return this.unregister();
   }
 });
 

--- a/packages/node_modules/@webex/internal-plugin-devices/test/integration/spec/webex.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/test/integration/spec/webex.js
@@ -1,0 +1,42 @@
+import '@webex/internal-plugin-devices';
+
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import WebexCore from '@webex/webex-core';
+import testUsers from '@webex/test-helper-test-users';
+
+describe('plugin-devices', () => {
+  describe('Webex', () => {
+    let devices;
+    let user;
+    let webex;
+
+    before('create users', () => testUsers.create({count: 1})
+      .then(([createdUser]) => {
+        user = createdUser;
+      }));
+
+    beforeEach('create webex instance', () => {
+      webex = new WebexCore({
+        credentials: user.token
+      });
+
+      devices = webex.internal.devices;
+
+      return devices.register();
+    });
+
+    describe('#onBeforeLogout()', () => {
+      beforeEach('setup spy', () => {
+        sinon.spy(devices, 'unregister');
+      });
+
+      it('unregisters the device', () =>
+        webex.logout({noRedirect: true})
+          .then(() => {
+            assert.called(devices.unregister);
+            assert.isFalse(devices.registered);
+          }));
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request Template

## Description

This change includes a new method for the mounting point for `@webex/internal-plugin-devices` plugin. This method is added so that when the Webex instance triggers a `logout` event, the Devices plugin unregisters the device.

Fixes # [SPARK-119625](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-119625)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Generated a test to confirm that the logout event triggers an unregister method.
- [x] Ran the package tests to validate the changes worked as expected.

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
