### PR TITLE
fix(support): only upload keys that exist

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-support/src/support.js
+++ b/packages/node_modules/@webex/internal-plugin-support/src/support.js
@@ -129,21 +129,26 @@ const Support = WebexPlugin.extend({
     })
       .filter((entry) => Boolean(entry));
 
-    metadataArray.push({
-      key: 'trackingId',
-      value: this.webex.sessionId
-    });
+    if (this.webex.sessionId) {
+      metadataArray.push({
+        key: 'trackingId',
+        value: this.webex.sessionId
+      });
+    }
 
-    metadataArray.push({
-      key: 'userId',
-      value: this.webex.internal.device.userId
-    });
+    if (this.webex.internal.device.userId) {
+      metadataArray.push({
+        key: 'userId',
+        value: this.webex.internal.device.userId
+      });
+    }
 
-    metadataArray.push({
-      key: 'orgId',
-      value: this.webex.internal.device.orgId
-    });
-
+    if (this.webex.internal.device.orgId) {
+      metadataArray.push({
+        key: 'orgId',
+        value: this.webex.internal.device.orgId
+      });
+    }
 
     return metadataArray;
   }

--- a/packages/node_modules/@webex/internal-plugin-support/test/unit/spec/support.js
+++ b/packages/node_modules/@webex/internal-plugin-support/test/unit/spec/support.js
@@ -2,6 +2,8 @@
  * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
  */
 
+/* eslint-disable no-underscore-dangle */
+
 import Support from '@webex/internal-plugin-support';
 import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
@@ -17,6 +19,9 @@ describe('plugin-support', function () {
         support: Support
       }
     });
+
+    webex.internal.device.userId = 'user-abc-123';
+    webex.internal.device.orgId = 'org-abc-123';
   });
 
   describe('#_constructFileMetadata()', () => {
@@ -36,6 +41,30 @@ describe('plugin-support', function () {
         key: 'orgId',
         value: webex.internal.device.orgId
       }]);
+    });
+
+    it('does not send sessionId key if sessionId is not defined', () => {
+      webex.sessionId = null;
+
+      const result = webex.internal.support._constructFileMetadata({});
+
+      assert.isTrue(result.filter((r) => r.key === 'sessionId').length === 0);
+    });
+
+    it('does not send userID key if device userId is not defined', () => {
+      webex.internal.device.userId = null;
+
+      const result = webex.internal.support._constructFileMetadata({});
+
+      assert.isTrue(result.filter((r) => r.key === 'userId').length === 0);
+    });
+
+    it('does not send orgId key if device orgId is not defined', () => {
+      webex.internal.device.orgId = null;
+
+      const result = webex.internal.support._constructFileMetadata({});
+
+      assert.isTrue(result.filter((r) => r.key === 'orgId').length === 0);
     });
   });
 


### PR DESCRIPTION
Client logs service does not handle empty key value pairs.

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-214511
