### PR TITLE
docs(nodejs): fix sample NodeJS usage

### DIFF
--- a/documentation/webex.md
+++ b/documentation/webex.md
@@ -118,7 +118,7 @@ app.get(`/login`, (req, res) => {
 
 app.get(`/oauth/redirect`, (req, res, next) => {
   assert(req.params.code);
-  req.webex.requestAuthorizationCodeGrant(req.params)
+  req.webex.authorization.requestAuthorizationCodeGrant(req.params)
     .then(() => {
       res.redirect(`/`).end();
     })


### PR DESCRIPTION
Accessing the code grant method is inside the authorization plugin and not at the top-level.

This was brought up in one of the developer help spaces.

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
