### PR TITLE
feat(meetings): emit triggers on reconnect completion

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2004,21 +2004,16 @@ export default class Meeting extends StatelessWebexPlugin {
 
     return this.reconnectionManager
       .reconnect(options)
-      .then((reconnect) => {
+      .then(() => {
         Trigger.trigger(
           this,
           {
             file: 'meeting/index',
             function: 'reconnect'
           },
-          EVENT_TRIGGERS.MEETING_RECONNECTION_SUCCESS,
-          {
-            reconnect
-          }
+          EVENT_TRIGGERS.MEETING_RECONNECTION_SUCCESS
         );
         LoggerProxy.logger.log('Meeting:index#reconnect --> Meeting reconnect success');
-
-        return Promise.resolve(reconnect);
       })
       .catch((error) => {
         Trigger.trigger(
@@ -2037,10 +2032,8 @@ export default class Meeting extends StatelessWebexPlugin {
 
         return Promise.reject(new ReconnectionError('Reconnection failure event', error));
       })
-      .finally((reconnect) => {
+      .finally(() => {
         this.reconnectionManager.reset();
-
-        return Promise.resolve(reconnect);
       });
   }
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -875,41 +875,51 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.reconnect);
         });
         describe('successful reconnect', () => {
-          it('should reconnect and trigger reconnection and return a promise', async () => {
-            meeting.reconnectionManager = new ReconnectionManager({config: {reconnection: {retry: {backOff: 1}}}});
-            meeting.reconnectionManager.reconnect = sinon.stub().returns(Promise.resolve(test1));
+          beforeEach(() => {
+            meeting.config.reconnection.enabled = true;
+            meeting.reconnectionManager = new ReconnectionManager(meeting);
+            meeting.reconnectionManager.reconnect = sinon.stub().returns(Promise.resolve());
             meeting.reconnectionManager.reset = sinon.stub().returns(true);
-            const reconnect = meeting.reconnect();
+          });
 
-            assert.exists(reconnect.then);
-            await reconnect;
-            assert.calledTwice(TriggerProxy.trigger);
+          it('should trigger reconnection success', async () => {
+            await meeting.reconnect();
             assert.calledWith(
               TriggerProxy.trigger,
               sinon.match.instanceOf(Meeting),
               {file: 'meeting/index', function: 'reconnect'},
-              'meeting:reconnectionSuccess',
-              {reconnect: test1}
+              'meeting:reconnectionSuccess'
             );
+          });
+
+          it('should reset after reconnection success', async () => {
+            await meeting.reconnect();
             assert.calledOnce(meeting.reconnectionManager.reset);
           });
         });
+
         describe('unsuccessful reconnect', () => {
-          it('should trigger an unsuccessful reconnection and return a promise', async () => {
-            meeting.reconnectionManager = new ReconnectionManager({config: {reconnection: {retry: {backOff: 1}}}});
+          beforeEach(() => {
+            meeting.config.reconnection.enabled = true;
+            meeting.reconnectionManager = new ReconnectionManager(meeting);
             meeting.reconnectionManager.reconnect = sinon.stub().returns(Promise.reject());
             meeting.reconnectionManager.reset = sinon.stub().returns(true);
-            await meeting.reconnect().catch(() => {
-              assert.calledTwice(TriggerProxy.trigger);
-              assert.calledWith(
-                TriggerProxy.trigger,
-                sinon.match.instanceOf(Meeting),
-                {file: 'meeting/index', function: 'reconnect'},
-                'meeting:reconnectionFailure',
-                {error: sinon.match.any}
-              );
-              assert.calledOnce(meeting.reconnectionManager.reset);
-            });
+          });
+
+          it('should trigger an unsuccessful reconnection', async () => {
+            await assert.isRejected(meeting.reconnect());
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meeting),
+              {file: 'meeting/index', function: 'reconnect'},
+              'meeting:reconnectionFailure',
+              {error: sinon.match.any}
+            );
+          });
+
+          it('should reset after an unsuccessful reconnection', async () => {
+            await assert.isRejected(meeting.reconnect());
+            assert.calledOnce(meeting.reconnectionManager.reset);
           });
         });
       });


### PR DESCRIPTION
Fixing triggers and unit tests around `meeting.reconnect()`.