### PR TITLE
fix(plugin-meetings): remove media inactive metrics

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -1140,13 +1140,15 @@ export const MQA_INTEVAL = 60000; // mqa analyzer interval its fixed to 60000
 // Metrics constants ----------------------------------------------------------
 
 export const METRICS_OPERATIONAL_MEASURES = {
+  JOIN_ATTEMPT: 'js_sdk_join_attempt',
   ADD_MEDIA_FAILURE: 'js_sdk_add_media_failures',
   GET_USER_MEDIA_FAILURE: 'js_sdk_get_user_media_failures',
   GET_DISPLAY_MEDIA_FAILURE: 'js_sdk_get_display_media_failures',
   JOIN_FAILURE: 'js_sdk_join_failures',
   JOIN_WITH_MEDIA_FAILURE: 'js_sdk_join_with_media_failures',
   MEETING_LEAVE_RELEASE: 'js_sdk_meeting_leave_release',
-  MEETING_MEDIA_RELEASE: 'js_sdk_meeting_media_release',
+  DISCONNECT_DUE_TO_INACTIVITY: 'js_sdk_disconnect_due_to_inactivity',
+  MEETING_MEDIA_INACTIVE: 'js_sdk_meeting_media_inactive',
   MEETING_RECONNECT_FAILURE: 'js_sdk_meeting_reconnect_failures',
   MEETING_SHARE_FAILURE: 'js_sdk_meeting_share_failures',
   MUTE_AUDIO_FAILURE: 'js_sdk_mute_audio_failures',

--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
@@ -14,13 +14,6 @@ import {
   _LEFT_,
   MEETING_REMOVED_REASON,
   CALL_REMOVED_REASON,
-  AUDIO_STATUS,
-  VIDEO_STATUS,
-  _RECEIVE_ONLY_,
-  _SEND_RECEIVE_,
-  _INACTIVE_,
-  PARTICIPANT_DELTAS,
-  METRICS_OPERATIONAL_MEASURES,
   RECORDING_STATE
 } from '../constants';
 import Metrics from '../metrics';
@@ -187,7 +180,6 @@ export default class LocusInfo extends EventsScope {
     }
     this.updateParticipantDeltas(locus.participants);
     this.participants = locus.participants;
-    this.reportParticipantChanges();
     this.updateLocusInfo(locus);
     this.updateParticipants(locus.participants);
     this.isMeetingActive();
@@ -469,92 +461,6 @@ export default class LocusInfo extends EventsScope {
         }
       );
     }
-  }
-
-  /**
-   * Report any participant changes via metrics requests.
-   *
-   * @returns {void}
-   */
-  reportParticipantChanges() {
-    // Used to find a participant from a given collection.
-    const findParticipant = (person = {}, collection = []) =>
-      collection.find((participant) => participant.person.id === person.id) ||
-      {};
-
-    // Used to setup a changes object for metrics.
-    const determineChanges = (participant, deltas) =>
-      Object.keys(deltas).reduce((states, key) => {
-        const changes = {
-          target: undefined,
-          state: undefined
-        };
-
-        switch (key) {
-          case AUDIO_STATUS:
-            changes.target = PARTICIPANT_DELTAS.TARGETS.AUDIO;
-            break;
-
-          case VIDEO_STATUS:
-            changes.target = PARTICIPANT_DELTAS.TARGETS.VIDEO;
-            break;
-
-          default:
-        }
-
-        switch (participant.status[key]) {
-          case _INACTIVE_:
-            changes.state = PARTICIPANT_DELTAS.STATES.DISABLED;
-            break;
-
-          case _RECEIVE_ONLY_:
-            changes.state = PARTICIPANT_DELTAS.STATES.MUTED;
-            break;
-
-          case _SEND_RECEIVE_:
-            changes.state = PARTICIPANT_DELTAS.STATES.UNMUTED;
-            break;
-
-          default:
-            changes.state = PARTICIPANT_DELTAS.STATES.UNKNOWN;
-        }
-
-        if (changes.target) {
-          states.push(changes);
-        }
-
-        return states;
-      }, []);
-
-    this.deltaParticipants.forEach(
-      (changedParticipant) => {
-        const participant = findParticipant(
-          changedParticipant.person,
-          this.participants
-        );
-
-        const changes = determineChanges(participant, changedParticipant.delta);
-
-        if (
-          changes.every(
-            (change) => (change.state === PARTICIPANT_DELTAS.STATES.DISABLED)
-          )
-        ) {
-          const meeting = this.webex.meetings.meetingCollection.get(
-            this.meetingId
-          );
-
-          Metrics.sendOperationalMetric(
-            METRICS_OPERATIONAL_MEASURES.MEETING_MEDIA_RELEASE,
-            {
-              correlation_id: meeting.correlationId,
-              locus_id: meeting.locusId,
-              reason: `${participant.person.id} left the meeting`
-            }
-          );
-        }
-      }
-    );
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -666,6 +666,14 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   setUpLocusInfoMediaInactiveListener() {
     this.locusInfo.on(EVENTS.DISCONNECT_DUE_TO_INACTIVITY, (res) => {
+      Metrics.sendOperationalMetric(
+        METRICS_OPERATIONAL_MEASURES.DISCONNECT_DUE_TO_INACTIVITY,
+        {
+          correlation_id: this.correlationId,
+          locus_id: this.locusId
+        }
+      );
+
       // TODO: need to send metric for locus disconnect
       LoggerProxy.logger.error(`Meeting:index#setUpLocusInfoMediaInactiveListener --> Meeting disconnected due to inactivity: ${res.reason}`);
       this.reconnect();
@@ -1183,6 +1191,13 @@ export default class Meeting extends StatelessWebexPlugin {
     });
 
     this.locusInfo.on(LOCUSINFO.EVENTS.MEDIA_INACTIVITY, () => {
+      Metrics.sendOperationalMetric(
+        METRICS_OPERATIONAL_MEASURES.MEETING_MEDIA_INACTIVE,
+        {
+          correlation_id: this.correlationId,
+          locus_id: this.locusId
+        }
+      );
       this.reconnect();
     });
   }
@@ -2400,6 +2415,13 @@ export default class Meeting extends StatelessWebexPlugin {
         meeting: this,
         data: {trigger: trigger.USER_INTERACTION}
       });
+
+      Metrics.sendOperationalMetric(
+        METRICS_OPERATIONAL_MEASURES.JOIN_ATTEMPT,
+        {
+          correlation_id: this.correlationId
+        }
+      );
     }
 
     LoggerProxy.logger.log('Meeting:index#join --> Joining a meeting');


### PR DESCRIPTION
No need to track participant left event as that does not represent the media inactive event ,
Currently causing too many API calls 
Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
