### PR TITLE
fix(meetings): sendOperational metrics directly with request

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2238,8 +2238,8 @@ export default class Meeting extends StatelessWebexPlugin {
               // with further troubleshooting
               const metricName = METRICS_OPERATIONAL_MEASURES.GET_USER_MEDIA_FAILURE;
               const data = {
-                correlationID: this.correlationId,
-                locusID: this.locusId,
+                correlation_id: this.correlationId,
+                locus_id: this.locusUrl.split('/').pop(),
                 reason: error.message
               };
               const metadata = {

--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
@@ -423,7 +423,6 @@ class Metrics {
    * @returns {void}
    */
   sendOperationalMetric(metricName, metricFields = {}, metricTags = {}) {
-    const sendMetric = this.webex.internal.metrics.submitClientMetrics;
     const fields = {
       ...metricFields,
       browser_version: bowser.version,
@@ -433,16 +432,28 @@ class Metrics {
 
     const tags = {
       ...metricTags,
+      browser: bowser.name,
       org_id: this.webex.credentials.getOrgId(),
-      os: bowser.osname,
-      platform: bowser.name
+      os: bowser.osname
     };
 
     if (!metricName) {
       throw Error('Missing operational metric name. Please provide one');
     }
 
-    sendMetric(metricName, {type: ['operational'], fields, tags});
+    this.webex.request({
+      method: 'POST',
+      service: 'metrics',
+      resource: 'clientmetrics',
+      body: {
+        metrics: [{
+          metricName,
+          type: ['operational'],
+          fields,
+          tags
+        }]
+      }
+    });
   }
 }
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/metrics/index.js
@@ -14,11 +14,11 @@ import {assert} from '@webex/test-helper-chai';
  * browser usage.
  */
 browserOnly(describe)('Meeting metrics', () => {
-  let webex, mockSubmitMetric, sandbox;
+  let webex, mockRequest, sandbox;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    mockSubmitMetric = sandbox.stub();
+    mockRequest = sandbox.stub();
     webex = new MockWebex({
       children: {
         metrics: Metrics
@@ -27,7 +27,7 @@ browserOnly(describe)('Meeting metrics', () => {
 
     webex.version = '1.2.3';
     webex.credentials.getOrgId = sinon.fake.returns('7890');
-    webex.internal.metrics.submitClientMetrics = mockSubmitMetric;
+    webex.request = mockRequest;
     metrics.initialSetup({}, webex);
   });
 
@@ -36,10 +36,10 @@ browserOnly(describe)('Meeting metrics', () => {
   });
 
   describe('#sendOperationalMetric', () => {
-    it('sends client metric via Metrics plugin', () => {
+    it('sends client metric request', () => {
       metrics.sendOperationalMetric('myMetric');
 
-      assert.calledOnce(mockSubmitMetric);
+      assert.calledOnce(mockRequest);
     });
 
     it('adds environment information to metric', () => {
@@ -49,21 +49,28 @@ browserOnly(describe)('Meeting metrics', () => {
       metrics.sendOperationalMetric('myMetric', data, metadata);
 
       assert.calledWithMatch(
-        mockSubmitMetric,
-        'myMetric',
+        mockRequest,
         {
-          type: ['operational'],
-          fields: {
-            browser_version: bowser.version,
-            os_version: bowser.osversion,
-            sdk_version: '1.2.3',
-            value: 567
-          },
-          tags: {
-            org_id: '7890',
-            os: bowser.osname,
-            platform: bowser.name,
-            test: true
+          method: 'POST',
+          service: 'metrics',
+          resource: 'clientmetrics',
+          body: {
+            metrics: [{
+              metricName: 'myMetric',
+              type: ['operational'],
+              fields: {
+                browser_version: bowser.version,
+                os_version: bowser.osversion,
+                sdk_version: '1.2.3',
+                value: 567
+              },
+              tags: {
+                browser: bowser.name,
+                org_id: '7890',
+                os: bowser.osname,
+                test: true
+              }
+            }]
           }
         }
       );


### PR DESCRIPTION
This is, instead of using the metrics plugin
For some reason the metrics plugin cannot find its own members.