### PR TITLE
Feat/create org retrieval method

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/lib/credentials/credentials.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/credentials/credentials.js
@@ -131,6 +131,34 @@ const Credentials = WebexPlugin.extend({
   },
 
   /**
+   * Get the determined OrgId.
+   *
+   * @throws {Error} - If the OrgId could not be determined.
+   * @returns {string} - The OrgId.
+   */
+  getOrgId() {
+    this.logger.info(
+      'credentials: attempting to retrieve the OrgId from token'
+    );
+
+    try {
+      // Attempt to extract a client-authenticated token's OrgId.
+      this.logger.info('credentials: trying to extract OrgId from JWT');
+
+      return this.extractOrgIdFromJWT(this.supertoken.access_token);
+    }
+    catch (e) {
+      // Attempt to extract a user token's OrgId.
+      this.logger.info('credentials: could not extract OrgId from JWT');
+      this.logger.info(
+        'credentials: attempting to extract OrgId from user token'
+      );
+
+      return this.extractOrgIdFromUserToken(this.supertoken.access_token);
+    }
+  },
+
+  /**
    * Extract the OrgId [realm] from a provided JWT.
    *
    * @private

--- a/packages/node_modules/@webex/webex-core/test/integration/spec/credentials/credentials.js
+++ b/packages/node_modules/@webex/webex-core/test/integration/spec/credentials/credentials.js
@@ -19,6 +19,25 @@ describe('webex-core', () => {
         user = u;
       }));
 
+    describe('#determineOrgId()', () => {
+      let credentials;
+      let webex;
+
+      beforeEach('generate the webex instance', () => {
+        webex = new WebexCore({
+          credentials: user.token
+        });
+
+        credentials = webex.credentials;
+      });
+
+      it('should return the OrgId of a client authenticated user', () => {
+        const orgId = credentials.getOrgId();
+
+        assert.equal(orgId, user.orgId);
+      });
+    });
+
     describe('#extractOrgIdFromJWT()', () => {
       let credentials;
       let webex;

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/credentials/credentials.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/credentials/credentials.js
@@ -228,6 +228,40 @@ describe('webex-core', () => {
       });
     });
 
+    describe('#getOrgId()', () => {
+      let credentials;
+      let orgId;
+      let webex;
+
+      beforeEach('generate webex and destructure credentials', () => {
+        webex = new MockWebex();
+        credentials = new Credentials(undefined, {parent: webex});
+      });
+
+      it('should return the OrgId of JWT-authenticated user', () => {
+        credentials.supertoken = {
+          access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyZWFsbSI6Im15LXJlYWxtIn0.U16gzUsaRW1VVikJA2VeXRHPX716tG1_B42oxzy1UMk'
+        };
+
+        orgId = 'my-realm';
+
+        assert.equal(credentials.getOrgId(), orgId);
+      });
+
+      it('should return the OrgId of a user-token-authenticated user', () => {
+        orgId = 'this-is-an-org-id';
+
+        credentials.supertoken = {
+          access_token: `000_000_${orgId}`
+        };
+
+        assert.equal(credentials.getOrgId(), orgId);
+      });
+
+      it('should throw if the OrgId was not determined', () =>
+        assert.throws(() => credentials.getOrgId()));
+    });
+
     describe('#extractOrgIdFromJWT()', () => {
       let credentials;
       let webex;


### PR DESCRIPTION
# Pull Request Template

## Description

The scope of the changes in this pull request are to address combining the logic provided by the `webex.credentials.extractOrgIdFromJWT()` and `webex.credentials.extractOrgIdFromUserToken()` methods into one simplified interface.

Fixes # [SPARK-125201](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-125201)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Generated new tests.
- [x] Ran tests to validate that the changes work as expected.

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
