### PR TITLE
fix(conversation): set returned edit activity IDs to original ID

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/activities.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/activities.js
@@ -124,6 +124,7 @@ export const createEditActivity = (editActivity, activities) => {
 
   const joinedEditAct = {
     ...parentAct,
+    id: editActivity.id,
     parent: editActParentObj,
     editParent: editActParentObj,
     object: editActivity.object,
@@ -141,6 +142,7 @@ export const createReplyEditActivity = (editActivity, activities) => {
 
   const joinedReplyEditActivity = {
     ...parentReplyAct,
+    id: editActivity.id,
     parent: editActParentObj,
     editParent: editActParentObj,
     replyParent: parentReplyAct.parent,

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
@@ -686,7 +686,7 @@ describe('plugin-conversation', function () {
     });
 
     describe('#_listActivitiesThreadOrdered', () => {
-      let conversation, firstParentBatch, getOlder, jumpToActivity;
+      let conversation, firstParentBatch, secondParentBatch, getOlder, jumpToActivity;
 
       const minActivities = 10;
       const displayNames = [
@@ -743,6 +743,7 @@ describe('plugin-conversation', function () {
           return Promise.all(secondParents.map((msg) => webex.internal.conversation.post(conversation, {displayName: msg})));
         })
         .then((parents) => {
+          secondParentBatch = parents;
           const threadObjects = [];
 
           for (const msg of threadDisplayNames) {
@@ -772,6 +773,40 @@ describe('plugin-conversation', function () {
       it('should return more than or exactly N minimum activities', () => getOlder().then(({value}) => {
         assert.isAtLeast(value.length, minActivities);
       }));
+
+      it('should return edit activity ID as activity ID when an activity has been edited', () => {
+        const lastParent = secondParentBatch[secondParentBatch.length - 1];
+
+        const message = {
+          displayName: 'edited',
+          content: 'edited'
+        };
+
+        const editingActivity = Object.assign(
+          {
+            parent: {
+              id: lastParent.id,
+              type: 'edit'
+            }
+          },
+          {
+            object: {
+              displayName: message.displayName,
+              content: message.content
+            }
+          }
+        );
+
+        return webex.internal.conversation.post(conversation, message, editingActivity)
+          .then(() => getOlder())
+          .then(({value}) => {
+            const activities = value.map((act) => act.activity);
+            const editedAct = find(activities, (act) => act.editParent);
+
+            assert.equal(editedAct.editParent.id, lastParent.id);
+            assert.notEqual(editedAct.id, lastParent.id);
+          });
+      });
 
       it('should return activities in thread order', () => getOlder().then(({value}) => {
         const oldestAct = value[0].activity;


### PR DESCRIPTION
This commit fixes an issue where the activities returned by the threading wrapper functions use the parent ID as the main ID when an activity has been edited. This change is necessary because when determining read receipts, convo service lists the edit's activity as the lastSeenActivityUUID, which made edits not appear as read.