### PR TITLE
fix(mercury): timing condition where disconnect did not close websockets

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js
@@ -167,6 +167,14 @@ const Mercury = WebexPlugin.extend({
 
     Promise.all([this._prepareUrl(socketUrl), this.webex.credentials.getUserToken()])
       .then(([webSocketUrl, token]) => {
+        if (!this.backoffCall) {
+          const msg = 'mercury: prevent socket open when backoffCall no longer defined';
+
+          this.logger.info(msg);
+
+          return Promise.reject(new Error(msg));
+        }
+
         attemptWSUrl = webSocketUrl;
 
         let options = {
@@ -184,10 +192,13 @@ const Mercury = WebexPlugin.extend({
           options = {...options, ...this.webex.config.defaultMercuryOptions};
         }
 
+        // Set the socket before opening it. This allows a disconnect() to close
+        // the socket if it is in the process of being opened.
+        this.socket = socket;
+
         return socket.open(webSocketUrl, options);
       })
       .then(() => {
-        this.socket = socket;
         this.webex.internal.metrics.submitClientMetrics('web-ha-mercury', {
           fields: {
             success: true
@@ -288,7 +299,7 @@ const Mercury = WebexPlugin.extend({
 
         this.backoffCall = undefined;
         if (err) {
-          this.logger.info(`mercury: failed to connect after ${call.getNumRetries()} retries; log statement about next retry was inaccurate`);
+          this.logger.info(`mercury: failed to connect after ${call.getNumRetries()} retries; log statement about next retry was inaccurate; ${err}`);
 
           return reject(err);
         }
@@ -315,7 +326,7 @@ const Mercury = WebexPlugin.extend({
 
       call.on('abort', () => {
         this.logger.info('mercury: connection aborted');
-        reject();
+        reject(new Error('Mercury Connection Aborted'));
       });
 
       call.on('callback', (err) => {

--- a/packages/node_modules/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -3,6 +3,12 @@
  */
 
 import {EventEmitter} from 'events';
+
+import {checkRequired} from '@webex/common';
+import {safeSetTimeout} from '@webex/common-timers';
+import {defaults, has, isObject} from 'lodash';
+import uuid from 'uuid';
+
 import {
   BadRequest,
   ConnectionError,
@@ -11,10 +17,6 @@ import {
   UnknownResponse
   // NotFound
 } from '../errors';
-import {checkRequired} from '@webex/common';
-import {safeSetTimeout} from '@webex/common-timers';
-import {defaults, has, isObject} from 'lodash';
-import uuid from 'uuid';
 
 const sockets = new WeakMap();
 
@@ -98,8 +100,16 @@ export default class Socket extends EventEmitter {
    */
   close(options) {
     return new Promise((resolve, reject) => {
-      this.logger.info('socket: closing');
       const socket = sockets.get(this);
+
+      if (!socket) {
+        // Open has not been called yet so there is no socket to close
+        resolve();
+
+        return;
+      }
+      // logger is defined once open is called
+      this.logger.info('socket: closing');
 
       if (socket.readyState === 2 || socket.readyState === 3) {
         this.logger.info('socket: already closed');
@@ -200,6 +210,7 @@ export default class Socket extends EventEmitter {
 
       socket.onclose = (event) => {
         event = this._fixCloseCode(event);
+        this.logger.info('socket: closed before open', event.code, event.reason);
         switch (event.code) {
           case 1005:
           // IE 11 doesn't seem to allow 4XXX codes, so if we get a 1005, assume

--- a/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/node_modules/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -504,18 +504,52 @@ describe('plugin-mercury', () => {
       });
 
       describe('when there is a connection attempt inflight', () => {
-        it('stops the attempt', () => {
+        it('stops the attempt when disconnect called', () => {
           socketOpenStub.restore();
           socketOpenStub = sinon.stub(Socket.prototype, 'open');
-          socketOpenStub.returns(Promise.reject(new ConnectionError()));
+          socketOpenStub.onCall(0).returns(
+            // Delay the opening of the socket so that disconnect is called while open
+            // is in progress
+            promiseTick(2 * webex.internal.mercury.config.backoffTimeReset)
+            // Pretend the socket opened successfully. Failing should be fine too but
+            // it generates more console output.
+              .then(() => Promise.resolve())
+          );
           const promise = mercury.connect();
 
-          return promiseTick(1)
-            .then(() => clock.tick(webex.internal.mercury.config.backoffTimeReset))
+          // Wait for the connect call to setup
+          return promiseTick(webex.internal.mercury.config.backoffTimeReset)
             .then(() => {
+              // By this time backoffCall and mercury socket should be defined by the
+              // 'connect' call
+              assert.isDefined(mercury.backoffCall, 'Mercury backoffCall is not defined');
+              assert.isDefined(mercury.socket, 'Mercury socket is not defined');
+              // Calling disconnect will abort the backoffCall, close the socket, and
+              // reject the connect
               mercury.disconnect();
+              assert.isUndefined(mercury.backoffCall, 'Mercury backoffCall is still defined');
+              // The socket will never be unset (which seems bad)
+              assert.isDefined(mercury.socket, 'Mercury socket is not defined');
 
               return assert.isRejected(promise);
+            });
+        });
+
+        it('stops the attempt when backoffCall is undefined', () => {
+          socketOpenStub.restore();
+          socketOpenStub = sinon.stub(Socket.prototype, 'open');
+          socketOpenStub.returns(Promise.resolve());
+
+          let reason;
+
+          mercury.backoffCall = undefined;
+          mercury._attemptConnection('ws://example.com', (_reason) => {
+            reason = _reason;
+          });
+
+          return promiseTick(webex.internal.mercury.config.backoffTimeReset)
+            .then(() => {
+              assert.equal(reason.message, 'mercury: prevent socket open when backoffCall no longer defined');
             });
         });
       });


### PR DESCRIPTION
# Pull Request Template

## Description

We've a E2E test app to validate the eDiscovery Download Manager. But we found the app was not shutting down without a `process.exit(..)` call. Using [wtfnode](https://www.npmjs.com/package/wtfnode) I identified the mercury socket as being the cause. It was not closed and this meant the app remained running. I "fixed" this with

    await spark.internal.mercury.disconnect()

in the test's `after` section. But, intermittently, the app would still hang and at the same time I'd see a `unhandledRejection` with an `undefined` error.

I tracked the rejection down to [mercury's abort handling](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js#L318) which gets called by the [abort event in the backoff module](https://github.com/MathieuTurcotte/node-backoff/blob/master/lib/function_call.js#L120) in turn triggered by [spark.internal.mercury.disconnect()](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js#L77).

Debugging into the code I noticed that `disconnect` could be called while a `socket.open(..)` was in progress. That meant the socket would never be closed as, at that time, the [mercury socket](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js#L80) was undefined.

To fix this I'm updating the code to set `this.socket` just before calling `socket.open(..)`. That means the disconnect can close the socket. i.e. Preventing my app from hanging.

**Caveat:** I'm no mercury expert and would appreciate the core team taking a careful look at this PR.

**Additional:** I see another bug in the code related to `spark.internal.mercury.disconnect()`. If the [socket times out when closed](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/%40webex/internal-plugin-mercury/src/socket/socket-base.js#L128) it causes the follow close event

          resolve(this.onclose({
            code: 1000,
            reason: 'Done (forced)'
          }));

The [mercury code](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js#L24) checks for the reason `Done (forced)` and if it detects it then the [socket will be re-connected](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/@webex/internal-plugin-mercury/src/mercury.js#L409). It seems to consider this case a _normalReconnectReasons_ but a [normal close](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/%40webex/internal-plugin-mercury/src/socket/socket-base.js#L139), which translates to

        this.onclose({
            code: 1000,
            reason: 'Done'
          }));

does not cause a re-connect.

This means when you call

    spark.internal.mercury.disconnect()

and it closes the socket, but there is a time out, the socket is re-opened. That is not intuitive and _seems_ like a mistake. But it also _looks very_ deliberate in the code. I can't figure out why the SDK would do this which means

 a) Its a long standing bug or
 b) I'm misunderstanding something

To fix this I'd like to removed `Done (forced)` from `normalReconnectReasons`. But I'm wary of breaking something I'm missing. Can one of the core team have a look?

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Unit test updated and unit test added.

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
