### PR TITLE
test(meeting): add unit tests for meetings stats analyzer packet loss

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
@@ -37,10 +37,11 @@ export default class StatsAnalyzer extends EventsScope {
    * @constructor
    * @public
    * @param {Object} config SDK Configuration Object
+   * @param {Object} statsResults Default properties for stats
    */
-  constructor(config) {
+  constructor(config, statsResults = defaultStats) {
     super();
-    this.statsResults = defaultStats;
+    this.statsResults = statsResults;
     this.config = config;
     this.correlationId = config.correlationId;
     this.mqaSentCount = 0;

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -1,0 +1,68 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+
+import StatsAnalyzer from '../../../../src/statsAnalyzer';
+
+const {assert} = chai;
+
+chai.use(chaiAsPromised);
+sinon.assert.expose(chai.assert, {prefix: ''});
+
+describe('plugin-meetings', () => {
+  describe('StatsAnalyzer', () => {
+    describe('compareSentAndReceived()', () => {
+      let statsAnalyzer;
+
+      const initialConfig = {
+        videoPacketLossRatioThreshold: 9
+      };
+
+      const defaultStats = {
+        internal: {
+          video: {
+            send: {
+              totalPacketsLostOnReceiver: 10
+            }
+          }
+        },
+        video: {
+          send: {
+            packetsSent: 2
+          }
+        }
+      };
+
+      const statusResult = {
+        type: 'remote-outbound-rtp',
+        packetsLost: 11
+      };
+
+      const sandbox = sinon.createSandbox();
+
+      beforeEach(() => {
+        statsAnalyzer = new StatsAnalyzer(initialConfig, defaultStats);
+        sandbox.spy(statsAnalyzer, 'emit');
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should trigger downgrade video callback because packet loss is high', async () => {
+        await statsAnalyzer.parseGetStatsResult(statusResult, 'video');
+
+        assert.calledOnce(statsAnalyzer.emit);
+      });
+
+      it('should not trigger downgrade video callback', async () => {
+        await statsAnalyzer.parseGetStatsResult({
+          ...statusResult,
+          packetsLost: 0
+        }, 'video');
+
+        assert.notCalled(statsAnalyzer.emit);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-147674

SDK Meetings Stats Analyzer Packet Loss Unit Tests

In order to test only the unit tests for plugin-meetings run this command from your terminal: `npm test -- --packages @webex/plugin-meetings --unit`

<img width="606" alt="Screen Shot 2020-07-16 at 2 29 10 PM" src="https://user-images.githubusercontent.com/3578942/87708511-dd393580-c770-11ea-8ba2-b7ab36083e3d.png">

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
