### PR TITLE
fix(i-p-mercury): reconnect with next available priority host

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js
@@ -375,7 +375,6 @@ const Mercury = WebexPlugin.extend({
 
     try {
       const reason = event.reason && event.reason.toLowerCase();
-      const socketUrl = this.socket.url;
 
       this.socket.removeAllListeners();
       this.unset('socket');
@@ -399,15 +398,15 @@ const Mercury = WebexPlugin.extend({
         case 1011:
           this.logger.info('mercury: socket disconnected; reconnecting');
           this._emit('offline.transient', event);
-          this._reconnect(socketUrl);
+          this._reconnect();
           // metric: disconnect
-          // if (code == 1011 && rason !== ping error) metric: unexpected disconnect
+          // if (code == 1011 && reason !== ping error) metric: unexpected disconnect
           break;
         case 1000:
           if (normalReconnectReasons.includes(reason)) {
             this.logger.info('mercury: socket disconnected; reconnecting');
             this._emit('offline.transient', event);
-            this._reconnect(socketUrl);
+            this._reconnect();
             // metric: disconnect
             // if (reason === done forced) metric: force closure
           }

--- a/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/mercury-events.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/mercury-events.js
@@ -331,7 +331,6 @@ describe('plugin-mercury', () => {
                   assert.isFalse(mercury.connected, 'Mercury is not connected');
                   if (action === 'reconnect') {
                     assert.called(mercury.connect);
-                    assert.calledWith(mercury.connect, mockWebSocket.url);
                     assert.isTrue(mercury.connecting, 'Mercury is connecting');
 
                     // Block until reconnect completes so logs don't overlap


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

allows client to reconnect to next available priority host instead of trying same web socket url

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test linking with web client and made sure it tries next available host

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
