### PR TITLE
fix: prevent updateVideo from updating the audio track

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2102,10 +2102,14 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   setLocalVideoTrack(videoTrack, emitEvent = true) {
     if (videoTrack) {
-      const {aspectRatio, frameRate, height, width, deviceId} = videoTrack.getSettings();
+      const {
+        aspectRatio, frameRate, height, width, deviceId
+      } = videoTrack.getSettings();
 
       this.mediaProperties.setLocalVideoTrack(videoTrack);
-      this.mediaProperties.setMediaSettings('video', {aspectRatio, frameRate, height, width});
+      this.mediaProperties.setMediaSettings('video', {
+        aspectRatio, frameRate, height, width
+      });
       // store and save the selected video input device
       if (deviceId) {
         this.mediaProperties.setVideoDeviceId(deviceId);

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2102,18 +2102,13 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   setLocalVideoTrack(videoTrack, emitEvent = true) {
     if (videoTrack) {
-      const settings = videoTrack.getSettings();
+      const {aspectRatio, frameRate, height, width, deviceId} = videoTrack.getSettings();
 
       this.mediaProperties.setLocalVideoTrack(videoTrack);
-      this.mediaProperties.setMediaSettings('video', {
-        aspectRatio: settings.aspectRatio,
-        frameRate: settings.frameRate,
-        height: settings.height,
-        width: settings.width
-      });
+      this.mediaProperties.setMediaSettings('video', {aspectRatio, frameRate, height, width});
       // store and save the selected video input device
-      if (settings.deviceId) {
-        this.mediaProperties.setVideoDeviceId(settings.deviceId);
+      if (deviceId) {
+        this.mediaProperties.setVideoDeviceId(deviceId);
       }
       LoggerProxy.logger.log('Meeting:index#setLocalVideoTrack --> Video settings.', JSON.stringify(this.mediaProperties.mediaSettings.video));
     }

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2046,6 +2046,84 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
+   * Emits the 'media:ready' event with a local stream that consists of 1 local audio and 1 local video track
+   * @returns {undefined}
+   * @private
+   * @memberof Meeting
+   */
+  sendLocalMediaReadyEvent() {
+    Trigger.trigger(
+      this,
+      {
+        file: 'meeting/index',
+        function: 'setLocalTracks'
+      },
+      EVENT_TRIGGERS.MEDIA_READY,
+      {
+        type: EVENT_TYPES.LOCAL,
+        stream: MediaUtil.createMediaStream([this.mediaProperties.audioTrack, this.mediaProperties.videoTrack])
+      }
+    );
+  }
+
+  /**
+   * Sets the local audio track on the class and emits an event to the developer
+   * @param {MediaStreamTrack} audioTrack
+   * @param {Boolean} emitEvent if true, a media ready event is emitted to the developer
+   * @returns {undefined}
+   * @private
+   * @memberof Meeting
+   */
+  setLocalAudioTrack(audioTrack, emitEvent = true) {
+    if (audioTrack) {
+      const settings = audioTrack.getSettings();
+
+      this.mediaProperties.setMediaSettings('audio', {
+        echoCancellation: settings.echoCancellation,
+        noiseSuppression: settings.noiseSuppression
+      });
+
+      LoggerProxy.logger.log('Meeting:index#setLocalAudioTrack --> Audio settings.', JSON.stringify(this.mediaProperties.mediaSettings.audio));
+      this.mediaProperties.setLocalAudioTrack(audioTrack);
+    }
+
+    if (emitEvent) {
+      this.sendLocalMediaReadyEvent();
+    }
+  }
+
+  /**
+   * Sets the local video track on the class and emits an event to the developer
+   * @param {MediaStreamTrack} videoTrack
+   * @param {Boolean} emitEvent if true, a media ready event is emitted to the developer
+   * @returns {undefined}
+   * @private
+   * @memberof Meeting
+   */
+  setLocalVideoTrack(videoTrack, emitEvent = true) {
+    if (videoTrack) {
+      const settings = videoTrack.getSettings();
+
+      this.mediaProperties.setLocalVideoTrack(videoTrack);
+      this.mediaProperties.setMediaSettings('video', {
+        aspectRatio: settings.aspectRatio,
+        frameRate: settings.frameRate,
+        height: settings.height,
+        width: settings.width
+      });
+      // store and save the selected video input device
+      if (settings.deviceId) {
+        this.mediaProperties.setVideoDeviceId(settings.deviceId);
+      }
+      LoggerProxy.logger.log('Meeting:index#setLocalVideoTrack --> Video settings.', JSON.stringify(this.mediaProperties.mediaSettings.video));
+    }
+
+    if (emitEvent) {
+      this.sendLocalMediaReadyEvent();
+    }
+  }
+
+  /**
    * Sets the local media stream on the class and emits an event to the developer
    * @param {Stream} localStream the local media stream
    * @returns {undefined}
@@ -2055,47 +2133,11 @@ export default class Meeting extends StatelessWebexPlugin {
   setLocalTracks(localStream) {
     if (localStream) {
       const {audioTrack, videoTrack} = MeetingUtil.getTrack(localStream);
-      let settings = null;
 
-      if (audioTrack) {
-        settings = audioTrack.getSettings();
-        this.mediaProperties.setMediaSettings('audio', {
-          echoCancellation: settings.echoCancellation,
-          noiseSuppression: settings.noiseSuppression
-        });
+      this.setLocalAudioTrack(audioTrack, false);
+      this.setLocalVideoTrack(videoTrack, false);
 
-        LoggerProxy.logger.log('Meeting:index#setLocalTracks --> Audio settings.', JSON.stringify(this.mediaProperties.mediaSettings.audio));
-        this.mediaProperties.setLocalAudioTrack(audioTrack);
-      }
-
-      if (videoTrack) {
-        settings = videoTrack.getSettings();
-        this.mediaProperties.setLocalVideoTrack(videoTrack);
-        this.mediaProperties.setMediaSettings('video', {
-          aspectRatio: settings.aspectRatio,
-          frameRate: settings.frameRate,
-          height: settings.height,
-          width: settings.width
-        });
-        // store and save the selected video input device
-        if (settings.deviceId) {
-          this.mediaProperties.setVideoDeviceId(settings.deviceId);
-        }
-        LoggerProxy.logger.log('Meeting:index#setLocalTracks --> Video settings.', JSON.stringify(this.mediaProperties.mediaSettings.video));
-      }
-
-      Trigger.trigger(
-        this,
-        {
-          file: 'meeting/index',
-          function: 'setLocalTracks'
-        },
-        EVENT_TRIGGERS.MEDIA_READY,
-        {
-          type: EVENT_TYPES.LOCAL,
-          stream: MediaUtil.createMediaStream([this.mediaProperties.audioTrack, this.mediaProperties.videoTrack])
-        }
-      );
+      this.sendLocalMediaReadyEvent();
     }
   }
 
@@ -2123,7 +2165,7 @@ export default class Meeting extends StatelessWebexPlugin {
           displaySurface: settings.displaySurface,
           cursor: settings.cursor
         });
-        LoggerProxy.logger.log('Meeting:index#setLocalTracks --> Screen settings.', JSON.stringify(this.mediaProperties.mediaSettings.screen));
+        LoggerProxy.logger.log('Meeting:index#setLocalShareTrack --> Screen settings.', JSON.stringify(this.mediaProperties.mediaSettings.screen));
       }
 
       contentTracks.onended = () => this.handleShareTrackEnded(localShare);
@@ -3373,11 +3415,11 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
-   * Update the main audio streams with new parameters
+   * Update the main audio track with new parameters
    * @param {Object} options
    * @param {boolean} options.sendAudio
    * @param {boolean} options.receiveAudio
-   * @param {MediaStream} options.stream
+   * @param {MediaStream} options.stream Stream that contains the audio track to update
    * @returns {Promise}
    * @public
    * @memberof Meeting
@@ -3391,7 +3433,7 @@ export default class Meeting extends StatelessWebexPlugin {
     const track = MeetingUtil.getTrack(stream).audioTrack;
 
     if (typeof sendAudio !== 'boolean' || typeof receiveAudio !== 'boolean') {
-      return Promise.reject(new ParameterError('Pass sendVideo and receiveVideo parameter'));
+      return Promise.reject(new ParameterError('Pass sendAudio and receiveAudio parameter'));
     }
 
     return MeetingUtil.validateOptions({sendAudio, localStream: stream})
@@ -3427,7 +3469,7 @@ export default class Meeting extends StatelessWebexPlugin {
         );
       })
       .then(() => {
-        this.setLocalTracks(stream);
+        this.setLocalAudioTrack(track);
         this.mediaProperties.mediaDirection.sendAudio = sendAudio;
         this.mediaProperties.mediaDirection.receiveAudio = receiveAudio;
 
@@ -3437,11 +3479,11 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
-   * Update the main video streams with new parameters
+   * Update the main video track with new parameters
    * @param {Object} options
    * @param {boolean} options.sendVideo
    * @param {boolean} options.receiveVideo
-   * @param {MediaStream} options.stream
+   * @param {MediaStream} options.stream Stream that contains the video track to update
    * @returns {Promise}
    * @public
    * @memberof Meeting
@@ -3478,7 +3520,7 @@ export default class Meeting extends StatelessWebexPlugin {
         id: this.id
       }))
       .then(() => {
-        this.setLocalTracks(stream);
+        this.setLocalVideoTrack(track);
         this.mediaProperties.mediaDirection.sendVideo = sendVideo;
         this.mediaProperties.mediaDirection.receiveVideo = receiveVideo;
 

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -386,7 +386,7 @@ skipInNode(describe)('plugin-meetings', () => {
       });
 
       it('alice update video', () => {
-        const oldAudioTrackId = alice.meeting.mediaProperties.videoTrack.id;
+        const oldAudioTrackId = alice.meeting.mediaProperties.audioTrack.id;
 
         return alice.meeting.getMediaStreams({sendVideo: true})
           .then((response) => Promise.all([

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -362,40 +362,50 @@ skipInNode(describe)('plugin-meetings', () => {
           });
       });
 
-      it('alice update Audio', () => alice.meeting.getMediaStreams({sendAudio: true})
-        .then((response) => Promise.all([
-          testUtils.delayedPromise(alice.meeting.updateAudio({
-            sendAudio: true,
-            receiveAudio: true,
-            stream: response[0]
-          })
-            .then(() => {
-              console.log('AUDIO ', alice.meeting.mediaProperties.peerConnection.audioTransceiver.sender.track);
-              assert.equal(alice.meeting.mediaProperties.audioTrack.id, response[0].getAudioTracks()[0].id);
-            })),
-          testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
-            .then((response) => {
-              console.log('MEDIA:READY event ', response[0].result);
-              assert.equal(response[0].result.type === 'local', true);
-            })
-        ])));
+      it('alice update Audio', () => {
+        const oldVideoTrackId = alice.meeting.mediaProperties.videoTrack.id;
 
-      it('alice update video', () => alice.meeting.getMediaStreams({sendVideo: true})
-        .then((response) => Promise.all([
-          testUtils.delayedPromise(alice.meeting.updateVideo({
-            sendVideo: true,
-            receiveVideo: true,
-            stream: response[0]
-          })
-            .then(() => {
-              assert.equal(alice.meeting.mediaProperties.videoTrack.id, response[0].getVideoTracks()[0].id);
-            })),
-          testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
-            .then((response) => {
-              console.log('MEDIA:READY event ', response[0].result);
-              assert.equal(response[0].result.type === 'local', true);
+        return alice.meeting.getMediaStreams({sendAudio: true})
+          .then((response) => Promise.all([
+            testUtils.delayedPromise(alice.meeting.updateAudio({
+              sendAudio: true,
+              receiveAudio: true,
+              stream: response[0]
             })
-        ])));
+              .then(() => {
+                console.log('AUDIO ', alice.meeting.mediaProperties.peerConnection.audioTransceiver.sender.track);
+                assert.equal(alice.meeting.mediaProperties.audioTrack.id, response[0].getAudioTracks()[0].id);
+                assert.equal(alice.meeting.mediaProperties.videoTrack.id, oldVideoTrackId);
+              })),
+            testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
+              .then((response) => {
+                console.log('MEDIA:READY event ', response[0].result);
+                assert.equal(response[0].result.type === 'local', true);
+              })
+          ]));
+      });
+
+      it('alice update video', () => {
+        const oldAudioTrackId = alice.meeting.mediaProperties.videoTrack.id;
+
+        return alice.meeting.getMediaStreams({sendVideo: true})
+          .then((response) => Promise.all([
+            testUtils.delayedPromise(alice.meeting.updateVideo({
+              sendVideo: true,
+              receiveVideo: true,
+              stream: response[0]
+            })
+              .then(() => {
+                assert.equal(alice.meeting.mediaProperties.videoTrack.id, response[0].getVideoTracks()[0].id);
+                assert.equal(alice.meeting.mediaProperties.audioTrack.id, oldAudioTrackId);
+              })),
+            testUtils.waitForEvents([{scope: alice.meeting, event: 'media:ready'}])
+              .then((response) => {
+                console.log('MEDIA:READY event ', response[0].result);
+                assert.equal(response[0].result.type === 'local', true);
+              })
+          ]));
+      });
 
       it('alice shares the screen with highFrameRate', () => Promise.all([
         testUtils.delayedPromise(alice.meeting.shareScreen({sharePreferences: {highFrameRate: true}})),


### PR DESCRIPTION
fixes #SPARK-209898

The problem was that updateVideo was updating also the audio track
reference in the meeting object, while the rtc connection was still
using the old audio track, so then muting would stop working, because
we would be muting the wrong track.

Same applies to updateAudio.

