### PR TITLE
fix(webex-core): service to credentials auth url

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/lib/services/services.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/services.js
@@ -410,6 +410,15 @@ const Services = WebexPlugin.extend({
     const {idbroker, identity} = this.list(true);
 
     if (idbroker && identity) {
+      const {authorizationString, authorizeUrl} = this.webex.config.credentials;
+
+      // This must be set outside of the setConfig method used to assign the
+      // idbroker and identity url values.
+      this.webex.config.credentials.authorizeUrl = authorizationString ?
+        authorizeUrl :
+        `${idbroker.replace(trailingSlashes, '')}/idb/oauth2/v1/authorize`;
+
+
       this.webex.setConfig({
         credentials: {
           idbroker: {

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/services.js
@@ -238,6 +238,24 @@ describe('webex-core', () => {
       it('sets the identity url properly when a trailing slash is present', () => {
         assert.equal(webex.config.credentials.identity.url, expectedServiceList.identity);
       });
+
+      it('sets the authorize url properly when authorization string is not provided', () => {
+        assert.equal(
+          webex.config.credentials.authorizeUrl,
+          `${expectedServiceList.idbroker}/idb/oauth2/v1/authorize`
+        );
+      });
+
+      it('should retain the authorize url property when authorization string is provided', () => {
+        const authUrl = 'http://example-auth-url.com/resource';
+
+        webex.config.credentials.authorizationString = authUrl;
+        webex.config.credentials.authorizeUrl = authUrl;
+
+        services.updateCredentialsConfig();
+
+        assert.equal(webex.config.credentials.authorizeUrl, authUrl);
+      });
     });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

The scope of the changes in this pull request are focused around generating the credentials config value `authorizeUrl`. An earlier bug fix seemed to have impacted the federation status of this `authorizeUrl` value.

Fixes # [SPARK-137781](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-137781)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Generated new tests to validate that the added functionality works
- [x] Ran package tests

**Test Configuration**:
* Node/Browser Version v10.18.0
* NPM Version v6.13.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
