### PR TITLE
fix(core): add headers and catch debug s3

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-support/src/support.js
+++ b/packages/node_modules/@webex/internal-plugin-support/src/support.js
@@ -106,7 +106,8 @@ const Support = WebexPlugin.extend({
         }
 
         return body;
-      });
+      })
+      .catch((err) => err);
   },
 
   _constructFileMetadata(metadata) {

--- a/packages/node_modules/@webex/webex-core/src/webex-core.js
+++ b/packages/node_modules/@webex/webex-core/src/webex-core.js
@@ -544,7 +544,8 @@ const WebexCore = AmpState.extend({
         return p;
       })
       .then((...args) => this._uploadPhaseFinalize(options, ...args))
-      .then((res) => res.body);
+      .then((res) => ({...res.body, ...res.headers}))
+      .catch((err) => err);
 
     proxyEvents(shunt, promise);
 


### PR DESCRIPTION
I might be way off here...

But i know there are some problems with uploading files to s3. In some cases, we are having problems retrieving uploaded logs from admin.webex.com, and these are uploaded into the s3 bucket. I know in some cases the SDK is returning 0 (not sure who investigated this and determined this) but in any case, for uploads we can return the trackingId so that we can investigate upload log failures. In the web client we upload logs on every app crash and we can't look at the logs if they don't end up there, so need to dig deeper with server side for why they aren't making it there, this is the first step in that direction?
