### PR TITLE
fix(plugin-meetings): camera still on when sendVideo is false

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -3040,8 +3040,8 @@ export default class Meeting extends StatelessWebexPlugin {
           Media.getUserMedia(
             {
               ...mediaDirection,
-              sendAudio: (mediaDirection.sendAudio === devicePermissions.sendAudio),
-              sendVideo: (mediaDirection.sendVideo === devicePermissions.sendVideo),
+              sendAudio: devicePermissions.sendAudio,
+              sendVideo: devicePermissions.sendVideo,
               isSharing: this.shareStatus === SHARE_STATUS.LOCAL_SHARE_ACTIVE
             },
             audioVideo,

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -478,16 +478,12 @@ describe('plugin-meetings', () => {
         });
       });
       describe('#getMediaStreams', () => {
-        let sandbox;
-
         beforeEach(() => {
-          sandbox = sinon.createSandbox();
-          sandbox.stub(Media, 'getSupportedDevice').returns(Promise.resolve({sendAudio: true, sendVideo: true}));
-          sandbox.stub(Media, 'getUserMedia').returns(Promise.resolve(['stream1', 'stream2']));
+          sinon.stub(Media, 'getSupportedDevice').callsFake((options) => Promise.resolve({sendAudio: options.sendAudio, sendVideo: options.sendVideo}));
+          sinon.stub(Media, 'getUserMedia').returns(Promise.resolve(['stream1', 'stream2']));
         });
         afterEach(() => {
-          sandbox.restore();
-          sandbox = null;
+          sinon.restore();
         });
         it('should have #getMediaStreams', () => {
           assert.exists(meeting.getMediaStreams);
@@ -497,12 +493,13 @@ describe('plugin-meetings', () => {
 
           assert.calledOnce(Media.getUserMedia);
         });
+
         it('uses the preferred video device if set', async () => {
           const videoDevice = 'video1';
           const mediaDirection = {sendAudio: true, sendVideo: true, sendShare: false};
           const audioVideoSettings = {};
 
-          sandbox.stub(meeting.mediaProperties, 'videoDeviceId').value(videoDevice);
+          sinon.stub(meeting.mediaProperties, 'videoDeviceId').value(videoDevice);
 
           await meeting.getMediaStreams(mediaDirection, audioVideoSettings);
 
@@ -525,12 +522,20 @@ describe('plugin-meetings', () => {
           const mediaDirection = {sendAudio: true, sendVideo: true, sendShare: false};
           const audioVideoSettings = {video: {deviceId: newVideoDevice}};
 
-          sandbox.stub(meeting.mediaProperties, 'videoDeviceId').value(oldVideoDevice);
-          sandbox.stub(meeting.mediaProperties, 'setVideoDeviceId');
+          sinon.stub(meeting.mediaProperties, 'videoDeviceId').value(oldVideoDevice);
+          sinon.stub(meeting.mediaProperties, 'setVideoDeviceId');
 
           await meeting.getMediaStreams(mediaDirection, audioVideoSettings);
 
           assert.calledWith(meeting.mediaProperties.setVideoDeviceId, newVideoDevice);
+        });
+
+        it('should not access camera if sendVideo is false ', async () => {
+          await meeting.getMediaStreams({sendAudio: true, sendVideo: false});
+
+          assert.calledOnce(Media.getUserMedia);
+
+          assert.equal(Media.getUserMedia.args[0][0].sendVideo, false);
         });
       });
       describe('#join', () => {


### PR DESCRIPTION


Fixes #SPARK-238731

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-238731

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
