### PR TITLE
fix(samples): add all chars to dtmf input

### DIFF
--- a/packages/node_modules/samples/browser-plugin-meetings/index.html
+++ b/packages/node_modules/samples/browser-plugin-meetings/index.html
@@ -297,7 +297,7 @@
         <button id="destroyStats" title="stop filter getStats" type="button">stop getStats</button>
         <p>
           <label for="sendDtmfInput">Send DTMF Tones</label>
-          <input id="sendDtmfInput" name="sendDtmf" value="" placeholder="DTMF Numbers" type="number" />
+          <input id="sendDtmfInput" name="sendDtmf" value="" placeholder="DTMF Numbers" type="text" />
           <button id="sendDtmf" title="Send DTMF" type="button">Send DTMF</button>
         </p>
         <p>


### PR DESCRIPTION
# Pull Request

## Description

The changes in this request is scoped to allowing all characters into the input field for DTMF in the meetings sample.

Fixes # [SPARK-143416](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-143416)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
