### PR TITLE
fix(plugin-meetings): decrease the timer for meeting connect failure

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -187,7 +187,7 @@ export const ICE_FAIL_TIMEOUT = 3000;
 export const RETRY_TIMEOUT = 3000;
 export const ROAP_SEQ_PRE = -1;
 
-export const PC_BAIL_TIMEOUT = 20000;
+export const PC_BAIL_TIMEOUT = 8000;
 
 // ******************** REGEX **********************
 // Please alphabetize


### PR DESCRIPTION
Change the default timer for connection failure 

Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
