### PR TITLE
Feat/add status methods service catalogs

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/lib/services/service-catalogs.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/service-catalogs.js
@@ -27,7 +27,8 @@ import ServiceHost from './service-host';
  * @property {Array<string> | string} [HostFilter.cluster] - Clusters to filter.
  * @property {boolean} [HostFilter.local] - Filter to the user's home cluster.
  * @property {boolean} [HostFilter.priority] - Filter for the highest priority.
- * @property {Array<string | string} [HostFilter.service] - Services to filter.
+ * @property {Array<string> | string} [HostFilter.service] - Services to filter.
+ * @property {Array<string> | string} [HostFilter.url] - URL to filter.
  */
 
 /**
@@ -106,6 +107,31 @@ export default class ServiceCatalogs {
   }
 
   /**
+   * Mark a collection of {@link ServiceHost} class objects from the
+   * {@link ServiceCatalogs#hosts} array as failed based on the provided
+   * {@link HostFilter}.
+   *
+   * @public
+   * @memberof ServiceCatalogs
+   * @param {HostFilter} filter - The inclusive filter for hosts to mark failed.
+   * @returns {Array<ServiceHost>} - The {@link ServiceHost}s marked failed.
+   */
+  failed(filter) {
+    // Collect a list of hosts to mark as failed based on the provided filter.
+    const failing = this.find(filter);
+
+    // Mark the hosts from the array as failed.
+    failing.forEach(
+      (host) => {
+        host.setStatus({failed: true});
+      }
+    );
+
+    // Return the marked hosts.
+    return failing;
+  }
+
+  /**
    * Filter the {@link ServiceCatalogs#hosts} array against their active states.
    *
    * @private
@@ -178,7 +204,7 @@ export default class ServiceCatalogs {
   }
 
   /**
-   * Filter the `{@link ServiceCatalogs#hosts} array for the highest priority
+   * Filter the {@link ServiceCatalogs#hosts} array for the highest priority
    * hosts for each specific service.
    *
    * @private
@@ -236,7 +262,7 @@ export default class ServiceCatalogs {
   }
 
   /**
-   * Filter the `{@link ServiceCatalogs#hosts} array for a host with a specified
+   * Filter the {@link ServiceCatalogs#hosts} array for hosts with a specified
    * set of service names.
    *
    * @private
@@ -245,12 +271,31 @@ export default class ServiceCatalogs {
    * @returns {Array<ServiceHost>} - The filtered host array.
    */
   filterService(service = []) {
-    // Generate an array of clusters regardless of parameter type.
+    // Generate an array of services regardless of parameter type.
     const services = (Array.isArray(service) ? service : [service]);
 
-    // Filter the host array against the provided clusters.
+    // Filter the host array against the provided services.
     return (services.length > 0) ?
-      this.hosts.filter((host) => service.includes(host.service)) :
+      this.hosts.filter((host) => services.includes(host.service)) :
+      [...this.hosts];
+  }
+
+  /**
+   * Filter the {@link ServiceCatalogs#hosts} array for hosts with a specified
+   * set of URLs.
+   *
+   * @private
+   * @memberof ServiceCatalogs
+   * @param {Array<string> | string} [url] - URL to filter.
+   * @returns {Array<ServiceHost>} - The filter host array.
+   */
+  filterUrl(url = []) {
+    // Generate an array of URLs regardless of the parameter type.
+    const urls = (Array.isArray(url) ? url : [url]);
+
+    // Filter the host array against the provided URLs.
+    return (urls.length > 0) ?
+      this.hosts.filter((host) => urls.includes(host.url)) :
       [...this.hosts];
   }
 
@@ -260,7 +305,7 @@ export default class ServiceCatalogs {
    *
    * @public
    * @memberof ServiceCatalogs
-   * @param {HostFilter} param - The inclusive filter for hosts to find.
+   * @param {HostFilter} [filter] - The inclusive filter for hosts to find.
    * @returns {Array<ServiceHost>} - The filtered hosts.
    */
   find({
@@ -269,7 +314,8 @@ export default class ServiceCatalogs {
     cluster,
     local,
     priority,
-    service
+    service,
+    url
   } = {}) {
     return this.hosts.filter(
       (host) => (
@@ -278,7 +324,8 @@ export default class ServiceCatalogs {
         this.filterCluster(cluster).includes(host) &&
         this.filterLocal(local).includes(host) &&
         this.filterPriority(priority).includes(host) &&
-        this.filterService(service).includes(host)
+        this.filterService(service).includes(host) &&
+        this.filterUrl(url).includes(host)
       )
     );
   }
@@ -307,6 +354,56 @@ export default class ServiceCatalogs {
     );
 
     return this;
+  }
+
+  /**
+   * Mark a collection of {@link ServiceHost} class objects from the
+   * {@link ServiceCatalogs#hosts} array as replaced based on the provided
+   * {@link HostFilter}.
+   *
+   * @public
+   * @memberof ServiceCatalogs
+   * @param {HostFilter} filter - The inclusive filter to mark replaced.
+   * @returns {Array<ServiceHost>} - The {@link ServiceHost}s marked replaced.
+   */
+  replaced(filter) {
+    // Collect a list of hosts to mark as replaced based on the provided filter.
+    const replacing = this.find(filter);
+
+    // Mark the hosts from the array as replaced.
+    replacing.forEach(
+      (host) => {
+        host.setStatus({replaced: true});
+      }
+    );
+
+    // Return the marked hosts.
+    return replacing;
+  }
+
+  /**
+   * Reset the failed status of a collection of {@link ServiceHost} class
+   * objects from the {@link ServiceCatalogs#hosts} array based on the provided
+   * {@link HostFilter}.
+   *
+   * @public
+   * @memberof ServiceCatalogs
+   * @param {HostFilter} filter - The inclusive filter of hosts to reset.
+   * @returns {Array<ServiceHost>} - The {@link ServiceHost}s that reset.
+   */
+  reset(filter) {
+    // Collect a list of hosts to mark as replaced based on the provided filter.
+    const resetting = this.find(filter);
+
+    // Mark the hosts from the array as replaced.
+    resetting.forEach(
+      (host) => {
+        host.setStatus({failed: false});
+      }
+    );
+
+    // Return the marked hosts.
+    return resetting;
   }
 
   /**

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/service-catalogs.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/service-catalogs.js
@@ -123,7 +123,8 @@ describe('webex-core', () => {
           cluster: host.id,
           local: true,
           priority: true,
-          service: host.service
+          service: host.service,
+          url: host.url
         };
       });
 
@@ -149,6 +150,48 @@ describe('webex-core', () => {
         const [removedHost] = serviceCatalogs.clear(filter);
 
         assert.equal(removedHost, host);
+      });
+    });
+
+    describe('#failed()', () => {
+      let filter;
+      let filteredHost;
+
+      beforeEach('generate the service host class objects', () => {
+        serviceCatalogs.load(ServiceCatalogs.mapRemoteCatalog({
+          catalog: SERVICE_CATALOGS[0],
+          ...fixture
+        }));
+
+        filteredHost = serviceCatalogs.hosts[0];
+
+        filter = {
+          active: true,
+          catalog: filteredHost.catalog,
+          cluster: filteredHost.id,
+          local: true,
+          priority: true,
+          service: filteredHost.service,
+          url: filteredHost.url
+        };
+      });
+
+      it('should mark all hosts as failed when called without a filter', () => {
+        serviceCatalogs.failed();
+        assert.isTrue(serviceCatalogs.hosts.every(
+          (failedHost) => failedHost.failed
+        ));
+      });
+
+      it('should mark the target hosts as failed', () => {
+        serviceCatalogs.failed(filter);
+        assert.isTrue(filteredHost.failed);
+      });
+
+      it('should return the marked host', () => {
+        const [failedHost] = serviceCatalogs.failed(filter);
+
+        assert.equal(failedHost, filteredHost);
       });
     });
 
@@ -406,9 +449,56 @@ describe('webex-core', () => {
         ));
       });
 
-      it('should return no hosts with an invalid service', () => {
+      it('should return an empty array when given an invalid service', () => {
         filteredHosts = serviceCatalogs.filterService('invalid');
 
+        assert.equal(filteredHosts.length, 0);
+      });
+    });
+
+    describe('#filterUrl()', () => {
+      let filteredHosts;
+      let filteredHostA;
+      let filteredHostB;
+
+      beforeEach('generate the service host class objects', () => {
+        serviceCatalogs.load(
+          ServiceCatalogs.mapRemoteCatalog({
+            catalog: SERVICE_CATALOGS[0],
+            ...fixture
+          })
+        );
+
+        filteredHostA = serviceCatalogs.hosts[0];
+        filteredHostB = serviceCatalogs.hosts[1];
+      });
+
+      it('should return all hosts when called without params', () => {
+        filteredHosts = serviceCatalogs.filterUrl();
+
+        assert.deepEqual(filteredHosts, serviceCatalogs.hosts);
+      });
+
+      it('should return only service hosts with a specific url', () => {
+        [filteredHosts] = serviceCatalogs.filterUrl(filteredHostA.url);
+
+        assert.equal(filteredHosts, filteredHostA);
+      });
+
+      it('should return service hosts for an array of urls', () => {
+        filteredHosts = serviceCatalogs.filterUrl([
+          filteredHostA.url,
+          filteredHostB.url
+        ]);
+
+        assert.equal(filteredHosts.length, 2);
+        assert.isTrue(filteredHosts.every(
+          (foundHost) => [filteredHostA, filteredHostB].includes(foundHost)
+        ));
+      });
+
+      it('should return an empty array when given an invalid url', () => {
+        filteredHosts = serviceCatalogs.filterUrl('invalid');
         assert.equal(filteredHosts.length, 0);
       });
     });
@@ -431,7 +521,8 @@ describe('webex-core', () => {
           cluster: host.id,
           local: true,
           priority: true,
-          service: host.service
+          service: host.service,
+          url: host.url
         };
       });
 
@@ -471,6 +562,12 @@ describe('webex-core', () => {
         assert.calledWith(serviceCatalogs.filterService, filter.service);
       });
 
+      it('should call the \'filterUrl()\' method with params', () => {
+        sinon.spy(serviceCatalogs, 'filterUrl');
+        serviceCatalogs.find(filter);
+        assert.calledWith(serviceCatalogs.filterUrl, filter.url);
+      });
+
       it('should return an array of filtered hosts', () => {
         const foundHosts = serviceCatalogs.find(filter);
 
@@ -508,6 +605,101 @@ describe('webex-core', () => {
 
       it('should return itself', () => {
         assert.equal(serviceCatalogs.load([]), serviceCatalogs);
+      });
+    });
+
+    describe('#replaced()', () => {
+      let filter;
+      let filteredHost;
+
+      beforeEach('generate the service host class objects', () => {
+        serviceCatalogs.load(ServiceCatalogs.mapRemoteCatalog({
+          catalog: SERVICE_CATALOGS[0],
+          ...fixture
+        }));
+
+        filteredHost = serviceCatalogs.hosts[0];
+
+        filter = {
+          active: true,
+          catalog: filteredHost.catalog,
+          cluster: filteredHost.id,
+          local: true,
+          priority: true,
+          service: filteredHost.service,
+          url: filteredHost.url
+        };
+      });
+
+      it('should mark all hosts as replaced when called without params', () => {
+        serviceCatalogs.replaced();
+        assert.isTrue(serviceCatalogs.hosts.every(
+          (replacedHost) => replacedHost.replaced
+        ));
+      });
+
+      it('should mark the target hosts as replaced', () => {
+        serviceCatalogs.replaced(filter);
+        assert.isTrue(filteredHost.replaced);
+      });
+
+      it('should return the marked host', () => {
+        const [replacedHost] = serviceCatalogs.replaced(filter);
+
+        assert.equal(replacedHost, filteredHost);
+      });
+    });
+
+    describe('#reset()', () => {
+      let filter;
+      let filteredHost;
+
+      beforeEach('generate the service host class objects', () => {
+        serviceCatalogs.load(ServiceCatalogs.mapRemoteCatalog({
+          catalog: SERVICE_CATALOGS[0],
+          ...fixture
+        }));
+
+        filteredHost = serviceCatalogs.hosts[0];
+
+        filter = {
+          url: filteredHost.url
+        };
+
+        serviceCatalogs.failed();
+      });
+
+      it('should reset all hosts when called withour a filter', () => {
+        serviceCatalogs.reset();
+        assert.isTrue(serviceCatalogs.hosts.every(
+          (resetHost) => resetHost.failed === false
+        ));
+      });
+
+      it('should reset the failed status of the target host', () => {
+        serviceCatalogs.reset(filter);
+        assert.isFalse(filteredHost.failed);
+      });
+
+      it('should not reset the failed status of non-targetted hosts', () => {
+        serviceCatalogs.reset(filter);
+        assert.isTrue(serviceCatalogs.hosts.every(
+          (foundHost) => foundHost.failed || foundHost === filteredHost
+        ));
+      });
+
+      it('should not reset the replaced status of hosts', () => {
+        serviceCatalogs.replaced();
+        serviceCatalogs.reset();
+        assert.isTrue(serviceCatalogs.hosts.every(
+          (foundHost) => foundHost.replaced
+        ));
+      });
+
+      it('should return the reset host', () => {
+        const [resetHost] = serviceCatalogs.reset(filter);
+
+        assert.equal(resetHost, filteredHost);
       });
     });
 


### PR DESCRIPTION
# Pull Request

## Description

The changes in this pull request are focused around adding status collection methods to `ServiceCatalogs` within `@webex/internal-plugin-services`. Additionally, a `filterUrl` method was amended to address a small gap within the current `ServiceCatalogs` class filters.

Fixes # [SPARK-119663](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-119663)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Generate new tests to validate the amended methods will work
- [x] Run the package tests to validate the changes worked as expected.

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
