### PR TITLE
fix(meeting-plugin): getMediaStreams uses last used video device

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/media/properties.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/properties.js
@@ -28,6 +28,7 @@ export default class MediaProperties {
     this.localQualityLevel = options.localQualityLevel || QUALITY_LEVELS.HIGH;
     this.remoteQualityLevel = options.remoteQualityLevel || QUALITY_LEVELS.HIGH;
     this.mediaSettings = {};
+    this.videoDeviceId = null;
 
     // deprecated after v1.89.3, remove when feasible.
     // backwards compatible code.
@@ -46,6 +47,14 @@ export default class MediaProperties {
         return MediaUtil.createMediaStream([this.remoteAudioTrack, this.remoteVideoTrack]);
       }
     });
+  }
+
+  /**
+   * Retrieves the preferred video input device
+   * @returns {Object|null}
+   */
+  getVideoDeviceId() {
+    return this.videoDeviceId || null;
   }
 
   setMediaDirection(mediaDirection) {
@@ -113,6 +122,15 @@ export default class MediaProperties {
    */
   setRemoteVideoTrack(remoteVideoTrack) {
     this.remoteVideoTrack = remoteVideoTrack;
+  }
+
+  /**
+   * Stores the preferred video input device
+   * @param {string} deviceId Preferred video input device
+   * @returns {void}
+   */
+  setVideoDeviceId(deviceId) {
+    this.videoDeviceId = deviceId;
   }
 
   unsetPeerConnection() {

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1701,6 +1701,10 @@ export default class Meeting extends StatelessWebexPlugin {
           height: settings.height,
           width: settings.width
         });
+        // store and save the selected video input device
+        if (settings.deviceId) {
+          this.mediaProperties.setVideoDeviceId(settings.deviceId);
+        }
         LoggerProxy.logger.log('Meeting:index#setLocalTracks --> Video settings.', JSON.stringify(this.mediaProperties.mediaSettings.video));
       }
 
@@ -2400,6 +2404,27 @@ export default class Meeting extends StatelessWebexPlugin {
 
         LoggerProxy.logger.warn('Meeting:index#getMediaStreams --> Enabling `sendShare` along with `sendAudio` & `sendVideo`, on Safari, causes a failure while setting up a screen share at the same time as the camera+mic stream');
         LoggerProxy.logger.warn('Meeting:index#getMediaStreams --> Please use `meeting.shareScreen()` to manually start the screen share after successfully joining the meeting');
+      }
+
+      // extract deviceId if exists otherwise default to null.
+      const {deviceId: preferredVideoDevice} = (audioVideo && audioVideo.video || {deviceId: null});
+      const lastVideoDeviceId = this.mediaProperties.getVideoDeviceId();
+
+      if (preferredVideoDevice) {
+        // Store new preferred video input device
+        this.mediaProperties.setVideoDeviceId(preferredVideoDevice);
+      }
+      else if (lastVideoDeviceId) {
+        // no new video preference specified so use last stored value,
+        // works with empty object {} or media constraint.
+        // eslint-disable-next-line no-param-reassign
+        audioVideo = {
+          ...audioVideo,
+          video: {
+            ...audioVideo.video,
+            deviceId: lastVideoDeviceId
+          }
+        };
       }
 
       return Media.getSupportedDevice({

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -374,7 +374,7 @@ describe('plugin-meetings', () => {
         let sandbox;
 
         beforeEach(() => {
-          sandbox = sinon.sandbox.create();
+          sandbox = sinon.createSandbox();
           sandbox.stub(Media, 'getSupportedDevice').returns(Promise.resolve({sendAudio: true, sendVideo: true}));
           sandbox.stub(Media, 'getUserMedia').returns(Promise.resolve(['stream1', 'stream2']));
         });
@@ -555,7 +555,7 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.leave);
         });
         beforeEach(() => {
-          sandbox = sinon.sandbox.create();
+          sandbox = sinon.createSandbox();
           meeting.meetingFiniteStateMachine.ring();
           meeting.meetingFiniteStateMachine.join();
           meeting.meetingRequest.leaveMeeting = sinon.stub().returns(Promise.resolve({body: 'test'}));
@@ -1181,7 +1181,7 @@ describe('plugin-meetings', () => {
       beforeEach(() => {
         const fakeMediaTrack = () => ({stop: () => {}, readyState: ENDED});
 
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.stub(Media, 'stopTracks').returns(Promise.resolve());
         sandbox.stub(meeting.mediaProperties, 'audioTrack').value(fakeMediaTrack());
         sandbox.stub(meeting.mediaProperties, 'videoTrack').value(fakeMediaTrack());
@@ -1419,7 +1419,7 @@ describe('plugin-meetings', () => {
       let sandbox;
 
       beforeEach(() => {
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         sandbox.stub(meeting.mediaProperties, 'unsetRemoteTracks').returns(Promise.resolve());
       });
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -371,16 +371,59 @@ describe('plugin-meetings', () => {
         });
       });
       describe('#getMediaStreams', () => {
+        let sandbox;
+
+        beforeEach(() => {
+          sandbox = sinon.sandbox.create();
+          sandbox.stub(Media, 'getSupportedDevice').returns(Promise.resolve({sendAudio: true, sendVideo: true}));
+          sandbox.stub(Media, 'getUserMedia').returns(Promise.resolve(['stream1', 'stream2']));
+        });
+        afterEach(() => {
+          sandbox.restore();
+          sandbox = null;
+        });
         it('should have #getMediaStreams', () => {
           assert.exists(meeting.getMediaStreams);
         });
         it('should proxy Media getUserMedia, and return a promise', async () => {
-          Media.getSupportedDevice = sinon.stub().returns(Promise.resolve({sendAudio: true, sendVideo: true}));
-          Media.getUserMedia = sinon.stub().returns(Promise.resolve(['stream1', 'stream2']));
-
           await meeting.getMediaStreams({sendAudio: true, sendVideo: true});
 
           assert.calledOnce(Media.getUserMedia);
+        });
+        it('uses the preferred video device if set', async () => {
+          const videoDevice = 'video1';
+          const mediaDirection = {sendAudio: true, sendVideo: true, sendShare: false};
+          const audioVideoSettings = {};
+
+          sandbox.stub(meeting.mediaProperties, 'videoDeviceId').value(videoDevice);
+
+          await meeting.getMediaStreams(mediaDirection, audioVideoSettings);
+
+          assert.calledWith(Media.getUserMedia, {
+            ...mediaDirection,
+            isSharing: false
+          },
+          {
+            video: {
+              deviceId: videoDevice
+            }
+          });
+        });
+        it('will set a new preferred video input device if passed in', async () => {
+          // if audioVideo settings parameter specifies a new video device it
+          // will store that device as the preferred video device.
+          // Which is the case with meeting.updateVideo()
+          const oldVideoDevice = 'video1';
+          const newVideoDevice = 'video2';
+          const mediaDirection = {sendAudio: true, sendVideo: true, sendShare: false};
+          const audioVideoSettings = {video: {deviceId: newVideoDevice}};
+
+          sandbox.stub(meeting.mediaProperties, 'videoDeviceId').value(oldVideoDevice);
+          sandbox.stub(meeting.mediaProperties, 'setVideoDeviceId');
+
+          await meeting.getMediaStreams(mediaDirection, audioVideoSettings);
+
+          assert.calledWith(meeting.mediaProperties.setVideoDeviceId, newVideoDevice);
         });
       });
       describe('#join', () => {
@@ -1259,6 +1302,22 @@ describe('plugin-meetings', () => {
           );
         });
       });
+      describe('#setLocalTracks', () => {
+        it('stores the current video device as the preferred video device', () => {
+          const videoDevice = 'video1';
+          const fakeTrack = {getSettings: () => ({deviceId: videoDevice})};
+          const fakeStream = 'stream1';
+
+          sandbox.stub(MeetingUtil, 'getTrack').returns({audioTrack: null, videoTrack: fakeTrack});
+          sandbox.stub(meeting.mediaProperties, 'setMediaSettings');
+          sandbox.stub(meeting.mediaProperties, 'setVideoDeviceId');
+          sandbox.stub(MediaUtil, 'createMediaStream').returns(true);
+
+          meeting.setLocalTracks(fakeStream);
+
+          assert.calledWith(meeting.mediaProperties.setVideoDeviceId, videoDevice);
+        });
+      });
       describe('#setLocalShareTrack', () => {
         it('should trigger a media:ready event with local share stream', () => {
           const track = {
@@ -1508,6 +1567,32 @@ describe('plugin-meetings', () => {
           assert.equal(meeting.selfId, uuid2);
           assert.equal(meeting.mediaId, uuid3);
           assert.equal(meeting.hostId, uuid4);
+        });
+      });
+      describe('preferred video device', () => {
+        describe('#getVideoDeviceId', () => {
+          it('returns the preferred video device', () => {
+            const videoDevice = 'video1';
+
+            sandbox.stub(meeting.mediaProperties, 'videoDeviceId').value(videoDevice);
+
+            assert.equal(meeting.mediaProperties.getVideoDeviceId(), videoDevice);
+          });
+          it('returns null if the preferred video device is not set', () => {
+            sandbox.stub(meeting.mediaProperties, 'videoDeviceId').value(undefined);
+
+            assert.equal(meeting.mediaProperties.getVideoDeviceId(), null);
+          });
+        });
+        describe('#setVideoDeviceId', () => {
+          it('sets the preferred video device', () => {
+            const videoDevice = 'video1';
+
+            sandbox.stub(meeting.mediaProperties, 'videoDeviceId').value(undefined);
+            meeting.mediaProperties.setVideoDeviceId(videoDevice);
+
+            assert.equal(meeting.mediaProperties.videoDeviceId, videoDevice);
+          });
         });
       });
     });


### PR DESCRIPTION
When first reported updating meeting quality level changed the video device if you had two video devices and was using your non-default camera. When recently tested using the samples, the local video stream of the caller did not change but the video displayed to the remote party did change to the other camera. Therefore the caller was unaware of that the remote party sees a different video stream.

If the caller leaves a meeting without closing the browser window and attempts to rejoin then the last camera used will be remembered. To rejoin the caller must getting media streams, click the join button and then click on the add media button.

Caller A - JS SDK (calls into space, must have two cameras)
Remote Party B - Native Desktop client (joins space)

**Steps to reproduce:**
Caller A should start the meeting, update their video to a non-default camera. Then proceed to change the video quality and note that the remote party sees a different video stream from the caller.

Fixes #SPARK-148663
GitHub Issue: #1694 

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.

✈️ (wing-wave)
