### PR TITLE
docs(samples): update stop share in advanced sample

### DIFF
--- a/packages/node_modules/samples/browser-plugin-meetings/app.js
+++ b/packages/node_modules/samples/browser-plugin-meetings/app.js
@@ -779,7 +779,10 @@ async function stopScreenShare() {
 
   console.log('MeetingControls#stopScreenShare()');
   try {
-    await meeting.stopShare();
+    await meeting.updateShare({
+      sendShare: false,
+      receiveShare: true
+    });
     toggleSourcesSendShareStatus.innerText = 'Screen share off!';
     console.log('MeetingControls#stopScreenShare() :: Successfully stopped sharing!');
   }


### PR DESCRIPTION
Updating how stopping share is handled in the advanced meeting sample, as it is incorrect and causes confusion with users.

Fixes #[SPARK-172553](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-172553)

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
