### PR TITLE
feat(meetings): Custom size remote video (coming soon)

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1,4 +1,5 @@
 import uuid from 'uuid';
+import {cloneDeep, isEqual} from 'lodash';
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
 import {
@@ -732,6 +733,15 @@ export default class Meeting extends StatelessWebexPlugin {
      * @memberof Meeting
      */
     this.hasWebsocketConnected = this.webex.internal.mercury.connected;
+
+    /**
+     * Last sent render information
+     * @instance
+     * @type {Object}
+     * @private
+     * @memberof Meeting
+     */
+    this.lastVideoLayoutInfo = {layoutType: undefined, main: undefined, content: undefined};
 
     this.setUpLocusInfoListeners();
     this.locusInfo.init(attrs.locus ? attrs.locus : {});
@@ -4008,6 +4018,19 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
+   * Logs an error message and returns a rejected promise with same message
+   * @param {String} message
+   * @returns {Promise}
+   * @private
+   * @memberof Meeting
+   */
+  rejectWithErrorLog(message) {
+    LoggerProxy.logger.error(message);
+
+    return Promise.reject(new Error(message));
+  }
+
+  /**
    * Sends DTMF tones to the current meeting
    * @param {String} tones a string of one or more DTMF tones to send
    * @returns {Promise}
@@ -4015,12 +4038,6 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   sendDTMF(tones) {
-    const reject = (message) => {
-      LoggerProxy.logger.error(message);
-
-      return Promise.reject(new Error(message));
-    };
-
     if (this.locusInfo && this.locusInfo.self) {
       if (this.locusInfo.self.enableDTMF) {
         return this.meetingRequest
@@ -4031,48 +4048,94 @@ export default class Meeting extends StatelessWebexPlugin {
           });
       }
 
-      return reject('Meeting:index#sendDTMF --> cannot send DTMF, meeting does not have DTMF enabled');
+      return this.rejectWithErrorLog('Meeting:index#sendDTMF --> cannot send DTMF, meeting does not have DTMF enabled');
     }
 
-    return reject('Meeting:index#sendDTMF --> cannot send DTMF, meeting does not have a connection to the "locus" call control service. Have you joined?');
+    return this.rejectWithErrorLog('Meeting:index#sendDTMF --> cannot send DTMF, meeting does not have a connection to the "locus" call control service. Have you joined?');
   }
 
   /**
    * Sends request to change layout type for the current meeting for the specific participant/device only
    * @param {String} layoutType a layout type that should be available in meeting constants LAYOUT_TYPES
+   * @param {Object} renderInfo preferred dimensions for the remote main and content streams (server can ignore it)
+   * @param {Object} renderInfo.main preferred dimensions for the remote main video stream
+   * @param {Number} renderInfo.main.width preferred width of main video stream
+   * @param {Number} renderInfo.main.height preferred height of main video stream
+   * @param {Object} renderInfo.content preferred dimensions for the remote content share stream
+   * @param {Number} renderInfo.content.width preferred width of content share stream
+   * @param {Number} renderInfo.content.height preferred height of content share stream
    * @returns {Promise}
    * @public
    * @memberof Meeting
    */
-  changeVideoLayout(layoutType) {
-    const reject = (message) => {
-      LoggerProxy.logger.error(message);
+  changeVideoLayout(layoutType, renderInfo = {}) {
+    const {main, content} = renderInfo;
+    const {mediaDirection, remoteShare, remoteVideoTrack} = this.mediaProperties;
 
-      return Promise.reject(new Error(message));
-    };
-
-    const {mediaDirection, remoteVideoTrack} = this.mediaProperties;
+    const layoutInfo = cloneDeep(this.lastVideoLayoutInfo);
 
     // TODO: We need a real time value for Audio, Video and Share send indicator
-    if (mediaDirection.receiveVideo === true && remoteVideoTrack) {
-      if (LAYOUT_TYPES.includes(layoutType)) {
-        return this.meetingRequest
-          .changeVideoLayout({
-            locusUrl: this.locusInfo.self.url,
-            deviceUrl: this.deviceUrl,
-            layoutType
-          })
-          .then((response) => {
-            if (response && response.body && response.body.locus) {
-              this.locusInfo.onFullLocus(response.body.locus);
-            }
-          });
-      }
-
-      return reject('Meeting:index#changeVideoLayout --> cannot change video layout, invalid layoutType recieved.');
+    if (mediaDirection.receiveVideo !== true || !remoteVideoTrack) {
+      return this.rejectWithErrorLog('Meeting:index#changeVideoLayout --> cannot change video layout, you are not recieving any video/share stream');
     }
 
-    return reject('Meeting:index#changeVideoLayout --> cannot change video layout, you are not recieving any video/share stream');
+    if (LAYOUT_TYPES.includes(layoutType)) {
+      layoutInfo.layoutType = layoutType;
+    }
+    else {
+      return this.rejectWithErrorLog('Meeting:index#changeVideoLayout --> cannot change video layout, invalid layoutType recieved.');
+    }
+
+    if (main) {
+      // Stop any "twitching" caused by very slight size changes
+      if (
+        !this.lastVideoLayoutInfo.main ||
+        Math.abs(this.lastVideoLayoutInfo.main.height - main.height) > 2 ||
+        Math.abs(this.lastVideoLayoutInfo.main.width - main.width) > 2
+      ) {
+        layoutInfo.main = {width: main.width, height: main.height};
+      }
+    }
+
+    if (content) {
+      if (this.mediaProperties.mediaDirection.receiveShare && remoteShare) {
+        // Stop any "twitching" caused by very slight size changes
+        if (!this.lastVideoLayoutInfo.content ||
+          Math.abs(this.lastVideoLayoutInfo.content.height - content.height) > 2 ||
+          Math.abs(this.lastVideoLayoutInfo.content.width - content.width) > 2
+        ) {
+          layoutInfo.content = {width: content.width, height: content.height};
+        }
+      }
+      else {
+        return this.rejectWithErrorLog('Meeting:index#changeVideoLayout --> unable to send renderInfo for content, you are not receiving remote share');
+      }
+    }
+
+    if (isEqual(layoutInfo, this.lastVideoLayoutInfo)) {
+      // nothing changed, no need to send any request
+      return Promise.resolve();
+    }
+    this.lastVideoLayoutInfo = cloneDeep(layoutInfo);
+
+    return this.meetingRequest
+      .changeVideoLayoutDebounced({
+        locusUrl: this.locusInfo.self.url,
+        deviceUrl: this.deviceUrl,
+        layoutType,
+        main: layoutInfo.main,
+        content: layoutInfo.content
+      })
+      .then((response) => {
+        if (response && response.body && response.body.locus) {
+          this.locusInfo.onFullLocus(response.body.locus);
+        }
+      })
+      .catch((error) => {
+        LoggerProxy.logger.error('Meeting:index#changeVideoLayout --> Error ', error);
+
+        return Promise.reject(error);
+      });
   }
 
   /**
@@ -4084,19 +4147,11 @@ export default class Meeting extends StatelessWebexPlugin {
     LoggerProxy.logger.log(`Meeting:index#setLocalVideoQuality --> Setting quality to ${level}`);
 
     if (!VIDEO_RESOLUTIONS[level]) {
-      const errorMessage = `Meeting:index#setLocalVideoQuality --> ${level} not defined`;
-
-      LoggerProxy.logger.error(errorMessage);
-
-      return Promise.reject(new Error(errorMessage));
+      return this.rejectWithErrorLog(`Meeting:index#setLocalVideoQuality --> ${level} not defined`);
     }
 
     if (!this.mediaProperties.mediaDirection.sendVideo) {
-      const errorMessage = 'Meeting:index#setLocalVideoQuality --> unable to change video quality, sendVideo is disabled';
-
-      LoggerProxy.logger.error(errorMessage);
-
-      return Promise.reject(new Error(errorMessage));
+      return this.rejectWithErrorLog('Meeting:index#setLocalVideoQuality --> unable to change video quality, sendVideo is disabled');
     }
 
     // If level is already the same, don't do anything
@@ -4133,19 +4188,11 @@ export default class Meeting extends StatelessWebexPlugin {
     LoggerProxy.logger.log(`Meeting:index#setRemoteQualityLevel --> Setting quality to ${level}`);
 
     if (!QUALITY_LEVELS[level]) {
-      const errorMessage = `Meeting:index#setRemoteQualityLevel --> ${level} not defined`;
-
-      LoggerProxy.logger.error(errorMessage);
-
-      return Promise.reject(new Error(errorMessage));
+      return this.rejectWithErrorLog(`Meeting:index#setRemoteQualityLevel --> ${level} not defined`);
     }
 
     if (!this.mediaProperties.mediaDirection.receiveAudio && !this.mediaProperties.mediaDirection.receiveVideo) {
-      const errorMessage = 'Meeting:index#setRemoteQualityLevel --> unable to change remote quality, receiveVideo and receiveAudio is disabled';
-
-      LoggerProxy.logger.error(errorMessage);
-
-      return Promise.reject(new Error(errorMessage));
+      return this.rejectWithErrorLog('Meeting:index#setRemoteQualityLevel --> unable to change remote quality, receiveVideo and receiveAudio is disabled');
     }
 
     // If level is already the same, don't do anything
@@ -4170,11 +4217,7 @@ export default class Meeting extends StatelessWebexPlugin {
     LoggerProxy.logger.log(`Meeting:index#setMeetingQuality --> Setting quality to ${level}`);
 
     if (!QUALITY_LEVELS[level]) {
-      const errorMessage = `Meeting:index#setMeetingQuality --> ${level} not defined`;
-
-      LoggerProxy.logger.error(errorMessage);
-
-      return Promise.reject(new Error(errorMessage));
+      return this.rejectWithErrorLog(`Meeting:index#setMeetingQuality --> ${level} not defined`);
     }
 
     const previousLevel = {

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
@@ -1,4 +1,5 @@
 import uuid from 'uuid';
+import {debounce} from 'lodash';
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
 import LoggerProxy from '../common/logs/logger-proxy';
@@ -23,6 +24,11 @@ import {
  * @class MeetingRequest
  */
 export default class MeetingRequest extends StatelessWebexPlugin {
+  constructor(attrs, options) {
+    super(attrs, options);
+    this.changeVideoLayoutDebounced = debounce(this.changeVideoLayout, 2000, {leading: true, trailing: true});
+  }
+
   /**
    * Make a network request to join a meeting
    * @param {Object} options
@@ -402,16 +408,46 @@ export default class MeetingRequest extends StatelessWebexPlugin {
    * @param {String} options.locusUrl
    * @param {String} options.deviceUrl
    * @param {String} options.layoutType a layout type that should be available in meeting constants LAYOUT_TYPES
+   * @param {Object} options.main preferred dimensions for the remote main video stream
+   * @param {Number} options.main.width preferred width of main video stream
+   * @param {Number} options.main.height preferred height of main video stream
+   * @param {Object} options.content preferred dimensions for the remote content share stream
+   * @param {Number} options.content.width preferred width of content share stream
+   * @param {Number} options.content.height preferred height of content share stream
    * @returns {Promise}
    */
-  changeVideoLayout({locusUrl, deviceUrl, layoutType}) {
+  changeVideoLayout({
+    locusUrl, deviceUrl, layoutType, main, content
+  }) {
+    // send main/content renderInfo only if both width and height are specified
+    if (main && (!main.width || !main.height)) {
+      return Promise.reject(new Error('Both width and height must be specified. One of them is missing for main'));
+    }
+
+    if (content && (!content.width || !content.height)) {
+      return Promise.reject(new Error('Both width and height must be specified. One of them is missing for content'));
+    }
+
+    const renderInfoMain = (main) ? {width: main.width, height: main.height} : undefined;
+    const renderInfoContent = (content) ? {width: content.width, height: content.height} : undefined;
+
+    const layoutParams = (renderInfoMain || renderInfoMain) ?
+      {
+        renderInfo:
+        {
+          main: renderInfoMain,
+          content: renderInfoContent
+        }
+      } : undefined;
+
     return this.request({
       method: HTTP_VERBS.PUT,
       uri: `${locusUrl}/${CONTROLS}`,
       body: {
         layout: {
           deviceUrl,
-          type: layoutType
+          type: layoutType,
+          layoutParams
         }
       }
     });

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1375,6 +1375,7 @@ describe('plugin-meetings', () => {
       describe('#changeVideoLayout', () => {
         describe('when media direction has recieve video and there is remoteStream', () => {
           let mediaDirection;
+          const layoutTypeSingle = 'Single';
 
           beforeEach(() => {
             mediaDirection = {
@@ -1387,6 +1388,12 @@ describe('plugin-meetings', () => {
             meeting.updateVideo = sinon.stub().returns(Promise.resolve());
             meeting.mediaProperties.mediaDirection = mediaDirection;
             meeting.mediaProperties.remoteVideoTrack = sinon.stub().returns({mockTrack: 'mockTrack'});
+
+            meeting.meetingRequest.changeVideoLayoutDebounced = sinon.stub().returns(Promise.resolve());
+
+            meeting.locusInfo.self = {
+              url: url2
+            };
           });
 
           it('should have receiveVideo true and remote video track should exist', () => {
@@ -1394,35 +1401,135 @@ describe('plugin-meetings', () => {
             assert.exists(meeting.mediaProperties.remoteVideoTrack);
           });
 
-          it('has layoutType which exists in the list of allowed layoutTypes and should call meetingRequest changeVideoLayout method', async () => {
+          it('has layoutType which exists in the list of allowed layoutTypes and should call meetingRequest changeVideoLayoutDebounced method', async () => {
             const layoutType = 'Equal';
-
-            meeting.meetingRequest.changeVideoLayout = sinon.stub().returns(Promise.resolve());
-
-            meeting.locusInfo.self = {
-              url: url2
-            };
 
             await meeting.changeVideoLayout(layoutType);
 
             assert(CONSTANTS.LAYOUT_TYPES.includes(layoutType));
-            assert.calledWith(meeting.meetingRequest.changeVideoLayout, {
+            assert.calledWith(meeting.meetingRequest.changeVideoLayoutDebounced, {
               locusUrl: meeting.locusInfo.self.url,
               deviceUrl: meeting.deviceUrl,
-              layoutType
+              layoutType,
+              main: undefined,
+              content: undefined
             });
           });
 
           it('doesn\'t have layoutType which exists in the list of allowed layoutTypes should throw an error', async () => {
             const layoutType = 'Invalid Layout';
 
-            meeting.meetingRequest.changeVideoLayout = sinon.stub().returns(Promise.resolve());
-
-            meeting.locusInfo.self = {
-              url: url2
-            };
-
             assert.isRejected(meeting.changeVideoLayout(layoutType));
+          });
+
+          it('throws if trying to send renderInfo for content when not receiving content', async () => {
+            assert.isRejected(meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1280, height: 720}}));
+          });
+
+          it('calls changeVideoLayoutDebounced with renderInfo for main and content', async () => {
+            // first set only the main renderInfo
+            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 100, height: 200}});
+
+            assert.calledWith(meeting.meetingRequest.changeVideoLayoutDebounced, {
+              locusUrl: meeting.locusInfo.self.url,
+              deviceUrl: meeting.deviceUrl,
+              layoutType: layoutTypeSingle,
+              main: {width: 100, height: 200},
+              content: undefined
+            });
+
+            meeting.mediaProperties.mediaDirection.receiveShare = true;
+            meeting.mediaProperties.remoteShare = sinon.stub().returns({mockTrack: 'mockTrack'});
+
+            // now call it again with just content
+            await meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 500, height: 600}});
+            // it should call changeVideoLayoutDebounced with content and previous main value
+            assert.calledWith(meeting.meetingRequest.changeVideoLayoutDebounced, {
+              locusUrl: meeting.locusInfo.self.url,
+              deviceUrl: meeting.deviceUrl,
+              layoutType: layoutTypeSingle,
+              main: {width: 100, height: 200},
+              content: {width: 500, height: 600}
+            });
+
+            // and now call with both
+            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 300, height: 400}, content: {width: 700, height: 800}});
+
+            assert.calledWith(meeting.meetingRequest.changeVideoLayoutDebounced, {
+              locusUrl: meeting.locusInfo.self.url,
+              deviceUrl: meeting.deviceUrl,
+              layoutType: layoutTypeSingle,
+              main: {width: 300, height: 400},
+              content: {width: 700, height: 800}
+            });
+
+            // and now set just the layoutType, the previous main and content values should be used
+            const layoutType = 'Equal';
+
+            await meeting.changeVideoLayout(layoutType);
+
+            assert.calledWith(meeting.meetingRequest.changeVideoLayoutDebounced, {
+              locusUrl: meeting.locusInfo.self.url,
+              deviceUrl: meeting.deviceUrl,
+              layoutType,
+              main: {width: 300, height: 400},
+              content: {width: 700, height: 800}
+            });
+          });
+
+          it('does not call changeVideoLayoutDebounced if renderInfo main changes only very slightly', async () => {
+            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 1024, height: 768}});
+
+            assert.calledWith(meeting.meetingRequest.changeVideoLayoutDebounced, {
+              locusUrl: meeting.locusInfo.self.url,
+              deviceUrl: meeting.deviceUrl,
+              layoutType: layoutTypeSingle,
+              main: {width: 1024, height: 768},
+              content: undefined
+            });
+            meeting.meetingRequest.changeVideoLayoutDebounced.resetHistory();
+
+            // now send main with width/height different by just 2px - it should be ignored
+            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 1026, height: 768}});
+            assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
+
+            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 1022, height: 768}});
+            assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
+
+            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 1024, height: 770}});
+            assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
+
+            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 1024, height: 766}});
+            assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
+          });
+
+          it('does not call changeVideoLayoutDebounced if renderInfo content changes only very slightly', async () => {
+            meeting.mediaProperties.mediaDirection.receiveShare = true;
+            meeting.mediaProperties.remoteShare = sinon.stub().returns({mockTrack: 'mockTrack'});
+
+            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 500, height: 510}, content: {width: 1024, height: 768}});
+
+            assert.calledWith(meeting.meetingRequest.changeVideoLayoutDebounced, {
+              locusUrl: meeting.locusInfo.self.url,
+              deviceUrl: meeting.deviceUrl,
+              layoutType: layoutTypeSingle,
+              main: {width: 500, height: 510},
+              content: {width: 1024, height: 768}
+            });
+            meeting.meetingRequest.changeVideoLayoutDebounced.resetHistory();
+
+            // now send main with width/height different by just 2px - it should be ignored
+            await meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1026, height: 768}});
+            assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
+
+            await meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1022, height: 768}});
+            assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
+
+            await meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1024, height: 770}});
+            assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
+
+            await meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1024, height: 766}});
+            assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
           });
         });
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/request.js
@@ -48,15 +48,17 @@ describe('plugin-meetings', () => {
     });
 
     describe('#changeVideoLayout', () => {
-      it('sends a PUT request to the controls endpoint', async () => {
-        const locusUrl = 'locusURL';
-        const deviceUrl = 'deviceUrl';
-        const layoutType = 'Equal';
+      const locusUrl = 'locusURL';
+      const deviceUrl = 'deviceUrl';
+      const layoutType = 'Equal';
 
+      it('sends a PUT request to the controls endpoint', async () => {
         await meetingsRequest.changeVideoLayout({
           locusUrl,
           deviceUrl,
-          layoutType
+          layoutType,
+          main: {width: 640, height: 480},
+          content: {width: 1280, height: 720}
         });
         const requestParams = meetingsRequest.request.getCall(0).args[0];
 
@@ -64,6 +66,43 @@ describe('plugin-meetings', () => {
         assert.equal(requestParams.uri, `${locusUrl}/controls`);
         assert.equal(requestParams.body.layout.type, layoutType);
         assert.equal(requestParams.body.layout.deviceUrl, deviceUrl);
+        assert.deepEqual(requestParams.body.layout.layoutParams, {renderInfo: {main: {width: 640, height: 480}, content: {width: 1280, height: 720}}});
+      });
+
+      it('throws if width is missing for main', async () => {
+        await assert.isRejected(meetingsRequest.changeVideoLayout({
+          locusUrl,
+          deviceUrl,
+          layoutType,
+          main: {height: 100}
+        }));
+      });
+
+      it('throws if height is missing for main', async () => {
+        await assert.isRejected(meetingsRequest.changeVideoLayout({
+          locusUrl,
+          deviceUrl,
+          layoutType,
+          main: {width: 100}
+        }));
+      });
+
+      it('throws if width is missing for content', async () => {
+        await assert.isRejected(meetingsRequest.changeVideoLayout({
+          locusUrl,
+          deviceUrl,
+          layoutType,
+          content: {height: 100}
+        }));
+      });
+
+      it('throws if height is missing for content', async () => {
+        await assert.isRejected(meetingsRequest.changeVideoLayout({
+          locusUrl,
+          deviceUrl,
+          layoutType,
+          content: {width: 100}
+        }));
       });
     });
 


### PR DESCRIPTION
fixes: SPARK-227135

Extending the changeVideoLayout API so that the app
can send renderInfo to the backend. The actual sending
of the request is debounced, because /control endpoint
has a rate limit of 24 per second and it's very likely
that developers will call this API very frequently in
some scenarios (for example on window size change).

