### PR TITLE
feat(meetings): add reconnect logic

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/common/errors/reconnection-in-progress.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/common/errors/reconnection-in-progress.js
@@ -1,0 +1,8 @@
+/**
+ *
+ *
+ * @export
+ * @class ReconnectInProgress
+ * @extends {Error}
+ */
+export default class ReconnectInProgress extends Error {}

--- a/packages/node_modules/@webex/plugin-meetings/src/common/events/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/common/events/util.js
@@ -1,3 +1,5 @@
+import {inspect} from 'util';
+
 import LoggerProxy from '../logs/logger-proxy';
 
 const EventsUtil = {};
@@ -6,10 +8,10 @@ EventsUtil.getEventLog = (args) => {
   let argString = '';
 
   try {
-    argString = JSON.stringify(args);
+    argString = inspect(args);
   }
   catch (e) {
-    LoggerProxy.logger.info(`Events:util#getEventLog --> ${e}`);
+    LoggerProxy.logger.warn(`Events:util#getEventLog --> ${e}`);
   }
 
   return argString;

--- a/packages/node_modules/@webex/plugin-meetings/src/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/config.js
@@ -18,13 +18,8 @@ export default {
       detection: true,
       // Timeout duration to wait for ICE to reconnect if a disconnect is received.
       iceReconnectionTimeout: 10000,
-      retry: {
-        times: 2,
-        backOff: {
-          start: 1000,
-          rate: 2
-        }
-      }
+      // Amount of times attempting to rejoin a meeting during reconnect
+      maxRejoinAttempts: 3
     },
     stats: {
       // Enable the webrtc stats analyzer that emits quality degradation events

--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -385,7 +385,8 @@ export const EVENT_TRIGGERS = {
   MEETING_STATE_CHANGE: 'meeting:stateChange',
   MEETING_HIGH_PACKETLOSS: 'meeting:highPacketLoss',
   MEDIA_QUALITY: 'media:quality',
-  MEETINGS_NETWORK_DISCONNECTED: 'network:disconnected'
+  MEETINGS_NETWORK_DISCONNECTED: 'network:disconnected',
+  MEETINGS_NETWORK_CONNECTED: 'network:connected'
 };
 
 export const EVENT_TYPES = {
@@ -512,6 +513,15 @@ export const ICE_STATE = {
   CONNECTED: 'connected',
   CLOSED: 'closed',
   COMPLETED: 'completed',
+  FAILED: 'failed',
+  DISCONNECTED: 'disconnected'
+};
+
+export const CONNECTION_STATE = {
+  NEW: 'new',
+  CONNECTING: 'connecting',
+  CONNECTED: 'connected',
+  CLOSED: 'closed',
   FAILED: 'failed',
   DISCONNECTED: 'disconnected'
 };
@@ -855,6 +865,12 @@ export const SDP = {
   B_LINE: 'b=TIAS',
   CARRIAGE_RETURN: '\r\n',
   BAD_MEDIA_PORTS: [0]
+};
+
+export const NETWORK_STATUS = {
+  DISCONNECTED: 'DISCONNECTED',
+  RECONNECTING: 'RECONNECTING',
+  CONNECTED: 'CONNECTED'
 };
 
 export const STATS = {

--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -422,6 +422,11 @@ export const CALL_REMOVED_REASON = {
   SELF_LEFT: 'SELF_LEFT'// you left/declined the call
 };
 
+export const SHARE_STOPPED_REASON = {
+  SELF_STOPPED: 'SELF_STOPPED',
+  MEETING_REJOIN: 'MEETING_REJOIN'
+};
+
 export const EVENTS = {
   ROAP_OK: 'ROAP_OK',
   ROAP_ANSWER: 'ROAP_ANSWER',

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -50,7 +50,8 @@ import {
   QUALITY_LEVELS,
   VIDEO_RESOLUTIONS,
   VIDEO,
-  LAYOUT_TYPES
+  LAYOUT_TYPES,
+  NETWORK_STATUS
 } from '../constants';
 import ParameterError from '../common/errors/parameter';
 import MediaError from '../common/errors/media';
@@ -591,6 +592,14 @@ export default class Meeting extends StatelessWebexPlugin {
      * @memberof Meeting
      */
     this.mqaProcessor = null;
+    /**
+     * @instance
+     * @type {String}
+     * @readonly
+     * @public
+     * @memberof Meeting
+     */
+    this.networkStatus = null;
     this.setUpLocusInfoListeners();
   }
 
@@ -771,6 +780,38 @@ export default class Meeting extends StatelessWebexPlugin {
     const payload = this.getAnalyzerMetricsPrePayload(options);
 
     return this.webex.internal.metrics.submitCallDiagnosticEvents(payload);
+  }
+
+  /**
+   * sets the network status on meeting object
+   * @param {String} networkStatus
+   * @private
+   * @returns {undefined}
+   * @memberof Meeting
+   */
+  setNetworkStatus(networkStatus) {
+    if (networkStatus === NETWORK_STATUS.DISCONNECTED) {
+      Trigger.trigger(
+        this,
+        {
+          file: 'meetings/index',
+          function: 'setNetworkStatus'
+        },
+        EVENT_TRIGGERS.MEETINGS_NETWORK_DISCONNECTED,
+      );
+    }
+    else if (networkStatus === NETWORK_STATUS.CONNECTED && this.networkStatus === NETWORK_STATUS.DISCONNECTED) {
+      Trigger.trigger(
+        this,
+        {
+          file: 'meetings/index',
+          function: 'setNetworkStatus'
+        },
+        EVENT_TRIGGERS.MEETINGS_NETWORK_CONNECTED,
+      );
+    }
+
+    this.networkStatus = networkStatus;
   }
 
   /**
@@ -2375,7 +2416,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this.mediaProperties.setMediaPeerConnection(MediaUtil.createPeerConnection());
         }
         this.setReconnectListener();
-        MeetingUtil.setPeerConnectionEvents(this);
+        PeerConnectionManager.setPeerConnectionEvents(this);
 
         return this.preMedia(localStream, localShare, mediaSettings);
       })

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -44,6 +44,7 @@ import {
   METRICS_OPERATIONAL_MEASURES,
   FULL_STATE,
   MEETING_REMOVED_REASON,
+  SHARE_STOPPED_REASON,
   SDP,
   QUALITY_LEVELS,
   VIDEO_RESOLUTIONS,
@@ -2922,6 +2923,9 @@ export default class Meeting extends StatelessWebexPlugin {
               function: 'stopShare'
             },
             EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
+            {
+              reason: SHARE_STOPPED_REASON.SELF_STOPPED
+            }
           );
         });
     }

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1955,11 +1955,13 @@ export default class Meeting extends StatelessWebexPlugin {
 
   /**
    * Initiates the reconnection of the media in the meeting
+   *
+   * @param {object} options
    * @returns {Promise} resolves with {reconnect} or errors with {error}
    * @public
    * @memberof Meeting
    */
-  reconnect() {
+  reconnect(options) {
     LoggerProxy.logger.log('Meeting:index#reconnect --> attempting to reconnect');
 
     if (!this.reconnectionManager || !this.reconnectionManager.reconnect) {
@@ -1976,7 +1978,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
 
     return this.reconnectionManager
-      .reconnect(this)
+      .reconnect(options)
       .then((reconnect) => {
         Trigger.trigger(
           this,

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2039,21 +2039,16 @@ export default class Meeting extends StatelessWebexPlugin {
 
     return this.reconnectionManager
       .reconnect(options)
-      .then((reconnect) => {
+      .then(() => {
         Trigger.trigger(
           this,
           {
             file: 'meeting/index',
             function: 'reconnect'
           },
-          EVENT_TRIGGERS.MEETING_RECONNECTION_SUCCESS,
-          {
-            reconnect
-          }
+          EVENT_TRIGGERS.MEETING_RECONNECTION_SUCCESS
         );
         LoggerProxy.logger.log('Meeting:index#reconnect --> Meeting reconnect success');
-
-        return Promise.resolve(reconnect);
       })
       .catch((error) => {
         Trigger.trigger(
@@ -2072,10 +2067,8 @@ export default class Meeting extends StatelessWebexPlugin {
 
         return Promise.reject(new ReconnectionError('Reconnection failure event', error));
       })
-      .finally((reconnect) => {
+      .finally(() => {
         this.reconnectionManager.reset();
-
-        return Promise.resolve(reconnect);
       });
   }
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -23,6 +23,7 @@ import WebRTCStats from '../stats/index';
 import StatsMetrics from '../stats/metrics';
 import StatsUtil from '../stats/util';
 import ReconnectionError from '../common/errors/reconnection';
+import ReconnectInProgress from '../common/errors/reconnection-in-progress';
 import {
   MEETINGS,
   EVENT_TRIGGERS,
@@ -1968,6 +1969,23 @@ export default class Meeting extends StatelessWebexPlugin {
     if (!this.reconnectionManager || !this.reconnectionManager.reconnect) {
       throw new ParameterError('Cannot reconnect, ReconnectionManager must first be defined.');
     }
+
+    try {
+      LoggerProxy.logger.info('Meeting:index#reconnect --> Validating reconnect ability.');
+      this.reconnectionManager.validate();
+    }
+    catch (error) {
+      // Unable to reconnect this call
+      if (error instanceof ReconnectInProgress) {
+        LoggerProxy.logger.info('Meeting:index#reconnect --> Unable to reconnect, reconnection in progress.');
+      }
+      else {
+        LoggerProxy.logger.log('Meeting:index#reconnect --> Unable to reconnect.', error);
+      }
+
+      return Promise.resolve();
+    }
+
     Trigger.trigger(
       this,
       {

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1960,7 +1960,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   reconnect() {
-    LoggerProxy.logger.log('meeting:index#reconnect --> attempting to reconnect');
+    LoggerProxy.logger.log('Meeting:index#reconnect --> attempting to reconnect');
 
     if (!this.reconnectionManager || !this.reconnectionManager.reconnect) {
       throw new ParameterError('Cannot reconnect, ReconnectionManager must first be defined.');
@@ -1973,8 +1973,7 @@ export default class Meeting extends StatelessWebexPlugin {
       },
       EVENT_TRIGGERS.MEETING_RECONNECTION_STARTING
     );
-    LoggerProxy.logger.log('Meeting:index#reconnect --> Meeting reconnect started');
-    Metrics.postEvent({event: eventType.MEDIA_RECONNECTING, meeting: this});
+
 
     return this.reconnectionManager
       .reconnect(this)
@@ -1990,10 +1989,6 @@ export default class Meeting extends StatelessWebexPlugin {
             reconnect
           }
         );
-        Metrics.postEvent({
-          event: eventType.MEDIA_RECOVERED,
-          meeting: this
-        });
         LoggerProxy.logger.log('Meeting:index#reconnect --> Meeting reconnect success');
 
         return Promise.resolve(reconnect);
@@ -2010,10 +2005,6 @@ export default class Meeting extends StatelessWebexPlugin {
             error: new ReconnectionError('Reconnection failure event', error)
           }
         );
-        Metrics.postEvent({
-          event: eventType.MEDIA_RECONNECTION_FAILED,
-          meeting: this
-        });
 
         LoggerProxy.logger.error('Meeting:index#reconnect --> Meeting reconnect failed', error);
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -2,14 +2,13 @@ import {isEmpty} from 'lodash';
 
 import StatsUtil from '../stats/util';
 import Metrics from '../metrics';
-import {eventType, trigger, mediaType, error} from '../metrics/config';
+import {eventType, trigger, mediaType} from '../metrics/config';
 import Media from '../media';
 import LoggerProxy from '../common/logs/logger-proxy';
 import WebRTCStats from '../stats/index';
 import {
   INTENT_TO_JOIN,
   _JOINED_,
-  ICE_STATE,
   STATS,
   EVENT_TRIGGERS
 } from '../constants';
@@ -658,60 +657,6 @@ MeetingUtil.startInternalStats = (meeting) => {
   }
 
   return meeting.internalStats;
-};
-
-MeetingUtil.setPeerConnectionEvents = (meeting) => {
-  // In case ICE fail
-  const {peerConnection} = meeting.mediaProperties;
-
-  peerConnection.oniceconnectionstatechange = () => {
-    LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE CHANGE.');
-    switch (peerConnection.iceConnectionState) {
-      case ICE_STATE.CHECKING:
-        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE CHECKING.');
-        Metrics.postEvent({event: eventType.ICE_START, meeting});
-        break;
-      case ICE_STATE.COMPLETED:
-        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE COMPLETED.');
-        Metrics.postEvent({event: eventType.ICE_END, meeting});
-        break;
-      case ICE_STATE.CONNECTED:
-        meeting.reconnectionManager.iceReconnected();
-        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE CONNECTED.');
-        break;
-      case ICE_STATE.CLOSED:
-        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE CLOSED.');
-        break;
-      case ICE_STATE.DISCONNECTED:
-        meeting.reconnectionManager.waitForIceReconnect()
-          .catch(() => {
-            LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE DISCONNECTED. Automatic Reconnection Timed Out.');
-
-            // TODO - uncomment this once meeting.reconnect() changes are implemented
-            // meeting.reconnect();
-          });
-
-        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE DISCONNECTED.');
-        break;
-      case ICE_STATE.FAILED:
-        LoggerProxy.logger.log('Meeting:util#setPeerConnectionEvents --> ICE STATE FAILED.');
-        // notify of ice failure
-        Metrics.postEvent({
-          event: eventType.ICE_END,
-          meeting,
-          data: {
-            canProceed: false,
-            errors: [
-              Metrics.generateErrorPayload(
-                2004, false, error.name.MEDIA_ENGINE
-              )]
-          }
-        });
-        break;
-      default:
-        break;
-    }
-  };
 };
 
 export default MeetingUtil;

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -229,7 +229,7 @@ MeetingUtil.joinMeetingOptions = (meeting, options = {}) => {
         // see https://sqbu-github.cisco.com/WebExSquared/locus/wiki/Locus-Lobby-and--IVR-Feature
         return Promise.reject(new IntentToJoinError('Error Joining Meeting', err));
       }
-      LoggerProxy.logger.log('Meeting:util#joinMeetingOptions --> Error joining the call, ', err);
+      LoggerProxy.logger.error('Meeting:util#joinMeetingOptions --> Error joining the call, ', err);
 
       return Promise.reject(new JoinMeetingError(options, 'Error Joining Meeting', err));
     });

--- a/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
@@ -14,9 +14,9 @@ import {
   ICE_TIMEOUT,
   AUDIO,
   SDP,
-  MEDIA_PEER_CONNECTION_NAME,
   ICE_STATE,
-  ICE_FAIL_TIMEOUT,
+  CONNECTION_STATE,
+  NETWORK_STATUS,
   PEER_CONNECTION_STATE,
   OFFER,
   QUALITY_LEVELS,
@@ -128,51 +128,6 @@ const limitBandwidth = (sdp) => {
   }
   offerSdp = sdpLines.join(SDP.CARRIAGE_RETURN);
   return offerSdp;
-};
-
-/**
- * sets up a listener for ice fails mid meeting
- * @param {RTCPeerConnection} peerConnection
- * @param {Function} fn
- * @param {Function} name - the name for logging, on the transceiver
- * @returns {undefined}
- */
-pc.iceFailListener = (peerConnection, fn, name) => {
-  if (!peerConnection) {
-    return;
-  }
-  peerConnection.oniceconnectionstatechange = () => {
-    switch (peerConnection.iceConnectionState) {
-      case ICE_STATE.FAILED:
-      case ICE_STATE.DISCONNECTED:
-        LoggerProxy.logger.warn(`PeerConnectionManager:index#iceFailListener --> oniceconnectionstatechange#${name} Interactive Connectivity Establishment(ICE)${peerConnection.iceConnectionState} at ${new Date()}`);
-        setTimeout(() => {
-          switch (peerConnection.iceConnectionState) {
-            case ICE_STATE.FAILED:
-            case ICE_STATE.DISCONNECTED:
-              // if ice is still failed after some time, do the reconnect
-              // else the browser resolves the ice failure on its own
-              fn();
-              break;
-            default:
-            break;
-          }
-        }, ICE_FAIL_TIMEOUT);
-        break;
-      default:
-        break;
-    }
-  };
-};
-
-/**
- * waits for failures and calls the reconnect function on failures
- * @param {RTCPeerConnection} peerConnection
- * @param {Function} [reconnectFn] - if not included, just prints a log
- * @returns {undefined}
- */
-pc.detectFailures = (peerConnection, reconnectFn = () => {LoggerProxy.logger.error('PeerConnectionManager:index#detectFailures --> Ice failed, no function to reconnect with.')}) => {
-  peerConnection.iceFailListener(peerConnection, reconnectFn, MEDIA_PEER_CONNECTION_NAME);
 };
 
 /**
@@ -490,6 +445,106 @@ pc.close = (peerConnection) => {
         peerConnection.close();
       }
     });
+};
+
+
+pc.setPeerConnectionEvents = (meeting) => {
+  // In case ICE fail
+  const {peerConnection} = meeting.mediaProperties;
+
+  const connectionFailed = () => {
+    if (meeting.reconnectionManager.iceState.resolve) {
+      // DISCONNECTED state triggers first then it goes to FAILED STATE
+      // sometimes the failed state can happen before 10 seconds (Which is the timer for the reconnect for ice disconnect)
+      meeting.reconnectionManager.iceState.resolve();
+    }
+
+    meeting.reconnect({networkDisconnect: true});
+    Metrics.postEvent({
+      event: eventType.ICE_END,
+      meeting,
+      data: {
+        canProceed: false,
+        errors: [
+          Metrics.generateErrorPayload(
+            2004, false, error.name.MEDIA_ENGINE
+          )]
+      }
+    });
+  };
+
+  peerConnection.oniceconnectionstatechange = () => {
+    LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> ICE STATE CHANGE.');
+    switch (peerConnection.iceConnectionState) {
+      case ICE_STATE.CHECKING:
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> ICE STATE CHECKING.');
+        Metrics.postEvent({event: eventType.ICE_START, meeting});
+        break;
+      case ICE_STATE.COMPLETED:
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> ICE STATE COMPLETED.');
+        break;
+      case ICE_STATE.CONNECTED:
+        // Ice connection state goes to connected when both client and server sends STUN packets and
+        // Established connected between them. Firefox does not trigger COMPLETED and only trigger CONNECTED
+        Metrics.postEvent({event: eventType.ICE_END, meeting});
+        meeting.setNetworkStatus(NETWORK_STATUS.CONNECTED);
+        meeting.reconnectionManager.iceReconnected();
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> ICE STATE CONNECTED.');
+        break;
+      case ICE_STATE.CLOSED:
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> ICE STATE CLOSED.');
+        break;
+      case ICE_STATE.DISCONNECTED:
+        meeting.setNetworkStatus(NETWORK_STATUS.DISCONNECTED);
+        meeting.reconnectionManager.waitForIceReconnect()
+          .catch(() => {
+            LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> ICE STATE DISCONNECTED. Automatic Reconnection Timed Out.');
+
+            connectionFailed();
+          });
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> ICE STATE DISCONNECTED.');
+        break;
+      case ICE_STATE.FAILED:
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> ICE STATE FAILED.');
+        // notify of ice failure
+        // Ice failure is the only indicator currently for identifying the actual connection drop
+        // Firefox takes sometime 10-15 seconds to go to failed state
+        connectionFailed();
+        break;
+      default:
+        break;
+    }
+  };
+
+  peerConnection.onconnectionstatechange = () => {
+    LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> CONNECTION STATE CHANGE.');
+    switch (peerConnection.connectionState) {
+      case CONNECTION_STATE.NEW:
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> CONNECTION STATE NEW.');
+        break;
+      case CONNECTION_STATE.CONNECTING:
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> CONNECTION STATE CONNECTING.');
+        break;
+      case CONNECTION_STATE.CONNECTED:
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> CONNECTION STATE CONNECTED.');
+        break;
+      case CONNECTION_STATE.CLOSED:
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> CONNECTION STATE CLOSED.');
+        break;
+      case CONNECTION_STATE.DISCONNECTED:
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> CONNECTION STATE DISCONNECTED.');
+        break;
+      case CONNECTION_STATE.FAILED:
+        LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> CONNECTION STATE FAILED.');
+        // Special case happens only on chrome where there is no ICE FAILED event
+        // only CONNECTION FAILED event gets triggred
+
+        connectionFailed();
+        break;
+      default:
+        break;
+    }
+  };
 };
 
 export default pc;

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -8,7 +8,9 @@ import LoggerProxy from '../common/logs/logger-proxy';
 import {RECONNECTION, _LEFT_} from '../constants';
 import ReconnectionError from '../common/errors/reconnection';
 import PeerConnectionManager from '../peer-connection-manager';
+import {eventType} from '../metrics/config';
 import Media from '../media';
+import Metrics from '../metrics';
 
 /**
  * @export
@@ -176,7 +178,26 @@ export default class ReconnectionManager {
     const validatedReconnect = this.validate();
 
     if (validatedReconnect === true) {
-      return this.executeReconnection({networkChange, networkDisconnect});
+      Metrics.postEvent({
+        event: eventType.MEDIA_RECONNECTING,
+        meeting: this.meeting
+      });
+
+      return this.executeReconnection({networkChange, networkDisconnect})
+        .then(() => {
+          Metrics.postEvent({
+            event: eventType.MEDIA_RECOVERED,
+            meeting: this.meeting
+          });
+        })
+        .catch((reconnectError) => {
+          Metrics.postEvent({
+            event: eventType.MEDIA_RECONNECTION_FAILED,
+            meeting: this.meeting
+          });
+
+          throw reconnectError;
+        });
     }
 
     return Promise.reject(validatedReconnect);
@@ -193,6 +214,7 @@ export default class ReconnectionManager {
   async executeReconnection({networkChange = false, networkDisconnect = false}) {
     this.status = RECONNECTION.STATE.IN_PROGRESS;
 
+    LoggerProxy.logger.info('ReconnectionManager:index#executeReconnection --> Attempting to reconnect to meeting.');
 
     if (networkChange) {
       // TODO: Calliope Discovery Needed (Out of band, no need to block execution) SPARK-153076

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -2,8 +2,10 @@
  * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
  */
 
+/* eslint-disable no-warning-comments */
+
 import LoggerProxy from '../common/logs/logger-proxy';
-import {_ACTIVE_, RECONNECTION, _LEFT_} from '../constants';
+import {RECONNECTION, _LEFT_} from '../constants';
 import ReconnectionError from '../common/errors/reconnection';
 import PeerConnectionManager from '../peer-connection-manager';
 import Media from '../media';
@@ -143,91 +145,108 @@ export default class ReconnectionManager {
    * @memberof ReconnectionManager
    */
   validate() {
-    // TODO: re write the validate function
     if (this.meeting.config.reconnection.enabled) {
       if (
-        this.meeting.locusInfo &&
-          this.meeting.locusInfo.fullState &&
-          (
-            this.meeting.locusInfo.fullState.state === _ACTIVE_ &&
-            this.meeting.locusInfo.fullState.active
-          )
+        this.status !== RECONNECTION.STATE.DEFAULT_STATUS ||
+        this.status !== RECONNECTION.STATE.COMPLETE
       ) {
-        if (this.meeting.webex.internal.mercury.connected) {
-          if (
-            this.status !== RECONNECTION.STATE.DEFAULT_STATUS ||
-            this.status !== RECONNECTION.STATE.COMPLETE
-          ) {
-            return true;
-          }
-
-          return new ReconnectionError('Multiple reconnections cannot occur concurrently');
-        }
-
-        return new ReconnectionError('mercury is not connected, cannot reconnect');
+        return true;
       }
 
-      return new ReconnectionError('locus server for this call is not active, cannot reconnect');
+      LoggerProxy.logger.info('ReconnectionManager:index#validate --> Reconnection already in progress.');
+
+      return new ReconnectionError('Reconnection already in progress.');
     }
+
+    LoggerProxy.logger.info('ReconnectionManager:index#validate --> Reconnection is not enabled.');
 
     return new ReconnectionError('Reconnection is not enabled.');
   }
 
   /**
    * Initiates a media reconnect for the active meeting
+   * @param {Object} reconnectOptions
+   * @param {boolean} [reconnectOptions.networkChange=false] indicates if a network change event happened
+   * @param {boolean} [reconnectOptions.networkDisconnect=false] indicates if a network disconnect event happened
    * @returns {Promise}
    * @public
    * @memberof ReconnectionManager
    */
-  reconnect() {
-    // TODO: re write the validate function
+  reconnect({networkChange = false, networkDisconnect = false}) {
     const validatedReconnect = this.validate();
 
     if (validatedReconnect === true) {
-      return this.execute();
+      return this.executeReconnection({networkChange, networkDisconnect});
     }
 
     return Promise.reject(validatedReconnect);
   }
 
   /**
-   * @param {Meeting} meeting
+   * @param {Object} reconnectOptions
+   * @param {boolean} [reconnectOptions.networkChange=false] indicates if a network change event happened
+   * @param {boolean} [reconnectOptions.networkDisconnect=false] indicates if a network disconnect event happened
    * @returns {Promise}
    * @private
    * @memberof ReconnectionManager
    */
-  execute() {
+  async executeReconnection({networkChange = false, networkDisconnect = false}) {
     this.status = RECONNECTION.STATE.IN_PROGRESS;
 
-    // Makes sure only join if you are not join else continue with reconnect
-    return new Promise((resolve, reject) => {
-      // Irrespective of who or when a reconnect is triggred try to join if in left state
-      if (this.meeting.state === _LEFT_) {
-        this.meeting.join()
-          .then(() => resolve())
-          .catch((error) => reject(error));
+
+    if (networkChange) {
+      // TODO: Calliope Discovery Needed (Out of band, no need to block execution) SPARK-153076
+    }
+
+    if (networkDisconnect) {
+      try {
+        await this.reconnectMercuryWithBackoff();
+      }
+      catch (error) {
+        // TODO: Add Metrics for Reconnect Failed
+        LoggerProxy.logger.error('ReconnectionManager:index#executeReconnection --> Unable to reconnect to websocket, giving up.');
+        this.status = RECONNECTION.STATE.FAILURE;
+        throw (error);
+      }
+    }
+
+    let rejoinMeeting = false;
+
+    if (this.meeting.state === _LEFT_) {
+      try {
+        rejoinMeeting = true;
+        await this.meeting.join();
+      }
+      catch (joinError) {
+        // TODO: Add Metrics for Reconnect Failed (expected failure)
+
+        // TODO: If meeting was inactive fail the reconnect, otherwise, retry executeReconnection({networkDisconnect: true}) SPARK-153084
+        LoggerProxy.logger.error('ReconnectionManager:index#executeReconnection --> Unable to join left meeting, giving up.');
+        this.status = RECONNECTION.STATE.FAILURE;
+        throw (joinError);
+      }
+    }
+
+    try {
+      const media = await this.reconnectMedia();
+
+      LoggerProxy.logger.log('ReconnectionManager:index#executeReconnection --> Media reestablished');
+      this.status = RECONNECTION.STATE.COMPLETE;
+
+      if (rejoinMeeting) {
+        // TODO: Emit event for reshare needed SPARK-153084
       }
 
-      resolve();
-    }).then(() => this.reconnectMedia()
-      .then((media) => {
-        LoggerProxy.logger.log(`ReconnectionManager:index#execute --> Media reestablished at: ${new Date()}`);
-        this.status = RECONNECTION.STATE.COMPLETE;
+      return media;
+    }
+    catch (error) {
+      // TODO: Add Metrics for Reconnect Failed
+      LoggerProxy.logger.error('ReconnectionManager:index#executeReconnection --> Media reestablishment failed');
+      this.status = RECONNECTION.STATE.FAILURE;
 
-        return Promise.resolve(media);
-      })
-      .catch((err) => { // eslint-disable-line
-        LoggerProxy.logger.error(`ReconnectionManager:index#execute --> Media reestablishment failed at: ${new Date()}`);
-        if (this.tryCount > this.meeting.config.reconnection.retry.times) {
-          this.status = RECONNECTION.STATE.FAILURE;
-
-          return Promise.reject(new ReconnectionError(err));
-        }
-        // exponential backoff and retry logic
-        setTimeout(() =>
-          this.reconnect(),
-        this.backOff *= this.meeting.config.reconnection.retry.backOff.rate);
-      }));
+      // TODO: Retry the join meeting and reconnect media flow depending on error code SPARK-153085
+      throw (error);
+    }
   }
 
   /**
@@ -237,8 +256,7 @@ export default class ReconnectionManager {
    * @memberof ReconnectionManager
    */
   reconnectMedia() {
-    this.tryCount += 1;
-    LoggerProxy.logger.log(`ReconnectionManager:index#media --> Begin reestablishment of media at ${new Date()}`);
+    LoggerProxy.logger.log('ReconnectionManager:index#reconnectMedia --> Begin reestablishment of media');
 
     ReconnectionManager.setupPeerConnection(this.meeting);
 
@@ -254,6 +272,17 @@ export default class ReconnectionManager {
           meeting: this.meeting,
           reconnect: true // Need to check if its a reconnect after rejoin or media inactivity
         }));
+  }
+
+  /**
+   * Attempt to Reconnect Mercury Websocket
+   * @returns {Promise}
+   * @private
+   * @memberof ReconnectionManager
+   */
+  reconnectMercuryWithBackoff() {
+    // TODO: Implement SPARK-153080
+    return Promise.reject(new Error('Reconnect to websocket has not been implemented yet.'));
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -65,7 +65,6 @@ export default class ReconnectionManager {
      */
     this.meeting = meeting;
 
-    this.backOff = meeting.config.reconnection.retry.backOff.start;
 
     // Make sure reconnection state is in default
     this.reset();
@@ -222,7 +221,7 @@ export default class ReconnectionManager {
 
     if (networkDisconnect) {
       try {
-        await this.reconnectMercuryWithBackoff();
+        await this.reconnectMercuryWebSocket();
       }
       catch (error) {
         // TODO: Add Metrics for Reconnect Failed
@@ -302,9 +301,32 @@ export default class ReconnectionManager {
    * @private
    * @memberof ReconnectionManager
    */
-  reconnectMercuryWithBackoff() {
-    // TODO: Implement SPARK-153080
-    return Promise.reject(new Error('Reconnect to websocket has not been implemented yet.'));
+  async reconnectMercuryWebSocket() {
+    LoggerProxy.logger.info('ReconnectionManager:index#reconnectMercuryWebSocket --> Reconnecting websocket.');
+    // First, attempt to disconnect if we think we are already connected.
+    if (this.webex.internal.mercury.connected) {
+      LoggerProxy.logger.info('ReconnectionManager:index#reconnectMercuryWebSocket --> Disconnecting existing websocket.');
+      try {
+        await this.webex.internal.mercury.disconnect();
+        LoggerProxy.logger.info('ReconnectionManager:index#reconnectMercuryWebSocket --> Websocket disconnected successfully.');
+      }
+      catch (disconnectError) {
+        // If we can't disconnect, the sdk is in such a bad state that reconnecting is not going to happen.
+        LoggerProxy.logger.error('ReconnectionManager:index#reconnectMercuryWebSocket --> Unable to disconnect to websocket, giving up.', disconnectError);
+        throw disconnectError;
+      }
+    }
+
+    try {
+      LoggerProxy.logger.info('ReconnectionManager:index#reconnectMercuryWebSocket --> Connecting websocket.');
+      await this.webex.internal.mercury.connect();
+      LoggerProxy.logger.info('ReconnectionManager:index#reconnectMercuryWebSocket --> Websocket connected successfully.');
+    }
+    catch (connectError) {
+      LoggerProxy.logger.error('ReconnectionManager:index#reconnectMercuryWebSocket --> Unable to connect to websocket, giving up.', connectError);
+
+      throw (connectError);
+    }
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -163,8 +163,8 @@ export default class ReconnectionManager {
   validate() {
     if (this.meeting.config.reconnection.enabled) {
       if (
-        this.status !== RECONNECTION.STATE.DEFAULT_STATUS ||
-        this.status !== RECONNECTION.STATE.COMPLETE
+        this.status === RECONNECTION.STATE.DEFAULT_STATUS ||
+        this.status === RECONNECTION.STATE.COMPLETE
       ) {
         return true;
       }
@@ -188,8 +188,15 @@ export default class ReconnectionManager {
    * @memberof ReconnectionManager
    */
   async reconnect({networkDisconnect = false} = {}) {
+    LoggerProxy.logger.info('ReconnectionManager:index#reconnect --> Reconnection start.');
     // First, validate that we can reconnect, if not, it will throw an error
-    this.validate();
+    try {
+      this.validate();
+    }
+    catch (error) {
+      LoggerProxy.logger.info('ReconnectionManager:index#reconnect --> Reconnection unable to begin.', error);
+      throw error;
+    }
 
     Metrics.postEvent({
       event: eventType.MEDIA_RECONNECTING,
@@ -198,6 +205,7 @@ export default class ReconnectionManager {
 
     return this.executeReconnection({networkDisconnect})
       .then(() => {
+        LoggerProxy.logger.info('ReconnectionManager:index#reconnect --> Reconnection successful.');
         Metrics.postEvent({
           event: eventType.MEDIA_RECOVERED,
           meeting: this.meeting
@@ -205,12 +213,14 @@ export default class ReconnectionManager {
       })
       .catch((reconnectError) => {
         if (reconnectError instanceof NeedsRetryError) {
+          LoggerProxy.logger.info('ReconnectionManager:index#reconnect --> Reconnection not successful, retrying.');
           // Reset our reconnect status since we are looping back to the beginning
           this.status = RECONNECTION.STATE.DEFAULT_STATUS;
 
           return this.reconnect({networkDisconnect: true});
         }
 
+        LoggerProxy.logger.error('ReconnectionManager:index#reconnect --> Reconnection failed.', reconnectError);
         Metrics.postEvent({
           event: eventType.MEDIA_RECONNECTION_FAILED,
           meeting: this.meeting

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -53,7 +53,18 @@ export default class ReconnectionManager {
      * @memberof ReconnectionManager
     */
     this.webex = meeting.webex;
-    this.configure(meeting);
+    /**
+     * @instance
+     * @type {Meeting}
+     * @private
+     * @memberof ReconnectionManager
+     */
+    this.meeting = meeting;
+
+    this.backOff = meeting.config.reconnection.retry.backOff.start;
+
+    // Make sure reconnection state is in default
+    this.reset();
   }
 
   /**
@@ -116,16 +127,6 @@ export default class ReconnectionManager {
   }
 
   /**
-   * @param {Meeting} meeting
-   * @returns {undefined}
-   * @public
-   * @memberof ReconnectionManager
-   */
-  configure(meeting) {
-    this.backOff = meeting.config.reconnection.retry.backOff.start;
-  }
-
-  /**
    * @returns {undefined}
    * @public
    * @memberof ReconnectionManager
@@ -136,24 +137,23 @@ export default class ReconnectionManager {
   }
 
   /**
-   * @param {Meeting} meeting
    * @returns {Boolean}
    * @returns {ReconnectionError}
    * @private
    * @memberof ReconnectionManager
    */
-  validate(meeting) {
+  validate() {
     // TODO: re write the validate function
-    if (meeting.config.reconnection.enabled) {
+    if (this.meeting.config.reconnection.enabled) {
       if (
-        meeting.locusInfo &&
-          meeting.locusInfo.fullState &&
+        this.meeting.locusInfo &&
+          this.meeting.locusInfo.fullState &&
           (
-            meeting.locusInfo.fullState.state === _ACTIVE_ &&
-            meeting.locusInfo.fullState.active
+            this.meeting.locusInfo.fullState.state === _ACTIVE_ &&
+            this.meeting.locusInfo.fullState.active
           )
       ) {
-        if (meeting.webex.internal.mercury.connected) {
+        if (this.meeting.webex.internal.mercury.connected) {
           if (
             this.status !== RECONNECTION.STATE.DEFAULT_STATUS ||
             this.status !== RECONNECTION.STATE.COMPLETE
@@ -175,17 +175,16 @@ export default class ReconnectionManager {
 
   /**
    * Initiates a media reconnect for the active meeting
-   * @param {Meeting} meeting
    * @returns {Promise}
    * @public
    * @memberof ReconnectionManager
    */
-  reconnect(meeting) {
+  reconnect() {
     // TODO: re write the validate function
-    const validatedReconnect = this.validate(meeting);
+    const validatedReconnect = this.validate();
 
     if (validatedReconnect === true) {
-      return this.execute(meeting);
+      return this.execute();
     }
 
     return Promise.reject(validatedReconnect);
@@ -197,20 +196,20 @@ export default class ReconnectionManager {
    * @private
    * @memberof ReconnectionManager
    */
-  execute(meeting) {
+  execute() {
     this.status = RECONNECTION.STATE.IN_PROGRESS;
 
     // Makes sure only join if you are not join else continue with reconnect
     return new Promise((resolve, reject) => {
       // Irrespective of who or when a reconnect is triggred try to join if in left state
-      if (meeting.state === _LEFT_) {
-        meeting.join()
+      if (this.meeting.state === _LEFT_) {
+        this.meeting.join()
           .then(() => resolve())
           .catch((error) => reject(error));
       }
 
       resolve();
-    }).then(() => this.reconnectMedia(meeting)
+    }).then(() => this.reconnectMedia()
       .then((media) => {
         LoggerProxy.logger.log(`ReconnectionManager:index#execute --> Media reestablished at: ${new Date()}`);
         this.status = RECONNECTION.STATE.COMPLETE;
@@ -219,15 +218,15 @@ export default class ReconnectionManager {
       })
       .catch((err) => { // eslint-disable-line
         LoggerProxy.logger.error(`ReconnectionManager:index#execute --> Media reestablishment failed at: ${new Date()}`);
-        if (this.tryCount > meeting.config.reconnection.retry.times) {
+        if (this.tryCount > this.meeting.config.reconnection.retry.times) {
           this.status = RECONNECTION.STATE.FAILURE;
 
           return Promise.reject(new ReconnectionError(err));
         }
         // exponential backoff and retry logic
         setTimeout(() =>
-          this.reconnect(meeting),
-        this.backOff *= meeting.config.reconnection.retry.backOff.rate);
+          this.reconnect(),
+        this.backOff *= this.meeting.config.reconnection.retry.backOff.rate);
       }));
   }
 
@@ -237,22 +236,22 @@ export default class ReconnectionManager {
    * @private
    * @memberof ReconnectionManager
    */
-  reconnectMedia(meeting) {
+  reconnectMedia() {
     this.tryCount += 1;
     LoggerProxy.logger.log(`ReconnectionManager:index#media --> Begin reestablishment of media at ${new Date()}`);
 
-    ReconnectionManager.setupPeerConnection(meeting);
+    ReconnectionManager.setupPeerConnection(this.meeting);
 
-    return Media.attachMedia(meeting.mediaProperties, {
-      meetingId: meeting.id,
-      remoteQualityLevel: meeting.mediaProperties.remoteQualityLevel
+    return Media.attachMedia(this.meeting.mediaProperties, {
+      meetingId: this.meeting.id,
+      remoteQualityLevel: this.meeting.mediaProperties.remoteQualityLevel
     })
-      .then((peerConnection) => meeting.setRemoteStream(peerConnection))
-      .then(() => meeting.roap
+      .then((peerConnection) => this.meeting.setRemoteStream(peerConnection))
+      .then(() => this.meeting.roap
         .sendRoapMediaRequest({
-          sdp: meeting.mediaProperties.peerConnection.sdp,
-          roapSeq: meeting.roapSeq,
-          meeting, // or can pass meeting ID
+          sdp: this.meeting.mediaProperties.peerConnection.sdp,
+          roapSeq: this.meeting.roapSeq,
+          meeting: this.meeting,
           reconnect: true // Need to check if its a reconnect after rejoin or media inactivity
         }));
   }

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -5,12 +5,23 @@
 /* eslint-disable no-warning-comments */
 
 import LoggerProxy from '../common/logs/logger-proxy';
-import {RECONNECTION, _LEFT_} from '../constants';
+import Trigger from '../common/events/trigger-proxy';
+import {
+  EVENT_TRIGGERS, RECONNECTION, SHARE_STOPPED_REASON, _LEFT_
+} from '../constants';
 import ReconnectionError from '../common/errors/reconnection';
 import PeerConnectionManager from '../peer-connection-manager';
 import {eventType} from '../metrics/config';
 import Media from '../media';
 import Metrics from '../metrics';
+
+/**
+ * Used to indicate that the reconnect logic needs to be retried.
+ *
+ * @class NeedsRetryError
+ * @extends {Error}
+ */
+class NeedsRetryError extends Error {}
 
 /**
  * @export
@@ -64,6 +75,9 @@ export default class ReconnectionManager {
      * @memberof ReconnectionManager
      */
     this.meeting = meeting;
+
+    this.maxRejoinAttempts = meeting.config.reconnection.maxRejoinAttempts;
+    this.rejoinAttempts = RECONNECTION.STATE.DEFAULT_TRY_COUNT;
 
 
     // Make sure reconnection state is in default
@@ -137,6 +151,7 @@ export default class ReconnectionManager {
   reset() {
     this.status = RECONNECTION.STATE.DEFAULT_STATUS;
     this.tryCount = RECONNECTION.STATE.DEFAULT_TRY_COUNT;
+    this.rejoinAttempts = RECONNECTION.STATE.DEFAULT_TRY_COUNT;
   }
 
   /**
@@ -173,7 +188,7 @@ export default class ReconnectionManager {
    * @public
    * @memberof ReconnectionManager
    */
-  reconnect({networkChange = false, networkDisconnect = false}) {
+  reconnect({networkChange = false, networkDisconnect = false} = {}) {
     const validatedReconnect = this.validate();
 
     if (validatedReconnect === true) {
@@ -190,6 +205,13 @@ export default class ReconnectionManager {
           });
         })
         .catch((reconnectError) => {
+          if (reconnectError instanceof NeedsRetryError) {
+            // Reset our reconnect status since we are looping back to the beginning
+            this.status = RECONNECTION.STATE.DEFAULT_STATUS;
+
+            return this.reconnect({networkDisconnect: true});
+          }
+
           Metrics.postEvent({
             event: eventType.MEDIA_RECONNECTION_FAILED,
             meeting: this.meeting
@@ -232,19 +254,34 @@ export default class ReconnectionManager {
     }
 
     let rejoinMeeting = false;
+    const wasSharing = this.meeting.isSharing;
+
+    try {
+      LoggerProxy.logger.info('ReconnectionManager:index#executeReconnection --> Updating meeting data from server.');
+      await this.webex.meetings.syncMeetings();
+    }
+    catch (syncError) {
+      LoggerProxy.logger.info('ReconnectionManager:index#executeReconnection --> Unable to sync meetings, reconnecting.', syncError);
+      throw (new NeedsRetryError(syncError));
+    }
 
     if (this.meeting.state === _LEFT_) {
       try {
         rejoinMeeting = true;
+
         await this.meeting.join();
       }
       catch (joinError) {
-        // TODO: Add Metrics for Reconnect Failed (expected failure)
-
-        // TODO: If meeting was inactive fail the reconnect, otherwise, retry executeReconnection({networkDisconnect: true}) SPARK-153084
-        LoggerProxy.logger.error('ReconnectionManager:index#executeReconnection --> Unable to join left meeting, giving up.');
-        this.status = RECONNECTION.STATE.FAILURE;
-        throw (joinError);
+        this.rejoinAttempts += 1;
+        if (this.rejoinAttempts <= this.maxRejoinAttempts) {
+          LoggerProxy.logger.info('ReconnectionManager:index#executeReconnection --> Unable to rejoin meeting, reconnecting.', joinError);
+          throw (new NeedsRetryError(joinError));
+        }
+        else {
+          LoggerProxy.logger.error('ReconnectionManager:index#executeReconnection --> Unable to rejoin meeting after max attempts.', joinError);
+          this.status = RECONNECTION.STATE.FAILURE;
+          throw joinError;
+        }
       }
     }
 
@@ -253,9 +290,18 @@ export default class ReconnectionManager {
 
       LoggerProxy.logger.log('ReconnectionManager:index#executeReconnection --> Media reestablished');
       this.status = RECONNECTION.STATE.COMPLETE;
-
-      if (rejoinMeeting) {
-        // TODO: Emit event for reshare needed SPARK-153084
+      if (rejoinMeeting && wasSharing) {
+        Trigger.trigger(
+          this.meeting,
+          {
+            file: 'reconnection-manager/index',
+            function: 'executeReconnection'
+          },
+          EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
+          {
+            reason: SHARE_STOPPED_REASON.MEETING_REJOIN
+          }
+        );
       }
 
       return media;

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -294,6 +294,10 @@ export default class ReconnectionManager {
       LoggerProxy.logger.log('ReconnectionManager:index#executeReconnection --> Media reestablished');
       this.status = RECONNECTION.STATE.COMPLETE;
       if (rejoinMeeting && wasSharing) {
+        // Stop the share streams if user tried to rejoin
+        Media.stopTracks(this.meeting.mediaProperties.shareTrack);
+        this.meeting.isSharing = false;
+        this.meeting.mediaProperties.mediaDirection.sendShare = false;
         Trigger.trigger(
           this.meeting,
           {
@@ -388,7 +392,7 @@ export default class ReconnectionManager {
     PeerConnectionManager.close(meeting.mediaProperties.peerConnection);
     meeting.mediaProperties.unsetPeerConnection();
     meeting.mediaProperties.reInitiatePeerconnection();
-
+    PeerConnectionManager.setPeerConnectionEvents(meeting);
     // update the peerconnection in the stats manager when ever we reconnect
     meeting.statsAnalyzer.updatePeerconnection(meeting.mediaProperties.peerConnection);
   }

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -156,7 +156,7 @@ export default class ReconnectionManager {
 
   /**
    * @returns {Boolean}
-   * @returns {ReconnectionError}
+   * @throws {ReconnectionError}
    * @private
    * @memberof ReconnectionManager
    */
@@ -171,75 +171,67 @@ export default class ReconnectionManager {
 
       LoggerProxy.logger.info('ReconnectionManager:index#validate --> Reconnection already in progress.');
 
-      return new ReconnectionError('Reconnection already in progress.');
+      throw new ReconnectionError('Reconnection already in progress.');
     }
 
     LoggerProxy.logger.info('ReconnectionManager:index#validate --> Reconnection is not enabled.');
 
-    return new ReconnectionError('Reconnection is not enabled.');
+    throw new ReconnectionError('Reconnection is not enabled.');
   }
 
   /**
    * Initiates a media reconnect for the active meeting
    * @param {Object} reconnectOptions
-   * @param {boolean} [reconnectOptions.networkChange=false] indicates if a network change event happened
    * @param {boolean} [reconnectOptions.networkDisconnect=false] indicates if a network disconnect event happened
    * @returns {Promise}
    * @public
    * @memberof ReconnectionManager
    */
-  reconnect({networkChange = false, networkDisconnect = false} = {}) {
-    const validatedReconnect = this.validate();
+  async reconnect({networkDisconnect = false} = {}) {
+    // First, validate that we can reconnect, if not, it will throw an error
+    this.validate();
 
-    if (validatedReconnect === true) {
-      Metrics.postEvent({
-        event: eventType.MEDIA_RECONNECTING,
-        meeting: this.meeting
-      });
+    Metrics.postEvent({
+      event: eventType.MEDIA_RECONNECTING,
+      meeting: this.meeting
+    });
 
-      return this.executeReconnection({networkChange, networkDisconnect})
-        .then(() => {
-          Metrics.postEvent({
-            event: eventType.MEDIA_RECOVERED,
-            meeting: this.meeting
-          });
-        })
-        .catch((reconnectError) => {
-          if (reconnectError instanceof NeedsRetryError) {
-            // Reset our reconnect status since we are looping back to the beginning
-            this.status = RECONNECTION.STATE.DEFAULT_STATUS;
-
-            return this.reconnect({networkDisconnect: true});
-          }
-
-          Metrics.postEvent({
-            event: eventType.MEDIA_RECONNECTION_FAILED,
-            meeting: this.meeting
-          });
-
-          throw reconnectError;
+    return this.executeReconnection({networkDisconnect})
+      .then(() => {
+        Metrics.postEvent({
+          event: eventType.MEDIA_RECOVERED,
+          meeting: this.meeting
         });
-    }
+      })
+      .catch((reconnectError) => {
+        if (reconnectError instanceof NeedsRetryError) {
+          // Reset our reconnect status since we are looping back to the beginning
+          this.status = RECONNECTION.STATE.DEFAULT_STATUS;
 
-    return Promise.reject(validatedReconnect);
+          return this.reconnect({networkDisconnect: true});
+        }
+
+        Metrics.postEvent({
+          event: eventType.MEDIA_RECONNECTION_FAILED,
+          meeting: this.meeting
+        });
+
+        throw reconnectError;
+      });
   }
 
   /**
    * @param {Object} reconnectOptions
-   * @param {boolean} [reconnectOptions.networkChange=false] indicates if a network change event happened
    * @param {boolean} [reconnectOptions.networkDisconnect=false] indicates if a network disconnect event happened
    * @returns {Promise}
+   * @throws {NeedsRetryError}
    * @private
    * @memberof ReconnectionManager
    */
-  async executeReconnection({networkChange = false, networkDisconnect = false}) {
+  async executeReconnection({networkDisconnect = false}) {
     this.status = RECONNECTION.STATE.IN_PROGRESS;
 
     LoggerProxy.logger.info('ReconnectionManager:index#executeReconnection --> Attempting to reconnect to meeting.');
-
-    if (networkChange) {
-      // TODO: Calliope Discovery Needed (Out of band, no need to block execution) SPARK-153076
-    }
 
     if (networkDisconnect) {
       try {
@@ -311,7 +303,6 @@ export default class ReconnectionManager {
       LoggerProxy.logger.error('ReconnectionManager:index#executeReconnection --> Media reestablishment failed');
       this.status = RECONNECTION.STATE.FAILURE;
 
-      // TODO: Retry the join meeting and reconnect media flow depending on error code SPARK-153085
       throw (error);
     }
   }

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -10,6 +10,7 @@ import {
   EVENT_TRIGGERS, RECONNECTION, SHARE_STOPPED_REASON, _LEFT_
 } from '../constants';
 import ReconnectionError from '../common/errors/reconnection';
+import ReconnectInProgress from '../common/errors/reconnection-in-progress';
 import PeerConnectionManager from '../peer-connection-manager';
 import {eventType} from '../metrics/config';
 import Media from '../media';
@@ -171,7 +172,7 @@ export default class ReconnectionManager {
 
       LoggerProxy.logger.info('ReconnectionManager:index#validate --> Reconnection already in progress.');
 
-      throw new ReconnectionError('Reconnection already in progress.');
+      throw new ReconnectInProgress('Reconnection already in progress.');
     }
 
     LoggerProxy.logger.info('ReconnectionManager:index#validate --> Reconnection is not enabled.');

--- a/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
@@ -1,7 +1,7 @@
 
 import EventsScope from '../common/events/events-scope';
 import {EVENT_TRIGGERS,
-  DEFAULT_GET_STATS_FILTER, PEER_CONNECTION_STATE, STATS, MQA_INTEVAL} from '../constants';
+  DEFAULT_GET_STATS_FILTER, CONNECTION_STATE, STATS, MQA_INTEVAL} from '../constants';
 import mqaData from '../mediaQualityMetrics/config';
 import LoggerProxy from '../common/logs/logger-proxy';
 
@@ -145,12 +145,6 @@ export default class StatsAnalyzer extends EventsScope {
    */
   startAnalyzer(peerConnection) {
     this.peerConnection = peerConnection;
-    this.peerConnection.onconnectionstatechange = () => {
-    // Automatically stop once the connection state is closed
-      if (this.peerConnection.connectionState === PEER_CONNECTION_STATE.CLOSED) {
-        this.stopAnalyzer();
-      }
-    };
     this.getStatsAndParse();
     this.statsInterval = setInterval(() => {
       this.getStatsAndParse();
@@ -251,6 +245,12 @@ export default class StatsAnalyzer extends EventsScope {
     if (!this.peerConnection) {
       return;
     }
+
+    if (this.peerConnection && this.peerConnection.connectionState === CONNECTION_STATE.FAILED) {
+      LoggerProxy.logger.trace('StatsAnalyzer:index#getStatsAndParse --> PeerConnection is in failed state');
+
+      return;
+    }
     LoggerProxy.logger.trace('StatsAnalyzer:index#getStatsAndParse --> Collecting Stats');
     this.peerConnection.videoTransceiver.sender.getStats().then((res) => {
       this.filterAndParseGetStatsResults(res, STATS.VIDEO_CORRELATE, true);
@@ -323,6 +323,10 @@ export default class StatsAnalyzer extends EventsScope {
       this.statsResults.internal[mediaType][sendrecvType].packetsSent = result.packetsSent;
       this.statsResults[mediaType][sendrecvType].totalPacketsSent = result.packetsSent;
 
+      if (this.statsResults[mediaType][sendrecvType].packetsSent === 0) {
+        LoggerProxy.logger.log(`StatsAnalyzer:index#processInboundRTPResult --> No packets sent for ${mediaType} `, this.statsResults[mediaType][sendrecvType].packetsSent);
+      }
+
       // Data saved to send MQA metrics
 
       this.statsResults[mediaType][sendrecvType].totalKeyFramesEncoded = result.keyFramesEncoded;
@@ -368,8 +372,8 @@ export default class StatsAnalyzer extends EventsScope {
         this.statsResults.internal[mediaType][sendrecvType].packetsLost = result.packetsLost;
       }
 
-      if (!this.statsResults.internal[mediaType][sendrecvType].packetsReceived) {
-        this.statsResults.internal[mediaType][sendrecvType].packetsReceived = result.packetsReceived;
+      if (!this.statsResults.internal[mediaType][sendrecvType].totalPacketsReceived) {
+        this.statsResults.internal[mediaType][sendrecvType].totalPacketsReceived = result.packetsReceived;
       }
 
       if (!this.statsResults.internal[mediaType][sendrecvType].lastPacketReceivedTimestamp) {
@@ -386,29 +390,25 @@ export default class StatsAnalyzer extends EventsScope {
 
       this.statsResults[mediaType][sendrecvType].pliCount = result.pliCount - this.statsResults.internal[mediaType][sendrecvType].pliCount;
       this.statsResults[mediaType][sendrecvType].currentPacketsLost = result.packetsLost - this.statsResults.internal[mediaType][sendrecvType].packetsLost;
-      if (this.statsResults[mediaType][sendrecvType].packetsLost < 0) {
-        this.statsResults[mediaType][sendrecvType].packetsLost = 0;
+      if (this.statsResults[mediaType][sendrecvType].currentPacketsLost < 0) {
+        this.statsResults[mediaType][sendrecvType].currentPacketsLost = 0;
       }
 
+      this.statsResults[mediaType][sendrecvType].packetsReceived = result.packetsReceived - this.statsResults.internal[mediaType][sendrecvType].totalPacketsReceived;
+      this.statsResults.internal[mediaType][sendrecvType].totalPacketsReceived = result.packetsReceived;
 
-      this.statsResults[mediaType][sendrecvType].totalPacketsReceived = result.packetsReceived;
-      this.statsResults[mediaType][sendrecvType].packetsReceived = result.packetsReceived - this.statsResults.internal[mediaType][sendrecvType].packetsReceived;
-      this.statsResults.internal[mediaType][sendrecvType].packetsReceived = result.packetsReceived;
-
-      if (this.statsResults.internal[mediaType][sendrecvType].packetsReceived === 0) {
-        LoggerProxy.logger.log(`StatsAnalyzer:index#processInboundRTPResult --> No packets received for ${mediaType} `, this.statsResults.internal[mediaType][sendrecvType].packetsReceived);
+      if (this.statsResults[mediaType][sendrecvType].packetsReceived === 0) {
+        LoggerProxy.logger.info(`StatsAnalyzer:index#processInboundRTPResult --> No packets received for ${mediaType} `, this.statsResults[mediaType][sendrecvType].packetsReceived);
       }
 
       //  Check the over all packet Lost ratio
-      this.statsResults[mediaType][sendrecvType].avaragePacketsLostRatio = result.packetsLost / result.packetsReceived;
-      this.statsResults[mediaType][sendrecvType].currentPacketLossRatio = this.statsResults[mediaType][sendrecvType].currentPacketsLost > 0 ? this.statsResults[mediaType][sendrecvType].currentPacketsLost / this.statsResults[mediaType][sendrecvType].packetsReceived : 0;
+      this.statsResults[mediaType][sendrecvType].currentPacketLossRatio = this.statsResults[mediaType][sendrecvType].currentPacketsLost > 0 ? this.statsResults[mediaType][sendrecvType].currentPacketsLost / (this.statsResults[mediaType][sendrecvType].packetsReceived + this.statsResults[mediaType][sendrecvType].currentPacketsLost) : 0;
       if (this.statsResults[mediaType][sendrecvType].currentPacketLossRatio > 3) {
-        LoggerProxy.logger.log('StatsAnalyzer:index#processInboundRTPResult --> Packets getting lost from the receiver ', this.statsResults[mediaType][sendrecvType].currentPacketLossRatio);
+        LoggerProxy.logger.info('StatsAnalyzer:index#processInboundRTPResult --> Packets getting lost from the receiver ', this.statsResults[mediaType][sendrecvType].currentPacketLossRatio);
       }
 
       this.statsResults[mediaType][sendrecvType].totalPacketsLost = result.packetsLost;
       this.statsResults[mediaType][sendrecvType].lastPacketReceivedTimestamp = result.lastPacketReceivedTimestamp;
-
 
       // From Thin
       this.statsResults[mediaType][sendrecvType].totalNackCount = result.nackCount;
@@ -416,10 +416,10 @@ export default class StatsAnalyzer extends EventsScope {
       this.statsResults[mediaType][sendrecvType].framesDecoded = result.framesDecoded;
       this.statsResults[mediaType][sendrecvType].keyFramesDecoded = result.keyFramesDecoded;
       this.statsResults[mediaType][sendrecvType].decoderImplementation = result.decoderImplementation;
-      this.statsResults[mediaType][sendrecvType].packetsReceived = result.packetsReceived;
+      this.statsResults[mediaType][sendrecvType].totalPacketsReceived = result.packetsReceived;
+
 
       this.statsResults[mediaType][sendrecvType].fecPacketsDiscarded = result.fecPacketsDiscarded;
-      this.statsResults[mediaType][sendrecvType].packetsReceived = result.packetsReceived;
       this.statsResults[mediaType][sendrecvType].fecPackets = result.fecPacketsReceived;
       this.statsResults[mediaType][sendrecvType].totalBytesReceived = result.bytesReceived;
       this.statsResults[mediaType][sendrecvType].headerBytesReceived = result.headerBytesReceived;

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1082,7 +1082,6 @@ describe('plugin-meetings', () => {
       // TODO: remove
       describe('#setReconnectListener', () => {
         it('should set the peer connections', () => {
-          PeerConnectionManager.detectFailures = sinon.stub().returns(true);
           meeting.reconnect = sinon.stub().returns(true);
           meeting.webex.internal.mercury.on = sinon.stub().returns(true);
           meeting.setReconnectListener(test1, test2);

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -875,41 +875,51 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.reconnect);
         });
         describe('successful reconnect', () => {
-          it('should reconnect and trigger reconnection and return a promise', async () => {
-            meeting.reconnectionManager = new ReconnectionManager({config: {reconnection: {retry: {backOff: 1}}}});
-            meeting.reconnectionManager.reconnect = sinon.stub().returns(Promise.resolve(test1));
+          beforeEach(() => {
+            meeting.config.reconnection.enabled = true;
+            meeting.reconnectionManager = new ReconnectionManager(meeting);
+            meeting.reconnectionManager.reconnect = sinon.stub().returns(Promise.resolve());
             meeting.reconnectionManager.reset = sinon.stub().returns(true);
-            const reconnect = meeting.reconnect();
+          });
 
-            assert.exists(reconnect.then);
-            await reconnect;
-            assert.calledTwice(TriggerProxy.trigger);
+          it('should trigger reconnection success', async () => {
+            await meeting.reconnect();
             assert.calledWith(
               TriggerProxy.trigger,
               sinon.match.instanceOf(Meeting),
               {file: 'meeting/index', function: 'reconnect'},
-              'meeting:reconnectionSuccess',
-              {reconnect: test1}
+              'meeting:reconnectionSuccess'
             );
+          });
+
+          it('should reset after reconnection success', async () => {
+            await meeting.reconnect();
             assert.calledOnce(meeting.reconnectionManager.reset);
           });
         });
+
         describe('unsuccessful reconnect', () => {
-          it('should trigger an unsuccessful reconnection and return a promise', async () => {
-            meeting.reconnectionManager = new ReconnectionManager({config: {reconnection: {retry: {backOff: 1}}}});
+          beforeEach(() => {
+            meeting.config.reconnection.enabled = true;
+            meeting.reconnectionManager = new ReconnectionManager(meeting);
             meeting.reconnectionManager.reconnect = sinon.stub().returns(Promise.reject());
             meeting.reconnectionManager.reset = sinon.stub().returns(true);
-            await meeting.reconnect().catch(() => {
-              assert.calledTwice(TriggerProxy.trigger);
-              assert.calledWith(
-                TriggerProxy.trigger,
-                sinon.match.instanceOf(Meeting),
-                {file: 'meeting/index', function: 'reconnect'},
-                'meeting:reconnectionFailure',
-                {error: sinon.match.any}
-              );
-              assert.calledOnce(meeting.reconnectionManager.reset);
-            });
+          });
+
+          it('should trigger an unsuccessful reconnection', async () => {
+            await assert.isRejected(meeting.reconnect());
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meeting),
+              {file: 'meeting/index', function: 'reconnect'},
+              'meeting:reconnectionFailure',
+              {error: sinon.match.any}
+            );
+          });
+
+          it('should reset after an unsuccessful reconnection', async () => {
+            await assert.isRejected(meeting.reconnect());
+            assert.calledOnce(meeting.reconnectionManager.reset);
           });
         });
       });

--- a/packages/node_modules/samples/browser-plugin-meetings/app.js
+++ b/packages/node_modules/samples/browser-plugin-meetings/app.js
@@ -39,7 +39,10 @@ function connect() {
           level: 'debug'
         },
         meetings: {
-          deviceType: 'WEB'
+          deviceType: 'WEB',
+          reconnection: {
+            enabled: true
+          }
         }
         // Any other sdk config we need
       },


### PR DESCRIPTION
It's finally here! After a few weeks of feature work, the meetings reconnect triggers and logic are ready to be merged into master. 

These live behind a configuration that has it defaulted to false, so users will need to opt-in to this feature at first.