### PR TITLE
fix(meetings): don’t set media ID on reconnect to avoid black screen

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/roap/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/index.js
@@ -1,5 +1,4 @@
 import {StatelessWebexPlugin} from '@webex/webex-core';
-import uuid from 'uuid';
 
 import {ROAP} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
@@ -243,7 +242,7 @@ export default class Roap extends StatelessWebexPlugin {
         roapMessage,
         correlationId: meeting.correlationId,
         locusSelfUrl: meeting.selfUrl,
-        mediaId: reconnect ? uuid.v4() : meeting.mediaId,
+        mediaId: reconnect ? '' : meeting.mediaId,
         audioMuted: meeting.isAudioMuted(),
         videoMuted: meeting.isVideoMuted(),
         meetingId: meeting.id

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
@@ -66,12 +66,12 @@ skipInNode(describe)('plugin-meetings', () => {
       .then(() => testUtils.waitForStateChange(bob.meeting, 'JOINED'))
       .then(() => testUtils.waitForStateChange(chris.meeting, 'JOINED')));
 
-    it('Bob and alice addsMedia', () => testUtils.addMedia(bob)
+    it('Bob and Alice addsMedia', () => testUtils.addMedia(bob)
       .then(() => testUtils.addMedia(alice)));
 
-    it('bob has flowing streams on reconnect', () => {
+    it('Bob has flowing streams on reconnect', () => {
       const retrieveStats = () => {
-        assert.isAbove(bob.meeting.statsAnalyzer.statsResults.audio.recv.totalPacketsReceived, 0, 'bytes Received greater than 0');
+        assert.isAbove(bob.meeting.statsAnalyzer.statsResults.audio.recv.totalPacketsReceived, 0, 'total packets received greater than 0');
       };
 
       return Promise.all([

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
@@ -66,8 +66,23 @@ skipInNode(describe)('plugin-meetings', () => {
       .then(() => testUtils.waitForStateChange(bob.meeting, 'JOINED'))
       .then(() => testUtils.waitForStateChange(chris.meeting, 'JOINED')));
 
-    it('Bob and Chris addsMedia', () => testUtils.addMedia(bob)
+    it('Bob and alice addsMedia', () => testUtils.addMedia(bob)
       .then(() => testUtils.addMedia(alice)));
+
+    it('bob has flowing streams on reconnect', () => {
+      const retrieveStats = () => {
+        assert.isAbove(bob.meeting.statsAnalyzer.statsResults.audio.recv.totalPacketsReceived, 0, 'bytes Received greater than 0');
+      };
+
+      return Promise.all([
+        testUtils.delayedPromise(bob.meeting.reconnect()),
+        testUtils.waitForEvents([{scope: bob.meeting, event: 'media:ready'}]),
+        testUtils.delayedTest(retrieveStats, 9000)
+      ]).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.warn('errror', error);
+      });
+    });
 
     it('alice Leaves the meeting', () =>
       Promise.all([

--- a/packages/node_modules/@webex/plugin-meetings/test/utils/testUtils.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/utils/testUtils.js
@@ -240,6 +240,7 @@ export default {
   waitForEvents,
   delayedPromise,
   addMedia,
-  waitUntil
+  waitUntil,
+  delayedTest
 };
 


### PR DESCRIPTION
This PR is to remove the unique ID sent for `mediaId` property when sending a ROAP request on reconnect. When a unique ID is sent, it prevents the media from streaming properly. We don't fully understand why yet, but we're reverting back how the request was previously sent.

Fixes #[214541](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-214541). See also [WEBEX-180532](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-180532)
