### PR TITLE
fix(conversation): threads iterator 'done' is true when no more activities can be fetched

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -1657,13 +1657,13 @@ const Conversation = WebexPlugin.extend({
      * @returns {IGeneratorResponse}
      */
     const getOlder = async () => {
-      const {value} = await threadOrderer.next(olderOptions);
+      const {value = []} = await threadOrderer.next(olderOptions);
 
-      const oldestInBatch = value[0];
-      const moreActivitiesExist = getActivityType(oldestInBatch) !== ACTIVITY_TYPES.CREATE;
+      const oldestInBatch = value[0] && value[0].activity;
+      const moreActivitiesExist = oldestInBatch && getActivityType(oldestInBatch) !== ACTIVITY_TYPES.CREATE;
 
       return {
-        done: moreActivitiesExist,
+        done: !moreActivitiesExist,
         value
       };
     };

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
@@ -805,6 +805,15 @@ describe('plugin-conversation', function () {
           });
       });
 
+      it('should return done as true when no more activities can be fetched', () => {
+        const {getOlder: getOlderWithLargeMin} = webex.internal.conversation.listActivitiesThreadOrdered({conversationId: conversation.id, minActivities: 50});
+
+        return getOlderWithLargeMin()
+          .then(({done}) => {
+            assert.isTrue(done);
+          });
+      });
+
       it('should return searched-for activity with surrounding activities when jumpToActivity is called with an activity', () => {
         const search = firstParentBatch[firstParentBatch.length - 1];
 


### PR DESCRIPTION
Fixes bug where listActivitiesThreadOredered (wrapper function for _listActivitiesThreadOrdered) determines the "done" value of its iteratator response incorrectly.