### PR TITLE
fix(meetings): remove non-Webex calls after user leaves

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -115,6 +115,7 @@ export const _RESOURCE_ROOM_ = 'RESOURCE_ROOM';
 export const _RECEIVE_ONLY_ = 'RECVONLY';
 export const _ROOM_ = hydraTypes.ROOM;
 
+export const _SIP_BRIDGE_ = 'SIP_BRIDGE';
 export const _SIP_URI_ = 'SIP_URI';
 export const _SEND_RECEIVE_ = 'SENDRECV';
 export const _SEND_ONLY_ = 'SENDONLY';

--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
@@ -7,6 +7,7 @@ import {
   LOCUSEVENT,
   _USER_,
   _CALL_,
+  _SIP_BRIDGE_,
   MEETING_STATE,
   _MEETING_,
   LOCUSINFO,
@@ -348,7 +349,7 @@ export default class LocusInfo extends EventsScope {
    * @memberof LocusInfo
    */
   isMeetingActive() {
-    if (this.parsedLocus.fullState.type === _CALL_) {
+    if ((this.parsedLocus.fullState.type === _CALL_) || (this.parsedLocus.fullState.type === _SIP_BRIDGE_)) {
       const partner = this.getLocusPartner(this.participants, this.self);
 
       this.updateMeeting({partner});


### PR DESCRIPTION
If you use the SDK to join a meeting via a SIP url and that meeting has nothing to do with webex (so it's not a url of a PMR or of any webex space) - for example if you call a meeting hosted by Cisco Meeting Server (CMS): example: `alpha_test2@alphauk.cisco.com` then the meeting object doesn't get destroyed after you leave the meeting and it remains there forever.

This kind of meeting is reported by locus as type = "SIP_BRIDGE". I've checked with Locus team and they confirmed that it's better to treat SIB_BRIDGE types of meetings like CALL ones (and not like MEETING ones)

Fixes [SPARK-248251](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-248251)