### PR TITLE
fix(plugin-meetings): reset audio and video state machines when leaving a meeting

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/media/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/index.js
@@ -54,7 +54,7 @@ const Media = {};
  */
 Media.setLocalTrack = (enabled, track) => {
   if (track) {
-    track.enabled = !enabled;
+    track.enabled = enabled;
 
     return true;
   }

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/audio.js
@@ -18,7 +18,7 @@ const handleTransition = (audio) => {
 };
 
 const doToggle = (transition, audio, meeting) => {
-  Media.setLocalTrack(audio.mute, meeting.mediaProperties.audioTrack);
+  Media.setLocalTrack(!audio.mute, meeting.mediaProperties.audioTrack);
   const meetingVideo = meeting.video;
   const videoMuted = meetingVideo ? meetingVideo.muted : true;
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -3429,6 +3429,8 @@ export default class Meeting extends StatelessWebexPlugin {
     return MeetingUtil.leaveMeeting(this, options)
       .then((leave) => {
         this.meetingFiniteStateMachine.leave();
+        this.audio = null;
+        this.video = null;
 
         // upload logs on leave irrespective of meeting delete
         Trigger.trigger(

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/video.js
@@ -18,7 +18,7 @@ const handleTransition = (video) => {
 };
 
 const doToggle = (transition, video, meeting) => {
-  Media.setLocalTrack(video.mute, meeting.mediaProperties.videoTrack);
+  Media.setLocalTrack(!video.mute, meeting.mediaProperties.videoTrack);
   const meetingAudio = meeting.audio;
   const audioMuted = meetingAudio ? meetingAudio.muted : true;
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -623,6 +623,26 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.unsetPeerConnections);
           assert.calledOnce(meeting.roap.stop);
         });
+        describe('after audio/video is defined', () => {
+          let toggle;
+
+          beforeEach(() => {
+            toggle = sinon.stub().returns(Promise.resolve(true));
+
+            meeting.audio = {toggle};
+            meeting.video = {toggle};
+          });
+
+          it('should delete audio and video state machines when leaving the meeting', async () => {
+            const leave = meeting.leave();
+
+            assert.exists(leave.then);
+            await leave;
+
+            assert.isNull(meeting.audio);
+            assert.isNull(meeting.video);
+          });
+        });
         it('should leave the meeting without leaving resource', async () => {
           const leave = meeting.leave({resourceId: null});
 


### PR DESCRIPTION
Fixes #SPARK-216287

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
