### PR TITLE
feat: expose getUserMedia on meetings object

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/README.md
+++ b/packages/node_modules/@webex/plugin-meetings/README.md
@@ -521,6 +521,16 @@ Use this if you want to change the actual streams send and receive for audio or 
     }));
 ```
 
+
+##### Accessing media directly (outside of a meeting)
+You can also directly access the following media properties that are not on a meeting instance
+
+```
+this.media.getUserMedia(mediaSetting, audioVideo, sharePreferences, config)
+```
+
+See the [Media](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/%40webex/plugin-meetings/src/media/index.js) util file for method signatures. 
+
 ##### Leave a Meeting
 To leave a meeting, simply call leave
 ```js

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -13,6 +13,7 @@ import StaticConfig from '../common/config';
 import LoggerProxy from '../common/logs/logger-proxy';
 import LoggerRequest from '../common/logs/request';
 import Trigger from '../common/events/trigger-proxy';
+import {getUserMedia} from '../media';
 import {
   MEETINGS,
   EVENTS,
@@ -162,6 +163,18 @@ export default class Meetings extends WebexPlugin {
        * @memberof Meetings
        */
       this.registered = false;
+
+      /**
+       * The public interface for the internal Media util files. These are helpful to expose outside the context
+       * of a meeting so that a user can access media without creating a meeting instance.
+       * @instance
+       * @type {Object}
+       * @private
+       * @memberof Meetings
+       */
+      this.media = {
+        getUserMedia
+      };
 
       this.onReady();
 


### PR DESCRIPTION
Hey there! 

On the interstitial page before actually creating and joining a meeting, we want to get the users local media streams to show their camera/mic is working. The current implementation requires you to have a meeting instance in order to call `.getMediaStream()`. 

There are 2 flows

1. We could create a meeting but not join it. The problem here is that if a sync is calling in between create/join the meeting gets destroyed
2. We could expose the media streams outside of the meeting instance (it's a util file as is) and then the user can grab those streams and pass them when creating and joining the meeting

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
