### PR TITLE
fix(meetings): person id destinations

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js
@@ -108,16 +108,21 @@ export default class MeetingInfo extends StatelessWebexPlugin {
    * @memberof MeetingInfo
    */
   fetchMeetingInfo(destination, type = null) {
-    return this.fetchInfoOptions(destination, type).then((options) =>
-    // fetch meeting info
-      this.requestFetchInfo(options).catch((error) => {
-      // if it failed the first time as meeting link
+    return this.fetchInfoOptions(destination, type).then((options) => {
+      if (options.people) {
+        return options;
+      }
+
+      // fetch meeting info
+      return this.requestFetchInfo(options).catch((error) => {
+        // if it failed the first time as meeting link
         if (options.type === _MEETING_LINK_) {
-        // convert the meeting link to sip URI and retry
+          // convert the meeting link to sip URI and retry
           return this.requestFetchInfo(this.fetchInfoOptions(MeetingInfoUtil.convertLinkToSip(destination), _SIP_URI_));
         }
 
         return Promise.reject(error);
-      }));
+      });
+    });
   }
 }

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js
@@ -184,6 +184,7 @@ MeetingInfoUtil.generateOptions = async (from) => {
 
     return MeetingInfoUtil.getSipUriFromHydraPersonId(hydraId.destination, webex).then((res) => {
       options.destination = res;
+      options.people = hydraId.people;
 
       return Promise.resolve(options);
     });

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -4,6 +4,7 @@
 
 import '@webex/internal-plugin-mercury';
 
+import {deconstructHydraId} from '@webex/common';
 import {WebexPlugin} from '@webex/webex-core';
 
 import Metrics from '../metrics';
@@ -28,9 +29,11 @@ import {
   CORRELATION_ID,
   SIP_URI,
   _LEFT_,
-  _ID_
+  _ID_,
+  _PEOPLE_
 } from '../constants';
 import MeetingInfo from '../meeting-info';
+import MeetingInfoUtil from '../meeting-info/util';
 import Meeting from '../meeting';
 import PersonalMeetingRoom from '../personal-meeting-room';
 import Reachability from '../reachability';
@@ -456,7 +459,7 @@ export default class Meetings extends WebexPlugin {
 
     /**
      * Create a meeting.
-     * @param {string} destination - sipURL, spaceId, phonenumber, meeting link, or locus object}
+     * @param {string} destination - sipURL, hydra spaceId, hydra personId, phonenumber, meeting link, or locus object
      * @param {string} [type] - the optional specified type, such as locusId
      * @returns {Promise} A new Meeting.
      * @public
@@ -464,26 +467,58 @@ export default class Meetings extends WebexPlugin {
      */
     create(destination, type = null) {
       // TODO: type should be from a dictionary
-      // Check if there is already meeting
-      const meeting = this.meetingCollection.getByKey(SIP_URI, destination);
+      // Create a generic promise for validating if the provided destination is
+      // a hydra personId.
+      let promise;
 
-      if (!meeting) {
-        return this.createMeeting(destination, type)
-          .then((meeting) => {
-            if (meeting && meeting.on) {
-              meeting.on(EVENTS.DESTROY_MEETING, (payload) => {
-                this.destroy(payload.meetingId, payload.reason);
-              });
-            }
-            else {
-              LoggerProxy.logger.error(`meetings->create#ERROR, meeting does not have on method, will not be destroyed, meeting cleanup impossible for meeting: ${meeting}`);
-            }
+      // Attempt to determine if the provided destination is a hydra personId.
+      try {
+        // Deconstruct the provided destination.
+        const deconstructedId = deconstructHydraId(destination);
 
-            return Promise.resolve(meeting);
-          });
+        if (deconstructedId.type === _PEOPLE_) {
+          // Get the usable sipUri if the provided destination is a hydra
+          // personId.
+          promise = MeetingInfoUtil.getSipUriFromHydraPersonId(destination, this.webex);
+        }
+        else {
+          // Assign an empty promise if the type was not a person.
+          promise = Promise.resolve();
+        }
+      }
+      catch (error) {
+        LoggerProxy.logger.info(`meetings->create#INFO, could not deconstruct ${destination} as a hydra ID`);
+
+        // Assign an empty promise if deconstructing the hydra ID failed.
+        promise = Promise.resolve();
       }
 
-      return Promise.resolve(meeting);
+      // Proceed with meeting creation logic.
+      return promise.then((personURI) => {
+        // Utilize the provided SIP URI if it exists.
+        const targetDestination = personURI || destination;
+
+        // Check if there is already meeting
+        const meeting = this.meetingCollection.getByKey(SIP_URI, targetDestination);
+
+        if (!meeting) {
+          return this.createMeeting(targetDestination, type)
+            .then((meeting) => {
+              if (meeting && meeting.on) {
+                meeting.on(EVENTS.DESTROY_MEETING, (payload) => {
+                  this.destroy(payload.meetingId, payload.reason);
+                });
+              }
+              else {
+                LoggerProxy.logger.error(`meetings->create#ERROR, meeting does not have on method, will not be destroyed, meeting cleanup impossible for meeting: ${meeting}`);
+              }
+
+              return Promise.resolve(meeting);
+            });
+        }
+
+        return Promise.resolve(meeting);
+      });
     }
 
     /**

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -4,7 +4,6 @@
 
 import '@webex/internal-plugin-mercury';
 
-import {deconstructHydraId} from '@webex/common';
 import {WebexPlugin} from '@webex/webex-core';
 
 import Metrics from '../metrics';
@@ -29,11 +28,9 @@ import {
   CORRELATION_ID,
   SIP_URI,
   _LEFT_,
-  _ID_,
-  _PEOPLE_
+  _ID_
 } from '../constants';
 import MeetingInfo from '../meeting-info';
-import MeetingInfoUtil from '../meeting-info/util';
 import Meeting from '../meeting';
 import PersonalMeetingRoom from '../personal-meeting-room';
 import Reachability from '../reachability';
@@ -467,58 +464,27 @@ export default class Meetings extends WebexPlugin {
      */
     create(destination, type = null) {
       // TODO: type should be from a dictionary
-      // Create a generic promise for validating if the provided destination is
-      // a hydra personId.
-      let promise;
 
-      // Attempt to determine if the provided destination is a hydra personId.
-      try {
-        // Deconstruct the provided destination.
-        const deconstructedId = deconstructHydraId(destination);
+      // Check if there is already meeting
+      const meeting = this.meetingCollection.getByKey(SIP_URI, destination);
 
-        if (deconstructedId.type === _PEOPLE_) {
-          // Get the usable sipUri if the provided destination is a hydra
-          // personId.
-          promise = MeetingInfoUtil.getSipUriFromHydraPersonId(destination, this.webex);
-        }
-        else {
-          // Assign an empty promise if the type was not a person.
-          promise = Promise.resolve();
-        }
-      }
-      catch (error) {
-        LoggerProxy.logger.info(`meetings->create#INFO, could not deconstruct ${destination} as a hydra ID`);
+      if (!meeting) {
+        return this.createMeeting(destination, type)
+          .then((meeting) => {
+            if (meeting && meeting.on) {
+              meeting.on(EVENTS.DESTROY_MEETING, (payload) => {
+                this.destroy(payload.meetingId, payload.reason);
+              });
+            }
+            else {
+              LoggerProxy.logger.error(`meetings->create#ERROR, meeting does not have on method, will not be destroyed, meeting cleanup impossible for meeting: ${meeting}`);
+            }
 
-        // Assign an empty promise if deconstructing the hydra ID failed.
-        promise = Promise.resolve();
+            return Promise.resolve(meeting);
+          });
       }
 
-      // Proceed with meeting creation logic.
-      return promise.then((personURI) => {
-        // Utilize the provided SIP URI if it exists.
-        const targetDestination = personURI || destination;
-
-        // Check if there is already meeting
-        const meeting = this.meetingCollection.getByKey(SIP_URI, targetDestination);
-
-        if (!meeting) {
-          return this.createMeeting(targetDestination, type)
-            .then((meeting) => {
-              if (meeting && meeting.on) {
-                meeting.on(EVENTS.DESTROY_MEETING, (payload) => {
-                  this.destroy(payload.meetingId, payload.reason);
-                });
-              }
-              else {
-                LoggerProxy.logger.error(`meetings->create#ERROR, meeting does not have on method, will not be destroyed, meeting cleanup impossible for meeting: ${meeting}`);
-              }
-
-              return Promise.resolve(meeting);
-            });
-        }
-
-        return Promise.resolve(meeting);
-      });
+      return Promise.resolve(meeting);
     }
 
     /**
@@ -546,8 +512,13 @@ export default class Meetings extends WebexPlugin {
       try {
         const info = await this.meetingInfo.fetchMeetingInfo(MeetingsUtil.extractDestination(destination, type), type);
 
-        meeting.parseMeetingInfo(info);
-        meeting.meetingInfo = info ? info.body : null;
+        if (info.people && info.destination) {
+          meeting.sipUri = info.destination;
+        }
+        else {
+          meeting.parseMeetingInfo(info);
+          meeting.meetingInfo = info ? info.body : null;
+        }
       }
       catch (err) {
         // if there is no meeting info we assume its a 1:1 call or wireless share

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -2,7 +2,8 @@
  * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
  */
 
-import {assert} from '@webex/test-helper-chai';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import MockWebex from '@webex/test-helper-mock-webex';
 import Device from '@webex/internal-plugin-device';
@@ -12,6 +13,7 @@ import PersonalMeetingRoom from '@webex/plugin-meetings/src/personal-meeting-roo
 import Reachability from '@webex/plugin-meetings/src/reachability';
 import MeetingCollection from '@webex/plugin-meetings/src/meetings/collection';
 import MeetingsUtil from '@webex/plugin-meetings/src/meetings/util';
+import MeetingInfoUtil from '@webex/plugin-meetings/src/meeting-info/util';
 import Meeting from '@webex/plugin-meetings/src/meeting';
 import MediaUtil from '@webex/plugin-meetings/src/media/util';
 import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
@@ -20,6 +22,11 @@ import StaticConfig from '@webex/plugin-meetings/src/common/config';
 import TriggerProxy from '@webex/plugin-meetings/src/common/events/trigger-proxy';
 import uuid from 'uuid';
 import {skipInBrowser} from '@webex/test-helper-mocha';
+
+const {assert} = chai;
+
+chai.use(chaiAsPromised);
+sinon.assert.expose(chai.assert, {prefix: ''});
 
 
 skipInBrowser(describe)('plugin-meetings', () => {
@@ -289,6 +296,34 @@ skipInBrowser(describe)('plugin-meetings', () => {
           await create;
           assert.calledOnce(webex.meetings.createMeeting);
           assert.calledWith(webex.meetings.createMeeting, test1, test2);
+        });
+
+        it('should attempt to determine the SIP URI of a personId destination', async () => {
+          const hydaPersonId = 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS8wMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDA=';
+
+          sinon.stub(MeetingInfoUtil, 'getSipUriFromHydraPersonId').resolves();
+
+          await webex.meetings.create(hydaPersonId);
+
+          assert.calledWith(
+            MeetingInfoUtil.getSipUriFromHydraPersonId,
+            hydaPersonId,
+            webex
+          );
+
+          MeetingInfoUtil.getSipUriFromHydraPersonId.restore();
+        });
+
+        it('should not attempt to get a personId\'s SIP URI if the destination is not a hydra personId', async () => {
+          const destination = 'not a hydra personId';
+
+          sinon.stub(MeetingInfoUtil, 'getSipUriFromHydraPersonId');
+
+          await webex.meetings.create(destination);
+
+          assert.notCalled(MeetingInfoUtil.getSipUriFromHydraPersonId);
+
+          MeetingInfoUtil.getSipUriFromHydraPersonId.restore();
         });
       });
     });


### PR DESCRIPTION
# Pull Request

## Description

The scope of the changes in this pull request are to fix the single party call sample to allow for the usage of `personId` values.

Fixes # [SPARK-127323](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-127323)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Generated additional test coverage for the added functionality
- [x] Ran package tests with no impacting failures.

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
