### PR TITLE
fix(http-core): json options param

### DIFF
--- a/packages/node_modules/@webex/http-core/src/index.js
+++ b/packages/node_modules/@webex/http-core/src/index.js
@@ -37,7 +37,7 @@ const protorequest = curry(function protorequest(defaultOptions, options) {
 
   lodashDefaults(options, defaultOptions);
 
-  if (!options.json) {
+  if (!options.json && options.json !== false) {
     Reflect.deleteProperty(options, 'json');
   }
 


### PR DESCRIPTION
# Pull Request Template

## Description

The scope of this pull request is to update the request options to include `json: false` in the case of uploading client logs.

Notes on this, we actually send three requests when uploading logs:
POST => this contains the file name and upload protocol
PUT => this contains the buffer as well as the content type of the buffer
POST => this contains the metadata of the uploaded file

Based on the scope of the task provided, we were sending the logs as `content-type: application/json` when the content type should have been handled via the `json: false` options parameter.

In my tests, in every case, the content-type of the put buffer was `content-type: application/octet-stream`

Based on the conditions that were provided as a hotfix from the requester, the changes in this PR should resolve this issue.

Examples of the requests will be attached to the associated task.

Fixes # [SPARK-148957](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-148957).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)