### PR TITLE
fix(meetings): check for empty for previous SDP offer

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/roap/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/util.js
@@ -1,3 +1,5 @@
+import {isEmpty} from 'lodash';
+
 import PeerConnectionManager from '../peer-connection-manager';
 import {
   _ANSWER_,
@@ -47,7 +49,7 @@ RoapUtil.compareLastRemoteOffer = (currentOffer, previousOffer) => {
   let index1, index2;
   let difference = false;
 
-  if (previousOffer === {}) {
+  if (isEmpty(previousOffer)) {
     return true;
   }
 
@@ -60,8 +62,6 @@ RoapUtil.compareLastRemoteOffer = (currentOffer, previousOffer) => {
         difference = true;
       }
     });
-
-    return difference;
   }
 
   return difference;

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/roap/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/roap/util.js
@@ -1,0 +1,11 @@
+import {assert} from '@webex/test-helper-chai';
+import RoapUtil from '@webex/plugin-meetings/src/roap/util';
+
+describe('RoapUtil', () => {
+  describe('compareLastRemoteOffer', () => {
+    it('should handle empty previousOffer', () => {
+      assert.equal(RoapUtil.compareLastRemoteOffer([], []), true);
+      assert.equal(RoapUtil.compareLastRemoteOffer([], [{sdp: 'sample sdp'}]), false);
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request Template

## Description
`RoapUtil.compareLastRemoteOffer` was incorrectly checking for a blank SDP remote offer. 

Fixes # (issue)
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-120894

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
