### PR TITLE
fix(plugin-meetings): fix hydra person id support

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js
@@ -185,6 +185,11 @@ MeetingInfoUtil.generateOptions = async (from) => {
     return MeetingInfoUtil.getSipUriFromHydraPersonId(hydraId.destination, webex).then((res) => {
       options.destination = res;
 
+      // Since hydra person ids require a unique case in which they are
+      // entirely converted to a SIP URI, we need to set a flag for detecting
+      // this type of destination.
+      options.wasHydraPerson = true;
+
       return Promise.resolve(options);
     });
   }

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -465,32 +465,53 @@ export default class Meetings extends WebexPlugin {
      * Create a meeting.
      * @param {string} destination - sipURL, spaceId, phonenumber, meeting link, or locus object}
      * @param {string} [type] - the optional specified type, such as locusId
-     * @returns {Promise} A new Meeting.
+     * @returns {Promise<Meeting>} A new Meeting.
      * @public
      * @memberof Meetings
      */
     create(destination, type = null) {
       // TODO: type should be from a dictionary
-      // Check if there is already meeting
-      const meeting = this.meetingCollection.getByKey(SIP_URI, destination);
 
-      if (!meeting) {
-        return this.createMeeting(destination, type)
-          .then((meeting) => {
-            if (meeting && meeting.on) {
-              meeting.on(EVENTS.DESTROY_MEETING, (payload) => {
-                this.destroy(payload.meetingId, payload.reason);
+      // Validate meeting information based on the provided destination and
+      // type. This must be performed prior to determining if the meeting is
+      // found in the collection, as we mutate the destination for hydra person
+      // id values.
+      return this.meetingInfo.fetchInfoOptions(destination, type)
+        // Catch a failure to fetch info options.
+        .catch((error) => {
+          LoggerProxy.logger.info(`meetings->create#INFO, unable to determine info options: ${error.message}`);
+        })
+        .then((options = {}) => {
+          // Normalize the destination.
+          const targetDest = options.wasHydraPerson ? options.destination : destination;
+
+          // Attempt to collect the meeting if it exists.
+          const meeting = this.meetingCollection.getByKey(SIP_URI, targetDest);
+
+          // Validate if a meeting was found.
+          if (!meeting) {
+            // Create a meeting based on the normalized destination and type.
+            return this.createMeeting(targetDest, type)
+              .then((createdMeeting) => {
+                // If the meeting was successfully created.
+                if (createdMeeting && createdMeeting.on) {
+                  // Create a destruction event for the meeting.
+                  createdMeeting.on(EVENTS.DESTROY_MEETING, (payload) => {
+                    this.destroy(payload.meetingId, payload.reason);
+                  });
+                }
+                else {
+                  LoggerProxy.logger.error(`meetings->create#ERROR, meeting does not have on method, will not be destroyed, meeting cleanup impossible for meeting: ${meeting}`);
+                }
+
+                // Return the newly created meeting.
+                return Promise.resolve(createdMeeting);
               });
-            }
-            else {
-              LoggerProxy.logger.error(`meetings->create#ERROR, meeting does not have on method, will not be destroyed, meeting cleanup impossible for meeting: ${meeting}`);
-            }
+          }
 
-            return Promise.resolve(meeting);
-          });
-      }
-
-      return Promise.resolve(meeting);
+          // Return the existing meeting.
+          return Promise.resolve(meeting);
+        });
     }
 
     /**

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/util.js
@@ -1,0 +1,29 @@
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import MeetingInfoUtil from '@webex/plugin-meetings/src/meeting-info/util';
+
+describe('plugin-meetings', () => {
+  describe('meeting-info#util', () => {
+    describe('#generateOptions()', () => {
+      it('should resolve with a \'wasHydraPerson\' key:value when provided a hydra person Id', () => {
+        const getSipUriFromHydraPersonId = sinon
+          .stub(MeetingInfoUtil, 'getSipUriFromHydraPersonId')
+          .resolves('example-destination');
+
+        const isConversationUrl = sinon
+          .stub(MeetingInfoUtil, 'isConversationUrl')
+          .returns(false);
+
+        return MeetingInfoUtil.generateOptions({
+          destination: 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS81NTU1NTU1NS01NTU1LTU1NTUtODU1NS01NTU1NTU1NTU1NTU='
+        })
+          .then(({wasHydraPerson}) => {
+            assert.isTrue(wasHydraPerson);
+
+            getSipUriFromHydraPersonId.restore();
+            isConversationUrl.restore();
+          });
+      });
+    });
+  });
+});

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -300,12 +300,39 @@ skipInBrowser(describe)('plugin-meetings', () => {
         });
       });
       describe('#create', () => {
+        let infoOptions;
+
         it('should have #create', () => {
           assert.exists(webex.meetings.create);
         });
         beforeEach(() => {
+          infoOptions = {
+            destination: 'dest-example',
+            type: 'type-example'
+          };
+
           webex.meetings.createMeeting = sinon.stub().returns(Promise.resolve({on: () => true}));
         });
+
+        it('should call MeetingInfo#fetchInfoOptions() with proper params',
+          () => {
+            webex.meetings.meetingInfo.fetchInfoOptions = sinon.stub().resolves(
+              infoOptions
+            );
+
+            return webex.meetings.create(
+              infoOptions.destination,
+              infoOptions.type
+            )
+              .then(() => {
+                assert.calledWith(
+                  webex.meetings.meetingInfo.fetchInfoOptions,
+                  infoOptions.destination,
+                  infoOptions.type
+                );
+              });
+          });
+
         it('calls createMeeting and returns its promise', async () => {
           const create = webex.meetings.create(test1, test2);
 


### PR DESCRIPTION
# Pull Request

## Description

The scope of the changes in this pull request are to fix the issue associated with using hydra person id values when utilizing `Meetings#create()`.

Fixes # [SPARK-134739](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-134739)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

- [x] Added additional tests to validate the changes work as expected.
- [x] Ran existing package tests to validate that they all pass.
- [x] Ran live testing to validate that the samples work in common scenarios.

**Test Configuration**:
* Node/Browser Version **v10.18.0**
* NPM Version **v6.13.4**

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
