### PR TITLE
fix(device): set TTL when registering device as ephemeral

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-device/src/device.js
+++ b/packages/node_modules/@webex/internal-plugin-device/src/device.js
@@ -443,6 +443,11 @@ const Device = WebexPlugin.extend({
           ...(this.config.headers ? this.config.headers : {})
         };
 
+        // Append a ttl value if the device is marked as ephemeral
+        if (this.config.ephemeral) {
+          body.ttl = this.config.ephemeralDeviceTTL;
+        }
+
         // This will be replaced by a `create()` method.
         return this.request({
           method: 'POST',

--- a/packages/node_modules/@webex/internal-plugin-device/test/integration/spec/device.js
+++ b/packages/node_modules/@webex/internal-plugin-device/test/integration/spec/device.js
@@ -725,6 +725,17 @@ describe('plugin-device', () => {
                     'method', 'POST'
                   )));
             });
+
+            it('should set TTL if configured as ephemeral', () => {
+              device.config.ephemeral = true;
+              device.config.ephemeralDeviceTTL = 3600;
+
+              return device.register()
+                .then(() =>
+                  assert.calledWith(device.request, sinon.match.hasNested(
+                    'body.ttl', 3600
+                  )));
+            });
           });
 
           describe('when the device is successfully registered', () => {


### PR DESCRIPTION
This adds TTL when to the device registration request whenever registrations are configured as ephemeral.

Fixes [SPARK-171365](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-171365)

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
