### PR TITLE
feat(meetings): fail meeting join if peer connection isn't stable

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -187,6 +187,8 @@ export const ICE_FAIL_TIMEOUT = 3000;
 export const RETRY_TIMEOUT = 3000;
 export const ROAP_SEQ_PRE = -1;
 
+export const PC_BAIL_TIMEOUT = 20000;
+
 // ******************** REGEX **********************
 // Please alphabetize
 export const DIALER_REGEX = {

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -26,35 +26,37 @@ import StatsUtil from '../stats/util';
 import ReconnectionError from '../common/errors/reconnection';
 import ReconnectInProgress from '../common/errors/reconnection-in-progress';
 import {
-  MEETINGS,
+  _BUSY_,
+  _CALL_,
+  _INCOMING_,
+  _JOIN_,
+  CONNECTION_STATE,
+  CONTENT,
   ENDED,
   EVENT_TRIGGERS,
   EVENT_TYPES,
   EVENTS,
   FLOOR_ACTION,
-  _BUSY_,
-  _INCOMING_,
-  ONLINE,
-  _CALL_,
-  CONTENT,
-  ROAP_SEQ_PRE,
-  LOCUSINFO,
-  MEETING_STATE_MACHINE,
-  _JOIN_,
-  STATS,
-  MQA_STATS,
-  MEETING_STATE,
-  METRICS_OPERATIONAL_MEASURES,
   FULL_STATE,
-  MEETING_REMOVED_REASON,
-  SHARE_STOPPED_REASON,
-  SDP,
-  QUALITY_LEVELS,
-  VIDEO_RESOLUTIONS,
-  VIDEO,
   LAYOUT_TYPES,
+  LOCUSINFO,
+  MEETING_REMOVED_REASON,
+  MEETING_STATE_MACHINE,
+  MEETING_STATE,
+  MEETINGS,
+  METRICS_OPERATIONAL_MEASURES,
+  MQA_STATS,
   NETWORK_STATUS,
-  RECORDING_STATE
+  ONLINE,
+  PC_BAIL_TIMEOUT,
+  QUALITY_LEVELS,
+  RECORDING_STATE,
+  ROAP_SEQ_PRE,
+  SDP,
+  SHARE_STOPPED_REASON,
+  STATS,
+  VIDEO_RESOLUTIONS,
+  VIDEO
 } from '../constants';
 import ParameterError from '../common/errors/parameter';
 import MediaError from '../common/errors/media';
@@ -2847,11 +2849,14 @@ export default class Meeting extends StatelessWebexPlugin {
       })
         .then((peerConnection) => {
           LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection Received from attachMedia ${peerConnection}`);
+
           this.setRemoteStream(peerConnection);
           MeetingUtil.startInternalStats(this);
+
           if (this.config.metrics.autoSendMQA) {
             this.startMediaQualityMetrics();
           }
+
           if (this.config.stats.enableStatsAnalyzer) {
             this.statsAnalyzer = new StatsAnalyzer(this.config.stats);
             this.statsAnalyzer.on(EVENT_TRIGGERS.MEDIA_QUALITY, (options) => {
@@ -2931,7 +2936,35 @@ export default class Meeting extends StatelessWebexPlugin {
           success: `${LOG_HEADER} Successfully send roap media request`,
           failure: `${LOG_HEADER} Error joining the call on send roap media request, `
         }))
+        .then(() => {
+          const {peerConnection} = this.mediaProperties;
 
+          return new Promise((resolve, reject) => {
+            if (peerConnection.connectionState === CONNECTION_STATE.CONNECTED) {
+              LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection CONNECTED`);
+
+              resolve(peerConnection);
+
+              return;
+            }
+            // Check if Peer Connection is STABLE (connected)
+            const stabilityTimeout = setTimeout(() => {
+              if (peerConnection.connectionState !== CONNECTION_STATE.CONNECTED) {
+                reject(new Error(`Unable to add media. PeerConnection NOT CONNECTED after ${PC_BAIL_TIMEOUT / 1000} seconds.`));
+              }
+              else {
+                LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection CONNECTED`);
+                resolve(peerConnection);
+              }
+            }, PC_BAIL_TIMEOUT);
+
+            this.once(EVENT_TRIGGERS.MEDIA_READY, () => {
+              LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection CONNECTED, clearing stability timer.`);
+              clearTimeout(stabilityTimeout);
+              resolve(peerConnection);
+            });
+          });
+        })
         .then(() => {
           if (mediaSettings && mediaSettings.sendShare && localShare) {
             if (this.state === MEETING_STATE.STATES.JOINED) {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -499,9 +499,6 @@ describe('plugin-meetings', () => {
         });
       });
       describe('#addMedia', () => {
-        it('should have #addMedia', () => {
-          assert.exists(meeting.addMedia);
-        });
         beforeEach(() => {
           meeting.mediaProperties.setMediaDirection = sinon.stub().returns(true);
           meeting.audio = true;
@@ -511,10 +508,18 @@ describe('plugin-meetings', () => {
           meeting.setRemoteStream = sinon.stub().returns(true);
           meeting.startMediaQualityMetrics = sinon.stub();
           meeting.setReconnectListener = sinon.stub();
-          meeting.roap.sendRoapMediaRequest = sinon.stub().returns(Promise.resolve());
+          meeting.roap.sendRoapMediaRequest = sinon.stub().returns(new Promise((resolve) => {
+            meeting.mediaProperties.peerConnection.connectionState = CONSTANTS.CONNECTION_STATE.CONNECTED;
+            resolve();
+          }));
           PeerConnectionManager.setContentSlides = sinon.stub().returns(true);
           MeetingUtil.startInternalStats = sinon.stub();
         });
+
+        it('should have #addMedia', () => {
+          assert.exists(meeting.addMedia);
+        });
+
 
         it('should attach the media and return promise', async () => {
           const media = meeting.addMedia({


### PR DESCRIPTION
Fixes [SPARK-194866](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-194866)

Replaces #1983 

I manually tested by setting a breakpoint and closing the peer connection before the stabilty check and it errored properly. Still need to figure out how to automate the testing for these features.