### PR TITLE
Add ability to use new conversationsSummary resource

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -650,6 +650,8 @@ const Conversation = WebexPlugin.extend({
    * Lists a set of conversations. By default does not fetch activities or
    * participants
    * @param {Object} options
+   * @param {boolean} options.summary - when true, use conversationSummary resource
+   * @param {Number} options.conversationsLimit - limit the number of conversations fetched
    * @param {boolean} options.deferDecrypt - when true, deferDecrypt tells the
    * payload transformer to normalize (but not decrypt) each received
    * conversation. Instead, the received conversations will each have a bound
@@ -659,8 +661,8 @@ const Conversation = WebexPlugin.extend({
   list(options = {}) {
     return this._list({
       service: 'conversation',
-      resource: 'conversations',
-      qs: omit(options, 'deferDecrypt'),
+      resource: options.summary ? 'conversationsSummary' : 'conversations',
+      qs: omit(options, ['deferDecrypt', 'summary']),
       deferDecrypt: options.deferDecrypt,
       limit: getConvoLimit(options)
     })

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/get.js
@@ -302,7 +302,7 @@ describe('plugin-conversation', function () {
         .then((response) => {
           const conversations = response.page.items;
 
-          assert.equal(conversations.length, 1);
+          assert.lengthOf(conversations, 1);
           assert.equal(conversations[0].displayName, conversation2.displayName);
 
           return webex.internal.conversation.paginate({page: response.page});
@@ -310,15 +310,57 @@ describe('plugin-conversation', function () {
         .then((response) => {
           const conversations = response.page.items;
 
-          assert.equal(conversations.length, 1);
+          assert.lengthOf(conversations, 1);
           assert.equal(conversations[0].displayName, conversation1.displayName);
         }));
+
+      describe('with summary = true (ConversationsSummary)', () => {
+        it('retrieves all conversations using conversationsSummary', () => webex.internal.conversation.list({
+          summary: true
+        })
+          .then((conversations) => {
+            assert.include(map(conversations, 'url'), conversation1.url);
+            assert.include(map(conversations, 'url'), conversation2.url);
+          }));
+
+        it('retrieves a set of (1) conversations using conversationsLimit', () => webex.internal.conversation.list({
+          summary: true,
+          conversationsLimit: 1
+        })
+          .then((conversations) => {
+            assert.lengthOf(conversations, 1);
+            assert.include(map(conversations, 'url'), conversation2.url);
+            assert.include(map(conversations, 'displayName'), conversation2.displayName);
+          }));
+      });
 
 
       describe('with deferDecrypt = true', () => {
         it('retrieves a non-decrypted set of conversations each with a bound decrypt method', () => webex.internal.conversation.list({
           conversationsLimit: 2,
           deferDecrypt: true
+        })
+          .then(([c1, c2]) => {
+            assert.lengthOf(c1.displayName.split('.'), 5, '5 periods implies this is a jwt and not a decrypted string');
+            assert.notInclude(['test 1, test 2'], c1.displayName);
+
+            assert.lengthOf(c2.displayName.split('.'), 5, '5 periods implies this is a jwt and not a decrypted string');
+            assert.notInclude(['test 1, test 2'], c2.displayName);
+
+            return Promise.all([
+              c1.decrypt()
+                .then(() => assert.notInclude(['test 1, test 2'], c1.displayName)),
+              c2.decrypt()
+                .then(() => assert.notInclude(['test 1, test 2'], c2.displayName))
+            ]);
+          }));
+      });
+
+      describe('with deferDecrypt && summary = true', () => {
+        it('retrieves a non-decrypted set of conversations each with a bound decrypt method', () => webex.internal.conversation.list({
+          conversationsLimit: 2,
+          deferDecrypt: true,
+          summary: true
         })
           .then(([c1, c2]) => {
             assert.lengthOf(c1.displayName.split('.'), 5, '5 periods implies this is a jwt and not a decrypted string');


### PR DESCRIPTION
Use new conversation endpoint that only returns a list of conversations without activities or participants.

Fixes #[SPARK-232873](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-232873)

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
