### PR TITLE
Fix/improve websocket detection

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-devices/src/devices.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/src/devices.js
@@ -597,8 +597,17 @@ const Devices = WebexPlugin.extend({
       ));
     }
 
-    return Promise.resolve()
-      .then(() => services.convertUrlToPriorityHostUrl(this.webSocketUrl));
+    // Attempt to collect the priority-host-mapped web socket URL.
+    const wsUrl = services.convertUrlToPriorityHostUrl(this.webSocketUrl);
+
+    // Validate that the url was collected.
+    if (wsUrl) {
+      return Promise.resolve(wsUrl);
+    }
+
+    return Promise.reject(new Error(
+      'devices: failed to get the current websocket url'
+    ));
   },
 
   /**

--- a/packages/node_modules/@webex/internal-plugin-devices/test/integration/spec/devices.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/test/integration/spec/devices.js
@@ -421,9 +421,9 @@ describe('plugin-devices', () => {
           });
 
           describe('when the priority host cannot be mapped', () => {
-            beforeEach('remove postauth services', () => {
-              /* eslint-disable-next-line no-underscore-dangle */
-              services._getCatalog().serviceGroups.postauth = [];
+            beforeEach('stub priority host url converting', () => {
+              services.convertUrlToPriorityHostUrl = sinon.stub();
+              services.convertUrlToPriorityHostUrl.returns(undefined);
             });
 
             it('should return a rejected promise',


### PR DESCRIPTION
# Pull Request

## Description

The changes in this pull request are targetted towards fixing a small bug within the `internal-plugin-devices` plugin. This allows for validation that the web socket URL was properly mapped against the service catalog before automatically resolving its value.

Fixes # [SPARK-119624](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-119624)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated the connected test related to this change.
- [x] Ran the package's tests to validate the changes worked as expected.

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
