### PR TITLE
fix(meetings): use proper metrics methods in move media calls

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2872,7 +2872,8 @@ export default class Meeting extends StatelessWebexPlugin {
       throw new ParameterError('Cannot move call without a resourceId.');
     }
 
-    Metrics.mediaCapabilities({
+    Metrics.postEvent({
+      event: eventType.MEDIA_CAPABILITIES,
       meeting: this,
       data: {
         mediaCapabilities: {
@@ -2893,7 +2894,8 @@ export default class Meeting extends StatelessWebexPlugin {
         }
       }
     });
-    Metrics.moveMedia({meeting: this});
+
+    Metrics.postEvent({event: eventType.MOVE_MEDIA, meeting: this});
 
     return MeetingUtil.joinMeetingOptions(this, {resourceId, moveToResource: true}).then(() => {
       this.meetingFiniteStateMachine.join();
@@ -2927,7 +2929,8 @@ export default class Meeting extends StatelessWebexPlugin {
 
     this.webex.meetings.meetingCollection.set(this);
 
-    Metrics.mediaCapabilities({
+    Metrics.postEvent({
+      event: eventType.MEDIA_CAPABILITIES,
       meeting: this,
       data: {
         mediaCapabilities: {
@@ -2948,7 +2951,7 @@ export default class Meeting extends StatelessWebexPlugin {
         }
       }
     });
-    Metrics.moveMedia({meeting: this});
+    Metrics.postEvent({event: eventType.MOVE_MEDIA, meeting: this});
 
     return MeetingUtil.joinMeetingOptions(this).then((join) => this.getMediaStreams({sendAudio: true, sendVideo: true, sendShare: false})
       .then(([localStream, localShare]) =>


### PR DESCRIPTION


Fixes #[SPARK-231755]
Currently the moveTo and moveFrom methods (which instantiate a new device) invoke methods on the Metrics object that currently do not exist and were previously removed.  This PR makes sure the metrics calls are using the appropriate methods and passing the appropriate options

---
