### PR TITLE
fix(plugin-meetings): throw error when guest is in IDLE state

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2920,7 +2920,7 @@ export default class Meeting extends StatelessWebexPlugin {
       return Promise.reject(new UserNotJoinedError());
     }
     // If the user is unjoined or guest waiting in lobby dont allow the user to addMedia
-    if (this.guest && MeetingUtil.isUserNotInIdleState(this.locusInfo) && !this.wirelessShare) {
+    if (this.guest && MeetingUtil.isUserInIdleState(this.locusInfo) && !this.wirelessShare) {
       return Promise.reject(new UserInLobbyError());
     }
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -207,8 +207,8 @@ MeetingUtil.declineMeeting = (meeting, reason) =>
 MeetingUtil.isUserInLeftState = (locusInfo) =>
    locusInfo.parsedLocus?.self?.state === _LEFT_;
 
-MeetingUtil.isUserNotInIdleState = (locusInfo) =>
-   locusInfo.parsedLocus?.self?.state !== _IDLE_;
+MeetingUtil.isUserInIdleState = (locusInfo) =>
+   locusInfo.parsedLocus?.self?.state === _IDLE_;
 MeetingUtil.isUserInJoinedState = (locusInfo) =>
   locusInfo.parsedLocus?.self?.state === _JOINED_;
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -611,9 +611,14 @@ describe('plugin-meetings', () => {
           meeting.meetingState = 'ACTIVE';
           meeting.locusInfo.parsedLocus = {self: {state: 'IDLE'}};
           meeting.guest = true;
-          await meeting.addMedia().catch((err) => {
+
+          try {
+            await meeting.addMedia();
+            assert.fail('addMedia should have thrown an exception.');
+          }
+          catch (err) {
             assert.instanceOf(err, UserInLobbyError);
-          });
+          }
         });
 
 


### PR DESCRIPTION
Fix broken code to check the IDLE state for guest user

Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
