### PR TITLE
fix(plugin-meetings): use fetch info for destination

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -616,8 +616,7 @@ export default class Meetings extends WebexPlugin {
         })
         .then((options = {}) => {
           // Normalize the destination.
-          const targetDest = options.wasHydraPerson ? options.destination : destination;
-
+          const targetDest = options.destination || destination;
 
           // check for the conversation URL then sip Url
           let meeting = null;


### PR DESCRIPTION
When using a conversation id from hydra, we were ignoring the work the meeting info utility was doing to decode and detect the destination type. 

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
