### PR TITLE
feat(ediscovery): support scr decryption on files that use their own key url

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/transforms.js
@@ -310,7 +310,9 @@ class Transforms {
           // leaves the tag, auth, IV, etc fields on the SCR object as undefined.
           if (share.scr || share.sslr) {
             promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptScr,
-              [activity.encryptionKeyUrl, share.scr || share.sslr, {onBehalfOf: container.onBehalfOfUser}])
+              // A share will have an encryptionKeyUrl when it's activity uses a different encryptionKeyUrl. This can happen when old activities are edited
+              // and key rotation is turn on.
+              [share.encryptionKeyUrl || activity.encryptionKeyUrl, share.scr || share.sslr, {onBehalfOf: container.onBehalfOfUser}])
               .then((decryptedSCR) => {
                 if (share.scr) {
                   share.scr = decryptedSCR;


### PR DESCRIPTION
This change supports an upcoming enhancement to edit message. Currently users cannot edit a message if it contains an attached file. In the future this will be possible. However it does mean that a file's `encryptionKeyUrl` may differ from the activity's `encryptionKeyUrl`. e.g. When editing an old activity in a space where key rotation has occurred. To support these scenarios in ediscovery the code will also check this new property. If it is not defined it'll default back to the activity's `encryptionKeyUrl`.