### PR TITLE
fix(server-interceptor): add additional error codes for failover

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/lib/services/interceptors/server-error.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/interceptors/server-error.js
@@ -24,7 +24,7 @@ export default class ServerErrorInterceptor extends Interceptor {
    * @returns {Object}
    */
   onResponseError(options, reason) {
-    if ((reason instanceof WebexHttpError.InternalServerError) && options.uri) {
+    if ((reason instanceof WebexHttpError.InternalServerError || reason instanceof WebexHttpError.BadGateway || reason instanceof WebexHttpError.ServiceUnavailable) && options.uri) {
       const feature = this.webex.internal.device.features.developer.get('web-high-availability');
 
       if (feature && feature.value) {

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/interceptors/server-error.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/interceptors/server-error.js
@@ -119,6 +119,26 @@ describe('webex-core', () => {
               });
           });
 
+          it('should mark a url as failed for a 503', (done) => {
+            reason = new WebexHttpError.ServiceUnavailable({
+              message: 'test message',
+              statusCode: 503,
+              options: {
+                url: 'http://not-a-url.com/',
+                headers: {
+                  trackingId: 'tid'
+                }
+              }
+            });
+
+            interceptor.onResponseError(options, reason)
+              .catch(() => {
+                assert.calledWith(markFailedUrl, options.uri);
+
+                done();
+              });
+          });
+
           it('should return a rejected promise with a reason', (done) => {
             interceptor.onResponseError(options, reason)
               .catch((error) => {


### PR DESCRIPTION
Adds 502 and 503 support to failover checks

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
