### PR TITLE
fix(plugin-meetings): calling invalid loggers

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2336,7 +2336,7 @@ export default class Meeting extends StatelessWebexPlugin {
           }
         })
         .catch((err) => {
-          this.logger.error('Meeting:index#join --> Error joining the call on roap initialization, ', err);
+          LoggerProxy.logger.error('Meeting:index#join --> Error joining the call on roap initialization, ', err);
           throw err;
         })
         .then(() => new Promise((resolve, reject) => {
@@ -2367,7 +2367,7 @@ export default class Meeting extends StatelessWebexPlugin {
             meeting: this // or can pass meeting ID
           })
           .catch((err) => {
-            this.logger.error('Meeting:index#join --> Error joining the call on send roap media request, ', err);
+            LoggerProxy.logger.error('Meeting:index#join --> Error joining the call on send roap media request, ', err);
             throw err;
           }))
 


### PR DESCRIPTION
# Pull Request

## Description

The scope of this pull request is to remove every instance of `console.log` and `this.logger` from `plugin-meetings` and replace these calls with `LoggerProxy.logger`. Note that this does not include `this.loggerRequest`.

Fixes # [SPARK-148852](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-148852)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)