### PR TITLE
fix(plugin-meetings): shareScreen pulls in sdk configuration

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/media/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/index.js
@@ -287,6 +287,8 @@ Media.updateTransceiver = ({meetingId, remoteQualityLevel}, peerConnection, tran
  * @returns {Promise.<MediaStream>}
  */
 Media.getDisplayMedia = (options, config = {}) => {
+  const resolutionConf = config.resolution || {};
+  const {screenResolution} = Config.meetings;
   const shareConstraints =
     options.sharePreferences && options.sharePreferences.shareConstraints ?
       options.sharePreferences.shareConstraints :
@@ -301,11 +303,11 @@ Media.getDisplayMedia = (options, config = {}) => {
           } :
           {
             frameRate: Config.meetings.screenFrameRate,
-            height: Config.meetings.screenResolution.idealHeight,
-            width: Config.meetings.screenResolution.idealWidth
+            height: resolutionConf.idealHeight || screenResolution.idealHeight,
+            width: resolutionConf.idealWidth || screenResolution.idealWidth
           }),
         // Leave last to apply overrides
-        ...config
+        ...resolutionConf
       };
 
   // chrome and webkit based browsers (edge, safari) automatically adjust everything

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -3284,7 +3284,7 @@ export default class Meeting extends StatelessWebexPlugin {
       ...options
     };
 
-    return Media.getDisplayMedia(shareConstraints)
+    return Media.getDisplayMedia(shareConstraints, this.config)
       .then((shareStream) => {
         this.updateShare({
           sendShare: true,

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -4,7 +4,10 @@ import {skipInNode} from '@webex/test-helper-mocha';
 import bowser from 'bowser';
 import sinon from 'sinon';
 
+import DEFAULT_RESOLUTIONS from '../../../src/config';
+
 import testUtils from './testUtils';
+
 
 require('dotenv').config();
 
@@ -461,9 +464,11 @@ skipInNode(describe)('plugin-meetings', () => {
           })
       ])
         .then(() => {
+          const heightResolution = DEFAULT_RESOLUTIONS.meetings.resolution.idealHeight;
+
           // TODO: Re-eanable Safari when screensharing issues have been resolved
           if (!bowser.safari) {
-            assert.equal(bob.meeting.mediaProperties.shareTrack.getConstraints().height, 1080);
+            assert.equal(bob.meeting.mediaProperties.shareTrack.getConstraints().height, heightResolution);
           }
           assert.equal(bob.meeting.isSharing, true);
           console.log('SCREEN SHARE PARTICIPANTS ', JSON.stringify(bob.meeting.locusInfo.participants));

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -25,7 +25,12 @@ import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
 import TriggerProxy from '@webex/plugin-meetings/src/common/events/trigger-proxy';
 import Metrics from '@webex/plugin-meetings/src/metrics';
+import bowser from 'bowser';
 
+import DefaultSDKConfig from '../../../../src/config';
+
+// Non-stubbed function
+const {getDisplayMedia} = Media;
 
 describe('plugin-meetings', () => {
   const logger = {
@@ -583,6 +588,177 @@ describe('plugin-meetings', () => {
           await meeting.shareScreen({sharePreferences: {highFrameRate: true}});
 
           assert.calledWith(Media.getDisplayMedia, {sendShare: true, sendAudio: false, sharePreferences: {highFrameRate: true}});
+        });
+      });
+
+      describe('#shareScreen resolutions', () => {
+        let _getDisplayMedia = null;
+        const config = DefaultSDKConfig.meetings;
+        const {resolution} = config;
+        const shareOptions = {
+          sendShare: true,
+          sendAudio: false
+        };
+        const fireFoxOptions = {
+          audio: false,
+          video: {
+            audio: shareOptions.sendAudio,
+            video: shareOptions.sendShare
+          }
+        };
+
+        const MediaStream = {
+          getVideoTracks: () => [{
+            applyConstraints: () => {}
+          }]
+        };
+
+        const MediaConstraint = {
+          cursor: 'always',
+          aspectRatio: config.aspectRatio,
+          frameRate: config.screenFrameRate,
+          width: null,
+          height: null
+        };
+
+        const browserConditionalValue = (value) => {
+          const key = bowser.name.toLowerCase();
+          const defaultKey = 'default';
+
+          return value[key] || value[defaultKey];
+        };
+
+        before(() => {
+          meeting.updateShare = sinon.stub().returns(Promise.resolve());
+
+          if (!global.navigator) {
+            global.navigator = {
+              mediaDevices: {
+                getDisplayMedia: null
+              }
+            };
+          }
+          _getDisplayMedia = global.navigator.mediaDevices.getDisplayMedia;
+          Object.defineProperty(
+            global.navigator.mediaDevices,
+            'getDisplayMedia',
+            {
+              value: sinon.stub().returns(Promise.resolve(MediaStream)),
+              writable: true
+            }
+          );
+        });
+
+        after(() => {
+          // clean up for browser
+          Object.defineProperty(
+            global.navigator.mediaDevices,
+            'getDisplayMedia',
+            {
+              value: _getDisplayMedia,
+              writable: true
+            }
+          );
+        });
+
+        // eslint-disable-next-line max-len
+        it('will use shareConstraints if defined in provided options', () => {
+          const SHARE_WIDTH = 640;
+          const SHARE_HEIGHT = 480;
+          const shareConstraints = {
+            highFrameRate: 2,
+            maxWidth: SHARE_WIDTH,
+            maxHeight: SHARE_HEIGHT,
+            idealWidth: SHARE_WIDTH,
+            idealHeight: SHARE_HEIGHT
+          };
+
+          // If sharePreferences.shareConstraints is defined it ignores
+          // default SDK config settings
+          getDisplayMedia({
+            ...shareOptions,
+            sharePreferences: {shareConstraints}
+          }, config);
+
+          // eslint-disable-next-line no-undef
+          assert.calledWith(navigator.mediaDevices.getDisplayMedia,
+            browserConditionalValue({
+              default: {
+                video: {...shareConstraints}
+              },
+              // Firefox is being handled differently
+              firefox: fireFoxOptions
+            }));
+        });
+
+        // eslint-disable-next-line max-len
+        it('will use default resolution if shareConstraints is undefined and highFrameRate is defined', () => {
+          // If highFrameRate is defined it ignores default SDK config settings
+          getDisplayMedia({
+            ...shareOptions,
+            sharePreferences: {
+              highFrameRate: true
+            }
+          }, config);
+
+          // eslint-disable-next-line no-undef
+          assert.calledWith(navigator.mediaDevices.getDisplayMedia,
+            browserConditionalValue({
+              default: {
+                video: {
+                  ...MediaConstraint,
+                  frameRate: config.videoShareFrameRate,
+                  width: resolution.idealWidth,
+                  height: resolution.idealHeight,
+                  maxWidth: resolution.maxWidth,
+                  maxHeight: resolution.maxHeight,
+                  idealWidth: resolution.idealWidth,
+                  idealHeight: resolution.idealHeight
+                }
+              },
+              firefox: fireFoxOptions
+            }));
+        });
+
+        // eslint-disable-next-line max-len
+        it('will use default screenResolution if shareConstraints, highFrameRate, and SDK defaults is undefined', () => {
+          getDisplayMedia(shareOptions);
+          const {screenResolution} = config;
+
+          // eslint-disable-next-line no-undef
+          assert.calledWith(navigator.mediaDevices.getDisplayMedia,
+            browserConditionalValue({
+              default: {
+                video: {
+                  ...MediaConstraint,
+                  width: screenResolution.idealWidth,
+                  height: screenResolution.idealHeight
+                }
+              },
+              firefox: fireFoxOptions
+            }));
+        });
+
+        // eslint-disable-next-line max-len
+        it('will use SDK default resolution if set, with shareConstraints and highFrameRate being undefined', () => {
+          getDisplayMedia(shareOptions, config);
+
+          // eslint-disable-next-line no-undef
+          assert.calledWith(navigator.mediaDevices.getDisplayMedia,
+            browserConditionalValue({
+              default: {
+                video: {
+                  ...MediaConstraint,
+                  width: resolution.idealWidth,
+                  height: resolution.idealHeight,
+                  maxWidth: resolution.maxWidth,
+                  maxHeight: resolution.maxHeight,
+                  idealWidth: resolution.idealWidth,
+                  idealHeight: resolution.idealHeight
+                }
+              },
+              firefox: fireFoxOptions
+            }));
         });
       });
 


### PR DESCRIPTION
Updated shareScreen to pull in SDK configuration defaults.

Currently shareScreen was not using any resolution preferences set via SDK configuration.
Updated the logic to use these settings if present.

Fixes #SPARK-162954

**Notes:**

[![](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggVERcbiAgU1RFUDEoKHNoYXJlU2NyZWVuKSkgLS0-fEdlbmVyYXRlcyBzaGFyZSBzdHJlYW1zIGJ5IGNhbGxpbmd8IFNURVAyKFwiTWVkaWEuZ2V0RGlzcGxheU1lZGlhIChzaGFyZUNvbnN0cmFpbnRzT3B0aW9ucywgc2RrQ29uZmlnKVwiKVxuICBcbiAgU1RFUDIgLS0-IHxMb2dpYyBmb3IgZ2VuZXJhdGluZyBjb25zdHJhaW50c3wgU1RFUDN7XCJEb2VzIHNoYXJlQ29uc3RyYWludHMgZXhpc3Q8YnI-d2l0aGluIHNoYXJlUHJlZmVyZW5jZXMgb3B0aW9uczxicj5wYXNzZWQgaW4gdG8gdGhlIGZ1bmN0aW9uP1wifVxuICBcbiAgU1RFUDMgLS0-fFlFUyAtIEV4aXN0c3wgU1RFUDNfMVtVc2Ugc2FtZSBzaGFyZSBwcmVmZXJlbmNlcyBwYXNzZWQgaW5dXG4gIFNURVAzIC0tPnxOT3wgU1RFUDNfMltCdWlsZCBvYmplY3QgbGl0ZXJhbF1cbiAgU1RFUDNfMiAtLT4gU1RFUDR7XCJJcyBoaWdoRnJhbWVSYXRlIGRlZmluZWQ8YnI-d2l0aGluIHNoYXJlUHJlZmVyZW5jZXMgb3B0aW9ucz9cIn1cblxuXG4gIFNURVA0IC0tPiB8WUVTIC0gRXhpc3RzfCBTVEVQNF8xKFB1bGwgdmFsdWVzIGZyb20gY29uZmlnLmpzIC0gQ29uZmlnLm1lZXRpbmdzPGJyPjxicj5mcmFtZVJhdGU6IHZpZGVvU2hhcmVGcmFtZVJhdGU8YnI-aGVpZ2h0OiByZXNvbHV0aW9uLmlkZWFsSGVpZ2h0PGJyPndpZHRoOiByZXNvbHV0aW9uLmlkZWFsV2lkdGgpXG4gIFNURVA0IC0tPiB8Tk98IFNURVA0XzIoXCJDb25maWcubWVldGluZ3MgPT4gY29uZmlnLmpzPGJyPnNka0NvbmZpZyA9PiBXZWJleC5pbml0IFNESyBDb25maWc8YnI-PGJyPjxicj5mcmFtZVJhdGU6IENvbmZpZy5tZWV0aW5ncy5zY3JlZW5GcmFtZVJhdGU8YnI-aGVpZ2h0OiBzZGtDb25maWcuaWRlYWxIZWlnaHQgfHwgQ29uZmlnLm1lZXRpbmdzLnNjcmVlblJlc29sdXRpb24uaWRlYWxIZWlnaHQ8YnI-d2lkdGg6IHNka0NvbmZpZy5pZGVhbFdpZHRoIHx8IENvbmZpZy5tZWV0aW5ncy5zY3JlZW5SZXNvbHV0aW9uLmlkZWFsV2lkdGhcIilcbiAgU1RFUDRfMSAtLT4gU1RFUDRfMUIoZmE6ZmEtZXhjbGFtYXRpb24tdHJpYW5nbGU8YnI-V2hhdCBpZiBJIHdhbnQgaGlnaEZyYW1lUmF0ZTxicj5hbG9uZyB3aXRoIGN1c3RvbSB3aWR0aCBhbmQgaGVpZ2h0PykgXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggVERcbiAgU1RFUDEoKHNoYXJlU2NyZWVuKSkgLS0-fEdlbmVyYXRlcyBzaGFyZSBzdHJlYW1zIGJ5IGNhbGxpbmd8IFNURVAyKFwiTWVkaWEuZ2V0RGlzcGxheU1lZGlhIChzaGFyZUNvbnN0cmFpbnRzT3B0aW9ucywgc2RrQ29uZmlnKVwiKVxuICBcbiAgU1RFUDIgLS0-IHxMb2dpYyBmb3IgZ2VuZXJhdGluZyBjb25zdHJhaW50c3wgU1RFUDN7XCJEb2VzIHNoYXJlQ29uc3RyYWludHMgZXhpc3Q8YnI-d2l0aGluIHNoYXJlUHJlZmVyZW5jZXMgb3B0aW9uczxicj5wYXNzZWQgaW4gdG8gdGhlIGZ1bmN0aW9uP1wifVxuICBcbiAgU1RFUDMgLS0-fFlFUyAtIEV4aXN0c3wgU1RFUDNfMVtVc2Ugc2FtZSBzaGFyZSBwcmVmZXJlbmNlcyBwYXNzZWQgaW5dXG4gIFNURVAzIC0tPnxOT3wgU1RFUDNfMltCdWlsZCBvYmplY3QgbGl0ZXJhbF1cbiAgU1RFUDNfMiAtLT4gU1RFUDR7XCJJcyBoaWdoRnJhbWVSYXRlIGRlZmluZWQ8YnI-d2l0aGluIHNoYXJlUHJlZmVyZW5jZXMgb3B0aW9ucz9cIn1cblxuXG4gIFNURVA0IC0tPiB8WUVTIC0gRXhpc3RzfCBTVEVQNF8xKFB1bGwgdmFsdWVzIGZyb20gY29uZmlnLmpzIC0gQ29uZmlnLm1lZXRpbmdzPGJyPjxicj5mcmFtZVJhdGU6IHZpZGVvU2hhcmVGcmFtZVJhdGU8YnI-aGVpZ2h0OiByZXNvbHV0aW9uLmlkZWFsSGVpZ2h0PGJyPndpZHRoOiByZXNvbHV0aW9uLmlkZWFsV2lkdGgpXG4gIFNURVA0IC0tPiB8Tk98IFNURVA0XzIoXCJDb25maWcubWVldGluZ3MgPT4gY29uZmlnLmpzPGJyPnNka0NvbmZpZyA9PiBXZWJleC5pbml0IFNESyBDb25maWc8YnI-PGJyPjxicj5mcmFtZVJhdGU6IENvbmZpZy5tZWV0aW5ncy5zY3JlZW5GcmFtZVJhdGU8YnI-aGVpZ2h0OiBzZGtDb25maWcuaWRlYWxIZWlnaHQgfHwgQ29uZmlnLm1lZXRpbmdzLnNjcmVlblJlc29sdXRpb24uaWRlYWxIZWlnaHQ8YnI-d2lkdGg6IHNka0NvbmZpZy5pZGVhbFdpZHRoIHx8IENvbmZpZy5tZWV0aW5ncy5zY3JlZW5SZXNvbHV0aW9uLmlkZWFsV2lkdGhcIilcbiAgU1RFUDRfMSAtLT4gU1RFUDRfMUIoZmE6ZmEtZXhjbGFtYXRpb24tdHJpYW5nbGU8YnI-V2hhdCBpZiBJIHdhbnQgaGlnaEZyYW1lUmF0ZTxicj5hbG9uZyB3aXRoIGN1c3RvbSB3aWR0aCBhbmQgaGVpZ2h0PykgXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)


```mermaid
graph TD
  STEP1((shareScreen)) -->|Generates share streams by calling| STEP2("Media.getDisplayMedia (shareConstraintsOptions, sdkConfig)")
  
  STEP2 --> |Logic for generating constraints| STEP3{"Does shareConstraints exist<br>within sharePreferences options<br>passed in to the function?"}
  
  STEP3 -->|YES - Exists| STEP3_1[Use same share preferences passed in]
  STEP3 -->|NO| STEP3_2[Build object literal]
  STEP3_2 --> STEP4{"Is highFrameRate defined<br>within sharePreferences options?"}


  STEP4 --> |YES - Exists| STEP4_1(Pull values from config.js - Config.meetings<br><br>frameRate: videoShareFrameRate<br>height: resolution.idealHeight<br>width: resolution.idealWidth)
  STEP4 --> |NO| STEP4_2("Config.meetings => config.js<br>sdkConfig => Webex.init SDK Config<br><br><br>frameRate: Config.meetings.screenFrameRate<br>height: sdkConfig.idealHeight || Config.meetings.screenResolution.idealHeight<br>width: sdkConfig.idealWidth || Config.meetings.screenResolution.idealWidth")
  STEP4_1 --> STEP4_1B(fa:fa-exclamation-triangle<br>What if I want highFrameRate<br>along with custom width and height?) 
```

[View Mermaid chart](https://mermaid-js.github.io/mermaid-live-editor/#/view/eyJjb2RlIjoiZ3JhcGggVERcbiAgU1RFUDEoKHNoYXJlU2NyZWVuKSkgLS0-fEdlbmVyYXRlcyBzaGFyZSBzdHJlYW1zIGJ5IGNhbGxpbmd8IFNURVAyKFwiTWVkaWEuZ2V0RGlzcGxheU1lZGlhIChzaGFyZUNvbnN0cmFpbnRzT3B0aW9ucywgc2RrQ29uZmlnKVwiKVxuICBcbiAgU1RFUDIgLS0-IHxMb2dpYyBmb3IgZ2VuZXJhdGluZyBjb25zdHJhaW50c3wgU1RFUDN7XCJEb2VzIHNoYXJlQ29uc3RyYWludHMgZXhpc3Q8YnI-d2l0aGluIHNoYXJlUHJlZmVyZW5jZXMgb3B0aW9uczxicj5wYXNzZWQgaW4gdG8gdGhlIGZ1bmN0aW9uP1wifVxuICBcbiAgU1RFUDMgLS0-fFlFUyAtIEV4aXN0c3wgU1RFUDNfMVtVc2Ugc2FtZSBzaGFyZSBwcmVmZXJlbmNlcyBwYXNzZWQgaW5dXG4gIFNURVAzIC0tPnxOT3wgU1RFUDNfMltCdWlsZCBvYmplY3QgbGl0ZXJhbF1cbiAgU1RFUDNfMiAtLT4gU1RFUDR7XCJJcyBoaWdoRnJhbWVSYXRlIGRlZmluZWQ8YnI-d2l0aGluIHNoYXJlUHJlZmVyZW5jZXMgb3B0aW9ucz9cIn1cblxuXG4gIFNURVA0IC0tPiB8WUVTIC0gRXhpc3RzfCBTVEVQNF8xKFB1bGwgdmFsdWVzIGZyb20gY29uZmlnLmpzIC0gQ29uZmlnLm1lZXRpbmdzPGJyPjxicj5mcmFtZVJhdGU6IHZpZGVvU2hhcmVGcmFtZVJhdGU8YnI-aGVpZ2h0OiByZXNvbHV0aW9uLmlkZWFsSGVpZ2h0PGJyPndpZHRoOiByZXNvbHV0aW9uLmlkZWFsV2lkdGgpXG4gIFNURVA0IC0tPiB8Tk98IFNURVA0XzIoXCJDb25maWcubWVldGluZ3MgPT4gY29uZmlnLmpzPGJyPnNka0NvbmZpZyA9PiBXZWJleC5pbml0IFNESyBDb25maWc8YnI-PGJyPjxicj5mcmFtZVJhdGU6IENvbmZpZy5tZWV0aW5ncy5zY3JlZW5GcmFtZVJhdGU8YnI-aGVpZ2h0OiBzZGtDb25maWcuaWRlYWxIZWlnaHQgfHwgQ29uZmlnLm1lZXRpbmdzLnNjcmVlblJlc29sdXRpb24uaWRlYWxIZWlnaHQ8YnI-d2lkdGg6IHNka0NvbmZpZy5pZGVhbFdpZHRoIHx8IENvbmZpZy5tZWV0aW5ncy5zY3JlZW5SZXNvbHV0aW9uLmlkZWFsV2lkdGhcIilcbiAgU1RFUDRfMSAtLT4gU1RFUDRfMUIoZmE6ZmEtZXhjbGFtYXRpb24tdHJpYW5nbGU8YnI-V2hhdCBpZiBJIHdhbnQgaGlnaEZyYW1lUmF0ZTxicj5hbG9uZyB3aXRoIGN1c3RvbSB3aWR0aCBhbmQgaGVpZ2h0PykgXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
