### PR TITLE
docs(meetings): reflect getAllMeetings() actual return value

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -714,7 +714,7 @@ export default class Meetings extends WebexPlugin {
      * @param {object} options
      * @param {object} options.startDate - get meetings after this start date
      * @param {object} options.endDate - get meetings before this end date
-     * @returns {Object} All active and scheduled meetings.
+     * @returns {Object} All currently active meetings.
      * @public
      * @memberof Meetings
      */


### PR DESCRIPTION
Minor doc update to reflect method's actual return value.
Addresses confusion in issue https://github.com/webex/webex-js-sdk/issues/1788
