### PR TITLE
Meetings set remote quality

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -817,7 +817,7 @@ export const SDP = {
   STABLE: 'stable',
   OFFER: 'offer',
   M_LINE: 'm=',
-  MAX_FS_8160: 'max-fs=8160',
+  MAX_FS: 'max-fs=',
   B_LINE: 'b=TIAS',
   CARRIAGE_RETURN: '\r\n',
   BAD_MEDIA_PORTS: [0]
@@ -1012,4 +1012,14 @@ export const VIDEO_RESOLUTIONS = {
       }
     }
   }
+};
+
+/**
+ * Max frame sizes based on h264 configs
+ * https://en.wikipedia.org/wiki/Advanced_Video_Coding
+ */
+export const MAX_FRAMESIZES = {
+  [QUALITY_LEVELS.LOW]: 1620,
+  [QUALITY_LEVELS.MEDIUM]: 3600,
+  [QUALITY_LEVELS.HIGH]: 8192
 };

--- a/packages/node_modules/@webex/plugin-meetings/src/media/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/index.js
@@ -63,16 +63,18 @@ Media.setLocalTrack = (enabled, track) => {
 
 /**
  * @param {RTCPeerConnection} peerConnection
- * @param {String} meetingId
+ * @param {Object} meetingProperties
+ * @param {string} meetingProperties.meetingId
+ * @param {string} meetingProperties.remoteQualityLevel LOW|MEDIUM|HIGH
  * @returns {Promise}
  */
-Media.reconnectMedia = (peerConnection, meetingId) => {
+Media.reconnectMedia = (peerConnection, {meetingId, remoteQualityLevel}) => {
   if (peerConnection.connectionState === PEER_CONNECTION_STATE.CLOSED ||
     peerConnection.connectionState === PEER_CONNECTION_STATE.FAILED) {
     return Promise.reject(new ReconnectionError('Reinitiate peerconnection'));
   }
 
-  return PeerConnectionManager.createOffer(peerConnection, meetingId);
+  return PeerConnectionManager.createOffer(peerConnection, {meetingId, remoteQualityLevel});
 };
 
 /**
@@ -155,10 +157,12 @@ Media.checkTracks = (trackType, track, receiveTracks) => {
 /**
  * creates peerconnection and attaches streams
  * @param {MediaDirection} mediaProperties
- * @param {Object} meetingId call flow id
+ * @param {Object} meetingProperties
+ * @param {string} meetingProperties.meetingId
+ * @param {string} meetingProperties.remoteQualityLevel LOW|MEDIUM|HIGH
  * @returns {Array} [peerConnection, ]
  */
-Media.attachMedia = (mediaProperties, meetingId) => {
+Media.attachMedia = (mediaProperties, {meetingId, remoteQualityLevel}) => {
   const {
     mediaDirection, audioTrack, videoTrack, shareTrack, peerConnection
   } = mediaProperties;
@@ -181,16 +185,18 @@ Media.attachMedia = (mediaProperties, meetingId) => {
     LoggerProxy.logger.info(`Media->attachMedia/onnegotiationneeded#PeerConnection: ${event}`);
   };
 
-  return PeerConnectionManager.createOffer(peerConnection, meetingId);
+  return PeerConnectionManager.createOffer(peerConnection, {meetingId, remoteQualityLevel});
 };
 
 /**
  * updates all the media streams and creates a new media offer
  * @param {MediaDirection} mediaProperties
- * @param {String} meetingId
+ * @param {Object} meetingProperties
+ * @param {string} meetingProperties.meetingId
+ * @param {string} meetingProperties.remoteQualityLevel LOW|MEDIUM|HIGH
  * @returns {Promise}
  */
-Media.updateMedia = (mediaProperties, meetingId) => {
+Media.updateMedia = (mediaProperties, {meetingId, remoteQualityLevel}) => {
   const {
     mediaDirection, audioTrack, videoTrack, shareTrack, peerConnection
   } = mediaProperties;
@@ -222,7 +228,7 @@ Media.updateMedia = (mediaProperties, meetingId) => {
     LoggerProxy.logger.info(`Media->attachMedia/onnegotiationneeded#PeerConnection: ${event}`);
   };
 
-  return PeerConnectionManager.createOffer(peerConnection, meetingId);
+  return PeerConnectionManager.createOffer(peerConnection, {meetingId, remoteQualityLevel});
 };
 
 /**
@@ -251,16 +257,18 @@ Media.setTrackOnTransceiver = (transceiver, options) => {
 
 /**
  * creates a new offer
- * @param {String} meetingId
+ * @param {Object} meetingProperties
+ * @param {string} meetingProperties.meetingId
+ * @param {string} meetingProperties.remoteQualityLevel LOW|MEDIUM|HIGH
  * @param {RTCPeerConnection} peerConnection
  * @param {RTCRtpTransceiver} transceiver
  * @param {Object} options see #Media.setTrackOnTransceiver
  * @returns {Promise}
  */
-Media.updateTransceiver = (meetingId, peerConnection, transceiver, options) => {
+Media.updateTransceiver = ({meetingId, remoteQualityLevel}, peerConnection, transceiver, options) => {
   Media.setTrackOnTransceiver(transceiver, options);
 
-  return PeerConnectionManager.createOffer(peerConnection, meetingId);
+  return PeerConnectionManager.createOffer(peerConnection, {meetingId, remoteQualityLevel});
 };
 
 /**

--- a/packages/node_modules/@webex/plugin-meetings/src/media/properties.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/properties.js
@@ -1,5 +1,6 @@
 import {
-  MEETINGS
+  MEETINGS,
+  QUALITY_LEVELS
 } from '../constants';
 
 import MediaUtil from './util';
@@ -22,6 +23,7 @@ export default class MediaProperties {
     this.shareTrack = options.shareTrack;
     this.remoteStream = options.remoteStream;
     this.remoteShare = options.remoteShare;
+    this.remoteQualityLevel = options.remoteQualityLevel || QUALITY_LEVELS.HIGH;
     this.mediaSettings = {};
   }
 
@@ -47,6 +49,10 @@ export default class MediaProperties {
 
   setLocalShareTrack(shareTrack) {
     this.shareTrack = shareTrack;
+  }
+
+  setRemoteQualityLevel(remoteQualityLevel) {
+    this.remoteQualityLevel = remoteQualityLevel;
   }
 
   setRemoteStream(remoteStream) {

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2180,7 +2180,10 @@ export default class Meeting extends StatelessWebexPlugin {
 
         return this.preMedia(localStream, localShare, mediaSettings);
       })
-      .then(() => Media.attachMedia(this.mediaProperties, this.id)
+      .then(() => Media.attachMedia(this.mediaProperties, {
+        meetingId: this.id,
+        remoteQualityLevel: this.mediaProperties.remoteQualityLevel
+      })
         .then((peerConnection) => {
           LoggerProxy.logger.log(`Meeting:index->addMedia#PeerConnection Received from attachMedia ${peerConnection}`);
           this.setRemoteStream(peerConnection);
@@ -2269,7 +2272,10 @@ export default class Meeting extends StatelessWebexPlugin {
 
     return MeetingUtil.validateOptions(options)
       .then(() => this.preMedia(localStream, localShare, mediaSettings))
-      .then(() => Media.updateMedia(this.mediaProperties, this.id)
+      .then(() => Media.updateMedia(this.mediaProperties, {
+        meetingId: this.id,
+        remoteQualityLevel: this.mediaProperties.remoteQualityLevel
+      })
         .then((peerConnection) => {
           LoggerProxy.logger.log(`Meeting:index->updateMedia#PeerConnection received from updateMedia, ${peerConnection}`);
           this.setRemoteStream(peerConnection);
@@ -2859,6 +2865,6 @@ export default class Meeting extends StatelessWebexPlugin {
     // Set the quality level in properties
     this.mediaProperties.setRemoteQualityLevel(level);
 
-    return this.updateMedia();
+    return this.updateMedia({mediaSettings: this.mediaProperties.mediaDirection});
   }
 }

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -43,6 +43,7 @@ import {
   FULL_STATE,
   MEETING_REMOVED_REASON,
   SDP,
+  QUALITY_LEVELS,
   VIDEO_RESOLUTIONS
 } from '../constants';
 import ParameterError from '../common/errors/parameter';
@@ -2829,5 +2830,35 @@ export default class Meeting extends StatelessWebexPlugin {
           receiveVideo: true,
           stream: localStream
         }));
+  }
+
+  /**
+   * Sets the quality level of the remote incoming media
+   * @param {String} level {LOW|MEDIUM|HIGH}
+   * @returns {Promise}
+   */
+  setRemoteQualityLevel(level) {
+    LoggerProxy.logger.log(`Meeting:index#setRemoteQualityLevel --> Setting quality to ${level}`);
+
+    if (!QUALITY_LEVELS[level]) {
+      const errorMessage = `Meeting:index#setRemoteQualityLevel --> ${level} not defined`;
+
+      LoggerProxy.logger.error(errorMessage);
+
+      return Promise.reject(new Error(errorMessage));
+    }
+
+    if (!this.mediaProperties.mediaDirection.receiveAudio && !this.mediaProperties.mediaDirection.receiveVideo) {
+      const errorMessage = 'Meeting:index#setRemoteQualityLevel --> unable to change remote quality, receiveVideo and receiveAudio is disabled';
+
+      LoggerProxy.logger.error(errorMessage);
+
+      return Promise.reject(new Error(errorMessage));
+    }
+
+    // Set the quality level in properties
+    this.mediaProperties.setRemoteQualityLevel(level);
+
+    return this.updateMedia();
   }
 }

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -271,13 +271,16 @@ MeetingUtil.updateTransceiver = (options, meetingOptions) => {
 
   if ((sendTrack !== undefined && sendTrack !== previousMediaDirection.sendTrack) ||
   (receiveTrack !== undefined && receiveTrack !== previousMediaDirection.receiveTrack)) {
-    return Media.updateTransceiver(meetingOptions.id, peerConnection, transceiver,
-      {
-        track,
-        type,
-        receiveTrack,
-        sendTrack
-      })
+    return Media.updateTransceiver({
+      meetingId: meetingOptions.meeting.id,
+      remoteQualityLevel: meetingOptions.mediaProperties.remoteQualityLevel
+    }, peerConnection, transceiver,
+    {
+      track,
+      type,
+      receiveTrack,
+      sendTrack
+    })
       .then(() => meetingOptions.meeting.roap
         .sendRoapMediaRequest({
           sdp: meetingOptions.mediaProperties.peerConnection.sdp,

--- a/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
@@ -18,12 +18,15 @@ import {
   ICE_STATE,
   ICE_FAIL_TIMEOUT,
   PEER_CONNECTION_STATE,
-  OFFER
+  OFFER,
+  QUALITY_LEVELS,
+  MAX_FRAMESIZES
 } from '../constants';
 
 import {error, eventType} from '../metrics/config'
 
 import MediaError from '../common/errors/media';
+import ParameterError from '../common/errors/parameter';
 
 /**
  * @export
@@ -32,8 +35,8 @@ import MediaError from '../common/errors/media';
 const pc = {};
 
 /**
- * munges the bandwidth limit into the sdp 
- * @param {String} sdpLines 
+ * munges the bandwidth limit into the sdp
+ * @param {String} sdpLines
  * @param {Number} index
  * @returns {String}
  */
@@ -52,20 +55,25 @@ const insertBandwidthLimit = (sdpLines, index) => {
 
 /**
  * needed for calliope max-fs
- * @param {String} sdp 
+ * @param {String} sdp
+ * @param {String} [level=QUALITY_LEVELS.HIGH] quality level for max-fs
  * @returns {String}
  */
-const setMaxFs = (sdp) => {
+const setMaxFs = (sdp, level = QUALITY_LEVELS.HIGH) => {
+  if (!MAX_FRAMESIZES[level]) {
+    throw new ParameterError(`setMaxFs: unable to set max framesize, value for level "${level}" is not defined`)
+  }
   // eslint-disable-next-line no-warning-comments
   // TODO convert with sdp parser, no munging
   let replaceSdp = sdp;
-  replaceSdp = replaceSdp.replace(/(\na=fmtp:(\d+).*level-asymmetry-allowed=1.*)/gi, `$1;${SDP.MAX_FS_8160}`)
+  const maxFsLine = `${SDP.MAX_FS}${MAX_FRAMESIZES[level]}`
+  replaceSdp = replaceSdp.replace(/(\na=fmtp:(\d+).*level-asymmetry-allowed=1.*)/gi, `$1;${maxFsLine}`)
   return replaceSdp;
 };
 
 /**
  * checks that sdp has h264 codec in it
- * @param {String} sdp 
+ * @param {String} sdp
  * @returns {boolean}
  */
 const checkH264Support = (sdp) => {
@@ -105,7 +113,7 @@ const validateSdp = (sdp) => {
 
 /**
  * munges the bandwidth into the sdp
- * @param {String} sdp 
+ * @param {String} sdp
  * @returns {String}
  */
 const limitBandwidth = (sdp) => {

--- a/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
@@ -190,14 +190,16 @@ pc.setContentSlides = (screenPc) => {
 /**
  * handles ice trickling and establishes ICE connection onto peer connection object
  * @param {Object} peerConnection
+ * @param {Object} options
+ * @param {String} options.remoteQualityLevel
  * @returns {RTCPeerConnection}
  */
-pc.iceCandidate = (peerConnection) =>
+pc.iceCandidate = (peerConnection, {remoteQualityLevel}) =>
   new Promise((resolve) => {
     // TODO: we dont need timeout as we can check the api state and validate.
     const timeout = setTimeout(() => {
       peerConnection.sdp = limitBandwidth(peerConnection.localDescription.sdp);
-      peerConnection.sdp = setMaxFs(peerConnection.sdp);
+      peerConnection.sdp = setMaxFs(peerConnection.sdp, remoteQualityLevel);
       peerConnection.sdp = peerConnection.sdp.replace(/\na=extmap.*/g, '');
 
       if (!validateSdp(peerConnection.sdp)) {
@@ -212,7 +214,7 @@ pc.iceCandidate = (peerConnection) =>
     peerConnection.onicecandidate = (evt) => {
       if (!evt.candidate && !peerConnection.sdp) {
         peerConnection.sdp = limitBandwidth(peerConnection.localDescription.sdp);
-        peerConnection.sdp = setMaxFs(peerConnection.sdp);
+        peerConnection.sdp = setMaxFs(peerConnection.sdp, remoteQualityLevel);
         peerConnection.sdp = peerConnection.sdp.replace(/\na=extmap.*/g, '');
 
         if (evt.candidate === null) {
@@ -329,10 +331,12 @@ pc.setRemoteSessionDetails = (peerConnection, typeStr, remoteSdp, meetingId) => 
 /**
  * create offer with a valid paramater
  * @param {Object} params
- * @param {Object} meetingId
+ * @param {Object} meetingProperties
+ * @param {string} meetingProperties.meetingId
+ * @param {string} meetingProperties.remoteQualityLevel LOW|MEDIUM|HIGH
  * @returns {RTCPeerConnection}
  */
-pc.createOffer = (peerConnection, meetingId) => {
+pc.createOffer = (peerConnection, {meetingId, remoteQualityLevel}) => {
   LoggerProxy.logger.log('PeerConnectionManager->createOffer#createOffer: creating a new offer');
 
   try {
@@ -340,17 +344,17 @@ pc.createOffer = (peerConnection, meetingId) => {
       .createOffer()
       .then((description) => {
         // bug https://bugs.chromium.org/p/chromium/issues/detail?id=1020642
-        // chrome currently generates RTX line irrespective of weither the server side supports it 
+        // chrome currently generates RTX line irrespective of weither the server side supports it
         // we are removing apt as well because its associated with rtx line
-        
+
         description.sdp = description.sdp.replace(/\r\na=rtpmap:\d+ rtx\/\d+/g, '');
         description.sdp = description.sdp.replace(/\r\na=fmtp:\d+ apt=\d+/g, '');
         peerConnection.setLocalDescription(description)
       })
-      .then(() => pc.iceCandidate(peerConnection))
+      .then(() => pc.iceCandidate(peerConnection, {remoteQualityLevel}))
       .then(() => {
         peerConnection.sdp = limitBandwidth(peerConnection.localDescription.sdp);
-        peerConnection.sdp = setMaxFs(peerConnection.sdp);
+        peerConnection.sdp = setMaxFs(peerConnection.sdp, remoteQualityLevel);
         if (!checkH264Support(peerConnection.sdp)) {
           throw new MediaError('openH264 is downloading please Wait. Upload logs if not working on second try');
         }
@@ -359,19 +363,20 @@ pc.createOffer = (peerConnection, meetingId) => {
 
         Metrics.postEvent({
           event: eventType.LOCAL_SDP_GENERATED,
-          meetingId: meetingId})
+          meetingId
+        });
         return peerConnection;
       })
       .catch((err) => {
         Metrics.postEvent({
           event: eventType.LOCAL_SDP_GENERATED,
-          meetingId: meetingId,
+          meetingId,
           data: {
             canProceed: false,
              errors: [
                Metrics.generateErrorPayload(2001, true,
               error.name.MEDIA_ENGINE)]
-        }})
+        }});
         pc.close(peerConnection);
         throw err;
       });
@@ -396,15 +401,16 @@ pc.rollBackLocalDescription = (peerConnection) => {
 
 /**
  * @param {Object} params {
- *  offerToReceiveAudio: {Boolean} sdp constraints
- *  offerToReceiveVideo: {Boolean} sdp constraints
- *  offerSdp: {sdp}
- *  stream: {pcStream}
- * }
- * @param {Object} meetingId meetingId for sending metrics 
- * @returns {Array} [MediaSDP, ScreenSDP]
+ * @param {Boolean} params.offerToReceiveAudio
+ * @param {Boolean} params.offerToReceiveVideo
+ * @param {string} params.offerSdp
+ * @param {MediaStream} params.stream
+ * @param {Object} meetingProperties
+ * @param {string} meetingProperties.meetingId
+ * @param {string} meetingProperties.remoteQualityLevel LOW|MEDIUM|HIGH
+ * @returns {Promise.<Array>} [MediaSDP, ScreenSDP]
  */
-pc.updatePeerConnection = (params, meetingId) => {
+pc.updatePeerConnection = (params, {meetingId, remoteQualityLevel}) => {
   LoggerProxy.logger.log(`PeerConnectionManager->updatePeerConnection#updating the peerConnection with params: ${params}`);
 
   const {peerConnection, offerSdp} = params;
@@ -412,22 +418,23 @@ pc.updatePeerConnection = (params, meetingId) => {
   return pc.createAnswer({
     peerConnection,
       offerSdp: offerSdp[0]
-    }, meetingId).then((peerconnection) => {
-      // The content slides should also be set when we are sending inactive 
+    }, {meetingId, remoteQualityLevel}).then((peerconnection) => {
+      // The content slides should also be set when we are sending inactive
       pc.setContentSlides(peerconnection);
     return Promise.resolve([peerconnection.sdp]);
   });
 };
 
 /**
- *  @param {Object} params {
- *  peerConnection: {Object} peerConnection
- *  sdpConstraints: {Object} sdp constraints
- * }
- * @param {Object} meetingId meetingId for metrics
+ * @param {Object} params
+ * @param {Object} params.peerConnection
+ * @param {Object} params.sdpConstraints
+ * @param {Object} meetingProperties
+ * @param {string} meetingProperties.meetingId
+ * @param {string} meetingProperties.remoteQualityLevel LOW|MEDIUM|HIGH
  * @returns {RTCPeerConnection} peerConnection
  */
-pc.createAnswer = (params, meetingId) => {
+pc.createAnswer = (params, {meetingId, remoteQualityLevel}) => {
   const {peerConnection} = params;
 
   // TODO: Some times to many mercury event comes at the same time
@@ -444,10 +451,10 @@ pc.createAnswer = (params, meetingId) => {
       //   }
       peerConnection.setLocalDescription(answer)
     )
-    .then(() => pc.iceCandidate(peerConnection))
+    .then(() => pc.iceCandidate(peerConnection, {remoteQualityLevel}))
     .then(() => {
       peerConnection.sdp = limitBandwidth(peerConnection.localDescription.sdp);
-      peerConnection.sdp = setMaxFs(peerConnection.sdp);
+      peerConnection.sdp = setMaxFs(peerConnection.sdp, remoteQualityLevel);
       if (!checkH264Support(peerConnection.sdp)) {
         throw new MediaError('openH264 is downloading please Wait. Upload logs if not working on second try');
       }

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -152,11 +152,14 @@ export default class ReconnectionManager {
     let promise = null;
 
     if (recreate) {
-      promise = Media.attachMedia(meeting.mediaProperties)
+      promise = Media.attachMedia(meeting.mediaProperties, {
+        meetingId: meeting.id,
+        remoteQualityLevel: meeting.mediaProperties.remoteQualityLevel
+      })
         .then((peerConnection) => meeting.setRemoteStream(peerConnection));
     }
     else {
-      promise = Media.reconnectMedia(meeting.mediaProperties.peerConnection, meeting.meetingId);
+      promise = Media.reconnectMedia(meeting.mediaProperties.peerConnection, meeting);
     }
 
     return Promise.resolve(promise)

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/util.js
@@ -47,7 +47,10 @@ RoapUtil.updatePeerConnection = (meeting, session) => PeerConnectionManager.upda
   offerSdp: session.OFFER.sdps,
   peerConnection: meeting.mediaProperties.peerConnection
 },
-meeting.id)
+{
+  meetingId: meeting.id,
+  remoteQualityLevel: meeting.mediaProperties.remoteQualityLevel
+})
   .then((res) => {
     meeting.roap.lastRoapOffer = session.OFFER.sdps;
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -664,6 +664,37 @@ describe('plugin-meetings', () => {
           assert.isRejected(meeting.setLocalVideoQuality('LOW'));
         });
       });
+
+      describe('#setRemoteQualityLevel', () => {
+        let mediaDirection;
+
+        beforeEach(() => {
+          mediaDirection = {receiveAudio: true, receiveVideo: true, receiveShare: false};
+          meeting.updateMedia = sinon.stub().returns(Promise.resolve());
+          meeting.mediaProperties.mediaDirection = mediaDirection;
+        });
+
+        it('should have #setRemoteQualityLevel', () => {
+          assert.exists(meeting.setRemoteQualityLevel);
+        });
+
+        it('should set mediaProperty with the proper level', () => meeting.setRemoteQualityLevel(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
+          assert.equal(meeting.mediaProperties.remoteQualityLevel, CONSTANTS.QUALITY_LEVELS.LOW);
+        }));
+
+        it('should call updateMedia', () => meeting.setRemoteQualityLevel(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
+          assert.calledOnce(meeting.updateMedia);
+        }));
+
+        it('should error if set to a invalid level', () => {
+          assert.isRejected(meeting.setRemoteQualityLevel('invalid'));
+        });
+
+        it('should error if receiveVideo is set to false', () => {
+          meeting.mediaProperties.mediaDirection = {receiveVideo: false};
+          assert.isRejected(meeting.setRemoteQualityLevel('LOW'));
+        });
+      });
     });
     describe('Public Event Triggers', () => {
       describe('#reconnect', () => {

--- a/packages/node_modules/samples/browser-plugin-meetings/app.js
+++ b/packages/node_modules/samples/browser-plugin-meetings/app.js
@@ -1290,6 +1290,16 @@ document.getElementById('setMeetingQuality').addEventListener('click', () => {
   }
 });
 
+document.getElementById('setRemoteMeetingQuality')
+  .addEventListener('click', () => {
+    if (meeting) {
+      const level =
+        document.getElementById('setRemoteMeetingQualityLevel').value;
+
+      meeting.setRemoteQualityLevel(level);
+    }
+  });
+
 function handleJoinIntent(err, meeting, deviceId) {
   if (err.joinIntentRequired) {
     toggleDisplay('joinAsHostOrGuest', true);

--- a/packages/node_modules/samples/browser-plugin-meetings/index.html
+++ b/packages/node_modules/samples/browser-plugin-meetings/index.html
@@ -309,6 +309,15 @@
           </select>
           <button id="setMeetingQuality" title="meeting.setLocalVideoQuality()" type="button">meeting.setLocalVideoQuality()</button>
         </p>
+        <p>
+          <label for="setRemoteMeetingQualityLevel">Set Remote Quality Level</label>
+          <select id="setRemoteMeetingQualityLevel" name="setRemoteMeetingQualityLevel">
+            <option value="LOW">LOW</option>
+            <option value="MEDIUM">MEDIUM</option>
+            <option value="HIGH">HIGH</option>
+          </select>
+          <button id="setRemoteMeetingQuality" title="meeting.setRemoteQualityLevel()" type="button">meeting.setRemoteQualityLevel()</button>
+        </p>
       </fieldset>
     </form>
     <button id="charting" title="charting" type="button">start charting getStats</button>


### PR DESCRIPTION
# Pull Request Template

## Description

This adds the `meeting.setRemoteQualityLevel` function. This will set the quality level in the meeting's mediaProperties object, then calls `updateMedia` to set the max framesize of the offer.

Fixes # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-133788

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

