### PR TITLE
docs(meeting): remove MediaStream param from updateShare [skip ci]

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2895,7 +2895,6 @@ export default class Meeting extends StatelessWebexPlugin {
    * @param {Object} options
    * @param {boolean} options.sendShare
    * @param {boolean} options.receiveShare
-   * @param {MediaStream} [stream]
    * @returns {Promise}
    * @public
    * @memberof Meeting


### PR DESCRIPTION
The JSDoc does not match the implementation.

Fixes #[SPARK-158533](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-158533)

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
