### PR TITLE
Add `meeting.shareScreen` function

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/README.md
+++ b/packages/node_modules/@webex/plugin-meetings/README.md
@@ -471,11 +471,7 @@ meeting.unmuteVideo();
 
 ##### Start Sending a Share
 ```js
-// First get the local screen share stream
-const mediaStreams = await meeting.getMediaStreams(mediaSettings);
-const [localStream, localShare] = mediaStreams;
-// Then, update share
-meeting.updateShare({sendShare: true, receiveShare:true, stream: localShare})
+meeting.shareScreen();
 ```
 
 ##### Stop Sending a Share

--- a/packages/node_modules/@webex/plugin-meetings/src/media/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/index.js
@@ -320,7 +320,15 @@ Media.getDisplayMedia = (options, config) => {
       });
   }
 
-  return navigator.mediaDevices.getDisplayMedia({audio: options.sendAudio, video: options.sendShare ? shareConstraints : false});
+  const getDisplayMediaParams = {video: options.sendShare ? shareConstraints : false};
+
+  // safari doesn't support audio
+  // https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia
+  if (options.sendAudio && bowser.name.toLowerCase() !== 'safari') {
+    getDisplayMediaParams.audio = options.sendAudio;
+  }
+
+  return navigator.mediaDevices.getDisplayMedia(getDisplayMediaParams);
 };
 
 /**

--- a/packages/node_modules/@webex/plugin-meetings/src/media/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/index.js
@@ -276,12 +276,15 @@ Media.updateTransceiver = ({meetingId, remoteQualityLevel}, peerConnection, tran
 
 /**
  * generates share streams
- * @param {object} options parameter
- * @param {Object} options.sendAudio sendAudio: {Boolean} sendAudio constraints
- * @param {Object} options.sendShare sendShare: {Boolean} sendShare constraints
- * @param {Object} options.sharePreferences sharePreferences: {Object} Share constraints and share constraints
+ * @param {Object} options parameter
+ * @param {Boolean} options.sendAudio send audio from the display share
+ * @param {Boolean} options.sendShare send video from the display share
+ * @param {Object} options.sharePreferences
+ * @param {MediaTrackConstraints} options.sharePreferences.shareConstraints constraints to apply to video
+ *   @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints}
+ * @param {Boolean} options.sharePreferences.highFrameRate if shareConstraints isn't provided, set default values based off of this boolean
  * @param {Object} config SDK Configuration for meetings plugin
- * @returns {Object} {streams}
+ * @returns {Promise.<MediaStream>}
  */
 Media.getDisplayMedia = (options, config) => {
   const shareConstraints = options.sharePreferences && options.sharePreferences.shareConstraints || {
@@ -322,7 +325,7 @@ Media.getDisplayMedia = (options, config) => {
 
   const getDisplayMediaParams = {video: options.sendShare ? shareConstraints : false};
 
-  // safari doesn't support audio
+  // safari doesn't support sending screen share audio
   // https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia
   if (options.sendAudio && bowser.name.toLowerCase() !== 'safari') {
     getDisplayMediaParams.audio = options.sendAudio;

--- a/packages/node_modules/@webex/plugin-meetings/src/media/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/index.js
@@ -10,6 +10,7 @@ import {
   VIDEO_INPUT,
   PEER_CONNECTION_STATE
 } from '../constants';
+import Config from '../config';
 import PeerConnectionManager from '../peer-connection-manager';
 import ReconnectionError from '../common/errors/reconnection';
 import MediaError from '../common/errors/media';
@@ -286,14 +287,28 @@ Media.updateTransceiver = ({meetingId, remoteQualityLevel}, peerConnection, tran
  * @param {Object} config SDK Configuration for meetings plugin
  * @returns {Promise.<MediaStream>}
  */
-Media.getDisplayMedia = (options, config) => {
-  const shareConstraints = options.sharePreferences && options.sharePreferences.shareConstraints || {
-    cursor: 'always',
-    frameRate: options.sharePreferences && options.sharePreferences.highFrameRate ? config.videoShareFrameRate : config.screenFrameRate,
-    aspectRatio: config.aspectRatio,
-    width: options.sharePreferences && options.sharePreferences.highFrameRate ? config.resolution.idealWidth : config.screenResolution.idealWidth,
-    height: options.sharePreferences && options.sharePreferences.highFrameRate ? config.resolution.idealHeight : config.screenResolution.idealHeight
-  };
+Media.getDisplayMedia = (options, config = {}) => {
+  const shareConstraints =
+    options.sharePreferences && options.sharePreferences.shareConstraints ?
+      options.sharePreferences.shareConstraints :
+      {
+        cursor: 'always',
+        aspectRatio: Config.meetings.aspectRatio,
+        ...(options.sharePreferences && options.sharePreferences.highFrameRate ?
+          {
+            frameRate: Config.meetings.videoShareFrameRate,
+            height: Config.meetings.resolution.idealHeight,
+            width: Config.meetings.resolution.idealWidth
+          } :
+          {
+            frameRate: Config.meetings.screenFrameRate,
+            height: Config.meetings.screenResolution.idealHeight,
+            width: Config.meetings.screenResolution.idealWidth
+          }),
+        // Leave last to apply overrides
+        ...config
+      };
+
   // chrome and webkit based browsers (edge, safari) automatically adjust everything
   // and we have noticed higher quality with those browser types
   // firefox specifically has some issues with resolution and frame rate decision making

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -3093,10 +3093,13 @@ export default class Meeting extends StatelessWebexPlugin {
   shareScreen(options = {}) {
     LoggerProxy.logger.log('Meeting:index#shareScreen --> Getting local share');
 
-    const defaults = {sendShare: true, sendAudio: false};
-    const getDisplayMediaOptions = Object.assign({}, defaults, options);
+    const shareConstraints = {
+      sendShare: true,
+      sendAudio: false,
+      ...options
+    };
 
-    return Media.getDisplayMedia(getDisplayMediaOptions).then((shareStream) => {
+    return Media.getDisplayMedia(shareConstraints).then((shareStream) => {
       this.updateShare({
         sendShare: true,
         receiveShare: this.mediaProperties.mediaDirection.receiveShare,

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -3079,4 +3079,29 @@ export default class Meeting extends StatelessWebexPlugin {
         return Promise.reject(error);
       });
   }
+
+  /**
+  * @param {Object} options parameter
+  * @param {Boolean} options.sendAudio send audio from the display share
+  * @param {Boolean} options.sendShare send video from the display share
+  * @param {Object} options.sharePreferences
+  * @param {MediaTrackConstraints} options.sharePreferences.shareConstraints constraints to apply to video
+  *   @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints}
+  * @param {Boolean} options.sharePreferences.highFrameRate if shareConstraints isn't provided, set default values based off of this boolean
+  * @returns {Promise.<MediaStream>}
+  */
+  shareScreen(options = {}) {
+    LoggerProxy.logger.log('Meeting:index#shareScreen --> Getting local share');
+
+    const defaults = {sendShare: true, sendAudio: false};
+    const getDisplayMediaOptions = Object.assign({}, defaults, options);
+
+    return Media.getDisplayMedia(getDisplayMediaOptions).then((shareStream) => {
+      this.updateShare({
+        sendShare: true,
+        receiveShare: this.mediaProperties.mediaDirection.receiveShare,
+        stream: shareStream
+      });
+    });
+  }
 }

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -410,26 +410,19 @@ skipInNode(describe)('plugin-meetings', () => {
             })
         ])));
 
-      it('alice shares the screen with highFrameRate', () => alice.meeting.getMediaStreams({
-        sendShare: true
-      }, {}, {highFrameRate: true})
-        .then((response) => Promise.all([
-          testUtils.delayedPromise(alice.meeting.updateShare({
-            sendShare: true,
-            receiveShare: true,
-            stream: response[1]
-          })),
-          testUtils.waitForEvents([{scope: alice.meeting, event: 'meeting:startedSharingLocal'}]),
-          testUtils.waitForEvents([{scope: bob.meeting.members, event: 'members:update'}])
-            .then((response) => {
-              console.log('SCREEN SHARE RESPONSE ', JSON.stringify(response));
-            }),
-          testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
-            .then((response) => {
-              console.log('MEDIA:READY event ', response[0].result);
-              assert.equal(response[0].result.type === 'localShare', true);
-            })
-        ]))
+      it('alice shares the screen with highFrameRate', () => Promise.all([
+        testUtils.delayedPromise(alice.meeting.shareScreen({sharePreferences: {highFrameRate: true}})),
+        testUtils.waitForEvents([{scope: alice.meeting, event: 'meeting:startedSharingLocal'}]),
+        testUtils.waitForEvents([{scope: bob.meeting.members, event: 'members:update'}])
+          .then((response) => {
+            console.log('SCREEN SHARE RESPONSE ', JSON.stringify(response));
+          }),
+        testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
+          .then((response) => {
+            console.log('MEDIA:READY event ', response[0].result);
+            assert.equal(response[0].result.type === 'localShare', true);
+          })
+      ])
         .then(() => {
           // TODO: Re-eanable Safari when screensharing issues have been resolved
           if (!bowser.safari) {
@@ -454,26 +447,19 @@ skipInNode(describe)('plugin-meetings', () => {
           return testUtils.waitUntil(10000);
         }));
 
-      it('bob shares the screen', () => bob.meeting.getMediaStreams({
-        sendShare: true
-      }, {}, {highFrameRate: false})
-        .then((response) => Promise.all([
-          testUtils.delayedPromise(bob.meeting.updateShare({
-            sendShare: true,
-            receiveShare: true,
-            stream: response[1]
-          })),
-          testUtils.waitForEvents([{scope: bob.meeting, event: 'meeting:startedSharingLocal'}]),
-          testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update'}])
-            .then((response) => {
-              console.log('SCREEN SHARE RESPONSE ', JSON.stringify(response));
-            }),
-          testUtils.waitForEvents([{scope: bob.meeting, event: 'media:ready'}])
-            .then((response) => {
-              console.log('MEDIA:READY event ', response[0].result);
-              assert.equal(response[0].result.type === 'localShare', true);
-            })
-        ]))
+      it('bob shares the screen', () => Promise.all([
+        testUtils.delayedPromise(bob.meeting.shareScreen()),
+        testUtils.waitForEvents([{scope: bob.meeting, event: 'meeting:startedSharingLocal'}]),
+        testUtils.waitForEvents([{scope: alice.meeting.members, event: 'members:update'}])
+          .then((response) => {
+            console.log('SCREEN SHARE RESPONSE ', JSON.stringify(response));
+          }),
+        testUtils.waitForEvents([{scope: bob.meeting, event: 'media:ready'}])
+          .then((response) => {
+            console.log('MEDIA:READY event ', response[0].result);
+            assert.equal(response[0].result.type === 'localShare', true);
+          })
+      ])
         .then(() => {
           // TODO: Re-eanable Safari when screensharing issues have been resolved
           if (!bowser.safari) {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -536,7 +536,7 @@ describe('plugin-meetings', () => {
       });
       describe('#share', () => {
         it('should have #share', () => {
-          assert.exists(meeting.invite);
+          assert.exists(meeting.share);
         });
         beforeEach(() => {
           meeting.locusInfo.mediaShares = [{name: 'content', url: url1}];
@@ -551,6 +551,40 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.meetingRequest.changeMeetingFloor);
         });
       });
+
+      describe('#shareScreen', () => {
+        let mediaDirection;
+
+        it('should have #shareScreen', () => {
+          assert.exists(meeting.shareScreen);
+        });
+
+        beforeEach(() => {
+          mediaDirection = {sendAudio: true, sendVideo: true, sendShare: false};
+          meeting.mediaProperties.mediaDirection = mediaDirection;
+          Media.getDisplayMedia = sinon.stub().returns(Promise.resolve());
+          meeting.updateShare = sinon.stub().returns(Promise.resolve());
+        });
+
+        it('should call get display media', async () => {
+          await meeting.shareScreen();
+
+          assert.calledOnce(Media.getDisplayMedia);
+        });
+
+        it('should call updateShare', async () => {
+          await meeting.shareScreen();
+
+          assert.calledOnce(meeting.updateShare);
+        });
+
+        it('properly assigns default values', async () => {
+          await meeting.shareScreen({sharePreferences: {highFrameRate: true}});
+
+          assert.calledWith(Media.getDisplayMedia, {sendShare: true, sendAudio: false, sharePreferences: {highFrameRate: true}});
+        });
+      });
+
       describe('#stopShare', () => {
         it('should have #stopShare', () => {
           assert.exists(meeting.stopShare);

--- a/packages/node_modules/samples/browser-call-with-screenshare/app.js
+++ b/packages/node_modules/samples/browser-call-with-screenshare/app.js
@@ -251,26 +251,8 @@ document.getElementById('share-screen').addEventListener('click', () => {
   if (activeMeeting) {
     // First check if we can update
     waitForMediaReady(activeMeeting).then(() => {
-      const mediaSettings = {
-        receiveShare: true,
-        sendShare: true
-      };
-
-      console.info('SHARE-SCREEN: Preparing to share screen via `getMediaStreams`');
-      activeMeeting.getMediaStreams(mediaSettings)
-        // `[, localShare]` is grabbing index 1 from the mediaSettingsResultsArray
-        // and storing it in a variable called localShare.
-        .then((mediaSettingsResultsArray) => {
-          const [, localShare] = mediaSettingsResultsArray;
-
-          console.info('SHARE-SCREEN: Add local share via `updateShare`');
-
-          return activeMeeting.updateShare({
-            sendShare: true,
-            receiveShare: true,
-            stream: localShare
-          });
-        })
+      console.info('SHARE-SCREEN: Sharing screen via `shareScreen()`');
+      activeMeeting.shareScreen()
         .then(() => {
           console.info('SHARE-SCREEN: Screen successfully added to meeting.');
         })

--- a/packages/node_modules/samples/browser-plugin-meetings/app.js
+++ b/packages/node_modules/samples/browser-plugin-meetings/app.js
@@ -600,7 +600,6 @@ document.getElementById('updateShare').addEventListener('click', () => {
   }
 });
 
-
 document.getElementById('updateMedia').addEventListener('click', () => {
   const audio = {};
   const video = {};
@@ -1296,6 +1295,12 @@ document.getElementById('reject').addEventListener('click', () => {
   document.getElementById('ringing-call').innerHTML = '';
   document.getElementById('alerted-call').innerHTML = '';
   toggleDisplay('incomingsection', false);
+});
+
+document.getElementById('start-sending-share').addEventListener('click', () => {
+  if (meeting) {
+    meeting.shareScreen();
+  }
 });
 
 document.getElementById('stop-sending-share').addEventListener('click', () => {

--- a/packages/node_modules/samples/browser-plugin-meetings/index.html
+++ b/packages/node_modules/samples/browser-plugin-meetings/index.html
@@ -295,7 +295,8 @@
         <button id="stop-sending-audio" title="stop sending audio" type="button">stop sending audio</button>
         <button id="start-sending-audio" title="start sending audio" type="button">start sending audio</button>
         <button id="stop-sending-video" title="stop sending video" type="button">stop sending video</button>
-        <button id="start-sending-video" title="start sending video" type="button">start sending video</button> <br />
+        <button id="start-sending-video" title="start sending video" type="button">start sending video</button>
+        <button id="start-sending-share" title="start sending share" type="button">start sending share</button>
         <button id="stop-sending-share" title="stop sending share" type="button">stop sending share</button>
 
         <button id="start-recording" title="start recording" type="button">start recording</button>


### PR DESCRIPTION
# Pull Request Template

## Description

In order to get screen sharing on safari to work, we needed to have less of a promise chain above the actual navigator call. This was causing issues on safari because it lost track that it was called via a user action (security). 

I've added a `meeting.shareScreen` function that reduces the steps to actually sharing a screen.

Samples and documentation have also been updated.

Fixes # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-141969

