### PR TITLE
fix(samples): update mediaSettings global to object

### DIFF
--- a/packages/node_modules/samples/browser-plugin-meetings/app.js
+++ b/packages/node_modules/samples/browser-plugin-meetings/app.js
@@ -10,7 +10,7 @@
 
 // Declare some globals that we'll need throughout
 let webex, meeting, meetings, newMeeting, callTime;
-const mediaSettings = [];
+const mediaSettings = {};
 const audioInputSelect = document.querySelector('select#audioSource');
 const audioOutputSelect = document.querySelector('select#audioOutput');
 const videoSelect = document.querySelector('select#videoSource');


### PR DESCRIPTION
# Pull Request 

## Description

The mediaSettings global variable in the kitchen sink app was set to an empty array when it should be set to an empty has object - Arrays in JS are objects and can have properties but in browsers like Safari you will not see the array's properties being logged out also in the future if code changes and they decide to pull keys or do some looping things could break

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
