### PR TITLE
feat(core): allow for options in sendUserActivation

### DIFF
--- a/packages/node_modules/@webex/webex-core/src/lib/services/services.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/services.js
@@ -222,6 +222,7 @@ const Services = WebexPlugin.extend({
    * @param {object} ValidateUserPTO
    * @property {string} ValidateUserPTO.email - The email of the user.
    * @property {string} [ValidateUserPTO.reqId] - The activation requester.
+   * @property {object} [ValidateUserPTO.activationOptions] - Extra options to pass when sending the activation
    */
 
   /**
@@ -230,7 +231,7 @@ const Services = WebexPlugin.extend({
    * @property {boolean} ValidateUserRTO.activated - If the user is activated.
    * @property {boolean} ValidateUserRTO.exists - If the user exists.
    * @property {string} ValidateUserRTO.details - A descriptive status message.
-   * @property {object} ValidateUserRTO.user - **Atlas** service user object.
+   * @property {object} ValidateUserRTO.user - **License** service user object.
    */
 
   /**
@@ -240,7 +241,12 @@ const Services = WebexPlugin.extend({
    * @param {ValidateUserPTO} - The parameter transfer object.
    * @returns {ValidateUserRTO} - The return transfer object.
    */
-  validateUser({email, reqId = 'WEBCLIENT', forceRefresh = false}) {
+  validateUser({
+    email,
+    reqId = 'WEBCLIENT',
+    forceRefresh = false,
+    activationOptions = {}
+  }) {
     this.logger.info('services: validating a user');
 
     // Validate that an email parameter key was provided.
@@ -258,7 +264,8 @@ const Services = WebexPlugin.extend({
         .then((token) => this.sendUserActivation({
           email,
           reqId,
-          token: token.toString()
+          token: token.toString(),
+          activationOptions
         }))
         .then((userObj) => ({
           activated: true,
@@ -321,7 +328,12 @@ const Services = WebexPlugin.extend({
           exists: true,
           details: 'user exists and is activated'
         },
-        this.sendUserActivation({email, reqId, token})
+        this.sendUserActivation({
+          email,
+          reqId,
+          token,
+          activationOptions
+        })
       ]))
       .then(([rto, user]) => ({...rto, user}))
       .catch((error) => {
@@ -363,15 +375,21 @@ const Services = WebexPlugin.extend({
    * @property {string} SendUserActivationPTO.email - The email of the user.
    * @property {string} SendUserActivationPTO.reqId - The activation requester.
    * @property {string} SendUserActivationPTO.token - The client auth token.
+   * @property {object} SendUserActivationPTO.activationOptions - Extra options to pass when sending the activation.
    */
 
   /**
    * Send a request to activate a user using a client token.
    *
    * @param {SendUserActivationPTO} - The Parameter transfer object.
-   * @returns {AtlasDTO} - The DTO returned from the **Atlas** service.
+   * @returns {LicenseDTO} - The DTO returned from the **License** service.
    */
-  sendUserActivation({email, reqId, token}) {
+  sendUserActivation({
+    email,
+    reqId,
+    token,
+    activationOptions
+  }) {
     this.logger.info('services: sending user activation request');
     let countryCode, timezone;
 
@@ -383,9 +401,9 @@ const Services = WebexPlugin.extend({
           ({countryCode, timezone} = clientRegionInfo);
         }
 
-        // Send the user activation request to the **Atlas** service.
+        // Send the user activation request to the **License** service.
         return this.request({
-          service: 'atlas',
+          service: 'license',
           resource: 'users/activations',
           method: 'POST',
           headers: {
@@ -394,14 +412,18 @@ const Services = WebexPlugin.extend({
             'x-prelogin-userid': undefined
           },
           body: {
-            email, reqId, countryCode, timeZone: timezone
+            email,
+            reqId,
+            countryCode,
+            timeZone: timezone,
+            ...activationOptions
           },
           shouldRefreshAccessToken: false
         });
       })
-      // On success, return the **Atlas** user object.
+      // On success, return the **License** user object.
       .then(({body}) => body)
-      // On failure, reject with error from **Atlas**.
+      // On failure, reject with error from **License**.
       .catch((error) => Promise.reject(error));
   },
 

--- a/packages/node_modules/@webex/webex-core/test/integration/spec/services/services.js
+++ b/packages/node_modules/@webex/webex-core/test/integration/spec/services/services.js
@@ -848,15 +848,32 @@ describe('webex-core', () => {
           assert.equal(Object.keys(unauthServices.list(false, 'postauth')).length, 0);
         }));
 
+      it('validates new user with activationOptions suppressEmail false', () => unauthServices.validateUser({email: `Collabctg+webex-js-sdk-${uuid.v4()}@gmail.com`, activationOptions: {suppressEmail: false}})
+        .then((r) => {
+          assert.hasAllKeys(r, ['activated', 'exists', 'user', 'details']);
+          assert.equal(r.activated, false);
+          assert.equal(r.exists, false);
+          assert.equal(r.user.verificationEmailTriggered, true);
+          assert.isAbove(Object.keys(unauthServices.list(false, 'preauth')).length, 0);
+          assert.equal(Object.keys(unauthServices.list(false, 'signin')).length, 0);
+          assert.equal(Object.keys(unauthServices.list(false, 'postauth')).length, 0);
+        }));
+
+      it('validates new user with activationOptions suppressEmail true', () => unauthServices.validateUser({email: `Collabctg+webex-js-sdk-${uuid.v4()}@gmail.com`, activationOptions: {suppressEmail: true}})
+        .then((r) => {
+          assert.hasAllKeys(r, ['activated', 'exists', 'user', 'details']);
+          assert.equal(r.activated, false);
+          assert.equal(r.exists, false);
+          assert.equal(r.user.verificationEmailTriggered, false);
+          assert.isAbove(Object.keys(unauthServices.list(false, 'preauth')).length, 0);
+          assert.equal(Object.keys(unauthServices.list(false, 'signin')).length, 0);
+          assert.equal(Object.keys(unauthServices.list(false, 'postauth')).length, 0);
+        }));
+
       it('validates an inactive user', () => {
-        // This will be changed to utilize a new test user generation
-        // method that can create a user without activating it. Currently,
-        // this will throw an error if too many requests to Atlas are triggered
-        // to send activation emails. A solution was to append a `skipEmail`
-        // parameter key to allow bypassing the email request when necessary.
         const inactive = 'webex.web.client+nonactivated@gmail.com';
 
-        return unauthServices.validateUser({email: inactive, skipEmail: true})
+        return unauthServices.validateUser({email: inactive, skipEmail: true, activationOptions: {suppressEmail: true}})
           .then((r) => {
             assert.hasAllKeys(r, ['activated', 'exists', 'user', 'details']);
             assert.equal(r.activated, false, 'activated');

--- a/packages/node_modules/@webex/webex-core/test/integration/spec/services/services.js
+++ b/packages/node_modules/@webex/webex-core/test/integration/spec/services/services.js
@@ -873,7 +873,7 @@ describe('webex-core', () => {
       it('validates an inactive user', () => {
         const inactive = 'webex.web.client+nonactivated@gmail.com';
 
-        return unauthServices.validateUser({email: inactive, skipEmail: true, activationOptions: {suppressEmail: true}})
+        return unauthServices.validateUser({email: inactive, activationOptions: {suppressEmail: true}})
           .then((r) => {
             assert.hasAllKeys(r, ['activated', 'exists', 'user', 'details']);
             assert.equal(r.activated, false, 'activated');


### PR DESCRIPTION
…ough to sendUserActivation


Allow for extra options to be passed through to sendUserActivation when sending the activation and to use license service.
This will be useful for webex web app in user activation flow to validate user.


Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
