### PR TITLE
fix(upload): add abort function on file upload for webex

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/webex-core.js
+++ b/packages/node_modules/@webex/webex-core/src/webex-core.js
@@ -78,6 +78,8 @@ const postInterceptors = [
   'RateLimitInterceptor'
 ];
 
+const MAX_FILE_SIZE_IN_MB = 2048;
+
 /**
  * @class
  */
@@ -550,12 +552,41 @@ const WebexCore = AmpState.extend({
     this.logger.debug('client: initiating upload session');
 
     return this.request(options.phases.initialize)
-      .then((...args) => this._uploadApplySession(options, ...args))
+      .then((...args) => {
+        const fileUploadSizeLimitInBytes = (args[0].body.fileUploadSizeLimit || MAX_FILE_SIZE_IN_MB) * 1024 * 1024;
+        const currentFileSizeInBytes = options.file.byteLength;
+
+        if (fileUploadSizeLimitInBytes && fileUploadSizeLimitInBytes < currentFileSizeInBytes) {
+          return this._uploadAbortSession(currentFileSizeInBytes, ...args);
+        }
+
+        return this._uploadApplySession(options, ...args);
+      })
       .then((res) => {
         this.logger.debug('client: initiated upload session');
 
         return res;
       });
+  },
+
+  _uploadAbortSession(currentFileSizeInBytes, response) {
+    this.logger.debug('client: deleting uploaded file');
+
+    return this.request({
+      method: 'DELETE',
+      url: response.body.url,
+      headers: response.options.headers
+    }).then(() => {
+      this.logger.debug('client: deleting uploaded file complete');
+
+      const abortErrorDetails = {
+        currentFileSizeInBytes,
+        fileUploadSizeLimitInMB: response.body.fileUploadSizeLimit || MAX_FILE_SIZE_IN_MB,
+        message: 'file-upload-size-limit-enabled'
+      };
+
+      return Promise.reject(new Error(`${JSON.stringify(abortErrorDetails)}`));
+    });
   },
 
   _uploadApplySession(options, res) {


### PR DESCRIPTION
Fixes [SPARK](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-203178)

On WebEx, when user uploads a file we should check for file limit and restrict the user to upload files within specified limit or 2048 MB by default

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
