### PR TITLE
feat(meetings): change stats analyzer log level

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
@@ -240,7 +240,7 @@ export default class StatsAnalyzer extends EventsScope {
     if (!pc) {
       return;
     }
-    LoggerProxy.logger.info('StatsAnalyzer:index#getStatsAndParse --> Collecting Stats');
+    LoggerProxy.logger.trace('StatsAnalyzer:index#getStatsAndParse --> Collecting Stats');
     pc.videoTransceiver.sender.getStats().then((res) => {
       this.filterAndParseGetStatsResults(res, STATS.VIDEO_CORRELATE, true);
     });
@@ -264,7 +264,7 @@ export default class StatsAnalyzer extends EventsScope {
     pc.shareTransceiver.receiver.getStats().then((res) => {
       this.filterAndParseGetStatsResults(res, STATS.SHARE_CORRELATE, false);
     });
-    LoggerProxy.logger.info('StatsAnalyzer:index#getStatsAndParse --> Finished Collecting Stats');
+    LoggerProxy.logger.trace('StatsAnalyzer:index#getStatsAndParse --> Finished Collecting Stats');
   }
 
   /**


### PR DESCRIPTION
Starting the collection of logs doesn't need to be "info" level.