### PR TITLE
feat(meetings): pass sdk config to media functions

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/media/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/index.js
@@ -13,7 +13,6 @@ import {
 import PeerConnectionManager from '../peer-connection-manager';
 import ReconnectionError from '../common/errors/reconnection';
 import MediaError from '../common/errors/media';
-import config from '../config';
 
 
 /**
@@ -103,15 +102,16 @@ Media.generateLocalMedias = (mediaId, audioMuted, videoMuted) => {
 /**
  * make a browser call to get the media
  * @param {SendOptions} options
+ * @param {Object} config SDK Configuration for meetings plugin
  * @returns {Promise}
  */
-Media.getLocalMedia = (options) => {
+Media.getLocalMedia = (options, config) => {
   const {
     sendAudio, sendVideo, sendShare, sharePreferences
   } = options;
 
   if (sendAudio || sendVideo) {
-    return Media.getMedia(sendAudio, sendVideo);
+    return Media.getMedia(sendAudio, sendVideo, config);
   }
 
   if (sendShare) {
@@ -120,7 +120,8 @@ Media.getLocalMedia = (options) => {
         sendAudio: false,
         sendShare: true,
         sharePreferences
-      }
+      },
+      config
     );
   }
 
@@ -277,15 +278,16 @@ Media.updateTransceiver = ({meetingId, remoteQualityLevel}, peerConnection, tran
  * @param {Object} options.sendAudio sendAudio: {Boolean} sendAudio constraints
  * @param {Object} options.sendShare sendShare: {Boolean} sendShare constraints
  * @param {Object} options.sharePreferences sharePreferences: {Object} Share constraints and share constraints
+ * @param {Object} config SDK Configuration for meetings plugin
  * @returns {Object} {streams}
  */
-Media.getDisplayMedia = (options) => {
+Media.getDisplayMedia = (options, config) => {
   const shareConstraints = options.sharePreferences && options.sharePreferences.shareConstraints || {
     cursor: 'always',
-    frameRate: options.sharePreferences && options.sharePreferences.highFrameRate ? config.meetings.videoShareFrameRate : config.meetings.screenFrameRate,
-    aspectRatio: config.meetings.aspectRatio,
-    width: options.sharePreferences && options.sharePreferences.highFrameRate ? config.meetings.resolution.idealWidth : config.meetings.screenResolution.idealWidth,
-    height: options.sharePreferences && options.sharePreferences.highFrameRate ? config.meetings.resolution.idealHeight : config.meetings.screenResolution.idealHeight
+    frameRate: options.sharePreferences && options.sharePreferences.highFrameRate ? config.videoShareFrameRate : config.screenFrameRate,
+    aspectRatio: config.aspectRatio,
+    width: options.sharePreferences && options.sharePreferences.highFrameRate ? config.resolution.idealWidth : config.screenResolution.idealWidth,
+    height: options.sharePreferences && options.sharePreferences.highFrameRate ? config.resolution.idealHeight : config.screenResolution.idealHeight
   };
   // chrome and webkit based browsers (edge, safari) automatically adjust everything
   // and we have noticed higher quality with those browser types
@@ -321,13 +323,14 @@ Media.getDisplayMedia = (options) => {
 
 /**
  * generates audio and video using constraints (often called after getSupportedDevices)
- * @param {Object} audio audio: {Boolean} gum constraints
- * @param {Object} video video: {Boolean} gum constraints
+ * @param {Object|Boolean} audio gum constraints
+ * @param {Object|Boolean} video gum constraints
+ * @param {Object} config SDK Configuration for meetings plugin
  * @returns {Object} {streams}
  */
-Media.getMedia = (audio, video) => {
-  const defaultWidth = {ideal: config.meetings.resolution.idealWidth, max: config.meetings.resolution.maxWidth};
-  const defaultHeight = {ideal: config.meetings.resolution.idealHeight, max: config.meetings.resolution.maxHeight};
+Media.getMedia = (audio, video, config) => {
+  const defaultWidth = {ideal: config.resolution.idealWidth, max: config.resolution.maxWidth};
+  const defaultHeight = {ideal: config.resolution.idealHeight, max: config.resolution.maxHeight};
   const mediaConfig = {
     audio,
     video: video ? {
@@ -472,14 +475,15 @@ Media.stopStream = (stream) => {
  * @param {Object} sharePreferences parameter
  * @param {Object} sharePreferences.shareConstraints parameter
  * @param {Boolean} sharePreferences.highFrameRate parameter
+ * @param {Object} config SDK Config
  * @returns {Array} [localStream, shareStream]
  */
-Media.getUserMedia = (mediaSetting, audioVideo, sharePreferences) => Media.getLocalMedia({
+Media.getUserMedia = (mediaSetting, audioVideo, sharePreferences, config) => Media.getLocalMedia({
   sendAudio: mediaSetting.sendAudio ? audioVideo.audio || mediaSetting.sendAudio : false,
   sendVideo: mediaSetting.sendVideo ? audioVideo.video || mediaSetting.sendVideo : false
-}).then((localStream) => Media.getLocalMedia({
+}, config).then((localStream) => Media.getLocalMedia({
   sendShare: mediaSetting.sendShare,
   sharePreferences
-}).then((shareStream) => [localStream, shareStream]));
+}, config).then((shareStream) => [localStream, shareStream]));
 
 export default Media;

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2127,7 +2127,8 @@ export default class Meeting extends StatelessWebexPlugin {
               sendVideo: (mediaDirection.sendVideo === devicePermissions.sendVideo)
             },
             audioVideo,
-            sharePreferences
+            sharePreferences,
+            this.config
           ))
         .then((response) => {
           if (!response[0] && !response[1]) {


### PR DESCRIPTION
Users were not able to override the default configuration and
the media utilities were taking the hard coded config from config.js

Fixes # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-145738

