### PR TITLE
remove chrome/edgeOptions since karma doesn't respect it [ci skip]

### DIFF
--- a/browsers-ng.js
+++ b/browsers-ng.js
@@ -359,13 +359,11 @@ module.exports = function (packageName, argv) {
           [key]:
           {
             ...browser,
-            'goog:chromeOptions': {
-              args: [
-                '--disable-features=WebRtcHideLocalIpsWithMdns',
-                '--use-fake-device-for-media-stream',
-                '--use-fake-ui-for-media-stream'
-              ]
-            }
+            flags: [
+              '--disable-features=WebRtcHideLocalIpsWithMdns',
+              '--use-fake-device-for-media-stream',
+              '--use-fake-ui-for-media-stream'
+            ]
           },
         };
       } else if (
@@ -394,13 +392,11 @@ module.exports = function (packageName, argv) {
           [key]:
           {
             ...browser,
-            'ms:edgeOptions': {
-              args: [
-                '--disable-features=WebRtcHideLocalIpsWithMdns',
-                '--use-fake-device-for-media-stream',
-                '--use-fake-ui-for-media-stream'
-              ]
-            }
+            flags: [
+              '--disable-features=WebRtcHideLocalIpsWithMdns',
+              '--use-fake-device-for-media-stream',
+              '--use-fake-ui-for-media-stream'
+            ]
           },
         };
       }

--- a/packages/node_modules/@webex/plugin-meetings/browsers.js
+++ b/packages/node_modules/@webex/plugin-meetings/browsers.js
@@ -15,13 +15,11 @@ module.exports = function createBrowsers() {
         browserName: 'Chrome',
         version: 'latest',
         extendedDebugging: true,
-        'goog:chromeOptions': {
-          args: [
-            '--disable-features=WebRtcHideLocalIpsWithMdns',
-            '--use-fake-device-for-media-stream',
-            '--use-fake-ui-for-media-stream'
-          ]
-        }
+        flags: [
+          '--disable-features=WebRtcHideLocalIpsWithMdns',
+          '--use-fake-device-for-media-stream',
+          '--use-fake-ui-for-media-stream'
+        ]
       },
       sl_edge_latest_Win_10: {
         base: 'SauceLabs',
@@ -93,13 +91,11 @@ module.exports = function createBrowsers() {
     },
     ChromeH264: {
       base: 'ChromeHeadless',
-      'goog:chromeOptions': {
-        args: [
-          '--disable-features=WebRtcHideLocalIpsWithMdns',
-          '--use-fake-device-for-media-stream',
-          '--use-fake-ui-for-media-stream'
-        ]
-      }
+      flags: [
+        '--disable-features=WebRtcHideLocalIpsWithMdns',
+        '--use-fake-device-for-media-stream',
+        '--use-fake-ui-for-media-stream'
+      ]
     }
   };
 };

--- a/packages/node_modules/@webex/plugin-phone/browsers.js
+++ b/packages/node_modules/@webex/plugin-phone/browsers.js
@@ -15,12 +15,10 @@ module.exports = function createBrowsers() {
         browserName: 'Chrome',
         version: 'latest',
         extendedDebugging: true,
-        'goog:chromeOptions': {
-          args: [
-            '--use-fake-device-for-media-stream',
-            '--use-fake-ui-for-media-stream'
-          ]
-        }
+        flags: [
+          '--use-fake-device-for-media-stream',
+          '--use-fake-ui-for-media-stream'
+        ]
       },
       // sl_firefox_latest_linux: {
       //   base: `SauceLabs`,


### PR DESCRIPTION
## Description

karma doesn't respect webdriver w3c `goog:chromeOptions` and `ms:edgeOptions` when passing in args
It will however respect `flags`, so revert back to the old style with `flags: []`


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
