### PR TITLE
test(samples): add wait for media ready

### DIFF
--- a/packages/node_modules/samples/browser-call-with-screenshare/app.js
+++ b/packages/node_modules/samples/browser-call-with-screenshare/app.js
@@ -188,6 +188,37 @@ function bindMeetingEvents(meeting) {
   });
 }
 
+
+// Waits for the meeting to be media update ready
+function waitForMediaReady(meeting) {
+  return new Promise((resolve, reject) => {
+    if (meeting.canUpdateMedia()) {
+      resolve();
+    }
+    else {
+      console.info('SHARE-SCREEN: Unable to update media, pausing to retry...');
+      let retryAttempts = 0;
+
+      const retryInterval = setInterval(() => {
+        retryAttempts += 1;
+        console.info('SHARE-SCREEN: Retry update media check');
+
+        if (meeting.canUpdateMedia()) {
+          console.info('SHARE-SCREEN: Able to update media, continuing');
+          clearInterval(retryInterval);
+          resolve();
+        }
+        // If we can't update our media after 15 seconds, something went wrong
+        else if (retryAttempts > 15) {
+          console.error('SHARE-SCREEN: Unable to share screen, media was not able to update.');
+          clearInterval(retryInterval);
+          reject();
+        }
+      }, 1000);
+    }
+  });
+}
+
 // Join the meeting and add media
 function joinMeeting(meeting) {
   // Save meeting to global object
@@ -224,33 +255,36 @@ function joinMeeting(meeting) {
 
 document.getElementById('share-screen').addEventListener('click', () => {
   if (activeMeeting) {
-    const mediaSettings = {
-      receiveShare: true,
-      sendShare: true
-    };
+    // First check if we can update
+    waitForMediaReady(activeMeeting).then(() => {
+      const mediaSettings = {
+        receiveShare: true,
+        sendShare: true
+      };
 
-    console.info('SHARE-SCREEN: Preparing to share screen via `getMediaStreams`');
-    activeMeeting.getMediaStreams(mediaSettings)
-      // `[, localShare]` is grabbing index 1 from the mediaSettingsResultsArray
-      // and storing it in a variable called localShare.
-      .then((mediaSettingsResultsArray) => {
-        const [, localShare] = mediaSettingsResultsArray;
+      console.info('SHARE-SCREEN: Preparing to share screen via `getMediaStreams`');
+      activeMeeting.getMediaStreams(mediaSettings)
+        // `[, localShare]` is grabbing index 1 from the mediaSettingsResultsArray
+        // and storing it in a variable called localShare.
+        .then((mediaSettingsResultsArray) => {
+          const [, localShare] = mediaSettingsResultsArray;
 
-        console.info('SHARE-SCREEN: Add local share via `updateShare`');
+          console.info('SHARE-SCREEN: Add local share via `updateShare`');
 
-        return activeMeeting.updateShare({
-          sendShare: true,
-          receiveShare: true,
-          stream: localShare
+          return activeMeeting.updateShare({
+            sendShare: true,
+            receiveShare: true,
+            stream: localShare
+          });
+        })
+        .then(() => {
+          console.info('SHARE-SCREEN: Screen successfully added to meeting.');
+        })
+        .catch((e) => {
+          console.error('SHARE-SCREEN: Unable to share screen, error:');
+          console.error(e);
         });
-      })
-      .then(() => {
-        console.info('SHARE-SCREEN: Screen successfully added to meeting.');
-      })
-      .catch((e) => {
-        console.error('SHARE-SCREEN: Unable to share screen, error:');
-        console.error(e);
-      });
+    });
   }
   else {
     console.error('No active meeting available to share screen.');
@@ -259,9 +293,12 @@ document.getElementById('share-screen').addEventListener('click', () => {
 
 document.getElementById('stop-screen-share').addEventListener('click', () => {
   if (activeMeeting) {
-    activeMeeting.updateShare({
-      sendShare: false,
-      receiveShare: true
+    // First check if we can update, if not, wait and retry
+    waitForMediaReady(activeMeeting).then(() => {
+      activeMeeting.updateShare({
+        sendShare: false,
+        receiveShare: true
+      });
     });
   }
 });


### PR DESCRIPTION
The screenshare samples tests have become quite flaky.
Upon investigation, it appears the ROAP is not ready in time when we update media.
Add a new function `waitForMediaReady` that waits for the meeting's media to be ready before progressing.

