### PR TITLE
fix: stop flooding logs with errors while screen sharing

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/networkQualityMonitor/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/networkQualityMonitor/index.js
@@ -45,7 +45,8 @@ export default class NetworkQualityMonitor extends EventsScope {
     this.networkQualityStatus = {
       [this.frequencyTypes.UPLINK]: {
         [STATS.VIDEO_CORRELATE]: {},
-        [STATS.AUDIO_CORRELATE]: {}
+        [STATS.AUDIO_CORRELATE]: {},
+        [STATS.SHARE_CORRELATE]: {}
       }
     };
     this.mediaType = null;


### PR DESCRIPTION
When screen sharing, the log is filled with errors:
"TypeError: Cannot set property 'packetLoss' of undefined

This PR fixes it.