### PR TITLE
test(internal-plugin-encryption): extend ping timeout

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/kms.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/kms.js
@@ -466,7 +466,7 @@ describe('Encryption', function () {
 
         before('alter config', () => {
           ecdhMaxTimeout = webex2.config.encryption.ecdhMaxTimeout;
-          webex2.config.encryption.ecdhMaxTimeout = 500;
+          webex2.config.encryption.ecdhMaxTimeout = 2000;
         });
 
         after(() => {
@@ -476,7 +476,7 @@ describe('Encryption', function () {
         it('limits the number of retries', () => webex2.internal.encryption.kms.ping()
           .then(() => {
             debug(`retry: spy call count: ${spy.callCount}`);
-            assert.isBelow(spy.callCount, 4);
+            assert.isBelow(spy.callCount, 5);
           }));
       });
     });


### PR DESCRIPTION
# Pull Request

## Description

The changes in this pull request are scoped to fixing the failing test within `internal-plugin-encryption`. It seems as though the timeout was too short, and a number of retries value was no longer correct. These have been addressed.

Fixes # [SPARK-120861](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-120861)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated existing tests.
- [x] Ran package tests to validate changes work as expected.

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
