### PR TITLE
Also check if video.width exists first

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/media/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/index.js
@@ -363,7 +363,7 @@ Media.getMedia = (audio, video, config) => {
     // TODO: Remove temporary workaround once Firefox fixes low constraint issues
     // eslint-disable-next-line no-nested-ternary
     video: video ?
-      bowser.firefox && video.width.max === 320 ?
+      bowser.firefox && video.width && video.width.max === 320 ?
         {
           deviceId: video.deviceId ? video.deviceId : undefined,
           width: 320,


### PR DESCRIPTION
# Pull Request Template

## Description

Javascript just... _sigh_ why?

Setting quality to LOW in Firefox (along with Safari iOS & Chrome Android) and providing a deviceID causes mediaConfig to break since `video.width` is not provided along with deviceID.
Extra work maybe needed to handle iOS and Android, since updating meetingQuality on those clients causes the same over-constraint issue seen on firefox

Fixes # (issue) (PENDING CREATION)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
