### PR TITLE
feat(conversation): add activity threading fetch methods

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,7 @@
     "transform-export-extensions",
     "lodash",
     "transform-object-rest-spread",
+    "transform-object-rest-spread",
     "syntax-async-generators",
     "transform-async-generator-functions"
   ],

--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,6 @@
     "transform-export-extensions",
     "lodash",
     "transform-object-rest-spread",
-    "transform-object-rest-spread",
     "syntax-async-generators",
     "transform-async-generator-functions"
   ],

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/activity-thread-ordering.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/activity-thread-ordering.js
@@ -2,17 +2,17 @@ import {sortBy, last} from 'lodash';
 
 // use accessors for ease of refactoring underlying implementation
 /**
-       * @param {Map} destination destination map object for data. Currently a Map, but could be refactored to use any type.
-       * @param {string} key
-       * @param {any} value
-       * @returns {Map}
-       */
+ * @param {Map} destination destination map object for data. Currently a Map, but could be refactored to use any type.
+ * @param {string} key
+ * @param {any} value
+ * @returns {Map}
+ */
 export const setValue = (destination, key, value) => destination.set(key, value);
 /**
-             * @param {Map} source source map object to access. Currently expects a Map, but could be refactored to use any type
-             * @param {string} key
-             * @returns {Map}
-             */
+ * @param {Map} source source map object to access. Currently expects a Map, but could be refactored to use any type
+ * @param {string} key
+ * @returns {Map}
+ */
 export const getValue = (source, key) => source.get(key);
 
 export const defaultMinDisplayableActivities = 20;
@@ -36,7 +36,6 @@ export const ACTIVITY_TYPES = {
   DELETE: 'DELETE'
 };
 
-// TODO: create type for tombstone edit? could make it easy to ignore older edits...
 export const getActivityType = (activity) => {
   if (activity.activityType === 'reply') {
     return ACTIVITY_TYPES.REPLY;
@@ -102,13 +101,6 @@ export const activityManager = () => {
   const reactionActivityHash = new Map();
   const reactionSelfActivityHash = new Map();
 
-  const getActivityByTypeAndId = (type, id) => ({
-    [ACTIVITY_TYPES.EDIT]: getValue(editActivityHash, id),
-    [ACTIVITY_TYPES.REPLY]: getValue(replyActivityHash, id),
-    [ACTIVITY_TYPES.REACTION]: getValue(reactionActivityHash, id),
-    [ACTIVITY_TYPES.REACTION_SELF]: getValue(reactionSelfActivityHash, id)
-  }[type]);
-
   const handleNewReply = (replyAct) => {
     const replyParentId = getParentId(replyAct);
     const existingReplyHash = getValue(replyActivityHash, replyParentId);
@@ -167,9 +159,16 @@ export const activityManager = () => {
     [ACTIVITY_TYPES.REPLY]: handleNewReply
   }[key]);
 
+  const getActivityByTypeAndParentId = (type, id) => ({
+    [ACTIVITY_TYPES.EDIT]: getValue(editActivityHash, id),
+    [ACTIVITY_TYPES.REPLY]: getValue(replyActivityHash, id),
+    [ACTIVITY_TYPES.REACTION]: getValue(reactionActivityHash, id),
+    [ACTIVITY_TYPES.REACTION_SELF]: getValue(reactionSelfActivityHash, id)
+  }[type]);
+
   return {
     getActivityHandlerByKey,
-    getActivityByTypeAndId
+    getActivityByTypeAndParentId
   };
 };
 
@@ -260,14 +259,15 @@ export const noMoreActivitiesManager = () => {
 
 export const rootActivityManager = () => {
   const rootActivityHash = new Map();
-  const handleNewRoot = (rootAct) => {
+
+  const addNewRoot = (rootAct) => {
     setValue(rootActivityHash, rootAct.id, rootAct);
   };
 
   const getRootActivityHash = () => rootActivityHash;
 
   return {
-    handleNewRoot,
+    addNewRoot,
     getRootActivityHash
   };
 };

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/activity-thread-ordering.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/activity-thread-ordering.js
@@ -36,26 +36,35 @@ export const ACTIVITY_TYPES = {
   DELETE: 'DELETE'
 };
 
+const REPLY = 'reply';
+const EDIT = 'edit';
+const REACTION_SUMMARY = 'reactionSummary';
+const REACTION_SELF_SUMMARY = 'reactionSelfSummary';
+const CREATE = 'create';
+const TOMBSTONE = 'tombstone';
+const DELETE = 'delete';
+const ADD = 'add';
+
 export const getActivityType = (activity) => {
-  if (activity.activityType === 'reply') {
+  if (activity.activityType === REPLY) {
     return ACTIVITY_TYPES.REPLY;
   }
-  if (activity.parent && activity.parent.type === 'edit') {
+  if (activity.parent && activity.parent.type === EDIT) {
     return ACTIVITY_TYPES.EDIT;
   }
-  if (activity.verb === 'add' || activity.type === 'reactionSummary') {
+  if (activity.verb === ADD || activity.type === REACTION_SUMMARY) {
     return ACTIVITY_TYPES.REACTION;
   }
-  if (activity.type === 'reactionSelfSummary') {
+  if (activity.type === REACTION_SELF_SUMMARY) {
     return ACTIVITY_TYPES.REACTION_SELF;
   }
-  if (activity.verb === 'create') {
+  if (activity.verb === CREATE) {
     return ACTIVITY_TYPES.CREATE;
   }
-  if (activity.verb === 'tombstone') {
+  if (activity.verb === TOMBSTONE) {
     return ACTIVITY_TYPES.TOMBSTONE;
   }
-  if (activity.verb === 'delete') {
+  if (activity.verb === DELETE) {
     return ACTIVITY_TYPES.DELETE;
   }
 
@@ -95,6 +104,12 @@ export const sanitizeActivity = (activity) => {
   return final;
 };
 
+/**
+ * creates maps for various activity types and defines handlers for working with stored activities
+ * utilizes revealing module pattern to close over state and only expose certain necessary functions for altering state
+ * @function
+ * @returns {object} returns
+ */
 export const activityManager = () => {
   const replyActivityHash = new Map();
   const editActivityHash = new Map();

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/activity-thread-ordering.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/activity-thread-ordering.js
@@ -1,0 +1,331 @@
+import {sortBy, last} from 'lodash';
+
+// use accessors for ease of refactoring underlying implementation
+/**
+       * @param {Map} destination destination map object for data. Currently a Map, but could be refactored to use any type.
+       * @param {string} key
+       * @param {any} value
+       * @returns {Map}
+       */
+export const setValue = (destination, key, value) => destination.set(key, value);
+/**
+             * @param {Map} source source map object to access. Currently expects a Map, but could be refactored to use any type
+             * @param {string} key
+             * @returns {Map}
+             */
+export const getValue = (source, key) => source.get(key);
+
+export const defaultMinDisplayableActivities = 20;
+export const minBatchSize = 10;
+export const fetchLoopCountMax = 100;
+export const batchSizeIncrementCount = 10;
+
+export const OLDER = 'older';
+export const NEWER = 'newer';
+export const MID = 'mid';
+export const INITIAL = 'initial';
+
+export const ACTIVITY_TYPES = {
+  REPLY: 'REPLY',
+  EDIT: 'EDIT',
+  REACTION: 'REACTION',
+  REACTION_SELF: 'REACTION_SELF',
+  ROOT: 'ROOT',
+  CREATE: 'CREATE',
+  TOMBSTONE: 'TOMBSTONE',
+  DELETE: 'DELETE'
+};
+
+// TODO: create type for tombstone edit? could make it easy to ignore older edits...
+export const getActivityType = (activity) => {
+  if (activity.activityType === 'reply') {
+    return ACTIVITY_TYPES.REPLY;
+  }
+  if (activity.parent && activity.parent.type === 'edit') {
+    return ACTIVITY_TYPES.EDIT;
+  }
+  if (activity.verb === 'add' || activity.type === 'reactionSummary') {
+    return ACTIVITY_TYPES.REACTION;
+  }
+  if (activity.type === 'reactionSelfSummary') {
+    return ACTIVITY_TYPES.REACTION_SELF;
+  }
+  if (activity.verb === 'create') {
+    return ACTIVITY_TYPES.CREATE;
+  }
+  if (activity.verb === 'tombstone') {
+    return ACTIVITY_TYPES.TOMBSTONE;
+  }
+  if (activity.verb === 'delete') {
+    return ACTIVITY_TYPES.DELETE;
+  }
+
+  return ACTIVITY_TYPES.ROOT;
+};
+
+export const getPublishedDate = (activity = {}) => new Date(activity.published).getTime();
+
+/**
+ * @param {Object} activity1
+ * @param {Object} activity2
+ * @returns {boolean} true if first activity is newer than second
+ */
+export const isNewer = (activity1, activity2) => getPublishedDate(activity1) > getPublishedDate(activity2);
+
+export const getActivityObjectsFromMap = (hashMap) => Array.from(hashMap).map(([, activity]) => activity);
+
+export const sortActivitiesByPublishedDate = (activities) => sortBy(activities, (activity) => getPublishedDate(activity));
+
+export const getParentId = (activity) => activity && activity.parent && activity.parent.id;
+
+export const isRootActivity = (act) => getActivityType(act) === ACTIVITY_TYPES.ROOT;
+export const isReplyActivity = (act) => getActivityType(act) === ACTIVITY_TYPES.REPLY;
+export const isEditActivity = (act) => getActivityType(act) === ACTIVITY_TYPES.EDIT;
+export const isCreateActivity = (act) => getActivityType(act) === ACTIVITY_TYPES.CREATE;
+export const isDeleteActivity = (act) => getActivityType(act) === ACTIVITY_TYPES.DELETE;
+
+export const sanitizeActivity = (activity) => {
+  const final = {...activity};
+
+  final.reaction = activity.reaction || {};
+  final.reactionSelf = activity.reactionSelf || {};
+
+  // replies will be spread in order beneath parent, no need to include on final objects
+  delete final.replies;
+
+  return final;
+};
+
+export const activityManager = () => {
+  const replyActivityHash = new Map();
+  const editActivityHash = new Map();
+  const reactionActivityHash = new Map();
+  const reactionSelfActivityHash = new Map();
+
+  const getActivityByTypeAndId = (type, id) => ({
+    [ACTIVITY_TYPES.EDIT]: getValue(editActivityHash, id),
+    [ACTIVITY_TYPES.REPLY]: getValue(replyActivityHash, id),
+    [ACTIVITY_TYPES.REACTION]: getValue(reactionActivityHash, id),
+    [ACTIVITY_TYPES.REACTION_SELF]: getValue(reactionSelfActivityHash, id)
+  }[type]);
+
+  const handleNewReply = (replyAct) => {
+    const replyParentId = getParentId(replyAct);
+    const existingReplyHash = getValue(replyActivityHash, replyParentId);
+
+    if (existingReplyHash) {
+      setValue(existingReplyHash, replyAct.id, replyAct);
+    }
+    else {
+      const replyHash = new Map();
+
+      setValue(replyHash, replyAct.id, replyAct);
+      setValue(replyActivityHash, replyParentId, replyHash);
+    }
+  };
+
+  const handleNewEdit = (editAct) => {
+    const isTombstone = editAct.verb === ACTIVITY_TYPES.TOMBSTONE;
+
+    // we can ignore tombstone edits in favor of the newer one
+    if (isTombstone) {
+      return;
+    }
+
+    const editParentId = getParentId(editAct);
+    const existingEdit = getValue(editActivityHash, editParentId);
+
+    // edited activity must be newer than what we already have
+    if (!existingEdit || isNewer(editAct, existingEdit)) {
+      setValue(editActivityHash, editParentId, editAct);
+    }
+  };
+
+  // logic is identical between reactions and reaction selfs, so handler simply passes the activity and the correct hash
+  const reactionHelper = (reactionAct, hash) => {
+    const reactionParentId = getParentId(reactionAct);
+    const existingReaction = getValue(hash, reactionParentId);
+
+    // reaction activity must be newer than what we already have
+    if (!existingReaction || isNewer(reactionAct, existingReaction)) {
+      setValue(hash, reactionParentId, reactionAct);
+    }
+  };
+
+  const handleNewReaction = (reactionAct) => {
+    reactionHelper(reactionAct, reactionActivityHash);
+  };
+
+  const handleNewReactionSelf = (reactionSelfAct) => {
+    reactionHelper(reactionSelfAct, reactionSelfActivityHash);
+  };
+
+  const getActivityHandlerByKey = (key) => ({
+    [ACTIVITY_TYPES.REACTION]: handleNewReaction,
+    [ACTIVITY_TYPES.REACTION_SELF]: handleNewReactionSelf,
+    [ACTIVITY_TYPES.EDIT]: handleNewEdit,
+    [ACTIVITY_TYPES.REPLY]: handleNewReply
+  }[key]);
+
+  return {
+    getActivityHandlerByKey,
+    getActivityByTypeAndId
+  };
+};
+
+/**
+ * encapsulates state and logic for managing oldest and newest activities
+ * @returns {object} setters and getters for activity state management
+ */
+export const bookendManager = () => {
+  // keep track of generator state, like what our current oldest & newest activities are
+  let oldestAct;
+  let newestAct;
+
+  const getOldestAct = () => oldestAct;
+  const getNewestAct = () => newestAct;
+
+  const setOldestAct = (act) => {
+    if (!oldestAct) {
+      oldestAct = act;
+    }
+    else if (isNewer(oldestAct, act)) {
+      oldestAct = act;
+    }
+  };
+
+  const setNewestAct = (act) => {
+    if (!newestAct) {
+      newestAct = act;
+    }
+    else if (isNewer(act, newestAct)) {
+      newestAct = act;
+    }
+  };
+
+  const setBookends = (activities) => {
+    const oldestActsFirst = sortActivitiesByPublishedDate(activities);
+
+    const newestInBatch = last(oldestActsFirst);
+    const oldestInBatch = oldestActsFirst[0];
+
+    setOldestAct(oldestInBatch);
+    setNewestAct(newestInBatch);
+  };
+
+  return {
+    setBookends,
+    getNewestAct,
+    getOldestAct
+  };
+};
+
+export const noMoreActivitiesManager = () => {
+  // used to determine if we should continue to fetch older activities
+  // must be set per iteration, as querying newer activities is still valid when all end of convo has been reached
+  let noMoreActs = false;
+  let noOlderActs = false;
+  let noNewerActs = false;
+
+  const getNoMoreActs = () => noMoreActs;
+
+  const checkAndSetNoOlderActs = (act) => {
+    if (!noOlderActs && getActivityType(act) === ACTIVITY_TYPES.CREATE) {
+      noOlderActs = true;
+    }
+  };
+
+  const checkAndSetNoNewerActs = (activities) => {
+    if (!activities || !activities.length) {
+      noNewerActs = true;
+    }
+  };
+
+  const checkAndSetNoMoreActs = (queryType) => {
+    if (
+      (queryType === NEWER && noNewerActs) ||
+      ((queryType === OLDER || queryType === INITIAL) && noOlderActs)
+    ) {
+      noMoreActs = true;
+    }
+  };
+
+  return {
+    getNoMoreActs,
+    checkAndSetNoMoreActs,
+    checkAndSetNoNewerActs,
+    checkAndSetNoOlderActs
+  };
+};
+
+export const rootActivityManager = () => {
+  const rootActivityHash = new Map();
+  const handleNewRoot = (rootAct) => {
+    setValue(rootActivityHash, rootAct.id, rootAct);
+  };
+
+  const getRootActivityHash = () => rootActivityHash;
+
+  return {
+    handleNewRoot,
+    getRootActivityHash
+  };
+};
+
+export const getLoopCounterFailsafe = () => {
+  let fetchLoopCount = 0;
+
+  return () => {
+    fetchLoopCount += 1;
+    if (fetchLoopCount > fetchLoopCountMax) {
+      throw new Error('max fetches reached');
+    }
+  };
+};
+
+/**
+ * creates activity query object
+ * @param {string} type type of query to create
+ * @param {object} queryOptions options to define query
+ * @param {string} [queryOptions.newestPublishedDate] the date of the newest fetched activity
+ * @param {string} [queryOptions.oldestPublishedDate] the date of the oldest fetched activity
+ * @param {number} [queryOptions.batchSize] the number of activities to query
+ * @param {object} [queryOptions.activityToSearch] a server activity to use to build middate query
+ * @returns {object}
+ */
+export const getQuery = (type, queryOptions) => {
+  const {
+    newestPublishedDate, oldestPublishedDate, batchSize, activityToSearch = {}
+  } = queryOptions;
+
+  switch (type) {
+    case NEWER: {
+      const sinceDate = newestPublishedDate + 1;
+      const lastActivityFirst = false;
+
+      return {sinceDate, lastActivityFirst};
+    }
+    case MID: {
+      const searchType = getActivityType(activityToSearch);
+      let midDate;
+
+      if (searchType === ACTIVITY_TYPES.REPLY || searchType === ACTIVITY_TYPES.EDIT) {
+        midDate = activityToSearch.parent.published;
+      }
+      else {
+        midDate = activityToSearch.published;
+      }
+
+      return {midDate, limit: batchSize};
+    }
+    case OLDER: {
+      const maxDate = oldestPublishedDate - 1;
+
+      return {maxDate};
+    }
+    case INITIAL:
+    default: {
+      return {};
+    }
+  }
+};

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/activity-thread-ordering.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/activity-thread-ordering.js
@@ -108,7 +108,9 @@ export const sanitizeActivity = (activity) => {
  * creates maps for various activity types and defines handlers for working with stored activities
  * utilizes revealing module pattern to close over state and only expose certain necessary functions for altering state
  * @function
- * @returns {object} returns
+ * @returns {object}
+ * getActivityHandlerByKey(activityType) - accepts a key to map to a defined activity handler
+ * getActivityByTypeAndParentId(activityType, parentId) accepts a key and a parent ID to return an activity of that type whose parent is the parentId
  */
 export const activityManager = () => {
   const replyActivityHash = new Map();
@@ -234,6 +236,10 @@ export const bookendManager = () => {
   };
 };
 
+/**
+ * encapsulates state and logic for when there are no more fetchable activities from convo
+ * @returns {object} setters and getters for no more activities logic
+ */
 export const noMoreActivitiesManager = () => {
   // used to determine if we should continue to fetch older activities
   // must be set per iteration, as querying newer activities is still valid when all end of convo has been reached
@@ -272,6 +278,10 @@ export const noMoreActivitiesManager = () => {
   };
 };
 
+/**
+ * encapsulates state and logic for managing root activities
+ * @returns {object} setters and getters for activity state management
+ */
 export const rootActivityManager = () => {
   const rootActivityHash = new Map();
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/activity-threading.md
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/activity-threading.md
@@ -1,0 +1,263 @@
+# Activity Threading Ordering
+
+Activity thread ordering (or "threading") is the act of flattening the hierarchical relationship of thread parents and thread replies.
+
+## Why Thread Order?
+When a client fetches activities from conversation service, convo returns chronologically ordered activities (by published date). If you are a client that attempts to display activities to a user, this is mostly useless. An example:
+
+Client: hey convo, give me 10 activities
+
+Convo: here.
+  1. reaction
+  2. root
+  3. reaction
+  4. reply
+  5. edit
+  6. edit
+  7. reply
+  8. reaction
+  9. meeting
+  10. reply
+  
+Client: ...
+
+Convo: ...
+
+By contrast, thread ordering returns activities in _thread order_, otherwise known as _useful order_. An example:
+
+Client: hey convo, give me 10 activities in thread order
+
+Convo: here.
+  1. root 4
+  2. reply to root 4
+  3. reply to root 4
+  4. root 3
+  5. reply to root 3
+  6. reply to root 3
+  7. root 2
+  8. reply to root 2
+  9. reply to root 2
+  10. root 1 (newest root activity)
+  
+Client: 👍
+
+Convo: 👍
+
+As you can see, thread ordering is useful, and as you may _not_ see, it is difficult to implement. The fewer clients that are forced to implement thread ordering themselves, the better for the wellbeing of the entire world.
+
+<!-- ## Useful terminology
+
+* thread parent, parent - an activity that has replies
+* root activity, root - an activity that is or could be a thread parent
+* child activity, child - an activity that points to a parent activity, but not necessarily a root
+* thread reply, thread - an activity that is a reply to a root activity
+* orphan - a child activity whose parent has not been fetched
+-->
+
+# The Code
+
+Thread ordering methods live in the internal converation plugin
+```
+webex.internal.conversation[*]
+```
+
+There are two methods that compose thread ordering, a public and private method. The public method is simply a facade of the private method, abstracting the complex away from the caller.
+
+### `_listActivitiesThreadOrdered(options)` (private)
+The `_listActivitiesThreadOrdered` method is a stateful async generator function that fetches thread ordered activities.
+
+#### Description
+The `_listActivitiesThreadOrdered` method instantiates a generator function that yields a promise. It yields results in an infinite loop for the life of the generator (until the instance is no longer referenced and JS garbage collects). This means when the method yields a result it pauses execution until its next invocation, freezing its current state to be used by the next invocation. The generator instance internally tracks the oldest and newest activities it has fetched, using them as the timestamps to query the next set of results in either direction, thus the caller is not required to maintain any state to fetch older and newer activities. This method does not cache all fetched activities, therefore the caller is still required to store their fetched activities or be forced to refetch them. 
+
+The generator's returned `next` method accepts arguments as well, which allows the caller to change the direction of their querying from newer messages to older ones without creating a new generator instance. `next`
+
+#### Parameters
+_generator initialization options_
+
+options
+
+  options.url: the conversation's convo URL
+
+  options.minActivities: the minimum number of activities you would like in your batch
+
+  options.queryType: the direction to fetch activities. One of 'newer', 'older', 'mid'
+
+  options.search: a server activity object to return as the middle point of the batch, along with its surrounding activities
+
+_parameters accepted by the generator's `next` method_
+
+options
+
+  options.queryType: see above
+
+  options.search: see above
+
+
+#### Return value
+Calling `_listActivitiesThreadOrdered` returns the generator instance, and does not execute any work. The generator returned has a `next` method that begins the first round of work and returns a `done` boolean and a `value`, the asked-for thread ordered activities.
+
+```
+interface IActivity {
+  id: string;
+  activity: <server Activity>;
+  reaction: <server ReactionSummary>
+  reactionSelf: <server ReactionSelfSummary>
+}
+
+done: boolean,
+value: IActivity[]
+```
+
+#### Examples
+```
+const options = {
+  url: 'myconvourl.com',
+  minActivities: 20,
+  queryType: 'older',
+  search: null
+}
+const threadOrderedFetcher = webex.internal.conversation._listActivitiesThreadOrdered(options);
+await threadOrderedFetcher.next() // => { done: booelan, value: IActivity[] }
+```
+
+#### The nitty gritty: design
+
+There are 3 main phases of the method, with one major subphase:
+1. initialization: up to the ` while (true)` loop
+2. execution: the ` while (true)` loop
+3. (subphase of execution) fetching: the ` while (!getNoMoreActs())` loop
+4. re-calculation: after the ` yield`
+
+##### initialization
+Parsing the arguments and initializing state is done in this first phase, before the generator's first execution. State that must be retained independent of each execution loop (the code run by the generator's `next` method) is instantiated here. The following variables (or grouped of variables) are created and maintained for the life of the generator:
+
+* oldestAct - the oldest activity (by published date) that has been fetched by the gen. instance
+* newestAct - the newest activity that has been fetched by the gen. instance
+* batchSize - the number of activities to fetch to achieve minActivities. This value is set lower in cases where we fetch children, because adding the children to their parents may help us reach minActivities count
+* query - initialize fetching query. The first query will be forced to fetch newest activities in a space to initialize the activity states, unless a search is requested
+* ***ActivityHash(es): cache objects for children activities. These caches store all child activity types returned from convo fetches in order to keep track of "orphans", or child activities that come in before their parent activity
+
+##### execution
+The execution phase will be run for every call to `next` method. Its job is to fetch activities until the minimum activity limit is reached, then it will build the ordered list of activities and yield them to the caller. Similar to init phase, execution phase has variables declared outside the fetching loop in order to keep track of what we have fetched so far, and whether continuing to fetch is necessary. The execuction phase runs the fetching subphase. The following state variables are tracked by this outer loop, before the fetching phase:
+
+* rootActivityHash - the data structure used to track root activities we have fetched in a given batch
+* [* helpers] - many helper functions are declared. They close over state variables and are used to group functionality used by the fetching loop, and for self-documenting purposes
+* fetchLoopCount - track count of fetch loops run. Used to break out of loop in unlikely case that we fetch the same query over and over.
+
+##### fetching
+The fetching phase is contained within the execution phase, and is a loop that will run until we run out of activities to fetch, or explicitly break the loop when we reach the minActivities count with what we've fetched so far. Each fetch loop begins by setting up the query and passing options to `#listActivities` method. All query types depend on a first query to activities to get N root activities. midDate queries (aliased MID) and sinceDate queries (aliased NEWER) also must recursively fetch children to ensure we don't return to caller a root activity that is missing children.*
+
+*NOTE: These sometimes-necessary children queries depend on the addition of a new method, `#listAllChildActivitiesByParentId`. This method is similar to `listChildActivitiesByParentId`, but this method recursively fetches all the chilren of a certain type, rather than forcing the calling method to fetch 10 children at a time (as is the current child limit set by underlying convo API).
+
+Activities returned to us by convo fetches are sorted and placed into maps based off their activity type. Root activities are stored on a per-batch basis, whereas children are stored globally (prevents orphans). Root activities are keyed by their ID, where children are keyed by their parent's ID (`activity.parent.id`).
+
+When reactions are fetched, however, we call a _different_ convo API that helps us reduce server roundtrips (this is why the fetch for reactions is different from the fetch for edits and replies).
+
+Fetching loop can be explicitly broken out of when we have decided we have the necessary activities for the current batch. If we _don't_ have enough activities, we initialize a new query derived from the former query and return to the top of the fetching loop to continue building our list.
+
+##### execution (revisited)
+After a successful series of fetches have given us the activities necessary for the current batch, we initialize an empty array that acts as our ordered list. To begin, the current batch's root activities are sorted by their published date, and using the ordered list of IDs, we begin to loop over the rootActivityHash. 
+
+For every root activity, the ID of the root is used to check all the child hashes (keyed by _parent ID_, recall), and implement IActivity. When a root activity has replies, a similar process is undergone for the reply activity: sorting it by published date, checking its ID against the edits and reactions hash, and sanitizing to implement IActivity. Replies are then looped over and added to the ordered list before moving on to the next root.
+
+We have successfully finished a batch, and will now yield the ordered list to the caller.
+
+##### recalculation
+The generator's `next` method may accepts arguments in order to alter the behavior of the existing generator. Assigning `yield` to a variable captures the arguments passed into `next` method. The `next` method accepts a new value for minActivities, as well as an override for `queryType`. This allows the same generator (and its state) to be used for multiple queries that build one upon another.
+
+The first call to `next` (the first call) is initialized automatically as an INITIAL fetch, to populate the generator state, but subsequent calls to `next` method without a passed-in `queryType` will close the generator.
+
+### `listActivitiesThreadOrdered(options)` (public)
+The public facade exposes wrappers for ease of managing an instance of the generator. All methods implement the iterator protocol The following methods are exposed:
+
+#### `getOlder()`
+Implements iterator protocol. Returns oldest activities, then returns any older activities than the oldest fetched.
+
+example:
+```
+const myGen = webex.internal.conversation.listActivitiesThreadOrdered(opts);
+const firstBatch = await myGen.getOlder();
+console.log(firstBatch)
+/*
+{
+  done: false,
+  value: IActivity[] // the most recent activities from the given conversation
+}
+*/
+const secondBatch = await myGen.getOlder();
+console.log(secondBatch)
+/*
+{
+  done: boolean (true if we reach beginning of convo, else false),
+  value: IActivity[] // activities older than firstBatch[0]
+}
+*/
+```
+
+#### jumpToActivity(searchActivity)
+Implements iterator protocol. Returns searched activity as the middle activity in a batch, with older and newer activities surrounding. 
+
+example: 
+```
+const activitySearchResult = IServerActivity // actual activity object returned by server, most commonly returned by activity search
+const myGen = webex.internal.conversation.listActivitiesThreadOrdered(opts);
+const results = await myGen.jumpToActivity(activitySearchResult);
+console.log(results)
+/*
+{
+  done: true,
+  value: [...IActivity[], IActivity<activitySearchResult>, ...IActivity[]]
+}
+*/
+```
+#### `getNewer()` 
+Implements iterator protocol. Returns most recent activities, then returns any newer activities than the newest fetched.
+
+example:
+```
+const myGen = webex.internal.conversation.listActivitiesThreadOrdered(opts);
+const firstBatch = await myGen.getNewer();
+console.log(firstBatch)
+/*
+{
+   done: false,
+   value: IActivity[] // the most recent activities from the given conversation
+}
+*/
+// NOTE: assume second batch is fetched before any new activities are created in the conversation
+const secondBatch = await myGen.getNewer();
+console.log(secondBatch)
+/*
+{
+  done: true,
+  value: []
+}
+*/
+```
+`getNewer()` is of limited use at first, but consider the following example, when used in conjunction with `jumpToActivity`:
+```
+const activitySearchResult = IServerActivity // actual activity object returned by server, most commonly returned by activity search
+const myGen = webex.internal.conversation.listActivitiesThreadOrdered(opts);
+const firstBatch = await myGen.jumpToActivity(activitySearchResult);
+console.log(firstBatch)
+/*
+{
+  done: true,
+  value: [...IActivity[], IActivity<activitySearchResult>, ...IActivity[]]
+}
+*/
+
+const secondBatch = await myGen.getNewer();
+console.log(secondBatch);
+/*
+{
+  done: false,
+  value: IActivity[] // where secondBatch[0] is the next activity after the last of firstBatch
+}
+*/
+```
+
+
+
+
+

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/activity-threading.md
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/activity-threading.md
@@ -117,7 +117,7 @@ const options = {
   search: null
 }
 const threadOrderedFetcher = webex.internal.conversation._listActivitiesThreadOrdered(options);
-await threadOrderedFetcher.next() // => { done: booelan, value: IActivity[] }
+await threadOrderedFetcher.next() // => { done: boolean, value: IActivity[] }
 ```
 
 #### The nitty gritty: design

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -1749,7 +1749,7 @@ const Conversation = WebexPlugin.extend({
     let batchSize = defaultBatchSize;
 
     // exposes activity states and handlers with simple getters
-    const {getActivityHandlerByKey, getActivityByTypeAndId} = activityManager();
+    const {getActivityHandlerByKey, getActivityByTypeAndParentId} = activityManager();
 
     // set initial query
     let query = getQuery(queryType, {activityToSearch: search, batchSize});
@@ -1763,7 +1763,7 @@ const Conversation = WebexPlugin.extend({
       // ***********************************************
 
       // stores all "root" activities (activities that are, or could be, thread parents)
-      const {getRootActivityHash, handleNewRoot} = rootActivityManager();
+      const {getRootActivityHash, addNewRoot} = rootActivityManager();
 
       // used to determine if we should continue to fetch older activities
       // must be set per iteration, as querying newer activities is still valid when all end of convo has been reached
@@ -1775,13 +1775,13 @@ const Conversation = WebexPlugin.extend({
       } = noMoreActivitiesManager();
 
       const getActivityHandlerByType = (type) => ({
-        [ACTIVITY_TYPES.ROOT]: handleNewRoot,
+        [ACTIVITY_TYPES.ROOT]: addNewRoot,
         [ACTIVITY_TYPES.REPLY]: getActivityHandlerByKey(ACTIVITY_TYPES.REPLY),
         [ACTIVITY_TYPES.EDIT]: getActivityHandlerByKey(ACTIVITY_TYPES.EDIT),
         [ACTIVITY_TYPES.REACTION]: getActivityHandlerByKey(ACTIVITY_TYPES.REACTION),
         [ACTIVITY_TYPES.REACTION_SELF]: getActivityHandlerByKey(ACTIVITY_TYPES.REACTION_SELF),
-        [ACTIVITY_TYPES.TOMBSTONE]: handleNewRoot,
-        [ACTIVITY_TYPES.CREATE]: handleNewRoot
+        [ACTIVITY_TYPES.TOMBSTONE]: addNewRoot,
+        [ACTIVITY_TYPES.CREATE]: addNewRoot
       }[type]);
 
       const handleNewActivity = (activity) => {
@@ -1941,7 +1941,7 @@ const Conversation = WebexPlugin.extend({
 
         for (const rootActivity of rootActivityHash.values()) {
           const {id: rootId} = rootActivity;
-          const repliesByRootId = getActivityByTypeAndId(ACTIVITY_TYPES.REPLY, rootId);
+          const repliesByRootId = getActivityByTypeAndParentId(ACTIVITY_TYPES.REPLY, rootId);
 
           if (repliesByRootId && repliesByRootId.size) {
             visibleActivitiesCount += repliesByRootId.size || 0;
@@ -1993,7 +1993,7 @@ const Conversation = WebexPlugin.extend({
       const getRepliesByParentId = (replyParentId) => {
         const replies = [];
 
-        const repliesByParentId = getActivityByTypeAndId(ACTIVITY_TYPES.REPLY, replyParentId);
+        const repliesByParentId = getActivityByTypeAndParentId(ACTIVITY_TYPES.REPLY, replyParentId);
 
         if (!repliesByParentId) {
           return replies;
@@ -2003,9 +2003,9 @@ const Conversation = WebexPlugin.extend({
 
         sortedReplies.forEach((replyActivity) => {
           const replyId = replyActivity.id;
-          const edit = getActivityByTypeAndId(ACTIVITY_TYPES.EDIT, replyId);
-          const reaction = getActivityByTypeAndId(ACTIVITY_TYPES.REACTION, replyId);
-          const reactionSelf = getActivityByTypeAndId(ACTIVITY_TYPES.REACTION_SELF, replyId);
+          const edit = getActivityByTypeAndParentId(ACTIVITY_TYPES.EDIT, replyId);
+          const reaction = getActivityByTypeAndParentId(ACTIVITY_TYPES.REACTION, replyId);
+          const reactionSelf = getActivityByTypeAndParentId(ACTIVITY_TYPES.REACTION_SELF, replyId);
 
           const finalReply = edit || replyActivity;
 
@@ -2029,9 +2029,9 @@ const Conversation = WebexPlugin.extend({
       orderedRoots.forEach((rootActivity) => {
         const rootId = rootActivity.id;
         const replies = getRepliesByParentId(rootId);
-        const edit = getActivityByTypeAndId(ACTIVITY_TYPES.EDIT, rootId);
-        const reaction = getActivityByTypeAndId(ACTIVITY_TYPES.REACTION, rootId);
-        const reactionSelf = getActivityByTypeAndId(ACTIVITY_TYPES.REACTION_SELF, rootId);
+        const edit = getActivityByTypeAndParentId(ACTIVITY_TYPES.EDIT, rootId);
+        const reaction = getActivityByTypeAndParentId(ACTIVITY_TYPES.REACTION, rootId);
+        const reactionSelf = getActivityByTypeAndParentId(ACTIVITY_TYPES.REACTION_SELF, rootId);
 
         const finalActivity = edit || rootActivity;
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -13,6 +13,23 @@ import {cloneDeep, cloneDeepWith, defaults, isArray, isObject, isString, last, m
 import {readExifData} from '@webex/helper-image';
 import uuid from 'uuid';
 
+import {
+  ACTIVITY_TYPES,
+  getActivityType,
+  minBatchSize, defaultMinDisplayableActivities,
+  getLoopCounterFailsafe,
+  batchSizeIncrementCount,
+  OLDER, NEWER, MID, INITIAL,
+  isDeleteActivity,
+  getPublishedDate, sortActivitiesByPublishedDate,
+  getActivityObjectsFromMap,
+  sanitizeActivity,
+  bookendManager,
+  noMoreActivitiesManager,
+  getQuery,
+  rootActivityManager,
+  activityManager
+} from './activity-thread-ordering';
 import {InvalidUserCreation} from './convo-error';
 import ShareActivity from './share-activity';
 import {
@@ -741,6 +758,112 @@ const Conversation = WebexPlugin.extend({
   },
 
   /**
+   * @typedef QueryOptions
+   * @param {number} [limit] The limit of child activities that can be returned per request
+   * @param {boolean} [latestActivityFirst] Sort order for the child activities
+   * @param {boolean} [includeParentActivity] Enables the parent activity to be returned in the activity list
+   * @param {string} [sinceDate] Get all child activities after this date
+   * @param {string} [maxDate] Get all child activities before this date
+   * @param {boolean} [latestActivityFirst] Sort order for the child activities
+   * @param {string} [activityType] The type of children to return the parents of, a null value here returns parents of all types of children.
+   * The value is one of 'reply', 'edit', 'cardAction', 'reaction', 'reactionSummary', 'reactionSelfSummary'
+   */
+
+  /**
+   * Get all parent ids for a conversation.
+   * @param {string} conversationUrl conversation URL.
+   * @param {QueryOptions} [query] object containing query string values to be appended to the url
+   * @returns {Promise<Array<String>>}
+   */
+  async listParentActivityIds(conversationUrl, query) {
+    const params = {
+      method: 'GET',
+      url: `${conversationUrl}/parents`,
+      qs: query
+    };
+
+    const response = await this.request(params);
+
+    return response.body;
+  },
+
+  /**
+   * Returns a list of _all_ child activities for a given parentId within a given conversation
+   * @param {object} [options = {}]
+   * @param {string} [options.conversationUrl] targeted conversation URL
+   * @param {string} [options.activityParentId] parent id of edit activities or thread activities
+   * @param {QueryOptions} [options.query] object containing query string values to be appended to the url
+   * @returns {Promise<Array>}
+   */
+  async listAllChildActivitiesByParentId(options = {}) {
+    const {conversationUrl, activityParentId, query} = options;
+    const {activityType} = query;
+
+    const initialResponse = await this.listChildActivitiesByParentId(conversationUrl, activityParentId, activityType, query);
+
+    let page = new Page(initialResponse, this.webex);
+
+    const items = [...page.items];
+
+    while (page.hasNext()) {
+      // eslint-disable-next-line no-await-in-loop
+      page = await page.next();
+      for (const activity of page) {
+        items.push(activity);
+      }
+    }
+
+    // reverse list if needed (see _list for precedent)
+    if (last(items).published < items[0].published) {
+      items.reverse();
+    }
+
+    return items;
+  },
+
+  /**
+   * Return a list of child activities with a given conversation, parentId and other constraints.
+   * @param {string} conversationUrl targeted conversation URL
+   * @param {string} activityParentId parent id of edit activities or thread activities
+   * @param {string} activityType type of child activity to return
+   * The value is one of 'reply', 'edit', 'cardAction', 'reaction', 'reactionSummary', 'reactionSelfSummary'
+   * @param {QueryOptions} [query = {}] object containing query string values to be appended to the url
+   * @returns {Promise<Array>}
+   */
+  async listChildActivitiesByParentId(conversationUrl, activityParentId, activityType, query = {}) {
+    const finalQuery = {
+      ...query,
+      activityType
+    };
+    const params = {
+      method: 'GET',
+      url: `${conversationUrl}/parents/${activityParentId}`,
+      qs: finalQuery
+    };
+
+    return this.request(params);
+  },
+
+  /**
+   * Return an array of reactionSummary and reactionSelfSummary objects
+   * @param {string} conversationUrl targeted conversation URL
+   * @param {string} activityParentId parent id of reaction activities
+   * @param {QueryOptions} query object representing query parameters to pass to convo endpoint
+   * @returns {Promise<Array>}
+   */
+  async getReactionSummaryByParentId(conversationUrl, activityParentId, query) {
+    const {body} = await this.request({
+      method: 'GET',
+      url: `${conversationUrl}/activities/${activityParentId}`,
+      qs: query
+    });
+
+    const reactionObjects = body.children ? body.children.filter((child) => child.type === 'reactionSelfSummary' || child.type === 'reactionSummary') : [];
+
+    return reactionObjects;
+  },
+
+  /**
    * Lists activities in which the current user was mentioned
    * @param {Object} options
    * @returns {Promise<Array<Activity>>}
@@ -1127,10 +1250,10 @@ const Conversation = WebexPlugin.extend({
       });
     }
     /**
-   * helper to cloneDeepWith for copying instance function
-   * @param {Object|String|Symbol|Array|Date} value (recursive value to clone from params)
-   * @returns {Object|null}
-   */
+     * helper to cloneDeepWith for copying instance function
+     * @param {Object|String|Symbol|Array|Date} value (recursive value to clone from params)
+     * @returns {Object|null}
+     */
     // eslint-disable-next-line consistent-return
     const customActivityCopy = (value) => {
       const {files} = params.body.object;
@@ -1461,109 +1584,490 @@ const Conversation = WebexPlugin.extend({
     });
   },
 
+
   /**
-   * @typedef QueryOptions
-   * @param {number} [limit] The limit of child activities that can be returned per request
-   * @param {boolean} [latestActivityFirst] Sort order for the child activities
-   * @param {boolean} [includeParentActivity] Enables the parent activity to be returned in the activity list
-   * @param {string} [sinceDate] Get all child activities after this date
-   * @param {string} [maxDate] Get all child activities before this date
-   * @param {boolean} [latestActivityFirst] Sort order for the child activities
-   * @param {string} [activityType] The type of children to return the parents of, a null value here returns parents of all types of children.
-   * The value is one of 'reply', 'edit', 'cardAction', 'reaction', 'reactionSummary', 'reactionSelfSummary'
+   * common interface for facade of generator functions
+   * @typedef {object} IGeneratorResponse
+   * @param {boolean} done whether there is more to fetch
+   * @param {any} value the value yielded or returned by generator
    */
 
   /**
-   * Returns a list of _all_ child activities for a given parentId within a given conversation
-   * @param {object} [options = {}]
-   * @param {string} [options.conversationUrl] targeted conversation URL
-   * @param {string} [options.activityParentId] parent id of edit activities or thread activities
-   * @param {QueryOptions} [options.query] object containing query string values to be appended to the url
-   * @returns {Promise<Array>}
+   * @param {object} options
+   * @param {string} options.conversationId
+   * @param {string} options.conversationUrl,
+   * @param {number} options.minActivities how many activities to return in first batch
+   * @param {?string} [options.queryType] one of older, newer, mid. defines which direction to fetch
+   * @param {?object} [options.search] server activity to use as search middle date
+   *
+   * @returns {object}
+   * returns three functions:
+   *
+   * getOlder - gets older activities than oldest fetched
+   *
+   * getNewer - gets newer activities than newest fetched
+   *
+   * jumpToActivity - gets searched-for activity and surrounding activities
    */
-  async listAllChildActivitiesByParentId(options = {}) {
-    const {conversationUrl, activityParentId, query} = options;
+  listActivitiesThreadOrdered(options) {
+    const {
+      conversationUrl,
+      conversationId
+    } = options;
 
-    const initialResponse = await this.listChildActivitiesByParentId(conversationUrl, activityParentId, query);
+    if (!conversationUrl && !conversationId) {
+      throw new Error('must provide a conversation URL or conversation ID');
+    }
 
-    let page = new Page(initialResponse, this.webex);
+    const url = this.getConvoUrl({url: conversationUrl, id: conversationId});
 
-    const items = [...page.items];
+    const baseOptions = {...omit(options, ['conversationUrl', 'conversationId']), url};
 
-    while (page.hasNext()) {
-      // eslint-disable-next-line no-await-in-loop
-      page = await page.next();
-      for (const activity of page) {
-        items.push(activity);
+    const olderOptions = {...baseOptions, queryType: OLDER};
+
+    let threadOrderer = this._listActivitiesThreadOrdered(baseOptions);
+
+    /**
+     * gets queried activity and surrounding activities
+     * calling this function creates a new generator instance, losing the previous instance's internal state
+     * this ensures that jumping to older and newer activities is relative to a single set of timestamps, not many
+     * @param {object} searchObject activity object from convo
+     * @returns {IGeneratorResponse}
+     */
+    const jumpToActivity = async (searchObject) => {
+      if (!searchObject) {
+        throw new Error('Search must be an activity object from conversation service');
+      }
+      const searchOptions = {
+        ...baseOptions, queryType: MID, search: searchObject
+      };
+
+      threadOrderer = this._listActivitiesThreadOrdered(searchOptions);
+
+      const {value: searchResults} = await threadOrderer.next(searchOptions);
+
+      return {
+        done: true,
+        value: searchResults
+      };
+    };
+
+    /**
+     * gets older activities than oldest fetched
+     * @returns {IGeneratorResponse}
+     */
+    const getOlder = async () => {
+      const {value} = await threadOrderer.next(olderOptions);
+
+      const oldestInBatch = value[0];
+      const moreActivitiesExist = getActivityType(oldestInBatch) !== ACTIVITY_TYPES.CREATE;
+
+      return {
+        done: moreActivitiesExist,
+        value
+      };
+    };
+
+    /**
+     * gets newer activities than newest fetched
+     * @returns {IGeneratorResponse}
+     */
+    const getNewer = async () => {
+      const newerOptions = {...baseOptions, queryType: NEWER};
+
+      const {value} = await threadOrderer.next(newerOptions);
+
+      return {
+        done: !value.length,
+        value
+      };
+    };
+
+    return {
+      jumpToActivity,
+      getNewer,
+      getOlder
+    };
+  },
+
+  /**
+    * Represents reactions to messages
+    * @typedef {object} Reaction
+    * @property {object} activity reaction2summary server activity object
+    */
+
+  /**
+   * Represents a root (parent, with or without children) activity, along with any replies and reactions
+   * @typedef {object} Activity
+   * @property {object} activity server activity object
+   * @property {Reaction} reactions
+   * @property {Reaction} reactionSelf
+   */
+
+  /**
+   * @generator
+   * @method
+   * @async
+   * @private
+   * @param {object} options
+   * @param {string} options.url
+   * @param {string} [options.minActivities] how many activities to return in first batch
+   * @param {string} [options.queryType] one of older, newer, mid. defines which direction to fetch
+   * @param {object} [options.search] server activity to use as search middle date
+   *
+   * @yields {Activity[]}
+   *
+   * @returns {void}
+   */
+  async* _listActivitiesThreadOrdered(options = {}) {
+    // ***********************************************
+    // INSTANCE STATE VARIABLES
+    // variables that will be used for the life of the generator
+    // ***********************************************
+
+    let {
+      minActivities = defaultMinDisplayableActivities,
+      queryType = INITIAL
+    } = options;
+
+    // must fetch initially before getting newer activities!
+    if (queryType === NEWER) {
+      queryType = INITIAL;
+    }
+
+    const {
+      url: convoUrl,
+      search = {}
+    } = options;
+
+    // manage oldest, newest activities (ie bookends)
+    const {setBookends, getNewestAct, getOldestAct} = bookendManager();
+
+    // default batch should be equal to minActivities when fetching back in time, but halved when fetching newer due to subsequent child fetches filling up the minActivities count
+    // reduces server RTs when fetching older activities
+    const defaultBatchSize = (queryType === INITIAL || queryType === OLDER) ? minActivities : Math.max(minBatchSize, Math.ceil(minActivities / 2));
+    let batchSize = defaultBatchSize;
+
+    // exposes activity states and handlers with simple getters
+    const {getActivityHandlerByKey, getActivityByTypeAndId} = activityManager();
+
+    // set initial query
+    let query = getQuery(queryType, {activityToSearch: search, batchSize});
+
+    /* eslint-disable no-await-in-loop */
+    /* eslint-disable no-loop-func */
+    while (true) {
+      // ***********************************************
+      // EXECUTION STATE VARIABLES
+      // variables that will be used for each "batch" of activities asked for
+      // ***********************************************
+
+      // stores all "root" activities (activities that are, or could be, thread parents)
+      const {getRootActivityHash, handleNewRoot} = rootActivityManager();
+
+      // used to determine if we should continue to fetch older activities
+      // must be set per iteration, as querying newer activities is still valid when all end of convo has been reached
+      const {
+        getNoMoreActs,
+        checkAndSetNoMoreActs,
+        checkAndSetNoOlderActs,
+        checkAndSetNoNewerActs
+      } = noMoreActivitiesManager();
+
+      const getActivityHandlerByType = (type) => ({
+        [ACTIVITY_TYPES.ROOT]: handleNewRoot,
+        [ACTIVITY_TYPES.REPLY]: getActivityHandlerByKey(ACTIVITY_TYPES.REPLY),
+        [ACTIVITY_TYPES.EDIT]: getActivityHandlerByKey(ACTIVITY_TYPES.EDIT),
+        [ACTIVITY_TYPES.REACTION]: getActivityHandlerByKey(ACTIVITY_TYPES.REACTION),
+        [ACTIVITY_TYPES.REACTION_SELF]: getActivityHandlerByKey(ACTIVITY_TYPES.REACTION_SELF),
+        [ACTIVITY_TYPES.TOMBSTONE]: handleNewRoot,
+        [ACTIVITY_TYPES.CREATE]: handleNewRoot
+      }[type]);
+
+      const handleNewActivity = (activity) => {
+        const actType = getActivityType(activity);
+
+        // ignore deletes
+        if (isDeleteActivity(activity)) {
+          return;
+        }
+
+        const activityHandler = getActivityHandlerByType(actType);
+
+        activityHandler(activity);
+      };
+
+      const handleNewActivities = (activities) => {
+        activities.forEach((act) => {
+          handleNewActivity(act);
+          checkAndSetNoOlderActs(act);
+        });
+      };
+
+      const handleOlderQuery = (activities) => {
+        setBookends(activities, OLDER);
+        handleNewActivities(activities);
+      };
+      const handleNewerQuery = (activities) => {
+        checkAndSetNoNewerActs(activities);
+        if (activities.length) {
+          setBookends(activities, NEWER);
+          handleNewActivities(activities);
+        }
+      };
+      const handleSearch = (activities) => {
+        setBookends(activities, MID);
+        handleNewActivities(activities);
+      };
+
+      const getQueryResponseHandler = (type) => ({
+        [OLDER]: handleOlderQuery,
+        [NEWER]: handleNewerQuery,
+        [MID]: handleSearch,
+        [INITIAL]: handleOlderQuery
+      }[type]);
+
+      // ***********************************************
+      // INNER LOOP
+      // responsible for fetching and building our maps of activities
+      // fetch until minActivities is reached, or no more acts to fetch, or we hit our max fetch count
+      // ***********************************************
+
+      const incrementLoopCounter = getLoopCounterFailsafe();
+
+      while (!getNoMoreActs()) {
+        // count loops and throw if we detect infinite loop
+        incrementLoopCounter();
+
+        // configure fetch request. Use a smaller limit when fetching newer or mids to account for potential children fetches
+        const allBatchActivitiesConfig = {
+          conversationUrl: convoUrl,
+          limit: batchSize,
+          ...query
+        };
+
+        // request activities in batches
+        const $allBatchActivitiesFetch = this.listActivities(allBatchActivitiesConfig);
+
+        // contain fetches in array to parallelize fetching as needed
+        const $fetchRequests = [$allBatchActivitiesFetch];
+
+        // if query requires recursive fetches for children acts, add the additional fetch
+        if (queryType === MID || queryType === NEWER) {
+          const params = {activityType: null};
+
+          if (query.sinceDate) {
+            params.sinceDate = query.sinceDate;
+          }
+
+          const $parentsFetch = this.listParentActivityIds(convoUrl, params);
+
+          $fetchRequests.push($parentsFetch);
+        }
+
+        // we dont always need to fetch for parents
+        const [
+          allBatchActivities,
+          parents = {}
+        ] = await Promise.all($fetchRequests);
+
+        // use query type to decide how to handle response
+        const handler = getQueryResponseHandler(queryType);
+
+        handler(allBatchActivities);
+
+        /*
+          next we must selectively fetch the children of each of the parents to ensure completeness
+          do this by checking the hash for each of the above parent IDs
+          fetch children when we have a parent whose ID is represented in the parent ID lists
+        */
+        const {
+          reply: replyIds = [],
+          edit: editIds = [],
+          reaction: reactionIds = []
+        } = parents;
+
+        // if no parent IDs returned, do nothing
+        if (replyIds.length || editIds.length || reactionIds.length) {
+          const $reactionFetches = [];
+          const $replyFetches = [];
+          const $editFetches = [];
+
+          for (const activity of allBatchActivities) {
+            const actId = activity.id;
+
+            const childFetchOptions = {
+              conversationUrl: convoUrl,
+              activityParentId: actId
+            };
+
+            if (reactionIds.includes(actId)) {
+              $reactionFetches.push(this.getReactionSummaryByParentId(convoUrl, actId, {activityType: 'reactionSummary', includeChildren: true}));
+            }
+            if (replyIds.includes(actId)) {
+              childFetchOptions.query = {activityType: 'reply'};
+              $replyFetches.push(this.listAllChildActivitiesByParentId(childFetchOptions));
+            }
+            if (editIds.includes(actId)) {
+              childFetchOptions.query = {activityType: 'edit'};
+              $editFetches.push(this.listAllChildActivitiesByParentId(childFetchOptions));
+            }
+          }
+
+          // parallelize fetch for speeedz
+          const [reactions, replies, edits] = await Promise.all([
+            Promise.all($reactionFetches),
+            Promise.all($replyFetches),
+            Promise.all($editFetches)
+          ]);
+
+          // new reactions may have come in that also need their reactions fetched
+          const newReplyReactions = await Promise.all(
+            replies
+              .filter((reply) => replyIds.includes(reply.id))
+              .map((reply) => this.getReactionSummaryByParentId(convoUrl, reply.id, {activityType: 'reactionSummary', includeChildren: true}))
+          );
+
+          const allReactions = [...reactions, ...newReplyReactions];
+
+          // stick them into activity hashes
+          replies.forEach((replyArr) => handleNewActivities(replyArr));
+          edits.forEach((editArr) => handleNewActivities(editArr));
+          allReactions.forEach((reactionArr) => handleNewActivities(reactionArr));
+        }
+
+        const rootActivityHash = getRootActivityHash();
+        let visibleActivitiesCount = rootActivityHash.size;
+
+        for (const rootActivity of rootActivityHash.values()) {
+          const {id: rootId} = rootActivity;
+          const repliesByRootId = getActivityByTypeAndId(ACTIVITY_TYPES.REPLY, rootId);
+
+          if (repliesByRootId && repliesByRootId.size) {
+            visibleActivitiesCount += repliesByRootId.size || 0;
+          }
+        }
+
+        if (visibleActivitiesCount >= minActivities) {
+          break;
+        }
+
+        // batchSize should be equal to minimum activities when fetching older activities
+        // covers "best case" when we reach minActivities on the first fetch
+        if (queryType === OLDER) {
+          batchSize = minActivities;
+        }
+
+        // since a MID query can bump the batchSize, we need to reset it _after_ a potential MID query
+        // reset batchSize in case of MID queries bumping it up
+        if (queryType === NEWER) {
+          batchSize = defaultBatchSize;
+        }
+
+        const currentOldestPublishedDate = getPublishedDate(getOldestAct());
+        const currentNewestPublishedDate = getPublishedDate(getNewestAct());
+
+        // we're still building our activity list - derive new query from prior query and start loop again
+        if (queryType === INITIAL) {
+          query = getQuery(OLDER, {oldestPublishedDate: currentOldestPublishedDate, batchSize});
+        }
+        else {
+          query = getQuery(queryType, {
+            batchSize,
+            activityToSearch: search,
+            oldestPublishedDate: currentOldestPublishedDate,
+            newestPublishedDate: currentNewestPublishedDate
+          });
+        }
+
+        // if we're still building out the midDate search, bump the search limit to include activities on both sides
+        if (queryType === MID) {
+          batchSize += batchSizeIncrementCount;
+        }
+
+        checkAndSetNoMoreActs(queryType);
+      }
+
+      const orderedActivities = [];
+
+      const getRepliesByParentId = (replyParentId) => {
+        const replies = [];
+
+        const repliesByParentId = getActivityByTypeAndId(ACTIVITY_TYPES.REPLY, replyParentId);
+
+        if (!repliesByParentId) {
+          return replies;
+        }
+
+        const sortedReplies = sortActivitiesByPublishedDate(getActivityObjectsFromMap(repliesByParentId));
+
+        sortedReplies.forEach((replyActivity) => {
+          const replyId = replyActivity.id;
+          const edit = getActivityByTypeAndId(ACTIVITY_TYPES.EDIT, replyId);
+          const reaction = getActivityByTypeAndId(ACTIVITY_TYPES.REACTION, replyId);
+          const reactionSelf = getActivityByTypeAndId(ACTIVITY_TYPES.REACTION_SELF, replyId);
+
+          const finalReply = edit || replyActivity;
+
+          const fullReply = {
+            id: replyId,
+            activity: finalReply,
+            reaction,
+            reactionSelf
+          };
+
+          const sanitizedFullReply = sanitizeActivity(fullReply);
+
+          replies.push(sanitizedFullReply);
+        });
+
+        return replies;
+      };
+
+      const orderedRoots = sortActivitiesByPublishedDate(getActivityObjectsFromMap(getRootActivityHash()));
+
+      orderedRoots.forEach((rootActivity) => {
+        const rootId = rootActivity.id;
+        const replies = getRepliesByParentId(rootId);
+        const edit = getActivityByTypeAndId(ACTIVITY_TYPES.EDIT, rootId);
+        const reaction = getActivityByTypeAndId(ACTIVITY_TYPES.REACTION, rootId);
+        const reactionSelf = getActivityByTypeAndId(ACTIVITY_TYPES.REACTION_SELF, rootId);
+
+        const finalActivity = edit || rootActivity;
+
+        const fullRoot = {
+          id: rootId,
+          activity: finalActivity,
+          reaction,
+          reactionSelf
+        };
+
+        const sanitizedFullRoot = sanitizeActivity(fullRoot);
+
+        orderedActivities.push(sanitizedFullRoot);
+        replies.forEach((reply) => orderedActivities.push(reply));
+      });
+
+      const nextOptions = yield orderedActivities;
+
+      if (nextOptions) {
+        minActivities = nextOptions.minActivities || minActivities;
+
+        const currentOldestPublishedDate = getPublishedDate(getOldestAct());
+        const currentNewestPublishedDate = getPublishedDate(getNewestAct());
+
+        queryType = nextOptions.queryType;
+        query = getQuery(queryType, {
+          activityToSearch: search,
+          oldestPublishedDate: currentOldestPublishedDate,
+          newestPublishedDate: currentNewestPublishedDate,
+          batchSize
+        });
+      }
+      else {
+        return;
       }
     }
-
-    // reverse list if needed (see _list for precedent)
-    if (last(items).published < items[0].published) {
-      items.reverse();
-    }
-
-    return items;
-  },
-
-  /**
-   * Get all parent ids for a conversation.
-   * @param {string} conversationUrl conversation URL.
-   * @param {QueryOptions} [query] object containing query string values to be appended to the url
-   * @returns {Promise<Array<String>>}
-   */
-  async listParentActivityIds(conversationUrl, query) {
-    const params = {
-      method: 'GET',
-      url: `${conversationUrl}/parents`,
-      qs: query
-    };
-
-    const response = await this.request(params);
-
-    return response.body;
-  },
-
-  /**
-   * Return a list of child activities with a given conversation, parentId and other constraints.
-   * @param {string} conversationUrl targeted conversation URL
-   * @param {string} activityParentId parent id of edit activities or thread activities
-   * @param {string} activityType type of child activity to return
-   * The value is one of 'reply', 'edit', 'cardAction', 'reaction', 'reactionSummary', 'reactionSelfSummary'
-   * @param {QueryOptions} [query = {}] object containing query string values to be appended to the url
-   * @returns {Promise<Array>}
-   */
-  async listChildActivitiesByParentId(conversationUrl, activityParentId, activityType, query = {}) {
-    const finalQuery = {
-      ...query,
-      activityType
-    };
-    const params = {
-      method: 'GET',
-      url: `${conversationUrl}/parents/${activityParentId}`,
-      qs: finalQuery
-    };
-
-    return this.request(params);
-  },
-
-  /**
-   * Return an array of reactionSummary and reactionSelfSummary objects
-   * @param {string} conversationUrl targeted conversation URL
-   * @param {string} activityParentId parent id of reaction activities
-   * @param {QueryOptions} query object representing query parameters to pass to convo endpoint
-   * @returns {Promise<Array>}
-   */
-  async getReactionSummaryByParentId(conversationUrl, activityParentId, query) {
-    const {body} = await this.request({
-      method: 'GET',
-      url: `${conversationUrl}/activities/${activityParentId}`,
-      qs: query
-    });
-
-    const reactionObjects = body.children ? body.children.filter((child) => child.type === 'reactionSelfSummary' || child.type === 'reactionSummary') : [];
-
-    return reactionObjects;
   },
 
   /**

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
@@ -10,7 +10,7 @@ import sinon from 'sinon';
 import testUsers from '@webex/test-helper-test-users';
 import fh from '@webex/test-helper-file';
 import makeLocalUrl from '@webex/test-helper-make-local-url';
-import {map} from 'lodash';
+import {map, find, findIndex, findLast} from 'lodash';
 import retry from '@webex/test-helper-retry';
 
 describe('plugin-conversation', function () {
@@ -683,6 +683,140 @@ describe('plugin-conversation', function () {
             assert.include(replies.map((reply) => reply.id), threadAct.id);
           });
         }));
+    });
+
+    describe('#_listActivitiesThreadOrdered', () => {
+      let conversation, firstParentBatch, getOlder, jumpToActivity;
+
+      const minActivities = 10;
+      const displayNames = [
+        'first message',
+        'second message',
+        'third message',
+        'fourth message',
+        'fifth message',
+        'sixth message',
+        'seventh message',
+        'eighth message',
+        'ninth message'
+      ];
+      const threadDisplayNames = ['thread 1', 'thread 2', 'thread 3'];
+
+
+      const initializeGenerator = () => webex.internal.conversation.listActivitiesThreadOrdered({
+        conversationUrl: conversation.url,
+        minActivities
+      });
+
+      before(() => webex.internal.conversation.create({participants})
+        .then((c) => {
+          conversation = c;
+
+          const firstParents = [...displayNames];
+
+          firstParents.length = 5;
+
+          return Promise.all(firstParents.map((msg) => webex.internal.conversation.post(conversation, {displayName: msg})));
+        }).then((parentActs) => {
+          firstParentBatch = parentActs;
+
+          const threadObjects = [];
+
+          for (const msg of threadDisplayNames) {
+            for (const [ix, parentAct] of parentActs.entries()) {
+              // add threads to every other, plus randoms for variability
+              if (ix % 2 || Math.round(Math.random())) {
+                threadObjects.push({displayName: `${parentAct.object.displayName} ${msg}`, parentActivityId: parentAct.id});
+              }
+            }
+          }
+
+          const threadPromises = threadObjects.map((threadObj) => webex.internal.conversation.post(conversation, threadObj.displayName, {
+            parentActivityId: threadObj.parentActivityId,
+            activityType: 'reply'
+          }));
+
+          return Promise.all(threadPromises);
+        }).then(() => {
+          const secondParents = [...displayNames.slice(4)];
+
+          return Promise.all(secondParents.map((msg) => webex.internal.conversation.post(conversation, {displayName: msg})));
+        })
+        .then((parents) => {
+          const threadObjects = [];
+
+          for (const msg of threadDisplayNames) {
+            for (const [ix, parentAct] of parents.entries()) {
+              // add threads to every other, plus randoms for variability
+              if (ix % 2 || Math.round(Math.random())) {
+                threadObjects.push({displayName: `${parentAct.object.displayName} ${msg}`, parentActivityId: parentAct.id});
+              }
+            }
+          }
+
+          const threadPromises = threadObjects.map((threadObj) => webex.internal.conversation.post(conversation, threadObj.displayName, {
+            parentActivityId: threadObj.parentActivityId,
+            activityType: 'reply'
+          }));
+
+          return Promise.all(threadPromises);
+        }));
+
+      beforeEach(() => {
+        const funcs = initializeGenerator();
+
+        getOlder = funcs.getOlder;
+        jumpToActivity = funcs.jumpToActivity;
+      });
+
+      it('should return more than or exactly N minimum activities', () => getOlder().then(({value}) => {
+        assert.isAtLeast(value.length, minActivities);
+      }));
+
+      it('should return activities in thread order', () => getOlder().then(({value}) => {
+        const oldestAct = value[0].activity;
+        const newestAct = value[value.length - 1].activity;
+
+        const oldestThreadIx = findIndex(value, ['activity.activityType', 'reply']);
+        const oldestParent = value[oldestThreadIx - 1].activity;
+
+        assert.isTrue(oldestAct.published < newestAct.published);
+
+        assert.doesNotHaveAnyKeys(oldestParent, 'parentActivityId');
+        assert.isTrue(oldestParent.object.objectType === 'comment');
+      }));
+
+      it('should return next batch when getOlder is called a second time', () => {
+        let firstBatch;
+
+        return getOlder()
+          .then(({value}) => {
+            firstBatch = value;
+
+            return getOlder();
+          })
+          .then(({value}) => {
+            const secondBatch = value;
+
+            const oldestRootInFirstBatch = find(firstBatch, ['activity.object.objectType', 'comment']).activity;
+            const newestRootInSecondBatch = findLast(secondBatch, ['activity.object.objectType', 'comment']).activity;
+
+            assert.isTrue(oldestRootInFirstBatch.published > newestRootInSecondBatch.published);
+          });
+      });
+
+      it('should return searched-for activity with surrounding activities when jumpToActivity is called with an activity', () => {
+        const search = firstParentBatch[firstParentBatch.length - 1];
+
+        return jumpToActivity(search)
+          .then(({value}) => {
+            const searchedForActivityIx = findIndex(value, ['id', search.id]);
+
+            assert.isFalse(searchedForActivityIx === -1);
+            assert.isTrue(searchedForActivityIx > 0);
+            assert.isTrue(searchedForActivityIx < value.length);
+          });
+      });
     });
   });
 });

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -158,6 +158,7 @@ describe('plugin-conversation', () => {
     });
 
     describe('#listAllChildActivitiesByParentId()', () => {
+      const options = {conversationUrl: convoUrl, activityParentId: '123-abc', query: {activityType: 'reply'}};
       let dayCount = 0;
       const createActivityItemBatch = (itemCount) => {
         const counter = [...Array(itemCount).keys()];
@@ -197,7 +198,7 @@ describe('plugin-conversation', () => {
             headers: {}
           })));
       });
-      it('retrieves correct children count', () => webex.internal.conversation.listAllChildActivitiesByParentId({conversationUrl: convoUrl, activityParentId: '123-abc'})
+      it('retrieves correct children count', () => webex.internal.conversation.listAllChildActivitiesByParentId(options)
         .then((res) => {
           assert.equal(res.length, 23);
         }));
@@ -205,13 +206,13 @@ describe('plugin-conversation', () => {
       it('calls #listChildActivitiesByParentId() to initiate the request', () => {
         const spy = sinon.spy(webex.internal.conversation, 'listChildActivitiesByParentId');
 
-        return webex.internal.conversation.listAllChildActivitiesByParentId({conversationUrl: convoUrl, activityParentId: '123-abc'})
+        return webex.internal.conversation.listAllChildActivitiesByParentId(options)
           .then(() => {
             assert(spy.calledOnce);
           });
       });
 
-      it('returns children in ascending published order', () => webex.internal.conversation.listAllChildActivitiesByParentId({conversationUrl: convoUrl, activityParentId: '123-abc'})
+      it('returns children in ascending published order', () => webex.internal.conversation.listAllChildActivitiesByParentId(options)
         .then((res) => {
           const firstMessageOlderThanLastMessage = res[0].published < res[res.length - 1].published;
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -7,6 +7,8 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import sinon from 'sinon';
 import Conversation from '@webex/internal-plugin-conversation';
 
+import {ACTIVITY_TYPES, getActivityType, rootActivityManager, getLoopCounterFailsafe, noMoreActivitiesManager, OLDER, NEWER, bookendManager, activityManager} from '../../../src/activity-thread-ordering';
+
 describe('plugin-conversation', () => {
   describe('Conversation', () => {
     let webex;
@@ -293,6 +295,304 @@ describe('plugin-conversation', () => {
               assert.hasAllKeys(result, ['done', 'value']);
             });
           });
+        });
+      });
+    });
+
+    describe('activity-thread-ordering helpers', () => {
+      const createSimpleActivityByType = (type) => ({
+        activityType: type
+      });
+
+      describe('getActivityType', () => {
+        it('should handle common activity types', () => {
+          const reply = createSimpleActivityByType('reply');
+          const reaction = {type: 'reactionSummary'};
+          const deleteAct = {verb: 'delete'};
+          const root = createSimpleActivityByType();
+
+          assert.equal(getActivityType(reply), 'REPLY');
+          assert.equal(getActivityType(reaction), 'REACTION');
+          assert.equal(getActivityType(deleteAct), 'DELETE');
+          assert.equal(getActivityType(root), 'ROOT');
+        });
+      });
+
+      describe('rootActivityManager', () => {
+        it('should return expected exposed functions', () => {
+          const functions = rootActivityManager();
+
+          assert.hasAllKeys(functions, ['addNewRoot', 'getRootActivityHash']);
+        });
+
+        it('should interface with internal storage object', () => {
+          const {addNewRoot, getRootActivityHash} = rootActivityManager();
+
+          const initialRootHash = getRootActivityHash();
+
+          assert.isEmpty(initialRootHash);
+
+          addNewRoot({id: '123'});
+
+          assert.isNotEmpty(initialRootHash);
+        });
+      });
+
+      describe('getLoopCounterFailsafe', () => {
+        it('should throw after looping 100 times', () => {
+          let externalCount = 1;
+          const incrementLoop = getLoopCounterFailsafe();
+
+          try {
+            while (externalCount < 150) {
+              externalCount += 1;
+              incrementLoop();
+            }
+          }
+          catch (e) {
+            assert.equal(e.message, 'max fetches reached');
+          }
+        });
+      });
+
+      describe('noMoreActivitiesManager', () => {
+        let getNoMoreActs, checkAndSetNoMoreActs, checkAndSetNoNewerActs, checkAndSetNoOlderActs;
+        const createAct = {verb: 'create'};
+
+        beforeEach(() => {
+          const funcs = noMoreActivitiesManager();
+
+          getNoMoreActs = funcs.getNoMoreActs;
+          checkAndSetNoMoreActs = funcs.checkAndSetNoMoreActs;
+          checkAndSetNoNewerActs = funcs.checkAndSetNoNewerActs;
+          checkAndSetNoOlderActs = funcs.checkAndSetNoOlderActs;
+        });
+
+
+        it('should return expected exposed functions', () => {
+          const functions = noMoreActivitiesManager();
+
+          assert.hasAllKeys(functions, ['getNoMoreActs', 'checkAndSetNoMoreActs', 'checkAndSetNoNewerActs', 'checkAndSetNoOlderActs']);
+        });
+
+        it('should set no more activities when no newer activities exist', () => {
+          checkAndSetNoOlderActs({});
+          checkAndSetNoNewerActs([]);
+          checkAndSetNoMoreActs(NEWER);
+
+          assert.isTrue(getNoMoreActs());
+        });
+
+        it('should set no more activities when no older activities exist', () => {
+          checkAndSetNoOlderActs(createAct);
+          checkAndSetNoNewerActs([]);
+          checkAndSetNoMoreActs(OLDER);
+
+          assert.isTrue(getNoMoreActs());
+        });
+
+        it('should not set no more activities when newer activities exist', () => {
+          checkAndSetNoNewerActs([1, 2, 3]);
+          checkAndSetNoOlderActs(createAct);
+          checkAndSetNoMoreActs(NEWER);
+
+          assert.isFalse(getNoMoreActs());
+        });
+
+        it('should not set no more activities when older activities exist', () => {
+          checkAndSetNoNewerActs([]);
+          checkAndSetNoOlderActs({});
+          checkAndSetNoMoreActs(OLDER);
+
+          assert.isFalse(getNoMoreActs());
+        });
+      });
+
+      describe('bookendManager', () => {
+        let setBookends, getNewestAct, getOldestAct;
+        const createDateISO = (min) => new Date(1, 1, 1, 1, min).toISOString();
+
+        beforeEach(() => {
+          const funcs = bookendManager();
+
+          setBookends = funcs.setBookends;
+          getNewestAct = funcs.getNewestAct;
+          getOldestAct = funcs.getOldestAct;
+        });
+
+        it('should return expected exposed functions', () => {
+          const functions = bookendManager();
+
+          assert.hasAllKeys(functions, ['setBookends', 'getNewestAct', 'getOldestAct']);
+        });
+
+        it('should set the oldest and newest activity in a batch', () => {
+          const acts = [
+            {published: createDateISO(1), order: 0},
+            {published: createDateISO(2), order: 1}
+          ];
+
+          setBookends(acts);
+          assert.equal(getOldestAct().order, 0);
+          assert.equal(getNewestAct().order, 1);
+        });
+
+        it('should bookends when newer and older activities exists', () => {
+          const acts = [
+            {published: createDateISO(5), order: 2},
+            {published: createDateISO(6), order: 3}
+          ];
+
+          setBookends(acts);
+
+          const nextActs = [
+            {published: createDateISO(1), order: 1},
+            {published: createDateISO(9), order: 4}
+          ];
+
+          setBookends(nextActs);
+
+          assert.equal(getOldestAct().order, 1);
+          assert.equal(getNewestAct().order, 4);
+        });
+
+        it('should not update oldest activity when only newer activities exist', () => {
+          const acts = [
+            {published: createDateISO(1), order: 1},
+            {published: createDateISO(5), order: 2}
+          ];
+
+          setBookends(acts);
+
+          const nextActs = [
+            {published: createDateISO(6), order: 3},
+            {published: createDateISO(9), order: 4}
+          ];
+
+          setBookends(nextActs);
+
+          assert.equal(getOldestAct().order, 1);
+          assert.equal(getNewestAct().order, 4);
+        });
+      });
+
+      describe('activityManager', () => {
+        let getActivityHandlerByKey, getActivityByTypeAndParentId;
+        const parentId = 'parentId';
+        const parentId2 = 'parentId2';
+
+        beforeEach(() => {
+          const funcs = activityManager();
+
+          getActivityHandlerByKey = funcs.getActivityHandlerByKey;
+          getActivityByTypeAndParentId = funcs.getActivityByTypeAndParentId;
+        });
+
+        it('should return expected exposed functions', () => {
+          const functions = activityManager();
+
+          assert.hasAllKeys(functions, ['getActivityHandlerByKey', 'getActivityByTypeAndParentId']);
+        });
+
+        it('should handle new replies', () => {
+          const replyAct = {
+            id: '1',
+            activityType: 'reply',
+            parent: {
+              id: parentId
+            }
+          };
+          const replyHandler = getActivityHandlerByKey(ACTIVITY_TYPES.REPLY);
+
+          replyHandler(replyAct);
+
+          const replyMap = getActivityByTypeAndParentId(ACTIVITY_TYPES.REPLY, parentId);
+
+          assert.equal(replyMap.get('1'), replyAct);
+
+          const secondReplyAct = {
+            id: '2',
+            activityType: 'reply',
+            parent: {
+              id: parentId
+            }
+          };
+
+          replyHandler(secondReplyAct);
+
+          assert.equal(replyMap.get('2'), secondReplyAct);
+
+          const thirdReply = {
+            id: '3',
+            activityType: 'reply',
+            parent: {
+              id: parentId2
+            }
+          };
+
+          replyHandler(thirdReply);
+
+          const replyMap2 = getActivityByTypeAndParentId(ACTIVITY_TYPES.REPLY, parentId2);
+
+          assert.equal(replyMap2.get('3'), thirdReply);
+        });
+
+        it('should handle edits', () => {
+          const editHandler = getActivityHandlerByKey(ACTIVITY_TYPES.EDIT);
+
+          const editAct = {
+            id: 'editId1',
+            parent: {
+              id: parentId,
+              type: 'edit'
+            },
+            published: new Date(1, 1, 1, 1, 1).toISOString()
+          };
+          const tombstoneEdit = {
+            ...editAct,
+            verb: ACTIVITY_TYPES.TOMBSTONE
+          };
+          const newerEdit = {
+            ...editAct,
+            published: new Date(1, 1, 1, 1, 3).toISOString()
+          };
+
+          editHandler(editAct);
+
+          assert.equal(getActivityByTypeAndParentId(ACTIVITY_TYPES.EDIT, parentId), editAct);
+
+          editHandler(tombstoneEdit);
+
+          assert.equal(getActivityByTypeAndParentId(ACTIVITY_TYPES.EDIT, parentId), editAct);
+
+          editHandler(newerEdit);
+
+          assert.equal(getActivityByTypeAndParentId(ACTIVITY_TYPES.EDIT, parentId), newerEdit);
+        });
+
+        it('should handle reactions', () => {
+          const reactionHandler = getActivityHandlerByKey(ACTIVITY_TYPES.REACTION);
+          const reaction = {
+            id: 'reaction1',
+            published: new Date(1, 1, 1, 1, 1).toISOString(),
+            type: 'reactionSummary',
+            parent: {
+              id: parentId
+            }
+          };
+
+          const newerReaction = {
+            ...reaction,
+            published: new Date(1, 1, 1, 1, 3).toISOString()
+          };
+
+          reactionHandler(reaction);
+
+          assert.equal(getActivityByTypeAndParentId(ACTIVITY_TYPES.REACTION, parentId), reaction);
+
+          reactionHandler(newerReaction);
+
+          assert.equal(getActivityByTypeAndParentId(ACTIVITY_TYPES.REACTION, parentId), newerReaction);
         });
       });
     });

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -218,5 +218,82 @@ describe('plugin-conversation', () => {
           assert.isTrue(firstMessageOlderThanLastMessage, 'activities out of order');
         }));
     });
+
+    describe('#listActivitiesThreadOrdered()', () => {
+      it('should throw an error when called without a conversationUrl option', (done) => {
+        try {
+          webex.internal.conversation.listActivitiesThreadOrdered({});
+        }
+        catch (e) {
+          assert.equal(e.message, 'must provide a conversation URL or conversation ID');
+          done();
+        }
+      });
+
+      it('calls #_listActivitiesThreadOrdered()', () => {
+        const spy = sinon.spy(webex.internal.conversation, '_listActivitiesThreadOrdered');
+
+        webex.internal.conversation.listActivitiesThreadOrdered({conversationUrl: convoUrl});
+        assert(spy.calledOnce);
+      });
+
+      it('returns expected wrapped functions', () => {
+        const functions = webex.internal.conversation.listActivitiesThreadOrdered({conversationUrl: convoUrl});
+
+        assert.hasAllKeys(functions, ['jumpToActivity', 'getOlder', 'getNewer']);
+      });
+
+      describe('returned functions', () => {
+        const returnedVal = [{}, {}, {}, {}];
+
+        beforeEach(() => {
+          webex.internal.conversation._listActivitiesThreadOrdered = sinon.stub().returns({
+            next() {
+              return new Promise((resolve) => resolve({
+                value: returnedVal,
+                next() {}
+              }));
+            }
+          });
+        });
+
+        it('getOlder() should implement the iterator protocol', () => {
+          const {getOlder} = webex.internal.conversation.listActivitiesThreadOrdered({conversationUrl: convoUrl});
+
+          return getOlder().then((result) => {
+            assert.hasAllKeys(result, ['done', 'value']);
+          });
+        });
+
+        it('getNewer() should implement the iterator protocol', () => {
+          const {getNewer} = webex.internal.conversation.listActivitiesThreadOrdered({conversationUrl: convoUrl});
+
+          return getNewer().then((result) => {
+            assert.hasAllKeys(result, ['done', 'value']);
+          });
+        });
+
+        describe('jumpToActivity()', () => {
+          it('should throw an error if search object is missing', () => {
+            const {jumpToActivity} = webex.internal.conversation.listActivitiesThreadOrdered({conversationUrl: convoUrl});
+
+            try {
+              jumpToActivity();
+            }
+            catch (e) {
+              assert.equal(e.message, 'Search must be an activity object from conversation service');
+            }
+          });
+
+          it('should implement the iterator protocol', () => {
+            const {jumpToActivity} = webex.internal.conversation.listActivitiesThreadOrdered({conversationUrl: convoUrl});
+
+            return jumpToActivity({}).then((result) => {
+              assert.hasAllKeys(result, ['done', 'value']);
+            });
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Add method to retrieve activities in thread order. Thread order means that each parent message is zipper-merged with any of its children, rather than being returned in simple chronological order.