### PR TITLE
fix(plugin-meetings): check peerConnection state before closing

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js
@@ -400,9 +400,16 @@ export default class Reachability extends StatelessWebexPlugin {
   setLatencyAndClose(peerConnection, elapsed) {
     const REACHABLE = 'reachable';
     const UNREACHABLE = 'unreachable';
+    const {CLOSED} = CONNECTION_STATE;
     const {key} = peerConnection;
     const resultKey = elapsed === null ? UNREACHABLE : REACHABLE;
     const intialState = {[REACHABLE]: 0, [UNREACHABLE]: 0};
+
+    if (peerConnection.connectionState === CLOSED) {
+      LoggerProxy.logger.info(`Reachability:index#setLatencyAndClose --> Attempting to set latency of ${elapsed} on closed peerConnection.`);
+
+      return;
+    }
 
     this.clusterLatencyResults[key] = this.clusterLatencyResults[key] || intialState;
     this.clusterLatencyResults[key][resultKey] += 1;


### PR DESCRIPTION
Fixes a bug in GDM Reachability where we call .close() on a connection
that has already been closed. This check prevents that.


Fixes #SPARK-165138

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
