### PR TITLE
fix(plugin-meetings): prevents screen share from getting out of sync

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -41,6 +41,7 @@ export const HOST = 'host';
 export const JOIN = 'join';
 
 export const LEAVE = 'leave';
+export const LIVE = 'live';
 export const LOCAL = 'local';
 export const LOCI = 'loci';
 export const LOCUS_URL = 'locusUrl';
@@ -59,6 +60,7 @@ export const REMOTE = 'remote';
 export const READY = 'ready';
 
 export const SEND_DTMF_ENDPOINT = 'sendDtmf';
+export const SENDRECV = 'sendrecv';
 export const SIP_URI = 'sipUri';
 export const SHARE = 'share';
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -39,6 +39,7 @@ import {
   FLOOR_ACTION,
   FULL_STATE,
   LAYOUT_TYPES,
+  LIVE,
   LOCUSINFO,
   MEETING_REMOVED_REASON,
   MEETING_STATE_MACHINE,
@@ -54,6 +55,7 @@ import {
   RECORDING_STATE,
   ROAP_SEQ_PRE,
   SDP,
+  SENDRECV,
   SHARE_STATUS,
   SHARE_STOPPED_REASON,
   STATS,
@@ -598,6 +600,29 @@ export default class Meeting extends StatelessWebexPlugin {
      * @memberof Meeting
      */
     this.shareStatus = SHARE_STATUS.NO_SHARE;
+    /**
+     * @instance
+     * @type {Boolean}
+     * @readonly
+     * @private
+     * @memberof Meeting
+     */
+    Object.defineProperty(this, 'isLocalShareLive', {
+      get: () => {
+        const {shareTransceiver} = this.mediaProperties.peerConnection;
+        const shareDirection = shareTransceiver?.direction;
+        const trackReadyState = shareTransceiver?.sender?.track?.readyState;
+        const activeShare = trackReadyState === LIVE;
+        const offersToSendData = shareDirection === SENDRECV;
+
+        if (activeShare && offersToSendData) {
+          return true;
+        }
+
+        return false;
+      },
+      configurable: true
+    });
     /**
      * @instance
      * @type {Array}
@@ -2096,14 +2121,7 @@ export default class Meeting extends StatelessWebexPlugin {
         LoggerProxy.logger.log('Meeting:index#setLocalTracks --> Screen settings.', JSON.stringify(this.mediaProperties.mediaSettings.screen));
       }
 
-      contentTracks.onended = () => {
-        if (this.wirelessShare) {
-          this.leave({reason: MEETING_REMOVED_REASON.USER_ENDED_SHARE_STREAMS});
-        }
-        else {
-          this.stopShare();
-        }
-      };
+      contentTracks.onended = () => this.handleShareTrackEnded(localShare);
 
       Trigger.trigger(
         this,
@@ -3497,7 +3515,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   updateShare(options) {
-    if (!this.canUpdateMedia()) {
+    if (!options.skipSignalingCheck && !this.canUpdateMedia()) {
       return Promise.reject(new MediaError('The peer connection is currently negotiation an offer. Please wait for a few seconds and try again.'));
     }
     const {sendShare, receiveShare, stream} = options;
@@ -3508,6 +3526,8 @@ export default class Meeting extends StatelessWebexPlugin {
       return Promise.reject(new ParameterError('Pass sendShare and receiveShare parameter'));
     }
     const previousSendShareStatus = this.mediaProperties.mediaDirection.sendShare;
+
+    this.setLocalShareTrack(stream);
 
     return MeetingUtil.validateOptions({sendShare, localShare: stream})
       .then(() => this.checkForStopShare(sendShare, previousSendShareStatus))
@@ -3537,9 +3557,28 @@ export default class Meeting extends StatelessWebexPlugin {
           return Promise.resolve();
         }))
       .then(() => {
-        this.setLocalShareTrack(stream);
         this.mediaProperties.mediaDirection.sendShare = sendShare;
         this.mediaProperties.mediaDirection.receiveShare = receiveShare;
+      })
+      .catch((error) => {
+        this.unsetLocalShareTrack(stream);
+        throw error;
+      })
+      .finally(() => {
+        const delay = 1e3;
+        // Check to see if share was stopped natively before onended was assigned.
+        const sharingModeIsActive = this.mediaProperties.peerConnection.shareTransceiver.direction === SENDRECV;
+        const isSharingOutOfSync = sharingModeIsActive && !this.isLocalShareLive;
+
+        if (isSharingOutOfSync) {
+          // Adding a delay to avoid a 409 from server
+          // which results in user still appearing as if sharing.
+          // Also delay give time for changes to peerConnection.
+          setTimeout(
+            () => this.handleShareTrackEnded(stream),
+            delay
+          );
+        }
       });
   }
 
@@ -3751,10 +3790,13 @@ export default class Meeting extends StatelessWebexPlugin {
    * @public
    * @memberof Meeting
    */
-  stopShare() {
+  // Internal only, temporarily allows optional params
+  // eslint-disable-next-line valid-jsdoc
+  stopShare(options = {}) {
     return this.updateShare({
       sendShare: false,
-      receiveShare: this.mediaProperties.mediaDirection.receiveShare
+      receiveShare: this.mediaProperties.mediaDirection.receiveShare,
+      ...options
     });
   }
 
@@ -4132,5 +4174,41 @@ export default class Meeting extends StatelessWebexPlugin {
         Metrics.sendOperationalMetric(metricName, data, metadata);
         throw new MediaError('Unable to retrieve display media stream', error);
       });
+  }
+
+  /**
+   * Functionality for when a share is ended.
+   * @private
+   * @memberof Meeting
+   * @param {MediaStream} localShare
+   * @returns {undefined}
+   */
+  handleShareTrackEnded(localShare) {
+    if (this.wirelessShare) {
+      this.leave({reason: MEETING_REMOVED_REASON.USER_ENDED_SHARE_STREAMS});
+    }
+    else {
+      // Skip checking for a stable peerConnection
+      // to allow immediately stopping screenshare
+      this.stopShare({
+        skipSignalingCheck: true
+      })
+        .catch((error) => {
+          LoggerProxy.logger.log('Meeting:index#handleShareTrackEnded --> Error stopping share: ', error);
+        });
+    }
+
+    Trigger.trigger(
+      this,
+      {
+        file: 'meeting/index',
+        function: 'handleShareTrackEnded'
+      },
+      EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
+      {
+        type: EVENT_TYPES.LOCAL_SHARE,
+        stream: localShare
+      }
+    );
   }
 }

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -822,35 +822,244 @@ describe('plugin-meetings', () => {
       });
 
       describe('#shareScreen', () => {
-        let mediaDirection;
+        let _mediaDirection;
+
+        beforeEach(() => {
+          _mediaDirection = meeting.mediaProperties.mediaDirection || {};
+          sinon.stub(meeting.mediaProperties, 'mediaDirection').value({sendAudio: true, sendVideo: true, sendShare: false});
+        });
+
+        afterEach(() => {
+          meeting.mediaProperties.mediaDirection = _mediaDirection;
+        });
 
         it('should have #shareScreen', () => {
           assert.exists(meeting.shareScreen);
         });
 
-        beforeEach(() => {
-          mediaDirection = {sendAudio: true, sendVideo: true, sendShare: false};
-          meeting.mediaProperties.mediaDirection = mediaDirection;
-          Media.getDisplayMedia = sinon.stub().returns(Promise.resolve());
-          meeting.updateShare = sinon.stub().returns(Promise.resolve());
+        describe('basic functionality', () => {
+          beforeEach(() => {
+            sinon.stub(Media, 'getDisplayMedia').returns(Promise.resolve());
+            sinon.stub(meeting, 'updateShare').returns(Promise.resolve());
+          });
+
+          afterEach(() => {
+            Media.getDisplayMedia.restore();
+            meeting.updateShare.restore();
+          });
+
+          it('should call get display media', async () => {
+            await meeting.shareScreen();
+
+            assert.calledOnce(Media.getDisplayMedia);
+          });
+
+          it('should call updateShare', async () => {
+            await meeting.shareScreen();
+
+            assert.calledOnce(meeting.updateShare);
+          });
+
+          it('properly assigns default values', async () => {
+            await meeting.shareScreen({sharePreferences: {highFrameRate: true}});
+
+            assert.calledWith(Media.getDisplayMedia, {sendShare: true, sendAudio: false, sharePreferences: {highFrameRate: true}});
+          });
         });
 
-        it('should call get display media', async () => {
-          await meeting.shareScreen();
+        describe('getter: isLocalShareLive', () => {
+          const LIVE = 'live';
+          const ENDED = 'ended';
+          const SENDRECV = 'sendrecv';
+          const RECVONLY = 'reconly';
+          let sandbox;
+          let _direction;
+          let _trackReadyState = ENDED;
 
-          assert.calledOnce(Media.getDisplayMedia);
+          beforeEach(() => {
+            sandbox = sinon.createSandbox();
+            sandbox.stub(meeting.mediaProperties, 'shareTrack').value(true);
+            sandbox.stub(meeting.mediaProperties, 'peerConnection').value({
+              shareTransceiver: {
+                get direction() {
+                  return _direction;
+                },
+                sender: {
+                  track: {
+                    get readyState() {
+                      return _trackReadyState;
+                    }
+                  }
+                }
+              }
+            });
+          });
+
+          afterEach(() => {
+            sandbox.restore();
+            sandbox = null;
+          });
+
+          it('sets isLocalShareLive to true when sharing screen', () => {
+            _direction = SENDRECV;
+            _trackReadyState = LIVE;
+
+            assert.isTrue(meeting.isLocalShareLive);
+          });
+
+          it('sets isLocalShareLive to false when not sharing screen', () => {
+            _direction = RECVONLY;
+            _trackReadyState = ENDED;
+
+            assert.isFalse(meeting.isLocalShareLive);
+          });
+
+          it('sets isLocalShareLive to false when track is live but share direction is recv only', () => {
+            _direction = RECVONLY;
+            _trackReadyState = LIVE;
+
+            assert.isFalse(meeting.isLocalShareLive);
+          });
         });
 
-        it('should call updateShare', async () => {
-          await meeting.shareScreen();
+        describe('stops share immediately', () => {
+          let sandbox;
 
-          assert.calledOnce(meeting.updateShare);
+          beforeEach(() => {
+            sandbox = sinon.createSandbox();
+          });
+
+          afterEach(() => {
+            sandbox.restore();
+            sandbox = null;
+          });
+
+          it('Can bypass canUpdateMedia() check', () => {
+            const sendShare = true;
+            const receiveShare = false;
+            const stream = 'stream';
+
+            sandbox.stub(meeting.mediaProperties, 'peerConnection').value({shareTransceiver: true});
+            sandbox.stub(MeetingUtil, 'getTrack').returns({videoTrack: true});
+            sandbox.stub(MeetingUtil, 'validateOptions').resolves(true);
+            sandbox.stub(meeting, 'canUpdateMedia').returns(true);
+            sandbox.stub(meeting, 'setLocalShareTrack');
+
+            meeting.updateShare({
+              sendShare,
+              receiveShare,
+              stream,
+              skipSignalingCheck: true
+            });
+
+            assert.notCalled(meeting.canUpdateMedia);
+          });
+
+
+          it('skips canUpdateMedia() check on contentTracks.onended', () => {
+            const {mediaProperties} = meeting;
+            const fakeTrack = {
+              getSettings: sinon.stub().returns({}),
+              onended: sinon.stub()
+            };
+
+            sandbox.stub(mediaProperties, 'setLocalShareTrack');
+            sandbox.stub(mediaProperties, 'shareTrack').value(fakeTrack);
+            sandbox.stub(mediaProperties, 'setMediaSettings');
+            sandbox.stub(meeting, 'stopShare').resolves(true);
+            meeting.setLocalShareTrack(fakeTrack);
+
+            fakeTrack.onended();
+
+            assert.calledWith(meeting.stopShare, {skipSignalingCheck: true});
+          });
+
+
+          it('stopShare accepts and passes along optional parameters', () => {
+            const args = {
+              abc: 123,
+              receiveShare: false,
+              sendShare: false
+            };
+
+            sandbox.stub(meeting, 'updateShare').returns(Promise.resolve());
+            sandbox.stub(meeting.mediaProperties, 'mediaDirection').value(false);
+
+            meeting.stopShare(args);
+
+            assert.calledWith(meeting.updateShare, args);
+          });
         });
 
-        it('properly assigns default values', async () => {
-          await meeting.shareScreen({sharePreferences: {highFrameRate: true}});
+        describe('out-of-sync sharing', () => {
+          let sandbox;
 
-          assert.calledWith(Media.getDisplayMedia, {sendShare: true, sendAudio: false, sharePreferences: {highFrameRate: true}});
+          beforeEach(() => {
+            sandbox = sinon.createSandbox();
+          });
+
+          afterEach(() => {
+            sandbox.restore();
+            sandbox = null;
+          });
+
+          it('calls handleShareTrackEnded if sharing is out of sync', async () => {
+            const sendShare = true;
+            const receiveShare = false;
+            const stream = 'stream';
+            const SENDRECV = 'sendrecv';
+            const delay = 1e3;
+
+            sandbox.stub(meeting, 'canUpdateMedia').returns(true);
+            sandbox.stub(MeetingUtil, 'getTrack').returns({videoTrack: null});
+            sandbox.stub(meeting, 'setLocalShareTrack');
+            sandbox.stub(meeting, 'unsetLocalShareTrack');
+            sandbox.stub(MeetingUtil, 'validateOptions').resolves(true);
+            sandbox.stub(meeting, 'checkForStopShare').returns(false);
+            sandbox.stub(MeetingUtil, 'updateTransceiver').resolves(true);
+            sandbox.stub(meeting, 'isLocalShareLive').value(false);
+            sandbox.stub(meeting, 'handleShareTrackEnded');
+            sandbox.stub(meeting.mediaProperties, 'peerConnection').value({
+              shareTransceiver: {
+                direction: SENDRECV
+              }
+            });
+            sandbox.useFakeTimers();
+
+            await meeting.updateShare({
+              sendShare,
+              receiveShare,
+              stream,
+              skipSignalingCheck: true
+            });
+            // simulate the setTimeout in code
+            sandbox.clock.tick(delay);
+
+            assert.calledOnce(meeting.handleShareTrackEnded);
+          });
+
+          it('handleShareTrackEnded triggers an event', () => {
+            const stream = 'stream';
+            const {EVENT_TRIGGERS, EVENT_TYPES} = CONSTANTS;
+
+            sandbox.stub(meeting, 'stopShare').resolves(true);
+
+            meeting.handleShareTrackEnded(stream);
+
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meeting),
+              {
+                file: 'meeting/index',
+                function: 'handleShareTrackEnded'
+              },
+              EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
+              {
+                stream,
+                type: EVENT_TYPES.LOCAL_SHARE
+              }
+            );
+          });
         });
       });
 
@@ -1537,7 +1746,7 @@ describe('plugin-meetings', () => {
 
           meeting.mediaProperties.setLocalShareTrack = sinon.stub().returns(true);
           meeting.mediaProperties.shareTrack = {getVideoTracks, getSettings: track.getSettings};
-          meeting.stopShare = sinon.stub().returns(true);
+          meeting.stopShare = sinon.stub().resolves(true);
           meeting.mediaProperties.mediaDirection = {};
           meeting.setLocalShareTrack(test1);
           assert.calledTwice(TriggerProxy.trigger);


### PR DESCRIPTION
Improved handling of stopping share stream natively, and checks/fixes if screen share is out of sync.

Fixes #SPARK-190274

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
