### PR TITLE
feat(plugin-meetings): add ice disconnect timeout

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/config.js
@@ -16,6 +16,8 @@ export default {
     reconnection: {
       enabled: true,
       detection: true,
+      // Timeout duration to wait for ICE to reconnect if a disconnect is received.
+      iceReconnectionTimeout: 10000,
       retry: {
         times: 2,
         backOff: {

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1909,6 +1909,8 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   reconnect() {
+    LoggerProxy.logger.log('meeting:index#reconnect --> attempting to reconnect');
+
     if (!this.reconnectionManager || !this.reconnectionManager.reconnect) {
       throw new ParameterError('Cannot reconnect, ReconnectionManager must first be defined.');
     }

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -675,12 +675,20 @@ MeetingUtil.setPeerConnectionEvents = (meeting) => {
         Metrics.postEvent({event: eventType.ICE_END, meeting});
         break;
       case ICE_STATE.CONNECTED:
+        meeting.reconnectionManager.iceReconnected();
         LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE CONNECTED.');
         break;
       case ICE_STATE.CLOSED:
         LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE CLOSED.');
         break;
       case ICE_STATE.DISCONNECTED:
+        meeting.reconnectionManager.waitForIceReconnect()
+          .catch(() => {
+            LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE DISCONNECTED. Automatic Reconnection Timed Out.');
+
+            meeting.reconnect();
+          });
+
         LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE DISCONNECTED.');
         break;
       case ICE_STATE.FAILED:

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -18,6 +18,21 @@ export default class ReconnectionManager {
    */
   constructor(meeting) {
     /**
+     * Stores ICE reconnection state data.
+     *
+     * @instance
+     * @type {Object}
+     * @private
+     * @memberof ReconnectionManager
+     */
+    this.iceState = {
+      disconnected: false,
+      resolve: () => {},
+      timer: undefined,
+      timeoutDuration: meeting.config.reconnection.iceReconnectionTimeout
+    };
+
+    /**
      * @instance
      * @type {String}
      * @private
@@ -39,6 +54,64 @@ export default class ReconnectionManager {
     */
     this.webex = meeting.webex;
     this.configure(meeting);
+  }
+
+  /**
+   * Sets the iceState to connected and clears any disconnect timeouts and
+   * related timeout data within the iceState.
+   *
+   * @returns {undefined}
+   * @public
+   * @memberof ReconnectionManager
+   */
+  iceReconnected() {
+    if (this.iceState.disconnected) {
+      LoggerProxy.logger.log('ReconnectionManager:index#iceReconnected --> ice has reconnected');
+
+      this.iceState.resolve();
+      this.iceState.resolve = () => {};
+
+      if (this.iceState.timer && this.iceState.timer.clearTimeout) {
+        this.iceState.timer.clearTimeout();
+      }
+
+      this.iceState.disconnected = false;
+    }
+  }
+
+  /**
+   * Set the iceState to disconnected and generates a timeout that waits for the
+   * iceState to reconnect and then resolves. If the ice state is already
+   * processing a reconnect, it immediately resolves. Rejects if the timeout
+   * duration is reached.
+   *
+   * @returns {Promise<undefined>}
+   * @public
+   * @memberof ReconnectionManager
+   */
+  waitForIceReconnect() {
+    if (!this.iceState.disconnected) {
+      LoggerProxy.logger.log('ReconnectionManager:index#waitForIceReconnect --> waiting for ice reconnect');
+
+      this.iceState.disconnected = true;
+
+      return new Promise((resolve, reject) => {
+        this.iceState.timer = setTimeout(() => {
+          if (this.iceState.disconnected === false) {
+            resolve();
+          }
+          else {
+            this.iceState.disconnected = false;
+            reject(new Error(`ice reconnection did not occur in ${this.iceState.timeoutDuration}ms`));
+          }
+        }, this.iceState.timeoutDuration);
+
+        this.iceState.resolve = resolve;
+      });
+    }
+
+    // return a resolved promise to prevent multiple catch executions of reconnect
+    return Promise.resolve();
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
@@ -1,0 +1,143 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+
+import ReconnectionManager from '../../../../src/reconnection-manager';
+
+const {assert} = chai;
+
+chai.use(chaiAsPromised);
+sinon.assert.expose(chai.assert, {prefix: ''});
+
+describe('plugin-meetings', () => {
+  describe('ReconnectionManager', () => {
+    let reconnectionManager;
+
+    beforeEach(() => {
+      reconnectionManager = new ReconnectionManager({
+        config: {
+          reconnection: {
+            enabled: true,
+            detection: true,
+            iceReconnectionTimeout: 10000,
+            retry: {
+              times: 2,
+              backOff: {
+                start: 1000,
+                rate: 2
+              }
+            }
+          }
+        }
+      });
+    });
+
+    describe('iceReconnected()', () => {
+      describe('when ice is marked as disconnected', () => {
+        beforeEach(() => {
+          reconnectionManager.iceState.disconnected = true;
+        });
+
+        it('should set disconnected to false', () => {
+          reconnectionManager.iceState.resolve = () => {};
+
+          reconnectionManager.iceReconnected();
+
+          assert.isFalse(reconnectionManager.iceState.disconnected);
+        });
+
+        it('should resolve the deferred promise', () => {
+          reconnectionManager.iceState.resolve =
+            sinon.spy();
+          const {resolve} = reconnectionManager.iceState;
+
+          reconnectionManager.iceReconnected();
+
+          assert.isTrue(resolve.called);
+        });
+
+        it('should clear the reconnect timer', () => {
+          reconnectionManager.iceState.resolve = () => {};
+          reconnectionManager.iceState.timer = {
+            clearTimeout: sinon.spy()
+          };
+
+          reconnectionManager.iceReconnected();
+
+          assert.isTrue(reconnectionManager.iceState.timer.clearTimeout.called);
+        });
+      });
+
+      describe('when ice is marked as connected', () => {
+        beforeEach(() => {
+          reconnectionManager.iceState.disconnected = false;
+        });
+
+        it('should not clear the timer', () => {
+          reconnectionManager.iceState.resolve = () => {};
+          reconnectionManager.iceState.timer = {
+            clearTimeout: sinon.spy()
+          };
+
+          reconnectionManager.iceReconnected();
+
+          assert.isTrue(
+            reconnectionManager.iceState.timer.clearTimeout.notCalled
+          );
+        });
+
+        it('should not resolve the deferred promise', () => {
+          reconnectionManager.iceState.resolve = sinon.spy();
+
+          reconnectionManager.iceReconnected();
+
+          assert.isTrue(reconnectionManager.iceState.resolve.notCalled);
+        });
+      });
+    });
+
+    describe('waitForIceReconnect()', () => {
+      describe('when ice is marked as not disconnected', () => {
+        beforeEach(() => {
+          reconnectionManager.iceState.disconnected = false;
+        });
+
+        it('should set the disconnected state to true', () => {
+          reconnectionManager.waitForIceReconnect();
+
+          assert.isTrue(reconnectionManager.iceState.disconnected);
+        });
+
+        it('should return a promise that rejects after a duration', () => {
+          reconnectionManager.iceState.timeoutDuration = 100;
+
+          return assert.isRejected(reconnectionManager.waitForIceReconnect());
+        });
+
+        it('should resolve return a resolved promise when triggered', () => {
+          const promise = reconnectionManager.waitForIceReconnect();
+
+          reconnectionManager.iceState.resolve();
+
+          assert.isFulfilled(promise);
+        });
+      });
+
+      describe('when ice is marked as disconnected', () => {
+        beforeEach(() => {
+          reconnectionManager.iceState.disconnected = true;
+        });
+
+        it('should return a resolved promise', () => {
+          assert.isFulfilled(reconnectionManager.waitForIceReconnect());
+        });
+
+        it('should not set the disconnected state to false', () => {
+          reconnectionManager.waitForIceReconnect();
+
+          assert.isTrue(reconnectionManager.iceState.disconnected);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The scope of the changes in this pull request is to add timeout logic to the ice disconnect event tree and remove all current logic from the `meeting.reconnect` method except for general logging.

Fixes # [SPARK-151805](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-151805)