### PR TITLE
fix(calendar): decrypt organizer email and name

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-calendar/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-calendar/src/index.js
@@ -98,6 +98,11 @@ registerInternalPlugin('calendar', Calendar, {
             ctx.transform('decryptTextProp', 'meetingJoinURL', object.encryptionKeyUrl, object.meetingJoinInfo)
           ]) : [];
 
+          const decryptedOrganizer = object.encryptedOrganizer ? Promise.all([
+            ctx.transform('decryptTextProp', 'encryptedEmailAddress', object.encryptionKeyUrl, object.encryptedOrganizer),
+            ctx.transform('decryptTextProp', 'encryptedName', object.encryptionKeyUrl, object.encryptedOrganizer)
+          ]) : [];
+
           return Promise.all([
             ctx.transform('decryptTextProp', 'encryptedSubject', object.encryptionKeyUrl, object),
             ctx.transform('decryptTextProp', 'encryptedLocation', object.encryptionKeyUrl, object),
@@ -107,7 +112,7 @@ registerInternalPlugin('calendar', Calendar, {
             ctx.transform('decryptTextProp', 'spaceMeetURL', object.encryptionKeyUrl, object),
             ctx.transform('decryptTextProp', 'spaceURI', object.encryptionKeyUrl, object),
             ctx.transform('decryptTextProp', 'spaceURL', object.encryptionKeyUrl, object)
-          ].concat(decryptedParticipants, decryptedMeetingJoinInfo));
+          ].concat(decryptedOrganizer, decryptedParticipants, decryptedMeetingJoinInfo));
         }
       },
       {


### PR DESCRIPTION
calendar service payloads include a `encryptedOrganizer` property, which has `encryptedEmailAddress` and `encryptedName` fields. currently, these properties are not decrypted. this PR fixes that.

if you'd like me to add tests for this change, please let me know where. i was thinking [here](https://github.com/webex/webex-js-sdk/blob/0bd7155d9a614b12cec844596d833580e94db427/packages/node_modules/%40webex/internal-plugin-calendar/test/integration/spec/calendar.js#L183) but i see this test is skipped...