### PR TITLE
better handling of screensharing takeover

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -762,6 +762,23 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   setUpLocusMediaSharesListener() {
     this.locusInfo.on(EVENTS.LOCUS_INFO_UPDATE_MEDIA_SHARES, (payload) => {
+      const {contentId, disposition} = payload.current;
+
+      // Check if screenshare is being taken over by a remote
+      // If so, terminate the share and allow the remote to be on the floor
+      // Terminating the share allows the user to screenshare again without any issues
+      if (
+        this.isSharing &&
+        this.selfId !== contentId &&
+        disposition !== FLOOR_ACTION.RELEASED
+      ) {
+        this.isSharing = false;
+        this.updateShare({
+          sendShare: false,
+          receiveShare: this.mediaProperties.mediaDirection.receiveShare
+        });
+      }
+
       this.members.locusMediaSharesUpdate(payload);
     });
   }


### PR DESCRIPTION
## Description

screensharing currently doesn't handle a takeover that well, and the `isSharing` variable doesn't get updated
The current solution is to check if a takeover happened and then stop the local share using `stopShare`

NOTE: This is still slightly buggy because once a takeover happens, locus gets conflicted and doesn't properly allow the plugin user to takeover

Fixes [SPARK-116558](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-116558)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)