### PR TITLE
fix(plugin-meetings): defer joining and duplicate metrics

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -621,6 +621,15 @@ export default class Meeting extends StatelessWebexPlugin {
      */
     this.recording = null;
 
+    /**
+     * Promise that exists if joining, and resolves upon method completion.
+     * @instance
+     * @type {Promise}
+     * @private
+     * @memberof Meeting
+     */
+    this.deferJoin = undefined;
+
     this.setUpLocusInfoListeners();
     this.locusInfo.init(attrs.locus ? attrs.locus : {});
   }
@@ -2290,6 +2299,22 @@ export default class Meeting extends StatelessWebexPlugin {
    * Scenario D: Joining any other way (sip, pstn, conversationUrl, link just need to specify resourceId)
    */
   join(options = {}) {
+    // If a join request is being processed, refer to the deferred promise.
+    if (this.deferJoin) {
+      return this.deferJoin;
+    }
+
+    // Scope-up the resolve/reject methods for handling within join().
+    let joinFailed;
+    let joinSuccess;
+
+    // Create a deferred promise for a consistent resolve value from utils.
+    // This also prevents redundant API calls.
+    this.deferJoin = new Promise((resolve, reject) => {
+      joinFailed = resolve;
+      joinSuccess = reject;
+    });
+
     // If Move or PSTN try merging into one
     if (false) {
       Metrics.postEvent({
@@ -2324,10 +2349,14 @@ export default class Meeting extends StatelessWebexPlugin {
       if (typeof options.meetingQuality === 'string') {
         if (!QUALITY_LEVELS[options.meetingQuality]) {
           const errorMessage = `Meeting:index#join --> ${options.meetingQuality} not defined`;
+          const error = new Error(errorMessage);
 
           LoggerProxy.logger.error(errorMessage);
 
-          return Promise.reject(new Error(errorMessage));
+          joinFailed(error);
+          this.deferJoin = undefined;
+
+          return Promise.reject(error);
         }
 
         this.mediaProperties.setLocalQualityLevel(options.meetingQuality);
@@ -2344,6 +2373,11 @@ export default class Meeting extends StatelessWebexPlugin {
           } not defined`;
 
           LoggerProxy.logger.error(errorMessage);
+
+          const error = new Error(errorMessage);
+
+          joinFailed(error);
+          this.deferJoin = undefined;
 
           return Promise.reject(new Error(errorMessage));
         }
@@ -2362,12 +2396,22 @@ export default class Meeting extends StatelessWebexPlugin {
       LoggerProxy.logger.log('Meeting:index#join --> Success');
 
       return join;
-    }).catch((error) => {
-      this.meetingFiniteStateMachine.fail(error);
-      LoggerProxy.logger.error('Meeting:index#join --> Failed', error);
+    })
+      .then((join) => {
+        joinSuccess(join);
+        this.deferJoin = undefined;
 
-      return Promise.reject(error);
-    });
+        return join;
+      })
+      .catch((error) => {
+        this.meetingFiniteStateMachine.fail(error);
+        LoggerProxy.logger.error('Meeting:index#join --> Failed', error);
+
+        joinFailed(error);
+        this.deferJoin = undefined;
+
+        return Promise.reject(error);
+      });
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
@@ -267,9 +267,14 @@ pc.setRemoteSessionDetails = (peerConnection, typeStr, remoteSdp, meetingId) => 
           sdp
         })
       )
-      .then(() => Metrics.postEvent({
-        event: eventType.REMOTE_SDP_RECEIVED,
-        meetingId: meetingId}))
+      .then(() => {
+        if (!peerConnection.remoteDescription) {
+          return Metrics.postEvent({
+            event: eventType.REMOTE_SDP_RECEIVED,
+            meetingId: meetingId
+          });
+        }
+      })
       .catch((error) =>  {
         LoggerProxy.logger.error(`Peer-connection-manager:index#setRemoteDescription --> ${error} missing remotesdp`);
         return Metrics.postEvent({


### PR DESCRIPTION
### Description

The scope of the changes in this pull request are to adjust the joining logic to prevent multiple events from being sent if the client [JS SDK] is already attempting to join the meeting. Additional deferring logic has been implemented to further improve the joining experience.

Fixes [SPARK-153106](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-153106)

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
