### PR TITLE
feat(meetings): change error log for 1:1 creation

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -516,8 +516,9 @@ export default class Meetings extends WebexPlugin {
       }
       catch (err) {
         // if there is no meeting info we assume its a 1:1 call or wireless share
-        LoggerProxy.logger.info(`Meetings->createMeeting#Error ${err} fetching /meetingInfo for creation.`);
+        LoggerProxy.logger.info(`Meetings->createMeeting#Info Unable to fetch meeting info for ${destination}.`);
         LoggerProxy.logger.info('Meetings->createMeeting#Info assuming this destination is a 1:1 or wireless share');
+        LoggerProxy.logger.debug(`Meetings->createMeeting#Debug ${err} fetching /meetingInfo for creation.`);
         // We need to save this info for future reference
         meeting.destination = destination;
       }


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-128909

When creating a 1:1 meeting with the meetings plugin, an error is logged to the console about not getting info from /meetingInfo. This error is expected and should not use the "error" wording causing unneeded customer requests to developer support.