### PR TITLE
fix(plugin-meetings): added client version and peripherals informatio…

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -1171,6 +1171,12 @@ export const MAX_FRAMESIZES = {
 export const MQA_INTEVAL = 60000; // mqa analyzer interval its fixed to 60000
 
 
+export const MEDIA_DEVICES = {
+  MICROPHONE: 'microphone',
+  SPEAKER: 'speaker',
+  CAMERA: 'camera'
+};
+
 // Metrics constants ----------------------------------------------------------
 
 export const METRICS_OPERATIONAL_MEASURES = {

--- a/packages/node_modules/@webex/plugin-meetings/src/mediaQualityMetrics/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/mediaQualityMetrics/config.js
@@ -104,12 +104,7 @@ export default {
       ],
       intervalMetadata: {
         peerReflexiveIP: '0.0.0.0',
-        peripherals: [
-          {
-            information: 'unknown',
-            name: 'camera'
-          }
-        ],
+        peripherals: [],
         processAverageCPU: 0,
         processMaximumCPU: 0,
         systemAverageCPU: 0,

--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/config.js
@@ -310,3 +310,5 @@ export const OS_NAME = {
   LINUX: 'linux',
   OTHERS: 'others'
 };
+
+export const CLIENT_NAME = 'webex-js-sdk';

--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
@@ -12,7 +12,7 @@ import LoggerProxy from '../common/logs/logger-proxy';
 import {MEETING_ERRORS} from '../constants';
 import StaticConfig from '../common/config';
 
-import {error, eventType, errorCodes as ERROR_CODE, OS_NAME, UNKNOWN} from './config';
+import {error, eventType, errorCodes as ERROR_CODE, OS_NAME, UNKNOWN, CLIENT_NAME} from './config';
 /**
  * @description Metrics handles all the call metrics events
  * @export
@@ -225,6 +225,7 @@ class Metrics {
         userAgent: this.userAgentToString(),
         clientInfo: {
           clientType: options.clientType, // TODO: Only clientType: 'TEAMS_CLIENT' is whitelisted
+          clientVersion: `${CLIENT_NAME}/${this.webex.version}`,
           os: this.getOsName(),
           osVersion: bowser.osversion || UNKNOWN,
           subClientType: options.subClientType,
@@ -242,7 +243,7 @@ class Metrics {
         intervals: [options.intervalData],
         eventData: {webClientDomain: window.location.hostname},
         sourceMetadata: {
-          applicationSoftwareType: 'webex-js-sdk',
+          applicationSoftwareType: CLIENT_NAME,
           applicationSoftwareVersion: this.webex.version,
           mediaEngineSoftwareType: bowser.name || 'browser',
           mediaEngineSoftwareVersion: bowser.osversion || UNKNOWN,

--- a/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
@@ -2,7 +2,7 @@ import {cloneDeep} from 'lodash';
 
 import EventsScope from '../common/events/events-scope';
 import {EVENT_TRIGGERS,
-  DEFAULT_GET_STATS_FILTER, CONNECTION_STATE, STATS, MQA_INTEVAL, NETWORK_TYPE} from '../constants';
+  DEFAULT_GET_STATS_FILTER, CONNECTION_STATE, STATS, MQA_INTEVAL, NETWORK_TYPE, MEDIA_DEVICES, _UNKNOWN_} from '../constants';
 import mqaData from '../mediaQualityMetrics/config';
 import LoggerProxy from '../common/logs/logger-proxy';
 
@@ -216,6 +216,13 @@ export default class StatsAnalyzer extends EventsScope {
     });
 
     mqaData.intervals[0].intervalMetadata.peerReflexiveIP = this.statsResults.connectionType.local.ipAddress[0];
+
+    // Adding peripheral information
+    mqaData.intervals[0].intervalMetadata.peripherals = [];
+    mqaData.intervals[0].intervalMetadata.peripherals.push({information: _UNKNOWN_, name: MEDIA_DEVICES.SPEAKER});
+    mqaData.intervals[0].intervalMetadata.peripherals.push({information: this.peerConnection?.audioTransceiver?.sender?.track?.label || _UNKNOWN_, name: MEDIA_DEVICES.MICROPHONE});
+    mqaData.intervals[0].intervalMetadata.peripherals.push({information: this.peerConnection?.videoTransceiver?.sender?.track?.label || _UNKNOWN_, name: MEDIA_DEVICES.CAMERA});
+
 
     mqaData.networkType = this.statsResults.connectionType.local.networkType;
 


### PR DESCRIPTION
Fixes 

SPARK-194861: MQE data has invalid values for packet loss for from sender side

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
