### PR TITLE
fix(meetings): use async instead of finally

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -493,7 +493,7 @@ export default class Meetings extends WebexPlugin {
      * @private
      * @memberof Meetings
      */
-    createMeeting(destination, type = null) {
+    async createMeeting(destination, type = null) {
       const meeting = new Meeting(
         {
           userId: this.webex.internal.device.userId,
@@ -508,34 +508,28 @@ export default class Meetings extends WebexPlugin {
 
       this.meetingCollection.set(meeting);
 
-      return this.meetingInfo
-        .fetchMeetingInfo(MeetingsUtil.extractDestination(destination, type), type)
-        .then((info) => {
-          meeting.parseMeetingInfo(info);
-          meeting.meetingInfo = info ? info.body : null;
+      try {
+        const info = await this.meetingInfo.fetchMeetingInfo(MeetingsUtil.extractDestination(destination, type), type);
 
-          return meeting;
-        })
-        .catch((err) => {
-          // if there is no meeting info we assume its a 1:1 call or wireless share
-          LoggerProxy.logger.info(`Meetings->createMeeting#Error ${err} fetching /meetingInfo for creation.`);
-          LoggerProxy.logger.info('Meetings->createMeeting#Info assuming this destination is a 1:1 or wireless share');
-          // We need to save this info for future reference
-          meeting.destination = destination;
-
-          return meeting;
-        })
-        .finally(() => {
-          // For type LOCUS_ID we need to parse the locus object to get the information
-          // about the caller and callee
-          // TODO: check for a better solution
-          if (type === _LOCUS_ID_) {
-            return;
-          }
-
+        meeting.parseMeetingInfo(info);
+        meeting.meetingInfo = info ? info.body : null;
+      }
+      catch (err) {
+        // if there is no meeting info we assume its a 1:1 call or wireless share
+        LoggerProxy.logger.info(`Meetings->createMeeting#Error ${err} fetching /meetingInfo for creation.`);
+        LoggerProxy.logger.info('Meetings->createMeeting#Info assuming this destination is a 1:1 or wireless share');
+        // We need to save this info for future reference
+        meeting.destination = destination;
+      }
+      finally {
+        // For type LOCUS_ID we need to parse the locus object to get the information
+        // about the caller and callee
+        // Meeting Added event will be created in `handleLocusEvent`
+        if (type !== _LOCUS_ID_) {
           if (!meeting.sipUri) {
             meeting.setSipUri(destination);
           }
+
           // TODO: check if we have to move this to parser
           const meetingAddedType = MeetingsUtil.getMeetingAddedType(type);
 
@@ -553,7 +547,10 @@ export default class Meetings extends WebexPlugin {
               type: meetingAddedType
             }
           );
-        });
+        }
+      }
+
+      return meeting;
 
       // Create the meeting calling the necessary service endpoints.
 


### PR DESCRIPTION
We’ve had customer reports that the meetings plugin wasn’t working with angular applications, and we were able to recreate the issue around the usage of finally. There might be a better babel config that works with angular, but consider this async conversion a “workaround” to get customers up and running.

I didn’t have full context on the workflow, but I tried to recreate it as best as possible without changing any of the tests. Let me know if I missed something.