### PR TITLE
Refactor/rename catalogs to registry

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/index.js
+++ b/packages/node_modules/@webex/webex-core/src/index.js
@@ -24,7 +24,7 @@ export {
 export {
   constants as serviceConstants,
   ServiceCatalog,
-  ServiceCatalogs,
+  ServiceRegistry,
   ServiceInterceptor,
   ServerErrorInterceptor,
   Services,

--- a/packages/node_modules/@webex/webex-core/src/lib/services/index.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/index.js
@@ -20,6 +20,6 @@ export {default as ServiceInterceptor} from './interceptors/service';
 export {default as ServerErrorInterceptor} from './interceptors/server-error';
 export {default as Services} from './services';
 export {default as ServiceCatalog} from './service-catalog';
-export {default as ServiceCatalogs} from './service-catalogs';
+export {default as ServiceRegistry} from './service-registry';
 export {default as ServiceHost} from './service-host';
 export {default as ServiceUrl} from './service-url';

--- a/packages/node_modules/@webex/webex-core/src/lib/services/service-registry.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/service-registry.js
@@ -5,7 +5,7 @@ import {
 import ServiceHost from './service-host';
 
 /**
- * The parameter transfer object for {@link ServiceCatalogs#mapRemoteCatalog}.
+ * The parameter transfer object for {@link ServiceRegistry#mapRemoteCatalog}.
  * This object is shaped to match the object returned from the **U2C** service.
  *
  * @typedef {Record<string, string>} RSL
@@ -19,7 +19,7 @@ import ServiceHost from './service-host';
 
 /**
  * Service manipulation filter object for retrieving services within the
- * {@link ServiceCatalogs} class.
+ * {@link ServiceRegistry} class.
  *
  * @typedef {Object} HostFilter
  * @property {boolean} [HostFilter.active] - Active state to filter.
@@ -35,7 +35,7 @@ import ServiceHost from './service-host';
  * @class
  * @classdesc - Manages a collection of {@link ServiceHost} class objects.
  */
-export default class ServiceCatalogs {
+export default class ServiceRegistry {
   /**
    * Generate a new {@link ServiceHost}.
    *
@@ -50,7 +50,7 @@ export default class ServiceCatalogs {
      * @instance
      * @type {Array<ServiceHost>}
      * @private
-     * @memberof ServiceCatalogs
+     * @memberof ServiceRegistry
      */
     this.hosts = [];
   }
@@ -85,11 +85,11 @@ export default class ServiceCatalogs {
 
   /**
    * Removes a collection of {@link ServiceHost} class objects from the
-   * {@link ServiceCatalogs#hosts} array based on the provided
+   * {@link ServiceRegistry#hosts} array based on the provided
    * {@link HostFilter}.
    *
    * @public
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {HostFilter} filter - The inclusive filter for hosts to remove.
    * @returns {Array<ServiceHost>} - The removed {@link ServiceHost}s.
    */
@@ -108,11 +108,11 @@ export default class ServiceCatalogs {
 
   /**
    * Mark a collection of {@link ServiceHost} class objects from the
-   * {@link ServiceCatalogs#hosts} array as failed based on the provided
+   * {@link ServiceRegistry#hosts} array as failed based on the provided
    * {@link HostFilter}.
    *
    * @public
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {HostFilter} filter - The inclusive filter for hosts to mark failed.
    * @returns {Array<ServiceHost>} - The {@link ServiceHost}s marked failed.
    */
@@ -132,10 +132,10 @@ export default class ServiceCatalogs {
   }
 
   /**
-   * Filter the {@link ServiceCatalogs#hosts} array against their active states.
+   * Filter the {@link ServiceRegistry#hosts} array against their active states.
    *
    * @private
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {boolean} [active] - Filter for the host state.
    * @returns {Array<ServiceHost>} - The filtered host array.
    */
@@ -147,18 +147,18 @@ export default class ServiceCatalogs {
   }
 
   /**
-   * Filter the {@link ServiceCatalogs#hosts} array against their assigned
+   * Filter the {@link ServiceRegistry#hosts} array against their assigned
    * catalog values.
    *
    * @private
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {Array<string> | string} [catalog] - Catalogs to filter.
    * @returns {Array<ServiceHost>} - The filtered host array.
    */
   filterCatalog(catalog = []) {
     // Generate a catalog names array based on the provided catalog param.
     const catalogs = (Array.isArray(catalog) ? catalog : [catalog])
-      .map((catalogId) => ServiceCatalogs.mapCatalogName({
+      .map((catalogId) => ServiceRegistry.mapCatalogName({
         id: catalogId,
         type: SERVICE_CATALOGS_ENUM_TYPES.STRING
       }) || catalogId);
@@ -170,11 +170,11 @@ export default class ServiceCatalogs {
   }
 
   /**
-   * Filter the {@link ServiceCatalogs#hosts} array against their assigned
+   * Filter the {@link ServiceRegistry#hosts} array against their assigned
    * cluster values.
    *
    * @private
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {Array<string> | string} [cluster] - Clusters to filter for.
    * @returns {Array<ServiceHost>} - The filtered host array.
    */
@@ -189,11 +189,11 @@ export default class ServiceCatalogs {
   }
 
   /**
-   * Filter the {@link ServiceCatalogs#hosts} array against their location in
+   * Filter the {@link ServiceRegistry#hosts} array against their location in
    * reference to the authenticated user.
    *
    * @private
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {boolean} [local] - Filter for the host location.
    * @returns {Array<ServiceHost>} - The filtered host array.
    */
@@ -204,11 +204,11 @@ export default class ServiceCatalogs {
   }
 
   /**
-   * Filter the {@link ServiceCatalogs#hosts} array for the highest priority
+   * Filter the {@link ServiceRegistry#hosts} array for the highest priority
    * hosts for each specific service.
    *
    * @private
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {boolean} [priority] - Filter for the highest priority
    * @returns {Array<ServiceHost>} - The filtered host array.
    */
@@ -235,13 +235,13 @@ export default class ServiceCatalogs {
           }
 
           // Map the found host's catalog to its priority value.
-          const foundHostCatalogPriority = ServiceCatalogs.mapCatalogName({
+          const foundHostCatalogPriority = ServiceRegistry.mapCatalogName({
             id: foundHost.catalog,
             type: SERVICE_CATALOGS_ENUM_TYPES.NUMBER
           });
 
           // Map the current host's catalog to its priority value.
-          const currentHostCatalogPriority = ServiceCatalogs.mapCatalogName({
+          const currentHostCatalogPriority = ServiceRegistry.mapCatalogName({
             id: currentHost.catalog,
             type: SERVICE_CATALOGS_ENUM_TYPES.NUMBER
           });
@@ -262,11 +262,11 @@ export default class ServiceCatalogs {
   }
 
   /**
-   * Filter the {@link ServiceCatalogs#hosts} array for hosts with a specified
+   * Filter the {@link ServiceRegistry#hosts} array for hosts with a specified
    * set of service names.
    *
    * @private
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {Array<string> | string} [service] - Services to filter.
    * @returns {Array<ServiceHost>} - The filtered host array.
    */
@@ -281,11 +281,11 @@ export default class ServiceCatalogs {
   }
 
   /**
-   * Filter the {@link ServiceCatalogs#hosts} array for hosts with a specified
+   * Filter the {@link ServiceRegistry#hosts} array for hosts with a specified
    * set of URLs.
    *
    * @private
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {Array<string> | string} [url] - URL to filter.
    * @returns {Array<ServiceHost>} - The filter host array.
    */
@@ -301,10 +301,10 @@ export default class ServiceCatalogs {
 
   /**
    * Get an array of {@link ServiceHost}s based on a provided
-   * {@link HostFilter} from the {@link ServiceCatalogs#hosts} array.
+   * {@link HostFilter} from the {@link ServiceRegistry#hosts} array.
    *
    * @public
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {HostFilter} [filter] - The inclusive filter for hosts to find.
    * @returns {Array<ServiceHost>} - The filtered hosts.
    */
@@ -333,17 +333,17 @@ export default class ServiceCatalogs {
   /**
    * Load a formatted array of {@link ServiceHost} constructor parameter
    * transfer objects as instances of {@link ServiceHost} class objects to the
-   * {@link ServiceCatalogs#hosts} array.
+   * {@link ServiceRegistry#hosts} array.
    *
    * @public
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {Array<ServiceHost.ConstructorPTO>} hosts
    * @returns {this}
    */
   load(hosts = []) {
     // Validate that the provided hosts are eligible to be loaded.
     const validHosts = hosts.filter((host) => !!(
-      ServiceCatalogs.mapCatalogName({
+      ServiceRegistry.mapCatalogName({
         id: host.catalog,
         type: SERVICE_CATALOGS_ENUM_TYPES.STRING
       })));
@@ -358,11 +358,11 @@ export default class ServiceCatalogs {
 
   /**
    * Mark a collection of {@link ServiceHost} class objects from the
-   * {@link ServiceCatalogs#hosts} array as replaced based on the provided
+   * {@link ServiceRegistry#hosts} array as replaced based on the provided
    * {@link HostFilter}.
    *
    * @public
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {HostFilter} filter - The inclusive filter to mark replaced.
    * @returns {Array<ServiceHost>} - The {@link ServiceHost}s marked replaced.
    */
@@ -383,11 +383,11 @@ export default class ServiceCatalogs {
 
   /**
    * Reset the failed status of a collection of {@link ServiceHost} class
-   * objects from the {@link ServiceCatalogs#hosts} array based on the provided
+   * objects from the {@link ServiceRegistry#hosts} array based on the provided
    * {@link HostFilter}.
    *
    * @public
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {HostFilter} filter - The inclusive filter of hosts to reset.
    * @returns {Array<ServiceHost>} - The {@link ServiceHost}s that reset.
    */
@@ -412,7 +412,7 @@ export default class ServiceCatalogs {
    *
    * @public
    * @static
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {Object} pto - The parameter transfer object.
    * @property {string | number} pto.id - The identifier to convert in the enum.
    * @property {SERVICE_CATALOGS_ENUM_TYPES} pto.type - The desired output.
@@ -452,18 +452,18 @@ export default class ServiceCatalogs {
 
   /**
    * Generate a formatted array based on the object received from the **U2C**
-   * service for usage in the {@link ServiceCatalogs#load} method.
+   * service for usage in the {@link ServiceRegistry#load} method.
    *
    * @public
    * @static
-   * @memberof ServiceCatalogs
+   * @memberof ServiceRegistry
    * @param {MapRemoteCatalogPTO} pto - The parameter transfer object.
    * @throws - If the target catalog does not exist.
    * @returns {Array<ServiceHost#ServiceHostConstructorPTO>}
    */
   static mapRemoteCatalog({catalog, hostCatalog, serviceLinks}) {
     // Collect the service catalog name if needed.
-    const catalogIndex = ServiceCatalogs.mapCatalogName({
+    const catalogIndex = ServiceRegistry.mapCatalogName({
       id: catalog,
       type: SERVICE_CATALOGS_ENUM_TYPES.STRING
     });

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/service-registry.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/service-registry.js
@@ -1,14 +1,14 @@
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
-import {ServiceCatalogs, serviceConstants} from '@webex/webex-core';
+import {ServiceRegistry, serviceConstants} from '@webex/webex-core';
 
 const {SERVICE_CATALOGS, SERVICE_CATALOGS_ENUM_TYPES: SCET} = serviceConstants;
 
 describe('webex-core', () => {
-  describe('ServiceCatalogs', () => {
+  describe('ServiceRegistry', () => {
     let fixture;
     let fixtureHosts;
-    let serviceCatalogs;
+    let serviceRegistry;
 
     before('generate fixture', () => {
       fixture = {
@@ -65,13 +65,13 @@ describe('webex-core', () => {
     });
 
     beforeEach('initialize a service catalog', () => {
-      serviceCatalogs = new ServiceCatalogs();
+      serviceRegistry = new ServiceRegistry();
     });
 
     describe('class members', () => {
       describe('#hosts', () => {
         it('should be an array', () => {
-          assert.isArray(serviceCatalogs.hosts);
+          assert.isArray(serviceRegistry.hosts);
         });
       });
 
@@ -79,8 +79,8 @@ describe('webex-core', () => {
         let priorityLocalHosts;
 
         beforeEach('setup hosts', () => {
-          serviceCatalogs.load(
-            ServiceCatalogs.mapRemoteCatalog({
+          serviceRegistry.load(
+            ServiceRegistry.mapRemoteCatalog({
               catalog: SERVICE_CATALOGS[0],
               ...fixture
             })
@@ -95,7 +95,7 @@ describe('webex-core', () => {
         });
 
         it('should only return hosts that are active/local/priority', () => {
-          const {map} = serviceCatalogs;
+          const {map} = serviceRegistry;
           const priorityLocalHostsKeys = Object.keys(priorityLocalHosts);
 
           assert.isTrue(priorityLocalHostsKeys.every(
@@ -110,12 +110,12 @@ describe('webex-core', () => {
       let host;
 
       beforeEach('generate the service host class objects', () => {
-        serviceCatalogs.load(ServiceCatalogs.mapRemoteCatalog({
+        serviceRegistry.load(ServiceRegistry.mapRemoteCatalog({
           catalog: SERVICE_CATALOGS[0],
           ...fixture
         }));
 
-        host = serviceCatalogs.hosts[0];
+        host = serviceRegistry.hosts[0];
 
         filter = {
           active: true,
@@ -129,25 +129,25 @@ describe('webex-core', () => {
       });
 
       it('should remove all hosts when called without a filter', () => {
-        serviceCatalogs.clear();
+        serviceRegistry.clear();
 
-        assert.equal(serviceCatalogs.hosts.length, 0);
+        assert.equal(serviceRegistry.hosts.length, 0);
       });
 
       it('should remove only filtered hosts when called with a filter', () => {
-        serviceCatalogs.clear(filter);
+        serviceRegistry.clear(filter);
 
-        assert.notInclude(serviceCatalogs.hosts, host);
+        assert.notInclude(serviceRegistry.hosts, host);
       });
 
       it('should remove multiple hosts based on the provided filter', () => {
         host.setStatus({failed: true});
-        serviceCatalogs.clear({active: true});
-        assert.deepEqual(serviceCatalogs.hosts, [host]);
+        serviceRegistry.clear({active: true});
+        assert.deepEqual(serviceRegistry.hosts, [host]);
       });
 
       it('should return the removed hosts', () => {
-        const [removedHost] = serviceCatalogs.clear(filter);
+        const [removedHost] = serviceRegistry.clear(filter);
 
         assert.equal(removedHost, host);
       });
@@ -158,12 +158,12 @@ describe('webex-core', () => {
       let filteredHost;
 
       beforeEach('generate the service host class objects', () => {
-        serviceCatalogs.load(ServiceCatalogs.mapRemoteCatalog({
+        serviceRegistry.load(ServiceRegistry.mapRemoteCatalog({
           catalog: SERVICE_CATALOGS[0],
           ...fixture
         }));
 
-        filteredHost = serviceCatalogs.hosts[0];
+        filteredHost = serviceRegistry.hosts[0];
 
         filter = {
           active: true,
@@ -177,19 +177,19 @@ describe('webex-core', () => {
       });
 
       it('should mark all hosts as failed when called without a filter', () => {
-        serviceCatalogs.failed();
-        assert.isTrue(serviceCatalogs.hosts.every(
+        serviceRegistry.failed();
+        assert.isTrue(serviceRegistry.hosts.every(
           (failedHost) => failedHost.failed
         ));
       });
 
       it('should mark the target hosts as failed', () => {
-        serviceCatalogs.failed(filter);
+        serviceRegistry.failed(filter);
         assert.isTrue(filteredHost.failed);
       });
 
       it('should return the marked host', () => {
-        const [failedHost] = serviceCatalogs.failed(filter);
+        const [failedHost] = serviceRegistry.failed(filter);
 
         assert.equal(failedHost, filteredHost);
       });
@@ -201,31 +201,31 @@ describe('webex-core', () => {
       let filteredHosts;
 
       beforeEach('generate the service host class objects', () => {
-        hostList = ServiceCatalogs.mapRemoteCatalog({
+        hostList = ServiceRegistry.mapRemoteCatalog({
           catalog: SERVICE_CATALOGS[0],
           ...fixture
         });
 
-        serviceCatalogs.load(hostList);
-        failedHost = serviceCatalogs.hosts[0];
+        serviceRegistry.load(hostList);
+        failedHost = serviceRegistry.hosts[0];
         failedHost.setStatus({failed: true, replaced: true});
       });
 
       it('should return all hosts when called without params', () => {
-        filteredHosts = serviceCatalogs.filterActive();
+        filteredHosts = serviceRegistry.filterActive();
 
         assert.equal(filteredHosts.length, hostList.length);
       });
 
       it('should return only active hosts when called with true', () => {
-        filteredHosts = serviceCatalogs.filterActive(true);
+        filteredHosts = serviceRegistry.filterActive(true);
 
         assert.isBelow(filteredHosts.length, hostList.length);
         assert.notInclude(filteredHosts, failedHost);
       });
 
       it('should return only inactive hosts when active is false', () => {
-        filteredHosts = serviceCatalogs.filterActive(false);
+        filteredHosts = serviceRegistry.filterActive(false);
 
         assert.equal(filteredHosts.length, 1);
         assert.include(filteredHosts[0], failedHost);
@@ -238,28 +238,28 @@ describe('webex-core', () => {
       let hostsCustomB;
 
       beforeEach('generate the service host class objects', () => {
-        hostsCustomA = ServiceCatalogs.mapRemoteCatalog({
+        hostsCustomA = ServiceRegistry.mapRemoteCatalog({
           catalog: SERVICE_CATALOGS[0],
           ...fixture
         });
 
-        hostsCustomB = ServiceCatalogs.mapRemoteCatalog({
+        hostsCustomB = ServiceRegistry.mapRemoteCatalog({
           catalog: SERVICE_CATALOGS[1],
           ...fixture
         });
 
-        serviceCatalogs.load(hostsCustomA);
-        serviceCatalogs.load(hostsCustomB);
+        serviceRegistry.load(hostsCustomA);
+        serviceRegistry.load(hostsCustomB);
       });
 
       it('should return all hosts when called without params', () => {
-        filteredHosts = serviceCatalogs.filterCatalog();
+        filteredHosts = serviceRegistry.filterCatalog();
 
-        assert.deepEqual(filteredHosts, serviceCatalogs.hosts);
+        assert.deepEqual(filteredHosts, serviceRegistry.hosts);
       });
 
       it('should return only service hosts in the specific catalog', () => {
-        filteredHosts = serviceCatalogs.filterCatalog(SERVICE_CATALOGS[0]);
+        filteredHosts = serviceRegistry.filterCatalog(SERVICE_CATALOGS[0]);
 
         assert.equal(filteredHosts.length, hostsCustomA.length);
         assert.isTrue(filteredHosts.every(
@@ -268,7 +268,7 @@ describe('webex-core', () => {
       });
 
       it('should return service hosts for an array of catalogs', () => {
-        filteredHosts = serviceCatalogs.filterCatalog(
+        filteredHosts = serviceRegistry.filterCatalog(
           [SERVICE_CATALOGS[0], SERVICE_CATALOGS[1]]
         );
 
@@ -285,7 +285,7 @@ describe('webex-core', () => {
       });
 
       it('should return only service hosts from valid catalogs', () => {
-        filteredHosts = serviceCatalogs.filterCatalog(
+        filteredHosts = serviceRegistry.filterCatalog(
           [SERVICE_CATALOGS[0], 'invalid', -1]
         );
 
@@ -302,8 +302,8 @@ describe('webex-core', () => {
       let localHosts;
 
       beforeEach('generate the service host class objects', () => {
-        serviceCatalogs.load(
-          ServiceCatalogs.mapRemoteCatalog({
+        serviceRegistry.load(
+          ServiceRegistry.mapRemoteCatalog({
             catalog: SERVICE_CATALOGS[0],
             ...fixture
           })
@@ -317,13 +317,13 @@ describe('webex-core', () => {
       });
 
       it('should return all hosts when called without params', () => {
-        filteredHosts = serviceCatalogs.filterLocal();
+        filteredHosts = serviceRegistry.filterLocal();
 
-        assert.deepEqual(filteredHosts, serviceCatalogs.hosts);
+        assert.deepEqual(filteredHosts, serviceRegistry.hosts);
       });
 
       it('should return only local hosts when called with true', () => {
-        filteredHosts = serviceCatalogs.filterLocal(true);
+        filteredHosts = serviceRegistry.filterLocal(true);
 
         assert.equal(filteredHosts.length, localHosts.length);
         assert.isTrue(filteredHosts.every(
@@ -332,7 +332,7 @@ describe('webex-core', () => {
       });
 
       it('should return only hosts remote hosts when called with false', () => {
-        filteredHosts = serviceCatalogs.filterLocal(false);
+        filteredHosts = serviceRegistry.filterLocal(false);
 
         assert.equal(filteredHosts.length, remoteHosts.length);
         assert.isTrue(filteredHosts.every(
@@ -346,8 +346,8 @@ describe('webex-core', () => {
       let priorityHosts;
 
       beforeEach('generate the service host class objects', () => {
-        serviceCatalogs.load(
-          ServiceCatalogs.mapRemoteCatalog({
+        serviceRegistry.load(
+          ServiceRegistry.mapRemoteCatalog({
             catalog: SERVICE_CATALOGS[0],
             ...fixture
           })
@@ -361,32 +361,32 @@ describe('webex-core', () => {
       });
 
       it('should return all hosts when called without params', () => {
-        filteredHosts = serviceCatalogs.filterPriority();
+        filteredHosts = serviceRegistry.filterPriority();
 
-        assert.deepEqual(filteredHosts, serviceCatalogs.hosts);
+        assert.deepEqual(filteredHosts, serviceRegistry.hosts);
       });
 
       it('should return only priority hosts when called with true', () => {
-        filteredHosts = serviceCatalogs.filterPriority(true);
+        filteredHosts = serviceRegistry.filterPriority(true);
 
         assert.equal(filteredHosts.length, priorityHosts.length);
       });
 
       it('should not return inactive hosts when called with true', () => {
-        filteredHosts = serviceCatalogs.filterPriority(true);
+        filteredHosts = serviceRegistry.filterPriority(true);
         filteredHosts[0].setStatus({failed: true});
 
         const failedHost = filteredHosts[0];
 
-        filteredHosts = serviceCatalogs.filterPriority(true);
+        filteredHosts = serviceRegistry.filterPriority(true);
 
         assert.notInclude(filteredHosts, failedHost);
       });
 
       it('should return all hosts when called with false', () => {
-        filteredHosts = serviceCatalogs.filterPriority(false);
+        filteredHosts = serviceRegistry.filterPriority(false);
 
-        assert.deepEqual(filteredHosts, serviceCatalogs.hosts);
+        assert.deepEqual(filteredHosts, serviceRegistry.hosts);
       });
     });
 
@@ -398,8 +398,8 @@ describe('webex-core', () => {
       let serviceName;
 
       beforeEach('generate the service host class objects', () => {
-        serviceCatalogs.load(
-          ServiceCatalogs.mapRemoteCatalog({
+        serviceRegistry.load(
+          ServiceRegistry.mapRemoteCatalog({
             catalog: SERVICE_CATALOGS[0],
             ...fixture
           })
@@ -419,13 +419,13 @@ describe('webex-core', () => {
       });
 
       it('should return all hosts when called without params', () => {
-        filteredHosts = serviceCatalogs.filterService();
+        filteredHosts = serviceRegistry.filterService();
 
-        assert.equal(filteredHosts.length, serviceCatalogs.hosts.length);
+        assert.equal(filteredHosts.length, serviceRegistry.hosts.length);
       });
 
       it('should return hosts that belong to a service', () => {
-        filteredHosts = serviceCatalogs.filterService(serviceName);
+        filteredHosts = serviceRegistry.filterService(serviceName);
 
         assert.equal(filteredHosts.length, serviceHosts.length);
         assert.isTrue(filteredHosts.every(
@@ -434,7 +434,7 @@ describe('webex-core', () => {
       });
 
       it('should return all hosts that belong to an array of services', () => {
-        filteredHosts = serviceCatalogs.filterService([
+        filteredHosts = serviceRegistry.filterService([
           otherServiceName,
           serviceName
         ]);
@@ -450,7 +450,7 @@ describe('webex-core', () => {
       });
 
       it('should return an empty array when given an invalid service', () => {
-        filteredHosts = serviceCatalogs.filterService('invalid');
+        filteredHosts = serviceRegistry.filterService('invalid');
 
         assert.equal(filteredHosts.length, 0);
       });
@@ -462,31 +462,31 @@ describe('webex-core', () => {
       let filteredHostB;
 
       beforeEach('generate the service host class objects', () => {
-        serviceCatalogs.load(
-          ServiceCatalogs.mapRemoteCatalog({
+        serviceRegistry.load(
+          ServiceRegistry.mapRemoteCatalog({
             catalog: SERVICE_CATALOGS[0],
             ...fixture
           })
         );
 
-        filteredHostA = serviceCatalogs.hosts[0];
-        filteredHostB = serviceCatalogs.hosts[1];
+        filteredHostA = serviceRegistry.hosts[0];
+        filteredHostB = serviceRegistry.hosts[1];
       });
 
       it('should return all hosts when called without params', () => {
-        filteredHosts = serviceCatalogs.filterUrl();
+        filteredHosts = serviceRegistry.filterUrl();
 
-        assert.deepEqual(filteredHosts, serviceCatalogs.hosts);
+        assert.deepEqual(filteredHosts, serviceRegistry.hosts);
       });
 
       it('should return only service hosts with a specific url', () => {
-        [filteredHosts] = serviceCatalogs.filterUrl(filteredHostA.url);
+        [filteredHosts] = serviceRegistry.filterUrl(filteredHostA.url);
 
         assert.equal(filteredHosts, filteredHostA);
       });
 
       it('should return service hosts for an array of urls', () => {
-        filteredHosts = serviceCatalogs.filterUrl([
+        filteredHosts = serviceRegistry.filterUrl([
           filteredHostA.url,
           filteredHostB.url
         ]);
@@ -498,7 +498,7 @@ describe('webex-core', () => {
       });
 
       it('should return an empty array when given an invalid url', () => {
-        filteredHosts = serviceCatalogs.filterUrl('invalid');
+        filteredHosts = serviceRegistry.filterUrl('invalid');
         assert.equal(filteredHosts.length, 0);
       });
     });
@@ -508,12 +508,12 @@ describe('webex-core', () => {
       let host;
 
       beforeEach('generate the service host class objects', () => {
-        serviceCatalogs.load(ServiceCatalogs.mapRemoteCatalog({
+        serviceRegistry.load(ServiceRegistry.mapRemoteCatalog({
           catalog: SERVICE_CATALOGS[0],
           ...fixture
         }));
 
-        host = serviceCatalogs.hosts[0];
+        host = serviceRegistry.hosts[0];
 
         filter = {
           active: true,
@@ -527,84 +527,84 @@ describe('webex-core', () => {
       });
 
       it('should call the \'filterActive()\' method with params', () => {
-        sinon.spy(serviceCatalogs, 'filterActive');
-        serviceCatalogs.find(filter);
-        assert.calledWith(serviceCatalogs.filterActive, filter.active);
+        sinon.spy(serviceRegistry, 'filterActive');
+        serviceRegistry.find(filter);
+        assert.calledWith(serviceRegistry.filterActive, filter.active);
       });
 
       it('should call the \'filterCatalog()\' method with params', () => {
-        sinon.spy(serviceCatalogs, 'filterCatalog');
-        serviceCatalogs.find(filter);
-        assert.calledWith(serviceCatalogs.filterCatalog, filter.catalog);
+        sinon.spy(serviceRegistry, 'filterCatalog');
+        serviceRegistry.find(filter);
+        assert.calledWith(serviceRegistry.filterCatalog, filter.catalog);
       });
 
       it('should call the \'filterCluster()\' method with params', () => {
-        sinon.spy(serviceCatalogs, 'filterCluster');
-        serviceCatalogs.find(filter);
-        assert.calledWith(serviceCatalogs.filterCluster, filter.cluster);
+        sinon.spy(serviceRegistry, 'filterCluster');
+        serviceRegistry.find(filter);
+        assert.calledWith(serviceRegistry.filterCluster, filter.cluster);
       });
 
       it('should call the \'filterLocal()\' method with params', () => {
-        sinon.spy(serviceCatalogs, 'filterLocal');
-        serviceCatalogs.find(filter);
-        assert.calledWith(serviceCatalogs.filterLocal, filter.local);
+        sinon.spy(serviceRegistry, 'filterLocal');
+        serviceRegistry.find(filter);
+        assert.calledWith(serviceRegistry.filterLocal, filter.local);
       });
 
       it('should call the \'filterPriority()\' method with params', () => {
-        sinon.spy(serviceCatalogs, 'filterPriority');
-        serviceCatalogs.find(filter);
-        assert.calledWith(serviceCatalogs.filterPriority, filter.priority);
+        sinon.spy(serviceRegistry, 'filterPriority');
+        serviceRegistry.find(filter);
+        assert.calledWith(serviceRegistry.filterPriority, filter.priority);
       });
 
       it('should call the \'filterService()\' method with params', () => {
-        sinon.spy(serviceCatalogs, 'filterService');
-        serviceCatalogs.find(filter);
-        assert.calledWith(serviceCatalogs.filterService, filter.service);
+        sinon.spy(serviceRegistry, 'filterService');
+        serviceRegistry.find(filter);
+        assert.calledWith(serviceRegistry.filterService, filter.service);
       });
 
       it('should call the \'filterUrl()\' method with params', () => {
-        sinon.spy(serviceCatalogs, 'filterUrl');
-        serviceCatalogs.find(filter);
-        assert.calledWith(serviceCatalogs.filterUrl, filter.url);
+        sinon.spy(serviceRegistry, 'filterUrl');
+        serviceRegistry.find(filter);
+        assert.calledWith(serviceRegistry.filterUrl, filter.url);
       });
 
       it('should return an array of filtered hosts', () => {
-        const foundHosts = serviceCatalogs.find(filter);
+        const foundHosts = serviceRegistry.find(filter);
 
         assert.equal(foundHosts[0], host);
         assert.equal(foundHosts.length, 1);
       });
 
       it('should return all of the hosts when called without params', () => {
-        const foundHosts = serviceCatalogs.find();
+        const foundHosts = serviceRegistry.find();
 
-        assert.deepEqual(foundHosts, serviceCatalogs.hosts);
+        assert.deepEqual(foundHosts, serviceRegistry.hosts);
       });
     });
 
     describe('#load()', () => {
       it('should amend all provided hosts to the hosts array', () => {
-        serviceCatalogs.load(ServiceCatalogs.mapRemoteCatalog({
+        serviceRegistry.load(ServiceRegistry.mapRemoteCatalog({
           catalog: SERVICE_CATALOGS[0],
           ...fixture
         }));
 
-        assert.equal(serviceCatalogs.hosts.length, fixtureHosts.length);
+        assert.equal(serviceRegistry.hosts.length, fixtureHosts.length);
       });
 
       it('should ignore unloadable hosts', () => {
-        const unloadables = ServiceCatalogs.mapRemoteCatalog({
+        const unloadables = ServiceRegistry.mapRemoteCatalog({
           catalog: SERVICE_CATALOGS[0],
           ...fixture
         }).map((unloadable) => ({...unloadable, catalog: 'invalid'}));
 
-        serviceCatalogs.load(unloadables);
+        serviceRegistry.load(unloadables);
 
-        assert.equal(serviceCatalogs.hosts.length, 0);
+        assert.equal(serviceRegistry.hosts.length, 0);
       });
 
       it('should return itself', () => {
-        assert.equal(serviceCatalogs.load([]), serviceCatalogs);
+        assert.equal(serviceRegistry.load([]), serviceRegistry);
       });
     });
 
@@ -613,12 +613,12 @@ describe('webex-core', () => {
       let filteredHost;
 
       beforeEach('generate the service host class objects', () => {
-        serviceCatalogs.load(ServiceCatalogs.mapRemoteCatalog({
+        serviceRegistry.load(ServiceRegistry.mapRemoteCatalog({
           catalog: SERVICE_CATALOGS[0],
           ...fixture
         }));
 
-        filteredHost = serviceCatalogs.hosts[0];
+        filteredHost = serviceRegistry.hosts[0];
 
         filter = {
           active: true,
@@ -632,19 +632,19 @@ describe('webex-core', () => {
       });
 
       it('should mark all hosts as replaced when called without params', () => {
-        serviceCatalogs.replaced();
-        assert.isTrue(serviceCatalogs.hosts.every(
+        serviceRegistry.replaced();
+        assert.isTrue(serviceRegistry.hosts.every(
           (replacedHost) => replacedHost.replaced
         ));
       });
 
       it('should mark the target hosts as replaced', () => {
-        serviceCatalogs.replaced(filter);
+        serviceRegistry.replaced(filter);
         assert.isTrue(filteredHost.replaced);
       });
 
       it('should return the marked host', () => {
-        const [replacedHost] = serviceCatalogs.replaced(filter);
+        const [replacedHost] = serviceRegistry.replaced(filter);
 
         assert.equal(replacedHost, filteredHost);
       });
@@ -655,49 +655,49 @@ describe('webex-core', () => {
       let filteredHost;
 
       beforeEach('generate the service host class objects', () => {
-        serviceCatalogs.load(ServiceCatalogs.mapRemoteCatalog({
+        serviceRegistry.load(ServiceRegistry.mapRemoteCatalog({
           catalog: SERVICE_CATALOGS[0],
           ...fixture
         }));
 
-        filteredHost = serviceCatalogs.hosts[0];
+        filteredHost = serviceRegistry.hosts[0];
 
         filter = {
           url: filteredHost.url
         };
 
-        serviceCatalogs.failed();
+        serviceRegistry.failed();
       });
 
       it('should reset all hosts when called withour a filter', () => {
-        serviceCatalogs.reset();
-        assert.isTrue(serviceCatalogs.hosts.every(
+        serviceRegistry.reset();
+        assert.isTrue(serviceRegistry.hosts.every(
           (resetHost) => resetHost.failed === false
         ));
       });
 
       it('should reset the failed status of the target host', () => {
-        serviceCatalogs.reset(filter);
+        serviceRegistry.reset(filter);
         assert.isFalse(filteredHost.failed);
       });
 
       it('should not reset the failed status of non-targetted hosts', () => {
-        serviceCatalogs.reset(filter);
-        assert.isTrue(serviceCatalogs.hosts.every(
+        serviceRegistry.reset(filter);
+        assert.isTrue(serviceRegistry.hosts.every(
           (foundHost) => foundHost.failed || foundHost === filteredHost
         ));
       });
 
       it('should not reset the replaced status of hosts', () => {
-        serviceCatalogs.replaced();
-        serviceCatalogs.reset();
-        assert.isTrue(serviceCatalogs.hosts.every(
+        serviceRegistry.replaced();
+        serviceRegistry.reset();
+        assert.isTrue(serviceRegistry.hosts.every(
           (foundHost) => foundHost.replaced
         ));
       });
 
       it('should return the reset host', () => {
-        const [resetHost] = serviceCatalogs.reset(filter);
+        const [resetHost] = serviceRegistry.reset(filter);
 
         assert.equal(resetHost, filteredHost);
       });
@@ -715,48 +715,48 @@ describe('webex-core', () => {
 
         it('should map an index to the matching name', () => {
           assert.equal(
-            ServiceCatalogs.mapCatalogName({id: index, type: SCET.STRING}),
+            ServiceRegistry.mapCatalogName({id: index, type: SCET.STRING}),
             name
           );
         });
 
         it('should map an index to the matching index', () => {
           assert.equal(
-            ServiceCatalogs.mapCatalogName({id: index, type: SCET.NUMBER}),
+            ServiceRegistry.mapCatalogName({id: index, type: SCET.NUMBER}),
             index
           );
         });
 
         it('should map a name to the matching index', () => {
           assert.equal(
-            ServiceCatalogs.mapCatalogName({id: name, type: SCET.NUMBER}),
+            ServiceRegistry.mapCatalogName({id: name, type: SCET.NUMBER}),
             index
           );
         });
 
         it('should map a name to the matching name', () => {
           assert.equal(
-            ServiceCatalogs.mapCatalogName({id: name, type: SCET.STRING}),
+            ServiceRegistry.mapCatalogName({id: name, type: SCET.STRING}),
             name
           );
         });
 
         it('should return undefined if an index doesn\'t exist', () => {
           assert.isUndefined(
-            ServiceCatalogs.mapCatalogName({id: -1, type: SCET.NUMBER})
+            ServiceRegistry.mapCatalogName({id: -1, type: SCET.NUMBER})
           );
         });
 
         it('should return undefined if a name doesn\'t exist', () => {
           assert.isUndefined(
-            ServiceCatalogs.mapCatalogName({id: 'invalid', type: SCET.NUMBER})
+            ServiceRegistry.mapCatalogName({id: 'invalid', type: SCET.NUMBER})
           );
         });
       });
 
       describe('#mapRemoteCatalog()', () => {
         it('should return an array', () => {
-          const mappedHosts = ServiceCatalogs.mapRemoteCatalog({
+          const mappedHosts = ServiceRegistry.mapRemoteCatalog({
             catalog: SERVICE_CATALOGS[0],
             ...fixture
           });
@@ -765,7 +765,7 @@ describe('webex-core', () => {
         });
 
         it('should include all provided hosts', () => {
-          const mappedHosts = ServiceCatalogs.mapRemoteCatalog({
+          const mappedHosts = ServiceRegistry.mapRemoteCatalog({
             catalog: SERVICE_CATALOGS[0],
             ...fixture
           });
@@ -774,7 +774,7 @@ describe('webex-core', () => {
         });
 
         it('should not map using an invalid catalog name', () => {
-          assert.throws(() => ServiceCatalogs.mapRemoteCatalog({
+          assert.throws(() => ServiceRegistry.mapRemoteCatalog({
             catalog: 'invalid',
             ...fixture
           }));
@@ -783,7 +783,7 @@ describe('webex-core', () => {
         it('should map catalog indexes to catalog names', () => {
           const catalogIndex = 4;
 
-          const mappedHosts = ServiceCatalogs.mapRemoteCatalog({
+          const mappedHosts = ServiceRegistry.mapRemoteCatalog({
             catalog: catalogIndex,
             ...fixture
           });


### PR DESCRIPTION
# Pull Request

## Description

The changes in this pull request are inclusive of renaming the `ServiceCatalogs` class to the `ServiceRegistry`, as the class name doesn't match the scope of the class. `ServiceRegistry` defines the class in a much clearer way, as it is a singular class that contains a registry of ServiceHosts.

Fixes # [SPARK-119590](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-119590)

## Type of Change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated the associated tests for the new namespace.
- [x] Ran the package test to validate the changes operated as expected.

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
