### PR TITLE
test(internal-conversation): rearrange post() tests to avoid failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,6 +495,11 @@ workflows:
           requires:
             - build_production
       - tap:
+          name: '@webex/internal-plugin-conversation tap'
+          package: '@webex/internal-plugin-conversation'
+          requires:
+            - build_production
+      - tap:
           name: '@webex/internal-plugin-encryption tap'
           package: '@webex/internal-plugin-encryption'
           requires:

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/verbs.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/verbs.js
@@ -217,93 +217,6 @@ describe('plugin-conversation', function () {
         message = 'mccoy, THIS IS A TEST MESSAGE';
         richMessage = `<webex-mention data-object-id="${mccoy.id}" data-object-type="person">mccoy</webex-mention>, THIS IS A TEST MESSAGE`;
       });
-      describe('when encryption key need to rotate', () => {
-        it('can post a plain text successfully', () => {
-          const {defaultActivityEncryptionKeyUrl} = conversation;
-
-          Promise.all([webex.request({
-            method: 'GET',
-            api: 'conversation',
-            resource: `/conversations/${conversation.id}/healed?resetKey=true`
-          }).then(() =>
-            webex.request({
-              method: 'GET',
-              api: 'conversation',
-              resource: `conversations/${conversation.id}`
-            }))])
-            .then((res) => {
-              res.body.defaultActivityEncryptionKeyUrl = defaultActivityEncryptionKeyUrl;
-
-              return webex.internal.conversation.post(res.body, message);
-            })
-            .then((res) => {
-              assert.notEqual(res.body.defaultActivityEncryptionKeyUrl, defaultActivityEncryptionKeyUrl);
-            });
-        });
-      });
-      it('posts a comment to the specified conversation', () => webex.internal.conversation.post(conversation, message)
-        .then((activity) => {
-          assert.isActivity(activity);
-
-          assert.isEncryptedActivity(activity);
-          assert.equal(activity.encryptionKeyUrl, conversation.defaultActivityEncryptionKeyUrl);
-
-          assert.equal(activity.object.displayName, message);
-        }));
-
-      it('updates the specified conversation\'s unread status', () => mccoy.webex.internal.conversation.get(conversation)
-        .then((c) => {
-          const {
-            lastSeenActivityDate,
-            lastReadableActivityDate
-          } = c;
-
-          return webex.internal.conversation.post(conversation, message)
-            .then(() => mccoy.webex.internal.conversation.get(conversation)
-              .then((c2) => {
-                assert.equal(c2.lastSeenActivityDate, lastSeenActivityDate);
-                assert.isAbove(Date.parse(c2.lastReadableActivityDate), Date.parse(lastReadableActivityDate));
-              }));
-        }));
-
-      it('posts rich content to the specified conversation', () => webex.internal.conversation.post(conversation, {
-        displayName: message,
-        content: richMessage
-      })
-        .then((activity) => {
-          assert.isActivity(activity);
-
-          assert.isEncryptedActivity(activity);
-          assert.equal(activity.encryptionKeyUrl, conversation.defaultActivityEncryptionKeyUrl);
-
-          assert.equal(activity.object.displayName, message);
-          assert.equal(activity.object.content, richMessage);
-        }));
-
-      it('submits mentions to the specified conversation', () => webex.internal.conversation.post(conversation, {
-        displayName: message,
-        content: richMessage,
-        mentions: {
-          items: [{
-            id: mccoy.id,
-            objectType: 'person'
-          }]
-        }
-      })
-        .then((activity) => {
-          assert.isActivity(activity);
-
-          assert.isEncryptedActivity(activity);
-          assert.equal(activity.encryptionKeyUrl, conversation.defaultActivityEncryptionKeyUrl);
-
-          assert.equal(activity.object.displayName, message);
-          assert.equal(activity.object.content, richMessage);
-
-          assert.isDefined(activity.object.mentions);
-          assert.isDefined(activity.object.mentions.items);
-          assert.lengthOf(activity.object.mentions.items, 1);
-          assert.equal(activity.object.mentions.items[0].id, mccoy.id);
-        }));
 
       // disable until helper-html has node support
       skipInNode(describe)('when there are html tags in rich messages', () => {
@@ -373,7 +286,7 @@ describe('plugin-conversation', function () {
                 return mccoy.webex.internal.conversation.get(conversation, {activitiesLimit: 1});
               })
               .then((convo) => {
-              // check latest message
+                // check latest message
                 const activity = find(convo.activities.items, {verb: 'post'});
 
                 assert.equal(activity.object.content, def.inboundMessage);
@@ -381,6 +294,95 @@ describe('plugin-conversation', function () {
           });
         });
       });
+
+      describe('when encryption key need to rotate', () => {
+        it('can post a plain text successfully', () => {
+          const {defaultActivityEncryptionKeyUrl} = conversation;
+
+          Promise.all([webex.request({
+            method: 'GET',
+            api: 'conversation',
+            resource: `/conversations/${conversation.id}/healed?resetKey=true`
+          }).then(() =>
+            webex.request({
+              method: 'GET',
+              api: 'conversation',
+              resource: `conversations/${conversation.id}`
+            }))])
+            .then((res) => {
+              res.body.defaultActivityEncryptionKeyUrl = defaultActivityEncryptionKeyUrl;
+
+              return webex.internal.conversation.post(res.body, message);
+            })
+            .then((res) => {
+              assert.notEqual(res.body.defaultActivityEncryptionKeyUrl, defaultActivityEncryptionKeyUrl);
+            });
+        });
+      });
+
+      it('posts a comment to the specified conversation', () => webex.internal.conversation.post(conversation, message)
+        .then((activity) => {
+          assert.isActivity(activity);
+
+          assert.isEncryptedActivity(activity);
+          assert.equal(activity.encryptionKeyUrl, conversation.defaultActivityEncryptionKeyUrl);
+
+          assert.equal(activity.object.displayName, message);
+        }));
+
+      it('updates the specified conversation\'s unread status', () => mccoy.webex.internal.conversation.get(conversation)
+        .then((c) => {
+          const {
+            lastSeenActivityDate,
+            lastReadableActivityDate
+          } = c;
+
+          return webex.internal.conversation.post(conversation, message)
+            .then(() => mccoy.webex.internal.conversation.get(conversation)
+              .then((c2) => {
+                assert.equal(c2.lastSeenActivityDate, lastSeenActivityDate);
+                assert.isAbove(Date.parse(c2.lastReadableActivityDate), Date.parse(lastReadableActivityDate));
+              }));
+        }));
+
+      it('posts rich content to the specified conversation', () => webex.internal.conversation.post(conversation, {
+        displayName: message,
+        content: richMessage
+      })
+        .then((activity) => {
+          assert.isActivity(activity);
+
+          assert.isEncryptedActivity(activity);
+          assert.equal(activity.encryptionKeyUrl, conversation.defaultActivityEncryptionKeyUrl);
+
+          assert.equal(activity.object.displayName, message);
+          assert.equal(activity.object.content, richMessage);
+        }));
+
+      it('submits mentions to the specified conversation', () => webex.internal.conversation.post(conversation, {
+        displayName: message,
+        content: richMessage,
+        mentions: {
+          items: [{
+            id: mccoy.id,
+            objectType: 'person'
+          }]
+        }
+      })
+        .then((activity) => {
+          assert.isActivity(activity);
+
+          assert.isEncryptedActivity(activity);
+          assert.equal(activity.encryptionKeyUrl, conversation.defaultActivityEncryptionKeyUrl);
+
+          assert.equal(activity.object.displayName, message);
+          assert.equal(activity.object.content, richMessage);
+
+          assert.isDefined(activity.object.mentions);
+          assert.isDefined(activity.object.mentions.items);
+          assert.lengthOf(activity.object.mentions.items, 1);
+          assert.equal(activity.object.mentions.items[0].id, mccoy.id);
+        }));
     });
 
     describe('#update()', () => {


### PR DESCRIPTION
This re-arranges the conversation plugin's integration tests because tests don't seem to idempotent.
By arranging them this way, tests that affected later test don't have an effect anymore. Tests seem to consistently pass at this  point.

<img width="673" alt="Screen Shot 2020-04-30 at 12 20 19 PM" src="https://user-images.githubusercontent.com/6610308/80750464-fd941500-8adc-11ea-978b-e39a6ab3d13b.png">