### PR TITLE
feat(meetings): send getDisplayMedia() failures as ops metric

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -1064,5 +1064,6 @@ export const MQA_INTEVAL = 60000; // mqa analyzer interval its fixed to 60000
 // Metrics constants ----------------------------------------------------------
 
 export const METRICS_OPERATIONAL_MEASURES = {
-  GET_USER_MEDIA_FAILURE: 'js_sdk_get_user_media_failures'
+  GET_USER_MEDIA_FAILURE: 'js_sdk_get_user_media_failures',
+  GET_DISPLAY_MEDIA_FAILURE: 'js_sdk_get_display_media_failures'
 };

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -3168,12 +3168,31 @@ export default class Meeting extends StatelessWebexPlugin {
       ...options
     };
 
-    return Media.getDisplayMedia(shareConstraints).then((shareStream) => {
-      this.updateShare({
-        sendShare: true,
-        receiveShare: this.mediaProperties.mediaDirection.receiveShare,
-        stream: shareStream
+    return Media.getDisplayMedia(shareConstraints)
+      .then((shareStream) => {
+        this.updateShare({
+          sendShare: true,
+          receiveShare: this.mediaProperties.mediaDirection.receiveShare,
+          stream: shareStream
+        });
+      })
+      .catch((error) => {
+        // Whenever there is a failure when trying to access a user's display
+        // report it as an operational metric
+        // This gives visibility into common errors and can help
+        // with further troubleshooting
+        const metricName = METRICS_OPERATIONAL_MEASURES.GET_DISPLAY_MEDIA_FAILURE;
+        const data = {
+          correlation_id: this.correlationId,
+          locus_id: this.locusUrl.split('/').pop(),
+          reason: error.message
+        };
+        const metadata = {
+          type: error.name
+        };
+
+        Metrics.sendOperationalMetric(metricName, data, metadata);
+        throw new MediaError('Unable to retrieve display media stream', error);
       });
-    });
   }
 }


### PR DESCRIPTION
Send `getDisplayMedia()` failures as operational metrics to metrics service for aggregation.