### PR TITLE
fix(meetings): set both streams when muting

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/muteState.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/muteState.js
@@ -173,8 +173,8 @@ class MuteState {
    * @returns {Promise}
    */
   sendLocalMuteRequestToServer(meeting) {
-    const audioMuted = (this.type === AUDIO) ? this.state.client.localMute : undefined;
-    const videoMuted = (this.type === VIDEO) ? this.state.client.localMute : undefined;
+    const audioMuted = (this.type === AUDIO) ? this.state.client.localMute : meeting.audio?.state.client.localMute;
+    const videoMuted = (this.type === VIDEO) ? this.state.client.localMute : meeting.video?.state.client.localMute;
 
     LoggerProxy.logger.info(`Meeting:muteState#sendLocalMuteRequestToServer --> ${this.type}: sending local mute (audio=${audioMuted}, video=${videoMuted}) to server`);
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
@@ -380,6 +380,31 @@ describe('plugin-meetings', () => {
         assert.calledWith(MeetingUtil.remoteUpdateAudioVideo, undefined, false, meeting);
         assert.notCalled(meeting.members.muteMember);
       });
+
+      it('sends correct audio value when sending local mute for video', async () => {
+        // make sure the meeting object has mute state machines for both audio and video
+        meeting.audio = audio;
+        meeting.video = video;
+
+        // mute audio -> request sent to server should have video unmuted
+        await audio.handleClientRequest(meeting, true);
+        assert.calledWith(MeetingUtil.remoteUpdateAudioVideo, true, false, meeting);
+        MeetingUtil.remoteUpdateAudioVideo.resetHistory();
+
+        // now mute video -> request sent to server should have mute for both audio and video
+        await video.handleClientRequest(meeting, true);
+        assert.calledWith(MeetingUtil.remoteUpdateAudioVideo, true, true, meeting);
+        MeetingUtil.remoteUpdateAudioVideo.resetHistory();
+
+        // now unmute the audio -> request sent to server should still have video muted
+        await audio.handleClientRequest(meeting, false);
+        assert.calledWith(MeetingUtil.remoteUpdateAudioVideo, false, true, meeting);
+        MeetingUtil.remoteUpdateAudioVideo.resetHistory();
+
+        // unmute video -> request sent to server should have both audio and video unmuted
+        await video.handleClientRequest(meeting, false);
+        assert.calledWith(MeetingUtil.remoteUpdateAudioVideo, false, false, meeting);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes bug where if muting only audio or video, the other would reset to default mode instead of staying on their previous state. This issue is fixed by sending the preferred state of both, audio and video, when requesting the server to mute either one.

Fixes [SPARK-242346](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-242346)