### PR TITLE
fix(plugin-logger): circular ref should not filter funcs or primatives

### DIFF
--- a/packages/node_modules/@webex/plugin-logger/src/logger.js
+++ b/packages/node_modules/@webex/plugin-logger/src/logger.js
@@ -47,7 +47,7 @@ const authTokenKeyPattern = /[Aa]uthorization/;
 function walkAndFilter(object, visited = []) {
   if (visited.includes(object)) {
     // Prevent circular references
-    return '[Circular]';
+    return object;
   }
 
   visited.push(object);

--- a/packages/node_modules/@webex/plugin-logger/test/unit/spec/logger.js
+++ b/packages/node_modules/@webex/plugin-logger/test/unit/spec/logger.js
@@ -409,7 +409,64 @@ describe('plugin-logger', () => {
       object.selfReference = object;
 
       webex.logger.log(object);
-      assert.calledWith(console.log, {Key: 'myKey', selfReference: '[Circular]', string: '-- REDACTED --'});
+
+      const expected = {
+        string: '-- REDACTED --',
+        Key: 'myKey'
+      };
+
+      expected.selfReference = expected;
+
+      assert.calledWith(console.log, expected);
+    });
+
+    it('handle circular references in complex objects', () => {
+      webex.config.logger.level = 'trace';
+
+      const func = () => true;
+      const sym = Symbol('foo');
+
+      const object = {
+        primativeString: 'justastring',
+        primativeNum: 5,
+        primativeBool: true,
+        primativeSymbol: sym,
+        myFunction: func,
+        subObject: {
+          subPrimativeString: 'justastring',
+          otherPrimativeString: 'otherstring',
+          subPrimativeNum: 5,
+          otherPrimativeNum: 6,
+          subPrimativeBool: true,
+          otherPrimativeBool: false,
+          subPrimativeSymbol: sym
+        }
+      };
+
+      object.subObject.circularObjectRef = object;
+      object.subObject.circularFunctionRef = func;
+      object.subObject.circularFunctionRef.cat = func;
+
+      webex.logger.log(object);
+
+      assert.calledWith(console.log, {
+        primativeString: 'justastring',
+        primativeNum: 5,
+        primativeBool: true,
+        primativeSymbol: sym,
+        myFunction: func,
+        subObject: {
+          subPrimativeString: 'justastring',
+          otherPrimativeString: 'otherstring',
+          subPrimativeNum: 5,
+          otherPrimativeNum: 6,
+          subPrimativeBool: true,
+          otherPrimativeBool: false,
+          subPrimativeSymbol: sym,
+          circularObjectRef: object,
+          circularFunctionRef: func
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
# Pull Request Template

## Description

Follow up to https://github.com/webex/webex-js-sdk/pull/1652. Noticed that while that PR fixed the recursive loop it also had an unintended side effect. Namely it caused issues like

> failed to execute Logger#warn RangeError [ERR_OUT_OF_RANGE]: The value of "defaultMaxListeners" is out of range. It must be a non-negative number. Received [Circular]

and

> uncaughtException TypeError: Function.prototype.apply was called on [Circular], which is a string and not a function

Realised that the original PR did not take into account primitives and functions were also being walked.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Added an enhanced unit test to cover this case.

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
