### PR TITLE
fix(bug): added a forceRefresh for collectPreAuth to bypass cache con…

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/lib/services/services.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/services.js
@@ -411,14 +411,15 @@ const Services = WebexPlugin.extend({
    * @param {object} query
    * @param {string} query.email - A standard format email.
    * @param {string} query.orgId - The user's OrgId.
+   * @param {boolean} forceRefresh - Boolean to bypass u2c cache control header
    * @returns {Promise<void>}
    */
-  collectPreauthCatalog(query) {
+  collectPreauthCatalog(query, forceRefresh = false) {
     if (!query) {
-      return this.updateServices({from: 'limited', query: {mode: 'DEFAULT_BY_PROXIMITY'}});
+      return this.updateServices({from: 'limited', query: {mode: 'DEFAULT_BY_PROXIMITY'}, forceRefresh});
     }
 
-    return this.updateServices({from: 'limited', query});
+    return this.updateServices({from: 'limited', query, forceRefresh});
   },
 
   /**

--- a/packages/node_modules/@webex/webex-core/test/integration/spec/services/services.js
+++ b/packages/node_modules/@webex/webex-core/test/integration/spec/services/services.js
@@ -767,6 +767,33 @@ describe('webex-core', () => {
             assert(true);
           });
       });
+
+      it('updates limited catalog and calls _fetchNewServiceHostmap with forceRefresh = true', (done) => {
+        const forceRefresh = true;
+        const fetchNewServiceHostmapSpy = sinon.spy(services, '_fetchNewServiceHostmap');
+
+        services.updateServices({
+          from: 'limited',
+          query: {email: webexUser.email},
+          forceRefresh
+        })
+          .then(() => {
+            assert.calledOnce(fetchNewServiceHostmapSpy);
+            assert.calledWith(
+              fetchNewServiceHostmapSpy,
+              sinon.match.has(
+                'from', 'limited',
+                'query', {emailhash: sinon.match(/\b[A-Fa-f0-9]{64}\b/)},
+                'forceFresh', forceRefresh
+              )
+            );
+
+            fetchNewServiceHostmapSpy.returnValues[0].then((res) => {
+              assert.isAbove(res.length, 0);
+            });
+            done();
+          });
+      });
     });
 
     describe('#fetchClientRegionInfo()', () => {
@@ -972,6 +999,7 @@ describe('webex-core', () => {
     describe('#collectPreauthCatalog()', () => {
       const unauthWebex = new WebexCore({config: {credentials: {federation: true}}});
       const unauthServices = unauthWebex.internal.services;
+      const forceRefresh = true;
 
       it('updates the preauth catalog without email', () => unauthServices.collectPreauthCatalog()
         .then(() => {
@@ -982,6 +1010,41 @@ describe('webex-core', () => {
         .then(() => {
           assert.isAbove(Object.keys(unauthServices.list()).length, 0);
         }));
+
+      it('updates the preauth catalog with email along with additional timestamp to address cache control', (done) => {
+        const updateServiceSpy = sinon.spy(unauthServices, 'updateServices');
+        const fetchNewServiceHostmapSpy = sinon.spy(unauthServices, '_fetchNewServiceHostmap');
+
+        unauthServices.collectPreauthCatalog(
+          {email: webexUser.email}, forceRefresh
+        )
+          .then(() => {
+            assert.calledOnce(updateServiceSpy);
+            assert.calledWith(
+              updateServiceSpy,
+              sinon.match.has(
+                'from', 'limited',
+                'query', {emailhash: sinon.match(/\b[A-Fa-f0-9]{64}\b/)},
+                'forceRefresh', forceRefresh
+              )
+            );
+
+            assert.calledOnce(fetchNewServiceHostmapSpy);
+            assert.calledWith(
+              fetchNewServiceHostmapSpy,
+              sinon.match.has(
+                'from', 'limited',
+                'query', {emailhash: sinon.match(/\b[A-Fa-f0-9]{64}\b/)},
+                'forceRefresh', forceRefresh
+              )
+            );
+
+            fetchNewServiceHostmapSpy.returnValues[0].then((res) => {
+              assert.isAbove(res.length, 0);
+            });
+            done();
+          });
+      });
     });
 
     describe('#collectSigninCatalog()', () => {


### PR DESCRIPTION
Currently the Webex web client onboarding process is broken due to negative entries in u2c. The flow is outlined below.

For onboarding, the web client calls `validateUser`. This function from the js sdk generates preauth service links and then calls atlas to create this user in signup service. Atlas also calls CI to send out activation links to the user's email. When a user clinks on the link, the web client attempts to validate the activation link's validity, but the problem is it is hitting the wrong CI cluster due to a negative entry that was first created during the preauth call that's coupled with `validateUser`. During the pre auth call to u2c to generate the service link, u2c does a emailhash lookup against CI to validate that the user exist. Since this user isn't created in CI yet (at this point in time), we've created a negative entry in u2c for this email/emailhash. A fix went in yesterday to production to remove the caching of invalid entries. This would normally fix the issue, but u2c has a cache control header of 300s. A fix was merged to the sdk a couple days ago but was missing this piece. 

https://github.com/webex/webex-js-sdk/pull/1959


Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
