### PR TITLE
docs(webex): fix init docs [skip ci]

### DIFF
--- a/packages/node_modules/webex/src/webex.js
+++ b/packages/node_modules/webex/src/webex.js
@@ -61,9 +61,7 @@ const Webex = WebexCore.extend({
  * @example
  * <caption>Create a new Webex instance configured for a Bot</caption>
  * const webex = Webex.init({
- *   config: {
- *     credentials: `<BOT TOKEN FROM DEVELOPER PORTAL>`
- *   }
+ *   credentials: `<BOT TOKEN FROM DEVELOPER PORTAL>`
  * });
  *
  *


### PR DESCRIPTION
Fixing the docs for `Webex.init` usage with an access token.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-136745