### PR TITLE
chore(circle): improve tap test naming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,26 +449,32 @@ workflows:
           requires:
             - npm_install
       - tap:
+          name: '@webex/webex-core tap'
           package: '@webex/webex-core'
           requires:
             - build
       - tap:
+          name: '@webex/plugin-meetings tap'
           package: '@webex/plugin-meetings'
           requires:
             - build
       - tap:
+          name: '@webex/internal-plugin-conversation tap'
           package: '@webex/internal-plugin-conversation'
           requires:
             - build
       - tap:
+          name: '@webex/internal-plugin-encryption tap'
           package: '@webex/internal-plugin-encryption'
           requires:
             - build
       - tap:
+          name: '@webex/internal-plugin-locus tap'
           package: '@webex/internal-plugin-locus'
           requires:
             - build
       - tap:
+          name: '@webex/internal-plugin-mercury tap'
           package: '@webex/internal-plugin-mercury'
           requires:
             - build


### PR DESCRIPTION
# Pull Request

## Description

The scope of the changes in this pull request are focused on adding naming to the tap test CI jobs to make their scope determinable before opening the job directly. The changes to the circle CI config require circle ci v2.1+.

See [this Circle CI documentation reference](https://circleci.com/docs/2.0/configuration-reference/#job_name-1).
