### PR TITLE
feat(conversation): add helper for fetching all child activities

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -1477,8 +1477,8 @@ const Conversation = WebexPlugin.extend({
    * Returns a list of _all_ child activities for a given parentId within a given conversation
    * @param {object} [options = {}]
    * @param {string} [options.conversationUrl] targeted conversation URL
-   * @param {string} [activityParentId] parent id of edit activities or thread activities
-   * @param {QueryOptions} [query] object containing query string values to be appended to the url
+   * @param {string} [options.activityParentId] parent id of edit activities or thread activities
+   * @param {QueryOptions} [options.query] object containing query string values to be appended to the url
    * @returns {Promise<Array>}
    */
   async listAllChildActivitiesByParentId(options = {}) {

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -1474,6 +1474,38 @@ const Conversation = WebexPlugin.extend({
    */
 
   /**
+   * Returns a list of _all_ child activities for a given parentId within a given conversation
+   * @param {object} [options = {}]
+   * @param {string} [options.conversationUrl] targeted conversation URL
+   * @param {string} [activityParentId] parent id of edit activities or thread activities
+   * @param {QueryOptions} [query] object containing query string values to be appended to the url
+   * @returns {Promise<Array>}
+   */
+  async listAllChildActivitiesByParentId(options = {}) {
+    const {conversationUrl, activityParentId, query} = options;
+
+    const initialResponse = await this.listChildActivitiesByParentId(conversationUrl, activityParentId, query);
+
+    let page = new Page(initialResponse, this.webex);
+
+    const items = [...page.items];
+
+    while (page.hasNext()) {
+      // eslint-disable-next-line no-await-in-loop
+      page = await page.next();
+      for (const activity of page) {
+        items.push(activity);
+      }
+    }
+
+    if (last(items).published < items[0].published) {
+      items.reverse();
+    }
+
+    return items;
+  },
+
+  /**
    * Get all parent ids for a conversation.
    * @param {string} conversationUrl conversation URL.
    * @param {QueryOptions} [query] object containing query string values to be appended to the url

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -1498,6 +1498,7 @@ const Conversation = WebexPlugin.extend({
       }
     }
 
+    // reverse list if needed (see _list for precedent)
     if (last(items).published < items[0].published) {
       items.reverse();
     }

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -145,20 +145,78 @@ describe('plugin-conversation', () => {
         }));
       });
 
-      it('should call request', () => {
-        webex.internal.conversation.getReactionSummaryByParentId(convoUrl, 'test-id')
+      it('should call request', () => webex.internal.conversation.getReactionSummaryByParentId(convoUrl, 'test-id')
+        .then(() => {
+          assert.called(webex.request);
+        }));
+
+      it('should not retrieve non reaction summary objects', () => webex.internal.conversation.getReactionSummaryByParentId(convoUrl, 'test-id')
+        .then((result) => {
+          assert.equal(result.length, 3);
+          assert.notInclude(result, {type: 'notAReaction'});
+        }));
+    });
+
+    describe('#listAllChildActivitiesByParentId()', () => {
+      let dayCount = 0;
+      const createActivityItemBatch = (itemCount) => {
+        const counter = [...Array(itemCount).keys()];
+
+        dayCount += 1;
+
+        return counter.map((n) => ({
+          published: new Date(2020, 0, 1, dayCount, n)
+        }));
+      };
+
+      const createMockChildResponse = (itemsToReturn = 10) => {
+        const response = {
+          body: {
+            items: createActivityItemBatch(itemsToReturn)
+          },
+          headers: {
+            link: '<https://www.cisco.com>; rel=next'
+          }
+        };
+
+        return response;
+      };
+
+      beforeEach(() => {
+        webex.request = sinon.stub()
+          .onCall(0)
+          .returns(Promise.resolve(createMockChildResponse()))
+          .onCall(1)
+          .returns(Promise.resolve(createMockChildResponse()))
+          .onCall(2)
+          .returns(Promise.resolve(createMockChildResponse(3)))
+          .returns(Promise.resolve(Promise.resolve({
+            body: {
+              items: []
+            },
+            headers: {}
+          })));
+      });
+      it('retrieves correct children count', () => webex.internal.conversation.listAllChildActivitiesByParentId({conversationUrl: convoUrl, activityParentId: '123-abc'})
+        .then((res) => {
+          assert.equal(res.length, 23);
+        }));
+
+      it('calls #listChildActivitiesByParentId() to initiate the request', () => {
+        const spy = sinon.spy(webex.internal.conversation, 'listChildActivitiesByParentId');
+
+        return webex.internal.conversation.listAllChildActivitiesByParentId({conversationUrl: convoUrl, activityParentId: '123-abc'})
           .then(() => {
-            assert.called(webex.request);
+            assert(spy.calledOnce);
           });
       });
 
-      it('should not retrieve non reaction summary objects', () => {
-        webex.internal.conversation.getReactionSummaryByParentId(convoUrl, 'test-id')
-          .then((result) => {
-            assert.equal(result.length, 3);
-            assert.notInclude(result, {type: 'notAReaction'});
-          });
-      });
+      it('returns children in ascending published order', () => webex.internal.conversation.listAllChildActivitiesByParentId({conversationUrl: convoUrl, activityParentId: '123-abc'})
+        .then((res) => {
+          const firstMessageOlderThanLastMessage = res[0].published < res[res.length - 1].published;
+
+          assert.equal(firstMessageOlderThanLastMessage, true, 'activities out of order');
+        }));
     });
   });
 });

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -215,7 +215,7 @@ describe('plugin-conversation', () => {
         .then((res) => {
           const firstMessageOlderThanLastMessage = res[0].published < res[res.length - 1].published;
 
-          assert.equal(firstMessageOlderThanLastMessage, true, 'activities out of order');
+          assert.isTrue(firstMessageOlderThanLastMessage, 'activities out of order');
         }));
     });
   });


### PR DESCRIPTION
Create helper method to recurse through the "next" links of convo's */parent/* endpoint.

Part 2 of 3 from suggested PR flow agreed upon [here](https://github.com/webex/webex-js-sdk/pull/1809#issuecomment-666576235)