### PR TITLE
Spark 159014

### DIFF
--- a/packages/node_modules/@webex/common/src/constants.js
+++ b/packages/node_modules/@webex/common/src/constants.js
@@ -67,3 +67,6 @@ export const hydraTypes = {
   ROOM: 'ROOM',
   TEAM: 'TEAM'
 };
+
+export const INTERNAL_US_CLUSTER_NAME = 'urn:TEAM:us-east-2_a';
+export const INTERNAL_US_INTEGRATION_CLUSTER_NAME = 'urn:TEAM:us-east-1_int13';

--- a/packages/node_modules/@webex/common/src/index.js
+++ b/packages/node_modules/@webex/common/src/index.js
@@ -25,7 +25,9 @@ export {default as deprecated} from './deprecated';
 export {default as inBrowser} from './in-browser';
 export {
   hydraTypes,
-  SDK_EVENT
+  SDK_EVENT,
+  INTERNAL_US_CLUSTER_NAME,
+  INTERNAL_US_INTEGRATION_CLUSTER_NAME
 } from './constants';
 export {
   buildHydraMembershipId,
@@ -34,6 +36,7 @@ export {
   buildHydraPersonId,
   buildHydraRoomId,
   getHydraRoomType,
+  getHydraClusterString,
   getHydraFiles,
   constructHydraId,
   deconstructHydraId

--- a/packages/node_modules/@webex/common/src/uuid-utils.js
+++ b/packages/node_modules/@webex/common/src/uuid-utils.js
@@ -1,5 +1,5 @@
 import {encode, decode} from './base64';
-import {SDK_EVENT, hydraTypes} from './constants';
+import {SDK_EVENT, hydraTypes, INTERNAL_US_CLUSTER_NAME, INTERNAL_US_INTEGRATION_CLUSTER_NAME} from './constants';
 
 const hydraBaseUrl = 'https://api.ciscospark.com/v1';
 
@@ -23,6 +23,11 @@ export function constructHydraId(
 ) {
   if (!type.toUpperCase) {
     throw Error('"type" must be a string');
+  }
+
+  if ((type === hydraTypes.PEOPLE) || (type === hydraTypes.ORGANIZATION)) {
+    // Cluster is always "us" for people and orgs
+    return encode(`ciscospark://us/${type.toUpperCase()}/${id}`);
   }
 
   return encode(`ciscospark://${cluster}/${type.toUpperCase()}/${id}`);
@@ -113,6 +118,32 @@ export function buildHydraOrgId(uuid, cluster) {
 export function buildHydraMembershipId(personUUID, spaceUUID, cluster) {
   return constructHydraId(hydraTypes.MEMBERSHIP,
     `${personUUID}:${spaceUUID}`, cluster);
+}
+
+/**
+ * Returns a hydra cluster string based on a conversation url
+ * @private
+ * @memberof Messages
+ * @param {Object} webex sdk instance
+ * @param {String} conversationUrl url of space where activity took place
+ * @returns {String} string suitable for UUID -> public ID encoding
+ */
+export function getHydraClusterString(webex, conversationUrl) {
+  const internalClusterString =
+    webex.internal.services.getClusterId(conversationUrl);
+
+  if ((internalClusterString.startsWith(INTERNAL_US_CLUSTER_NAME)) ||
+    (internalClusterString.startsWith(INTERNAL_US_INTEGRATION_CLUSTER_NAME))) {
+    // Original US cluster is simply 'us' for backwards compatibility
+    return 'us';
+  }
+  const clusterParts = internalClusterString.split(':');
+
+  if (clusterParts.length < 3) {
+    throw Error(`Unable to determine cluster for convo: ${conversationUrl}`);
+  }
+
+  return `${clusterParts[0]}:${clusterParts[1]}:${clusterParts[2]}`;
 }
 
 /**

--- a/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js
+++ b/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js
@@ -9,6 +9,7 @@ import {
   SDK_EVENT,
   createEventEnvelope,
   constructHydraId,
+  getHydraClusterString,
   hydraTypes
 } from '@webex/common';
 import {cloneDeep} from 'lodash';
@@ -285,23 +286,24 @@ const AttachmentActions = WebexPlugin.extend({
   getattachmentActionEvent(activity, event) {
     try {
       const sdkEvent = cloneDeep(this.eventEnvelope);
+      const cluster = getHydraClusterString(this.webex, activity.target.url);
 
       sdkEvent.event = event;
       sdkEvent.data.created = activity.published;
       sdkEvent.actorId =
-        constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
+        constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID, cluster);
       sdkEvent.data.roomId =
-        constructHydraId(hydraTypes.ROOM, activity.target.id);
+        constructHydraId(hydraTypes.ROOM, activity.target.id, cluster);
       sdkEvent.data.messageId =
-        constructHydraId(hydraTypes.MESSAGE, activity.parent.id);
+        constructHydraId(hydraTypes.MESSAGE, activity.parent.id, cluster);
       sdkEvent.data.personId =
-        constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
+        constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID, cluster);
       // Seems like it would be nice to have this, but its not in the hydra webhook
       // sdkEvent.data.personEmail =
       //   activity.actor.emailAddress || activity.actor.entryEmail;
 
       sdkEvent.data.id =
-        constructHydraId(hydraTypes.ATTACHMENT_ACTION, activity.id);
+        constructHydraId(hydraTypes.ATTACHMENT_ACTION, activity.id, cluster);
       if (activity.object.inputs) {
         sdkEvent.data.inputs = activity.object.inputs;
       }

--- a/packages/node_modules/@webex/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@webex/plugin-memberships/src/memberships.js
@@ -11,6 +11,7 @@ import {
   buildHydraOrgId,
   buildHydraPersonId,
   buildHydraRoomId,
+  getHydraClusterString,
   getHydraRoomType,
   deconstructHydraId
 } from '@webex/common';
@@ -264,7 +265,7 @@ const Memberships = WebexPlugin.extend({
             try {
               // We keep track of the last read message by each user
               const roomUUID = resp.id;
-              const roomId = buildHydraRoomId(roomUUID);
+              const roomId = buildHydraRoomId(roomUUID, conversation.cluster);
               const particpants = resp.participants.items;
               const lastReadInfo = {items: []};
               const roomType = getHydraRoomType(resp.tags);
@@ -274,13 +275,15 @@ const Memberships = WebexPlugin.extend({
               for (let i = 0; i < particpants.length; i += 1) {
                 const participant = particpants[i];
                 const participantInfo = {
-                  id: buildHydraMembershipId(participant.entryUUID, roomUUID),
+                  id: buildHydraMembershipId(participant.entryUUID, roomUUID,
+                    conversation.cluster),
                   roomId,
                   personId: buildHydraPersonId(participant.entryUUID),
                   personEmail: participant.entryEmailAddress ||
                     participant.entryEmail,
                   personDisplayName: participant.displayName,
-                  personOrgId: buildHydraOrgId(participant.orgId),
+                  personOrgId: buildHydraOrgId(participant.orgId,
+                    conversation.cluster),
                   isMonitor: false, // deprecated, but included for completeness
                   roomType
                   // created is not available in the conversations payload
@@ -293,7 +296,8 @@ const Memberships = WebexPlugin.extend({
                 if ('roomProperties' in participant) {
                   if ('lastSeenActivityDate' in participant.roomProperties) {
                     participantInfo.lastSeenId =
-                      buildHydraMessageId(participant.roomProperties.lastSeenActivityUUID);
+                      buildHydraMessageId(participant.roomProperties.lastSeenActivityUUID,
+                        conversation.cluster);
                     participantInfo.lastSeenDate =
                       participant.roomProperties.lastSeenActivityDate;
                   }
@@ -432,14 +436,14 @@ const Memberships = WebexPlugin.extend({
     return this.webex.internal.services.waitForCatalog('postauth')
       .then(() => this.webex.internal.conversation.acknowledge(conversation, activity)
         .then((ack) => ({
-          lastSeenId: buildHydraMessageId(ack.object.id),
+          lastSeenId: buildHydraMessageId(ack.object.id, conversation.cluster),
           id: buildHydraMembershipId(ack.actor.entryUUID,
-            ack.target.id),
-          personId: buildHydraPersonId(ack.actor.entryUUID),
+            ack.target.id, conversation.cluster),
+          personId: buildHydraPersonId(ack.actor.entryUUID, conversation.cluster),
           personEmail: ack.actor.emailAddress || ack.actor.entryEmail,
           personDisplayName: ack.actor.displayName,
-          personOrgId: buildHydraOrgId(ack.actor.orgId),
-          roomId: buildHydraRoomId(ack.target.id),
+          personOrgId: buildHydraOrgId(ack.actor.orgId, conversation.cluster),
+          roomId: buildHydraRoomId(ack.target.id, conversation.cluster),
           roomType: getHydraRoomType(ack.target.tags),
           isRoomHidden: false, // any activity unhides a space.
           isMonitor: false, // deprecated, returned for back compat
@@ -545,19 +549,20 @@ const Memberships = WebexPlugin.extend({
   getMembershipEvent(activity, event) {
     try {
       const sdkEvent = cloneDeep(this.eventEnvelope);
+      const cluster = getHydraClusterString(this.webex, activity.target.url);
       let member;
       let space;
 
       sdkEvent.event = event;
       sdkEvent.data.created = activity.published;
-      sdkEvent.actorId = buildHydraPersonId(activity.actor.entryUUID);
+      sdkEvent.actorId = buildHydraPersonId(activity.actor.entryUUID, cluster);
       if (activity.verb !== SDK_EVENT.INTERNAL.ACTIVITY_VERB.HIDE) {
-        sdkEvent.data.roomId = buildHydraRoomId(activity.target.id);
+        sdkEvent.data.roomId = buildHydraRoomId(activity.target.id, cluster);
         sdkEvent.data.roomType = getHydraRoomType(activity.target.tags);
         sdkEvent.data.isRoomHidden = false; // any activity unhides a space.
       }
       else {
-        sdkEvent.data.roomId = buildHydraRoomId(activity.object.id);
+        sdkEvent.data.roomId = buildHydraRoomId(activity.object.id, cluster);
         sdkEvent.data.roomType = SDK_EVENT.EXTERNAL.SPACE_TYPE.DIRECT;
         // currently hidden attribute is only set on 1-1
         sdkEvent.data.isRoomHidden = true;
@@ -580,7 +585,7 @@ const Memberships = WebexPlugin.extend({
         // The space with the read message is the "target"
         space = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.TARGET;
         // And the "object" is the message that was last seen
-        sdkEvent.data.lastSeenId = buildHydraMessageId(activity.object.id);
+        sdkEvent.data.lastSeenId = buildHydraMessageId(activity.object.id, cluster);
       }
       else if (activity.verb === SDK_EVENT.INTERNAL.ACTIVITY_VERB.HIDE) {
         // For a hide activity the person is also the "actor"
@@ -596,12 +601,12 @@ const Memberships = WebexPlugin.extend({
       }
 
       sdkEvent.data.id = buildHydraMembershipId(activity[member].entryUUID,
-        activity[space].id);
-      sdkEvent.data.personId = buildHydraPersonId(activity[member].entryUUID);
+        activity[space].id, cluster);
+      sdkEvent.data.personId = buildHydraPersonId(activity[member].entryUUID, cluster);
       sdkEvent.data.personEmail =
         activity[member].emailAddress || activity[member].entryEmail;
       sdkEvent.data.personDisplayName = activity[member].displayName;
-      sdkEvent.data.personOrgId = buildHydraOrgId(activity[member].orgId);
+      sdkEvent.data.personOrgId = buildHydraOrgId(activity[member].orgId, cluster);
 
       return sdkEvent;
     }

--- a/packages/node_modules/@webex/plugin-memberships/test/integration/spec/memberships.js
+++ b/packages/node_modules/@webex/plugin-memberships/test/integration/spec/memberships.js
@@ -172,15 +172,10 @@ describe('plugin-memberships', function () {
           })
           // validate data
           .then(async ({items: [membership]}) => {
-            // Santize event membership data discrepencies between 'get and 'create'.
             const event = await created;
-            const sanitizedEvent = Object.assign({}, event);
-
-            delete sanitizedEvent.data.roomType;
 
             validateMembership(membership, false);
-
-            validateMembershipEvent(sanitizedEvent, membership, actor);
+            validateMembershipEvent(event, membership, actor);
           });
       });
     });
@@ -209,12 +204,7 @@ describe('plugin-memberships', function () {
 
       it('retrieves a single membership', () => webex.memberships.get(membership)
         .then((m) => {
-          // Hydra's `create` returns a more concise membership object than `get`.
-          // Trim the property we don't need.
-          const sanitizedMembership = Object.assign({}, membership);
-
-          delete sanitizedMembership.roomType;
-          assert.deepEqual(m, sanitizedMembership);
+          assert.deepEqual(m, membership);
         }));
     });
 

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -6,6 +6,7 @@ import {
   SDK_EVENT,
   createEventEnvelope,
   constructHydraId,
+  getHydraClusterString,
   getHydraFiles,
   hydraTypes
 } from '@webex/common';
@@ -347,18 +348,19 @@ const Messages = WebexPlugin.extend({
   getMessageEvent(activity, event) {
     try {
       const sdkEvent = cloneDeep(this.eventEnvelope);
+      const cluster = getHydraClusterString(this.webex, activity.target.url);
 
       sdkEvent.event = event;
       sdkEvent.data.created = activity.published;
-      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
+      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID, cluster);
       sdkEvent.data.roomType =
         activity.target.tags.includes(SDK_EVENT.INTERNAL.ACTIVITY_TAG.ONE_ON_ONE) ?
           SDK_EVENT.EXTERNAL.SPACE_TYPE.DIRECT :
           SDK_EVENT.EXTERNAL.SPACE_TYPE.GROUP;
       sdkEvent.data.roomId =
-        constructHydraId(hydraTypes.ROOM, activity.target.id);
+        constructHydraId(hydraTypes.ROOM, activity.target.id, cluster);
       sdkEvent.data.personId =
-        constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
+        constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID, cluster);
       sdkEvent.data.personEmail =
         activity.actor.emailAddress || activity.actor.entryEmail;
 
@@ -367,7 +369,7 @@ const Messages = WebexPlugin.extend({
         const text = content || displayName;
         const files = getHydraFiles(activity);
 
-        sdkEvent.data.id = constructHydraId(hydraTypes.MESSAGE, activity.id);
+        sdkEvent.data.id = constructHydraId(hydraTypes.MESSAGE, activity.id, cluster);
         if (text) {
           sdkEvent.data.text = text;
         }
@@ -387,12 +389,12 @@ const Messages = WebexPlugin.extend({
           }
         }
         if (activity.parent && activity.parent.id) {
-          sdkEvent.data.parentId = constructHydraId(hydraTypes.MESSAGE, activity.parent.id);
+          sdkEvent.data.parentId = constructHydraId(hydraTypes.MESSAGE, activity.parent.id, cluster);
         }
       }
       else {
         sdkEvent.data.id =
-          constructHydraId(hydraTypes.MESSAGE, activity.object.id);
+          constructHydraId(hydraTypes.MESSAGE, activity.object.id, cluster);
       }
 
       return sdkEvent;
@@ -404,6 +406,7 @@ const Messages = WebexPlugin.extend({
       return null;
     }
   }
+
 
 });
 

--- a/packages/node_modules/@webex/plugin-rooms/src/rooms.js
+++ b/packages/node_modules/@webex/plugin-rooms/src/rooms.js
@@ -9,6 +9,7 @@ import {
   createEventEnvelope,
   buildHydraPersonId,
   buildHydraRoomId,
+  getHydraClusterString,
   getHydraRoomType,
   deconstructHydraId
 } from '@webex/common';
@@ -243,7 +244,7 @@ const Rooms = WebexPlugin.extend({
 
     return this.webex.internal.services.waitForCatalog('postauth')
       .then(() => this.webex.internal.conversation.list(options))
-      .then((conversations) => buildRoomInfoList(conversations));
+      .then((conversations) => buildRoomInfoList(this.webex, conversations));
   },
 
   /**
@@ -291,7 +292,7 @@ const Rooms = WebexPlugin.extend({
           computeTitleIfEmpty: true,
           activitiesLimit: 0 // don't send the whole history of activity
         })
-        .then((convo) => buildRoomInfo(convo)));
+        .then((convo) => buildRoomInfo(this.webex, convo)));
   },
 
   /**
@@ -392,7 +393,7 @@ const Rooms = WebexPlugin.extend({
     switch (activity.verb) {
       case SDK_EVENT.INTERNAL.ACTIVITY_VERB.CREATE:
         const roomCreatedEvent =
-          this.getRoomEvent(activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED);
+          this.getRoomEvent(this.webex, activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED);
 
         if (roomCreatedEvent) {
           debug(`room "created" payload: \
@@ -403,7 +404,7 @@ const Rooms = WebexPlugin.extend({
 
       case SDK_EVENT.INTERNAL.ACTIVITY_VERB.UPDATE:
         const roomUpdatedEvent =
-          this.getRoomEvent(activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.UPDATED);
+          this.getRoomEvent(this.webex, activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.UPDATED);
 
         if (roomUpdatedEvent) {
           debug(`room "updated" payload: \
@@ -423,21 +424,23 @@ const Rooms = WebexPlugin.extend({
    * External users of the SDK should not call this function
    * @private
    * @memberof Rooms
+   * @param {Object} webex sdk instance
    * @param {Object} activity from mercury
    * @param {Object} event type of "webhook" event
    * @returns {Object} constructed event
    */
-  getRoomEvent(activity, event) {
+  getRoomEvent(webex, activity, event) {
     try {
       const sdkEvent = cloneDeep(this.eventEnvelope);
+      const cluster = getHydraClusterString(webex, activity.object.url);
       let room;
 
       sdkEvent.event = event;
       sdkEvent.data.created = activity.published;
-      sdkEvent.actorId = buildHydraPersonId(activity.actor.entryUUID);
+      sdkEvent.actorId = buildHydraPersonId(activity.actor.entryUUID, cluster);
       if (event === SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED) {
         room = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.OBJECT;
-        sdkEvent.data.creatorId = buildHydraPersonId(activity.actor.entryUUID);
+        sdkEvent.data.creatorId = buildHydraPersonId(activity.actor.entryUUID, cluster);
         sdkEvent.data.lastActivity = activity.published;
       }
       else if (event === SDK_EVENT.EXTERNAL.EVENT_TYPE.UPDATED) {
@@ -452,7 +455,7 @@ const Rooms = WebexPlugin.extend({
         throw new Error('unexpected event type');
       }
       sdkEvent.data.id =
-      buildHydraRoomId(activity[room].id);
+      buildHydraRoomId(activity[room].id, cluster);
       sdkEvent.data.type = getHydraRoomType(activity[room].tags);
       sdkEvent.data.isLocked =
         activity[room].tags.includes(SDK_EVENT.INTERNAL.ACTIVITY_TAG.LOCKED);
@@ -473,12 +476,14 @@ export default Rooms;
 
 /**
  * Helper method to build a roomInfo object from a conversation object
+ * @param {Object} webex sdk object
  * @param {Conversation~ConversationObject} conversation
  * @returns {Promise<RoomInfoObject>}
  */
-async function buildRoomInfo(conversation) {
+async function buildRoomInfo(webex, conversation) {
   try {
     const type = getHydraRoomType(conversation.tags);
+    const cluster = getHydraClusterString(webex, conversation.url);
     const title = conversation.displayName ?
       conversation.displayName : conversation.computedTitle;
     const lastActivityDate = conversation.lastReadableActivityDate ?
@@ -486,7 +491,7 @@ async function buildRoomInfo(conversation) {
       conversation.lastRelevantActivityDate;
 
     const roomInfo = {
-      id: buildHydraRoomId(conversation.id),
+      id: buildHydraRoomId(conversation.id, cluster),
       type,
       ...(title && {title: conversation.displayName}),
       ...(lastActivityDate && {lastActivityDate}),
@@ -505,16 +510,17 @@ async function buildRoomInfo(conversation) {
 
 /**
  * Helper method to build a list of roomInfo object from conversation list
+ * @param {Object} webex sdk object
  * @param {Conversation~ConversationObjectList} conversations
  * @returns {Promise<RoomInfoList>}
  */
-async function buildRoomInfoList(conversations) {
+async function buildRoomInfoList(webex, conversations) {
   // Convert each Conversation into a roomInfo object
   const roomReadInfo = {items: []};
   const roomInfoPromises = [];
 
   for (const conversation of conversations) {
-    roomInfoPromises.push(buildRoomInfo(conversation));
+    roomInfoPromises.push(buildRoomInfo(webex, conversation));
   }
 
   return Promise.all(roomInfoPromises)


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes and Tests for the issue where IDs were not being properly encoded in the websocket events for the attachmentAction, membership, message and rooms resources.

Fixes # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-159014

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

- [x] Mocha Tests for the four modules that were changed
- [x] New node based test in the samples directory

Note, two plugin-membership tests were failing.  I believe this was unrelated to this change, it looks like someone modified the tests so that the roomType element of some membership objects were not being tested.  Restored this to include this check.

**Test Configuration**:
Relevant plugin tests all pass

The new webhook/websocket comparison test is in the samples directory.  To run cd to /packages/node_modules/samples/node-compare-sockets-webhooks.  Run `npm install` to load dependencies.   Set environment variables:
 * TOKEN - user token to test -- ideally run this once with token of a user in all 3 clusters 
 * WEBHOOK_URL - url where this app is running, ie local ngrok
 * PORT - port where app should listen for webhooks

This test is configured to use the local build version of webex, but to understand the existing problem it's interesting to modify the following code to include the current npm version of webex:
```js
// Use public webex instance
// const Webex = require('webex');
// Use this builds webex instance
const Webex = require('../../webex');
```
Prior to this PR being accepted and published, the npm version of webex should generate about 20 errors when run wit a token of a user who is not in the ACHM cluster.
Using this branches build should eliminate these errors.

It would be nice to see if there is a way to make running this test part of the build process.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
