### PR TITLE
fix(meetings): checking for undefined in a few places

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/media/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/index.js
@@ -171,15 +171,15 @@ Media.attachMedia = (mediaProperties, {meetingId, remoteQualityLevel, enableRtx}
   let result = null;
 
   // Add Transceiver for audio
-  result = Media.checkTracks('audio', mediaDirection.sendAudio && audioTrack, mediaDirection.receiveAudio);
+  result = Media.checkTracks('audio', mediaDirection?.sendAudio && audioTrack, mediaDirection?.receiveAudio);
   peerConnection.audioTransceiver = peerConnection.addTransceiver(result.track, {direction: result.direction});
 
   // Add Transceiver for video
-  result = Media.checkTracks('video', mediaDirection.sendVideo && videoTrack, mediaDirection.receiveVideo);
+  result = Media.checkTracks('video', mediaDirection?.sendVideo && videoTrack, mediaDirection?.receiveVideo);
   peerConnection.videoTransceiver = peerConnection.addTransceiver(result.track, {direction: result.direction});
 
   // Add Transceiver for share
-  result = Media.checkTracks('video', mediaDirection.sendShare && shareTrack, mediaDirection.receiveShare);
+  result = Media.checkTracks('video', mediaDirection?.sendShare && shareTrack, mediaDirection?.receiveShare);
   peerConnection.shareTransceiver = peerConnection.addTransceiver(result.track, {direction: result.direction});
 
   peerConnection.onnegotiationneeded = (event) => {

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -496,6 +496,11 @@ export default class ReconnectionManager {
     meeting.mediaProperties.reInitiatePeerconnection();
     PeerConnectionManager.setPeerConnectionEvents(meeting);
     // update the peerconnection in the stats manager when ever we reconnect
-    meeting.statsAnalyzer.updatePeerconnection(meeting.mediaProperties.peerConnection);
+    if (meeting.statsAnalyzer) {
+      meeting.statsAnalyzer.updatePeerconnection(meeting.mediaProperties.peerConnection);
+    }
+    else {
+      LoggerProxy.logger.log('ReconnectionManager:index#setupPeerConnection --> statsAnalyzer missing!');
+    }
   }
 }


### PR DESCRIPTION
These checks are required for reconnection to not fail after
page is refreshed while you're in a meeting.
