### PR TITLE
fix(plugin-meetings): utilize metrics submission method

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
@@ -441,18 +441,10 @@ class Metrics {
       throw Error('Missing operational metric name. Please provide one');
     }
 
-    this.webex.request({
-      method: 'POST',
-      service: 'metrics',
-      resource: 'clientmetrics',
-      body: {
-        metrics: [{
-          metricName,
-          type: ['operational'],
-          fields,
-          tags
-        }]
-      }
+    this.webex.internal.metrics.submitClientMetrics(metricName, {
+      type: ['operational'],
+      fields,
+      tags
     });
   }
 }

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/metrics/index.js
@@ -14,11 +14,11 @@ import {assert} from '@webex/test-helper-chai';
  * browser usage.
  */
 browserOnly(describe)('Meeting metrics', () => {
-  let webex, mockRequest, sandbox;
+  let webex, mockSubmitMetric, sandbox;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    mockRequest = sandbox.stub();
+    mockSubmitMetric = sandbox.stub();
     webex = new MockWebex({
       children: {
         metrics: Metrics
@@ -27,7 +27,7 @@ browserOnly(describe)('Meeting metrics', () => {
 
     webex.version = '1.2.3';
     webex.credentials.getOrgId = sinon.fake.returns('7890');
-    webex.request = mockRequest;
+    webex.internal.metrics.submitClientMetrics = mockSubmitMetric;
     metrics.initialSetup({}, webex);
   });
 
@@ -36,10 +36,10 @@ browserOnly(describe)('Meeting metrics', () => {
   });
 
   describe('#sendOperationalMetric', () => {
-    it('sends client metric request', () => {
+    it('sends client metric via Metrics plugin', () => {
       metrics.sendOperationalMetric('myMetric');
 
-      assert.calledOnce(mockRequest);
+      assert.calledOnce(mockSubmitMetric);
     });
 
     it('adds environment information to metric', () => {
@@ -49,28 +49,21 @@ browserOnly(describe)('Meeting metrics', () => {
       metrics.sendOperationalMetric('myMetric', data, metadata);
 
       assert.calledWithMatch(
-        mockRequest,
+        mockSubmitMetric,
+        'myMetric',
         {
-          method: 'POST',
-          service: 'metrics',
-          resource: 'clientmetrics',
-          body: {
-            metrics: [{
-              metricName: 'myMetric',
-              type: ['operational'],
-              fields: {
-                browser_version: bowser.version,
-                os_version: bowser.osversion,
-                sdk_version: '1.2.3',
-                value: 567
-              },
-              tags: {
-                browser: bowser.name,
-                org_id: '7890',
-                os: bowser.osname,
-                test: true
-              }
-            }]
+          type: ['operational'],
+          fields: {
+            browser_version: bowser.version,
+            os_version: bowser.osversion,
+            sdk_version: '1.2.3',
+            value: 567
+          },
+          tags: {
+            org_id: '7890',
+            os: bowser.osname,
+            browser: bowser.name,
+            test: true
           }
         }
       );


### PR DESCRIPTION
# Pull Request

## Description

The scope of the changes in this pull request are to update client metrics to be sent via the metrics plugin instead of utilizing `request` directly.

Fixes # [SPARK-153055](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-153055)