### PR TITLE
fix(plugin-meeting): meeting object not deleted on end

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js
@@ -41,19 +41,19 @@ ControlsUtils.parse = (controls) => {
 ControlsUtils.getControls = (oldControls, newControls) => {
   const previous = ControlsUtils.parse(oldControls);
   const current = ControlsUtils.parse(newControls);
-  const hasRecord = (controls) => controls && controls.record;
+  const hasRecord = (controls) => controls && !!controls.record;
 
   return {
     previous,
     current,
     updates: {
-      hasRecordingPausedChanged: !isEqual(
+      hasRecordingPausedChanged: hasRecord(current) && !isEqual(
         hasRecord(previous) && previous.record.paused,
-        hasRecord(current) && current.record.paused
+        current.record.paused
       ),
-      hasRecordingChanged: !isEqual(
+      hasRecordingChanged: hasRecord(current) && !isEqual(
         hasRecord(previous) && previous.record.recording,
-        hasRecord(current) && current.record.recording
+        current.record.recording
       )
     }
   };

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -817,7 +817,7 @@ export default class Meeting extends StatelessWebexPlugin {
       Trigger.trigger(
         this,
         {
-          file: 'meetings/index',
+          file: 'meeting/index',
           function: 'setNetworkStatus'
         },
         EVENT_TRIGGERS.MEETINGS_NETWORK_DISCONNECTED,
@@ -827,7 +827,7 @@ export default class Meeting extends StatelessWebexPlugin {
       Trigger.trigger(
         this,
         {
-          file: 'meetings/index',
+          file: 'meeting/index',
           function: 'setNetworkStatus'
         },
         EVENT_TRIGGERS.MEETINGS_NETWORK_CONNECTED,

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -63,7 +63,19 @@ describe('plugin-meetings', () => {
         assert.equal(locusInfo.controls, newControls);
       });
 
-      it('should keep the recording state to `IDLE`', () => {
+      it('should keep the recording state to `IDLE` when stopped recording', () => {
+        locusInfo.controls = {
+          record: {
+            recording: true,
+            paused: false,
+            meta: {
+              lastModified: 'TODAY',
+              modifiedBy: 'George Kittle'
+            }
+          },
+          shareControl: {},
+          transcribe: {}
+        };
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateControls(newControls);
 


### PR DESCRIPTION
Fixes issue where if recording is not found it does not delete the meeting object from the store 
---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
