### PR TITLE
fix(plugin-meetings):  throw error when meeting is inactive on a action

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/common/errors/webex-errors.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/common/errors/webex-errors.js
@@ -1,0 +1,103 @@
+// The document would auto generate the doc for errors
+
+// 1) Error codes for Oauth, login, mercury should be separated out (Code range)
+// 2) Errors from the actual locus server or other server in case, we can use the same error code as locus and redirect it
+// 3) Any errors we generate from the SDK can be split into various categories
+// Parameter validation, user action, connection, media specific(They can have different range)
+
+
+// TODO: all the errors from the server need to be captured
+
+// add a way to log and send metrics if needed
+import WebexMeetingsError from './webex-meetings-error';
+
+const WebExMeetingsErrors = {};
+
+/**
+ * Create a {@link WebexMeetingsError} for a given code and message.
+ * @private
+ * @param {number} [code] - Error code
+ * @param {string} [message] - Error message
+ * @returns {WebexMeetingsError}
+ */
+export function createMeetingsError(code, message) {
+  code = typeof code === 'number' ? code : 0;
+  message = typeof message === 'string' && message ? message : 'Unknown error';
+
+  return WebExMeetingsErrors[code] ? new WebExMeetingsErrors[code]() : new WebexMeetingsError(code, message);
+}
+
+/**
+ * @class MeetingNotActiveError
+ * @classdesc Raised whenever Meeting has already ended and user tries to do a action.
+ * @extends WebexMeetingsError
+ * @property {number} code - 30101
+ * @property {string} message - 'Meeting has already Ended or not Active'
+ */
+class MeetingNotActiveError extends WebexMeetingsError {
+  static CODE = 30101;
+
+  constructor() {
+    super(MeetingNotActiveError.CODE, 'Meeting has already Ended or not Active');
+  }
+}
+
+export {MeetingNotActiveError};
+WebExMeetingsErrors[MeetingNotActiveError.CODE] = MeetingNotActiveError;
+
+/**
+ * @class UserNotJoinedError
+ * @classdesc Raised whenever the user has already left the meeting and user tries to do a action.
+ * @extends WebexMeetingsError
+ * @property {number} code - 30102
+ * @property {string} message - 'User has already left the meeting'
+ */
+class UserNotJoinedError extends WebexMeetingsError {
+  static CODE = 30102;
+
+  constructor() {
+    super(UserNotJoinedError.CODE, 'User has already left the meeting');
+  }
+}
+
+export {UserNotJoinedError};
+WebExMeetingsErrors[UserNotJoinedError.CODE] = UserNotJoinedError;
+
+
+/**
+ * @class NoMediaEstablishedYetError
+ * @classdesc Raised whenever the user has not established media yet.
+ * @extends WebexMeetingsError
+ * @property {number} code - 30103
+ * @property {string} message - 'User has not established media yet'
+ */
+class NoMediaEstablishedYetError extends WebexMeetingsError {
+  static CODE= 30103;
+
+  constructor() {
+    super(NoMediaEstablishedYetError.CODE, 'User has not established media yet');
+  }
+}
+
+export {NoMediaEstablishedYetError};
+WebExMeetingsErrors[NoMediaEstablishedYetError.CODE] = NoMediaEstablishedYetError;
+
+
+/**
+ * @class UserInLobbyError
+ * @classdesc Raised whenever the user is in lobby and not joined yet.
+ * @extends WebexMeetingsError
+ * @property {number} code - 30104
+ * @property {string} message - 'user is still in the lobby or not joined'
+ */
+class UserInLobbyError extends WebexMeetingsError {
+  static CODE = 30104;
+
+  constructor() {
+    super(UserInLobbyError.CODE, 'user is still in the lobby or not joined');
+  }
+}
+
+export {UserInLobbyError};
+WebExMeetingsErrors[UserInLobbyError.CODE] = UserInLobbyError;
+

--- a/packages/node_modules/@webex/plugin-meetings/src/common/errors/webex-meetings-error.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/common/errors/webex-meetings-error.js
@@ -1,0 +1,33 @@
+/**
+ * @extends Error
+ * @property {number} code - Error code
+ */
+export default class WebexMeetingsError extends Error {
+  /**
+   * Creates a new {@link WebexMeetingsError}
+   * @param {number} code - Error code
+   * @param {string} [message] - Error message
+   * @param {string} [fileName] - Name of the script file where error was generated
+   * @param {number} [lineNumber] - Line number of the script file where error was generated
+   */
+  constructor(code, ...args) {
+    super(...args);
+
+    this.name = 'WebexMeetingsError';
+
+    Object.defineProperty(this, 'code', {
+      value: code,
+      enumerable: true
+    });
+  }
+
+  /**
+   * Returns human readable string describing the error.
+   * @returns {string}
+   */
+  toString() {
+    const message = this.message ? `: ${this.message}` : '';
+
+    return `${this.name} ${this.code}${message}`;
+  }
+}

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2,6 +2,7 @@ import uuid from 'uuid';
 import bowser from 'bowser';
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
+import {MeetingNotActiveError, UserInLobbyError, NoMediaEstablishedYetError, UserNotJoinedError} from '../common/errors/webex-errors';
 import StatsAnalyzer from '../statsAnalyzer';
 import LoggerProxy from '../common/logs/logger-proxy';
 import Trigger from '../common/events/trigger-proxy';
@@ -272,7 +273,7 @@ const logRequest = (request, {header = '', success = '', failure = ''}) => {
 
 /**
  * Meeting Self Guest Admitted Event
- * Emitted when a member admitted to the meeting by another member
+ * Emitted when a joined user get admitted to the meeting by another member or host
  * @event meeting:self:guestAdmitted
  * @instance
  * @type {Object}
@@ -282,7 +283,7 @@ const logRequest = (request, {header = '', success = '', failure = ''}) => {
 
 /**
  * Meeting Self Lobby Waiting Event
- * Emitted when this member enters the lobby and is waiting for the webex meeting to begin
+ * Emitted when joined user enters the lobby and is waiting for the webex meeting to begin
  * @event meeting:self:lobbyWaiting
  * @instance
  * @type {Object}
@@ -2160,6 +2161,15 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   muteAudio() {
+    if (!MeetingUtil.isUserInJoinedState(this.locusInfo)) {
+      return Promise.reject(new UserNotJoinedError());
+    }
+
+    if (!this.mediaId) {
+      // Happens when addMedia and mute are triggered in succession
+      return Promise.reject(new NoMediaEstablishedYetError());
+    }
+
     if (!this.audio || (this.audio && !this.audio.toggle)) {
       return Promise.reject(new ParameterError('no audio control associated to the meeting'));
     }
@@ -2204,6 +2214,15 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   unmuteAudio() {
+    if (!MeetingUtil.isUserInJoinedState(this.locusInfo)) {
+      return Promise.reject(new UserNotJoinedError());
+    }
+
+    if (!this.mediaId) {
+      // Happens when addMedia and mute are triggered in succession
+      return Promise.reject(new NoMediaEstablishedYetError());
+    }
+
     if (!this.audio || (this.audio && !this.audio.toggle)) {
       return Promise.reject(new ParameterError('no audio control associated to the meeting'));
     }
@@ -2250,6 +2269,15 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   muteVideo() {
+    if (!MeetingUtil.isUserInJoinedState(this.locusInfo)) {
+      return Promise.reject(new UserNotJoinedError());
+    }
+
+    if (!this.mediaId) {
+      // Happens when addMedia and mute are triggered in succession
+      return Promise.reject(new NoMediaEstablishedYetError());
+    }
+
     if (!this.video || (this.video && !this.video.toggle)) {
       return Promise.reject(new ParameterError('no video control associated to the meeting'));
     }
@@ -2293,6 +2321,15 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   unmuteVideo() {
+    if (!MeetingUtil.isUserInJoinedState(this.locusInfo)) {
+      return Promise.reject(new UserNotJoinedError());
+    }
+
+    if (!this.mediaId) {
+      // Happens when addMedia and mute are triggered in succession
+      return Promise.reject(new NoMediaEstablishedYetError());
+    }
+
     if (!this.video || (this.video && !this.video.toggle)) {
       return Promise.reject(new ParameterError('no audio control associated to the meeting'));
     }
@@ -2876,9 +2913,18 @@ export default class Meeting extends StatelessWebexPlugin {
   addMedia(options = {}) {
     const LOG_HEADER = 'Meeting:index#addMedia -->';
 
-    if (MeetingUtil.isGuestUnjoined(this.locusInfo) && !this.wirelessShare) {
-      return Promise.reject(new MediaError(`To add media, the ${this.guest ? 'guest' : ''} user must be ${this.guest ? 'admitted. Wait to be admitted' : 'joined to the meeting'} to call addMedia`));
+    if (this.meetingState !== FULL_STATE.ACTIVE) {
+      return Promise.reject(new MeetingNotActiveError());
     }
+
+    if (MeetingUtil.isUserInLeftState(this.locusInfo)) {
+      return Promise.reject(new UserNotJoinedError());
+    }
+    // If the user is unjoined or guest waiting in lobby dont allow the user to addMedia
+    if (this.guest && MeetingUtil.isUserNotInIdleState(this.locusInfo) && !this.wirelessShare) {
+      return Promise.reject(new UserInLobbyError());
+    }
+
     const {localStream, localShare, mediaSettings} = options;
 
     LoggerProxy.logger.info(`${LOG_HEADER} Adding Media.`);
@@ -3506,7 +3552,8 @@ export default class Meeting extends StatelessWebexPlugin {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
             reason: error.message,
-            stack: error.stack
+            stack: error.stack,
+            code: error.code
           }
         );
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -1,22 +1,25 @@
 import {isEmpty} from 'lodash';
 
+import {MeetingNotActiveError, UserNotJoinedError} from '../common/errors/webex-errors';
 import StatsUtil from '../stats/util';
 import Metrics from '../metrics';
 import {eventType, trigger, mediaType} from '../metrics/config';
 import Media from '../media';
 import LoggerProxy from '../common/logs/logger-proxy';
 import WebRTCStats from '../stats/index';
-import {
-  INTENT_TO_JOIN,
+import {INTENT_TO_JOIN,
+  _LEFT_,
+  _IDLE_,
   _JOINED_,
   STATS,
   EVENT_TRIGGERS
-} from '../constants';
+  , FULL_STATE} from '../constants';
 import Trigger from '../common/events/trigger-proxy';
 import IntentToJoinError from '../common/errors/intent-to-join';
 import JoinMeetingError from '../common/errors/join-meeting';
 import ParameterError from '../common/errors/parameter';
 import PermissionError from '../common/errors/permission';
+
 
 const MeetingUtil = {};
 
@@ -146,6 +149,15 @@ MeetingUtil.cleanUp = (meeting) => {
 // {resourceId: null}
 // TODO: chris, you can modify this however you want
 MeetingUtil.leaveMeeting = (meeting, options = {}) => {
+  if (meeting.meetingState === FULL_STATE.INACTIVE) {
+    // TODO: clean up if the meeting is already inactive
+    return Promise.reject(new MeetingNotActiveError());
+  }
+
+  if (MeetingUtil.isUserInLeftState(meeting.locusInfo)) {
+    return Promise.reject(new UserNotJoinedError());
+  }
+
   const defaultOptions = {
     locusUrl: meeting.locusUrl,
     selfId: meeting.selfId,
@@ -173,6 +185,9 @@ MeetingUtil.leaveMeeting = (meeting, options = {}) => {
       return MeetingUtil.cleanUp(meeting);
     })
     .catch((err) => {
+      // TODO: If the meeting state comes as LEFT or INACTIVE as response then
+      // 1)  on leave clean up the meeting or simply do a sync on the meeting
+      // 2) If the error says meeting is inactive then destroy the meeting object
       LoggerProxy.logger.error(
         `Meeting:util#leaveMeeting --> An error occured while trying to leave meeting with an id of ${
           meeting.id
@@ -189,8 +204,14 @@ MeetingUtil.declineMeeting = (meeting, reason) =>
     reason
   });
 
-MeetingUtil.isGuestUnjoined = (locusInfo) =>
-  locusInfo.parsedLocus && locusInfo.parsedLocus.self && locusInfo.parsedLocus.self.guest && locusInfo.parsedLocus.self.state !== _JOINED_;
+MeetingUtil.isUserInLeftState = (locusInfo) =>
+   locusInfo.parsedLocus?.self?.state === _LEFT_;
+
+MeetingUtil.isUserNotInIdleState = (locusInfo) =>
+   locusInfo.parsedLocus?.self?.state !== _IDLE_;
+MeetingUtil.isUserInJoinedState = (locusInfo) =>
+  locusInfo.parsedLocus?.self?.state === _JOINED_;
+
 
 MeetingUtil.joinMeetingOptions = (meeting, options = {}) => {
   meeting.resourceId = meeting.resourceId || options.resourceId;

--- a/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/statsAnalyzer/index.js
@@ -899,7 +899,6 @@ export default class StatsAnalyzer extends EventsScope {
 
     // Total packloss ratio on this video section of the call
     this.statsResults[mediaType].send.overAllPacketLossRatio = this.statsResults[mediaType].send.totalPacketsLostOnReceiver > 0 ? this.statsResults[mediaType].send.totalPacketsLostOnReceiver / this.statsResults[mediaType].send.totalPacketsSent : 0;
-
     this.statsResults[mediaType].send.currentPacketLossRatio = this.statsResults[mediaType].send.packetsLostOnReceiver > 0 ? this.statsResults[mediaType].send.packetsLostOnReceiver * 100 / (this.statsResults[mediaType].send.packetsSent + this.statsResults[mediaType].send.packetsLostOnReceiver) : 0;
 
     if (this.statsResults[mediaType].send.maxPacketLossRatio < this.statsResults[mediaType].send.currentPacketLossRatio) {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -29,6 +29,8 @@ import TriggerProxy from '@webex/plugin-meetings/src/common/events/trigger-proxy
 import Metrics from '@webex/plugin-meetings/src/metrics';
 import bowser from 'bowser';
 
+import {UserNotJoinedError, MeetingNotActiveError, UserInLobbyError, NoMediaEstablishedYetError} from '../../../../src/common/errors/webex-errors';
+import ParameterError from '../../../../src/common/errors/parameter';
 import DefaultSDKConfig from '../../../../src/config';
 
 // Non-stubbed function
@@ -259,7 +261,22 @@ describe('plugin-meetings', () => {
         describe('before audio is defined', () => {
           it('should reject and return a promise', async () => {
             await meeting.muteAudio().catch((err) => {
-              assert.instanceOf(err, Error);
+              assert.instanceOf(err, UserNotJoinedError);
+            });
+          });
+
+          it('should reject and return a promise', async () => {
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
+            await meeting.muteAudio().catch((err) => {
+              assert.instanceOf(err, NoMediaEstablishedYetError);
+            });
+          });
+
+          it('should reject and return a promise', async () => {
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
+            meeting.mediaId = 'mediaId';
+            await meeting.muteAudio().catch((err) => {
+              assert.instanceOf(err, ParameterError);
             });
           });
         });
@@ -268,11 +285,13 @@ describe('plugin-meetings', () => {
 
           beforeEach(() => {
             toggle = sinon.stub().returns(Promise.resolve(true));
-
             meeting.audio = {toggle};
           });
 
           it('should return a promise resolution', async () => {
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
+            meeting.mediaId = 'mediaId';
+
             const audio = meeting.muteAudio();
 
             assert.exists(audio.then);
@@ -287,9 +306,24 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.unmuteAudio);
         });
         describe('before audio is defined', () => {
-          it('should reject and return a promise', async () => {
+          it('should reject when user not joined', async () => {
             await meeting.unmuteAudio().catch((err) => {
-              assert.instanceOf(err, Error);
+              assert.instanceOf(err, UserNotJoinedError);
+            });
+          });
+
+          it('should reject when no media is established yet ', async () => {
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
+            await meeting.unmuteAudio().catch((err) => {
+              assert.instanceOf(err, NoMediaEstablishedYetError);
+            });
+          });
+
+          it('should reject when audio is not there or established', async () => {
+            meeting.mediaId = 'mediaId';
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
+            await meeting.unmuteAudio().catch((err) => {
+              assert.instanceOf(err, ParameterError);
             });
           });
         });
@@ -299,13 +333,16 @@ describe('plugin-meetings', () => {
           beforeEach(() => {
             toggle = sinon.stub().returns(Promise.resolve(true));
             participantMute = sinon.stub().returns(Promise.resolve(true));
-
+            meeting.mediaId = 'mediaId';
             meeting.audio = {toggle};
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
             meeting.mute = participantMute;
           });
 
           it('should return a promise resolution', async () => {
             meeting.audio = {toggle};
+
+
             const audio = meeting.unmuteAudio();
 
             assert.exists(audio.then);
@@ -314,11 +351,14 @@ describe('plugin-meetings', () => {
             assert.calledWith(toggle, {mute: false, self: true});
           });
 
-          it('should call the participant unmute', () => meeting.unmuteAudio()
-            .then(() => {
-              assert.calledOnce(participantMute);
-              assert.calledWith(participantMute, uuid1, false);
-            }));
+          it('should call the participant unmute', () => {
+            meeting.mediaId = 'mediaId';
+            meeting.unmuteAudio()
+              .then(() => {
+                assert.calledOnce(participantMute);
+                assert.calledWith(participantMute, uuid1, false);
+              });
+          });
         });
       });
       describe('#muteVideo', () => {
@@ -326,9 +366,24 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.muteVideo);
         });
         describe('before video is defined', () => {
-          it('should reject and return a promise', async () => {
+          it('should reject when user not joined', async () => {
             await meeting.muteVideo().catch((err) => {
-              assert.instanceOf(err, Error);
+              assert.instanceOf(err, UserNotJoinedError);
+            });
+          });
+
+          it('should reject when no media is established', async () => {
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
+            await meeting.muteVideo().catch((err) => {
+              assert.instanceOf(err, NoMediaEstablishedYetError);
+            });
+          });
+
+          it('should reject when no video added or established', async () => {
+            meeting.mediaId = 'mediaId';
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
+            await meeting.muteVideo().catch((err) => {
+              assert.instanceOf(err, ParameterError);
             });
           });
         });
@@ -336,6 +391,8 @@ describe('plugin-meetings', () => {
           it('should return a promise resolution', async () => {
             const toggle = sinon.stub().returns(Promise.resolve(true));
 
+            meeting.mediaId = 'mediaId';
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
             meeting.video = {toggle};
             const video = meeting.muteVideo();
 
@@ -351,7 +408,22 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.unmuteVideo);
         });
         describe('before video is defined', () => {
-          it('should reject and return a promise', async () => {
+          it('should reject no user joined', async () => {
+            await meeting.unmuteVideo().catch((err) => {
+              assert.instanceOf(err, Error);
+            });
+          });
+
+          it('should reject no media established', async () => {
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
+            await meeting.unmuteVideo().catch((err) => {
+              assert.instanceOf(err, Error);
+            });
+          });
+
+          it('should reject when no video added or established', async () => {
+            meeting.mediaId = 'mediaId';
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
             await meeting.unmuteVideo().catch((err) => {
               assert.instanceOf(err, Error);
             });
@@ -361,6 +433,8 @@ describe('plugin-meetings', () => {
           it('should return a promise resolution', async () => {
             const toggle = sinon.stub().returns(Promise.resolve(true));
 
+            meeting.mediaId = 'mediaId';
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
             meeting.video = {toggle};
             const video = meeting.unmuteVideo();
 
@@ -520,13 +594,34 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.addMedia);
         });
 
+        it('should reject promise if meeting is not active', async () => {
+          await meeting.addMedia().catch((err) => {
+            assert.instanceOf(err, MeetingNotActiveError);
+          });
+        });
+
+        it('should reject promise if user already in left state', async () => {
+          meeting.meetingState = 'ACTIVE';
+          await meeting.addMedia().catch((err) => {
+            assert.instanceOf(err, UserNotJoinedError);
+          });
+        });
+
+        it('should reject promise if user is guest and in lobby ', async () => {
+          meeting.meetingState = 'ACTIVE';
+          meeting.locusInfo.parsedLocus = {self: {state: 'IDLE'}};
+          meeting.guest = true;
+          await meeting.addMedia().catch((err) => {
+            assert.instanceOf(err, UserInLobbyError);
+          });
+        });
+
 
         it('should attach the media and return promise', async () => {
+          meeting.meetingState = 'ACTIVE';
           const media = meeting.addMedia({
             mediaSettings: {}
           });
-
-          meeting.meetingState = 'ACTIVE';
 
           assert.exists(media);
           await media;
@@ -582,6 +677,20 @@ describe('plugin-meetings', () => {
         it('should have #leave', () => {
           assert.exists(meeting.leave);
         });
+
+        it('should reject if meeting is already inactive', async () => {
+          await meeting.leave().catch((err) => {
+            assert.instanceOf(err, MeetingNotActiveError);
+          });
+        });
+
+        it('should reject if meeting is already left', async () => {
+          meeting.meetingState = 'ACTIVE';
+          await meeting.leave().catch((err) => {
+            assert.instanceOf(err, UserNotJoinedError);
+          });
+        });
+
         beforeEach(() => {
           sandbox = sinon.createSandbox();
           meeting.meetingFiniteStateMachine.ring();
@@ -602,6 +711,10 @@ describe('plugin-meetings', () => {
           meeting.unsetPeerConnections = sinon.stub().returns(true);
           meeting.roap.stop = sinon.stub().returns(Promise.resolve());
           meeting.logger.error = sinon.stub().returns(true);
+
+          // A meeting needs to be joined to leave
+          meeting.meetingState = 'ACTIVE';
+          meeting.state = 'JOINED';
         });
         afterEach(() => {
           sandbox.restore();


### PR DESCRIPTION
Currently metrics gets flooded with errors when user is trying to do a action due to meeting inactivity 

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-215716

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
