### PR TITLE
fix(plugin-meetings): media:ready on safari  not trigged due to tranc…

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1621,9 +1621,9 @@ export default class Meeting extends StatelessWebexPlugin {
       let trackMediaID = null;
 
 
-      // **In case of safari some time the transceiver is not present for specific os version
+      // In case of safari some time the transceiver is not present for specific os version
       // sdk tries to determine the transceive using the track id present
-      if (event.transceiver) {
+      if (event.transceiver && event.transceiver.mid) {
         trackMediaID = event.transceiver.mid;
       }
       else {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1368,7 +1368,7 @@ describe('plugin-meetings', () => {
 
 
           // special case for safari
-          pc.ontrack({target: {audioTransceiver: {receiver: {track: {id: 'trackId'}}}}, track: {id: 'trackId'}});
+          pc.ontrack({target: {audioTransceiver: {receiver: {track: {id: 'trackId'}}}}, transceiver: {}, track: {id: 'trackId'}});
           assert.equal(TriggerProxy.trigger.getCall(1).args[2], 'media:ready');
           assert.deepEqual(TriggerProxy.trigger.getCall(1).args[3], {type: 'remoteAudio', stream: true});
         });


### PR DESCRIPTION
transciver  mid  attribute not present in safari

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-170709
Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
