### PR TITLE
fix(plugin-meetings): fix media: ready not triggering issue with late…

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -3299,10 +3299,10 @@ export default class Meeting extends StatelessWebexPlugin {
         remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
         enableRtx: this.config.enableRtx
       })
-        .then(() => this.getDevices().then((devices) => {
+        .then((peerConnection) => this.getDevices().then((devices) => {
           MeetingUtil.handleDeviceLogging(devices);
 
-          return devices;
+          return peerConnection;
         }))
         .then((peerConnection) => {
           this.handleMediaLogging(this.mediaProperties);


### PR DESCRIPTION
Media:ready event not getting triggered with the latest logger PR

Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
