### PR TITLE
docs(attachment-actions): fix typo in attachmentActions.js [skip npm] 

### DIFF
--- a/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js
+++ b/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js
@@ -69,7 +69,7 @@ const AttachmentActions = WebexPlugin.extend({
    * webex.attachmentActions.listen()
    *   .then(() => {
    *     console.log('listening to attachmentActions events');
-   *     webex.attachmentActions.on('created', (event) => console.log(`Got an attachmentActions:created event:\n${event}`);
+   *     webex.attachmentActions.on('created', (event) => console.log(`Got an attachmentActions:created event:\n${event}`));
    *   })
    *   .catch((e) => console.error(`Unable to register for attachmentAction events: ${e}`));
    * // Some app logic...


### PR DESCRIPTION
Missing closing parenthesis in documentation