### PR TITLE
Ice peer connection events

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/config.js
@@ -78,6 +78,6 @@ export default {
     videoShareFrameRate: 30,
     aspectRatio: 1.7695852534562213,
     // When enabled, as calls are ended, it will upload the SDK logs and correlate them
-    autoUploadLogs: false
+    autoUploadLogs: true
   }
 };

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1702,14 +1702,11 @@ export default class Meeting extends StatelessWebexPlugin {
    * // TODO: remove??
    */
   setReconnectListener() {
-    // TODO: need to test more with the triggers for reconnect, we also need to add triggers based on getStats reports
-    if (this.config.reconnection.detection) {
-      // Client will have a socket manager and handle reconnecting to mercury, when we reconnect to mercury
-      // if the meeting has active peer connections, it should try to reconnect.
-      this.webex.internal.mercury.on(ONLINE, () => {
-        this.reconnect();
-      });
-    }
+    // Client will have a socket manager and handle reconnecting to mercury, when we reconnect to mercury
+    // if the meeting has active peer connections, it should try to reconnect.
+    this.webex.internal.mercury.on(ONLINE, () => {
+      LoggerProxy.logger.log('Meeting:index#setReconnectListener --> Web socket online');
+    });
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -664,21 +664,28 @@ MeetingUtil.setPeerConnectionEvents = (meeting) => {
   const {peerConnection} = meeting.mediaProperties;
 
   peerConnection.oniceconnectionstatechange = () => {
+    LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE CHANGE.');
     switch (peerConnection.iceConnectionState) {
       case ICE_STATE.CHECKING:
+        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE CHECKING.');
         Metrics.postEvent({event: eventType.ICE_START, meeting});
         break;
       case ICE_STATE.COMPLETED:
+        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE COMPLETED.');
         Metrics.postEvent({event: eventType.ICE_END, meeting});
         break;
       case ICE_STATE.CONNECTED:
+        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE CONNECTED.');
         break;
       case ICE_STATE.CLOSED:
+        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE CLOSED.');
         break;
       case ICE_STATE.DISCONNECTED:
-
+        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE DISCONNECTED.');
+        Metrics.postEvent({event: eventType.ICE_DISCONNECT, meeting});
         break;
       case ICE_STATE.FAILED:
+        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE FAILED.');
         // notify of ice failure
         Metrics.postEvent({
           event: eventType.ICE_END,

--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/config.js
@@ -83,6 +83,7 @@ export const eventType = {
   // when ICE negotiation starts
   ICE_START: 'client.ice.start',
   ICE_END: 'client.ice.end',
+  ICE_DISCONNECT: 'client.ice.disconnect',
   // Fired when the media engine reports receiving a new media stream. Media events MUST have the mediaType property.
   RECEIVING_MEDIA_START: 'client.media.rx.start',
   // Fired when the media engine reports the end of receiving a media stream.


### PR DESCRIPTION
In order to stabilize the reconnection logic, we need to disable the auto reconnect based on mercury connection. This is the first step in getting peer connection reconnects working properly.

Additional changes are adding logs for all the peer connection events as well as auto uploading logs after calls at the request of @jpjpjp 