### PR TITLE
fix(samples): use play and pause for muting

### DIFF
--- a/packages/node_modules/samples/browser-single-party-call-with-mute/app.js
+++ b/packages/node_modules/samples/browser-single-party-call-with-mute/app.js
@@ -266,12 +266,12 @@ document.getElementById('stop-sending-video').addEventListener('click', () => {
 // the video element
 
 document.getElementById('start-receiving-audio').addEventListener('click', () => {
-  document.getElementById('remote-view-audio').muted = false;
+  document.getElementById('remote-view-audio').play();
   document.getElementById('microphone-state-remote').innerHTML = 'on';
 });
 
 document.getElementById('stop-receiving-audio').addEventListener('click', () => {
-  document.getElementById('remote-view-audio').muted = true;
+  document.getElementById('remote-view-audio').pause();
   document.getElementById('microphone-state-remote').innerHTML = 'off';
 });
 


### PR DESCRIPTION
We were using the `.muted` property which isn't supported by safari
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#browser_compatibility

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-196047

