### PR TITLE
Fix/server error failover

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-device/src/device.js
+++ b/packages/node_modules/@webex/internal-plugin-device/src/device.js
@@ -1,5 +1,5 @@
 // Internal Dependencies
-import {oneFlight} from '@webex/common';
+import {deprecated, oneFlight} from '@webex/common';
 import {persist, waitForValue, WebexPlugin} from '@webex/webex-core';
 import {safeSetTimeout} from '@webex/common-timers';
 
@@ -726,6 +726,19 @@ const Device = WebexPlugin.extend({
         resolve();
       });
     });
+  },
+
+  // Deprecated methods.
+
+  /**
+   * Mark a url as failed and get the next priority host url.
+   *
+   * @param {string} url - The url to mark as failed.
+   * @returns {Promise<string>} - The next priority url.
+   */
+  @deprecated('device#markUrlFailedAndGetNew(): Use services#markFailedUrl()')
+  markUrlFailedAndGetNew(url) {
+    return Promise.resolve(this.webex.internal.services.markFailedUrl(url));
   },
 
   // Ampersand method members

--- a/packages/node_modules/@webex/internal-plugin-device/test/integration/spec/device.js
+++ b/packages/node_modules/@webex/internal-plugin-device/test/integration/spec/device.js
@@ -362,6 +362,27 @@ describe('plugin-device', () => {
       });
     });
 
+    describe('#markUrlFailedAndGetNew()', () => {
+      let markFailedUrl;
+
+      beforeEach('create stubs', () => {
+        markFailedUrl = sinon.stub();
+        markFailedUrl.returns('a new url');
+        webex.internal.services.markFailedUrl = markFailedUrl;
+      });
+
+      it('should return a resolved promise', () =>
+        assert.isFulfilled(device.markUrlFailedAndGetNew('a url')));
+
+      it('should call services#markFailedUrl()', () => {
+        const url = 'a sent url';
+
+        device.markUrlFailedAndGetNew(url);
+
+        assert.calledWith(markFailedUrl, url);
+      });
+    });
+
     describe('#meetingEnded()', () => {
       let spy;
 

--- a/packages/node_modules/@webex/internal-plugin-device/test/integration/spec/device.js
+++ b/packages/node_modules/@webex/internal-plugin-device/test/integration/spec/device.js
@@ -366,8 +366,7 @@ describe('plugin-device', () => {
       let markFailedUrl;
 
       beforeEach('create stubs', () => {
-        markFailedUrl = sinon.stub();
-        markFailedUrl.returns('a new url');
+        markFailedUrl = sinon.stub().returns('a new url');
         webex.internal.services.markFailedUrl = markFailedUrl;
       });
 

--- a/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -68,7 +68,6 @@ describe('plugin-mercury', () => {
       webex.internal.device = {
         register: sinon.stub().returns(Promise.resolve()),
         refresh: sinon.stub().returns(Promise.resolve()),
-        markUrlFailedAndGetNew: sinon.stub().returns(Promise.resolve()),
         webSocketUrl: 'ws://example.com',
         getWebSocketUrl: sinon.stub().returns(Promise.resolve('ws://example-2.com')),
         useServiceCatalogUrl: sinon.stub().returns(Promise.resolve('https://service-catalog-url.com'))

--- a/packages/node_modules/@webex/webex-core/src/lib/services/interceptors/server-error.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/interceptors/server-error.js
@@ -33,7 +33,7 @@ export default class ServerErrorInterceptor extends Interceptor {
           tags: {action: 'failed', error: reason.message, url: options.uri}
         });
 
-        return this.webex.internal.device.markUrlFailedAndGetNew(options.uri)
+        return Promise.resolve(this.webex.internal.services.markFailedUrl(options.uri))
           .then(() => Promise.reject(reason));
       }
     }

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/interceptors/server-error.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/interceptors/server-error.js
@@ -29,7 +29,7 @@ describe('webex-core', () => {
 
       describe('when reason is a webex server error and the uri exist', () => {
         let get;
-        let markUrlFailedAndGetNew;
+        let markFailedUrl;
         let submitClientMetrics;
 
         beforeEach(() => {
@@ -52,28 +52,30 @@ describe('webex-core', () => {
                   developer: {
                     get: sinon.stub()
                   }
-                },
-                markUrlFailedAndGetNew: sinon.stub()
+                }
               },
               metrics: {
                 submitClientMetrics: sinon.spy()
+              },
+              services: {
+                markFailedUrl: sinon.stub()
               }
             }
           };
 
           get = interceptor.webex.internal.device.features.developer.get;
-          markUrlFailedAndGetNew = interceptor
+          markFailedUrl = interceptor
             .webex
             .internal
-            .device
-            .markUrlFailedAndGetNew;
+            .services
+            .markFailedUrl;
           submitClientMetrics = interceptor
             .webex
             .internal
             .metrics
             .submitClientMetrics;
 
-          markUrlFailedAndGetNew.resolves();
+          markFailedUrl.returns();
         });
 
         it('should get the feature \'web-high-availability\'', (done) => {
@@ -111,7 +113,7 @@ describe('webex-core', () => {
           it('should mark a url as failed', (done) => {
             interceptor.onResponseError(options, reason)
               .catch(() => {
-                assert.calledWith(markUrlFailedAndGetNew, options.uri);
+                assert.calledWith(markFailedUrl, options.uri);
 
                 done();
               });
@@ -153,7 +155,7 @@ describe('webex-core', () => {
           it('should not attempt to mark a url as failed', (done) => {
             interceptor.onResponseError(options, reason)
               .catch(() => {
-                assert.notCalled(markUrlFailedAndGetNew);
+                assert.notCalled(markFailedUrl);
 
                 done();
               });


### PR DESCRIPTION
# Pull Request

## Description

The scope of this pull request is inclusive of updating the server error interceptors host failover target method, as well as cleaning up any other src/test files that target `device#markUrlFailedAndGetNew()` and update them to target `service#markFailedUrl()`.

Fixes # [SPARK-123663](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-123663)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Generated new tests in multiple plugins to validate the changes.
- [x] Ran tests for each of the changed plugins to validate that the changes work as expected.

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
