### PR TITLE
Threading api v3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@
       - [Body](#body)
       - [Footer](#footer)
       - [Special Commit Messages](#special-commit-messages)
-        - [[skip npm]](#skip-npm)
-        - [[skip ci]](#skip-ci)
+        - [`[skip npm]`](#skip-npm)
+        - [`[skip ci]`](#skip-ci)
     - [Submitting a Pull Request](#submitting-a-pull-request)
   - [Updating the Documentation](#updating-the-documentation)
     - [Set Up Environment (with Bundler)](#set-up-environment-with-bundler)
@@ -58,7 +58,7 @@ Before you can build the Cisco Webex JS SDK, you will need the following depende
 - [Node.js](https://nodejs.org/) (LTS)
   - We recommend using [nvm](https://github.com/creationix/nvm) (or [nvm-windows](https://github.com/coreybutler/nvm-windows))
     to easily switch between Node.js versions.
-  - Install the latest Node.js Long Term Support using `nvm install --lts`
+  - Run `nvm use` to set your node version to the one this package expects.  If it is not installed, this program will tell you the command needed to install the required version.
   - Install the latest npm to enable security audits using `npm install npm@latest -g`
 - [Git](https://git-scm.com/)
 - [node-gyp](https://www.npmjs.com/package/node-gyp)
@@ -95,6 +95,12 @@ Build the SDK:
 
 ```bash
 npm run build
+```
+
+If at any point your builds or tests are failing with complaints of an invalid node version, the following commands will reset and rebuild everything:
+
+```bash
+nvm use; npm ci
 ```
 
 *Build issues?* See [BUILD-ISSUES.md](./BUILD-ISSUES.md) for help.

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -374,19 +374,20 @@ const Messages = WebexPlugin.extend({
         if (displayName && displayName !== sdkEvent.data.text) {
           sdkEvent.data.markdown = displayName;
         }
-        if (files.length) {
+        if (files && files.length) {
           sdkEvent.data.files = files;
         }
-        if (cards) {
-          if ((typeof cards === 'object') && (cards.length)) {
-            sdkEvent.data.attachments = [];
-            for (const card of cards) {
-              sdkEvent.data.attachments.push({
-                contentType: SDK_EVENT.EXTERNAL.ATTACHMENTS.CARD_CONTENT_TYPE,
-                content: JSON.parse(card)
-              });
-            }
+        if (cards && cards.length) {
+          sdkEvent.data.attachments = [];
+          for (const card of cards) {
+            sdkEvent.data.attachments.push({
+              contentType: SDK_EVENT.EXTERNAL.ATTACHMENTS.CARD_CONTENT_TYPE,
+              content: JSON.parse(card)
+            });
           }
+        }
+        if (activity.parent && activity.parent.id) {
+          sdkEvent.data.parentId = constructHydraId(hydraTypes.MESSAGE, activity.parent.id);
         }
       }
       else {

--- a/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
@@ -376,6 +376,79 @@ describe('plugin-messages', function () {
             assert.calledThrice(spy);
           });
       });
+
+      describe('when a message is threaded', () => {
+        let parentId;
+
+        before(() => webex.rooms.create({
+          title: 'Room List Test'
+        })
+          .then((r) => {
+            room = r;
+          }));
+
+        before(() => {
+          const createdParent = new Promise((resolve) => {
+            webex.messages.once('created', (event) => {
+              debug('Threaded Test: parent message created event called');
+              resolve(event);
+            });
+          });
+
+          return webex.messages.listen()
+            .then(() => webex.messages.create({
+              roomId: room.id,
+              text: 'This is the parent message'
+            })
+              .then(async (message) => {
+                parentId = message.id;
+
+                validateMessage(message);
+                const event = await createdParent;
+
+                validateMessageEvent(event, message, actor);
+                const createdReply = new Promise((resolve) => {
+                  webex.messages.once('created', (e) => {
+                    debug('Threaded Test: reply message created event called');
+                    resolve(e);
+                  });
+                });
+
+                return webex.messages.create({
+                  roomId: room.id,
+                  text: 'This is the reply',
+                  parentId
+                })
+                  .then(async (message2) => {
+                    validateMessage(message2);
+                    const event2 = await createdReply;
+
+                    return Promise.resolve(validateMessageEvent(event2, message2, actor));
+                  });
+              }));
+        });
+
+        it('returns all messages for a room', () => webex.messages.list({roomId: room.id})
+          .then((messages) => {
+            assert.isDefined(messages);
+            assert.lengthOf(messages.items, 2);
+            for (const message of messages.items) {
+              assert.isMessage(message);
+              if (message.parentId) {
+                assert.equal(message.parentId, parentId);
+              }
+            }
+          }));
+
+        it('returns only the replies for particular message thread', () => webex.messages.list({roomId: room.id, parentId})
+          .then((messages) => {
+            assert.lengthOf(messages.items, 1);
+            const message = messages.items[0];
+
+            assert.isMessage(message);
+            assert.strictEqual(message.parentId, parentId);
+          }));
+      });
     });
   });
 });
@@ -494,5 +567,8 @@ function validateMessageEvent(event, message, actor) {
     assert.isArray(event.data.attachments);
     assert.isDefined(event.data.attachments.length);
     validateAdaptiveCard(message, event.data.attachments[0]);
+  }
+  if (message.parentId) {
+    assert.equal(message.parentId, event.data.parentId);
   }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Update message:created websocket event to include a parentId field if the messages is a threaded reply.

Also add tests to validate that the plugin-messages.create and plugin-messages.list functions handle threaded replies as expected

Fixes # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-119677

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Coverage

Added #threadedMessageTests() to the plugin-messages test suite.   Test sends two messages, one that is a "regular" message, and one that is a threaded reply.  Validate that the event for the reply includes a parentId.  Query the messages and ensure that the parentId exists when it should.  Validate that the parentId query parameter works as expected.

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
