### PR TITLE
Add ignore and unignore functionality

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -914,6 +914,18 @@ const Conversation = WebexPlugin.extend({
   },
 
   /**
+   * Starts ignoring conversation
+   * @param {Conversation~ConversationObject} conversation
+   * @param {Conversation~ActivityObject} activity
+   * @returns {Promise} Resolves with the created activity
+   */
+  ignore(conversation, activity) {
+    return this.tag(conversation, {
+      tags: ['IGNORED']
+    }, activity);
+  },
+
+  /**
    * @param {Object} conversation
    * @param {Object} inputs
    * @param {Object} parentActivity
@@ -1358,6 +1370,18 @@ const Conversation = WebexPlugin.extend({
   unmuteMessages(conversation, activity) {
     return this.tag(conversation, {
       tags: ['MESSAGE_NOTIFICATIONS_ON']
+    }, activity);
+  },
+
+  /**
+   * Stops ignoring conversation
+   * @param {Conversation~ConversationObject} conversation
+   * @param {Conversation~ActivityObject} activity
+   * @returns {Promise} Resolves with the created activity
+   */
+  unignore(conversation, activity) {
+    return this.untag(conversation, {
+      tags: ['IGNORED']
     }, activity);
   },
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/verbs.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/verbs.js
@@ -697,6 +697,24 @@ describe('plugin-conversation', function () {
             assert.notInclude(c.tags, 'MESSAGE_NOTIFICATIONS_OFF');
           }));
       });
+
+      describe('#ignore()', () => {
+        it('ignores the specified conversation', () => webex.internal.conversation.ignore(conversation)
+          .then(() => webex.internal.conversation.get(conversation))
+          .then((c) => {
+            assert.include(c.tags, 'IGNORED');
+          }));
+      });
+
+      describe('#unignore()', () => {
+        before(() => webex.internal.conversation.ignore(conversation));
+
+        it('ignores the specified conversation', () => webex.internal.conversation.unignore(conversation)
+          .then(() => webex.internal.conversation.get(conversation))
+          .then((c) => {
+            assert.notInclude(c.tags, 'IGNORED');
+          }));
+      });
     });
 
     describe('verbs that update objects', () => {


### PR DESCRIPTION
The intention of this PR is to add the ability to "hide" and "unhide" conversations via the js sdk as can be done in the thick clients, so that this can be added to the web client. This appears to be done via the "IGNORED" tag. I'm not certain if this is the best way of doing it, but I tried to follow the pattern used for muting./ unmuting messages and mentions.