### PR TITLE
test(internal-conversation): remove assertions for kmsResourceObjectURL

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/encryption.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/encryption.js
@@ -110,7 +110,6 @@ describe('plugin-conversation', () => {
       .then((c) => {
         conversation = c;
         assert.notProperty(conversation, 'defaultActivityEncryptionKeyUrl');
-        assert.property(conversation, 'kmsResourceObjectUrl');
       }));
 
     describe('when the conversation is a grouped conversation', () => {
@@ -190,7 +189,6 @@ describe('plugin-conversation', () => {
           .then(() => checkov.webex.internal.conversation.get(conversation))
           .then((c) => {
             assert.isUndefined(c.defaultActivityEncryptionKeyUrl);
-            assert.property(c, 'kmsResourceObjectUrl');
           }));
 
         describe('when the KMS key has been unset', () => {
@@ -255,7 +253,6 @@ describe('plugin-conversation', () => {
         .then((c) => {
           conversation = c;
           assert.notProperty(conversation, 'defaultActivityEncryptionKeyUrl');
-          assert.property(conversation, 'kmsResourceObjectUrl');
           assert.include(c.tags, 'ONE_ON_ONE');
         }));
 


### PR DESCRIPTION
After a recent change in conversation service, unencrypted conversations no longer contain the kmsResourceObjectURL property.
This removes all such assertions in the tests for conversation plugin.