### PR TITLE
feat(plugin-meetings): enable rtx media resiliency by default

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/config.js
@@ -76,6 +76,6 @@ export default {
     aspectRatio: 1.7695852534562213,
     // When enabled, as calls are ended, it will upload the SDK logs and correlate them
     autoUploadLogs: true,
-    enableRtx: false
+    enableRtx: true
   }
 };


### PR DESCRIPTION
Enable RTX media resiliency for video 
---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
