### PR TITLE
add meeting:media:{local,remote}:start event

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/README.md
+++ b/packages/node_modules/@webex/plugin-meetings/README.md
@@ -1084,6 +1084,8 @@ meeting.on(...)
 | `meetings:unregistered` | Fired when the meetings plugin has been disconnected from websockets and unregistered as a device |
 | `media:ready` | Fired when remote or local media has been acquired |
 | `media:stopped` | Fired when remote or local media has been torn down |
+| `meeting:media:local:start` | Fired when local media has started sending bytes |
+| `meeting:media:remote:start` | Fired when local media has started receiving bytes from the remote audio or video streams |
 | `meeting:alerted` | Fired when locus was notified that user received meeting |
 | `meeting:ringing` | Fired when meeting should have a ringing sound on repeat |
 | `meeting:ringingStop` | Fired when meeting should stop a ringing sound |

--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -345,6 +345,8 @@ export const EVENT_TRIGGERS = {
   MEDIA_UPDATE: 'media:update',
   MEETING_STARTED_SHARING_LOCAL: 'meeting:startedSharingLocal',
   MEETING_STOPPED_SHARING_LOCAL: 'meeting:stoppedSharingLocal',
+  MEETING_MEDIA_LOCAL_STARTED: 'meeting:media:local:start',
+  MEETING_MEDIA_REMOTE_STARTED: 'meeting:media:remote:start',
   MEETING_ADDED: 'meeting:added',
   MEETING_REMOVED: 'meeting:removed',
   MEETING_RINGING: 'meeting:ringing',

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -12,8 +12,10 @@ import {
   MODERATOR_FALSE,
   _JOINED_,
   ICE_STATE,
-  STATS
+  STATS,
+  EVENT_TRIGGERS
 } from '../constants';
+import Trigger from '../common/events/trigger-proxy';
 import IntentToJoinError from '../common/errors/intent-to-join';
 import JoinMeetingError from '../common/errors/join-meeting';
 import ParameterError from '../common/errors/parameter';
@@ -448,6 +450,17 @@ MeetingUtil.startInternalStats = (meeting) => {
             // TODO: we don't need checks like this since it comes from the transceiver
             // refactor event linkage to use callbacks instead of events
             if (event.kind === 'audio' && event.stat === 'bytesSent') {
+              Trigger.trigger(
+                meeting,
+                {
+                  file: 'meeting/util',
+                  function: 'startInternalStats'
+                },
+                EVENT_TRIGGERS.MEETING_MEDIA_LOCAL_STARTED,
+                {
+                  type: mediaType.AUDIO
+                }
+              );
               Metrics.postEvent({
                 event: eventType.SENDING_MEDIA_START,
                 meeting,
@@ -474,6 +487,17 @@ MeetingUtil.startInternalStats = (meeting) => {
           history: true,
           onEvent: (event) => {
             if (event.kind === 'video' && event.stat === 'bytesSent') {
+              Trigger.trigger(
+                meeting,
+                {
+                  file: 'meeting/util',
+                  function: 'startInternalStats'
+                },
+                EVENT_TRIGGERS.MEETING_MEDIA_LOCAL_STARTED,
+                {
+                  type: mediaType.VIDEO
+                }
+              );
               Metrics.postEvent({
                 event: eventType.SENDING_MEDIA_START,
                 meeting,
@@ -497,6 +521,37 @@ MeetingUtil.startInternalStats = (meeting) => {
         {
           id: 'mainShare',
           correlate: 'video',
+          onEvent: (event) => {
+            if (event.kind === 'share' && event.stat === 'bytesSent') {
+              Trigger.trigger(
+                meeting,
+                {
+                  file: 'meeting/util',
+                  function: 'startInternalStats'
+                },
+                EVENT_TRIGGERS.MEETING_MEDIA_LOCAL_STARTED,
+                {
+                  type: mediaType.SHARE
+                }
+              );
+              Metrics.postEvent({
+                event: eventType.SENDING_SHARE_START,
+                meeting,
+                data: {
+                  mediaType: mediaType.SHARE
+                }
+              });
+            }
+            else if (event.stop && event.stat === 'bytesSent') {
+              Metrics.postEvent({
+                event: eventType.SENDING_SHARE_STOP,
+                meeting,
+                data: {
+                  mediaType: mediaType.SHARE
+                }
+              });
+            }
+          },
           onData: () => {}
         }
       ],
@@ -507,6 +562,17 @@ MeetingUtil.startInternalStats = (meeting) => {
           history: true,
           onEvent: (event) => {
             if (event.kind === 'audio' && event.stat === 'bytesReceived') {
+              Trigger.trigger(
+                meeting,
+                {
+                  file: 'meeting/util',
+                  function: 'startInternalStats'
+                },
+                EVENT_TRIGGERS.MEETING_MEDIA_REMOTE_STARTED,
+                {
+                  type: mediaType.AUDIO
+                }
+              );
               Metrics.postEvent({
                 event: eventType.RECEIVING_MEDIA_START,
                 meeting,
@@ -533,6 +599,17 @@ MeetingUtil.startInternalStats = (meeting) => {
           history: true,
           onEvent: (event) => {
             if (event.kind === 'video' && event.stat === 'bytesReceived') {
+              Trigger.trigger(
+                meeting,
+                {
+                  file: 'meeting/util',
+                  function: 'startInternalStats'
+                },
+                EVENT_TRIGGERS.MEETING_MEDIA_REMOTE_STARTED,
+                {
+                  type: mediaType.VIDEO
+                }
+              );
               Metrics.postEvent({
                 event: eventType.RECEIVING_MEDIA_START,
                 meeting,
@@ -556,6 +633,37 @@ MeetingUtil.startInternalStats = (meeting) => {
         {
           id: 'mainShare',
           correlate: 'video',
+          onEvent: (event) => {
+            if (event.kind === 'share' && event.stat === 'bytesReceived') {
+              Trigger.trigger(
+                meeting,
+                {
+                  file: 'meeting/util',
+                  function: 'startInternalStats'
+                },
+                EVENT_TRIGGERS.MEETING_MEDIA_REMOTE_STARTED,
+                {
+                  type: mediaType.SHARE
+                }
+              );
+              Metrics.postEvent({
+                event: eventType.RECEIVING_MEDIA_START,
+                meeting,
+                data: {
+                  mediaType: mediaType.SHARE
+                }
+              });
+            }
+            else if (event.stop && event.stat === 'bytesReceived') {
+              Metrics.postEvent({
+                event: eventType.RECEIVING_MEDIA_STOP,
+                meeting,
+                data: {
+                  mediaType: mediaType.SHARE
+                }
+              });
+            }
+          },
           onData: () => {}
         }
       ]

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -194,7 +194,12 @@ skipInNode(describe)('plugin-meetings', () => {
           // Wait for openH264 to finsish downloading and peerConnection to be stable
           testUtils.waitUntil(4000);
         })
-        .then(() => testUtils.addMedia(alice)));
+        .then(() => Promise.all([
+          testUtils.addMedia(alice),
+          testUtils.waitForEvents([
+            {scope: alice.meeting, event: 'meeting:media:local:start', user: alice}
+          ])
+        ])));
 
       it('bob joins the meeting', () => {
         bob.meeting.acknowledge('INCOMING');
@@ -208,7 +213,13 @@ skipInNode(describe)('plugin-meetings', () => {
               assert.equal(bobParticipant.status, 'IN_MEETING');
             })
         ])
-          .then(() => testUtils.addMedia(bob))
+          .then(() => Promise.all([
+            testUtils.addMedia(bob),
+            testUtils.waitForEvents([
+              {scope: bob.meeting, event: 'meeting:media:local:start', user: bob},
+              {scope: alice.meeting, event: 'meeting:media:remote:start', user: alice}
+            ])
+          ]))
           .then(() => {
             assert.equal(bob.meeting.sipUri, alice.emailAddress);
             assert.equal(alice.meeting.sipUri, bob.emailAddress);


### PR DESCRIPTION
## Description

Adds a meeting event which states that media has started receiving bytes

Fixes [SPARK-128912](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-128912)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update