### PR TITLE
Fix/improve deviceurl interceptor

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-devices/src/constants.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/constants.js
@@ -9,6 +9,8 @@ export const FEATURE_COLLECTION_NAMES = [
   FEATURE_COLLECTION_USER
 ];
 
+export const CISCO_DEVICE_URL = 'cisco-device-url';
+
 // Devices constants.
 export const DEVICES_EVENT_REGISTRATION_SUCCESS = 'registration:success';
 

--- a/packages/node_modules/@webex/internal-plugin-devices/src/interceptors/device-url.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/interceptors/device-url.js
@@ -5,6 +5,8 @@
 import {Interceptor} from '@webex/http-core';
 import {set} from 'lodash';
 
+import {CISCO_DEVICE_URL} from '../constants';
+
 /**
   * Adds 'cisco-device-url' header, as appropriate, to requests
   */
@@ -27,15 +29,14 @@ export default class DeviceUrlInterceptor extends Interceptor {
     const {devices, services} = this.webex.internal;
 
     // Check if header is already set before moving forward
-    if (!devices.url || (headers && !headers['cisco-device-url'])) {
+    if (
+      !devices.url ||
+      (headers && CISCO_DEVICE_URL in headers && !headers[CISCO_DEVICE_URL])
+    ) {
       return Promise.resolve(options);
     }
 
-    /**
-     * Wait for catalog and service to be defined
-     * Can take either service or uri
-     * Returns the service url
-    */
+    // Wait for catalog and service to be defined.
     return services.waitForService({service, url: uri})
       .then((url) => {
         // Grab the service name with the url returned from waitForService
@@ -45,7 +46,7 @@ export default class DeviceUrlInterceptor extends Interceptor {
         // Check if service is not one of the invalid services
         // Assign the url to the device header
         if (!invalidServices.includes(serviceName)) {
-          set(options, 'headers[\'cisco-device-url\']', devices.url);
+          set(options, `headers['${CISCO_DEVICE_URL}']`, devices.url);
         }
 
         return options;

--- a/packages/node_modules/@webex/internal-plugin-devices/test/unit/spec/interceptors/device-url.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/test/unit/spec/interceptors/device-url.js
@@ -44,7 +44,7 @@ describe('plugin-devices', () => {
 
     describe('#onRequest()', () => {
       describe('when `cisco-device-url` header is are already set', () => {
-        it('returns the options', () => {
+        it('should return the options unchanged', () => {
           interceptor.webex.internal.devices.url = undefined;
           options = {
             headers: {
@@ -53,8 +53,23 @@ describe('plugin-devices', () => {
             ...options
           };
 
-          interceptor.onRequest(options)
-            .then((results) => assert.equal(results, options));
+          return interceptor.onRequest({...options})
+            .then((results) => assert.deepEqual(results, options));
+        });
+
+        describe('when `cisco-device-url` header exists but is not set', () => {
+          it('should return the options unchanged', () => {
+            interceptor.webex.internal.devices.url = undefined;
+            options = {
+              headers: {
+                'cisco-device-url': undefined
+              },
+              ...options
+            };
+
+            return interceptor.onRequest({...options})
+              .then((results) => assert.deepEqual(results, options));
+          });
         });
       });
 


### PR DESCRIPTION
# Pull Request

## Description

The changes in this pull request targets updating the `DeviceUrl` interceptor to allow additional header options to be caught if they exist as a key, but are not defined as a value.

Fixes # [SPARK-119626](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-119626)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Created a test to validate the changes
- [x] Ran the test to validate the changes worked as expected.

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
