### PR TITLE
fix(webex-core): remove logging entire client region info response

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/lib/services/services.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/services.js
@@ -345,7 +345,7 @@ const Services = WebexPlugin.extend({
         'spark-user-agent': null
       }
     }).then((res) => {
-      this.logger.info('services: received user region info', res);
+      this.logger.info('services: received user region info');
 
       return res.body;
     }).catch((err) => {


### PR DESCRIPTION
Updating to not log entire response since it's not needed

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
