### PR TITLE
fix(plugin-meetings): fix hostId error when host is not present

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
@@ -425,21 +425,27 @@ export default class LocusInfo extends EventsScope {
   }
 
   /**
+   * checks if the host permissions have changed while in the meeting
+   * This would be the case if your role as host or moderator has been updated
    * @returns {undefined}
    * @memberof LocusInfo
    */
   compareAndUpdate() {
+    // TODO: check with locus team on host and moderator doc
+    // use host as a validator if needed
     if (this.compareAndUpdateFlags.compareSelfAndHost || this.compareAndUpdateFlags.compareHostAndSelf) {
       this.compareSelfAndHost();
     }
   }
 
   /**
+   * compared the self object to check if the user has host permissions
    * @returns {undefined}
    * @memberof LocusInfo
    */
   compareSelfAndHost() {
-    if ((this.parsedLocus.self.selfIdentity === this.parsedLocus.host.hostId) && this.parsedLocus.self.moderator) {
+    // In some cases the host info is not present but the moderator values changes from null to false so it triggers an update
+    if ((this.parsedLocus.self.selfIdentity === this.parsedLocus.host?.hostId) && this.parsedLocus.self.moderator) {
       this.emitScoped(
         {
           file: 'locus-info',
@@ -821,6 +827,7 @@ export default class LocusInfo extends EventsScope {
       if (result.sipUri) {
         this.updateMeeting(result);
       }
+
       if (parsedSelves.updates.moderatorChanged) {
         this.compareAndUpdateFlags.compareHostAndSelf = true;
       }


### PR DESCRIPTION
Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-180894

In scenario where the host joins first then leaves the meeting without assigning a new host , The locus does not send any host info so we make sure to not parse host info it its not present

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
