### PR TITLE
fix(encryption): setting onbehalfof to support an edge case

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-ediscovery/README.md
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/README.md
@@ -39,6 +39,12 @@ Run the ediscovery from the top level using
 
 > npm test -- --packages @webex/internal-plugin-ediscovery
 
+## Debug Tests
+
+Run the following command
+
+> npm test -- --packages @webex/internal-plugin-ediscovery --grep "test name" --karmaDebug --browsers=Chrome
+
 ## Maintainers
 
 This package is maintained by [Cisco Webex for Developers](https://developer.webex.com/).

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/README.md
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/README.md
@@ -35,7 +35,7 @@ webex.internal.plugin.ediscovery.WHATEVER
 
 ## Tests
 
-Run the ediscovery from the top level using
+Run the ediscovery from the top level using 
 
 > npm test -- --packages @webex/internal-plugin-ediscovery
 

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/README.md
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/README.md
@@ -37,7 +37,7 @@ webex.internal.plugin.ediscovery.WHATEVER
 
 Run the ediscovery from the top level using
 
-> npm test -- --packages @webex/internal-plugin-ediscovery --node
+> npm test -- --packages @webex/internal-plugin-ediscovery
 
 ## Maintainers
 

--- a/packages/node_modules/@webex/internal-plugin-encryption/src/kms.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/src/kms.js
@@ -662,6 +662,7 @@ const KMS = WebexPlugin.extend({
       clientId: originalContext.clientInfo.clientId,
       credential: {
         userId: onBehalfOf,
+        onBehalfOf, // Supports running onBehalfOf self. i.e. A CO which calls onBehalfOf with CO.id.
         bearer: originalContext.clientInfo.credential.bearer
       }
     };

--- a/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/kms.js
+++ b/packages/node_modules/@webex/internal-plugin-encryption/test/integration/spec/kms.js
@@ -371,6 +371,38 @@ describe('Encryption', function () {
           assert.equal(key2.uri, key.uri);
         }));
 
+      it('retrieve key on behalf of self', () => jim.webex.internal.encryption.kms.createUnboundKeys({count: 1})
+        .then(([k]) => {
+          key = k;
+
+          // Compliance Officer Jim fetches a key on behalf of himself
+          // This covers an edge case documented by https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-240862.
+          return jim.webex.internal.encryption.kms.fetchKey({uri: key.uri, onBehalfOf: jim.id});
+        })
+        .then((key2) => {
+          assert.property(key2, 'uri');
+          assert.property(key2, 'jwk');
+          assert.notEqual(key2, key);
+          assert.equal(key2.uri, key.uri);
+        }));
+
+      // Spock creates the key and Jim is not in the KRO so he should not have access
+      it('retrieve key on behalf of self but self does not have access', () => spock.webex.internal.encryption.kms.createUnboundKeys({count: 1})
+        .then(([k]) => {
+          key = k;
+
+          // Compliance Officer Jim fetches a key on behalf of himself but he is not in the KRO
+          return jim.webex.internal.encryption.kms.fetchKey({uri: key.uri, onBehalfOf: jim.id});
+        })
+        .then(() => {
+          expect.fail('It should not be possible to retrieve a key on behalf of another user without the spark.kms_orgagent role');
+        })
+        .catch((error) => {
+          // Expect a Forbidden error
+          expect(error.body.status).to.equal(403);
+        }));
+
+
       it('error retrieving key, on behalf of another user, without spark.kms_orgagent role',
         () => spock.webex.internal.encryption.kms.createUnboundKeys({count: 1})
           .then(([k]) => {


### PR DESCRIPTION
This PR will fix [SPARK-257081 - Update webex-js-sdk to support `onBehalfOf` as well as `userId` for scenarios where the CO does an onBehalfOf himself](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-257081). Basically it's an edge case where a Compliance Officer is decrypting content **onBehalfOf** himself. KMS had a bug where, in this scenario, the code flow assumed this is not an **onBehalfOf** request, and as a result fails with a 403.

This issue is being covered by 

 * BEMS01309085 [New] C3 TO BE ASSIGNED CPR COMPANY   691741276  Failed to download Summary Report via ediscovery Download Manager. Hangs at downloading... Indicates 'disconnected-waiting to try' and can't download the data finaly
 * Cisco TAC Case : 691741276

The customer is also complaining about how long it's taken for this issue to be resolved. i.e. It's been 30+ days so far.