### PR TITLE
test(internal-plugin-devices): remove unnecessary assertions

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-devices/test/integration/spec/devices.js
+++ b/packages/node_modules/@webex/internal-plugin-devices/test/integration/spec/devices.js
@@ -101,12 +101,9 @@ describe('plugin-devices', () => {
           });
 
           describe('when the \'wdm\' service does exist after wait', () => {
-            beforeEach('validate that the catalog is collecting', () => {
+            it('should return a resolved promise', () => {
               /* eslint-disable-next-line no-underscore-dangle */
               assert.isTrue(services._getCatalog().status.postauth.collecting);
-            });
-
-            it('should return a resolved promise', () => {
               assert.isFulfilled(devices.canRegister(wait));
             });
           });
@@ -115,12 +112,11 @@ describe('plugin-devices', () => {
             beforeEach('remove wdm service', () => {
               services.get = sinon.stub().returns(undefined);
               services.waitForCatalog = sinon.stub().resolves();
-
-              /* eslint-disable-next-line no-underscore-dangle */
-              assert.isTrue(services._getCatalog().status.postauth.collecting);
             });
 
             it('should return a rejected promise', () => {
+              /* eslint-disable-next-line no-underscore-dangle */
+              assert.isTrue(services._getCatalog().status.postauth.collecting);
               assert.isRejected(devices.canRegister(wait));
             });
           });
@@ -136,8 +132,6 @@ describe('plugin-devices', () => {
             catalog = services._getCatalog();
 
             catalog.serviceGroups.postauth = [];
-
-            assert.isUndefined(services.get('wdm'));
           });
 
           it('should return a rejected promise', () => {
@@ -159,8 +153,7 @@ describe('plugin-devices', () => {
           beforeEach('destructure services plugin', () => {
             services = webex.internal.services;
 
-            return services.updateServices()
-              .then(() => assert.isDefined(services.get('wdm')));
+            return services.updateServices();
           });
 
           it('should return a resolved promise', () => {
@@ -179,12 +172,11 @@ describe('plugin-devices', () => {
             catalog.serviceGroups.postauth = [];
 
             services.updateServices();
-
-            /* eslint-disable-next-line no-underscore-dangle */
-            assert.isTrue(services._getCatalog().status.postauth.collecting);
           });
 
           it('should return a rejected promise', () => {
+            /* eslint-disable-next-line no-underscore-dangle */
+            assert.isTrue(services._getCatalog().status.postauth.collecting);
             assert.isRejected(devices.canRegister(wait));
           });
         });
@@ -199,8 +191,6 @@ describe('plugin-devices', () => {
             catalog = services._getCatalog();
 
             catalog.serviceGroups.postauth = [];
-
-            assert.isUndefined(services.get('wdm'));
           });
 
           it('should return a rejected promise', () => {
@@ -374,20 +364,19 @@ describe('plugin-devices', () => {
         });
 
         describe('when the device is not registered', () => {
-          beforeEach('check that the device is not registered', () => {
-            assert.isFalse(devices.registered);
-          });
-
           describe('when the device successfully registers', () => {
-            it('should resolve the promise with the websocket url', () => Promise.all([
-              devices.getWebSocketUrl(wait),
-              devices.register()
-            ])
-              .then(([url]) => {
-                assert.isDefined(url);
-                assert.isTrue(services.isServiceUrl(url));
-                assert.include(url, 'mercury');
-              }));
+            it('should resolve the promise with the websocket url',
+              () => Promise.all([
+                devices.getWebSocketUrl(wait),
+                devices.register()
+              ])
+                .then(([url]) => {
+                  assert.isTrue(services.isServiceUrl(url));
+                  assert.include(
+                    services.getServiceFromUrl(url).name,
+                    'mercury'
+                  );
+                }));
           });
 
           it('should return a rejected promise if the device never registers',
@@ -406,11 +395,6 @@ describe('plugin-devices', () => {
           beforeEach('register the device', () => devices.register());
 
           describe('when the priority host can be mapped', () => {
-            beforeEach('validate device and service', () => {
-              assert.isDefined(services.get('wdm'));
-              assert.isTrue(devices.registered);
-            });
-
             it('should resolve the promise with the websocket url',
               () => devices.getWebSocketUrl(wait)
                 .then((url) => {
@@ -432,9 +416,6 @@ describe('plugin-devices', () => {
         });
 
         describe('when the device is not registered', () => {
-          beforeEach('check that the device is not registered',
-            () => assert.isFalse(devices.registered));
-
           it('should return a rejected promise',
             () => assert.isRejected(devices.getWebSocketUrl(wait)));
         });
@@ -526,8 +507,6 @@ describe('plugin-devices', () => {
         describe('when the device is not registered', () => {
           beforeEach('setup spy function', () => {
             devices.register = sinon.spy();
-
-            assert.isFalse(devices.registered);
           });
 
           it('should attempt to register', () => devices.refresh()
@@ -546,8 +525,6 @@ describe('plugin-devices', () => {
 
             return devices.register()
               .then(() => {
-                assert.isTrue(devices.registered);
-
                 devices.request = sinon.stub().returns(Promise.resolve(
                   {...exampleResponse}
                 ));
@@ -630,14 +607,12 @@ describe('plugin-devices', () => {
             it('should return a resolved promise',
               () => assert.isFulfilled(devices.refresh()));
 
-            it('should call \'processRegistrationSuccess()\'', () => devices.refresh()
-              .then(() => assert.called(devices.processRegistrationSuccess)));
+            it('should call \'processRegistrationSuccess()\'',
+              () => devices.refresh()
+                .then(() => assert.called(devices.processRegistrationSuccess)));
           });
 
           describe('when the device fails to refresh', () => {
-            beforeEach('setup \'register()\' stub', () => {
-            });
-
             describe('when the device is not found', () => {
               let request;
 
@@ -666,8 +641,9 @@ describe('plugin-devices', () => {
               it('should clear the current device', () => devices.refresh()
                 .then(() => assert.isUndefined(devices.url)));
 
-              it('should attempt to register a new device', () => devices.refresh()
-                .then(() => assert.called(devices.register)));
+              it('should attempt to register a new device', () =>
+                devices.refresh()
+                  .then(() => assert.called(devices.register)));
             });
 
             describe('when the device was found', () => {
@@ -718,8 +694,7 @@ describe('plugin-devices', () => {
           beforeEach('setup \'register()\' spy and register', () => {
             devices.refresh = sinon.spy();
 
-            return devices.register()
-              .then(() => assert.isTrue(devices.registered));
+            return devices.register();
           });
 
           it('should attempt to refresh', () => devices.register()
@@ -739,8 +714,6 @@ describe('plugin-devices', () => {
             devices.request = sinon.stub().returns(Promise.resolve(
               {...exampleResponse}
             ));
-
-            assert.isFalse(devices.registered);
           });
 
           describe('when the registration request is sent', () => {
@@ -913,8 +886,7 @@ describe('plugin-devices', () => {
 
     describe('#unregister()', () => {
       describe('when the device is registered', () => {
-        beforeEach('register the device', () => devices.register()
-          .then(() => assert.isTrue(devices.registered)));
+        beforeEach('register the device', () => devices.register());
 
         describe('when the unregistration request is sent', () => {
           let url;
@@ -985,10 +957,6 @@ describe('plugin-devices', () => {
       });
 
       describe('when the device is not registered', () => {
-        beforeEach('verify the device is not registered', () => {
-          assert.isFalse(devices.registered);
-        });
-
         describe('when the device registers', () => {
           it('should return a resolved promise once registered',
             () => Promise.all([


### PR DESCRIPTION
Remove unnecessary assertions in the devices plugin
integration tests that assert details during the
setup stages.

# Pull Request

## Description

The changes within this pull requests are scoped to unnecessary assertions within setup blocks, such as `before` and `beforeEach` methods within the integration tests for the `internal-plugin-devices` plugin. These methods have been updated to no longer include redundant assertions within the setup stages, as well as other miscellaneous changes to blocks that were unnecessary.

Fixes # [SPARK-119621](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-119621)

## Type of Change

Please delete options that are not relevant.

- [x] Test Refactor

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Refactored `internal-plugin-devices` integration tests.
- [x] Validated these tests passed by running the test suite for `internal-plugin-devices`

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
