### PR TITLE
Gdm discovery during register

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -381,17 +381,14 @@ export default class Meetings extends WebexPlugin {
         LoggerConfig.set(this.config.logging);
         LoggerProxy.set(this.webex.logger);
 
-        // SDK need to perform reachability check on app load
-        this.startReachability().then(() => {
-          Trigger.trigger(
-            this,
-            {
-              file: 'meetings',
-              function: 'onReady'
-            },
-            EVENT_TRIGGERS.MEETINGS_READY
-          );
-        });
+        Trigger.trigger(
+          this,
+          {
+            file: 'meetings',
+            function: 'onReady'
+          },
+          EVENT_TRIGGERS.MEETINGS_READY
+        );
       });
     }
 
@@ -416,20 +413,22 @@ export default class Meetings extends WebexPlugin {
         return Promise.resolve();
       }
 
-      return this.webex.internal.device.register()
-        .then(() => this.webex.internal.mercury.connect())
-        .then(() => {
-          this.listenForEvents();
-          Trigger.trigger(
-            this,
-            {
-              file: 'meetings',
-              function: 'register'
-            },
-            EVENT_TRIGGERS.MEETINGS_REGISTERED
-          );
-          this.registered = true;
-        })
+      return Promise.all([
+        this.startReachability(),
+        this.webex.internal.device.register()
+          .then(() => this.webex.internal.mercury.connect())
+      ]).then(() => {
+        this.listenForEvents();
+        Trigger.trigger(
+          this,
+          {
+            file: 'meetings',
+            function: 'register'
+          },
+          EVENT_TRIGGERS.MEETINGS_REGISTERED
+        );
+        this.registered = true;
+      })
         .catch((error) => {
           LoggerProxy.logger.error(`Meetings:index#register --> ERROR, Unable to register, ${error.message}`);
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -520,7 +520,7 @@ export default class Meetings extends WebexPlugin {
      * @memberof Meetings
      */
     setReachability() {
-      this.reachability = new Reachability({}, {parent: this.webex});
+      this.reachability = new Reachability(this.webex);
     }
 
     /**

--- a/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js
@@ -4,14 +4,12 @@
 
 /* eslint-disable class-methods-use-this */
 /* globals window */
-import {StatelessWebexPlugin} from '@webex/webex-core';
 import _ from 'lodash';
 
 import LoggerProxy from '../common/logs/logger-proxy';
 import {
   ICE_GATHERING_STATE,
   CONNECTION_STATE,
-  MEETINGS,
   REACHABILITY
 } from '../constants';
 
@@ -21,11 +19,15 @@ import ReachabilityRequest from './request';
  * @class Reachability
  * @export
  */
-export default class Reachability extends StatelessWebexPlugin {
-  namespace = MEETINGS;
+export default class Reachability {
+  /**
+   * Creates an instance of Reachability.
+   * @param {object} webex
+   * @memberof Reachability
+   */
+  constructor(webex) {
+    this.webex = webex;
 
-  constructor(attrs, options) {
-    super({}, options);
     /**
      * internal request object for the server
      * @instance
@@ -33,7 +35,7 @@ export default class Reachability extends StatelessWebexPlugin {
      * @private
      * @memberof Reachability
      */
-    this.reachabilityRequest = new ReachabilityRequest({}, options);
+    this.reachabilityRequest = new ReachabilityRequest(this.webex);
 
     /**
      * internal object of clusters latency results
@@ -57,7 +59,7 @@ export default class Reachability extends StatelessWebexPlugin {
     this.setup();
 
     // Remove stored reachability results to ensure no stale data
-    if (window.localStorage && window.localStorage.removeItem) {
+    if (window?.localStorage?.removeItem) {
       window.localStorage.removeItem(REACHABILITY.localStorage);
     }
     else {
@@ -226,7 +228,7 @@ export default class Reachability extends StatelessWebexPlugin {
       if (peerConnection.iceConnectionState === COMPLETE) {
         const elapsed = this.getElapsedTime(peerConnection);
 
-        LoggerProxy.logger.info(`Reachability:index#onIceGatheringStateChange --> Successfully pinged ${peerConnection.key}:`, elapsed);
+        LoggerProxy.logger.log(`Reachability:index#onIceGatheringStateChange --> Successfully pinged ${peerConnection.key}:`, elapsed);
         this.setLatencyAndClose(peerConnection, elapsed);
       }
     };
@@ -248,7 +250,7 @@ export default class Reachability extends StatelessWebexPlugin {
       if (e.candidate && String(e.candidate.type).toLowerCase() === SERVER_REFLEXIVE) {
         const elapsed = this.getElapsedTime(peerConnection);
 
-        LoggerProxy.logger.info(`Reachability:index#onIceCandidate --> Successfully pinged ${peerConnection.key}:`, elapsed);
+        LoggerProxy.logger.log(`Reachability:index#onIceCandidate --> Successfully pinged ${peerConnection.key}:`, elapsed);
         this.setLatencyAndClose(peerConnection, elapsed);
       }
     };
@@ -374,7 +376,7 @@ export default class Reachability extends StatelessWebexPlugin {
         .then((localSDPData) => {
           if (!localSDPData || !Object.keys(localSDPData).length) {
             // TODO: handle the error condition properly and try retry
-            LoggerProxy.logger.info('Reachability:index#performReachabilityCheck --> Local SDP is empty or has missing elements..returning');
+            LoggerProxy.logger.log('Reachability:index#performReachabilityCheck --> Local SDP is empty or has missing elements..returning');
             resolve({});
           }
           else {
@@ -406,7 +408,7 @@ export default class Reachability extends StatelessWebexPlugin {
     const intialState = {[REACHABLE]: 0, [UNREACHABLE]: 0};
 
     if (peerConnection.connectionState === CLOSED) {
-      LoggerProxy.logger.info(`Reachability:index#setLatencyAndClose --> Attempting to set latency of ${elapsed} on closed peerConnection.`);
+      LoggerProxy.logger.log(`Reachability:index#setLatencyAndClose --> Attempting to set latency of ${elapsed} on closed peerConnection.`);
 
       return;
     }
@@ -430,16 +432,5 @@ export default class Reachability extends StatelessWebexPlugin {
    */
   setup() {
     this.clusterLatencyResults = {};
-  }
-
-
-  /**
-   * proxy to the server request for clusters
-   * @returns {Promise}
-   * @private
-   * @memberof Reachability
-   */
-  getClusters() {
-    return this.reachabilityRequest.getClusters();
   }
 }

--- a/packages/node_modules/@webex/plugin-meetings/src/reachability/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reachability/request.js
@@ -1,5 +1,3 @@
-import {StatelessWebexPlugin} from '@webex/webex-core';
-
 import LoggerProxy from '../common/logs/logger-proxy';
 import {
   HTTP_VERBS,
@@ -10,42 +8,51 @@ import {
 /**
  * @class RechabilityRequest
  */
-class RechabilityRequest extends StatelessWebexPlugin {
+class RechabilityRequest {
+  /**
+   * Creates an instance of RechabilityRequest.
+   * @param {object} webex
+   * @memberof RechabilityRequest
+   */
+  constructor(webex) {
+    this.webex = webex;
+  }
+
   /**
    * gets the cluster information
    * @returns {Promise}
    */
-getClusters = () => this.request({
-  method: HTTP_VERBS.GET,
-  shouldRefreshAccessToken: false,
-  api: API.CALLIOPEDISCOVERY,
-  resource: RESOURCE.CLUSTERS
-})
-  .then((res) => {
-    const {clusters} = res.body;
+  getClusters = () => this.webex.request({
+    method: HTTP_VERBS.GET,
+    shouldRefreshAccessToken: false,
+    api: API.CALLIOPEDISCOVERY,
+    resource: RESOURCE.CLUSTERS
+  })
+    .then((res) => {
+      const {clusters} = res.body;
 
-    LoggerProxy.logger.log(`Reachability:request#getClusters --> get clusters successful:${JSON.stringify(clusters)}`);
+      LoggerProxy.logger.log(`Reachability:request#getClusters --> get clusters successful:${JSON.stringify(clusters)}`);
 
-    return clusters;
-  });
+      return clusters;
+    });
 
-/**
+  /**
    * gets remote SDP For Clusters
    * @param {Object} localSDPList localSDPs for the cluster
    * @returns {Object}
    */
-remoteSDPForClusters = (localSDPList) => this.request({
-  method: HTTP_VERBS.POST,
-  shouldRefreshAccessToken: false,
-  api: API.CALLIOPEDISCOVERY,
-  resource: RESOURCE.REACHABILITY,
-  body: {offers: localSDPList}
-})
-  .then((res) => {
-    LoggerProxy.logger.log('Reachability:request#remoteSDPForClusters --> Remote SDPs got succcessfully');
+  remoteSDPForClusters = (localSDPList) => this.webex.request({
+    method: HTTP_VERBS.POST,
+    shouldRefreshAccessToken: false,
+    api: API.CALLIOPEDISCOVERY,
+    resource: RESOURCE.REACHABILITY,
+    body: {offers: localSDPList}
+  })
+    .then((res) => {
+      LoggerProxy.logger.log('Reachability:request#remoteSDPForClusters --> Remote SDPs got succcessfully');
 
-    return res.body;
-  });
+      return res.body;
+    });
 }
 
 export default RechabilityRequest;

--- a/packages/node_modules/@webex/plugin-meetings/src/reachability/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reachability/request.js
@@ -24,7 +24,7 @@ getClusters = () => this.request({
   .then((res) => {
     const {clusters} = res.body;
 
-    LoggerProxy.logger.info(`Reachability:request#getClusters --> get clusters successful:${JSON.stringify(clusters)}`);
+    LoggerProxy.logger.log(`Reachability:request#getClusters --> get clusters successful:${JSON.stringify(clusters)}`);
 
     return clusters;
   });
@@ -42,7 +42,7 @@ remoteSDPForClusters = (localSDPList) => this.request({
   body: {offers: localSDPList}
 })
   .then((res) => {
-    LoggerProxy.logger.info('Reachability:request#remoteSDPForClusters --> Remote SDPs got succcessfully');
+    LoggerProxy.logger.log('Reachability:request#remoteSDPForClusters --> Remote SDPs got succcessfully');
 
     return res.body;
   });


### PR DESCRIPTION
Move the GDM discovery to the meetings registration flow.

Also refactored the unnecessary usage of webex stateless plugin and made the webex object a class instance variable instead.
 
Fixes #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-192941

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
