### PR TITLE
fix(ediscovery): handle reportids that can be either uuids or urls

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/ediscovery.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/ediscovery.js
@@ -1,9 +1,10 @@
 /* eslint-disable prefer-template */
+/* eslint-disable no-useless-escape */
 /*!
  * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
  */
 import {waitForValue, WebexPlugin} from '@webex/webex-core';
-import {oneFlight, tap} from '@webex/common';
+import {oneFlight} from '@webex/common';
 
 import {InvalidEmailAddressError} from './ediscovery-error';
 
@@ -187,7 +188,7 @@ const EDiscovery = WebexPlugin.extend({
   @oneFlight({keyFactory: (reportId, options) => createOneFlightKey(reportId, options)})
   /**
    * Retrieves content associated with a report
-   * @param {UUID} reportId - Id of the report which contains the content
+   * @param {UUID|string} reportId - UUID or url of the report which contains the content
    * @param {Object} options - optional parameters for this method
    * @param {number} options.offset - start position from which to retrieve records
    * @param {number} options.size - the number of records to retrieve
@@ -202,44 +203,11 @@ const EDiscovery = WebexPlugin.extend({
     // use spread operator to set default options
     options = {...this.config.defaultOptions, ...options};
 
-    return this.request({
-      method: 'GET',
-      service: 'ediscovery',
-      resource: `reports/${reportId}/contents`,
-      qs: {offset: options.offset, size: options.size},
-      timeout: options.timeoutMs
-    });
-  },
-
-  @waitForValue('@')
-  @oneFlight({keyFactory: (reportUrl, options) => createOneFlightKey(reportUrl, options)})
-  /**
-   * Retrieves content associated with a report
-   * @param {String} reportUrl - full destination address (including report id parameter) for the http request being sent
-   * e.g. 'http://ediscovery-intb.wbx2.com/ediscovery/api/v1/reports/3b10e625-2bd5-4efa-b866-58d6c93c505c'
-   * @param {Object} options - optional parameters for this method
-   * @param {number} options.offset - start position from which to retrieve records
-   * @param {number} options.size - the number of records to retrieve
-   * @param {number} options.timeoutMs - connection timeout in milliseconds, defaults to 30s
-   * @returns {Promise<ResponseEntity<[Activity]>>} Http response containing the activities
-   */
-  getRemoteContent(reportUrl, options) {
-    if (!reportUrl) {
-      throw Error('Undefined parameter');
-    }
-
-    const reportId = this._getReportIdFromUrl(reportUrl);
-
-    if (!reportId) {
-      throw Error('Report url does not contain a report id');
-    }
-
-    // use spread operator to set default options
-    options = {...this.config.defaultOptions, ...options};
+    const [requestOptions] = this._createRequestOptions(reportId, '/contents');
 
     return this.request({
       method: 'GET',
-      url: `${reportUrl}/contents`,
+      ...requestOptions,
       qs: {offset: options.offset, size: options.size},
       timeout: options.timeoutMs
     });
@@ -249,7 +217,7 @@ const EDiscovery = WebexPlugin.extend({
   @oneFlight({keyFactory: (reportId, options) => createOneFlightKey(reportId, options)})
   /**
    * Retrieves a list of the spaces relevant to a specified report
-   * @param {UUID} reportId - Id of the report being requested
+   * @param {UUID|string} reportId - UUID or url of the report being requested
    * @param {Object} options - optional parameters for this method
    * @param {number} options.offset - start position from which to retrieve records
    * @param {number} options.size - the number of records to retrieve
@@ -264,64 +232,26 @@ const EDiscovery = WebexPlugin.extend({
     // use spread operator to set default options
     options = {...this.config.defaultOptions, ...options};
 
+    const [requestOptions, reportUUID] = this._createRequestOptions(reportId, '/contents/summary/');
+
     return this.request({
       method: 'GET',
-      service: 'ediscovery',
-      resource: `reports/${reportId}/contents/summary`,
+      ...requestOptions,
       qs: {offset: options.offset, size: options.size},
       timeout: options.timeoutMs
     })
       .then(async (res) => {
-        await this._writeSpacesToContentSummaryBySpaceIdCache(reportId, res.body);
+        await this._writeSpacesToContentSummaryBySpaceIdCache(reportUUID, res.body);
 
         return Promise.resolve(res);
       });
   },
 
   @waitForValue('@')
-  @oneFlight({keyFactory: (reportUrl, options) => createOneFlightKey(reportUrl, options)})
-  /**
-   * Retrieves a list of the spaces relevant to a specified report
-   * @param {String} reportUrl - full destination address (including report id parameter) for the http request being sent
-   * e.g. 'http://ediscovery-intb.wbx2.com/ediscovery/api/v1/reports/3b10e625-2bd5-4efa-b866-58d6c93c505c'
-   * @param {Object} options - optional parameters for this method
-   * @param {number} options.offset - start position from which to retrieve records
-   * @param {number} options.size - the number of records to retrieve
-   * @param {number} options.timeoutMs - connection timeout in milliseconds, defaults to 30s
-   * @returns {Promise<ResponseEntity<ContentSummary>>} Http response containing the content summary
-   */
-  getRemoteContentSummary(reportUrl, options) {
-    if (!reportUrl) {
-      throw Error('Undefined parameter');
-    }
-
-    const reportId = this._getReportIdFromUrl(reportUrl);
-
-    if (!reportId) {
-      throw Error('Report url does not contain a report id');
-    }
-
-    // use spread operator to set default options
-    options = {...this.config.defaultOptions, ...options};
-
-    return this.request({
-      method: 'GET',
-      url: `${reportUrl}/contents/summary`,
-      qs: {offset: options.offset, size: options.size},
-      timeout: options.timeoutMs
-    })
-      .then(tap((res) => {
-        this.logger.error('report id is ' + reportId);
-
-        return this._writeSpacesToContentSummaryBySpaceIdCache(reportId, res.body);
-      }));
-  },
-
-  @waitForValue('@')
   @oneFlight({keyFactory: (reportId, spaceId) => String(reportId + spaceId)})
   /**
    * Retrieves information for a specific conversation relevant to a specified report
-   * @param {UUID} reportId - Id of the report which contains the relevant content summary
+   * @param {UUID|string} reportId - UUID or url of the report being requested
    * @param {UUID} spaceId - Id of the conversation being requested
    * @param {Object} options - optional parameters for this method
    * @param {number} options.timeoutMs - connection timeout in milliseconds, defaults to 30s
@@ -335,64 +265,34 @@ const EDiscovery = WebexPlugin.extend({
     // use spread operator to set default options
     options = {...this.config.defaultOptions, ...options};
 
+    const [requestOptions, reportUUID] = this._createRequestOptions(reportId, `/contents/summary/${spaceId}`);
+
     // If the content summary for this space has already been cached then it can be retrieved from there instead of making a network call to ediscovery
-    if (this.contentSummaryBySpaceIdCache.has(reportId) && this.contentSummaryBySpaceIdCache.get(reportId).has(spaceId)) {
-      return {body: this.contentSummaryBySpaceIdCache.get(reportId).get(spaceId), statusCode: 200};
+    if (this.contentSummaryBySpaceIdCache.has(reportUUID) && this.contentSummaryBySpaceIdCache.get(reportUUID).has(spaceId)) {
+      return {body: this.contentSummaryBySpaceIdCache.get(reportUUID).get(spaceId), statusCode: 200};
     }
 
     this.logger.warn(`Cache miss for space ${spaceId} in getContentSummaryBySpaceId`);
 
     return this.request({
       method: 'GET',
-      service: 'ediscovery',
-      resource: `reports/${reportId}/contents/summary/${spaceId}`,
+      ...requestOptions,
       timeout: options.timeoutMs
     })
       .then(async (res) => {
-        await this._writeSpacesToContentSummaryBySpaceIdCache(reportId, [res.body]);
+        await this._writeSpacesToContentSummaryBySpaceIdCache(reportUUID, [res.body]);
 
         return Promise.resolve(res);
       });
   },
 
-  @waitForValue('@')
-  @oneFlight({keyFactory: (reportUrl, spaceId) => String(reportUrl + spaceId)})
   /**
-   * Retrieves information for a specific conversation relevant to a specified report
-   * @param {String} reportUrl - full destination address (including report id parameter) for the http request being sent
-   * e.g. 'http://ediscovery-intb.wbx2.com/ediscovery/api/v1/reports/3b10e625-2bd5-4efa-b866-58d6c93c505c'
-   * @param {UUID} spaceId - Id of the conversation being requested
-   * @param {Object} options - optional parameters for this method
-   * @param {number} options.timeoutMs - connection timeout in milliseconds, defaults to 30s
-   * @returns {Promise<ResponseEntity<ContentSummary>>} Http response containing the specified content summary
+   * Wipe the cache used by eDiscovery to store the space summaries. Good practice to clear it down
+   * when finished with a report to save RAM.
+   * @returns {undefined}
    */
-  getRemoteContentSummaryBySpaceId(reportUrl, spaceId, options) {
-    if (!reportUrl || !spaceId) {
-      throw Error('Undefined parameter(s)');
-    }
-
-    const reportId = this._getReportIdFromUrl(reportUrl);
-
-    if (!reportId) {
-      throw Error('Report url does not contain a report id');
-    }
-
-    // use spread operator to set default options
-    options = {...this.config.defaultOptions, ...options};
-
-    // If the content summary for this space has already been cached then it can be retrieved from there instead of making a network call to ediscovery
-    if (this.contentSummaryBySpaceIdCache.has(reportId) && this.contentSummaryBySpaceIdCache.get(reportId).has(spaceId)) {
-      return {body: this.contentSummaryBySpaceIdCache.get(reportId).get(spaceId), statusCode: 200};
-    }
-
-    this.logger.warn(`Cache miss for space ${spaceId} in getContentSummaryBySpaceId`);
-
-    return this.request({
-      method: 'GET',
-      url: `${reportUrl}/contents/summary/${spaceId}`,
-      timeout: options.timeoutMs
-    })
-      .then(tap((res) => this._writeSpacesToContentSummaryBySpaceIdCache(reportId, [res.body])));
+  clearCache() {
+    this.contentSummaryBySpaceIdCache.clear();
   },
 
   /**
@@ -408,9 +308,6 @@ const EDiscovery = WebexPlugin.extend({
     }
 
     if (!this.contentSummaryBySpaceIdCache.has(reportId)) {
-      // wipe the cache - we will only need to store one reports data at any one time
-      this.contentSummaryBySpaceIdCache.clear();
-
       this.contentSummaryBySpaceIdCache.set(reportId, new Map());
     }
 
@@ -447,6 +344,51 @@ const EDiscovery = WebexPlugin.extend({
     }
 
     return '';
+  },
+
+  _isUrl(string) {
+    // Regex found from `https://ihateregex.io/expr/url`
+    return /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&\/\/=]*)/g.test(string);
+  },
+
+  /**
+   * Create the appropriate request options based on whether the reportId is a url or a uuid.
+   * @param {UUID|string} reportId - May be either a url for the report or a uuid.
+   * e.g. 'http://ediscovery-intb.wbx2.com/ediscovery/api/v1/reports/3b10e625-2bd5-4efa-b866-58d6c93c505c' or '3b10e625-2bd5-4efa-b866-58d6c93c505c'.
+   * @param {String} resource - The resource on the remote server to request
+   * @returns {[Options, uuid]} - The options to pass to `request` and the report uuid.
+   */
+  _createRequestOptions(reportId, resource) {
+    let requestOptions;
+    let reportUUID;
+    const isUrl = this._isUrl(reportId);
+
+    if (isUrl) {
+      reportUUID = this._getReportIdFromUrl(reportId);
+
+      if (!reportUUID) {
+        throw Error('Report url does not contain a report id');
+      }
+
+      // Ensure the url is formatted to
+      // https://ediscovery.intb1.ciscospark.com/ediscovery/api/v1/reports/16bf0d01-b1f7-483b-89a2-915144158fb9
+      // index.js for example passes the url in as
+      // https://ediscovery.intb1.ciscospark.com/ediscovery/api/v1/reports/16bf0d01-b1f7-483b-89a2-915144158fb9/contents
+      const reportUrl = reportId.substring(0, reportId.lastIndexOf(reportUUID) + reportUUID.length);
+
+      requestOptions = {
+        url: reportUrl + resource
+      };
+    }
+    else {
+      requestOptions = {
+        service: 'ediscovery',
+        resource: `reports/${reportId}/${resource}`
+      };
+      reportUUID = reportId;
+    }
+
+    return [requestOptions, reportUUID];
   },
 
   @waitForValue('@')

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/index.js
@@ -131,11 +131,9 @@ registerInternalPlugin('ediscovery', EDiscovery, {
           if (!object || !object.body) {
             return Promise.resolve();
           }
-          // the report id is needed in order to retrieve space information for activities with whiteboards so that
-          // the list of users in those spaces can be accessed and the content can be decrypted on their behalf
-          const reportId = object.options.resource.split('/')[1];
 
-          return Promise.all(object.body.map((item) => ctx.transform('decryptReportContent', {body: item}, reportId)));
+          // Always use the report url as this'll resolve correctly for remote reports
+          return Promise.all(object.body.map((item) => ctx.transform('decryptReportContent', {body: item}, object.options.uri)));
         }
       },
       {

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/test/integration/spec/ediscovery.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/test/integration/spec/ediscovery.js
@@ -144,8 +144,8 @@ describe('internal-plugin-ediscovery', () => {
       const validUrl = `https://ediscovery-intb.wbx2.com/ediscovery/api/v1/reports/${reportId}`;
       const invalidUrl = `https://ediscovery-intz.wbx2.com/ediscovery/api/v1/reports/${reportId}`;
 
-      it('getRemoteContent succeeds with valid url', async () => {
-        await complianceUser.webex.internal.ediscovery.getRemoteContent(validUrl)
+      it('getContent by url succeeds with valid url', async () => {
+        await complianceUser.webex.internal.ediscovery.getContent(validUrl)
           .then(() => {
             assert.fail('Expected error response due to invalid report id');
           })
@@ -155,8 +155,8 @@ describe('internal-plugin-ediscovery', () => {
           });
       });
 
-      it('getRemoteContent fails with invalid url', async () => {
-        await complianceUser.webex.internal.ediscovery.getRemoteContent(invalidUrl)
+      it('getContent by url fails with invalid url', async () => {
+        await complianceUser.webex.internal.ediscovery.getContent(invalidUrl)
           .then(() => {
             assert.fail('Expected error response due to invalid url');
           })
@@ -165,8 +165,8 @@ describe('internal-plugin-ediscovery', () => {
           });
       });
 
-      it('getRemoteContentSummary succeeds with valid url', async () => {
-        await complianceUser.webex.internal.ediscovery.getRemoteContentSummary(validUrl)
+      it('getContentSummary by url succeeds with valid url', async () => {
+        await complianceUser.webex.internal.ediscovery.getContentSummary(validUrl)
           .then(() => {
             assert.fail('Expected error response due to invalid report id');
           })
@@ -176,8 +176,8 @@ describe('internal-plugin-ediscovery', () => {
           });
       });
 
-      it('getRemoteContentSummary fails with invalid url', async () => {
-        await complianceUser.webex.internal.ediscovery.getRemoteContentSummary(invalidUrl)
+      it('getContentSummary by url fails with invalid url', async () => {
+        await complianceUser.webex.internal.ediscovery.getContentSummary(invalidUrl)
           .then(() => {
             assert.fail('Expected error response due to invalid url');
           })
@@ -186,8 +186,8 @@ describe('internal-plugin-ediscovery', () => {
           });
       });
 
-      it('getRemoteContentSummaryBySpaceId succeeds with valid url', async () => {
-        await complianceUser.webex.internal.ediscovery.getRemoteContentSummaryBySpaceId(validUrl, spaceId)
+      it('getContentSummaryBySpaceId succeeds with valid url', async () => {
+        await complianceUser.webex.internal.ediscovery.getContentSummaryBySpaceId(validUrl, spaceId)
           .then(() => {
             assert.fail('Expected error response due to invalid report id');
           })
@@ -197,8 +197,8 @@ describe('internal-plugin-ediscovery', () => {
           });
       });
 
-      it('getRemoteContentSummaryBySpaceId fails with invalid url', async () => {
-        await complianceUser.webex.internal.ediscovery.getRemoteContentSummaryBySpaceId(invalidUrl, spaceId)
+      it('getContentSummaryBySpaceId fails with invalid url', async () => {
+        await complianceUser.webex.internal.ediscovery.getContentSummaryBySpaceId(invalidUrl, spaceId)
           .then(() => {
             assert.fail('Expected error response due to invalid url');
           })

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/test/unit/spec/content.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/test/unit/spec/content.js
@@ -75,9 +75,9 @@ describe('EDiscovery Content API Tests', () => {
     });
   });
 
-  describe('GetRemoteContent Tests', () => {
-    it('GetRemoteContent succeeds', async () => {
-      const result = webex.internal.ediscovery.getRemoteContent(url, {offset: 0, size: 1})
+  describe('GetContent by url Tests', () => {
+    it('GetContent by url succeeds', async () => {
+      const result = webex.internal.ediscovery.getContent(url, {offset: 0, size: 1})
         .then((res) => {
           expect(res.statusCode).equal(200);
         });
@@ -85,20 +85,20 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContent fails with no params', async () => {
-      const result = expect(webex.internal.ediscovery.getRemoteContent()).to.be.rejectedWith(Error, 'Undefined parameter');
+    it('GetContent by url fails with no params', async () => {
+      const result = expect(webex.internal.ediscovery.getContent()).to.be.rejectedWith(Error, 'Undefined parameter');
 
       return result;
     });
 
-    it('GetRemoteContent fails with a url that does not contain a report id', async () => {
-      const result = expect(webex.internal.ediscovery.getRemoteContent(invalidUrl)).to.be.rejectedWith(Error, 'Report url does not contain a report id');
+    it('GetContent by url fails with a url that does not contain a report id', async () => {
+      const result = expect(webex.internal.ediscovery.getContent(invalidUrl)).to.be.rejectedWith(Error, 'Report url does not contain a report id');
 
       return result;
     });
 
-    it('GetRemoteContent timeout defaults to 30s', async () => {
-      const result = webex.internal.ediscovery.getRemoteContent(url)
+    it('GetContent by url timeout defaults to 30s', async () => {
+      const result = webex.internal.ediscovery.getContent(url)
         .then(() => {
           sinon.assert.calledWith(webex.request, sinon.match.has('timeout', defaultTimeout));
         });
@@ -106,8 +106,8 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContent timeout defaults to 30s when other options are specified', async () => {
-      const result = webex.internal.ediscovery.getRemoteContent(url, {offset: 0, size: 1})
+    it('GetContent by url timeout defaults to 30s when other options are specified', async () => {
+      const result = webex.internal.ediscovery.getContent(url, {offset: 0, size: 1})
         .then(() => {
           sinon.assert.calledWith(webex.request, sinon.match.has('timeout', defaultTimeout));
         });
@@ -115,8 +115,8 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContent timeout can be overwritten to 5s with timeout as the only option', async () => {
-      const result = webex.internal.ediscovery.getRemoteContent(url, {timeoutMs: 5000})
+    it('GetContent by url timeout can be overwritten to 5s with timeout as the only option', async () => {
+      const result = webex.internal.ediscovery.getContent(url, {timeoutMs: 5000})
         .then(() => {
           sinon.assert.calledWith(webex.request, sinon.match.has('timeout', 5000));
         });
@@ -124,8 +124,8 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContent timeout can be overwritten to 5s when other options are specified', async () => {
-      const result = webex.internal.ediscovery.getRemoteContent(url, {offset: 0, size: 1, timeoutMs: 5000})
+    it('GetContent by url timeout can be overwritten to 5s when other options are specified', async () => {
+      const result = webex.internal.ediscovery.getContent(url, {offset: 0, size: 1, timeoutMs: 5000})
         .then(() => {
           sinon.assert.calledWith(webex.request, sinon.match.has('timeout', 5000));
           sinon.assert.calledWith(webex.request, sinon.match.has('qs', {offset: 0, size: 1}));
@@ -201,7 +201,6 @@ describe('EDiscovery Content API Tests', () => {
       const result = webex.internal.ediscovery.getContentSummary(uuid, {offset: 0, size: 1})
         .then(() => {
           assert.calledWith(webex.internal.ediscovery.contentSummaryBySpaceIdCache.has, uuid);
-          assert.calledOnce(webex.internal.ediscovery.contentSummaryBySpaceIdCache.clear);
           assert.calledWith(webex.internal.ediscovery.contentSummaryBySpaceIdCache.set, uuid, new Map());
         });
 
@@ -285,9 +284,9 @@ describe('EDiscovery Content API Tests', () => {
     });
   });
 
-  describe('GetRemoteContentSummary Tests', () => {
-    it('GetRemoteContentSummary succeeds', async () => {
-      const result = webex.internal.ediscovery.getRemoteContentSummary(url, {offset: 0, size: 1})
+  describe('GetContentSummary by url Tests', () => {
+    it('GetContentSummary succeeds', async () => {
+      const result = webex.internal.ediscovery.getContentSummary(url, {offset: 0, size: 1})
         .then((res) => {
           expect(res.statusCode).equal(200);
         });
@@ -295,20 +294,20 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummary fails with no params', async () => {
-      const result = expect(webex.internal.ediscovery.getRemoteContentSummary()).to.be.rejectedWith(Error, 'Undefined parameter');
+    it('GetContentSummary fails with no params', async () => {
+      const result = expect(webex.internal.ediscovery.getContentSummary()).to.be.rejectedWith(Error, 'Undefined parameter');
 
       return result;
     });
 
-    it('GetRemoteContentSummary fails with a url that does not contain a report id', async () => {
-      const result = expect(webex.internal.ediscovery.getRemoteContentSummary(invalidUrl)).to.be.rejectedWith(Error, 'Report url does not contain a report id');
+    it('GetContentSummary fails with a url that does not contain a report id', async () => {
+      const result = expect(webex.internal.ediscovery.getContentSummary(invalidUrl)).to.be.rejectedWith(Error, 'Report url does not contain a report id');
 
       return result;
     });
 
-    it('GetRemoteContentSummary timeout defaults to 30s', async () => {
-      const result = webex.internal.ediscovery.getRemoteContentSummary(url)
+    it('GetContentSummary timeout defaults to 30s', async () => {
+      const result = webex.internal.ediscovery.getContentSummary(url)
         .then(() => {
           sinon.assert.calledWith(webex.request, sinon.match.has('timeout', defaultTimeout));
         });
@@ -316,8 +315,8 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummary timeout defaults to 30s when other options are specified', async () => {
-      const result = webex.internal.ediscovery.getRemoteContentSummary(url, {offset: 0, size: 1})
+    it('GetContentSummary timeout defaults to 30s when other options are specified', async () => {
+      const result = webex.internal.ediscovery.getContentSummary(url, {offset: 0, size: 1})
         .then(() => {
           sinon.assert.calledWith(webex.request, sinon.match.has('timeout', defaultTimeout));
         });
@@ -325,8 +324,8 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummary timeout can be overwritten to 5s with timeout as the only option', async () => {
-      const result = webex.internal.ediscovery.getRemoteContentSummary(url, {timeoutMs: 5000})
+    it('GetContentSummary timeout can be overwritten to 5s with timeout as the only option', async () => {
+      const result = webex.internal.ediscovery.getContentSummary(url, {timeoutMs: 5000})
         .then(() => {
           sinon.assert.calledWith(webex.request, sinon.match.has('timeout', 5000));
         });
@@ -334,8 +333,8 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummary timeout can be overwritten to 5s when other options are specified', async () => {
-      const result = webex.internal.ediscovery.getRemoteContentSummary(url, {offset: 0, size: 1, timeoutMs: 5000})
+    it('GetContentSummary timeout can be overwritten to 5s when other options are specified', async () => {
+      const result = webex.internal.ediscovery.getContentSummary(url, {offset: 0, size: 1, timeoutMs: 5000})
         .then(() => {
           sinon.assert.calledWith(webex.request, sinon.match.has('timeout', 5000));
           sinon.assert.calledWith(webex.request, sinon.match.has('qs', {offset: 0, size: 1}));
@@ -344,7 +343,7 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummary sets report in contentSummaryBySpaceIdCache if it does not exist', async () => {
+    it('GetContentSummary sets report in contentSummaryBySpaceIdCache if it does not exist', async () => {
       const mockResponse = {body: [{spaceId: uuid}]};
 
       webex.internal.ediscovery.request = sinon.stub().resolves(mockResponse);
@@ -354,17 +353,16 @@ describe('EDiscovery Content API Tests', () => {
         has: sinon.stub().returns(false),
         clear: sinon.stub()
       };
-      const result = webex.internal.ediscovery.getRemoteContentSummary(url, {offset: 0, size: 1})
+      const result = webex.internal.ediscovery.getContentSummary(url, {offset: 0, size: 1})
         .then(() => {
           assert.calledWith(webex.internal.ediscovery.contentSummaryBySpaceIdCache.has, uuid);
-          assert.calledOnce(webex.internal.ediscovery.contentSummaryBySpaceIdCache.clear);
           assert.calledWith(webex.internal.ediscovery.contentSummaryBySpaceIdCache.set, uuid, new Map());
         });
 
       return result;
     });
 
-    it('GetRemoteContentSummary does not retrieves space from contentSummaryBySpaceIdCache if available', async () => {
+    it('GetContentSummary does not retrieves space from contentSummaryBySpaceIdCache if available', async () => {
       const mockCachedSpace = {spaceId: uuid};
       const spaceIdMap = {
         get: sinon.stub().withArgs(uuid).returns(mockCachedSpace),
@@ -378,7 +376,7 @@ describe('EDiscovery Content API Tests', () => {
         has: sinon.stub().returns(true),
         clear: sinon.stub()
       };
-      const result = webex.internal.ediscovery.getRemoteContentSummary(url, {offset: 0, size: 1})
+      const result = webex.internal.ediscovery.getContentSummary(url, {offset: 0, size: 1})
         .then((res) => {
           expect(res).to.not.equal(mockCachedSpace);
           assert.callCount(webex.internal.ediscovery.contentSummaryBySpaceIdCache.has, 0);
@@ -389,7 +387,7 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummary populates contentSummaryBySpaceIdCache with space when retrieved', async () => {
+    it('GetContentSummary populates contentSummaryBySpaceIdCache with space when retrieved', async () => {
       const mockResponse = {body: [{spaceId: uuid}]};
 
       webex.internal.ediscovery.request = sinon.stub().resolves(mockResponse);
@@ -404,7 +402,7 @@ describe('EDiscovery Content API Tests', () => {
         has: sinon.stub().returns(true),
         clear: sinon.stub()
       };
-      const result = webex.internal.ediscovery.getRemoteContentSummary(url, {offset: 0, size: 1})
+      const result = webex.internal.ediscovery.getContentSummary(url, {offset: 0, size: 1})
         .then((res) => {
           expect(res).to.equal(mockResponse);
           assert.callCount(webex.internal.ediscovery.contentSummaryBySpaceIdCache.has, 1);
@@ -462,7 +460,6 @@ describe('EDiscovery Content API Tests', () => {
       const result = webex.internal.ediscovery.getContentSummaryBySpaceId(uuid, uuid)
         .then(() => {
           assert.calledWith(webex.internal.ediscovery.contentSummaryBySpaceIdCache.has, uuid);
-          assert.calledOnce(webex.internal.ediscovery.contentSummaryBySpaceIdCache.clear);
           assert.calledWith(webex.internal.ediscovery.contentSummaryBySpaceIdCache.set, uuid, new Map());
         });
 
@@ -550,9 +547,9 @@ describe('EDiscovery Content API Tests', () => {
     });
   });
 
-  describe('GetRemoteContentSummaryBySpaceId Tests', () => {
-    it('GetRemoteContentSummaryBySpaceId succeeds', async () => {
-      const result = webex.internal.ediscovery.getRemoteContentSummaryBySpaceId(url, uuid)
+  describe('GetContentSummaryBySpaceId By Url Tests', () => {
+    it('GetContentSummaryBySpaceId by url succeeds', async () => {
+      const result = webex.internal.ediscovery.getContentSummaryBySpaceId(url, uuid)
         .then((res) => {
           expect(res).to.not.equal(undefined);
         });
@@ -560,20 +557,20 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummaryBySpaceId fails with no params', async () => {
-      const result = expect(webex.internal.ediscovery.getRemoteContentSummaryBySpaceId()).to.be.rejectedWith(Error, 'Undefined parameter');
+    it('GetContentSummaryBySpaceId by url fails with no params', async () => {
+      const result = expect(webex.internal.ediscovery.getContentSummaryBySpaceId()).to.be.rejectedWith(Error, 'Undefined parameter');
 
       return result;
     });
 
-    it('GetRemoteContentSummaryBySpaceId fails with a url that does not contain a report id', async () => {
-      const result = expect(webex.internal.ediscovery.getRemoteContentSummaryBySpaceId(invalidUrl, uuid)).to.be.rejectedWith(Error, 'Report url does not contain a report id');
+    it('GetContentSummaryBySpaceId by url fails with a url that does not contain a report id', async () => {
+      const result = expect(webex.internal.ediscovery.getContentSummaryBySpaceId(invalidUrl, uuid)).to.be.rejectedWith(Error, 'Report url does not contain a report id');
 
       return result;
     });
 
-    it('GetRemoteContentSummaryBySpaceId timeout defaults to 30s', async () => {
-      const result = webex.internal.ediscovery.getRemoteContentSummaryBySpaceId(url, uuid)
+    it('GetContentSummaryBySpaceId by url timeout defaults to 30s', async () => {
+      const result = webex.internal.ediscovery.getContentSummaryBySpaceId(url, uuid)
         .then(() => {
           sinon.assert.calledWith(webex.request, sinon.match.has('timeout', defaultTimeout));
         });
@@ -581,8 +578,8 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummaryBySpaceId timeout can be overwritten to 5s with timeout as the only option', async () => {
-      const result = webex.internal.ediscovery.getRemoteContentSummaryBySpaceId(url, uuid, {timeoutMs: 5000})
+    it('GetContentSummaryBySpaceId by url timeout can be overwritten to 5s with timeout as the only option', async () => {
+      const result = webex.internal.ediscovery.getContentSummaryBySpaceId(url, uuid, {timeoutMs: 5000})
         .then(() => {
           sinon.assert.calledWith(webex.request, sinon.match.has('timeout', 5000));
         });
@@ -590,27 +587,25 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummaryBySpaceId sets report in contentSummaryBySpaceIdCache if it does not exist', async () => {
+    it('GetContentSummaryBySpaceId by url sets report in contentSummaryBySpaceIdCache if it does not exist', async () => {
       const mockResponse = {body: {spaceId: uuid}};
 
       webex.internal.ediscovery.request = sinon.stub().resolves(mockResponse);
 
       webex.internal.ediscovery.contentSummaryBySpaceIdCache = {
         set: sinon.stub(),
-        has: sinon.stub().returns(false),
-        clear: sinon.stub()
+        has: sinon.stub().returns(false)
       };
-      const result = webex.internal.ediscovery.getRemoteContentSummaryBySpaceId(url, uuid)
-        .then(() => {
-          assert.calledWith(webex.internal.ediscovery.contentSummaryBySpaceIdCache.has, uuid);
-          assert.calledOnce(webex.internal.ediscovery.contentSummaryBySpaceIdCache.clear);
-          assert.calledWith(webex.internal.ediscovery.contentSummaryBySpaceIdCache.set, uuid, new Map());
-        });
+
+      const result = await webex.internal.ediscovery.getContentSummaryBySpaceId(url, uuid);
+
+      assert.calledWith(webex.internal.ediscovery.contentSummaryBySpaceIdCache.has, uuid);
+      assert.calledWith(webex.internal.ediscovery.contentSummaryBySpaceIdCache.set, uuid, new Map());
 
       return result;
     });
 
-    it('GetRemoteContentSummaryBySpaceId retrieves space from contentSummaryBySpaceIdCache if available', async () => {
+    it('GetContentSummaryBySpaceId by url retrieves space from contentSummaryBySpaceIdCache if available', async () => {
       const mockCachedSpace = {spaceId: uuid};
 
       const spaceIdMap = {
@@ -625,7 +620,7 @@ describe('EDiscovery Content API Tests', () => {
         has: sinon.stub().returns(true),
         clear: sinon.stub()
       };
-      const result = webex.internal.ediscovery.getRemoteContentSummaryBySpaceId(url, uuid)
+      const result = webex.internal.ediscovery.getContentSummaryBySpaceId(url, uuid)
         .then((res) => {
           expect(res.body).to.equal(mockCachedSpace);
           assert.callCount(webex.internal.ediscovery.contentSummaryBySpaceIdCache.has, 1);
@@ -636,7 +631,7 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummaryBySpaceId populates contentSummaryBySpaceIdCache with space when retrieved', async () => {
+    it('GetContentSummaryBySpaceId by url populates contentSummaryBySpaceIdCache with space when retrieved', async () => {
       const mockResponse = {body: {spaceId: uuid}};
 
       webex.internal.ediscovery.request = sinon.stub().resolves(mockResponse);
@@ -652,7 +647,7 @@ describe('EDiscovery Content API Tests', () => {
         has: sinon.stub().returns(true),
         clear: sinon.stub()
       };
-      const result = webex.internal.ediscovery.getRemoteContentSummaryBySpaceId(url, uuid)
+      const result = webex.internal.ediscovery.getContentSummaryBySpaceId(url, uuid)
         .then((res) => {
           expect(res).to.equal(mockResponse);
           assert.callCount(webex.internal.ediscovery.contentSummaryBySpaceIdCache.has, 2);
@@ -663,7 +658,7 @@ describe('EDiscovery Content API Tests', () => {
       return result;
     });
 
-    it('GetRemoteContentSummaryBySpaceId cannot write space to contentSummaryBySpaceIdCache without spaceId', async () => {
+    it('GetContentSummaryBySpaceId by url cannot write space to contentSummaryBySpaceIdCache without spaceId', async () => {
       const mockResponse = {body: {}};
 
       webex.internal.ediscovery.request = sinon.stub().resolves(mockResponse);
@@ -679,7 +674,7 @@ describe('EDiscovery Content API Tests', () => {
         has: sinon.stub().returns(true),
         clear: sinon.stub()
       };
-      const result = webex.internal.ediscovery.getRemoteContentSummaryBySpaceId(url, uuid)
+      const result = webex.internal.ediscovery.getContentSummaryBySpaceId(url, uuid)
         .then((res) => {
           expect(res).to.equal(mockResponse);
           assert.callCount(webex.internal.ediscovery.contentSummaryBySpaceIdCache.has, 2);
@@ -688,6 +683,91 @@ describe('EDiscovery Content API Tests', () => {
         });
 
       return result;
+    });
+  });
+
+  describe('ClearCache Tests', () => {
+    it('ClearCache of space summaries', async () => {
+      const spaceIdMap = {
+        set: sinon.stub(),
+        has: sinon.stub().returns(false)
+      };
+
+      webex.internal.ediscovery.contentSummaryBySpaceIdCache = {
+        get: sinon.stub().withArgs(uuid).returns(spaceIdMap),
+        set: sinon.stub(),
+        has: sinon.stub().returns(true),
+        clear: sinon.stub()
+      };
+
+      webex.internal.ediscovery.clearCache();
+
+      assert.callCount(webex.internal.ediscovery.contentSummaryBySpaceIdCache.clear, 1);
+    });
+  });
+
+  describe('_getReportIdFromUrl Tests', () => {
+    it('_getReportIdFromUrl of report url', async () => {
+      const url = 'https://ediscovery-intb.ciscospark.com/ediscovery/api/v1/reports/16bf0d01-b1f7-483b-89a2-915144158fb9';
+
+      const uuid = webex.internal.ediscovery._getReportIdFromUrl(url);
+
+      expect(uuid).equal('16bf0d01-b1f7-483b-89a2-915144158fb9');
+    });
+
+    it('_createRequestOptions of report url with multiple uuids', async () => {
+      const url = 'https://ediscovery-intb.ciscospark.com/ediscovery/api/v1/reports/16bf0d01-b1f7-483b-89a2-915144158fb9/contents/0498830f-1d63-4faa-b53b-35e1b12ccf9f';
+
+      const uuid = webex.internal.ediscovery._getReportIdFromUrl(url);
+
+      expect(uuid).equal('16bf0d01-b1f7-483b-89a2-915144158fb9');
+    });
+  });
+
+  describe('_isUrl Tests', () => {
+    it('_isUrl with a url', async () => {
+      const url = 'https://ediscovery-intb.ciscospark.com/ediscovery/api/v1/reports/16bf0d01-b1f7-483b-89a2-915144158fb9';
+
+      assert(webex.internal.ediscovery._isUrl(url));
+    });
+
+    it('_isUrl with a uuid', async () => {
+      assert(!webex.internal.ediscovery._isUrl('16bf0d01-b1f7-483b-89a2-915144158fb9'));
+    });
+
+    it('_isUrl with a string', async () => {
+      assert(!webex.internal.ediscovery._isUrl('abcdefghij'));
+    });
+  });
+
+  describe('_createRequestOptions Tests', () => {
+    it('_createRequestOptions with uuid', async () => {
+      const uuid = '16bf0d01-b1f7-483b-89a2-915144158fb9';
+      const resource = '/my/extra/resource/path';
+      const [options, returnedUUID] = webex.internal.ediscovery._createRequestOptions(uuid, resource);
+
+      expect(uuid).equal(returnedUUID);
+      expect(options.service).equal('ediscovery');
+      expect(options.resource).equal(`reports/${uuid}/${resource}`);
+    });
+
+    it('_createRequestOptions with url', async () => {
+      const url = 'https://ediscovery-intb.ciscospark.com/ediscovery/api/v1/reports/16bf0d01-b1f7-483b-89a2-915144158fb9';
+      const resource = '/my/extra/resource/path';
+      const [options, returnedUUID] = webex.internal.ediscovery._createRequestOptions(url, resource);
+
+      expect(returnedUUID).equal('16bf0d01-b1f7-483b-89a2-915144158fb9');
+      expect(options.url).equal(url + resource);
+    });
+
+    it('_createRequestOptions with url with details after the uuid', async () => {
+      const url = 'https://ediscovery-intb.ciscospark.com/ediscovery/api/v1/reports/16bf0d01-b1f7-483b-89a2-915144158fb9';
+      const urlPlus = 'https://ediscovery-intb.ciscospark.com/ediscovery/api/v1/reports/16bf0d01-b1f7-483b-89a2-915144158fb9/contents/and/more';
+      const resource = '/my/extra/resource/path';
+      const [options, returnedUUID] = webex.internal.ediscovery._createRequestOptions(urlPlus, resource);
+
+      expect(returnedUUID).equal('16bf0d01-b1f7-483b-89a2-915144158fb9');
+      expect(options.url).equal(url + resource);
     });
   });
 });


### PR DESCRIPTION
# Pull Request Template

## Description

As part of federation work we need ediscovery.js to support reaching out to remote (i.e. None home cluster) eDiscovery servers. There is code to support this already. But we discovered that it has problems with the decryption of space activities. Namely the code

 * assumed all requests would have a `resource` property and failed when they did not
 * tried to retrieve a remote space id from the home cluster eDiscovery (which cannot find it)
 * wiped the space summary cache when the remote report summaries were also cached

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I'm removing APIs which could breaking existing clients. But as we control the only client of eDiscovery this is not a concern.

## Test Coverage

Introduced appropriate tests and updated existing tests. I also integration this version of ediscovery.js into a local build of the eDiscovery Download Manager.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
