### PR TITLE
fix(authorization): optional chain

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/lib/services/services.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/services.js
@@ -8,6 +8,7 @@ import ServiceCatalog from './service-catalog';
 import ServiceRegistry from './service-registry';
 import ServiceState from './service-state';
 
+
 const trailingSlashes = /(?:^\/)|(?:\/$)/;
 
 /* eslint-disable no-underscore-dangle */
@@ -188,7 +189,7 @@ const Services = WebexPlugin.extend({
 
       formattedQuery = {};
 
-      if (queryKey === 'email') {
+      if (queryKey === 'email' && query.email) {
         formattedQuery.emailhash = sha256(query.email.toLowerCase()).toString();
       }
       else {


### PR DESCRIPTION
I could be way out of left field here... but i was trying to add emailhash autosignin functionality to the web client, and this was standing in my way. since the .catch always .resolve anyway, this just makes sure the function doesn't call it on silly params
