### PR TITLE
Metric for MQA and share fix

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -918,6 +918,8 @@ export const SDP = {
   M_LINE: 'm=',
   MAX_FS: 'max-fs=',
   B_LINE: 'b=TIAS',
+  // Edonus repeated key frames request
+  PERIODIC_KEYFRAME: 'a=periodic-keyframes:20',
   CARRIAGE_RETURN: '\r\n',
   BAD_MEDIA_PORTS: [0]
 };

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1667,6 +1667,13 @@ export default class Meeting extends StatelessWebexPlugin {
         }
         else {
           trackMediaID = null;
+          Metrics.sendOperationalMetric(
+            METRICS_OPERATIONAL_MEASURES.MUTE_AUDIO_FAILURE,
+            {
+              correlation_id: this.correlationId,
+              locus_id: this.locusUrl.split('/').pop()
+            }
+          );
         }
       }
 
@@ -1690,6 +1697,10 @@ export default class Meeting extends StatelessWebexPlugin {
           LoggerProxy.logger.log('Meeting:index#setRemoteStream --> no matching media track id');
         }
       }
+
+      // start stats here the stats are coming null if you dont receive streams
+
+      this.statsAnalyzer.startAnalyzer(this.mediaProperties.peerConnection);
 
       if (eventType && mediaTrack) {
         Trigger.trigger(
@@ -2722,7 +2733,7 @@ export default class Meeting extends StatelessWebexPlugin {
               };
 
               Metrics.sendOperationalMetric(metricName, data, metadata);
-              throw new MediaError('Unable to retrieve media streams');
+              throw new MediaError('Unable to retrieve media streams', error);
             }));
     }
 
@@ -2845,8 +2856,6 @@ export default class Meeting extends StatelessWebexPlugin {
                 );
               }
             });
-            // This is the right place to start the stats
-            this.statsAnalyzer.startAnalyzer(peerConnection);
           }
         })
         .catch((error) => {
@@ -2907,7 +2916,22 @@ export default class Meeting extends StatelessWebexPlugin {
           }
 
           return Promise.resolve();
-        }));
+        }))
+      .catch((error) => {
+        LoggerProxy.logger.error(`${LOG_HEADER} Error joining the call on roap initialization, `, error);
+
+        Metrics.sendOperationalMetric(
+          METRICS_OPERATIONAL_MEASURES.ADD_MEDIA_FAILURE,
+          {
+            correlation_id: this.correlationId,
+            locus_id: this.locusUrl.split('/').pop(),
+            reason: error.message,
+            stack: error.stack
+          }
+        );
+
+        throw error;
+      });
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1902,7 +1902,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this.leave({reason: MEETING_REMOVED_REASON.USER_ENDED_SHARE_STREAMS});
         }
         else {
-          this.stopFloorRequest();
+          this.stopShare();
         }
       };
 

--- a/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
@@ -20,7 +20,8 @@ import {
   PEER_CONNECTION_STATE,
   OFFER,
   QUALITY_LEVELS,
-  MAX_FRAMESIZES
+  MAX_FRAMESIZES,
+  METRICS_OPERATIONAL_MEASURES
 } from '../constants';
 
 import {error, eventType} from '../metrics/config'
@@ -44,10 +45,13 @@ const insertBandwidthLimit = (sdpLines, index) => {
   // eslint-disable-next-line no-warning-comments
   // TODO convert to sdp parser
   let limit;
+  let periodicKeyFrame = '';
   if (sdpLines[index].search(AUDIO) !== -1) {
     limit = StaticConfig.meetings.bandwidth.audio;
   } else {
     limit = StaticConfig.meetings.bandwidth.video;
+    periodicKeyFrame = SDP.PERIODIC_KEYFRAME
+    sdpLines.splice(index + 2, 0, periodicKeyFrame);
   }
   sdpLines.splice(index + 1, 0, `${SDP.B_LINE}:${limit}`);
   return sdpLines;
@@ -279,7 +283,7 @@ pc.setRemoteSessionDetails = (peerConnection, typeStr, remoteSdp, meetingId) => 
         LoggerProxy.logger.error(`Peer-connection-manager:index#setRemoteDescription --> ${error} missing remotesdp`);
 
 
-        const metricName = METRICS_OPERATIONAL_MEASURES.PEERCONNCTION_FAILURE;
+        const metricName = METRICS_OPERATIONAL_MEASURES.PEERCONNECTION_FAILURE;
         const data = {
           correlation_id: meetingId,
           reason: error.message,
@@ -323,7 +327,6 @@ pc.createOffer = (peerConnection, {meetingId, remoteQualityLevel}) => {
         // bug https://bugs.chromium.org/p/chromium/issues/detail?id=1020642
         // chrome currently generates RTX line irrespective of weither the server side supports it
         // we are removing apt as well because its associated with rtx line
-
         description.sdp = description.sdp.replace(/\r\na=rtpmap:\d+ rtx\/\d+/g, '');
         description.sdp = description.sdp.replace(/\r\na=fmtp:\d+ apt=\d+/g, '');
         peerConnection.setLocalDescription(description)
@@ -347,7 +350,7 @@ pc.createOffer = (peerConnection, {meetingId, remoteQualityLevel}) => {
       .catch((error) => {
         LoggerProxy.logger.error(`Peer-connection-manager:index#createOffer --> ${error}`);
 
-        const metricName = METRICS_OPERATIONAL_MEASURES.PEERCONNCTION_FAILURE;
+        const metricName = METRICS_OPERATIONAL_MEASURES.PEERCONNECTION_FAILURE;
         const data = {
           correlation_id: meetingId,
           reason: error.message,
@@ -454,7 +457,7 @@ pc.createAnswer = (params, {meetingId, remoteQualityLevel}) => {
       return peerConnection;
     })
     .catch((error) => {
-      const metricName = METRICS_OPERATIONAL_MEASURES.PEERCONNCTION_FAILURE;
+      const metricName = METRICS_OPERATIONAL_MEASURES.PEERCONNECTION_FAILURE;
       const data = {
         correlation_id: meetingId,
         reason: error.message,

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js
@@ -32,6 +32,8 @@ const checkForAndHandleErrors = (action, meeting, correlationId) => {
   return false;
 };
 
+const compareRemoteRoapOffer = (lastRoapMessage, currentRoapMessage) => lastRoapMessage?.msg?.seq === currentRoapMessage.msg.seq;
+
 const handleSessionStep = ({
   roap, session, locusUrl, correlationId
 }) => {
@@ -68,6 +70,7 @@ export default class RoapHandler extends StatelessWebexPlugin {
     this.options = options;
     this.roapOk = roapOk;
     this.roapAnswer = roapAnswer;
+    this.lastRoapMessage = null;
   }
 
   /**
@@ -184,7 +187,14 @@ export default class RoapHandler extends StatelessWebexPlugin {
 
     switch (action.type) {
       case ROAP.RECEIVE_ROAP_MSG:
-        action.remote = true;
+        if (compareRemoteRoapOffer(this.lastRoapMessage, action)) {
+          LoggerProxy.logger.warn(`Roap:handler#handleAction --> duplicate roap offer from server: ${action.msg.seq}`); break;
+        }
+        else {
+          this.lastRoapMessage = action;
+          action.remote = true;
+        }
+
         this.execute(signal, session, action, meeting, ROAP.RX_);
         break;
       case ROAP.SEND_ROAP_MSG:

--- a/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
@@ -41,6 +41,7 @@ export default class StatsAnalyzer extends EventsScope {
    */
   constructor(config, statsResults = defaultStats) {
     super();
+    this.statsStarted = false;
     this.statsResults = statsResults;
     this.config = config;
     this.correlationId = config.correlationId;
@@ -145,16 +146,19 @@ export default class StatsAnalyzer extends EventsScope {
    * @returns {void}
    */
   startAnalyzer(peerConnection) {
-    this.peerConnection = peerConnection;
-    this.getStatsAndParse();
-    this.statsInterval = setInterval(() => {
+    if (!this.statsStarted) {
+      this.statsStarted = true;
+      this.peerConnection = peerConnection;
       this.getStatsAndParse();
-    }, this.config.analyzerInterval);
-    // Trigger initial fetch
-    this.sendMqaData();
-    this.mqaInterval = setInterval(() => {
+      this.statsInterval = setInterval(() => {
+        this.getStatsAndParse();
+      }, this.config.analyzerInterval);
+      // Trigger initial fetch
       this.sendMqaData();
-    }, MQA_INTEVAL);
+      this.mqaInterval = setInterval(() => {
+        this.sendMqaData();
+      }, MQA_INTEVAL);
+    }
   }
 
   /**
@@ -269,6 +273,7 @@ export default class StatsAnalyzer extends EventsScope {
       this.filterAndParseGetStatsResults(res, STATS.AUDIO_CORRELATE, false);
     });
 
+    // TODO: add checks for screen share
     this.peerConnection.shareTransceiver.sender.getStats().then((res) => {
       this.filterAndParseGetStatsResults(res, STATS.SHARE_CORRELATE, true);
     });
@@ -416,6 +421,9 @@ export default class StatsAnalyzer extends EventsScope {
       this.statsResults[mediaType][sendrecvType].totalPliCount = result.pliCount;
       this.statsResults[mediaType][sendrecvType].framesDecoded = result.framesDecoded;
       this.statsResults[mediaType][sendrecvType].keyFramesDecoded = result.keyFramesDecoded;
+      this.statsResults[mediaType][sendrecvType].totalSamplesReceived = result.totalSamplesReceived || 0;
+      this.statsResults[mediaType][sendrecvType].totalSamplesDecoded = result.totalSamplesDecoded || 0;
+
       this.statsResults[mediaType][sendrecvType].decoderImplementation = result.decoderImplementation;
       this.statsResults[mediaType][sendrecvType].totalPacketsReceived = result.packetsReceived;
 

--- a/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.js
@@ -12,8 +12,13 @@ export const getAudioReceiverMqa = ({audioReceiver, statsResults, lastMqaDataSen
   audioReceiver.streams[0].common.rtpJitter = statsResults[mediaType][sendrecvType].jitter * 1000 || 0;
 
   audioReceiver.streams[0].common.rtpEndToEndLost = statsResults[mediaType][sendrecvType].totalPacketsLost - lastMqaDataSent[mediaType][sendrecvType].totalPacketsLost || 0;
-  audioReceiver.streams[0].common.framesReceived = statsResults.resolutions[mediaType][sendrecvType].framesReceived - lastMqaDataSent.resolutions[mediaType][sendrecvType].framesReceived || 0;
+
+  audioReceiver.streams[0].common.framesDropped = statsResults[mediaType][sendrecvType].totalSamplesDecoded - lastMqaDataSent[mediaType][sendrecvType].totalSamplesDecoded || 0;
+  audioReceiver.streams[0].common.renderedFrameRate = audioReceiver.streams[0].common.framesDropped * 100 / 60 || 0;
+
+  audioReceiver.streams[0].common.framesReceived = statsResults[mediaType][sendrecvType].totalSamplesReceived - lastMqaDataSent[mediaType][sendrecvType].totalSamplesReceived || 0;
   audioReceiver.streams[0].common.receivedFrameRate = audioReceiver.streams[0].common.framesReceived * 100 / 60 || 0;
+
   audioReceiver.streams[0].common.receivedBitrate = (statsResults[mediaType][sendrecvType].totalBytesReceived - lastMqaDataSent[mediaType][sendrecvType].totalBytesReceived) * 8 / 60 || 0;
 };
 
@@ -67,8 +72,12 @@ export const getVideoReceiverMqa = ({
   videoReceiver.streams[0].common.receivedBitrate = totalBytesReceivedInaMin ? (totalBytesReceivedInaMin) * 8 / 60 : 0;
   // From tracks //TODO: calculate a proper one
   const totalFrameReceivedInaMin = statsResults.resolutions[mediaType][sendrecvType].framesReceived - lastMqaDataSent.resolutions[mediaType][sendrecvType].framesReceived;
+  const totalFrameDecodedInaMin = statsResults.resolutions[mediaType][sendrecvType].framesDecoded - lastMqaDataSent.resolutions[mediaType][sendrecvType].framesDecoded;
 
   videoReceiver.streams[0].common.receivedFrameRate = totalFrameReceivedInaMin ? totalFrameReceivedInaMin * 100 / 60 : 0;
+  videoReceiver.streams[0].common.renderedFrameRate = totalFrameDecodedInaMin ? totalFrameDecodedInaMin * 100 / 60 : 0;
+
+  videoReceiver.streams[0].common.framesDropped = statsResults.resolutions[mediaType][sendrecvType].framesDropped - lastMqaDataSent.resolutions[mediaType][sendrecvType].framesDropped;
   videoReceiver.streams[0].receivedHeight = statsResults.resolutions[mediaType][sendrecvType].height;
   videoReceiver.streams[0].receivedWidth = statsResults.resolutions[mediaType][sendrecvType].width;
   videoReceiver.streams[0].receivedFrameSize = statsResults.resolutions[mediaType][sendrecvType].height * statsResults.resolutions[mediaType][sendrecvType].height / 256;

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1361,10 +1361,10 @@ describe('plugin-meetings', () => {
           };
           const getVideoTracks = sinon.stub().returns([track]);
 
-          meeting.stopFloorRequest = sinon.stub().returns(Promise.resolve());
           meeting.mediaProperties.setLocalShareTrack = sinon.stub().returns(true);
           meeting.mediaProperties.shareTrack = {getVideoTracks, getSettings: track.getSettings};
-          meeting.stopFloorRequest = sinon.stub().returns(true);
+          meeting.stopShare = sinon.stub().returns(true);
+          meeting.mediaProperties.mediaDirection = {};
           meeting.setLocalShareTrack(test1);
           assert.calledTwice(TriggerProxy.trigger);
           assert.calledWith(
@@ -1376,12 +1376,13 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.mediaProperties.setLocalShareTrack);
           assert.equal(meeting.mediaProperties.localStream, undefined);
           meeting.mediaProperties.shareTrack.onended();
-          assert.calledOnce(meeting.stopFloorRequest);
+          assert.calledOnce(meeting.stopShare);
         });
       });
       describe('#setRemoteStream', () => {
         beforeEach(() => {
           MediaUtil.createMediaStream = sinon.stub().returns(true);
+          meeting.statsAnalyzer = {startAnalyzer: sinon.stub()};
         });
         it('should trigger a media:ready event when remote stream track ontrack is fired', () => {
           const pc = {};


### PR DESCRIPTION


fix(plugin-meeting): add periodic key frame request to edonus

fix(plugin-meetings): neglects duplicate roap event with same seq

fix(meeting-plugin): send metrics for framesDropped and framesRendred

fix(plugin-meetings): cannot share second time when stopping using stop share overlay

Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
