### PR TITLE
feat(samples): update confirm to return promise

### DIFF
--- a/packages/node_modules/samples/browser-single-party-call/app.js
+++ b/packages/node_modules/samples/browser-single-party-call/app.js
@@ -46,17 +46,13 @@ function connect() {
       if (addedMeetingEvent.type === 'INCOMING') {
         const addedMeeting = addedMeetingEvent.meeting;
 
-        // Acknowledge to the server that we received the call on our device
-        addedMeeting.acknowledge(addedMeetingEvent.type)
-          .then(() => {
-            if (confirm('Answer incoming call')) {
-              joinMeeting(addedMeeting);
-              bindMeetingEvents(addedMeeting);
-            }
-            else {
-              addedMeeting.decline();
-            }
-          });
+        addedMeeting.acknowledge(addedMeetingEvent.type);
+        confirmDialog('Answer incoming call').then(() => {
+          joinMeeting(addedMeeting);
+          bindMeetingEvents(addedMeeting);
+        }).catch(() => {
+          addedMeeting.decline();
+        });
       }
     });
 
@@ -273,3 +269,11 @@ window.addEventListener('load', () => {
     video.disabled = true;
   }
 });
+
+function confirmDialog(msg) {
+  return new Promise(((resolve, reject) => {
+    const confirmed = window.confirm(msg);
+
+    return confirmed ? resolve(true) : reject(new Error('cancelled by user'));
+  }));
+}


### PR DESCRIPTION
# Pull Request 

## Description

There is an end to end test that occasionally fails during Circle CI builds in dial-before-connect.js within the browser-single-party call - I believe it may be due to the fact that confirm is being handle synchronously instead of asynchronously so the functionality behind confirm will now return a promise instead of just being handle in a normal manner

Fixes # [SPARK-103927](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-103927) 

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
