### PR TITLE
fix(internal-plugin-user): for update name any one name is required

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-user/src/user.js
+++ b/packages/node_modules/@webex/internal-plugin-user/src/user.js
@@ -265,15 +265,14 @@ const User = WebexPlugin.extend({
    * Updates a user's name with webex.
    * @instance
    * @memberof User
-   * @param {Object} options
-   * @param {string} options.givenName (required)
-   * @param {string} options.familyName (required)
-   * @param {string} options.displayName (required)
+   * @param {string} givenName
+   * @param {string} familyName
+   * @param {string} displayName
    * @returns {Promise<Object>}
    */
   updateName({givenName, familyName, displayName} = {}) {
-    if (!givenName || !familyName || !displayName) {
-      return Promise.reject(new Error('`options.givenName` and `options.familyName` and `options.displayName` are required'));
+    if (!(givenName || familyName || displayName)) {
+      return Promise.reject(new Error('One of `givenName` and `familyName` or `displayName` is required'));
     }
 
     return this._setUser({

--- a/packages/node_modules/@webex/internal-plugin-user/test/integration/spec/user.js
+++ b/packages/node_modules/@webex/internal-plugin-user/test/integration/spec/user.js
@@ -248,16 +248,45 @@ runs.forEach((run) => {
         }));
     });
     describe('#updateName()', () => {
-      it('updates a user\'s givenName familyName and displayName', () => webex.internal.user.updateName({givenName: 'Jack', familyName: 'Jill', displayName: 'Jack Jill'})
+      it('updates a user\'s displayName', () => webex.internal.user.updateName({displayName: 'New Name'})
         .then((user) => {
           assert.equal(user.id, webex.internal.device.userId);
           assert.property(user, 'displayName');
-          assert.equal(user.displayName, 'Jack Jill');
+          assert.equal(user.displayName, 'New Name');
+        }));
+      it('updates a user\'s givenName', () => webex.internal.user.updateName({givenName: 'Jack'})
+        .then((user) => {
+          assert.equal(user.id, webex.internal.device.userId);
+          assert.property(user, 'name');
+          assert.property(user.name, 'givenName');
+          assert.equal(user.name.givenName, 'Jack');
+        }));
+      it('updates a user\'s familyName', () => webex.internal.user.updateName({familyName: 'Jill'})
+        .then((user) => {
+          assert.equal(user.id, webex.internal.device.userId);
+          assert.property(user, 'name');
+          assert.property(user.name, 'familyName');
+          assert.equal(user.name.familyName, 'Jill');
+        }));
+      it('updates a user\'s givenName and familyName', () => webex.internal.user.updateName({givenName: 'T', familyName: 'Rex'})
+        .then((user) => {
+          assert.equal(user.id, webex.internal.device.userId);
           assert.property(user, 'name');
           assert.property(user.name, 'givenName');
           assert.property(user.name, 'familyName');
-          assert.equal(user.name.givenName, 'Jack');
-          assert.equal(user.name.familyName, 'Jill');
+          assert.equal(user.name.givenName, 'T');
+          assert.equal(user.name.familyName, 'Rex');
+        }));
+      it('updates a user\'s givenName familyName and displayName', () => webex.internal.user.updateName({givenName: 'Max', familyName: 'Bob', displayName: 'Max Bob'})
+        .then((user) => {
+          assert.equal(user.id, webex.internal.device.userId);
+          assert.property(user, 'displayName');
+          assert.equal(user.displayName, 'Max Bob');
+          assert.property(user, 'name');
+          assert.property(user.name, 'givenName');
+          assert.property(user.name, 'familyName');
+          assert.equal(user.name.givenName, 'Max');
+          assert.equal(user.name.familyName, 'Bob');
         }));
     });
   });

--- a/packages/node_modules/@webex/internal-plugin-user/test/unit/spec/user.js
+++ b/packages/node_modules/@webex/internal-plugin-user/test/unit/spec/user.js
@@ -85,6 +85,10 @@ describe('plugin-user', () => {
       it('requires a `displayName`', () => assert.isRejected(userService.update(), /`options.displayName` is required/));
     });
 
+    describe('#updateName()', () => {
+      it('requires one of `givenName` `familyName` or `displayName`', () => assert.isRejected(userService.updateName(), /One of `givenName` and `familyName` or `displayName` is required/));
+    });
+
     describe('#verify()', () => {
       it('requires an `email` param', () => assert.isRejected(userService.verify(), /`options.email` is required/));
     });


### PR DESCRIPTION
Fix for updateName- from webclient a user can only provide a givenName so removing the check which required all names to be provided. 
Now check is that at-least  one of givenName, familyName or displayName should be there.

Fixes SPARK-257436

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
