### PR TITLE
chore: update pull request template [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,39 +1,14 @@
-# Pull Request Template
+[ ⛔️ ----- REMOVE THIS SECTION  ----- ⛔️
 
-## Description
+Hey there,\
+Thank you for taking the time to improve our code! 🙂\
+Please let us know why this change is necessary. \
+This ensures our reviewers understand the impact of your change.
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+⛔️ ----- SECTION END  ----- ⛔️]
 
-Fixes # (issue)
+Fixes #[INSERT LINK TO ISSUE NUMBER]
 
-## Type of Change
+---
 
-Please delete options that are not relevant.
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-
-## Test Coverage
-
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-
-- [ ] Test A
-- [ ] Test B
-
-**Test Configuration**:
-* SDK Version
-* Node/Browser Version
-* NPM Version
-
-## Checklist:
-
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published in downstream modules
+Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -375,6 +375,19 @@ git rebase master
 
 Finally, open a [new Pull Request](https://github.com/webex/webex-js-sdk/compare) with your changes. Be sure to mention the issues this request addresses in the body of the request. Once your request is opened, a developer will review, comment, and, when approved, merge your changes!
 
+### Pull Request Checklist
+
+Before you open that new pull request, make sure to have completed the following checklist:
+
+- Code follows the style guidelines of this project
+- I have performed a self-review of my own code
+- I have commented my code, particularly in hard-to-understand areas
+- I have made corresponding changes to the documentation
+- My changes generate no new warnings
+- I have added tests that prove my fix is effective or that my feature works
+- New and existing unit tests pass locally with my changes
+- Any dependent changes have been merged and published in downstream modules
+
 ## Updating the Documentation
 
 To compile the documentation locally, make sure you have [Bundler](http://bundler.io/) or


### PR DESCRIPTION
This PR updates the pull request template to make it more concise. The idea is to avoid contributors leaving the default 
template untouched, and encourage them to give context on the changes.

This also moves the checklist from the PR template to the contributing guide
