### PR TITLE
Use enumerateDevices to check if Device Permissions match media constraints

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2109,19 +2109,46 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   getMediaStreams = (mediaDirection, audioVideo = {}, sharePreferences) => {
-    if (mediaDirection && (mediaDirection.sendAudio || mediaDirection.sendVideo || mediaDirection.sendShare)) {
-      return Media.getUserMedia(mediaDirection, audioVideo, sharePreferences)
+    if (
+      mediaDirection &&
+      (
+        mediaDirection.sendAudio ||
+        mediaDirection.sendVideo ||
+        mediaDirection.sendShare
+      )
+    ) {
+      return Media.getSupportedDevice({
+        sendAudio: mediaDirection.sendAudio,
+        sendVideo: mediaDirection.sendVideo
+      })
+        .catch((error) => Promise.reject(
+          new MediaError('Given constraints do not match permission set for either camera or microphone', error)
+        ))
+        .then((devicePermissions) =>
+          Media.getUserMedia(
+            {
+              ...mediaDirection,
+              sendAudio: (mediaDirection.sendAudio === devicePermissions.sendAudio),
+              sendVideo: (mediaDirection.sendVideo === devicePermissions.sendVideo)
+            },
+            audioVideo,
+            sharePreferences
+          ))
         .then((response) => {
           if (!response[0] && !response[1]) {
-            return Promise.reject(new MediaError('Was not able to retrive media Stream'));
+            return Promise.reject(
+              new MediaError('Was not able to retrieve media Stream')
+            );
           }
 
           return Promise.resolve(response);
         });
     }
 
-    return Promise.reject(new MediaError('Atleaset one of the mediaDirection value should be true'));
-  }
+    return Promise.reject(
+      new MediaError('At least one of the mediaDirection value should be true')
+    );
+  };
 
   /**
    * Get the devices from the Media module

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -6,12 +6,11 @@ import sinon from 'sinon';
 
 import testUtils from './testUtils';
 
-
 require('dotenv').config();
 
 const webexTestUsers = require('./webex-test-users');
 
-let userSet, alice, bob, chris;
+let userSet, alice, bob, chris, enumerateSpy;
 
 skipInNode(describe)('plugin-meetings', () => {
   describe('journey', () => {
@@ -34,6 +33,14 @@ skipInNode(describe)('plugin-meetings', () => {
         console.log(error);
         throw error;
       }));
+
+    before(() => {
+      enumerateSpy = sinon.spy(navigator.mediaDevices, 'enumerateDevices');
+    });
+
+    beforeEach(() => {
+      enumerateSpy.resetHistory();
+    });
 
     describe('Check configuration values', () => {
       it('properly sets the Media Quality Analyzer `metrics` config', () => {
@@ -199,7 +206,8 @@ skipInNode(describe)('plugin-meetings', () => {
           testUtils.waitForEvents([
             {scope: alice.meeting, event: 'meeting:media:local:start', user: alice}
           ])
-        ])));
+        ]))
+        .then(() => assert(enumerateSpy.calledOnce)));
 
       it('bob joins the meeting', () => {
         bob.meeting.acknowledge('INCOMING');
@@ -226,6 +234,7 @@ skipInNode(describe)('plugin-meetings', () => {
             assert.exists(alice.meeting.members.locusUrl);
             assert.equal(alice.meeting.type, 'CALL');
             assert.equal(bob.meeting.type, 'CALL');
+            assert(enumerateSpy.calledOnce);
           })
           .then(function bobState() {
             testUtils.waitForStateChange(bob.meeting, 'JOINED');
@@ -515,7 +524,8 @@ skipInNode(describe)('plugin-meetings', () => {
               assert.equal(alice.meeting.members.membersCollection.get(chris.meeting.members.selfId).participant.state, 'JOINED');
             })
             .then(() => testUtils.waitForStateChange(chris.meeting, 'JOINED'))
-            .then(() => testUtils.addMedia(chris));
+            .then(() => testUtils.addMedia(chris))
+            .then(() => assert(enumerateSpy.calledOnce));
         })
         .then(() => Promise.all([
           testUtils.delayedPromise(chris.meeting.leave()),

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -340,8 +340,11 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.getMediaStreams);
         });
         it('should proxy Media getUserMedia, and return a promise', async () => {
+          Media.getSupportedDevice = sinon.stub().returns(Promise.resolve({sendAudio: true, sendVideo: true}));
           Media.getUserMedia = sinon.stub().returns(Promise.resolve(['stream1', 'stream2']));
+
           await meeting.getMediaStreams({sendAudio: true, sendVideo: true});
+
           assert.calledOnce(Media.getUserMedia);
         });
       });


### PR DESCRIPTION
## Description

Check if camera and mic exists/have permissions and then check against given getUserMedia constraints

Fixes [SPARK-132100](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-132100)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
