### PR TITLE
Refactor/create new meetings samples

### DIFF
--- a/packages/node_modules/samples/browser-meetings/index.html
+++ b/packages/node_modules/samples/browser-meetings/index.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Sample: Meetings</title>
+    <style>
+      body {
+        background-color: #eee;
+      }
+
+      section {
+        background-color: #fff;
+        padding: 1rem;
+        margin: 1rem;
+      }
+
+      .flex {
+        display: flex;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      video {
+        height: 20vh;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>THIS IS A WORK IN PROGRESS SAMPLE</h1>
+    <section>
+      <h2>Meetings</h2>
+      <p>[[APPLICATION DESCRIPTION]]</p>
+    </section>
+
+    <section>
+      <h2>Authentication</h2>
+      <p>[[AUTHENTICATION DESCRIPTION]]</p>
+      <form id="credentials">
+        <fieldset>
+          <legend>Credentials</legend>
+          <input id="access-token" name="accessToken" placeholder="Access Token" value="" type="text" />
+          <button id="access-token-save" type="button">Save</button>
+          <label id="access-token-status">[[CREDENTIALS STATUS]]</label>
+        </fieldset>
+      </form>
+
+      <br />
+
+      <form>
+        <fieldset>
+          <legend>Registration</legend>
+          <button id="registration-register" type="button">Register</button>
+          <button id="registration-unregister" type="button">Unregister</button>
+          <label id="registration-status">[[REGISTRATION STATUS]]</label>
+        </fieldset>
+      </form>
+    </section>
+
+    <section>
+      <h2>Meetings Management</h2>
+      <p>[[MEETINGS MANAGEMENT DESCRIPTION]]</p>
+      <form id="meetings-create">
+        <fieldset>
+          <legend>Create a Meeting</legend>
+          <input id="create-meeting-destination" name="createMeetingDestination" placeholder="Destination" value="" type="text" />
+          <button id="create-meeting-action" type="button">Create</button>
+        </fieldset>
+      </form>
+
+      <br />
+
+      <form id="meetings-list">
+        <fieldset>
+          <legend>Current Meetings List</legend>
+          <div>
+            <input id="meetings-join-b-hostpin" name="createMeetingHostpin" placeholder="Host PIN" value="" type="text" />
+            <input id="meetings-join-b-moderator" type="checkbox" />
+            <label>Join as Moderator</label>
+          </div>
+          <br />
+          <div>
+            <button id="meetings-join-a-wom" type="button" value="[[MEETING IDENTIFIER]]">Join Without Media</button>
+            <button id="meetings-join-a-wm" type="button" value="[[MEETING IDENTIFIER]]">Join With Media</button>
+            <label>[[MEETING IDENTIFIER]]</label>
+          </div>
+          <div>
+            <button id="meetings-join-b-wom" type="button" value="[[MEETING IDENTIFIER]]">Join Without Media</button>
+            <button id="meetings-join-b-wm" type="button" value="[[MEETING IDENTIFIER]]">Join With Media</button>
+            <label>[[MEETING IDENTIFIER]]</label>
+          </div>
+          <div>
+            <button id="meetings-join-c-wom" type="button" value="[[MEETING IDENTIFIER]]">Join Without Media</button>
+            <button id="meetings-join-c-wm" type="button" value="[[MEETING IDENTIFIER]]">Join With Media</button>
+            <label>[[MEETING IDENTIFIER]]</label>
+          </div>
+        </fieldset>
+      </form>
+
+      <br />
+
+      <form id="current-meeting">
+        <fieldset>
+          <legend>Current Joined Meeting</legend>
+          <button id="meetings-leave" type="button">Leave</button>
+          <label>[[CURRENT MEETING IDENTIFIER]]</label>
+        </fieldset>
+      </form>
+    </section>
+
+    <section>
+      <h2>Meeting Controls</h2>
+      <p>[[MEETING CONTROLS DESCRIPTION]]</p>
+      <form id="general-controls">
+        <fieldset>
+          <legend>General Controls</legend>
+          <div>
+            <button id="general-controls-lock" type="button">Lock Meeting</button>
+            <button id="general-controls-unlock" type="button">Unlock Meeting</button>
+            <label id="general-controls-lock-state">[[LOCK STATE]]</label>
+          </div>
+          <div>
+            <button id="general-controls-start-recording" type="button">Start Recording</button>
+            <button id="general-controls-stop-recording" type="button">Stop Recording</button>
+            <label id="general-controls-recording-state">[[RECORDING STATE]]</label>
+          </div>
+          <div>
+            <select id="general-controls-qualities">
+              <option value="LOW">Low</option>
+              <option value="MEDIUM">Medium</option>
+              <option value="HIGH">High</option>
+            </select>
+            <button id="general-controls-set-quality" type="button">Set Quality</button>
+            <label id="general-controls-quality">[[QUALITY STATE]]</label>
+          </div>
+          <div>
+            <input id="dtmf-tones" name="dtmfTones" placeholder="DTMF Tones" value="" type="text" />
+            <button id="dtmf-tones-send" type="button">Send</button>
+          </div>
+        </fieldset>
+      </form>
+
+      <br />
+
+      <form id="source-devices-controls">
+        <fieldset>
+          <legend>Source Devices</legend>
+          <div>
+            <select id="audio-input-devices">
+              <option value="DEVICEA">Device A</option>
+              <option value="DEVICEB">Device B</option>
+              <option value="DEVICEC">Device C</option>
+            </select>
+            <button id="set-audio-input-device" type="button">Set Audio Input Device</button>
+            <label id="audio-input-device">[[CURRENT AUDIO INPUT DEVICE]]</label>
+          </div>
+          <div>
+            <select id="audio-output-devices">
+              <option value="DEVICEA">Device A</option>
+              <option value="DEVICEB">Device B</option>
+              <option value="DEVICEC">Device C</option>
+            </select>
+            <button id="set-audio-output-device" type="button">Set Audio Output Device</button>
+            <label id="audio-output-device">[[CURRENT AUDIO OUTPUT DEVICE]]</label>
+          </div>
+          <div>
+            <select id="video-input-devices">
+              <option value="DEVICEA">Device A</option>
+              <option value="DEVICEB">Device B</option>
+              <option value="DEVICEC">Device C</option>
+            </select>
+            <button id="set-video-input-device" type="button">Set Video Input Device</button>
+            <label id="video-input-device">[[CURRENT VIDEO INPUT DEVICE]]</label>
+          </div>
+        </fieldset>
+      </form>
+
+      <br />
+
+      <form id="sending-sources-controls">
+        <fieldset>
+          <legend>Sending Sources</legend>
+          <div>
+            <button id="source-controls-send-audio" type="button">Toggle Sending Audio</button>
+            <label id="source-controls-sending-audio">[[SENDING AUDIO STATE]]</label>
+          </div>
+          <div>
+            <button id="source-controls-send-video" type="button">Toggle Sending Video</button>
+            <label id="source-controls-sending-video">[[SENDING VIDEO STATE]]</label>
+          </div>
+          <div>
+            <button id="source-controls-send-screenshare" type="button">Toggle Sending Screenshare</button>
+            <label id="source-controls-sending-screenshare">[[SENDING SCREENSHARE STATE]]</label>
+          </div>
+          <div>
+            <select id="source-controls-sending-qualities">
+              <option value="LOW">Low</option>
+              <option value="MEDIUM">Medium</option>
+              <option value="HIGH">High</option>
+            </select>
+            <button id="source-controls-set-sending-quality" type="button">Set Quality</button>
+            <label id="source-controls-sending-quality">[[SENDING QUALITY STATE]]</label>
+          </div>
+        </fieldset>
+      </form>
+
+      <br />
+
+      <form id="receiving-sources-controls">
+        <fieldset>
+          <legend>Receiving Sources</legend>
+          <div>
+            <button id="source-controls-receive-audio" type="button">Toggle Receiving Audio</button>
+            <label id="source-controls-receiving-audio">[[RECEIVING AUDIO STATE]]</label>
+          </div>
+          <div>
+            <button id="source-controls-receive-video" type="button">Toggle Receiving Video</button>
+            <label id="source-controls-receiving-video">[[RECEIVING VIDEO STATE]]</label>
+          </div>
+          <div>
+            <select id="source-controls-receiving-qualities">
+              <option value="LOW">Low</option>
+              <option value="MEDIUM">Medium</option>
+              <option value="HIGH">High</option>
+            </select>
+            <button id="source-controls-set-receiving-quality" type="button">Set Quality</button>
+            <label id="source-controls-receiving-quality">[[RECEIVING QUALITY STATE]]</label>
+          </div>
+        </fieldset>
+      </form>
+
+      <br />
+
+      <form id="participants">
+        <fieldset>
+          <legend>Participants</legend>
+          <div>
+            <input id="add-participant-query" name="participantQuery" placeholder="Email Address" value="" type="email" />
+            <button id="add-participant" type="button">Add</button>
+          </div>
+          <br />
+          <div>
+            <button id="participant-a-admit" type="button" value="[[PARTICIPANT ID]]">Admit</button>
+            <button id="participant-a-remove" type="button" value="[[PARTICIPANT ID]]">Remove</button>
+            <button id="participant-a-mute" type="button" value="[[PARTICIPANT ID]]">Mute</button>
+            <button id="participant-a-transfer-ownership" type="button" value="[[PARTICIPANT ID]]">Transfer Ownership To</button>
+            <label id="participant-a-id">[[PARTICIPANT ID]]</label>
+            <label id="participant-a-status">[[PARTICIPANT STATUS]]</label>
+            <label id="participant-a-name">[[PARTICIPANT NAME]]</label>
+          </div>
+          <div>
+            <button id="participant-b-admit" type="button" value="[[PARTICIPANT ID]]">Admit</button>
+            <button id="participant-b-remove" type="button" value="[[PARTICIPANT ID]]">Remove</button>
+            <button id="participant-b-mute" type="button" value="[[PARTICIPANT ID]]">Mute</button>
+            <button id="participant-b-transfer-ownership" type="button" value="[[PARTICIPANT ID]]">Transfer Ownership To</button>
+            <label id="participant-b-id">[[PARTICIPANT ID]]</label>
+            <label id="participant-b-status">[[PARTICIPANT STATUS]]</label>
+            <label id="participant-b-name">[[PARTICIPANT NAME]]</label>
+          </div>
+          <div>
+            <button id="participant-c-admit" type="button" value="[[PARTICIPANT ID]]">Admit</button>
+            <button id="participant-c-remove" type="button" value="[[PARTICIPANT ID]]">Remove</button>
+            <button id="participant-c-mute" type="button" value="[[PARTICIPANT ID]]">Mute</button>
+            <button id="participant-c-transfer-ownership" type="button" value="[[PARTICIPANT ID]]">Transfer Ownership To</button>
+            <label id="participant-c-id">[[PARTICIPANT ID]]</label>
+            <label id="participant-c-status">[[PARTICIPANT STATUS]]</label>
+            <label id="participant-c-name">[[PARTICIPANT NAME]]</label>
+          </div>
+          <br />
+          <button id="participants-update" type="button">Update Participants</button>
+        </fieldset>
+      </form>
+    </section>
+
+    <section>
+      <h2>Meetings Devices</h2>
+      <p>[[MEETINGS DEVICES DESCRIPTION]]</p>
+      <form id="current-device">
+        <fieldset>
+          <legend>Current Device</legend>
+          <label>[[CURRENT DEVICE IDENTIFIER && DETAILS]]</label>
+        </fieldset>
+      </form>
+
+      <br />
+
+      <form id="devices-list">
+        <fieldset>
+          <legend>Current Devices List</legend>
+          <div>
+            <button id="devices-select-a" type="button" value="[[DEVICE IDENTIFIER]]">Select</button>
+            <button id="devices-remove-a" type="button" value="[[DEVICE IDENTIFIER]]">Remove</button>
+            <label>[[DEVICE IDENTIFIER]]</label>
+          </div>
+          <div>
+            <button id="devices-select-b" type="button" value="[[DEVICE IDENTIFIER]]">Select</button>
+            <button id="devices-remove-b" type="button" value="[[DEVICE IDENTIFIER]]">Remove</button>
+            <label>[[DEVICE IDENTIFIER]]</label>
+          </div>
+          <div>
+            <button id="devices-select-c" type="button" value="[[DEVICE IDENTIFIER]]">Select</button>
+            <button id="devices-remove-c" type="button" value="[[DEVICE IDENTIFIER]]">Remove</button>
+            <label>[[DEVICE IDENTIFIER]]</label>
+          </div>
+        </fieldset>
+      </form>
+
+      <br />
+
+      <form id="find-devices">
+        <fieldset>
+          <legend>Find Devices</legend>
+          <div>
+            <input id="find-devices-query" name="searchQuery" placeholder="Device ID" value="" type="text" />
+            <button id="find-devices-action" type="button">Search</button>
+          </div>
+          <br />
+          <div>
+            <button id="found-device-a-select" type="button" value="[[DEVICE IDENTIFIER]]">Select</button>
+            <button id="found-device-a-send-pin" type="button" value="[[DEVICE IDENTIFIER]]">Send Pin</button>
+            <input id="found-device-a-pin" name="devicePin" placeholder="Device Pin" value="" type="text" />
+            <label>[[DEVICE IDENTIFIER]]</label>
+          </div>
+          <div>
+            <button id="found-device-b-select" type="button" value="[[DEVICE IDENTIFIER]]">Select</button>
+            <button id="found-device-b-send-pin" type="button" value="[[DEVICE IDENTIFIER]]">Send Pin</button>
+            <input id="found-device-b-pin" name="devicePin" placeholder="Device Pin" value="" type="text" />
+            <label>[[DEVICE IDENTIFIER]]</label>
+          </div>
+          <div>
+            <button id="found-device-c-select" type="button" value="[[DEVICE IDENTIFIER]]">Select</button>
+            <button id="found-device-c-send-pin" type="button" value="[[DEVICE IDENTIFIER]]">Send Pin</button>
+            <input id="found-device-c-pin" name="devicePin" placeholder="Device Pin" value="" type="text" />
+            <label>[[DEVICE IDENTIFIER]]</label>
+          </div>
+        </fieldset>
+      </form>
+
+      <br />
+
+      <form id="pmr-management">
+        <fieldset>
+          <legend>Personal Meeting Room</legend>
+          <input id="prm-id" name="PmrId" placeholder="PMR ID" value="" type="text" />
+          <input id="prm-pin" name="prmPin" placeholder="PMR PIN" value="" type="text" />
+          <button id="pmr-claim" type="button">Claim</button>
+          <p id="pmr-details">[[PERSONAL MEETING ROOM DETAILS]]</p>
+        </fieldset>
+      </form>
+    </section>
+    
+    <section>
+      <h2>Meeting Streams</h2>
+      <form id="streams">
+        <div class="flex">
+          <fieldset>
+            <legend>Local Video</legend>
+            <video id="local-video"></video>
+          </fieldset>
+
+          <fieldset>
+            <legend>Local Screenshare</legend>
+            <video id="local-screenshare"></video>
+          </fieldset>
+
+          <fieldset>
+            <legend>Remote Video</legend>
+            <video id="remote-video"></video>
+          </fieldset>
+
+          <fieldset>
+            <legend>Remote Screenshare</legend>
+            <video id="remote-screenshare"></video>
+          </fieldset>
+        </div>
+      </form>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
# Pull Request

## Description

The scope of this pull request is to implement the HTML frame needed to further migrate the functionality of the original meetings plugin samples to the new meetings samples. Note that all content within the `<section>` elements can be re-written based on the needs of each section, and the content of these areas are implemented to help provide a base shape for developers to implement against.

The sample can be viewed by running `npm run samples:serve`, then navigating to `https://localhost:8000/browser-meetings/`.

Fixes # [SPARK-142730](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-142730)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)