### PR TITLE
chore(browsers): tweak chrome flags for saucelabs [skip-ci]

### DIFF
--- a/browsers-ng.js
+++ b/browsers-ng.js
@@ -359,6 +359,13 @@ module.exports = function (packageName, argv) {
           [key]:
           {
             ...browser,
+            'goog:chromeOptions': {
+              args: [
+                '--disable-features=WebRtcHideLocalIpsWithMdns',
+                '--use-fake-device-for-media-stream',
+                '--use-fake-ui-for-media-stream'
+              ]
+            },
             flags: [
               '--disable-features=WebRtcHideLocalIpsWithMdns',
               '--use-fake-device-for-media-stream',
@@ -392,6 +399,13 @@ module.exports = function (packageName, argv) {
           [key]:
           {
             ...browser,
+            'ms:edgeOptions': {
+              args: [
+                '--disable-features=WebRtcHideLocalIpsWithMdns',
+                '--use-fake-device-for-media-stream',
+                '--use-fake-ui-for-media-stream'
+              ]
+            },
             flags: [
               '--disable-features=WebRtcHideLocalIpsWithMdns',
               '--use-fake-device-for-media-stream',

--- a/packages/node_modules/@webex/plugin-meetings/browsers.js
+++ b/packages/node_modules/@webex/plugin-meetings/browsers.js
@@ -15,6 +15,13 @@ module.exports = function createBrowsers() {
         browserName: 'Chrome',
         version: 'latest',
         extendedDebugging: true,
+        'goog:chromeOptions': {
+          args: [
+            '--disable-features=WebRtcHideLocalIpsWithMdns',
+            '--use-fake-device-for-media-stream',
+            '--use-fake-ui-for-media-stream'
+          ]
+        },
         flags: [
           '--disable-features=WebRtcHideLocalIpsWithMdns',
           '--use-fake-device-for-media-stream',


### PR DESCRIPTION
## Description

Removing `goog:chromeOptions` broke saucelabs for some reason, so adding back the code that will fix it.
Reporting the issue to saucelabs so hopefully they will fix it.
Issue is that `flags: []` is being reported as a `oversized non-string` and not respecting the the flags given, so that means mic permissions notification pops up again

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
