### PR TITLE
fix(meetings): make reason for decline optional

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -72,9 +72,6 @@ export const VIDEO_STATUS = 'videoStatus';
 // Please alphabetize
 export const _ANSWER_ = 'ANSWER';
 export const _ACTIVE_ = 'ACTIVE';
-
-export const _BUSY_ = 'BUSY';
-
 export const _CALL_ = 'CALL';
 export const _CREATED_ = 'CREATED';
 export const _CONFLICT_ = 'CONFLICT';

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -27,7 +27,6 @@ import StatsUtil from '../stats/util';
 import ReconnectionError from '../common/errors/reconnection';
 import ReconnectInProgress from '../common/errors/reconnection-in-progress';
 import {
-  _BUSY_,
   _CALL_,
   _INCOMING_,
   _JOIN_,
@@ -3471,7 +3470,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @public
    * @memberof Meeting
    */
-  decline(reason = _BUSY_) {
+  decline(reason) {
     return MeetingUtil.declineMeeting(this, reason).then((decline) => {
       this.meetingFiniteStateMachine.decline();
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
@@ -289,7 +289,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
         deviceType: this.config.meetings.deviceType,
         url: options.deviceUrl
       },
-      reason: options.reason
+      ...(options.reason && {reason: options.reason})
     };
 
     return this.request({


### PR DESCRIPTION
when declining a meeting the current SDK defaults to a `reason: 'BUSY'`. the reason part of the request payload is optional, so we should allow people to decline a call with no reason. currently in the web client, declining with a reason of "busy" causes different behavior when rejecting an incoming call compared to the desktop clients. when rejecting the 1:1 on desktop, they don't send a reason.


Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
