### PR TITLE
fix(meeting-plugin): allow share frame rate override

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/media/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/index.js
@@ -290,6 +290,8 @@ Media.updateTransceiver = ({meetingId, remoteQualityLevel}, peerConnection, tran
 Media.getDisplayMedia = (options, config = {}) => {
   // SDK screen share resolution settings from Webex.init
   const customResolution = config.screenResolution || {};
+  // user defined screen share frame rate
+  const customShareFrameRate = config.screenFrameRate || null;
   // user defined share preferences
   const hasSharePreferences = options.sharePreferences;
   const hasCustomConstraints = hasSharePreferences && hasSharePreferences.shareConstraints;
@@ -322,7 +324,7 @@ Media.getDisplayMedia = (options, config = {}) => {
   else {
     shareConstraints = {
       ...shareConstraints,
-      frameRate: screenFrameRate,
+      frameRate: customShareFrameRate || screenFrameRate,
       height: customResolution.idealHeight || screenResolution.idealHeight,
       width: customResolution.idealWidth || screenResolution.idealWidth,
       ...config.screenResolution

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -739,6 +739,7 @@ describe('plugin-meetings', () => {
             }));
         });
 
+        // Test screenResolution
         // eslint-disable-next-line max-len
         it('will use SDK config screenResolution if set, with shareConstraints and highFrameRate being undefined', () => {
           const SHARE_WIDTH = 800;
@@ -760,6 +761,41 @@ describe('plugin-meetings', () => {
               default: {
                 video: {
                   ...MediaConstraint,
+                  width: SHARE_WIDTH,
+                  height: SHARE_HEIGHT,
+                  maxWidth: SHARE_WIDTH,
+                  maxHeight: SHARE_HEIGHT,
+                  idealWidth: SHARE_WIDTH,
+                  idealHeight: SHARE_HEIGHT
+                }
+              },
+              firefox: fireFoxOptions
+            }));
+        });
+
+        // Test screenFrameRate
+        it('will use SDK config screenFrameRate if set, with shareConstraints and highFrameRate being undefined', () => {
+          const SHARE_WIDTH = 800;
+          const SHARE_HEIGHT = 600;
+          const customConfig = {
+            screenFrameRate: 999,
+            screenResolution: {
+              maxWidth: SHARE_WIDTH,
+              maxHeight: SHARE_HEIGHT,
+              idealWidth: SHARE_WIDTH,
+              idealHeight: SHARE_HEIGHT
+            }
+          };
+
+          getDisplayMedia(shareOptions, customConfig);
+
+          // eslint-disable-next-line no-undef
+          assert.calledWith(navigator.mediaDevices.getDisplayMedia,
+            browserConditionalValue({
+              default: {
+                video: {
+                  ...MediaConstraint,
+                  frameRate: customConfig.screenFrameRate,
                   width: SHARE_WIDTH,
                   height: SHARE_HEIGHT,
                   maxWidth: SHARE_WIDTH,


### PR DESCRIPTION
Allow screenShare to override the frameRate by using screenFrameRate.

When calling shareScreen() it will look to SDK config settings to see if screenFrameRate is defined and use it under certain conditions.

Fixes #SPARK-162954

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
