### PR TITLE
docs(api): remove phone plugin reference

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -186,623 +186,9 @@
               
                 
                 <li><a
-                  href='#calling'
+                  href='#webex-meetings'
                   class="h5 bold black caps">
-                  Calling
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#phone'
-                  class=" toggle-sibling">
-                  Phone
-                  <span class='icon'>▸</span>
-                </a>
-                
-                <div class='toggle-target display-none'>
-                  
-                  <ul class='list-reset py1-ul pl1'>
-                    <li class='h5'><span>Static members</span></li>
-                    
-                      <li><a
-                        href='#phonelistactivecalls'
-                        class='regular pre-open'>
-                        .listActiveCalls
-                      </a></li>
-                    
-                      <li><a
-                        href='#phone_triggercallevents'
-                        class='regular pre-open'>
-                        ._triggerCallEvents
-                      </a></li>
-                    
-                    </ul>
-                  
-                  
-                    <ul class='list-reset py1-ul pl1'>
-                      <li class='h5'><span>Instance members</span></li>
-                      
-                      <li><a
-                        href='#phoneconnected'
-                        class='regular pre-open'>
-                        #connected
-                      </a></li>
-                      
-                      <li><a
-                        href='#phonedefaultfacingmode'
-                        class='regular pre-open'>
-                        #defaultFacingMode
-                      </a></li>
-                      
-                      <li><a
-                        href='#phoneregistered'
-                        class='regular pre-open'>
-                        #registered
-                      </a></li>
-                      
-                      <li><a
-                        href='#phoneiscallingsupported'
-                        class='regular pre-open'>
-                        #isCallingSupported
-                      </a></li>
-                      
-                      <li><a
-                        href='#phoneregister'
-                        class='regular pre-open'>
-                        #register
-                      </a></li>
-                      
-                      <li><a
-                        href='#phonederegister'
-                        class='regular pre-open'>
-                        #deregister
-                      </a></li>
-                      
-                      <li><a
-                        href='#phonecreatelocalmediastream'
-                        class='regular pre-open'>
-                        #createLocalMediaStream
-                      </a></li>
-                      
-                      <li><a
-                        href='#phonedial'
-                        class='regular pre-open'>
-                        #dial
-                      </a></li>
-                      
-                    </ul>
-                  
-                  
-                  
-                    <ul class='list-reset py1-ul pl1'>
-                      <li class='h5'>Events</li>
-                      
-                        <li><a
-                          href='#phoneeventcallcreated'
-                          class='regular pre-open'>
-                          ⓔ call:created
-                        </a></li>
-                      
-                        <li><a
-                          href='#phoneeventcallincoming'
-                          class='regular pre-open'>
-                          ⓔ call:incoming
-                        </a></li>
-                      
-                    </ul>
-                  
-                </div>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#phoneconfig'
-                  class=" toggle-sibling">
-                  PhoneConfig
-                  <span class='icon'>▸</span>
-                </a>
-                
-                <div class='toggle-target display-none'>
-                  
-                  <ul class='list-reset py1-ul pl1'>
-                    <li class='h5'><span>Static members</span></li>
-                    
-                      <li><a
-                        href='#phoneconfighangupbehavior'
-                        class='regular pre-open'>
-                        .HangupBehavior
-                      </a></li>
-                    
-                    </ul>
-                  
-                  
-                  
-                  
-                </div>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#call'
-                  class=" toggle-sibling">
-                  Call
-                  <span class='icon'>▸</span>
-                </a>
-                
-                <div class='toggle-target display-none'>
-                  
-                  <ul class='list-reset py1-ul pl1'>
-                    <li class='h5'><span>Static members</span></li>
-                    
-                      <li><a
-                        href='#callgettargetfrominvitee'
-                        class='regular pre-open'>
-                        .getTargetFromInvitee
-                      </a></li>
-                    
-                      <li><a
-                        href='#callstartapplicationshare'
-                        class='regular pre-open'>
-                        .startApplicationShare
-                      </a></li>
-                    
-                      <li><a
-                        href='#callstartscreenshare'
-                        class='regular pre-open'>
-                        .startScreenShare
-                      </a></li>
-                    
-                      <li><a
-                        href='#callstopscreenshare'
-                        class='regular pre-open'>
-                        .stopScreenShare
-                      </a></li>
-                    
-                    </ul>
-                  
-                  
-                    <ul class='list-reset py1-ul pl1'>
-                      <li class='h5'><span>Instance members</span></li>
-                      
-                      <li><a
-                        href='#callmemberships'
-                        class='regular pre-open'>
-                        #memberships
-                      </a></li>
-                      
-                      <li><a
-                        href='#callremoteaudiomuted'
-                        class='regular pre-open'>
-                        #remoteAudioMuted
-                      </a></li>
-                      
-                      <li><a
-                        href='#callremotevideomuted'
-                        class='regular pre-open'>
-                        #remoteVideoMuted
-                      </a></li>
-                      
-                      <li><a
-                        href='#callfacingmode'
-                        class='regular pre-open'>
-                        #facingMode
-                      </a></li>
-                      
-                      <li><a
-                        href='#calllocalmediastream'
-                        class='regular pre-open'>
-                        #localMediaStream
-                      </a></li>
-                      
-                      <li><a
-                        href='#callremotemember'
-                        class='regular pre-open'>
-                        #remoteMember
-                      </a></li>
-                      
-                      <li><a
-                        href='#callfrom'
-                        class='regular pre-open'>
-                        #from
-                      </a></li>
-                      
-                      <li><a
-                        href='#callstate'
-                        class='regular pre-open'>
-                        #state
-                      </a></li>
-                      
-                      <li><a
-                        href='#callstatus'
-                        class='regular pre-open'>
-                        #status
-                      </a></li>
-                      
-                      <li><a
-                        href='#callhost'
-                        class='regular pre-open'>
-                        #host
-                      </a></li>
-                      
-                      <li><a
-                        href='#callroomid'
-                        class='regular pre-open'>
-                        #roomId
-                      </a></li>
-                      
-                      <li><a
-                        href='#callremotemediastream'
-                        class='regular pre-open'>
-                        #remoteMediaStream
-                      </a></li>
-                      
-                      <li><a
-                        href='#calllocalscreenshare'
-                        class='regular pre-open'>
-                        #localScreenShare
-                      </a></li>
-                      
-                      <li><a
-                        href='#callacknowledge'
-                        class='regular pre-open'>
-                        #acknowledge
-                      </a></li>
-                      
-                      <li><a
-                        href='#callanswer'
-                        class='regular pre-open'>
-                        #answer
-                      </a></li>
-                      
-                      <li><a
-                        href='#callcreateorjoinlocus'
-                        class='regular pre-open'>
-                        #createOrJoinLocus
-                      </a></li>
-                      
-                      <li><a
-                        href='#calldecline'
-                        class='regular pre-open'>
-                        #decline
-                      </a></li>
-                      
-                      <li><a
-                        href='#callgetrawstatsstream'
-                        class='regular pre-open'>
-                        #getRawStatsStream
-                      </a></li>
-                      
-                      <li><a
-                        href='#callgetstatsstream'
-                        class='regular pre-open'>
-                        #getStatsStream
-                      </a></li>
-                      
-                      <li><a
-                        href='#callhangup'
-                        class='regular pre-open'>
-                        #hangup
-                      </a></li>
-                      
-                      <li><a
-                        href='#callreject'
-                        class='regular pre-open'>
-                        #reject
-                      </a></li>
-                      
-                      <li><a
-                        href='#callsenddtmf'
-                        class='regular pre-open'>
-                        #sendDtmf
-                      </a></li>
-                      
-                      <li><a
-                        href='#callsendfeedback'
-                        class='regular pre-open'>
-                        #sendFeedback
-                      </a></li>
-                      
-                      <li><a
-                        href='#callstartreceivingaudio'
-                        class='regular pre-open'>
-                        #startReceivingAudio
-                      </a></li>
-                      
-                      <li><a
-                        href='#callstartreceivingvideo'
-                        class='regular pre-open'>
-                        #startReceivingVideo
-                      </a></li>
-                      
-                      <li><a
-                        href='#callstartsendingaudio'
-                        class='regular pre-open'>
-                        #startSendingAudio
-                      </a></li>
-                      
-                      <li><a
-                        href='#callstartsendingvideo'
-                        class='regular pre-open'>
-                        #startSendingVideo
-                      </a></li>
-                      
-                      <li><a
-                        href='#callstopreceivingaudio'
-                        class='regular pre-open'>
-                        #stopReceivingAudio
-                      </a></li>
-                      
-                      <li><a
-                        href='#callstopreceivingvideo'
-                        class='regular pre-open'>
-                        #stopReceivingVideo
-                      </a></li>
-                      
-                      <li><a
-                        href='#callstopsendingaudio'
-                        class='regular pre-open'>
-                        #stopSendingAudio
-                      </a></li>
-                      
-                      <li><a
-                        href='#callstopsendingvideo'
-                        class='regular pre-open'>
-                        #stopSendingVideo
-                      </a></li>
-                      
-                      <li><a
-                        href='#calltogglefacingmode'
-                        class='regular pre-open'>
-                        #toggleFacingMode
-                      </a></li>
-                      
-                      <li><a
-                        href='#calltogglereceivingaudio'
-                        class='regular pre-open'>
-                        #toggleReceivingAudio
-                      </a></li>
-                      
-                      <li><a
-                        href='#calltogglereceivingvideo'
-                        class='regular pre-open'>
-                        #toggleReceivingVideo
-                      </a></li>
-                      
-                      <li><a
-                        href='#calltogglesendingaudio'
-                        class='regular pre-open'>
-                        #toggleSendingAudio
-                      </a></li>
-                      
-                      <li><a
-                        href='#calltogglesendingvideo'
-                        class='regular pre-open'>
-                        #toggleSendingVideo
-                      </a></li>
-                      
-                    </ul>
-                  
-                  
-                  
-                    <ul class='list-reset py1-ul pl1'>
-                      <li class='h5'>Events</li>
-                      
-                        <li><a
-                          href='#calleventringing'
-                          class='regular pre-open'>
-                          ⓔ ringing
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventconnected'
-                          class='regular pre-open'>
-                          ⓔ connected
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventdisconnected'
-                          class='regular pre-open'>
-                          ⓔ disconnected
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventactive'
-                          class='regular pre-open'>
-                          ⓔ active
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventinitializing'
-                          class='regular pre-open'>
-                          ⓔ initializing
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventinactive'
-                          class='regular pre-open'>
-                          ⓔ inactive
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventterminating'
-                          class='regular pre-open'>
-                          ⓔ terminating
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventlocalmediastreamchange'
-                          class='regular pre-open'>
-                          ⓔ localMediaStream:change
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventremotemediastreamchange'
-                          class='regular pre-open'>
-                          ⓔ remoteMediaStream:change
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventerror'
-                          class='regular pre-open'>
-                          ⓔ error
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventmembershipnotified'
-                          class='regular pre-open'>
-                          ⓔ membership:notified
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventmembershipconnected'
-                          class='regular pre-open'>
-                          ⓔ membership:connected
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventmembershipdeclined'
-                          class='regular pre-open'>
-                          ⓔ membership:declined
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventmembershipdisconnected'
-                          class='regular pre-open'>
-                          ⓔ membership:disconnected
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventmembershipwaiting'
-                          class='regular pre-open'>
-                          ⓔ membership:waiting
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventmembershipchange'
-                          class='regular pre-open'>
-                          ⓔ membership:change
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventmembershipsadd'
-                          class='regular pre-open'>
-                          ⓔ memberships:add
-                        </a></li>
-                      
-                        <li><a
-                          href='#calleventmembershipsremove'
-                          class='regular pre-open'>
-                          ⓔ memberships:remove
-                        </a></li>
-                      
-                    </ul>
-                  
-                </div>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#callmemberships'
-                  class="">
-                  CallMemberships
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#callmembership'
-                  class=" toggle-sibling">
-                  CallMembership
-                  <span class='icon'>▸</span>
-                </a>
-                
-                <div class='toggle-target display-none'>
-                  
-                  
-                    <ul class='list-reset py1-ul pl1'>
-                      <li class='h5'><span>Instance members</span></li>
-                      
-                      <li><a
-                        href='#callmembershipisinitiator'
-                        class='regular pre-open'>
-                        #isInitiator
-                      </a></li>
-                      
-                      <li><a
-                        href='#callmembershippersonid'
-                        class='regular pre-open'>
-                        #personId
-                      </a></li>
-                      
-                      <li><a
-                        href='#callmembershipstate'
-                        class='regular pre-open'>
-                        #state
-                      </a></li>
-                      
-                      <li><a
-                        href='#callmembershipaudiomuted'
-                        class='regular pre-open'>
-                        #audioMuted
-                      </a></li>
-                      
-                      <li><a
-                        href='#callmembershipvideomuted'
-                        class='regular pre-open'>
-                        #videoMuted
-                      </a></li>
-                      
-                    </ul>
-                  
-                  
-                  
-                </div>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#statsstream'
-                  class="">
-                  StatsStream
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#statsstream'
-                  class="">
-                  StatsStream
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#statsfilter'
-                  class="">
-                  StatsFilter
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#statsfilter'
-                  class="">
-                  StatsFilter
+                  Webex Meetings
                   
                 </a>
                 
@@ -961,12 +347,6 @@
                       <li class='h5'>Events</li>
                       
                         <li><a
-                          href='#meetingseventmeetingsready'
-                          class='regular pre-open'>
-                          ⓔ meetings:ready
-                        </a></li>
-                      
-                        <li><a
                           href='#meetingseventnetworkdisconnected'
                           class='regular pre-open'>
                           ⓔ network:disconnected
@@ -988,6 +368,12 @@
                           href='#meetingseventmeetingadded'
                           class='regular pre-open'>
                           ⓔ meeting:added
+                        </a></li>
+                      
+                        <li><a
+                          href='#meetingseventmeetingsready'
+                          class='regular pre-open'>
+                          ⓔ meetings:ready
                         </a></li>
                       
                     </ul>
@@ -1548,16 +934,6 @@
               
                 
                 <li><a
-                  href='#attachmentactionobject'
-                  class="">
-                  AttachmentActionObject
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
                   href='#attachmentactions'
                   class=" toggle-sibling">
                   AttachmentActions
@@ -1587,6 +963,16 @@
                   
                   
                 </div>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#attachmentactionobject'
+                  class="">
+                  AttachmentActionObject
+                  
+                </a>
                 
                 </li>
               
@@ -1893,46 +1279,6 @@
               
                 
                 <li><a
-                  href='#mediadirection'
-                  class="">
-                  MediaDirection
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#mediadirection'
-                  class="">
-                  MediaDirection
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#sendoptions'
-                  class="">
-                  SendOptions
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#sendoptions'
-                  class="">
-                  SendOptions
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
                   href='#media'
                   class=" toggle-sibling">
                   Media
@@ -2052,6 +1398,46 @@
                   
                   
                 </div>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#mediadirection'
+                  class="">
+                  MediaDirection
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#mediadirection'
+                  class="">
+                  MediaDirection
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#sendoptions'
+                  class="">
+                  SendOptions
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#sendoptions'
+                  class="">
+                  SendOptions
+                  
+                </a>
                 
                 </li>
               
@@ -2346,46 +1732,6 @@
                   href='#getresourceurl'
                   class="">
                   getResourceUrl
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#audiovideo'
-                  class="">
-                  AudioVideo
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#sharepreferences'
-                  class="">
-                  SharePreferences
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#joinoptions'
-                  class="">
-                  JoinOptions
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
-                  href='#recording'
-                  class="">
-                  Recording
                   
                 </a>
                 
@@ -2928,6 +2274,12 @@
                       <li class='h5'>Events</li>
                       
                         <li><a
+                          href='#meetingeventmeetingactionsupdate'
+                          class='regular pre-open'>
+                          ⓔ meeting:actionsUpdate
+                        </a></li>
+                      
+                        <li><a
                           href='#meetingeventmeetingstatechange'
                           class='regular pre-open'>
                           ⓔ meeting:stateChange
@@ -2970,18 +2322,6 @@
                         </a></li>
                       
                         <li><a
-                          href='#meetingeventmeetingstartedsharingremote'
-                          class='regular pre-open'>
-                          ⓔ meeting:startedSharingRemote
-                        </a></li>
-                      
-                        <li><a
-                          href='#meetingeventmeetingstoppedsharingremote'
-                          class='regular pre-open'>
-                          ⓔ meeting:stoppedSharingRemote
-                        </a></li>
-                      
-                        <li><a
                           href='#meetingeventmeetinglocked'
                           class='regular pre-open'>
                           ⓔ meeting:locked
@@ -2991,12 +2331,6 @@
                           href='#meetingeventmeetingunlocked'
                           class='regular pre-open'>
                           ⓔ meeting:unlocked
-                        </a></li>
-                      
-                        <li><a
-                          href='#meetingeventmeetingactionsupdate'
-                          class='regular pre-open'>
-                          ⓔ meeting:actionsUpdate
                         </a></li>
                       
                         <li><a
@@ -3056,6 +2390,46 @@
                     </ul>
                   
                 </div>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#audiovideo'
+                  class="">
+                  AudioVideo
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#sharepreferences'
+                  class="">
+                  SharePreferences
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#joinoptions'
+                  class="">
+                  JoinOptions
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#recording'
+                  class="">
+                  Recording
+                  
+                </a>
                 
                 </li>
               
@@ -3183,9 +2557,9 @@
               
                 
                 <li><a
-                  href='#roapoptions'
+                  href='#seqoptions'
                   class="">
-                  RoapOptions
+                  SeqOptions
                   
                 </a>
                 
@@ -3193,9 +2567,9 @@
               
                 
                 <li><a
-                  href='#seqoptions'
+                  href='#roapoptions'
                   class="">
-                  SeqOptions
+                  RoapOptions
                   
                 </a>
                 
@@ -3741,16 +3115,6 @@
               
                 
                 <li><a
-                  href='#locuscontrols'
-                  class="">
-                  LocusControls
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
                   href='#parse'
                   class="">
                   parse
@@ -3774,6 +3138,16 @@
                   href='#getid'
                   class="">
                   getId
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#locuscontrols'
+                  class="">
+                  LocusControls
                   
                 </a>
                 
@@ -4256,9 +3630,9 @@
                         </a></li>
                       
                         <li><a
-                          href='#memberseventmemberscontentupdate'
+                          href='#memberseventmembersselfupdate'
                           class='regular pre-open'>
-                          ⓔ members:content:update
+                          ⓔ members:self:update
                         </a></li>
                       
                         <li><a
@@ -4268,9 +3642,9 @@
                         </a></li>
                       
                         <li><a
-                          href='#memberseventmembersselfupdate'
+                          href='#memberseventmemberscontentupdate'
                           class='regular pre-open'>
-                          ⓔ members:self:update
+                          ⓔ members:content:update
                         </a></li>
                       
                     </ul>
@@ -5224,6 +4598,46 @@
               
                 
                 <li><a
+                  href='#statsstream'
+                  class="">
+                  StatsStream
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#statsstream'
+                  class="">
+                  StatsStream
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#statsfilter'
+                  class="">
+                  StatsFilter
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#statsfilter'
+                  class="">
+                  StatsFilter
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#webrtcdata'
                   class=" toggle-sibling">
                   WebRTCData
@@ -5515,16 +4929,6 @@
               
                 
                 <li><a
-                  href='#parametererror'
-                  class="">
-                  ParameterError
-                  
-                </a>
-                
-                </li>
-              
-                
-                <li><a
                   href='#difference'
                   class="">
                   difference
@@ -5625,6 +5029,16 @@
               
                 
                 <li><a
+                  href='#eventmediacodecloaded'
+                  class="">
+                  media:codec:loaded
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#eventmediacodecmissing'
                   class="">
                   media:codec:missing
@@ -5635,9 +5049,9 @@
               
                 
                 <li><a
-                  href='#eventmediacodecloaded'
+                  href='#parametererror'
                   class="">
-                  media:codec:loaded
+                  ParameterError
                   
                 </a>
                 
@@ -5665,11 +5079,585 @@
               
                 
                 <li><a
+                  href='#phone'
+                  class=" toggle-sibling">
+                  Phone
+                  <span class='icon'>▸</span>
+                </a>
+                
+                <div class='toggle-target display-none'>
+                  
+                  <ul class='list-reset py1-ul pl1'>
+                    <li class='h5'><span>Static members</span></li>
+                    
+                      <li><a
+                        href='#phonelistactivecalls'
+                        class='regular pre-open'>
+                        .listActiveCalls
+                      </a></li>
+                    
+                      <li><a
+                        href='#phone_triggercallevents'
+                        class='regular pre-open'>
+                        ._triggerCallEvents
+                      </a></li>
+                    
+                    </ul>
+                  
+                  
+                    <ul class='list-reset py1-ul pl1'>
+                      <li class='h5'><span>Instance members</span></li>
+                      
+                      <li><a
+                        href='#phoneconnected'
+                        class='regular pre-open'>
+                        #connected
+                      </a></li>
+                      
+                      <li><a
+                        href='#phonedefaultfacingmode'
+                        class='regular pre-open'>
+                        #defaultFacingMode
+                      </a></li>
+                      
+                      <li><a
+                        href='#phoneregistered'
+                        class='regular pre-open'>
+                        #registered
+                      </a></li>
+                      
+                      <li><a
+                        href='#phoneiscallingsupported'
+                        class='regular pre-open'>
+                        #isCallingSupported
+                      </a></li>
+                      
+                      <li><a
+                        href='#phoneregister'
+                        class='regular pre-open'>
+                        #register
+                      </a></li>
+                      
+                      <li><a
+                        href='#phonederegister'
+                        class='regular pre-open'>
+                        #deregister
+                      </a></li>
+                      
+                      <li><a
+                        href='#phonecreatelocalmediastream'
+                        class='regular pre-open'>
+                        #createLocalMediaStream
+                      </a></li>
+                      
+                      <li><a
+                        href='#phonedial'
+                        class='regular pre-open'>
+                        #dial
+                      </a></li>
+                      
+                    </ul>
+                  
+                  
+                  
+                    <ul class='list-reset py1-ul pl1'>
+                      <li class='h5'>Events</li>
+                      
+                        <li><a
+                          href='#phoneeventcallincoming'
+                          class='regular pre-open'>
+                          ⓔ call:incoming
+                        </a></li>
+                      
+                        <li><a
+                          href='#phoneeventcallcreated'
+                          class='regular pre-open'>
+                          ⓔ call:created
+                        </a></li>
+                      
+                    </ul>
+                  
+                </div>
+                
+                </li>
+              
+                
+                <li><a
                   href='#has'
                   class="">
                   has
                   
                 </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#phoneconfig'
+                  class=" toggle-sibling">
+                  PhoneConfig
+                  <span class='icon'>▸</span>
+                </a>
+                
+                <div class='toggle-target display-none'>
+                  
+                  <ul class='list-reset py1-ul pl1'>
+                    <li class='h5'><span>Static members</span></li>
+                    
+                      <li><a
+                        href='#phoneconfighangupbehavior'
+                        class='regular pre-open'>
+                        .HangupBehavior
+                      </a></li>
+                    
+                    </ul>
+                  
+                  
+                  
+                  
+                </div>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#call'
+                  class=" toggle-sibling">
+                  Call
+                  <span class='icon'>▸</span>
+                </a>
+                
+                <div class='toggle-target display-none'>
+                  
+                  <ul class='list-reset py1-ul pl1'>
+                    <li class='h5'><span>Static members</span></li>
+                    
+                      <li><a
+                        href='#callgettargetfrominvitee'
+                        class='regular pre-open'>
+                        .getTargetFromInvitee
+                      </a></li>
+                    
+                      <li><a
+                        href='#callstartapplicationshare'
+                        class='regular pre-open'>
+                        .startApplicationShare
+                      </a></li>
+                    
+                      <li><a
+                        href='#callstartscreenshare'
+                        class='regular pre-open'>
+                        .startScreenShare
+                      </a></li>
+                    
+                      <li><a
+                        href='#callstopscreenshare'
+                        class='regular pre-open'>
+                        .stopScreenShare
+                      </a></li>
+                    
+                    </ul>
+                  
+                  
+                    <ul class='list-reset py1-ul pl1'>
+                      <li class='h5'><span>Instance members</span></li>
+                      
+                      <li><a
+                        href='#callmemberships'
+                        class='regular pre-open'>
+                        #memberships
+                      </a></li>
+                      
+                      <li><a
+                        href='#callremoteaudiomuted'
+                        class='regular pre-open'>
+                        #remoteAudioMuted
+                      </a></li>
+                      
+                      <li><a
+                        href='#callremotevideomuted'
+                        class='regular pre-open'>
+                        #remoteVideoMuted
+                      </a></li>
+                      
+                      <li><a
+                        href='#callfacingmode'
+                        class='regular pre-open'>
+                        #facingMode
+                      </a></li>
+                      
+                      <li><a
+                        href='#calllocalmediastream'
+                        class='regular pre-open'>
+                        #localMediaStream
+                      </a></li>
+                      
+                      <li><a
+                        href='#callremotemember'
+                        class='regular pre-open'>
+                        #remoteMember
+                      </a></li>
+                      
+                      <li><a
+                        href='#callfrom'
+                        class='regular pre-open'>
+                        #from
+                      </a></li>
+                      
+                      <li><a
+                        href='#callstate'
+                        class='regular pre-open'>
+                        #state
+                      </a></li>
+                      
+                      <li><a
+                        href='#callstatus'
+                        class='regular pre-open'>
+                        #status
+                      </a></li>
+                      
+                      <li><a
+                        href='#callhost'
+                        class='regular pre-open'>
+                        #host
+                      </a></li>
+                      
+                      <li><a
+                        href='#callroomid'
+                        class='regular pre-open'>
+                        #roomId
+                      </a></li>
+                      
+                      <li><a
+                        href='#callremotemediastream'
+                        class='regular pre-open'>
+                        #remoteMediaStream
+                      </a></li>
+                      
+                      <li><a
+                        href='#calllocalscreenshare'
+                        class='regular pre-open'>
+                        #localScreenShare
+                      </a></li>
+                      
+                      <li><a
+                        href='#callacknowledge'
+                        class='regular pre-open'>
+                        #acknowledge
+                      </a></li>
+                      
+                      <li><a
+                        href='#callanswer'
+                        class='regular pre-open'>
+                        #answer
+                      </a></li>
+                      
+                      <li><a
+                        href='#callcreateorjoinlocus'
+                        class='regular pre-open'>
+                        #createOrJoinLocus
+                      </a></li>
+                      
+                      <li><a
+                        href='#calldecline'
+                        class='regular pre-open'>
+                        #decline
+                      </a></li>
+                      
+                      <li><a
+                        href='#callgetrawstatsstream'
+                        class='regular pre-open'>
+                        #getRawStatsStream
+                      </a></li>
+                      
+                      <li><a
+                        href='#callgetstatsstream'
+                        class='regular pre-open'>
+                        #getStatsStream
+                      </a></li>
+                      
+                      <li><a
+                        href='#callhangup'
+                        class='regular pre-open'>
+                        #hangup
+                      </a></li>
+                      
+                      <li><a
+                        href='#callreject'
+                        class='regular pre-open'>
+                        #reject
+                      </a></li>
+                      
+                      <li><a
+                        href='#callsenddtmf'
+                        class='regular pre-open'>
+                        #sendDtmf
+                      </a></li>
+                      
+                      <li><a
+                        href='#callsendfeedback'
+                        class='regular pre-open'>
+                        #sendFeedback
+                      </a></li>
+                      
+                      <li><a
+                        href='#callstartreceivingaudio'
+                        class='regular pre-open'>
+                        #startReceivingAudio
+                      </a></li>
+                      
+                      <li><a
+                        href='#callstartreceivingvideo'
+                        class='regular pre-open'>
+                        #startReceivingVideo
+                      </a></li>
+                      
+                      <li><a
+                        href='#callstartsendingaudio'
+                        class='regular pre-open'>
+                        #startSendingAudio
+                      </a></li>
+                      
+                      <li><a
+                        href='#callstartsendingvideo'
+                        class='regular pre-open'>
+                        #startSendingVideo
+                      </a></li>
+                      
+                      <li><a
+                        href='#callstopreceivingaudio'
+                        class='regular pre-open'>
+                        #stopReceivingAudio
+                      </a></li>
+                      
+                      <li><a
+                        href='#callstopreceivingvideo'
+                        class='regular pre-open'>
+                        #stopReceivingVideo
+                      </a></li>
+                      
+                      <li><a
+                        href='#callstopsendingaudio'
+                        class='regular pre-open'>
+                        #stopSendingAudio
+                      </a></li>
+                      
+                      <li><a
+                        href='#callstopsendingvideo'
+                        class='regular pre-open'>
+                        #stopSendingVideo
+                      </a></li>
+                      
+                      <li><a
+                        href='#calltogglefacingmode'
+                        class='regular pre-open'>
+                        #toggleFacingMode
+                      </a></li>
+                      
+                      <li><a
+                        href='#calltogglereceivingaudio'
+                        class='regular pre-open'>
+                        #toggleReceivingAudio
+                      </a></li>
+                      
+                      <li><a
+                        href='#calltogglereceivingvideo'
+                        class='regular pre-open'>
+                        #toggleReceivingVideo
+                      </a></li>
+                      
+                      <li><a
+                        href='#calltogglesendingaudio'
+                        class='regular pre-open'>
+                        #toggleSendingAudio
+                      </a></li>
+                      
+                      <li><a
+                        href='#calltogglesendingvideo'
+                        class='regular pre-open'>
+                        #toggleSendingVideo
+                      </a></li>
+                      
+                    </ul>
+                  
+                  
+                  
+                    <ul class='list-reset py1-ul pl1'>
+                      <li class='h5'>Events</li>
+                      
+                        <li><a
+                          href='#calleventringing'
+                          class='regular pre-open'>
+                          ⓔ ringing
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventconnected'
+                          class='regular pre-open'>
+                          ⓔ connected
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventdisconnected'
+                          class='regular pre-open'>
+                          ⓔ disconnected
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventactive'
+                          class='regular pre-open'>
+                          ⓔ active
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventinitializing'
+                          class='regular pre-open'>
+                          ⓔ initializing
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventinactive'
+                          class='regular pre-open'>
+                          ⓔ inactive
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventterminating'
+                          class='regular pre-open'>
+                          ⓔ terminating
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventlocalmediastreamchange'
+                          class='regular pre-open'>
+                          ⓔ localMediaStream:change
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventremotemediastreamchange'
+                          class='regular pre-open'>
+                          ⓔ remoteMediaStream:change
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventerror'
+                          class='regular pre-open'>
+                          ⓔ error
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventmembershipnotified'
+                          class='regular pre-open'>
+                          ⓔ membership:notified
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventmembershipconnected'
+                          class='regular pre-open'>
+                          ⓔ membership:connected
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventmembershipdeclined'
+                          class='regular pre-open'>
+                          ⓔ membership:declined
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventmembershipdisconnected'
+                          class='regular pre-open'>
+                          ⓔ membership:disconnected
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventmembershipwaiting'
+                          class='regular pre-open'>
+                          ⓔ membership:waiting
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventmembershipchange'
+                          class='regular pre-open'>
+                          ⓔ membership:change
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventmembershipsadd'
+                          class='regular pre-open'>
+                          ⓔ memberships:add
+                        </a></li>
+                      
+                        <li><a
+                          href='#calleventmembershipsremove'
+                          class='regular pre-open'>
+                          ⓔ memberships:remove
+                        </a></li>
+                      
+                    </ul>
+                  
+                </div>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#callmemberships'
+                  class="">
+                  CallMemberships
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#callmembership'
+                  class=" toggle-sibling">
+                  CallMembership
+                  <span class='icon'>▸</span>
+                </a>
+                
+                <div class='toggle-target display-none'>
+                  
+                  
+                    <ul class='list-reset py1-ul pl1'>
+                      <li class='h5'><span>Instance members</span></li>
+                      
+                      <li><a
+                        href='#callmembershipisinitiator'
+                        class='regular pre-open'>
+                        #isInitiator
+                      </a></li>
+                      
+                      <li><a
+                        href='#callmembershippersonid'
+                        class='regular pre-open'>
+                        #personId
+                      </a></li>
+                      
+                      <li><a
+                        href='#callmembershipstate'
+                        class='regular pre-open'>
+                        #state
+                      </a></li>
+                      
+                      <li><a
+                        href='#callmembershipaudiomuted'
+                        class='regular pre-open'>
+                        #audioMuted
+                      </a></li>
+                      
+                      <li><a
+                        href='#callmembershipvideomuted'
+                        class='regular pre-open'>
+                        #videoMuted
+                      </a></li>
+                      
+                    </ul>
+                  
+                  
+                  
+                </div>
                 
                 </li>
               
@@ -5854,7 +5842,7 @@ app.get(`/oauth/redirect`, (req, res, next) =&gt; {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/webex/src/webex.js#L44-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/webex/src/webex.js#L44-L47'>
       <span>packages/node_modules/webex/src/webex.js</span>
       </a>
     
@@ -5918,7 +5906,7 @@ app.get(`/oauth/redirect`, (req, res, next) =&gt; {
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/webex/src/webex.js#L74-L78'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/webex/src/webex.js#L74-L78'>
       <span>packages/node_modules/webex/src/webex.js</span>
       </a>
     
@@ -6066,7 +6054,7 @@ app.get(`/oauth/redirect`, (req, res, next) =&gt; {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L24-L357'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L24-L357'>
       <span>packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js</span>
       </a>
     
@@ -6119,7 +6107,7 @@ token</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L32-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L32-L37'>
       <span>packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js</span>
       </a>
     
@@ -6182,7 +6170,7 @@ token</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L47-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L47-L50'>
       <span>packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js</span>
       </a>
     
@@ -6245,7 +6233,7 @@ token</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L122-L133'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L122-L133'>
       <span>packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js</span>
       </a>
     
@@ -6325,7 +6313,7 @@ token</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L144-L149'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L144-L149'>
       <span>packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js</span>
       </a>
     
@@ -6405,7 +6393,7 @@ token</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L160-L165'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L160-L165'>
       <span>packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js</span>
       </a>
     
@@ -6485,7 +6473,7 @@ token</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L183-L214'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L183-L214'>
       <span>packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js</span>
       </a>
     
@@ -6594,7 +6582,7 @@ identifies a user in your system
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L224-L228'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js#L224-L228'>
       <span>packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js</span>
       </a>
     
@@ -6707,7 +6695,7 @@ identifies a user in your system
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-node/src/authorization.js#L15-L152'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-node/src/authorization.js#L15-L152'>
       <span>packages/node_modules/@webex/plugin-authorization-node/src/authorization.js</span>
       </a>
     
@@ -6759,7 +6747,7 @@ identifies a user in your system
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-node/src/authorization.js#L23-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-node/src/authorization.js#L23-L28'>
       <span>packages/node_modules/@webex/plugin-authorization-node/src/authorization.js</span>
       </a>
     
@@ -6822,7 +6810,7 @@ identifies a user in your system
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-node/src/authorization.js#L38-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-node/src/authorization.js#L38-L41'>
       <span>packages/node_modules/@webex/plugin-authorization-node/src/authorization.js</span>
       </a>
     
@@ -6885,7 +6873,7 @@ identifies a user in your system
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-node/src/authorization.js#L67-L102'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-node/src/authorization.js#L67-L102'>
       <span>packages/node_modules/@webex/plugin-authorization-node/src/authorization.js</span>
       </a>
     
@@ -6989,7 +6977,7 @@ identifies a user in your system
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-authorization-node/src/authorization.js#L120-L151'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-authorization-node/src/authorization.js#L120-L151'>
       <span>packages/node_modules/@webex/plugin-authorization-node/src/authorization.js</span>
       </a>
     
@@ -7098,8 +7086,8 @@ identifies a user in your system
           
             <div class='keyline-top-not py2'><section class='py2 clearfix'>
 
-  <h2 id='calling' class='mt0'>
-    Calling
+  <h2 id='webex-meetings' class='mt0'>
+    Webex Meetings
   </h2>
 
   
@@ -7115,5831 +7103,12 @@ identifies a user in your system
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='phone'>
-      Phone
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L46-L312'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>new Phone()</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Static Members</div>
-    <div class="clearfix">
-  
-    <div class='border-bottom' id='phonelistactivecalls'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>listActiveCalls()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L192-L213'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Fetches a list of all of the current user's active calls</p>
-
-    <div class='pre p1 fill-light mt0'>listActiveCalls(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#call">Call</a>>></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#call">Call</a>>></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='phone_triggercallevents'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>_triggerCallEvents(call, locus)</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L303-L311'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Triggers call events for a given call/locus</p>
-
-    <div class='pre p1 fill-light mt0'>_triggerCallEvents(call: <a href="#call">Call</a>, locus: Types~Locus): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>call</span> <code class='quiet'>(<a href="#call">Call</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>locus</span> <code class='quiet'>(Types~Locus)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-</div>
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Instance Members</div>
-    <div class="clearfix">
-  
-    <div class='border-bottom' id='phoneconnected'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>connected</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L59-L62'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Indicates whether or not the WebSocket is connected</p>
-
-    <div class='pre p1 fill-light mt0'>connected</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='phonedefaultfacingmode'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>defaultFacingMode</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L76-L80'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Specifies the facingMode to be used by <a href="#phonedial">Phone#dial</a> and
-<a href="#callanswer">Call#answer</a> when no constraint is specified. Does not apply if</p>
-<ul>
-<li>a <a href="MediaStream">MediaStream</a> is passed to <a href="#phonedial">Phone#dial</a> or
-<a href="#callanswer">Call#answer</a></li>
-<li>constraints are passed to <a href="#phonedial">Phone#dial</a> or  <a href="#callanswer">Call#answer</a>
-The only valid values are <code>user</code> and <code>environment</code>. For any other values,
-you must provide your own constrains or <a href="MediaStream">MediaStream</a></li>
-</ul>
-
-    <div class='pre p1 fill-light mt0'>defaultFacingMode</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='phoneregistered'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>registered</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L89-L92'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>indicates whether or not the client is registered with the Webex
-cloud</p>
-
-    <div class='pre p1 fill-light mt0'>registered</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='phoneiscallingsupported'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>isCallingSupported()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L105-L114'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Indicates if the current browser appears to support webrtc calling. Note:
-at this time, there's no way to determine if the current browser supports
-h264 without asking for camera permissions</p>
-
-    <div class='pre p1 fill-light mt0'>isCallingSupported(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='phoneregister'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>register()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L125-L149'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Registers the client with the Webex cloud and starts listening for
-WebSocket events.</p>
-<p>Subsequent calls refresh the device registration.</p>
-
-    <div class='pre p1 fill-light mt0'>register(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='phonederegister'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>deregister()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L159-L162'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Disconnects from WebSocket and unregisters from the Webex cloud.</p>
-<p>Subsequent calls will be a noop.</p>
-
-    <div class='pre p1 fill-light mt0'>deregister(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='phonecreatelocalmediastream'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>createLocalMediaStream(options)</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L175-L184'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Create a MediaStream to be used for video preview.</p>
-<p>Note: You must explicitly pass the resultant stream to <a href="Call#answer()">Call#answer()</a>
-or <a href="Phone#dial()">Phone#dial()</a></p>
-
-    <div class='pre p1 fill-light mt0'>createLocalMediaStream(options: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | MediaStreamConstraints)): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;MediaStream></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>options</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | MediaStreamConstraints)
-            = <code>{}</code>)</code>
-	    
-          </div>
-          
-          <table class='mt1 mb2 fixed-table h5 col-12'>
-            <colgroup>
-              <col width='30%' />
-              <col width='70%' />
-            </colgroup>
-            <thead>
-              <tr class='bold fill-light'>
-                <th>Name</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody class='mt1'>
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.constraints</span> <code class='quiet'>MediaStreamConstraints</code>
-  </td>
-  <td class='break-word'><span></span></td>
-</tr>
-
-
-              
-            </tbody>
-          </table>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;MediaStream></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='phonedial'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>dial(dialString, options)</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L288-L295'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Place a call to the specified dialString. A dial string may be an email
-address or sip uri.
-If you set <a href="config.phone.enableExperimentalGroupCallingSupport">config.phone.enableExperimentalGroupCallingSupport</a> to
-<code>true</code>, the dialString may also be a room id.</p>
-
-    <div class='pre p1 fill-light mt0'>dial(dialString: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="#call">Call</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>dialString</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-	    
-          </div>
-          
-          <table class='mt1 mb2 fixed-table h5 col-12'>
-            <colgroup>
-              <col width='30%' />
-              <col width='70%' />
-            </colgroup>
-            <thead>
-              <tr class='bold fill-light'>
-                <th>Name</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody class='mt1'>
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.constraints</span> <code class='quiet'>MediaStreamConstraints</code>
-  </td>
-  <td class='break-word'><span></span></td>
-</tr>
-
-
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.localMediaStream</span> <code class='quiet'>MediaStream</code>
-  </td>
-  <td class='break-word'><span>if no stream is specified, a
-new one will be created based on options.constraints
-</span></td>
-</tr>
-
-
-              
-            </tbody>
-          </table>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="#call">Call</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-</div>
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Events</div>
-    <div class="clearfix">
-  
-    <div class='border-bottom' id='phoneeventcallcreated'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>call:created</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L46-L312'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Call Created Event</p>
-<p>Emitted when a call begins outside of the sdk</p>
-
-    <div class='pre p1 fill-light mt0'>call:created</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>call</span> <code class='quiet'>(<a href="#call">Call</a>)</code>
-          : The created call
-
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='phoneeventcallincoming'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>call:incoming</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/phone.js#L46-L312'>
-      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Incoming Call Event</p>
-<p>Emitted when a call begins and when <a href="#phoneregister">Phone#register</a> is invoked and
-there are active calls.</p>
-
-    <div class='pre p1 fill-light mt0'>call:incoming</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>call</span> <code class='quiet'>(<a href="#call">Call</a>)</code>
-          : The incoming call
-
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-</div>
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='phoneconfig'>
-      PhoneConfig
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/config.js#L5-L26'>
-      <span>packages/node_modules/@webex/plugin-phone/src/config.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>PhoneConfig</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>audioBandwidthLimit</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>videoBandwidthLimit</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>enableExperimentalGroupCallingSupport</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?)</code>
-          : Group
-calling support should work, but necessarily introduces some breaking changes
-to the API. In order to get feedback, we're keeping the API unchanged by
-default and requiring folks to opt-in to these breakages. As these changes
-evolve, you may see some breaking changes that don't necessarily follow
-semantic versioning. When we're ready to drop the "experimental" moniker,
-we'll release an official SemVer Major bump.
-
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'>{
-  <span class="hljs-attr">audioBandwidthLimit</span>: <span class="hljs-number">64000</span>,
-  <span class="hljs-attr">videoBandwidthLimit</span>: <span class="hljs-number">1000000</span>,
-  <span class="hljs-attr">enableExperimentalGroupCallingSupport</span>: <span class="hljs-literal">false</span>,
-  <span class="hljs-attr">hangupIfLastActive</span>: {
-    <span class="hljs-attr">call</span>: <span class="hljs-literal">true</span>,
-    <span class="hljs-attr">meeting</span>: <span class="hljs-literal">false</span>
-  }
-}</pre>
-    
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Static Members</div>
-    <div class="clearfix">
-  
-    <div class='border-bottom' id='phoneconfighangupbehavior'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>HangupBehavior</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/config.js#L28-L37'>
-      <span>packages/node_modules/@webex/plugin-phone/src/config.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>HangupBehavior</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>call</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?)</code>
-          :  Indicates if a call (i.e. two-party
-audio-video experience) should be ended automatically if the current user is
-the last active member of the experience.
-
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>meeting</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?)</code>
-          : Indicates if a meeting (i.e.
-multi-party audio-video experience) should be ended automatically if the
-current user is the last active member of the experience
-
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-</div>
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='call'>
-      Call
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>new Call()</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Static Members</div>
-    <div class="clearfix">
-  
-    <div class='border-bottom' id='callgettargetfrominvitee'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>getTargetFromInvitee(invitee)</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1035-L1070'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Gets the target from the invitee</p>
-
-    <div class='pre p1 fill-light mt0'>getTargetFromInvitee(invitee: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>invitee</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>></code>:
-        The locus target
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstartapplicationshare'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>startApplicationShare()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1740-L1750'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Shares a particular application as a second stream in the call</p>
-
-    <div class='pre p1 fill-light mt0'>startApplicationShare(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstartscreenshare'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>startScreenShare()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1756-L1766'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Shares the whole screen as a second stream in the call</p>
-
-    <div class='pre p1 fill-light mt0'>startScreenShare(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstopscreenshare'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>stopScreenShare()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1812-L1820'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Stops sharing an application or whole screen media stream</p>
-
-    <div class='pre p1 fill-light mt0'>stopScreenShare(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-</div>
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Instance Members</div>
-    <div class="clearfix">
-  
-    <div class='border-bottom' id='callmemberships'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>memberships</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L272-L272'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>memberships</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callremoteaudiomuted'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>remoteAudioMuted</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L289-L293'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Indicates if the other party in the call has turned off their microphone.
-<code>undefined</code> for multiparty calls</p>
-
-    <div class='pre p1 fill-light mt0'>remoteAudioMuted</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callremotevideomuted'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>remoteVideoMuted</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L303-L307'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Indicates if the other party in the call has turned off their camera.
-<code>undefined</code> for multiparty calls</p>
-
-    <div class='pre p1 fill-light mt0'>remoteVideoMuted</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callfacingmode'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>facingMode</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L316-L319'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>facingMode</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calllocalmediastream'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>localMediaStream</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L350-L350'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Returns the local MediaStream for the call. May initially be <code>null</code>
-between the time @{Phone#dial is invoked and the  media stream is
-acquired if <a href="#phonedial">Phone#dial</a> is invoked without a <code>localMediaStream</code>
-option.</p>
-<p>This property can also be set mid-call in which case the streams sent to
-the remote party are replaced by this stream. On success, the
-<a href="#call">Call</a>'s <a href="localMediaStream:change">localMediaStream:change</a> event fires, notifying any
-listeners that we are now sending media from a new source.</p>
-
-    <div class='pre p1 fill-light mt0'>localMediaStream</div>
-  
-    <p>
-      Type:
-      MediaStream
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callremotemember'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>remoteMember</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L461-L477'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>The other participant in a two-party call. <code>undefined</code> for multiparty
-calls</p>
-
-    <div class='pre p1 fill-light mt0'>remoteMember</div>
-  
-    <p>
-      Type:
-      <a href="#callmembership">CallMembership</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callfrom'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>from</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L504-L519'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>The initiating participant in a two-party call.</p>
-
-    <div class='pre p1 fill-light mt0'>from</div>
-  
-    <p>
-      Type:
-      <a href="#callmembership">CallMembership</a>
-    </p>
-  
-  
-
-  <div>Deprecated: The 
-<a href="#callfrom">Call#from</a>
- attribute will likely be replaced by
-the 
-<a href="#callhost">Call#host</a>
-.
-</div>
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstate'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>state</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L550-L565'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p><b>active</b> - At least one person (not necessarily this user) is
-participating in the call<br/>
-<b>inactive</b> - No one is participating in the call<br/>
-<b>initializing</b> - reserved for future use<br/>
-<b>terminating</b> - reserved for future use<br/>
-Only defined if
-<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a> has been
-enabled</p>
-
-    <div class='pre p1 fill-light mt0'>state</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstatus'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>status</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L585-L596'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p><b>initiated</b> - Offer was sent to remote party but they have not yet
-accepted <br>
-<b>ringing</b> - Remote party has acknowledged the call <br>
-<b>connected</b> - At least one party is still on the call <br>
-<b>disconnected</b> - All parties have dropped <br>
-<b>replaced</b> - In (hopefully) rare cases, the underlying data backing
-a Call instance may change in such a way that further interaction with
-that Call is handled by a different instance. In such cases, the first
-Call's status, will transition to <code>replaced</code>, which is almost the same
-state as <code>disconnected</code>. Generally speaking, such a transition should not
-happen for a Call instance that is actively sending/receiving media.</p>
-
-    <div class='pre p1 fill-light mt0'>status</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-    </p>
-  
-  
-
-  <div>Deprecated: The 
-<a href="#callstatus">Call#status</a>
- attribute will likely be replaced by
-the 
-<a href="#callstate">Call#state</a>
-.
-</div>
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callhost'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>host</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L607-L622'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>The host of the call
-Only defined if
-<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a> has been
-enabled</p>
-
-    <div class='pre p1 fill-light mt0'>host</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callroomid'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>roomId</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L633-L648'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>The room id of the call
-Only defined if
-<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a> has been
-enabled</p>
-
-    <div class='pre p1 fill-light mt0'>roomId</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callremotemediastream'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>remoteMediaStream</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L656-L665'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Access to the remote party’s <code>MediaStream</code>.</p>
-
-    <div class='pre p1 fill-light mt0'>remoteMediaStream</div>
-  
-    <p>
-      Type:
-      MediaStream
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calllocalscreenshare'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>localScreenShare</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L673-L682'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Access to the local party’s screen share <code>MediaStream</code>.</p>
-
-    <div class='pre p1 fill-light mt0'>localScreenShare</div>
-  
-    <p>
-      Type:
-      MediaStream
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callacknowledge'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>acknowledge()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L753-L759'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Use to acknowledge (without answering) an incoming call. Will cause the
-initiator's Call instance to emit the ringing event.</p>
-
-    <div class='pre p1 fill-light mt0'>acknowledge(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callanswer'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>answer</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L774-L793'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Answers an incoming call.</p>
-
-    <div class='pre p1 fill-light mt0'>answer</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-	    
-          </div>
-          
-          <table class='mt1 mb2 fixed-table h5 col-12'>
-            <colgroup>
-              <col width='30%' />
-              <col width='70%' />
-            </colgroup>
-            <thead>
-              <tr class='bold fill-light'>
-                <th>Name</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody class='mt1'>
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.constraints</span> <code class='quiet'>MediaStreamConstraints</code>
-  </td>
-  <td class='break-word'><span></span></td>
-</tr>
-
-
-              
-            </tbody>
-          </table>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callcreateorjoinlocus'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>createOrJoinLocus(target, options)</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L896-L984'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Call and answer require nearly identical logic, so this method unifies them.</p>
-
-    <div class='pre p1 fill-light mt0'>createOrJoinLocus(target: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | locus), options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>target</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | locus))</code>
-	    
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-            = <code>{}</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calldecline'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>decline()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L995-L997'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Alias of <a href="#callreject">Call#reject</a></p>
-
-    <div class='pre p1 fill-light mt0'>decline(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Related</div>
-    
-      
-        <a href="#callreject">Call#reject</a>
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callgetrawstatsstream'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>getRawStatsStream()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1079-L1081'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Returns a <a href="Readable">Readable</a> that emits <a href="Call#media.pc">Call#media.pc</a>'s
-<a href="https://developer.mozilla.org/docs/Web/API/RTCStatsReport">RTCStatsReport</a> every second.</p>
-
-    <div class='pre p1 fill-light mt0'>getRawStatsStream(): <a href="#statsstream">StatsStream</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="#statsstream">StatsStream</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callgetstatsstream'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>getStatsStream()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1089-L1092'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Returns a <a href="#statsstream">StatsStream</a> piped through a <a href="#statsfilter">StatsFilter</a></p>
-
-    <div class='pre p1 fill-light mt0'>getStatsStream(): Readable</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code>Readable</code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callhangup'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>hangup()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1102-L1125'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Disconnects the active call. Applies to both incoming and outgoing calls.
-This method may be invoked in any call state and the SDK should take care
-to tear down the call and free up all resources regardless of the state.</p>
-
-    <div class='pre p1 fill-light mt0'>hangup(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callreject'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>reject()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1600-L1612'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Rejects an incoming call. Only applies to incoming calls. Invoking this
-method on an outgoing call is a no-op.</p>
-
-    <div class='pre p1 fill-light mt0'>reject(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callsenddtmf'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>sendDtmf(tones)</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1717-L1723'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Send DTMF tones to the current call</p>
-
-    <div class='pre p1 fill-light mt0'>sendDtmf(tones: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>tones</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callsendfeedback'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>sendFeedback(feedback)</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1732-L1734'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Sends feedback about the call to the Webex cloud</p>
-
-    <div class='pre p1 fill-light mt0'>sendFeedback(feedback: <a href="#feedbackobject">FeedbackObject</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>feedback</span> <code class='quiet'>(<a href="#feedbackobject">FeedbackObject</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstartreceivingaudio'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>startReceivingAudio()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1774-L1776'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Start receiving audio</p>
-
-    <div class='pre p1 fill-light mt0'>startReceivingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstartreceivingvideo'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>startReceivingVideo()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1784-L1786'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Start receiving video</p>
-
-    <div class='pre p1 fill-light mt0'>startReceivingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstartsendingaudio'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>startSendingAudio()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1794-L1796'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Starts sending audio to the Webex Cloud</p>
-
-    <div class='pre p1 fill-light mt0'>startSendingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstartsendingvideo'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>startSendingVideo()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1804-L1806'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Starts sending video to the Webex Cloud</p>
-
-    <div class='pre p1 fill-light mt0'>startSendingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstopreceivingaudio'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>stopReceivingAudio()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1828-L1830'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Stop receiving audio</p>
-
-    <div class='pre p1 fill-light mt0'>stopReceivingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstopreceivingvideo'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>stopReceivingVideo()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1838-L1840'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Stop receiving video</p>
-
-    <div class='pre p1 fill-light mt0'>stopReceivingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstopsendingaudio'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>stopSendingAudio()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1849-L1851'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Stops sending audio to the Webex Cloud. (stops broadcast immediately,
-even if renegotiation has not completed)</p>
-
-    <div class='pre p1 fill-light mt0'>stopSendingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callstopsendingvideo'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>stopSendingVideo()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1860-L1862'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Stops sending video to the Webex Cloud. (stops broadcast immediately,
-even if renegotiation has not completed)</p>
-
-    <div class='pre p1 fill-light mt0'>stopSendingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calltogglefacingmode'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>toggleFacingMode()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1873-L1894'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Replaces the current mediaStrem with one with identical constraints, except
-for an opposite facing mode. If the current facing mode cannot be
-determined, the facing mode will be set to <code>user</code>. If the call is audio
-only, this function will throw.</p>
-
-    <div class='pre p1 fill-light mt0'>toggleFacingMode(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calltogglereceivingaudio'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>toggleReceivingAudio()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1902-L1904'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Toggles receiving audio from the Webex Cloud</p>
-
-    <div class='pre p1 fill-light mt0'>toggleReceivingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calltogglereceivingvideo'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>toggleReceivingVideo()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1912-L1914'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Toggles receiving video from the Webex Cloud</p>
-
-    <div class='pre p1 fill-light mt0'>toggleReceivingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calltogglesendingaudio'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>toggleSendingAudio()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1922-L1924'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Toggles sending audio to the Webex Cloud</p>
-
-    <div class='pre p1 fill-light mt0'>toggleSendingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calltogglesendingvideo'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>toggleSendingVideo()</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L1932-L1934'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Toggles sending video to the Webex Cloud</p>
-
-    <div class='pre p1 fill-light mt0'>toggleSendingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
-        
-
-      
-    
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-</div>
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Events</div>
-    <div class="clearfix">
-  
-    <div class='border-bottom' id='calleventringing'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>ringing</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>ringing</div>
-  
-  
-
-  <div>Deprecated: with 
-<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a>
-
-enabled; instead, listen for 
-<a href="Call.membership:notified">Call.membership:notified</a>
-</div>
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventconnected'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>connected</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>connected</div>
-  
-  
-
-  <div>Deprecated: with 
-<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a>
-
-enabled; instead, listen for 
-<a href="Call.active">Call.active</a>
-</div>
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventdisconnected'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>disconnected</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>disconnected</div>
-  
-  
-
-  <div>Deprecated: with 
-<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a>
-
-enabled; instead, listen for 
-<a href="Call.inactive">Call.inactive</a>
-</div>
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventactive'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>active</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>only emitted if enableExperimentalGroupCallingSupport is enabled</p>
-
-    <div class='pre p1 fill-light mt0'>active</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventinitializing'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>initializing</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>only emitted if enableExperimentalGroupCallingSupport is enabled</p>
-
-    <div class='pre p1 fill-light mt0'>initializing</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventinactive'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>inactive</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>only emitted if enableExperimentalGroupCallingSupport is enabled</p>
-
-    <div class='pre p1 fill-light mt0'>inactive</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventterminating'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>terminating</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>only emitted if enableExperimentalGroupCallingSupport is enabled</p>
-
-    <div class='pre p1 fill-light mt0'>terminating</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventlocalmediastreamchange'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>localMediaStream:change</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>localMediaStream:change</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventremotemediastreamchange'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>remoteMediaStream:change</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>remoteMediaStream:change</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventerror'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>error</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>error</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventmembershipnotified'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>membership:notified</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>This replaces the <a href="Call.ringing">Call.ringing</a> event, but note that it's
-subtly different. <a href="Call.ringing">Call.ringing</a> is emitted when the remote party calls
-<a href="Call#acknowledge()">Call#acknowledge()</a> whereas <a href="Call.membership:notified">Call.membership:notified</a> emits
-shortly after (but as a direct result of) locally calling
-<a href="Phone#dial()">Phone#dial()</a></p>
-
-    <div class='pre p1 fill-light mt0'>membership:notified</div>
-  
-    <p>
-      Type:
-      <a href="#callmembership">CallMembership</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventmembershipconnected'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>membership:connected</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>membership:connected</div>
-  
-    <p>
-      Type:
-      <a href="#callmembership">CallMembership</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventmembershipdeclined'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>membership:declined</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>membership:declined</div>
-  
-    <p>
-      Type:
-      <a href="#callmembership">CallMembership</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventmembershipdisconnected'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>membership:disconnected</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>membership:disconnected</div>
-  
-    <p>
-      Type:
-      <a href="#callmembership">CallMembership</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventmembershipwaiting'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>membership:waiting</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>membership:waiting</div>
-  
-    <p>
-      Type:
-      <a href="#callmembership">CallMembership</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventmembershipchange'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>membership:change</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>membership:change</div>
-  
-    <p>
-      Type:
-      <a href="#callmembership">CallMembership</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventmembershipsadd'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>memberships:add</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Emitted when a new <a href="#callmembership">CallMembership</a> is added to
-<a href="#callmemberships">Call#memberships</a>. Note that <a href="#callmembershipstate">CallMembership#state</a> still needs
-to be read to determine if the instance represents someone actively
-participating the call.</p>
-
-    <div class='pre p1 fill-light mt0'>memberships:add</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='calleventmembershipsremove'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>memberships:remove</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Emitted when a <a href="#callmembership">CallMembership</a> is removed from
-<a href="#callmemberships">Call#memberships</a>.</p>
-
-    <div class='pre p1 fill-light mt0'>memberships:remove</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-</div>
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='callmemberships'>
-      CallMemberships
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call-memberships.js#L10-L15'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call-memberships.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>new CallMemberships()</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='callmembership'>
-      CallMembership
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L6-L120'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>new CallMembership()</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Instance Members</div>
-    <div class="clearfix">
-  
-    <div class='border-bottom' id='callmembershipisinitiator'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>isInitiator</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L43-L47'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Indicates if the member started the call</p>
-
-    <div class='pre p1 fill-light mt0'>isInitiator</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callmembershippersonid'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>personId</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L55-L57'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>personId</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callmembershipstate'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>state</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L84-L94'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Indicates the member's relationship with the call. One of</p>
-<ul>
-<li>notified - the party has been invited to the call but has not yet accepted</li>
-<li>connected - the party is participating in the call</li>
-<li>declined - the party chose not to accept the call</li>
-<li>disconnected - the party is no longer participating in the call</li>
-<li>waiting - reserved for future use</li>
-</ul>
-
-    <div class='pre p1 fill-light mt0'>state</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callmembershipaudiomuted'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>audioMuted</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L103-L106'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Indicates if the member has muted their microphone</p>
-
-    <div class='pre p1 fill-light mt0'>audioMuted</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='callmembershipvideomuted'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>videoMuted</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L115-L118'>
-      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Indicates if the member has disable their camera</p>
-
-    <div class='pre p1 fill-light mt0'>videoMuted</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-</div>
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='statsstream'>
-      StatsStream
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/stats/stream.js#L46-L89'>
-      <span>packages/node_modules/@webex/plugin-phone/src/stats/stream.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Polls an <a href="https://developer.mozilla.org/docs/Web/API/RTCPeerConnection">RTCPeerConnection</a> once per second and emits its
-<a href="https://developer.mozilla.org/docs/Web/API/RTCStatsReport">RTCStatsReport</a></p>
-
-    <div class='pre p1 fill-light mt0'>new StatsStream(pc: <a href="https://developer.mozilla.org/docs/Web/API/RTCPeerConnection">RTCPeerConnection</a>)</div>
-  
-  
-    <p>
-      Extends
-      
-        Readable
-      
-    </p>
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>pc</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/API/RTCPeerConnection">RTCPeerConnection</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='statsstream'>
-      StatsStream
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stream.js#L55-L107'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/stats/stream.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Polls an <a href="https://developer.mozilla.org/docs/Web/API/RTCPeerConnection">RTCPeerConnection</a> once per second and emits its <a href="https://developer.mozilla.org/docs/Web/API/RTCStatsReport">RTCStatsReport</a>
-<a href="https://developer.mozilla.org/docs/Web/API/RTCStatsReport">RTCStatsReport</a></p>
-
-    <div class='pre p1 fill-light mt0'>new StatsStream(config: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</div>
-  
-  
-    <p>
-      Extends
-      
-        Readable
-      
-    </p>
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>config</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-            = <code>{}</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='statsfilter'>
-      StatsFilter
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/stats/filter.js#L6-L83'>
-      <span>packages/node_modules/@webex/plugin-phone/src/stats/filter.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Reforms the interesting data from an RTCStatsReport into something grokkable</p>
-
-    <div class='pre p1 fill-light mt0'>new StatsFilter()</div>
-  
-  
-    <p>
-      Extends
-      
-        Transform
-      
-    </p>
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='statsfilter'>
-      StatsFilter
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/filter.js#L9-L40'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/stats/filter.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Reforms the interesting data from an RTCStatsReport to a new format</p>
-
-    <div class='pre p1 fill-light mt0'>new StatsFilter()</div>
-  
-  
-    <p>
-      Extends
-      
-        Transform
-      
-    </p>
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='meetings'>
       Meetings
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L885'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L882'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13009,7 +7178,7 @@ participating the call.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L403-L442'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L403-L442'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13076,7 +7245,7 @@ the device, connecting to mercury, and listening for locus events.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L452-L474'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L452-L474'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13143,7 +7312,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L530-L532'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L527-L529'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13209,7 +7378,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L540-L542'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L537-L539'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13275,7 +7444,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L550-L556'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L547-L553'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13341,7 +7510,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L576-L578'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L573-L575'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13407,7 +7576,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L612-L688'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L609-L685'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13497,7 +7666,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L785-L787'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L782-L784'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13584,7 +7753,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L798-L802'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L795-L799'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13698,7 +7867,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L810-L844'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L807-L841'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13764,7 +7933,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L854-L856'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L851-L853'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13877,7 +8046,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L872-L874'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L869-L871'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -13943,7 +8112,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L882-L884'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L879-L881'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -14009,7 +8178,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2823-L2823'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2782-L2782'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -14124,7 +8293,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2830-L2830'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2789-L2789'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -14198,7 +8367,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L148-L148'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L148-L148'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -14261,7 +8430,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L166-L166'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L166-L166'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -14324,7 +8493,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L488-L522'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L485-L519'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -14369,15 +8538,6 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
             <tbody class='mt1'>
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.callStart</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
-  </td>
-  <td class='break-word'><span>Call Start Time
-</span></td>
-</tr>
-
-
-              
-                <tr>
   <td class='break-word'><span class='code bold'>options.feedbackId</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
   </td>
   <td class='break-word'><span>ID used for tracking
@@ -14405,26 +8565,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
                 <tr>
   <td class='break-word'><span class='code bold'>options.meetingId</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
   </td>
-  <td class='break-word'><span>webex meeting ID
-</span></td>
-</tr>
-
-
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.userId</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
-  </td>
-  <td class='break-word'><span>userId
-</span></td>
-</tr>
-
-
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.orgId</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
-  </td>
-  <td class='break-word'><span>org id
-</span></td>
+  <td class='break-word'><span></span></td>
 </tr>
 
 
@@ -14481,7 +8622,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L862-L864'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L859-L861'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -14547,7 +8688,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L27-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L27-L27'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/collection.js</span>
       </a>
     
@@ -14610,7 +8751,7 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L35-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L35-L35'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/collection.js</span>
       </a>
     
@@ -14669,65 +8810,6 @@ the device, disconnecting from mercury, and stops listening to locus events</p>
     <div class='py1 quiet mt1 prose-big'>Events</div>
     <div class="clearfix">
   
-    <div class='border-bottom' id='meetingseventmeetingsready'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>meetings:ready</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L885'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Meetings Ready Event
-Emitted when the meetings instance on webex is ready</p>
-
-    <div class='pre p1 fill-light mt0'>meetings:ready</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
     <div class='border-bottom' id='meetingseventnetworkdisconnected'>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
@@ -14742,7 +8824,7 @@ Emitted when the meetings instance on webex is ready</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L885'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L882'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -14802,7 +8884,7 @@ the internal mercury server</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L885'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L882'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -14861,7 +8943,7 @@ Emitted when the meetings instance has been registered and listening</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L885'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L882'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -14951,7 +9033,7 @@ Emitted when a meeting was removed from the cache of meetings</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L885'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L882'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
       </a>
     
@@ -15020,6 +9102,65 @@ Emitted when a meeting was added to the cache of meetings</p>
       </div>
     </div>
   
+    <div class='border-bottom' id='meetingseventmeetingsready'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>meetings:ready</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js#L105-L882'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/meetings/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Meetings Ready Event
+Emitted when the meetings instance on webex is ready</p>
+
+    <div class='pre p1 fill-light mt0'>meetings:ready</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
 </div>
 
   
@@ -15052,7 +9193,7 @@ Emitted when a meeting was added to the cache of meetings</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L42-L655'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L42-L655'>
       <span>packages/node_modules/@webex/plugin-memberships/src/memberships.js</span>
       </a>
     
@@ -15107,7 +9248,7 @@ or deleted to remove them from the room.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L87-L101'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L87-L101'>
       <span>packages/node_modules/@webex/plugin-memberships/src/memberships.js</span>
       </a>
     
@@ -15214,7 +9355,7 @@ webex.memberships.off(<span class="hljs-string">'deleted'</span>);</pre>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L132-L140'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L132-L140'>
       <span>packages/node_modules/@webex/plugin-memberships/src/memberships.js</span>
       </a>
     
@@ -15319,7 +9460,7 @@ as a moderator.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L168-L176'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L168-L176'>
       <span>packages/node_modules/@webex/plugin-memberships/src/memberships.js</span>
       </a>
     
@@ -15421,7 +9562,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L214-L221'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L214-L221'>
       <span>packages/node_modules/@webex/plugin-memberships/src/memberships.js</span>
       </a>
     
@@ -15577,7 +9718,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L250-L318'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L250-L318'>
       <span>packages/node_modules/@webex/plugin-memberships/src/memberships.js</span>
       </a>
     
@@ -15694,7 +9835,7 @@ objects returned in the list function.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L355-L372'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L355-L372'>
       <span>packages/node_modules/@webex/plugin-memberships/src/memberships.js</span>
       </a>
     
@@ -15805,7 +9946,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L436-L446'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L436-L446'>
       <span>packages/node_modules/@webex/plugin-memberships/src/memberships.js</span>
       </a>
     
@@ -15944,7 +10085,7 @@ webex.people.get(<span class="hljs-string">'me'</span>)
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L458-L484'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L458-L484'>
       <span>packages/node_modules/@webex/plugin-memberships/src/memberships.js</span>
       </a>
     
@@ -16034,7 +10175,7 @@ space where the message is.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-messages/src/messages.js#L55-L389'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-messages/src/messages.js#L55-L389'>
       <span>packages/node_modules/@webex/plugin-messages/src/messages.js</span>
       </a>
     
@@ -16090,7 +10231,7 @@ for a list of supported media types.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js#L81-L95'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js#L81-L95'>
       <span>packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js</span>
       </a>
     
@@ -16182,7 +10323,7 @@ webex.attachmentActions.off(<span class="hljs-string">'created'</span>);</pre>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-messages/src/messages.js#L101-L115'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-messages/src/messages.js#L101-L115'>
       <span>packages/node_modules/@webex/plugin-messages/src/messages.js</span>
       </a>
     
@@ -16279,7 +10420,7 @@ webex.messages.off(<span class="hljs-string">'deleted'</span>);</pre>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-messages/src/messages.js#L142-L164'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-messages/src/messages.js#L142-L164'>
       <span>packages/node_modules/@webex/plugin-messages/src/messages.js</span>
       </a>
     
@@ -16380,7 +10521,7 @@ webex.messages.off(<span class="hljs-string">'deleted'</span>);</pre>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-messages/src/messages.js#L192-L200'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-messages/src/messages.js#L192-L200'>
       <span>packages/node_modules/@webex/plugin-messages/src/messages.js</span>
       </a>
     
@@ -16482,7 +10623,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-messages/src/messages.js#L241-L248'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-messages/src/messages.js#L241-L248'>
       <span>packages/node_modules/@webex/plugin-messages/src/messages.js</span>
       </a>
     
@@ -16627,7 +10768,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-messages/src/messages.js#L290-L307'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-messages/src/messages.js#L290-L307'>
       <span>packages/node_modules/@webex/plugin-messages/src/messages.js</span>
       </a>
     
@@ -16751,7 +10892,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-people/src/people.js#L21-L199'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-people/src/people.js#L21-L199'>
       <span>packages/node_modules/@webex/plugin-people/src/people.js</span>
       </a>
     
@@ -16802,7 +10943,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-people/src/people.js#L57-L67'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-people/src/people.js#L57-L67'>
       <span>packages/node_modules/@webex/plugin-people/src/people.js</span>
       </a>
     
@@ -16908,7 +11049,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-people/src/people.js#L148-L161'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-people/src/people.js#L148-L161'>
       <span>packages/node_modules/@webex/plugin-people/src/people.js</span>
       </a>
     
@@ -17114,7 +11255,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L38-L486'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L38-L486'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -17169,7 +11310,7 @@ posting and managing content.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L67-L78'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L67-L78'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -17261,7 +11402,7 @@ webex.rooms.off(<span class="hljs-string">'updated'</span>);</pre>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L100-L108'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L100-L108'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -17357,7 +11498,7 @@ more people to the room.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L131-L140'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L131-L140'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -17461,7 +11602,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L174-L181'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L174-L181'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -17593,7 +11734,7 @@ response.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L227-L248'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L227-L248'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -17704,7 +11845,7 @@ objects returned in the list function.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L282-L296'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L282-L296'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -17803,7 +11944,7 @@ object returned in the get function.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L325-L342'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L325-L342'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -17906,7 +12047,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L368-L378'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L368-L378'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -18014,7 +12155,7 @@ webex.rooms.update({<span class="hljs-attr">title</span>: <span class="hljs-stri
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-teams/src/teams.js#L18-L154'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-teams/src/teams.js#L18-L154'>
       <span>packages/node_modules/@webex/plugin-teams/src/teams.js</span>
       </a>
     
@@ -18065,7 +12206,7 @@ webex.rooms.update({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-teams/src/teams.js#L36-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-teams/src/teams.js#L36-L44'>
       <span>packages/node_modules/@webex/plugin-teams/src/teams.js</span>
       </a>
     
@@ -18158,7 +12299,7 @@ webex.rooms.update({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-teams/src/teams.js#L67-L76'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-teams/src/teams.js#L67-L76'>
       <span>packages/node_modules/@webex/plugin-teams/src/teams.js</span>
       </a>
     
@@ -18262,7 +12403,7 @@ webex.teams.create({<span class="hljs-attr">name</span>: <span class="hljs-strin
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-teams/src/teams.js#L109-L116'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-teams/src/teams.js#L109-L116'>
       <span>packages/node_modules/@webex/plugin-teams/src/teams.js</span>
       </a>
     
@@ -18393,7 +12534,7 @@ response.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-teams/src/teams.js#L143-L153'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-teams/src/teams.js#L143-L153'>
       <span>packages/node_modules/@webex/plugin-teams/src/teams.js</span>
       </a>
     
@@ -18501,7 +12642,7 @@ webex.teams.create({<span class="hljs-attr">name</span>: <span class="hljs-strin
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L28-L214'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L28-L214'>
       <span>packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js</span>
       </a>
     
@@ -18558,7 +12699,7 @@ its memberships or invite people.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L56-L64'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L56-L64'>
       <span>packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js</span>
       </a>
     
@@ -18661,7 +12802,7 @@ a moderator.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L92-L100'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L92-L100'>
       <span>packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js</span>
       </a>
     
@@ -18763,7 +12904,7 @@ webex.teams.create({<span class="hljs-attr">name</span>: <span class="hljs-strin
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L133-L140'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L133-L140'>
       <span>packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js</span>
       </a>
     
@@ -18893,7 +13034,7 @@ webex.teams.create({<span class="hljs-attr">name</span>: <span class="hljs-strin
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L177-L194'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L177-L194'>
       <span>packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js</span>
       </a>
     
@@ -19004,7 +13145,7 @@ webex.teams.create({<span class="hljs-attr">name</span>: <span class="hljs-strin
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L203-L213'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L203-L213'>
       <span>packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js</span>
       </a>
     
@@ -19091,7 +13232,7 @@ webex.teams.create({<span class="hljs-attr">name</span>: <span class="hljs-strin
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L24-L243'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L24-L243'>
       <span>packages/node_modules/@webex/plugin-webhooks/src/webhooks.js</span>
       </a>
     
@@ -19145,7 +13286,7 @@ notified when a new message is posted into a specific room.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L54-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L54-L62'>
       <span>packages/node_modules/@webex/plugin-webhooks/src/webhooks.js</span>
       </a>
     
@@ -19250,7 +13391,7 @@ notified when a new message is posted into a specific room.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L93-L101'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L93-L101'>
       <span>packages/node_modules/@webex/plugin-webhooks/src/webhooks.js</span>
       </a>
     
@@ -19355,7 +13496,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L136-L143'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L136-L143'>
       <span>packages/node_modules/@webex/plugin-webhooks/src/webhooks.js</span>
       </a>
     
@@ -19488,7 +13629,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L180-L197'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L180-L197'>
       <span>packages/node_modules/@webex/plugin-webhooks/src/webhooks.js</span>
       </a>
     
@@ -19599,7 +13740,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L232-L242'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L232-L242'>
       <span>packages/node_modules/@webex/plugin-webhooks/src/webhooks.js</span>
       </a>
     
@@ -19730,7 +13871,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-logger/src/logger.js#L92-L301'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-logger/src/logger.js#L92-L301'>
       <span>packages/node_modules/@webex/plugin-logger/src/logger.js</span>
       </a>
     
@@ -19781,7 +13922,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-logger/src/logger.js#L266-L300'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-logger/src/logger.js#L266-L300'>
       <span>packages/node_modules/@webex/plugin-logger/src/logger.js</span>
       </a>
     
@@ -19856,7 +13997,7 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-logger/src/config.js#L5-L16'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-logger/src/config.js#L5-L16'>
       <span>packages/node_modules/@webex/plugin-logger/src/config.js</span>
       </a>
     
@@ -19958,7 +14099,7 @@ silent|error|warn|log|info|debug|trace
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/call.js#L240-L252'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L240-L252'>
       <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
       </a>
     
@@ -20049,7 +14190,7 @@ SDK's logger, you should make sure to avoid logging PII as well.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L23-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-memberships/src/memberships.js#L23-L32'>
       <span>packages/node_modules/@webex/plugin-memberships/src/memberships.js</span>
       </a>
     
@@ -20161,7 +14302,7 @@ SDK's logger, you should make sure to avoid logging PII as well.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-messages/src/messages.js#L33-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-messages/src/messages.js#L33-L45'>
       <span>packages/node_modules/@webex/plugin-messages/src/messages.js</span>
       </a>
     
@@ -20284,7 +14425,7 @@ Guide for a list of supported media types.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-people/src/people.js#L10-L16'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-people/src/people.js#L10-L16'>
       <span>packages/node_modules/@webex/plugin-people/src/people.js</span>
       </a>
     
@@ -20375,7 +14516,7 @@ Guide for a list of supported media types.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L19-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L19-L28'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -20469,7 +14610,7 @@ room was created
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-teams/src/teams.js#L7-L13'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-teams/src/teams.js#L7-L13'>
       <span>packages/node_modules/@webex/plugin-teams/src/teams.js</span>
       </a>
     
@@ -20554,7 +14695,7 @@ team was created
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L7-L16'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js#L7-L16'>
       <span>packages/node_modules/@webex/plugin-team-memberships/src/team-memberships.js</span>
       </a>
     
@@ -20662,7 +14803,7 @@ moderator
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L7-L16'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-webhooks/src/webhooks.js#L7-L16'>
       <span>packages/node_modules/@webex/plugin-webhooks/src/webhooks.js</span>
       </a>
     
@@ -20774,7 +14915,7 @@ moderator
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/webex/src/index.js#L20-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/webex/src/index.js#L20-L23'>
       <span>packages/node_modules/webex/src/index.js</span>
       </a>
     
@@ -20833,7 +14974,7 @@ moderator
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/webex/src/index.js#L13-L18'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/webex/src/index.js#L13-L18'>
       <span>packages/node_modules/webex/src/index.js</span>
       </a>
     
@@ -20888,124 +15029,12 @@ format (e.g. <code>2015-10-18T14:26:16+00:00</code>).</p>
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='attachmentactionobject'>
-      AttachmentActionObject
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js#L20-L29'>
-      <span>packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>AttachmentActionObject</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>id</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          : (server generated) Unique identifier for the attachment action
-
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>messageId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          : The ID of the message in which attachment action is to be performed
-
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>type</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          : The type of attachment action eg., submit
-
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>inputs</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-          : The inputs for form fields in attachment message
-
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>personId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          : (server generated) The ID for the author of the attachment action
-
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>roomId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          : (server generated) The ID for the room of the message
-
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>created</span> <code class='quiet'>(<a href="#isodate">isoDate</a>)</code>
-          : (server generated) The date and time that the message was created
-
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='attachmentactions'>
       AttachmentActions
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js#L40-L322'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js#L40-L322'>
       <span>packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js</span>
       </a>
     
@@ -21062,7 +15091,7 @@ for more details</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js#L162-L170'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js#L162-L170'>
       <span>packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js</span>
       </a>
     
@@ -21203,7 +15232,7 @@ for more details</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js#L234-L242'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js#L234-L242'>
       <span>packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js</span>
       </a>
     
@@ -21344,12 +15373,124 @@ webex.rooms.create({<span class="hljs-attr">title</span>: <span class="hljs-stri
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='attachmentactionobject'>
+      AttachmentActionObject
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js#L20-L29'>
+      <span>packages/node_modules/@webex/plugin-attachment-actions/src/attachmentActions.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>AttachmentActionObject</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>id</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          : (server generated) Unique identifier for the attachment action
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>messageId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          : The ID of the message in which attachment action is to be performed
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>type</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          : The type of attachment action eg., submit
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>inputs</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+          : The inputs for form fields in attachment message
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>personId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          : (server generated) The ID for the author of the attachment action
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>roomId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          : (server generated) The ID for the room of the message
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>created</span> <code class='quiet'>(<a href="#isodate">isoDate</a>)</code>
+          : (server generated) The date and time that the message was created
+
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='getall'>
       getAll
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L31-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L31-L33'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -21412,7 +15553,7 @@ the device list gets populated from Redis</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L40-L75'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L40-L75'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -21475,7 +15616,7 @@ the device list gets populated from Redis</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L83-L103'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L83-L103'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -21574,7 +15715,7 @@ the device list gets populated from Redis</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L111-L151'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L111-L151'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -21673,7 +15814,7 @@ the device list gets populated from Redis</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L158-L186'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L158-L186'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -21748,7 +15889,7 @@ the device list gets populated from Redis</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L194-L211'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L194-L211'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -21824,7 +15965,7 @@ similar to space.deleteBinding()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L220-L259'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L220-L259'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -21932,7 +16073,7 @@ similar to space.deleteBinding()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L269-L292'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L269-L292'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22034,7 +16175,7 @@ similar to space.join()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L303-L317'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L303-L317'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22137,7 +16278,7 @@ similar to space.leave()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L327-L356'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L327-L356'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22248,7 +16389,7 @@ similar to space.bindConversation()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L363-L382'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L363-L382'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22311,7 +16452,7 @@ similar to space.unbindConversation()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L389-L397'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L389-L397'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22374,7 +16515,7 @@ similar to device.getAudioState()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L407-L409'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L407-L409'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22460,7 +16601,7 @@ similar to device.putAudioState()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L416-L424'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L416-L424'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22523,7 +16664,7 @@ similar to device.mute()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L431-L439'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L431-L439'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22586,7 +16727,7 @@ similar to device.unmute()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L446-L454'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L446-L454'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22649,7 +16790,7 @@ similar to device.increaseVolume()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L461-L469'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L461-L469'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22712,7 +16853,7 @@ similar to device.decreaseVolume()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L477-L485'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L477-L485'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22789,7 +16930,7 @@ similar to device.setVolume()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L492-L514'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L492-L514'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22865,7 +17006,7 @@ similar to device.setVolume()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L521-L545'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L521-L545'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -22941,7 +17082,7 @@ similar to device.setVolume()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L552-L595'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-device-manager/src/device-manager.js#L552-L595'>
       <span>packages/node_modules/@webex/plugin-device-manager/src/device-manager.js</span>
       </a>
     
@@ -23016,7 +17157,7 @@ similar to device.setVolume()</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L21-L475'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L21-L475'>
       <span>packages/node_modules/@webex/plugin-meetings/src/metrics/index.js</span>
       </a>
     
@@ -23066,7 +17207,7 @@ similar to device.setVolume()</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L217-L256'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L217-L256'>
       <span>packages/node_modules/@webex/plugin-meetings/src/metrics/index.js</span>
       </a>
     
@@ -23243,7 +17384,7 @@ similar to device.setVolume()</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L71-L74'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L71-L74'>
       <span>packages/node_modules/@webex/plugin-meetings/src/metrics/index.js</span>
       </a>
     
@@ -23332,7 +17473,7 @@ similar to device.setVolume()</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L85-L115'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L85-L115'>
       <span>packages/node_modules/@webex/plugin-meetings/src/metrics/index.js</span>
       </a>
     
@@ -23461,7 +17602,7 @@ similar to device.setVolume()</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L123-L176'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L123-L176'>
       <span>packages/node_modules/@webex/plugin-meetings/src/metrics/index.js</span>
       </a>
     
@@ -23550,7 +17691,7 @@ similar to device.setVolume()</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L405-L431'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L405-L431'>
       <span>packages/node_modules/@webex/plugin-meetings/src/metrics/index.js</span>
       </a>
     
@@ -23616,7 +17757,7 @@ similar to device.setVolume()</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L448-L474'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js#L448-L474'>
       <span>packages/node_modules/@webex/plugin-meetings/src/metrics/index.js</span>
       </a>
     
@@ -23729,7 +17870,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/logs/request.js#L8-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/logs/request.js#L8-L46'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/logs/request.js</span>
       </a>
     
@@ -23778,7 +17919,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/logs/request.js#L31-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/logs/request.js#L29-L45'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/logs/request.js</span>
       </a>
     
@@ -23849,24 +17990,6 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
 
 
               
-                <tr>
-  <td class='break-word'><span class='code bold'>options.callStart</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
-  </td>
-  <td class='break-word'><span>Call Start Time
-</span></td>
-</tr>
-
-
-              
-                <tr>
-  <td class='break-word'><span class='code bold'>options.meetingId</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?</code>
-  </td>
-  <td class='break-word'><span>webex meeting ID
-</span></td>
-</tr>
-
-
-              
             </tbody>
           </table>
           
@@ -23924,370 +18047,12 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='mediadirection'>
-      MediaDirection
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L19-L28'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>MediaDirection</p>
-
-    <div class='pre p1 fill-light mt0'>MediaDirection</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>sendAudio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>receiveAudio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>sendVideo</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>receiveVideo</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>sendShare</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>receiveShare</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='mediadirection'>
-      MediaDirection
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L82-L92'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>MediaDirection</p>
-
-    <div class='pre p1 fill-light mt0'>MediaDirection</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>sendAudio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>receiveAudio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>sendVideo</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>receiveVideo</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>sendShare</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>receiveShare</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>isSharing</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='sendoptions'>
-      SendOptions
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L30-L38'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>SendOptions</p>
-
-    <div class='pre p1 fill-light mt0'>SendOptions</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>sharePreferences</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='sendoptions'>
-      SendOptions
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L122-L128'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>SendOptions</p>
-
-    <div class='pre p1 fill-light mt0'>SendOptions</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>sendAudio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>sendVideo</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>sendShare</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='media'>
       Media
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L47-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L47-L47'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -24336,7 +18101,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L55-L63'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L55-L63'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -24422,7 +18187,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L72-L79'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L72-L79'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -24549,7 +18314,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L88-L102'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L88-L102'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -24644,7 +18409,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L110-L131'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L110-L131'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -24732,7 +18497,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L139-L159'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L139-L159'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -24830,7 +18595,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L168-L192'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L168-L192'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -24958,7 +18723,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L202-L235'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L202-L235'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -25086,7 +18851,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L243-L260'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L243-L260'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -25196,7 +18961,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L272-L276'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L272-L276'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -25341,7 +19106,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L290-L372'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L290-L372'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -25501,7 +19266,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L381-L412'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L381-L412'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -25599,7 +19364,7 @@ See <a href="https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+sta
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L426-L446'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L426-L446'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -25717,7 +19482,7 @@ sendVideo: true/false
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L452-L458'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L452-L458'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -25783,7 +19548,7 @@ sendVideo: true/false
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L466-L466'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L466-L466'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -25850,7 +19615,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L473-L488'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L473-L488'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -25930,7 +19695,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L497-L518'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L497-L518'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -26011,7 +19776,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L536-L543'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L536-L543'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
       </a>
     
@@ -26243,12 +20008,370 @@ noop as of now, does nothing</p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='mediadirection'>
+      MediaDirection
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L19-L28'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>MediaDirection</p>
+
+    <div class='pre p1 fill-light mt0'>MediaDirection</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>sendAudio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>receiveAudio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>sendVideo</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>receiveVideo</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>sendShare</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>receiveShare</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='mediadirection'>
+      MediaDirection
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L82-L92'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>MediaDirection</p>
+
+    <div class='pre p1 fill-light mt0'>MediaDirection</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>sendAudio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>receiveAudio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>sendVideo</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>receiveVideo</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>sendShare</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>receiveShare</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>isSharing</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='sendoptions'>
+      SendOptions
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/index.js#L30-L38'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/media/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>SendOptions</p>
+
+    <div class='pre p1 fill-light mt0'>SendOptions</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>sharePreferences</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='sendoptions'>
+      SendOptions
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L122-L128'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>SendOptions</p>
+
+    <div class='pre p1 fill-light mt0'>SendOptions</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>sendAudio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>sendVideo</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>sendShare</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='pc'>
       pc
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L36-L36'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L36-L36'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -26297,7 +20420,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L167-L173'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L167-L173'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -26376,7 +20499,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L182-L222'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L182-L222'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -26487,7 +20610,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L230-L245'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L230-L245'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -26574,7 +20697,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L253-L280'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L253-L280'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -26661,7 +20784,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L290-L354'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L290-L354'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -26764,7 +20887,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L365-L428'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L365-L428'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -26892,7 +21015,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L435-L442'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L435-L442'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -26971,7 +21094,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L455-L469'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L455-L469'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -27139,7 +21262,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L480-L520'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L480-L520'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -27290,7 +21413,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L527-L546'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L527-L546'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -27379,7 +21502,7 @@ noop as of now, does nothing</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L44-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L44-L61'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -27462,7 +21585,7 @@ noop as of now, does nothing</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L69-L81'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L69-L81'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -27547,7 +21670,7 @@ noop as of now, does nothing</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L88-L99'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L88-L99'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -27622,7 +21745,7 @@ noop as of now, does nothing</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L106-L140'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L106-L140'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -27697,7 +21820,7 @@ noop as of now, does nothing</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L147-L160'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js#L147-L160'>
       <span>packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js</span>
       </a>
     
@@ -27772,7 +21895,7 @@ noop as of now, does nothing</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/errors/reconnection.js#L6-L21'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/errors/reconnection.js#L6-L21'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/errors/reconnection.js</span>
       </a>
     
@@ -27856,7 +21979,7 @@ noop as of now, does nothing</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/errors/media.js#L6-L21'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/errors/media.js#L6-L21'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/errors/media.js</span>
       </a>
     
@@ -27940,7 +22063,7 @@ noop as of now, does nothing</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js#L18-L123'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js#L18-L123'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js</span>
       </a>
     
@@ -27989,7 +22112,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js#L50-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js#L50-L52'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js</span>
       </a>
     
@@ -28067,7 +22190,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js#L61-L63'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js#L61-L63'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js</span>
       </a>
     
@@ -28153,7 +22276,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js#L110-L122'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js#L110-L122'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/index.js</span>
       </a>
     
@@ -28253,7 +22376,7 @@ noop as of now, does nothing</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/collection.js#L9-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/collection.js#L9-L37'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/collection.js</span>
       </a>
     
@@ -28302,7 +22425,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/collection.js#L27-L36'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/collection.js#L27-L36'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/collection.js</span>
       </a>
     
@@ -28391,7 +22514,7 @@ noop as of now, does nothing</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/request.js#L8-L36'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/request.js#L8-L36'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/request.js</span>
       </a>
     
@@ -28440,7 +22563,7 @@ noop as of now, does nothing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/request.js#L27-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/request.js#L27-L35'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/request.js</span>
       </a>
     
@@ -28540,7 +22663,7 @@ with the desination matching
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/request.js#L12-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/request.js#L12-L39'>
       <span>packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/request.js</span>
       </a>
     
@@ -28589,7 +22712,7 @@ with the desination matching
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/request.js#L27-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/request.js#L27-L35'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/request.js</span>
       </a>
     
@@ -28689,7 +22812,7 @@ with the desination matching
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js#L64-L70'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js#L64-L70'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js</span>
       </a>
     
@@ -28765,7 +22888,7 @@ with the desination matching
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js#L226-L255'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js#L226-L255'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting-info/util.js</span>
       </a>
     
@@ -28846,362 +22969,12 @@ with the desination matching
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='audiovideo'>
-      AudioVideo
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L94-L101'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>AudioVideo</p>
-
-    <div class='pre p1 fill-light mt0'>AudioVideo</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>audio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-          
-          
-            <ul>
-              
-                <li><code>audio.deviceId</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>
-                  
-                  </li>
-              
-            </ul>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>video</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-          
-          
-            <ul>
-              
-                <li><code>video.deviceId</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>
-                  
-                  </li>
-              
-            </ul>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='sharepreferences'>
-      SharePreferences
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L103-L108'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>SharePreferences</p>
-
-    <div class='pre p1 fill-light mt0'>SharePreferences</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>shareConstraints</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>highFrameRate</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>?)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='joinoptions'>
-      JoinOptions
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L110-L120'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>JoinOptions</p>
-
-    <div class='pre p1 fill-light mt0'>JoinOptions</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>resourceId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>pin</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>moderator</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>?)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>meetingQuality</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)?)</code>
-          
-          
-            <ul>
-              
-                <li><code>meetingQuality.local</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?
-                  
-                  </li>
-              
-                <li><code>meetingQuality.remote</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?
-                  
-                  </li>
-              
-            </ul>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>rejoin</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>?)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    <h3 class='fl m0' id='recording'>
-      Recording
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L130-L135'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Recording</p>
-
-    <div class='pre p1 fill-light mt0'>Recording</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>state</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>modifiedBy</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='meeting'>
       Meeting
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -29251,7 +23024,7 @@ with the desination matching
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L784-L829'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L754-L799'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -29370,7 +23143,7 @@ with the desination matching
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1352-L1354'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1322-L1324'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -29490,7 +23263,7 @@ with the desination matching
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1363-L1365'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1333-L1335'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -29569,7 +23342,7 @@ with the desination matching
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1374-L1376'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1344-L1346'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -29648,7 +23421,7 @@ with the desination matching
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1386-L1388'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1356-L1358'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -29736,7 +23509,7 @@ with the desination matching
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1398-L1400'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1368-L1370'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -29824,7 +23597,7 @@ with the desination matching
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1408-L1410'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1378-L1380'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -29890,7 +23663,7 @@ with the desination matching
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1419-L1423'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1389-L1393'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -29957,7 +23730,7 @@ not restart unless the start function is called again</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1433-L1445'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1403-L1415'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30025,7 +23798,7 @@ but it is separate than history, so history will not be available</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1489-L1502'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1459-L1472'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30114,7 +23887,7 @@ but it is separate than history, so history will not be available</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1511-L1519'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1481-L1489'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30194,7 +23967,7 @@ but it is separate than history, so history will not be available</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1527-L1533'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1497-L1503'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30260,7 +24033,7 @@ but it is separate than history, so history will not be available</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1541-L1543'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1511-L1513'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30326,7 +24099,7 @@ but it is separate than history, so history will not be available</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1551-L1553'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1521-L1523'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30392,7 +24165,7 @@ but it is separate than history, so history will not be available</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1561-L1563'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1531-L1533'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30458,7 +24231,7 @@ but it is separate than history, so history will not be available</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1571-L1573'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1541-L1543'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30524,7 +24297,7 @@ but it is separate than history, so history will not be available</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1687-L1782'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1657-L1752'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30605,7 +24378,7 @@ event to developers</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1792-L1795'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1762-L1765'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30673,7 +24446,7 @@ to developers</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1813-L1816'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1783-L1786'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30741,7 +24514,7 @@ to developers</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1824-L1879'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1794-L1849'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30808,7 +24581,7 @@ to developers</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1888-L1933'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1858-L1903'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30888,7 +24661,7 @@ to developers</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1942-L1984'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1912-L1954'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -30968,7 +24741,7 @@ to developers</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2056-L2058'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2026-L2028'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31034,7 +24807,7 @@ to developers</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2066-L2068'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2036-L2038'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31100,7 +24873,7 @@ to developers</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2078-L2084'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2048-L2054'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31166,7 +24939,7 @@ to developers</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2093-L2095'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2063-L2065'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31233,7 +25006,7 @@ when each is closed.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2105-L2110'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2075-L2080'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31313,7 +25086,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2129-L2165'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2099-L2135'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31379,7 +25152,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2173-L2211'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2143-L2181'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31445,7 +25218,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2219-L2254'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2189-L2224'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31511,7 +25284,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2262-L2297'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2232-L2267'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31577,7 +25350,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2324-L2358'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2294-L2328'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31720,7 +25493,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2368-L2444'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2338-L2414'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31799,7 +25572,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2607-L2648'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2566-L2607'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31878,7 +25651,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2657-L2706'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2616-L2665'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -31957,7 +25730,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2718-L2812'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2677-L2771'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -32056,7 +25829,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2843-L3049'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2802-L2997'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -32187,7 +25960,7 @@ warning DO NOT CALL WITHOUT CLOSING PEER CONNECTIONS FIRST</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3071-L3133'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3019-L3081'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -32308,7 +26081,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3145-L3197'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3093-L3145'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -32427,7 +26200,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3209-L3248'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3157-L3196'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -32546,7 +26319,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3284-L3329'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3232-L3277'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -32657,7 +26430,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3360-L3386'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3308-L3334'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -32736,7 +26509,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3395-L3405'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3343-L3353'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -32816,7 +26589,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3415-L3480'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3363-L3428'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -32922,7 +26695,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3541-L3546'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3489-L3494'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -32988,7 +26761,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3608-L3610'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3556-L3558'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33054,7 +26827,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3618-L3620'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3566-L3568'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33120,7 +26893,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3628-L3630'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3576-L3578'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33186,7 +26959,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3638-L3640'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3586-L3588'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33252,7 +27025,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3648-L3650'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3596-L3598'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33318,7 +27091,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3658-L3660'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3606-L3608'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33384,7 +27157,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3669-L3690'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3617-L3638'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33464,7 +27237,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3699-L3728'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3647-L3676'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33552,7 +27325,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L369-L369'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L351-L351'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33614,7 +27387,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L378-L378'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L360-L360'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33677,7 +27450,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L386-L386'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L368-L368'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33739,7 +27512,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L395-L395'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L377-L377'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33802,7 +27575,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L403-L403'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L385-L385'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33864,7 +27637,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L411-L411'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L393-L393'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33926,7 +27699,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L429-L429'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L411-L411'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -33988,7 +27761,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L436-L436'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L418-L418'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34050,7 +27823,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L461-L461'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L443-L443'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34113,7 +27886,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L469-L469'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L451-L451'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34176,7 +27949,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L477-L477'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L459-L459'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34238,7 +28011,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L484-L484'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L466-L466'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34300,7 +28073,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L500-L500'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L482-L482'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34362,7 +28135,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L508-L508'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L490-L490'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34424,7 +28197,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L516-L516'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L498-L498'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34486,7 +28259,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L524-L524'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L506-L506'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34548,7 +28321,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L532-L532'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L514-L514'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34610,7 +28383,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L540-L540'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L522-L522'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34672,7 +28445,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L548-L548'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L530-L530'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34734,7 +28507,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L556-L556'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L538-L538'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34796,7 +28569,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L572-L572'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L554-L554'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34859,7 +28632,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L579-L579'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L561-L561'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34921,7 +28694,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L587-L587'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L569-L569'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -34983,7 +28756,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L595-L595'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L577-L577'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35045,7 +28818,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L634-L634'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L616-L616'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35107,7 +28880,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L651-L651'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L633-L633'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35169,7 +28942,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1801-L1803'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1771-L1773'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35235,7 +29008,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3055-L3057'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3003-L3005'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35301,7 +29074,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3735-L3777'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3683-L3725'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35381,7 +29154,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3784-L3814'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3732-L3762'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35461,7 +29234,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3821-L3877'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3769-L3825'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35541,7 +29314,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3889-L3926'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L3837-L3874'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35687,6 +29460,93 @@ this function re-establishes all of the media streams with new options</p>
     <div class='py1 quiet mt1 prose-big'>Events</div>
     <div class="clearfix">
   
+    <div class='border-bottom' id='meetingeventmeetingactionsupdate'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>meeting:actionsUpdate</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Meeting Actions Update Event
+Emitted when a user can take actions on a meeting such as lock, unlock, assign host</p>
+
+    <div class='pre p1 fill-light mt0'>meeting:actionsUpdate</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>canLock</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>canUnlock</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>canAssignHost</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
     <div class='border-bottom' id='meetingeventmeetingstatechange'>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
@@ -35701,7 +29561,7 @@ this function re-establishes all of the media streams with new options</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35784,7 +29644,7 @@ Emitted when ever there is a meeting state change</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35867,7 +29727,7 @@ Emitted when a stream is ready to be rendered</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -35943,7 +29803,7 @@ Emitted when a stream has stopped sending</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36026,7 +29886,7 @@ or sending out an incoming meeting</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36119,7 +29979,7 @@ Emitted when this client should stop playing a ringing sound</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36183,7 +30043,7 @@ Emitted when this member starts sharing</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36194,134 +30054,6 @@ Emitted when this member starts sharing</p>
 Emitted when this member stops sharing</p>
 
     <div class='pre p1 fill-light mt0'>meeting:stoppedSharingLocal</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='meetingeventmeetingstartedsharingremote'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>meeting:startedSharingRemote</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Meeting Started Sharing Remote Event
-Emitted when remote sharing starts</p>
-
-    <div class='pre p1 fill-light mt0'>meeting:startedSharingRemote</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='meetingeventmeetingstoppedsharingremote'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>meeting:stoppedSharingRemote</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Meeting Stopped Sharing Remote Event
-Emitted when remote screen sharing ends</p>
-
-    <div class='pre p1 fill-light mt0'>meeting:stoppedSharingRemote</div>
   
     <p>
       Type:
@@ -36375,7 +30107,7 @@ Emitted when remote screen sharing ends</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36450,7 +30182,7 @@ Emitted when a meeting is locked</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36511,93 +30243,6 @@ Emitted when a meeting is unlocked</p>
       </div>
     </div>
   
-    <div class='border-bottom' id='meetingeventmeetingactionsupdate'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>meeting:actionsUpdate</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Meeting Actions Update Event
-Emitted when a user can take actions on a meeting such as lock, unlock, assign host</p>
-
-    <div class='pre p1 fill-light mt0'>meeting:actionsUpdate</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>canLock</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>canUnlock</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>canAssignHost</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
     <div class='border-bottom' id='meetingeventmeetingselfmutedbyothers'>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
@@ -36612,7 +30257,7 @@ Emitted when a user can take actions on a meeting such as lock, unlock, assign h
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36687,7 +30332,7 @@ Emitted when a member is muted by another member</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36762,7 +30407,7 @@ Emitted when a member admitted to the meeting by another member</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36837,7 +30482,7 @@ Emitted when this member enters the lobby and is waiting for the webex meeting t
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36896,7 +30541,7 @@ Emitted when reconnection of media to the active meeting was successful</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -36971,7 +30616,7 @@ Emitted when reconnection of media to the active meeting was successful</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -37046,7 +30691,7 @@ Emitted when reconnection of media to the active meeting was successful</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L335-L3927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L317-L3875'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -37129,7 +30774,7 @@ Emitted when ever there is high packet loss detected</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1993-L2018'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1963-L1988'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -37195,7 +30840,7 @@ Emitted when ever there is high packet loss detected</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2027-L2048'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L1997-L2018'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -37260,12 +30905,362 @@ Emitted when ever there is high packet loss detected</p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='audiovideo'>
+      AudioVideo
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L94-L101'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>AudioVideo</p>
+
+    <div class='pre p1 fill-light mt0'>AudioVideo</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>audio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+          
+          
+            <ul>
+              
+                <li><code>audio.deviceId</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>
+                  
+                  </li>
+              
+            </ul>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>video</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+          
+          
+            <ul>
+              
+                <li><code>video.deviceId</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>
+                  
+                  </li>
+              
+            </ul>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='sharepreferences'>
+      SharePreferences
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L103-L108'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>SharePreferences</p>
+
+    <div class='pre p1 fill-light mt0'>SharePreferences</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>shareConstraints</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>highFrameRate</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>?)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='joinoptions'>
+      JoinOptions
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L110-L120'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>JoinOptions</p>
+
+    <div class='pre p1 fill-light mt0'>JoinOptions</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>resourceId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>pin</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>moderator</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>?)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>meetingQuality</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)?)</code>
+          
+          
+            <ul>
+              
+                <li><code>meetingQuality.local</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?
+                  
+                  </li>
+              
+                <li><code>meetingQuality.remote</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?
+                  
+                  </li>
+              
+            </ul>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>rejoin</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>?)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='recording'>
+      Recording
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L130-L135'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Recording</p>
+
+    <div class='pre p1 fill-light mt0'>Recording</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>state</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>modifiedBy</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='meeting'>
       meeting
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L102-L102'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L102-L102'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/state.js</span>
       </a>
     
@@ -37319,7 +31314,7 @@ Emitted when ever there is high packet loss detected</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2458-L2598'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js#L2428-L2557'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/index.js</span>
       </a>
     
@@ -37396,7 +31391,7 @@ Emitted when ever there is high packet loss detected</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L35-L926'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L35-L926'>
       <span>packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js</span>
       </a>
     
@@ -37453,7 +31448,7 @@ Emitted when ever there is high packet loss detected</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L161-L163'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L161-L163'>
       <span>packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js</span>
       </a>
     
@@ -37533,7 +31528,7 @@ Emitted when ever there is high packet loss detected</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L172-L251'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L172-L251'>
       <span>packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js</span>
       </a>
     
@@ -37599,7 +31594,7 @@ Emitted when ever there is high packet loss detected</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L273-L287'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L273-L287'>
       <span>packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js</span>
       </a>
     
@@ -37678,7 +31673,7 @@ Emitted when ever there is high packet loss detected</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L296-L309'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L296-L309'>
       <span>packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js</span>
       </a>
     
@@ -37744,7 +31739,7 @@ Emitted when ever there is high packet loss detected</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/analyzer/analyzer.js#L19-L76'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/analyzer/analyzer.js#L19-L76'>
       <span>packages/node_modules/@webex/plugin-meetings/src/analyzer/analyzer.js</span>
       </a>
     
@@ -37870,7 +31865,7 @@ Emitted when ever there is high packet loss detected</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L379-L388'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L379-L388'>
       <span>packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js</span>
       </a>
     
@@ -37967,7 +31962,7 @@ Emitted when ever there is high packet loss detected</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L35-L926'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js#L35-L926'>
       <span>packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js</span>
       </a>
     
@@ -38054,7 +32049,7 @@ Emitted when ever there is high packet loss detected</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/events/events-scope.js#L13-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/events/events-scope.js#L13-L26'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/events/events-scope.js</span>
       </a>
     
@@ -38115,7 +32110,7 @@ Used to emit events internally between modules specific to an object</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/events/events-scope.js#L21-L25'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/events/events-scope.js#L21-L25'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/events/events-scope.js</span>
       </a>
     
@@ -38213,12 +32208,93 @@ Used to emit events internally between modules specific to an object</p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='seqoptions'>
+      SeqOptions
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/index.js#L20-L25'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/roap/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>SeqOptions</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>correlationId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>mediaId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>seq</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='roapoptions'>
       RoapOptions
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/index.js#L11-L18'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/index.js#L11-L18'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/index.js</span>
       </a>
     
@@ -38301,93 +32377,12 @@ Used to emit events internally between modules specific to an object</p>
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='seqoptions'>
-      SeqOptions
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/index.js#L20-L25'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/roap/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-    <div class='pre p1 fill-light mt0'>SeqOptions</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>correlationId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>mediaId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>seq</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='roaphandler'>
       RoapHandler
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js#L68-L250'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js#L68-L250'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/handler.js</span>
       </a>
     
@@ -38438,7 +32433,7 @@ Used to emit events internally between modules specific to an object</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js#L85-L154'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js#L85-L154'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/handler.js</span>
       </a>
     
@@ -38532,7 +32527,7 @@ Used to emit events internally between modules specific to an object</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js#L165-L177'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js#L165-L177'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/handler.js</span>
       </a>
     
@@ -38642,7 +32637,7 @@ Used to emit events internally between modules specific to an object</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js#L187-L227'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js#L187-L227'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/handler.js</span>
       </a>
     
@@ -38744,7 +32739,7 @@ Used to emit events internally between modules specific to an object</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js#L234-L249'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js#L234-L249'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/handler.js</span>
       </a>
     
@@ -38830,7 +32825,7 @@ Used to emit events internally between modules specific to an object</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/request.js#L20-L193'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/request.js#L20-L193'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/request.js</span>
       </a>
     
@@ -38881,7 +32876,7 @@ Used to emit events internally between modules specific to an object</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/request.js#L28-L46'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/request.js#L28-L46'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/request.js</span>
       </a>
     
@@ -38968,7 +32963,7 @@ Used to emit events internally between modules specific to an object</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/request.js#L126-L192'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/request.js#L126-L192'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/request.js</span>
       </a>
     
@@ -39111,7 +33106,7 @@ Used to emit events internally between modules specific to an object</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L12-L229'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L12-L229'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39162,7 +33157,7 @@ Used to emit events internally between modules specific to an object</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L56-L58'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L56-L58'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39228,7 +33223,7 @@ Used to emit events internally between modules specific to an object</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L99-L103'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L99-L103'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39309,7 +33304,7 @@ and setRemoteShareTrack.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L114-L116'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L114-L116'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39389,7 +33384,7 @@ and setRemoteShareTrack.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L123-L125'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L123-L125'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39469,7 +33464,7 @@ and setRemoteShareTrack.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L132-L134'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L132-L134'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39549,7 +33544,7 @@ and setRemoteShareTrack.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L161-L165'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L161-L165'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39616,7 +33611,7 @@ and setRemoteShareTrack.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L171-L174'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L171-L174'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39682,7 +33677,7 @@ and setRemoteShareTrack.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L190-L194'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L190-L194'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39749,7 +33744,7 @@ and setRemoteShareTrack.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L200-L203'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L200-L203'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39815,7 +33810,7 @@ and setRemoteShareTrack.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L215-L219'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L215-L219'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39882,7 +33877,7 @@ and setRemoteShareTrack.
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L225-L228'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/media/properties.js#L225-L228'>
       <span>packages/node_modules/@webex/plugin-meetings/src/media/properties.js</span>
       </a>
     
@@ -39956,7 +33951,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L16-L173'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L16-L173'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/state.js</span>
       </a>
     
@@ -40032,7 +34027,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L47-L59'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L47-L59'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/state.js</span>
       </a>
     
@@ -40138,7 +34133,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L71-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L71-L73'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js</span>
       </a>
     
@@ -40256,7 +34251,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L69-L71'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L69-L71'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/video.js</span>
       </a>
     
@@ -40331,7 +34326,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L111-L126'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L111-L126'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/state.js</span>
       </a>
     
@@ -40416,7 +34411,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L133-L148'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L133-L148'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/state.js</span>
       </a>
     
@@ -40501,7 +34496,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L155-L157'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L155-L157'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/state.js</span>
       </a>
     
@@ -40584,7 +34579,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L166-L168'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js#L166-L168'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/state.js</span>
       </a>
     
@@ -40659,7 +34654,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L53-L137'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L53-L137'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js</span>
       </a>
     
@@ -40743,7 +34738,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L85-L87'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L85-L87'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js</span>
       </a>
     
@@ -40805,7 +34800,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L83-L85'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L83-L85'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/video.js</span>
       </a>
     
@@ -40867,7 +34862,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L93-L95'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L93-L95'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js</span>
       </a>
     
@@ -40929,7 +34924,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L90-L92'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L90-L92'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/video.js</span>
       </a>
     
@@ -40991,7 +34986,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L102-L105'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L102-L105'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js</span>
       </a>
     
@@ -41066,7 +35061,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L101-L104'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L101-L104'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/video.js</span>
       </a>
     
@@ -41175,7 +35170,7 @@ and setRemoteShareTrack.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L114-L126'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L114-L126'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js</span>
       </a>
     
@@ -41261,7 +35256,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L114-L126'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L114-L126'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/video.js</span>
       </a>
     
@@ -41347,7 +35342,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L131-L133'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js#L131-L133'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js</span>
       </a>
     
@@ -41408,7 +35403,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L131-L133'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L131-L133'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/video.js</span>
       </a>
     
@@ -41469,7 +35464,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L54-L137'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js#L54-L137'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/video.js</span>
       </a>
     
@@ -41578,7 +35573,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js#L66-L72'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js#L66-L72'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js</span>
       </a>
     
@@ -41656,7 +35651,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js#L670-L695'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js#L670-L695'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js</span>
       </a>
     
@@ -41732,7 +35727,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js#L753-L772'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js#L753-L772'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js</span>
       </a>
     
@@ -41808,7 +35803,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js#L804-L927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js#L804-L927'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js</span>
       </a>
     
@@ -41893,7 +35888,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L23-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L23-L52'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js</span>
       </a>
     
@@ -41976,7 +35971,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L147-L153'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L147-L153'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js</span>
       </a>
     
@@ -42051,7 +36046,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L160-L166'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L160-L166'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js</span>
       </a>
     
@@ -42126,7 +36121,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L180-L181'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L180-L181'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js</span>
       </a>
     
@@ -42209,7 +36204,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L188-L188'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L188-L188'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js</span>
       </a>
     
@@ -42283,7 +36278,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L194-L194'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L194-L194'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js</span>
       </a>
     
@@ -42357,7 +36352,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L201-L207'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L201-L207'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js</span>
       </a>
     
@@ -42439,7 +36434,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L226-L236'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L226-L236'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js</span>
       </a>
     
@@ -42529,7 +36524,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L253-L260'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js#L253-L260'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js</span>
       </a>
     
@@ -42628,7 +36623,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js#L8-L16'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js#L8-L16'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js</span>
       </a>
     
@@ -42703,7 +36698,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js#L25-L36'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js#L25-L36'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js</span>
       </a>
     
@@ -42786,7 +36781,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js#L44-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js#L44-L44'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js</span>
       </a>
     
@@ -42869,7 +36864,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js#L51-L57'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js#L51-L57'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/hostUtils.js</span>
       </a>
     
@@ -42939,94 +36934,12 @@ If this fails, return false will cancel the transition and the state will remain
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='locuscontrols'>
-      LocusControls
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js#L5-L12'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Controls</p>
-
-    <div class='pre p1 fill-light mt0'>LocusControls</div>
-  
-    <p>
-      Type:
-      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>record</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-          
-          
-            <ul>
-              
-                <li><code>record.recording</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>
-                  
-                  </li>
-              
-                <li><code>record.meta</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
-                  
-                  </li>
-              
-            </ul>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='parse'>
       parse
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js#L20-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js#L20-L33'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js</span>
       </a>
     
@@ -43107,7 +37020,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js#L41-L57'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js#L41-L57'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js</span>
       </a>
     
@@ -43192,7 +37105,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js#L64-L70'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js#L64-L70'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js</span>
       </a>
     
@@ -43262,12 +37175,94 @@ If this fails, return false will cancel the transition and the state will remain
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='locuscontrols'>
+      LocusControls
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js#L5-L12'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Controls</p>
+
+    <div class='pre p1 fill-light mt0'>LocusControls</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>record</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+          
+          
+            <ul>
+              
+                <li><code>record.recording</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>
+                  
+                  </li>
+              
+                <li><code>record.meta</code> <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+                  
+                  </li>
+              
+            </ul>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='parse'>
       parse
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L10-L19'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L10-L19'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js</span>
       </a>
     
@@ -43342,7 +37337,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L28-L36'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L28-L36'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js</span>
       </a>
     
@@ -43425,7 +37420,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L43-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L43-L47'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js</span>
       </a>
     
@@ -43500,7 +37495,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L54-L60'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L54-L60'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js</span>
       </a>
     
@@ -43575,7 +37570,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L67-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L67-L73'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js</span>
       </a>
     
@@ -43650,7 +37645,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L80-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L80-L84'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js</span>
       </a>
     
@@ -43725,7 +37720,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L91-L99'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js#L91-L99'>
       <span>packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js</span>
       </a>
     
@@ -43800,7 +37795,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L31-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L31-L31'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js</span>
       </a>
     
@@ -43861,7 +37856,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L39-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L39-L52'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js</span>
       </a>
     
@@ -43922,7 +37917,7 @@ If this fails, return false will cancel the transition and the state will remain
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L58-L493'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L58-L493'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js</span>
       </a>
     
@@ -43971,7 +37966,7 @@ If this fails, return false will cancel the transition and the state will remain
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L123-L137'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L123-L137'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js</span>
       </a>
     
@@ -44038,7 +38033,7 @@ related timeout data within the iceState.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L149-L172'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L149-L172'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js</span>
       </a>
     
@@ -44107,7 +38102,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L179-L183'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L179-L183'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js</span>
       </a>
     
@@ -44172,7 +38167,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L219-L284'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L219-L284'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js</span>
       </a>
     
@@ -44298,7 +38293,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L356-L412'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js#L356-L412'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js</span>
       </a>
     
@@ -44386,7 +38381,7 @@ duration is reached.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/state.js#L102-L144'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/state.js#L102-L144'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/state.js</span>
       </a>
     
@@ -44461,7 +38456,7 @@ duration is reached.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/state.js#L116-L124'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/state.js#L116-L124'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/state.js</span>
       </a>
     
@@ -44553,7 +38548,7 @@ duration is reached.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/roap/state.js#L133-L139'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/roap/state.js#L133-L139'>
       <span>packages/node_modules/@webex/plugin-meetings/src/roap/state.js</span>
       </a>
     
@@ -44628,7 +38623,7 @@ duration is reached.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L25-L419'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L25-L419'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -44679,7 +38674,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L41-L118'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L41-L118'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -44855,7 +38850,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L127-L147'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L127-L147'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -44968,7 +38963,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L156-L176'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L156-L176'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -45081,7 +39076,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L188-L211'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L188-L211'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -45217,7 +39212,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L221-L236'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L221-L236'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -45336,7 +39331,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L246-L260'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L246-L260'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -45455,7 +39450,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L285-L300'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L285-L300'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -45574,7 +39569,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L312-L333'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L312-L333'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -45715,7 +39710,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L345-L375'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L345-L375'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -45856,7 +39851,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L385-L397'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L385-L397'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -45976,7 +39971,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L407-L418'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L407-L418'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -46096,7 +40091,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L18-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L18-L27'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/request.js</span>
       </a>
     
@@ -46162,7 +40157,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L33-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L33-L35'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/request.js</span>
       </a>
     
@@ -46228,7 +40223,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L44-L64'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L44-L64'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/request.js</span>
       </a>
     
@@ -46316,7 +40311,7 @@ duration is reached.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L13-L65'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L13-L65'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/request.js</span>
       </a>
     
@@ -46367,7 +40362,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L41-L118'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L41-L118'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -46543,7 +40538,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L127-L147'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L127-L147'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -46656,7 +40651,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L156-L176'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L156-L176'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -46769,7 +40764,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L188-L211'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L188-L211'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -46905,7 +40900,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L221-L236'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L221-L236'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -47024,7 +41019,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L246-L260'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L246-L260'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -47143,7 +41138,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L285-L300'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L285-L300'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -47262,7 +41257,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L312-L333'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L312-L333'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -47403,7 +41398,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L345-L375'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L345-L375'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -47544,7 +41539,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L385-L397'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L385-L397'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -47664,7 +41659,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L407-L418'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js#L407-L418'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/request.js</span>
       </a>
     
@@ -47784,7 +41779,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L18-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L18-L27'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/request.js</span>
       </a>
     
@@ -47850,7 +41845,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L33-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L33-L35'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/request.js</span>
       </a>
     
@@ -47916,7 +41911,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L44-L64'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js#L44-L64'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/request.js</span>
       </a>
     
@@ -48004,7 +41999,7 @@ duration is reached.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L62-L671'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L62-L671'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48053,7 +42048,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L423-L433'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L423-L433'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48149,7 +42144,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L444-L454'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L444-L454'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48245,7 +42240,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L465-L475'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L465-L475'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48341,7 +42336,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L485-L495'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L485-L495'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48437,7 +42432,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L505-L525'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L505-L525'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48532,7 +42527,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L583-L595'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L583-L595'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48619,7 +42614,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L604-L611'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L604-L611'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48698,7 +42693,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L620-L630'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L620-L630'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48777,7 +42772,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L640-L650'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L640-L650'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48866,7 +42861,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L660-L670'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L660-L670'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -48967,7 +42962,7 @@ duration is reached.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L62-L671'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L62-L671'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -49045,158 +43040,6 @@ Emitted when something in the roster list needs to be updated</p>
       </div>
     </div>
   
-    <div class='border-bottom' id='memberseventmemberscontentupdate'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>members:content:update</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L62-L671'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Members Content Update Event
-Emitted when who is sharing changes</p>
-
-    <div class='pre p1 fill-light mt0'>members:content:update</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>activeContentSharingId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>endedContentSharingId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
-    <div class='border-bottom' id='memberseventmembershostupdate'>
-      <div class="clearfix small pointer toggle-sibling">
-        <div class="py1 contain">
-            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>members:host:update</span>
-        </div>
-      </div>
-      <div class="clearfix display-none toggle-target">
-        <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L62-L671'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Members Host Update Event
-Emitted when who is the host changes</p>
-
-    <div class='pre p1 fill-light mt0'>members:host:update</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Properties</div>
-    <div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>activeHostId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-          
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <span class='code bold'>endedHostId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
-          
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-      </div>
-    </div>
-  
     <div class='border-bottom' id='memberseventmembersselfupdate'>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
@@ -49211,7 +43054,7 @@ Emitted when who is the host changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L62-L671'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L62-L671'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
       </a>
     
@@ -49273,6 +43116,158 @@ Emitted when who is the self changes</p>
       </div>
     </div>
   
+    <div class='border-bottom' id='memberseventmembershostupdate'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>members:host:update</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L62-L671'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Members Host Update Event
+Emitted when who is the host changes</p>
+
+    <div class='pre p1 fill-light mt0'>members:host:update</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>activeHostId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>endedHostId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='memberseventmemberscontentupdate'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>members:content:update</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/index.js#L62-L671'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/members/index.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Members Content Update Event
+Emitted when who is sharing changes</p>
+
+    <div class='pre p1 fill-light mt0'>members:content:update</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>activeContentSharingId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>endedContentSharingId</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
 </div>
 
   
@@ -49291,7 +43286,7 @@ Emitted when who is the self changes</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L16-L386'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L16-L386'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -49340,7 +43335,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L286-L288'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L286-L288'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -49419,7 +43414,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L297-L299'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L297-L299'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -49498,7 +43493,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L308-L310'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L308-L310'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -49577,7 +43572,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L320-L327'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L320-L327'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -49664,7 +43659,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L337-L339'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L337-L339'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -49759,7 +43754,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L45-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L45-L45'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -49822,7 +43817,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L53-L53'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L53-L53'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -49885,7 +43880,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L60-L60'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L60-L60'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -49947,7 +43942,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L67-L67'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L67-L67'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50009,7 +44004,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L74-L74'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L74-L74'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50071,7 +44066,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L81-L81'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L81-L81'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50133,7 +44128,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L88-L88'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L88-L88'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50195,7 +44190,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L95-L95'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L95-L95'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50257,7 +44252,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L102-L102'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L102-L102'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50319,7 +44314,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L109-L109'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L109-L109'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50381,7 +44376,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L116-L116'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L116-L116'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50443,7 +44438,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L123-L123'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L123-L123'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50505,7 +44500,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L130-L130'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L130-L130'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50567,7 +44562,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L137-L137'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L137-L137'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50629,7 +44624,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L145-L145'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L145-L145'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50692,7 +44687,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L152-L152'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L152-L152'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50754,7 +44749,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L159-L159'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L159-L159'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50816,7 +44811,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L166-L166'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L166-L166'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50878,7 +44873,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L180-L180'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L180-L180'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -50940,7 +44935,7 @@ Emitted when who is the self changes</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L187-L187'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/index.js#L187-L187'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/index.js</span>
       </a>
     
@@ -51010,7 +45005,7 @@ Emitted when who is the self changes</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L26-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L26-L26'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51085,7 +45080,7 @@ Emitted when who is the self changes</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L34-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L34-L34'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51160,7 +45155,7 @@ Emitted when who is the self changes</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L40-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L40-L40'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51235,7 +45230,7 @@ Emitted when who is the self changes</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L51-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L51-L52'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51320,7 +45315,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L61-L63'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L61-L63'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51405,7 +45400,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L71-L74'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L71-L74'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51496,7 +45491,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L80-L96'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L80-L96'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51571,7 +45566,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L102-L108'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L102-L108'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51646,7 +45641,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L116-L127'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L116-L127'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51729,7 +45724,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L134-L143'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L134-L143'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51804,7 +45799,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L149-L158'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L149-L158'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51879,7 +45874,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L195-L216'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L195-L216'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -51954,7 +45949,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L222-L228'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L222-L228'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -52029,7 +46024,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L234-L240'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/member/util.js#L234-L240'>
       <span>packages/node_modules/@webex/plugin-meetings/src/member/util.js</span>
       </a>
     
@@ -52104,7 +46099,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/collection.js#L6-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/collection.js#L6-L40'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/collection.js</span>
       </a>
     
@@ -52153,7 +46148,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/collection.js#L37-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/collection.js#L37-L39'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/collection.js</span>
       </a>
     
@@ -52226,7 +46221,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/collection.js#L29-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/collection.js#L29-L31'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/collection.js</span>
       </a>
     
@@ -52312,7 +46307,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/request.js#L12-L76'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/request.js#L12-L76'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/request.js</span>
       </a>
     
@@ -52361,7 +46356,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/request.js#L22-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/request.js#L22-L29'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/request.js</span>
       </a>
     
@@ -52448,7 +46443,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/request.js#L38-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/request.js#L38-L45'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/request.js</span>
       </a>
     
@@ -52544,7 +46539,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L18-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L18-L22'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/util.js</span>
       </a>
     
@@ -52635,7 +46630,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L29-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L29-L32'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/util.js</span>
       </a>
     
@@ -52717,7 +46712,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L38-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L38-L45'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/util.js</span>
       </a>
     
@@ -52794,7 +46789,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L51-L53'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L51-L53'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/util.js</span>
       </a>
     
@@ -52869,7 +46864,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L59-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L59-L68'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/util.js</span>
       </a>
     
@@ -52944,7 +46939,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L74-L83'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/members/util.js#L74-L83'>
       <span>packages/node_modules/@webex/plugin-meetings/src/members/util.js</span>
       </a>
     
@@ -53019,7 +47014,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/errors/intent-to-join.js#L6-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/errors/intent-to-join.js#L6-L22'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/errors/intent-to-join.js</span>
       </a>
     
@@ -53103,7 +47098,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/errors/join-meeting.js#L6-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/errors/join-meeting.js#L6-L23'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/errors/join-meeting.js</span>
       </a>
     
@@ -53196,7 +47191,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/errors/permission.js#L6-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/errors/permission.js#L6-L20'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/errors/permission.js</span>
       </a>
     
@@ -53280,7 +47275,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L14-L320'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L14-L320'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -53329,7 +47324,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L105-L107'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L105-L107'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -53407,7 +47402,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L115-L119'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L115-L119'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -53485,7 +47480,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L128-L137'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L128-L137'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -53572,7 +47567,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L146-L156'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L146-L156'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -53659,7 +47654,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L165-L171'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L165-L171'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -53737,7 +47732,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L180-L186'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L180-L186'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -53815,7 +47810,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L195-L204'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L195-L204'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -53902,7 +47897,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L213-L223'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L213-L223'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -53989,7 +47984,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L230-L232'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L230-L232'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54054,7 +48049,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L239-L241'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L239-L241'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54119,7 +48114,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L249-L251'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L249-L251'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54197,7 +48192,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L259-L261'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L259-L261'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54275,7 +48270,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L268-L272'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L268-L272'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54340,7 +48335,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L279-L283'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L279-L283'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54405,7 +48400,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L291-L301'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L291-L301'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54483,7 +48478,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L309-L319'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L309-L319'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54569,7 +48564,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L45-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L45-L45'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54631,7 +48626,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L52-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L52-L52'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54693,7 +48688,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L66-L66'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/index.js#L66-L66'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/index.js</span>
       </a>
     
@@ -54763,7 +48758,7 @@ there are multiple ids that can be used</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L19-L477'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L19-L477'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -54812,7 +48807,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L165-L169'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L165-L169'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -54890,7 +48885,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L177-L183'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L177-L183'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -54968,7 +48963,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L191-L195'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L191-L195'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55046,7 +49041,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L250-L256'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L250-L256'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55133,7 +49128,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L265-L271'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L265-L271'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55212,7 +49207,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L279-L285'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L279-L285'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55278,7 +49273,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L293-L299'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L293-L299'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55344,7 +49339,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L309-L319'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L309-L319'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55431,7 +49426,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L328-L334'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L328-L334'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55517,7 +49512,7 @@ there are multiple ids that can be used</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L344-L353'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L344-L353'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55597,7 +49592,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L360-L362'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L360-L362'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55662,7 +49657,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L370-L372'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L370-L372'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55740,7 +49735,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L380-L382'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L380-L382'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55818,7 +49813,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L390-L392'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L390-L392'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55896,7 +49891,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L400-L402'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L400-L402'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -55974,7 +49969,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L410-L412'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L410-L412'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -56052,7 +50047,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L420-L422'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L420-L422'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -56130,7 +50125,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L429-L431'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L429-L431'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -56195,7 +50190,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L438-L440'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L438-L440'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -56260,7 +50255,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L447-L449'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L447-L449'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -56325,7 +50320,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L456-L458'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L456-L458'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -56390,7 +50385,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L465-L467'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L465-L467'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -56455,7 +50450,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L474-L476'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stats.js#L474-L476'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/stats.js</span>
       </a>
     
@@ -56530,7 +50525,7 @@ takes params as precedence</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L8-L107'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L8-L107'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -56593,7 +50588,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L35-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L35-L37'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -56662,7 +50657,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L45-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L45-L47'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -56728,7 +50723,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L56-L58'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L56-L58'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -56808,7 +50803,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L66-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L66-L68'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -56882,7 +50877,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L20-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L20-L20'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -56944,7 +50939,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L27-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L27-L27'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57006,7 +51001,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L74-L79'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L74-L79'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57072,7 +51067,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L86-L88'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L86-L88'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57151,7 +51146,7 @@ takes params as precedence</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L97-L106'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L97-L106'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57241,7 +51236,7 @@ to make space for the new stats data report to be added to the front
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L8-L107'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L8-L107'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57290,7 +51285,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L35-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L35-L37'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57359,7 +51354,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L45-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L45-L47'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57425,7 +51420,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L56-L58'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L56-L58'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57505,7 +51500,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L66-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L66-L68'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57579,7 +51574,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L20-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L20-L20'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57641,7 +51636,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L27-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L27-L27'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57703,7 +51698,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L74-L79'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L74-L79'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57769,7 +51764,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L86-L88'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L86-L88'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57848,7 +51843,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L97-L106'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/history.js#L97-L106'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/history.js</span>
       </a>
     
@@ -57933,12 +51928,285 @@ to make space for the new stats data report to be added to the front
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='statsstream'>
+      StatsStream
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/stream.js#L55-L107'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/stats/stream.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Polls an <a href="https://developer.mozilla.org/docs/Web/API/RTCPeerConnection">RTCPeerConnection</a> once per second and emits its <a href="https://developer.mozilla.org/docs/Web/API/RTCStatsReport">RTCStatsReport</a>
+<a href="https://developer.mozilla.org/docs/Web/API/RTCStatsReport">RTCStatsReport</a></p>
+
+    <div class='pre p1 fill-light mt0'>new StatsStream(config: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</div>
+  
+  
+    <p>
+      Extends
+      
+        Readable
+      
+    </p>
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>config</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+            = <code>{}</code>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='statsstream'>
+      StatsStream
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/stats/stream.js#L46-L89'>
+      <span>packages/node_modules/@webex/plugin-phone/src/stats/stream.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Polls an <a href="https://developer.mozilla.org/docs/Web/API/RTCPeerConnection">RTCPeerConnection</a> once per second and emits its
+<a href="https://developer.mozilla.org/docs/Web/API/RTCStatsReport">RTCStatsReport</a></p>
+
+    <div class='pre p1 fill-light mt0'>new StatsStream(pc: <a href="https://developer.mozilla.org/docs/Web/API/RTCPeerConnection">RTCPeerConnection</a>)</div>
+  
+  
+    <p>
+      Extends
+      
+        Readable
+      
+    </p>
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>pc</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/API/RTCPeerConnection">RTCPeerConnection</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='statsfilter'>
+      StatsFilter
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/filter.js#L9-L40'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/stats/filter.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Reforms the interesting data from an RTCStatsReport to a new format</p>
+
+    <div class='pre p1 fill-light mt0'>new StatsFilter()</div>
+  
+  
+    <p>
+      Extends
+      
+        Transform
+      
+    </p>
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='statsfilter'>
+      StatsFilter
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/stats/filter.js#L6-L83'>
+      <span>packages/node_modules/@webex/plugin-phone/src/stats/filter.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Reforms the interesting data from an RTCStatsReport into something grokkable</p>
+
+    <div class='pre p1 fill-light mt0'>new StatsFilter()</div>
+  
+  
+    <p>
+      Extends
+      
+        Transform
+      
+    </p>
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='webrtcdata'>
       WebRTCData
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/data.js#L10-L56'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/data.js#L10-L56'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/data.js</span>
       </a>
     
@@ -57989,7 +52257,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/data.js#L23-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/data.js#L23-L31'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/data.js</span>
       </a>
     
@@ -58055,7 +52323,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/data.js#L37-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/data.js#L37-L39'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/data.js</span>
       </a>
     
@@ -58121,7 +52389,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/data.js#L45-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/data.js#L45-L47'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/data.js</span>
       </a>
     
@@ -58187,7 +52455,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/data.js#L53-L55'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/data.js#L53-L55'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/data.js</span>
       </a>
     
@@ -58261,7 +52529,7 @@ to make space for the new stats data report to be added to the front
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/events.js#L51-L185'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/events.js#L51-L185'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/events.js</span>
       </a>
     
@@ -58312,7 +52580,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/events.js#L104-L127'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/events.js#L104-L127'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/events.js</span>
       </a>
     
@@ -58391,7 +52659,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/events.js#L133-L172'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/events.js#L133-L172'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/events.js</span>
       </a>
     
@@ -58457,7 +52725,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/stats/events.js#L179-L184'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/stats/events.js#L179-L184'>
       <span>packages/node_modules/@webex/plugin-meetings/src/stats/events.js</span>
       </a>
     
@@ -58544,7 +52812,7 @@ to make space for the new stats data report to be added to the front
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/errors/stats.js#L6-L21'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/errors/stats.js#L6-L21'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/errors/stats.js</span>
       </a>
     
@@ -58628,7 +52896,7 @@ to make space for the new stats data report to be added to the front
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/errors/reconnection-in-progress.js#L8-L8'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/errors/reconnection-in-progress.js#L8-L8'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/errors/reconnection-in-progress.js</span>
       </a>
     
@@ -58688,7 +52956,7 @@ to make space for the new stats data report to be added to the front
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/metrics/mqa-processor.js#L14-L116'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/metrics/mqa-processor.js#L14-L116'>
       <span>packages/node_modules/@webex/plugin-meetings/src/metrics/mqa-processor.js</span>
       </a>
     
@@ -58738,7 +53006,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/metrics/mqa-processor.js#L36-L93'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/metrics/mqa-processor.js#L36-L93'>
       <span>packages/node_modules/@webex/plugin-meetings/src/metrics/mqa-processor.js</span>
       </a>
     
@@ -58825,7 +53093,7 @@ to make space for the new stats data report to be added to the front
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/metrics/mqa-processor.js#L102-L115'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/metrics/mqa-processor.js#L102-L115'>
       <span>packages/node_modules/@webex/plugin-meetings/src/metrics/mqa-processor.js</span>
       </a>
     
@@ -58903,7 +53171,7 @@ this method clears the data as a side effect</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meeting/in-meeting-actions.js#L12-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meeting/in-meeting-actions.js#L12-L44'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meeting/in-meeting-actions.js</span>
       </a>
     
@@ -58956,7 +53224,7 @@ this method clears the data as a side effect</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L13-L149'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L13-L149'>
       <span>packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js</span>
       </a>
     
@@ -59005,7 +53273,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L90-L108'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L90-L108'>
       <span>packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js</span>
       </a>
     
@@ -59102,7 +53370,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L132-L148'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L132-L148'>
       <span>packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js</span>
       </a>
     
@@ -59189,7 +53457,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L30-L30'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L30-L30'>
       <span>packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js</span>
       </a>
     
@@ -59252,7 +53520,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L38-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L38-L38'>
       <span>packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js</span>
       </a>
     
@@ -59315,7 +53583,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L46-L46'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L46-L46'>
       <span>packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js</span>
       </a>
     
@@ -59378,7 +53646,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L54-L54'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L54-L54'>
       <span>packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js</span>
       </a>
     
@@ -59441,7 +53709,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L62-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js#L62-L62'>
       <span>packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/index.js</span>
       </a>
     
@@ -59512,7 +53780,7 @@ this method clears the data as a side effect</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/request.js#L21-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/request.js#L21-L38'>
       <span>packages/node_modules/@webex/plugin-meetings/src/personal-meeting-room/request.js</span>
       </a>
     
@@ -59587,7 +53855,7 @@ this method clears the data as a side effect</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js#L22-L436'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js#L22-L436'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reachability/index.js</span>
       </a>
     
@@ -59636,7 +53904,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js#L58-L87'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js#L58-L87'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reachability/index.js</span>
       </a>
     
@@ -59712,7 +53980,7 @@ this method clears the data as a side effect</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reachability/request.js#L11-L56'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reachability/request.js#L11-L56'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reachability/request.js</span>
       </a>
     
@@ -59763,7 +54031,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reachability/request.js#L25-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reachability/request.js#L25-L37'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reachability/request.js</span>
       </a>
     
@@ -59829,7 +54097,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/reachability/request.js#L44-L55'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/reachability/request.js#L44-L55'>
       <span>packages/node_modules/@webex/plugin-meetings/src/reachability/request.js</span>
       </a>
     
@@ -59912,96 +54180,12 @@ this method clears the data as a side effect</p>
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='parametererror'>
-      ParameterError
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/errors/parameter.js#L6-L26'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/common/errors/parameter.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Extended Error object for general parameter errors</p>
-
-    <div class='pre p1 fill-light mt0'>new ParameterError(message: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?, error: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</div>
-  
-  
-    <p>
-      Extends
-      
-        <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>
-      
-    </p>
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>message</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?
-            = <code>ERROR_DICTIONARY.PARAMETER.MESSAGE</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>error</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?
-            = <code>null</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='difference'>
       difference
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/analyzer/calculator.js#L14-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/analyzer/calculator.js#L14-L43'>
       <span>packages/node_modules/@webex/plugin-meetings/src/analyzer/calculator.js</span>
       </a>
     
@@ -60084,7 +54268,7 @@ this method clears the data as a side effect</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/analyzer/calculator.js#L52-L75'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/analyzer/calculator.js#L52-L75'>
       <span>packages/node_modules/@webex/plugin-meetings/src/analyzer/calculator.js</span>
       </a>
     
@@ -60167,7 +54351,7 @@ this method clears the data as a side effect</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/collection.js#L8-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/collection.js#L8-L40'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/collection.js</span>
       </a>
     
@@ -60216,7 +54400,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/collection.js#L33-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/collection.js#L33-L39'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/collection.js</span>
       </a>
     
@@ -60313,7 +54497,7 @@ this method clears the data as a side effect</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L9-L92'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L9-L92'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/collection.js</span>
       </a>
     
@@ -60362,7 +54546,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L44-L46'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L44-L46'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/collection.js</span>
       </a>
     
@@ -60441,7 +54625,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L55-L59'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L55-L59'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/collection.js</span>
       </a>
     
@@ -60529,7 +54713,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L68-L70'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L68-L70'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/collection.js</span>
       </a>
     
@@ -60609,7 +54793,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L77-L79'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L77-L79'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/collection.js</span>
       </a>
     
@@ -60674,7 +54858,7 @@ this method clears the data as a side effect</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L87-L91'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/collection.js#L87-L91'>
       <span>packages/node_modules/@webex/plugin-meetings/src/common/collection.js</span>
       </a>
     
@@ -60758,68 +54942,12 @@ this method clears the data as a side effect</p>
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='eventmediacodecmissing'>
-      media:codec:missing
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js#L33-L33'>
-      <span>packages/node_modules/@webex/plugin-meetings/src/meetings/util.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Meetings Media Codec Missing Event
-Emitted when H.264 codec is not
-found in the browser.</p>
-
-    <div class='pre p1 fill-light mt0'>media:codec:missing</div>
-  
-  
-
-  
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-          
-        
-          
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='eventmediacodecloaded'>
       media:codec:loaded
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js#L33-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js#L33-L33'>
       <span>packages/node_modules/@webex/plugin-meetings/src/meetings/util.js</span>
       </a>
     
@@ -60870,12 +54998,152 @@ loaded in the browser.</p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='eventmediacodecmissing'>
+      media:codec:missing
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js#L33-L33'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/meetings/util.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Meetings Media Codec Missing Event
+Emitted when H.264 codec is not
+found in the browser.</p>
+
+    <div class='pre p1 fill-light mt0'>media:codec:missing</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='parametererror'>
+      ParameterError
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/common/errors/parameter.js#L6-L26'>
+      <span>packages/node_modules/@webex/plugin-meetings/src/common/errors/parameter.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Extended Error object for general parameter errors</p>
+
+    <div class='pre p1 fill-light mt0'>new ParameterError(message: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?, error: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?)</div>
+  
+  
+    <p>
+      Extends
+      
+        <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a>
+      
+    </p>
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>message</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">String</a>?
+            = <code>ERROR_DICTIONARY.PARAMETER.MESSAGE</code>)</code>
+	    
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>error</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>?
+            = <code>null</code>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='audio'>
       AUDIO
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/constants.js#L13-L13'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/constants.js#L13-L13'>
       <span>packages/node_modules/@webex/plugin-meetings/src/constants.js</span>
       </a>
     
@@ -60936,7 +55204,7 @@ loaded in the browser.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-meetings/src/constants.js#L1160-L1164'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-meetings/src/constants.js#L1160-L1164'>
       <span>packages/node_modules/@webex/plugin-meetings/src/constants.js</span>
       </a>
     
@@ -60986,12 +55254,1020 @@ loaded in the browser.</p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='phone'>
+      Phone
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L46-L312'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>new Phone()</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Static Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='phonelistactivecalls'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>listActiveCalls()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L192-L213'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Fetches a list of all of the current user's active calls</p>
+
+    <div class='pre p1 fill-light mt0'>listActiveCalls(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#call">Call</a>>></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#call">Call</a>>></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='phone_triggercallevents'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>_triggerCallEvents(call, locus)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L303-L311'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Triggers call events for a given call/locus</p>
+
+    <div class='pre p1 fill-light mt0'>_triggerCallEvents(call: <a href="#call">Call</a>, locus: Types~Locus): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>call</span> <code class='quiet'>(<a href="#call">Call</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>locus</span> <code class='quiet'>(Types~Locus)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Instance Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='phoneconnected'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>connected</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L59-L62'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Indicates whether or not the WebSocket is connected</p>
+
+    <div class='pre p1 fill-light mt0'>connected</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='phonedefaultfacingmode'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>defaultFacingMode</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L76-L80'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Specifies the facingMode to be used by <a href="#phonedial">Phone#dial</a> and
+<a href="#callanswer">Call#answer</a> when no constraint is specified. Does not apply if</p>
+<ul>
+<li>a <a href="MediaStream">MediaStream</a> is passed to <a href="#phonedial">Phone#dial</a> or
+<a href="#callanswer">Call#answer</a></li>
+<li>constraints are passed to <a href="#phonedial">Phone#dial</a> or  <a href="#callanswer">Call#answer</a>
+The only valid values are <code>user</code> and <code>environment</code>. For any other values,
+you must provide your own constrains or <a href="MediaStream">MediaStream</a></li>
+</ul>
+
+    <div class='pre p1 fill-light mt0'>defaultFacingMode</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='phoneregistered'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>registered</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L89-L92'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>indicates whether or not the client is registered with the Webex
+cloud</p>
+
+    <div class='pre p1 fill-light mt0'>registered</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='phoneiscallingsupported'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>isCallingSupported()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L105-L114'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Indicates if the current browser appears to support webrtc calling. Note:
+at this time, there's no way to determine if the current browser supports
+h264 without asking for camera permissions</p>
+
+    <div class='pre p1 fill-light mt0'>isCallingSupported(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a>></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='phoneregister'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>register()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L125-L149'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Registers the client with the Webex cloud and starts listening for
+WebSocket events.</p>
+<p>Subsequent calls refresh the device registration.</p>
+
+    <div class='pre p1 fill-light mt0'>register(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='phonederegister'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>deregister()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L159-L162'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Disconnects from WebSocket and unregisters from the Webex cloud.</p>
+<p>Subsequent calls will be a noop.</p>
+
+    <div class='pre p1 fill-light mt0'>deregister(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='phonecreatelocalmediastream'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>createLocalMediaStream(options)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L175-L184'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Create a MediaStream to be used for video preview.</p>
+<p>Note: You must explicitly pass the resultant stream to <a href="Call#answer()">Call#answer()</a>
+or <a href="Phone#dial()">Phone#dial()</a></p>
+
+    <div class='pre p1 fill-light mt0'>createLocalMediaStream(options: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | MediaStreamConstraints)): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;MediaStream></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | MediaStreamConstraints)
+            = <code>{}</code>)</code>
+	    
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.constraints</span> <code class='quiet'>MediaStreamConstraints</code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;MediaStream></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='phonedial'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>dial(dialString, options)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L288-L295'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Place a call to the specified dialString. A dial string may be an email
+address or sip uri.
+If you set <a href="config.phone.enableExperimentalGroupCallingSupport">config.phone.enableExperimentalGroupCallingSupport</a> to
+<code>true</code>, the dialString may also be a room id.</p>
+
+    <div class='pre p1 fill-light mt0'>dial(dialString: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="#call">Call</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>dialString</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+	    
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.constraints</span> <code class='quiet'>MediaStreamConstraints</code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.localMediaStream</span> <code class='quiet'>MediaStream</code>
+  </td>
+  <td class='break-word'><span>if no stream is specified, a
+new one will be created based on options.constraints
+</span></td>
+</tr>
+
+
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="#call">Call</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Events</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='phoneeventcallincoming'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>call:incoming</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L46-L312'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Incoming Call Event</p>
+<p>Emitted when a call begins and when <a href="#phoneregister">Phone#register</a> is invoked and
+there are active calls.</p>
+
+    <div class='pre p1 fill-light mt0'>call:incoming</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>call</span> <code class='quiet'>(<a href="#call">Call</a>)</code>
+          : The incoming call
+
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='phoneeventcallcreated'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>call:created</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/phone.js#L46-L312'>
+      <span>packages/node_modules/@webex/plugin-phone/src/phone.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Call Created Event</p>
+<p>Emitted when a call begins outside of the sdk</p>
+
+    <div class='pre p1 fill-light mt0'>call:created</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>call</span> <code class='quiet'>(<a href="#call">Call</a>)</code>
+          : The created call
+
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='has'>
       has
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/calls.js#L47-L63'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/calls.js#L47-L63'>
       <span>packages/node_modules/@webex/plugin-phone/src/calls.js</span>
       </a>
     
@@ -61061,12 +56337,4550 @@ loaded in the browser.</p>
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='phoneconfig'>
+      PhoneConfig
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/config.js#L5-L26'>
+      <span>packages/node_modules/@webex/plugin-phone/src/config.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>PhoneConfig</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>audioBandwidthLimit</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>videoBandwidthLimit</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>enableExperimentalGroupCallingSupport</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?)</code>
+          : Group
+calling support should work, but necessarily introduces some breaking changes
+to the API. In order to get feedback, we're keeping the API unchanged by
+default and requiring folks to opt-in to these breakages. As these changes
+evolve, you may see some breaking changes that don't necessarily follow
+semantic versioning. When we're ready to drop the "experimental" moniker,
+we'll release an official SemVer Major bump.
+
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'>{
+  <span class="hljs-attr">audioBandwidthLimit</span>: <span class="hljs-number">64000</span>,
+  <span class="hljs-attr">videoBandwidthLimit</span>: <span class="hljs-number">1000000</span>,
+  <span class="hljs-attr">enableExperimentalGroupCallingSupport</span>: <span class="hljs-literal">false</span>,
+  <span class="hljs-attr">hangupIfLastActive</span>: {
+    <span class="hljs-attr">call</span>: <span class="hljs-literal">true</span>,
+    <span class="hljs-attr">meeting</span>: <span class="hljs-literal">false</span>
+  }
+}</pre>
+    
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Static Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='phoneconfighangupbehavior'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>HangupBehavior</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/config.js#L28-L37'>
+      <span>packages/node_modules/@webex/plugin-phone/src/config.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>HangupBehavior</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>call</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?)</code>
+          :  Indicates if a call (i.e. two-party
+audio-video experience) should be ended automatically if the current user is
+the last active member of the experience.
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>meeting</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>?)</code>
+          : Indicates if a meeting (i.e.
+multi-party audio-video experience) should be ended automatically if the
+current user is the last active member of the experience
+
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='call'>
+      Call
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>new Call()</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Static Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='callgettargetfrominvitee'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>getTargetFromInvitee(invitee)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1035-L1070'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Gets the target from the invitee</p>
+
+    <div class='pre p1 fill-light mt0'>getTargetFromInvitee(invitee: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>invitee</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>></code>:
+        The locus target
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstartapplicationshare'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>startApplicationShare()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1740-L1750'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Shares a particular application as a second stream in the call</p>
+
+    <div class='pre p1 fill-light mt0'>startApplicationShare(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstartscreenshare'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>startScreenShare()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1756-L1766'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Shares the whole screen as a second stream in the call</p>
+
+    <div class='pre p1 fill-light mt0'>startScreenShare(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstopscreenshare'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>stopScreenShare()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1812-L1820'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Stops sharing an application or whole screen media stream</p>
+
+    <div class='pre p1 fill-light mt0'>stopScreenShare(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Instance Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='callmemberships'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>memberships</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L272-L272'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>memberships</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callremoteaudiomuted'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>remoteAudioMuted</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L289-L293'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Indicates if the other party in the call has turned off their microphone.
+<code>undefined</code> for multiparty calls</p>
+
+    <div class='pre p1 fill-light mt0'>remoteAudioMuted</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callremotevideomuted'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>remoteVideoMuted</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L303-L307'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Indicates if the other party in the call has turned off their camera.
+<code>undefined</code> for multiparty calls</p>
+
+    <div class='pre p1 fill-light mt0'>remoteVideoMuted</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callfacingmode'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>facingMode</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L316-L319'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>facingMode</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calllocalmediastream'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>localMediaStream</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L350-L350'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Returns the local MediaStream for the call. May initially be <code>null</code>
+between the time @{Phone#dial is invoked and the  media stream is
+acquired if <a href="#phonedial">Phone#dial</a> is invoked without a <code>localMediaStream</code>
+option.</p>
+<p>This property can also be set mid-call in which case the streams sent to
+the remote party are replaced by this stream. On success, the
+<a href="#call">Call</a>'s <a href="localMediaStream:change">localMediaStream:change</a> event fires, notifying any
+listeners that we are now sending media from a new source.</p>
+
+    <div class='pre p1 fill-light mt0'>localMediaStream</div>
+  
+    <p>
+      Type:
+      MediaStream
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callremotemember'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>remoteMember</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L461-L477'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>The other participant in a two-party call. <code>undefined</code> for multiparty
+calls</p>
+
+    <div class='pre p1 fill-light mt0'>remoteMember</div>
+  
+    <p>
+      Type:
+      <a href="#callmembership">CallMembership</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callfrom'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>from</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L504-L519'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>The initiating participant in a two-party call.</p>
+
+    <div class='pre p1 fill-light mt0'>from</div>
+  
+    <p>
+      Type:
+      <a href="#callmembership">CallMembership</a>
+    </p>
+  
+  
+
+  <div>Deprecated: The 
+<a href="#callfrom">Call#from</a>
+ attribute will likely be replaced by
+the 
+<a href="#callhost">Call#host</a>
+.
+</div>
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstate'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>state</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L550-L565'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p><b>active</b> - At least one person (not necessarily this user) is
+participating in the call<br/>
+<b>inactive</b> - No one is participating in the call<br/>
+<b>initializing</b> - reserved for future use<br/>
+<b>terminating</b> - reserved for future use<br/>
+Only defined if
+<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a> has been
+enabled</p>
+
+    <div class='pre p1 fill-light mt0'>state</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstatus'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>status</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L585-L596'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p><b>initiated</b> - Offer was sent to remote party but they have not yet
+accepted <br>
+<b>ringing</b> - Remote party has acknowledged the call <br>
+<b>connected</b> - At least one party is still on the call <br>
+<b>disconnected</b> - All parties have dropped <br>
+<b>replaced</b> - In (hopefully) rare cases, the underlying data backing
+a Call instance may change in such a way that further interaction with
+that Call is handled by a different instance. In such cases, the first
+Call's status, will transition to <code>replaced</code>, which is almost the same
+state as <code>disconnected</code>. Generally speaking, such a transition should not
+happen for a Call instance that is actively sending/receiving media.</p>
+
+    <div class='pre p1 fill-light mt0'>status</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+    </p>
+  
+  
+
+  <div>Deprecated: The 
+<a href="#callstatus">Call#status</a>
+ attribute will likely be replaced by
+the 
+<a href="#callstate">Call#state</a>
+.
+</div>
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callhost'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>host</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L607-L622'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>The host of the call
+Only defined if
+<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a> has been
+enabled</p>
+
+    <div class='pre p1 fill-light mt0'>host</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callroomid'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>roomId</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L633-L648'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>The room id of the call
+Only defined if
+<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a> has been
+enabled</p>
+
+    <div class='pre p1 fill-light mt0'>roomId</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callremotemediastream'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>remoteMediaStream</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L656-L665'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Access to the remote party’s <code>MediaStream</code>.</p>
+
+    <div class='pre p1 fill-light mt0'>remoteMediaStream</div>
+  
+    <p>
+      Type:
+      MediaStream
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calllocalscreenshare'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>localScreenShare</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L673-L682'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Access to the local party’s screen share <code>MediaStream</code>.</p>
+
+    <div class='pre p1 fill-light mt0'>localScreenShare</div>
+  
+    <p>
+      Type:
+      MediaStream
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callacknowledge'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>acknowledge()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L753-L759'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Use to acknowledge (without answering) an incoming call. Will cause the
+initiator's Call instance to emit the ringing event.</p>
+
+    <div class='pre p1 fill-light mt0'>acknowledge(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callanswer'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>answer</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L774-L793'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Answers an incoming call.</p>
+
+    <div class='pre p1 fill-light mt0'>answer</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+	    
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.constraints</span> <code class='quiet'>MediaStreamConstraints</code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callcreateorjoinlocus'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>createOrJoinLocus(target, options)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L896-L984'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Call and answer require nearly identical logic, so this method unifies them.</p>
+
+    <div class='pre p1 fill-light mt0'>createOrJoinLocus(target: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | locus), options: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>target</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | locus))</code>
+	    
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+            = <code>{}</code>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calldecline'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>decline()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L995-L997'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Alias of <a href="#callreject">Call#reject</a></p>
+
+    <div class='pre p1 fill-light mt0'>decline(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Related</div>
+    
+      
+        <a href="#callreject">Call#reject</a>
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callgetrawstatsstream'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>getRawStatsStream()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1079-L1081'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Returns a <a href="Readable">Readable</a> that emits <a href="Call#media.pc">Call#media.pc</a>'s
+<a href="https://developer.mozilla.org/docs/Web/API/RTCStatsReport">RTCStatsReport</a> every second.</p>
+
+    <div class='pre p1 fill-light mt0'>getRawStatsStream(): <a href="#statsstream">StatsStream</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="#statsstream">StatsStream</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callgetstatsstream'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>getStatsStream()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1089-L1092'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Returns a <a href="#statsstream">StatsStream</a> piped through a <a href="#statsfilter">StatsFilter</a></p>
+
+    <div class='pre p1 fill-light mt0'>getStatsStream(): Readable</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code>Readable</code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callhangup'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>hangup()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1102-L1125'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Disconnects the active call. Applies to both incoming and outgoing calls.
+This method may be invoked in any call state and the SDK should take care
+to tear down the call and free up all resources regardless of the state.</p>
+
+    <div class='pre p1 fill-light mt0'>hangup(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callreject'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>reject()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1600-L1612'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Rejects an incoming call. Only applies to incoming calls. Invoking this
+method on an outgoing call is a no-op.</p>
+
+    <div class='pre p1 fill-light mt0'>reject(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callsenddtmf'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>sendDtmf(tones)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1717-L1723'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Send DTMF tones to the current call</p>
+
+    <div class='pre p1 fill-light mt0'>sendDtmf(tones: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>tones</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callsendfeedback'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>sendFeedback(feedback)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1732-L1734'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Sends feedback about the call to the Webex cloud</p>
+
+    <div class='pre p1 fill-light mt0'>sendFeedback(feedback: <a href="#feedbackobject">FeedbackObject</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>feedback</span> <code class='quiet'>(<a href="#feedbackobject">FeedbackObject</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstartreceivingaudio'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>startReceivingAudio()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1774-L1776'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Start receiving audio</p>
+
+    <div class='pre p1 fill-light mt0'>startReceivingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstartreceivingvideo'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>startReceivingVideo()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1784-L1786'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Start receiving video</p>
+
+    <div class='pre p1 fill-light mt0'>startReceivingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstartsendingaudio'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>startSendingAudio()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1794-L1796'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Starts sending audio to the Webex Cloud</p>
+
+    <div class='pre p1 fill-light mt0'>startSendingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstartsendingvideo'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>startSendingVideo()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1804-L1806'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Starts sending video to the Webex Cloud</p>
+
+    <div class='pre p1 fill-light mt0'>startSendingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstopreceivingaudio'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>stopReceivingAudio()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1828-L1830'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Stop receiving audio</p>
+
+    <div class='pre p1 fill-light mt0'>stopReceivingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstopreceivingvideo'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>stopReceivingVideo()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1838-L1840'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Stop receiving video</p>
+
+    <div class='pre p1 fill-light mt0'>stopReceivingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstopsendingaudio'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>stopSendingAudio()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1849-L1851'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Stops sending audio to the Webex Cloud. (stops broadcast immediately,
+even if renegotiation has not completed)</p>
+
+    <div class='pre p1 fill-light mt0'>stopSendingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callstopsendingvideo'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>stopSendingVideo()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1860-L1862'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Stops sending video to the Webex Cloud. (stops broadcast immediately,
+even if renegotiation has not completed)</p>
+
+    <div class='pre p1 fill-light mt0'>stopSendingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calltogglefacingmode'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>toggleFacingMode()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1873-L1894'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Replaces the current mediaStrem with one with identical constraints, except
+for an opposite facing mode. If the current facing mode cannot be
+determined, the facing mode will be set to <code>user</code>. If the call is audio
+only, this function will throw.</p>
+
+    <div class='pre p1 fill-light mt0'>toggleFacingMode(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calltogglereceivingaudio'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>toggleReceivingAudio()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1902-L1904'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Toggles receiving audio from the Webex Cloud</p>
+
+    <div class='pre p1 fill-light mt0'>toggleReceivingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calltogglereceivingvideo'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>toggleReceivingVideo()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1912-L1914'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Toggles receiving video from the Webex Cloud</p>
+
+    <div class='pre p1 fill-light mt0'>toggleReceivingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calltogglesendingaudio'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>toggleSendingAudio()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1922-L1924'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Toggles sending audio to the Webex Cloud</p>
+
+    <div class='pre p1 fill-light mt0'>toggleSendingAudio(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calltogglesendingvideo'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>toggleSendingVideo()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L1932-L1934'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Toggles sending video to the Webex Cloud</p>
+
+    <div class='pre p1 fill-light mt0'>toggleSendingVideo(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></code>:
+        
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Events</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='calleventringing'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>ringing</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>ringing</div>
+  
+  
+
+  <div>Deprecated: with 
+<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a>
+
+enabled; instead, listen for 
+<a href="Call.membership:notified">Call.membership:notified</a>
+</div>
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventconnected'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>connected</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>connected</div>
+  
+  
+
+  <div>Deprecated: with 
+<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a>
+
+enabled; instead, listen for 
+<a href="Call.active">Call.active</a>
+</div>
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventdisconnected'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>disconnected</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>disconnected</div>
+  
+  
+
+  <div>Deprecated: with 
+<a href="PhoneConfig.enableExperimentalGroupCallingSupport">PhoneConfig.enableExperimentalGroupCallingSupport</a>
+
+enabled; instead, listen for 
+<a href="Call.inactive">Call.inactive</a>
+</div>
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventactive'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>active</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>only emitted if enableExperimentalGroupCallingSupport is enabled</p>
+
+    <div class='pre p1 fill-light mt0'>active</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventinitializing'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>initializing</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>only emitted if enableExperimentalGroupCallingSupport is enabled</p>
+
+    <div class='pre p1 fill-light mt0'>initializing</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventinactive'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>inactive</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>only emitted if enableExperimentalGroupCallingSupport is enabled</p>
+
+    <div class='pre p1 fill-light mt0'>inactive</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventterminating'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>terminating</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>only emitted if enableExperimentalGroupCallingSupport is enabled</p>
+
+    <div class='pre p1 fill-light mt0'>terminating</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventlocalmediastreamchange'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>localMediaStream:change</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>localMediaStream:change</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventremotemediastreamchange'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>remoteMediaStream:change</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>remoteMediaStream:change</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventerror'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>error</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>error</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventmembershipnotified'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>membership:notified</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>This replaces the <a href="Call.ringing">Call.ringing</a> event, but note that it's
+subtly different. <a href="Call.ringing">Call.ringing</a> is emitted when the remote party calls
+<a href="Call#acknowledge()">Call#acknowledge()</a> whereas <a href="Call.membership:notified">Call.membership:notified</a> emits
+shortly after (but as a direct result of) locally calling
+<a href="Phone#dial()">Phone#dial()</a></p>
+
+    <div class='pre p1 fill-light mt0'>membership:notified</div>
+  
+    <p>
+      Type:
+      <a href="#callmembership">CallMembership</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventmembershipconnected'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>membership:connected</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>membership:connected</div>
+  
+    <p>
+      Type:
+      <a href="#callmembership">CallMembership</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventmembershipdeclined'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>membership:declined</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>membership:declined</div>
+  
+    <p>
+      Type:
+      <a href="#callmembership">CallMembership</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventmembershipdisconnected'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>membership:disconnected</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>membership:disconnected</div>
+  
+    <p>
+      Type:
+      <a href="#callmembership">CallMembership</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventmembershipwaiting'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>membership:waiting</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>membership:waiting</div>
+  
+    <p>
+      Type:
+      <a href="#callmembership">CallMembership</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventmembershipchange'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>membership:change</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>membership:change</div>
+  
+    <p>
+      Type:
+      <a href="#callmembership">CallMembership</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventmembershipsadd'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>memberships:add</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Emitted when a new <a href="#callmembership">CallMembership</a> is added to
+<a href="#callmemberships">Call#memberships</a>. Note that <a href="#callmembershipstate">CallMembership#state</a> still needs
+to be read to determine if the instance represents someone actively
+participating the call.</p>
+
+    <div class='pre p1 fill-light mt0'>memberships:add</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='calleventmembershipsremove'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>memberships:remove</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call.js#L257-L2051'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Emitted when a <a href="#callmembership">CallMembership</a> is removed from
+<a href="#callmemberships">Call#memberships</a>.</p>
+
+    <div class='pre p1 fill-light mt0'>memberships:remove</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='callmemberships'>
+      CallMemberships
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call-memberships.js#L10-L15'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call-memberships.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>new CallMemberships()</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='callmembership'>
+      CallMembership
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L6-L120'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>new CallMembership()</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Instance Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='callmembershipisinitiator'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>isInitiator</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L43-L47'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Indicates if the member started the call</p>
+
+    <div class='pre p1 fill-light mt0'>isInitiator</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callmembershippersonid'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>personId</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L55-L57'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>personId</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callmembershipstate'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>state</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L84-L94'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Indicates the member's relationship with the call. One of</p>
+<ul>
+<li>notified - the party has been invited to the call but has not yet accepted</li>
+<li>connected - the party is participating in the call</li>
+<li>declined - the party chose not to accept the call</li>
+<li>disconnected - the party is no longer participating in the call</li>
+<li>waiting - reserved for future use</li>
+</ul>
+
+    <div class='pre p1 fill-light mt0'>state</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callmembershipaudiomuted'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>audioMuted</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L103-L106'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Indicates if the member has muted their microphone</p>
+
+    <div class='pre p1 fill-light mt0'>audioMuted</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='callmembershipvideomuted'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>videoMuted</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/call-membership.js#L115-L118'>
+      <span>packages/node_modules/@webex/plugin-phone/src/call-membership.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Indicates if the member has disable their camera</p>
+
+    <div class='pre p1 fill-light mt0'>videoMuted</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='findshare'>
       findShare
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/state-parsers.js#L47-L67'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/state-parsers.js#L47-L67'>
       <span>packages/node_modules/@webex/plugin-phone/src/state-parsers.js</span>
       </a>
     
@@ -61129,7 +60943,7 @@ shares</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-phone/src/state-parsers.js#L376-L378'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-phone/src/state-parsers.js#L376-L378'>
       <span>packages/node_modules/@webex/plugin-phone/src/state-parsers.js</span>
       </a>
     
@@ -61212,7 +61026,7 @@ shares</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L496-L522'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L496-L522'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     
@@ -61296,7 +61110,7 @@ shares</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/webex/webex-js-sdk/blob/661dd2805e7ff8122226f012dd4a048daf1006b9/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L530-L546'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/abailey-dev/webex-js-sdk/blob/527a86026f72d85f230993c9c70ccda31521f365/packages/node_modules/@webex/plugin-rooms/src/rooms.js#L530-L546'>
       <span>packages/node_modules/@webex/plugin-rooms/src/rooms.js</span>
       </a>
     

--- a/documentation/config.yml
+++ b/documentation/config.yml
@@ -5,14 +5,7 @@ toc:
   - name: Authorization
   - AuthorizationBrowser
   - AuthorizationNode
-  - name: Calling
-  - Phone
-  - PhoneConfig
-  - Call
-  - CallMemberships
-  - CallMembership
-  - StatsStream
-  - StatsFilter
+  - name: Webex Meetings
   - Meetings
   - name: Resources
     description: |


### PR DESCRIPTION
Removes phone plugin references in the SDK docs "calling" section and renames section to "meetings".
Fixes #SPARK-117145

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
