### PR TITLE
build(codeowners): set web client team as meetings plugin owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*  @webex/js-sdk-widgets-core
+*                                             @webex/js-sdk-widgets-core
+packages/node_modules/@webex/plugin-meetings  @webex/spark-web-client-team


### PR DESCRIPTION
Makes web client team code owners of the meetings plugin.

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
