### PR TITLE
fix(plugin-meeting):  locus replace always with the last active

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -208,8 +208,8 @@ export default class Meetings extends WebexPlugin {
       // https://sqbu-github.cisco.com/WebExSquared/locus/wiki/Locus-changing-mid-call
 
       if (data.locus && data.locus.replaces && data.locus.replaces.length > 0) {
-        // Findes the first occurence of the meeting in the collection with same locus url
-        meeting = data.locus.replaces.some((replacedLocus) => this.meetingCollection.getByKey(LOCUS_URL, replacedLocus.locusUrl));
+        // Always the last element in the replace is the active one
+        meeting = this.meetingCollection.getByKey(LOCUS_URL, data.locus.replaces[data.locus.replaces.length - 1].locusUrl);
       }
 
       if (!meeting) {


### PR DESCRIPTION
Fixes issues with replace locus , Always last active locus url will get replaced
---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
