### PR TITLE
fix(meeting-plugin): send share error metrics

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -3523,18 +3523,19 @@ export default class Meeting extends StatelessWebexPlugin {
     };
 
     return Media.getDisplayMedia(shareConstraints, this.config)
-      .then((shareStream) => {
-        this.updateShare({
-          sendShare: true,
-          receiveShare: this.mediaProperties.mediaDirection.receiveShare,
-          stream: shareStream
-        });
-      })
+      .then((shareStream) => this.updateShare({
+        sendShare: true,
+        receiveShare: this.mediaProperties.mediaDirection.receiveShare,
+        stream: shareStream
+      }))
       .catch((error) => {
         // Whenever there is a failure when trying to access a user's display
         // report it as an operational metric
         // This gives visibility into common errors and can help
         // with further troubleshooting
+
+        // This metrics will get erros for getDisplayMedia and share errors for now
+        // TODO: The getDisplayMedia errors need to be moved inside `media.getDisplayMedia`
         const metricName = METRICS_OPERATIONAL_MEASURES.GET_DISPLAY_MEDIA_FAILURE;
         const data = {
           correlation_id: this.correlationId,


### PR DESCRIPTION
Currently getDisplayMedia failure metrics is only being used to track the getDisplayMedia failure

We dont have any for screen share failures and the promise does not reject if share fails

Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
