### PR TITLE
fix(plugin-meetings):  add browser info to call-analyzer events

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
@@ -131,9 +131,12 @@ class Metrics {
         userAgent: this.userAgentToString(),
         clientInfo: {
           clientType: options.clientType,
-          os: 'linux', // TODO: BUG AND DOESNT ACCEPT OSNAME ON CA -> bowser.osname || 'null'
+          clientVersion: `${CLIENT_NAME}/${this.webex.version}`,
           osVersion: bowser.osVersion || 'unknown',
-          subClientType: options.subClientType
+          subClientType: options.subClientType,
+          os: this.getOsName(),
+          browser: bowser.name,
+          browserVersion: bowser.version
         }
       },
       originTime: {


### PR DESCRIPTION
Add browser information to the call analyzer events
Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
