### PR TITLE
docs(plugin-meetings): play video streams manually

### DIFF
--- a/packages/node_modules/samples/browser-plugin-meetings/app.js
+++ b/packages/node_modules/samples/browser-plugin-meetings/app.js
@@ -8,6 +8,7 @@
 /* eslint-disable no-console */
 /* eslint-disable no-global-assign */
 /* eslint-disable no-multi-assign */
+/* eslint-disable max-len */
 
 // Globals
 let webex;
@@ -221,6 +222,8 @@ function leaveMeeting(meetingId) {
   meeting.leave()
     .then(() => {
       meetingsCurrentDetailsElm.innerHTML = 'Not currently in a meeting';
+      // eslint-disable-next-line no-use-before-define
+      cleanUpMedia(htmlMediaElements);
     });
 }
 
@@ -278,6 +281,37 @@ function getMediaSettings() {
 
   return settings;
 }
+
+
+const htmlMediaElements = [
+  meetingStreamsLocalVideo,
+  meetingStreamsLocalShare,
+  meetingStreamsRemotelVideo,
+  meetingStreamsRemoteShare,
+  meetingStreamsRemoteAudio
+];
+
+
+function cleanUpMedia(mediaElements) {
+  mediaElements.forEach((elem) => {
+    if (elem.srcObject) {
+      elem.srcObject.getTracks().forEach((track) => track.stop());
+      // eslint-disable-next-line no-param-reassign
+      elem.srcObject = null;
+    }
+  });
+}
+
+
+function addPlayIfPausedEvents(mediaElements) {
+  mediaElements.forEach((elem) => {
+    elem.addEventListener('canplaythrough', (event) => {
+      console.log('playVideoIfPaused#canplaythrough :: Play started', elem);
+      if (elem.paused) elem.play();
+    });
+  });
+}
+
 
 function getNormalizedMeetingId(meeting) {
   return meeting.sipUri || meeting.id;
@@ -457,7 +491,7 @@ function getMediaStreams(mediaSettings = getMediaSettings(), audioVideoInputDevi
        * In the event of updating only a particular stream, other streams return as undefined.
        * We default back to previous stream in this case.
        */
-      currentMediaStreams = [localStream || currLocalShare, localShare || currLocalShare];
+      currentMediaStreams = [localStream || currLocalStream, localShare || currLocalShare];
 
       return currentMediaStreams;
     })
@@ -827,6 +861,7 @@ function addMedia() {
     }
   });
 }
+
 
 let currentDevice;
 
@@ -1228,3 +1263,6 @@ function rejectMeeting() {
   }
 }
 
+// Separate logic for Safari enables video playback after previously
+// setting the srcObject to null regardless if autoplay is set.
+window.onload = () => addPlayIfPausedEvents(htmlMediaElements);


### PR DESCRIPTION
Fixes a safari related video playback issue where the autoplay
attribute does not play the video stream after the srcObject
has been previously set to null.

Updating fix to use [`canplaythrough`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/canplaythrough_event) event which works for all
browsers and devices.

Fixes #SPARK-148169

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
