### PR TITLE
feat(meetings): add call start to logs

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -469,7 +469,10 @@ export default class Meetings extends WebexPlugin {
     destroy(meeting, reason) {
       if (this.config.autoUploadLogs) {
         LoggerProxy.logger.info('Meetings->index#destroy Meeting destroyed, uploading logs');
+        const callStart = meeting.locusInfo && meeting.locusInfo.fullState ? meeting.locusInfo.fullState.lastActive : undefined;
+
         this.uploadLogs({
+          callStart,
           correlationId: meeting.correlationId,
           feedbackId: meeting.correlationId,
           locusId: meeting.locusId


### PR DESCRIPTION
We missed adding the call start time to logs and it is helpful when correlating meetings.