### PR TITLE
test(internal-plugin-conversation): update test

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/verbs.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/verbs.js
@@ -466,20 +466,13 @@ describe('plugin-conversation', function () {
 
     describe('#updateTypingStatus()', () => {
       let blockUntilMercuryStart;
-      let blockUntilMercuryStop;
       const startTypingSpy = sinon.spy();
-      const stopTypingSpy = sinon.spy();
 
       beforeEach(() => {
         blockUntilMercuryStart = new Defer();
-        blockUntilMercuryStop = new Defer();
         mccoy.webex.internal.mercury.on('event:status.start_typing', () => {
           startTypingSpy();
           blockUntilMercuryStart.resolve();
-        });
-        mccoy.webex.internal.mercury.on('event:status.stop_typing', () => {
-          stopTypingSpy();
-          blockUntilMercuryStop.resolve();
         });
 
         return webex.internal.conversation.create({participants, comment: 'THIS IS A COMMENT'})
@@ -490,7 +483,6 @@ describe('plugin-conversation', function () {
 
       afterEach(() => {
         startTypingSpy.resetHistory();
-        stopTypingSpy.resetHistory();
       });
 
       it('sets the typing indicator for the specified conversation', () => webex.internal.conversation.updateTypingStatus(conversation, {typing: true})
@@ -499,11 +491,9 @@ describe('plugin-conversation', function () {
           assert.calledOnce(startTypingSpy);
         }));
 
-      // Bring back this test when 'updateTypingStatus' is fixed
-      it.skip('clears the typing indicator for the specified conversation', () => webex.internal.conversation.updateTypingStatus(conversation, {typing: false})
-        .then(() => blockUntilMercuryStop.promise)
-        .then(() => {
-          assert.called(stopTypingSpy);
+      it('clears the typing indicator for the specified conversation', () => webex.internal.conversation.updateTypingStatus(conversation, {typing: false})
+        .then(({statusCode}) => {
+          assert.equal(statusCode, 204);
         }));
 
       it('fails if called with a bad conversation object', () => {


### PR DESCRIPTION
- Convo server no longer broadcasts the 'stop_typing' event over mercury

Because the server is no longer sending the 'stop_typing' event over mercury, I decided to check if we successfully sent the 'stop_typing' event from the return value.

[SPARK-141543](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-141543) #done

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
