### PR TITLE
feat(meetings): locus info participant deltas

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
@@ -54,6 +54,26 @@ export default class LocusInfo extends EventsScope {
     this.membership = locus.membership || null;
     this.identities = locus.identities || null;
     this.participants = locus.participants || null;
+
+    /**
+     * Stores the delta values for a changed participant.
+     *
+     * @typedef {Object} DeltaParticipant
+     * @property {Record<string, boolean>} delta - Contains changed streams.
+     * @property {Object} person - Contains person data.
+     */
+
+    /**
+     * Stored participant changes between the last event and the current event.
+     * All previously stored events are overwritten between events.
+     *
+     * @instance
+     * @type {Array<DeltaParticipant>}
+     * @private
+     * @member LocusInfo
+     */
+    this.deltaParticipants = [];
+
     // above section only updates the locusInfo object
     // The below section makes sure it updates the locusInfo as well as updates the meeting object
     this.updateParticipants(locus.participants);
@@ -149,6 +169,7 @@ export default class LocusInfo extends EventsScope {
     if (!locus) {
       LoggerProxy.logger.error('Locus-info:index#onFullLocus --> object passed as argument was invalid, continuing.');
     }
+    this.updateParticipantDeltas(locus.participants);
     this.participants = locus.participants;
     this.updateLocusInfo(locus);
     this.updateParticipants(locus.participants);
@@ -431,6 +452,62 @@ export default class LocusInfo extends EventsScope {
         }
       );
     }
+  }
+
+  /**
+   * Update the deltaParticipants property of this object based on a list of
+   * provided participants.
+   *
+   * @param {Array} [participants] - The participants to update against.
+   * @returns {void}
+   */
+  updateParticipantDeltas(participants = []) {
+    // Used to find a participant within a participants collection.
+    const findParticipant = (participant, collection) =>
+      collection.find((item) => item.person.id === participant.person.id);
+
+    // Generates an object that indicates which state properties have changed.
+    const generateDelta = (prevState = {}, newState = {}) => {
+      // Setup deltas.
+      const deltas = {
+        audioStatus: prevState.audioStatus !== newState.audioStatus,
+        videoSlidesStatus: prevState.videoSlidesStatus !== newState.videoSlidesStatus,
+        videoStatus: prevState.videoStatus !== newState.videoStatus
+      };
+
+      // Clean the object
+      Object.keys(deltas).forEach(
+        (key) => {
+          if (deltas[key] !== true) {
+            delete deltas[key];
+          }
+        }
+      );
+
+      return deltas;
+    };
+
+    this.deltaParticipants = participants.reduce(
+      (collection, participant) => {
+        const existingParticipant = findParticipant(
+          participant,
+          this.participants || []
+        ) || {};
+
+        const delta = generateDelta(existingParticipant.status, participant.status);
+
+        const changed = (Object.keys(delta).length > 0);
+
+        if (changed) {
+          collection.push({
+            person: participant.person,
+            delta
+          });
+        }
+
+        return collection;
+      }, []
+    );
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -28,7 +28,64 @@ describe('plugin-meetings', () => {
         updateMeeting, locus, webex, meetingId
       );
 
-      locusInfo.parsedLocus = {states: [{one: 'one'}], fullState: {type: 'MEETING'}, info: {sipUri: 'abc@webex.com'}};
+      locusInfo.parsedLocus = {
+        states: [{one: 'one'}],
+        fullState: {type: 'MEETING'},
+        info: {sipUri: 'abc@webex.com'}
+      };
+    });
+
+    describe('#updateParticipants()', () => {
+      let newParticipants;
+
+      beforeEach('setup new participants', () => {
+        newParticipants = [
+          {
+            person: {
+              id: 1234
+            },
+            status: {
+              audioStatus: 'testValue',
+              videoSlidesStatus: 'testValue',
+              videoStatus: 'testValue'
+            }
+          }
+        ];
+      });
+
+      it('should update the deltaParticipants object', () => {
+        const prev = locusInfo.deltaParticipants;
+
+        locusInfo.updateParticipantDeltas(newParticipants);
+
+        assert.notEqual(locusInfo.deltaParticipants, prev);
+      });
+
+      it('should update the delta property on all changed states', () => {
+        locusInfo.updateParticipantDeltas(newParticipants);
+
+        const [exampleParticipant] = locusInfo.deltaParticipants;
+
+        assert.isTrue(exampleParticipant.delta.audioStatus);
+        assert.isTrue(exampleParticipant.delta.videoSlidesStatus);
+        assert.isTrue(exampleParticipant.delta.videoStatus);
+      });
+
+      it('should include the person details of the changed participant', () => {
+        locusInfo.updateParticipantDeltas(newParticipants);
+
+        const [exampleParticipant] = locusInfo.deltaParticipants;
+
+        assert.equal(exampleParticipant.person, newParticipants[0].person);
+      });
+
+      it('should clear deltaParticipants when no changes occured', () => {
+        locusInfo.participants = [...newParticipants];
+
+        locusInfo.updateParticipantDeltas(locusInfo.participants);
+
+        assert.isTrue(locusInfo.deltaParticipants.length === 0);
+      });
     });
 
     describe('#updateSelf', () => {


### PR DESCRIPTION
The scope of the changes in this pull request are to add the ability to determine which participants have changed their state between locus events.

Fixes #[SPARK-161919](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-161919)
