### PR TITLE
fix(plugin-meetings): prevent success message when log upload fails

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/common/logs/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/common/logs/request.js
@@ -37,6 +37,8 @@ export default class LogsRequest {
     }
     catch (error) {
       LoggerProxy.logger.error('Logs:request#uploadLogs --> uploading user logs failed', error);
+
+      return Promise.reject(error);
     }
 
     return id;


### PR DESCRIPTION
Currently `meeting:logUpload:success` fires even when logs fail to upload. This ensures the failure is handled correctly.

Fixes #SPARK-210681

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
