### PR TITLE
feat(internal-plugin-user): generate and validate otp

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-user/src/user.js
+++ b/packages/node_modules/@webex/internal-plugin-user/src/user.js
@@ -133,6 +133,30 @@ const User = WebexPlugin.extend({
       .then((user) => this.recordUUID(Object.assign({emailAddress: email}, user))
         .then(() => user.id));
   },
+  /**
+   * Generates One Time Password.
+   * @instance
+   * @param {Object} options
+   * @param {string} options.email
+   * @param {string} options.id
+   * @returns {Promise}
+   */
+  generateOTP(options = {}) {
+    if (!(options.email || options.id)) {
+      return Promise.reject(new Error('One of `options.email` or `options.id` is required'));
+    }
+
+    return this.request({
+      uri: this.webex.config.credentials.generateOtpUrl,
+      method: 'POST',
+      body: options,
+      auth: {
+        user: this.webex.config.credentials.client_id,
+        pass: this.webex.config.credentials.client_secret
+      }
+    })
+      .then((res) => res.body);
+  },
 
   /**
    * Fetches details about the current user
@@ -302,6 +326,38 @@ const User = WebexPlugin.extend({
       body: options
     })
       .then((res) => res.body);
+  },
+
+  /**
+   * Validated One Time Password.
+   * @instance
+   * @param {Object} options
+   * @param {string} options.email
+   * @param {string} options.id
+   * @param {string} options.oneTimePassword
+   * @returns {Promise}
+   */
+  validateOTP(options = {}) {
+    if (!(options.email || options.id) || !options.oneTimePassword) {
+      return Promise.reject(new Error('One of `options.email` or `options.id` and `options.oneTimePassword` are required'));
+    }
+
+    options.scope = this.webex.config.credentials.scope;
+
+    return this.request({
+      uri: this.webex.config.credentials.validateOtpUrl,
+      method: 'POST',
+      body: options,
+      auth: {
+        user: this.webex.config.credentials.client_id,
+        pass: this.webex.config.credentials.client_secret
+      }
+    })
+      .then((res) => {
+        this.webex.credentials.set({supertoken: res.body.tokenData});
+
+        return res.body;
+      });
   },
 
   /**

--- a/packages/node_modules/@webex/internal-plugin-user/test/integration/spec/user.js
+++ b/packages/node_modules/@webex/internal-plugin-user/test/integration/spec/user.js
@@ -172,6 +172,50 @@ runs.forEach((run) => {
       });
     });
 
+    describe('#generateOTP() and #validateOTP()', () => {
+      it('generates and validates OTP', () => {
+        const unauthWebex = new WebexCore(run.attrs);
+
+        assert.isUndefined(unauthWebex.credentials.supertoken);
+        // NOTE: need collabctg+*@gmail.com to get oneTimePassword
+        const email = `collabctg+webex-js-sdk-${uuid.v4()}@gmail.com`;
+
+        return unauthWebex.internal.user.verify({email})
+          .then((res) => {
+            const {query} = url.parse(res.verifyEmailURL);
+            const token = querystring.parse(query).t;
+
+            return unauthWebex.internal.user.activate({email, verificationToken: token});
+          })
+          .then(() => unauthWebex.internal.device.register())
+          .then(() => unauthWebex.internal.user.get())
+          .then((user) => unauthWebex.internal.user.setPassword({email: user.email, password: 'P@ssword123'}))
+          .then(() => unauthWebex.internal.user.verify({email}))
+          .then(() => unauthWebex.internal.user.generateOTP({email}))
+          .then((res) => {
+            assert.property(res, 'oneTimePassword');
+            assert.property(res, 'email');
+            assert.equal(res.email, email);
+            assert.property(res, 'id');
+            assert.property(res, 'url');
+            assert.property(res, 'status');
+
+            return unauthWebex.internal.user.validateOTP({email, oneTimePassword: res.oneTimePassword});
+          })
+          .then((res) => {
+            assert.property(res, 'email');
+            assert.property(res, 'id');
+            assert.property(res, 'url');
+            assert.property(res, 'tokenData');
+            assert.equal(res.email, email);
+            assert.equal(res.tokenData.token_type, unauthWebex.credentials.supertoken.token_type);
+            assert.equal(res.tokenData.expires_in, unauthWebex.credentials.supertoken.expires_in);
+            assert.equal(res.tokenData.access_token, unauthWebex.credentials.supertoken.access_token);
+            assert.equal(res.tokenData.refresh_token_expires_in, unauthWebex.credentials.supertoken.refresh_token_expires_in);
+          });
+      });
+    });
+
     describe('#get()', () => {
       it('gets the current user', () => webex.internal.user.get()
         .then((user) => {

--- a/packages/node_modules/@webex/internal-plugin-user/test/unit/spec/user.js
+++ b/packages/node_modules/@webex/internal-plugin-user/test/unit/spec/user.js
@@ -77,6 +77,17 @@ describe('plugin-user', () => {
       });
     });
 
+    describe('#generateOTP()', () => {
+      it('requires one of `email` or `id`', () => assert.isRejected(userService.generateOTP(), /One of `options.email` or `options.id` is required/));
+    });
+
+    describe('#validateOTP()', () => {
+      it('requires one of `email` or `id` and `oneTimePassword`', () => assert.isRejected(userService.validateOTP(), /One of `options.email` or `options.id` and `options.oneTimePassword` are required/));
+      it('requires one of `email` or `id` even when otp is given', () => assert.isRejected(userService.validateOTP({oneTimePassword: '123456'}), /One of `options.email` or `options.id` and `options.oneTimePassword` are required/));
+      it('requires oneTimePassword even when email is given', () => assert.isRejected(userService.validateOTP({email: 'example@test.com'}), /One of `options.email` or `options.id` and `options.oneTimePassword` are required/));
+      it('requires oneTimePassword even when id is given', () => assert.isRejected(userService.validateOTP({id: 'some-fake-id'}), /One of `options.email` or `options.id` and `options.oneTimePassword` are required/));
+    });
+
     describe('#setPassword()', () => {
       it('requires a `password`', () => assert.isRejected(userService.setPassword(), /`options.password` is required/));
     });

--- a/packages/node_modules/@webex/webex-core/src/credentials-config.js
+++ b/packages/node_modules/@webex/webex-core/src/credentials-config.js
@@ -92,6 +92,32 @@ const CredentialsConfig = AmpState.extend({
       cache: false
     },
 
+    /**
+      * Generate OTP URL
+      * {@link config.credentials.generateOtpUrl}
+      * @type {string}
+      */
+    generateOtpUrl: {
+      deps: ['idbroker.url'],
+      fn() {
+        return `${this.idbroker.url || 'https://idbroker.webex.com'}/idb/token/v1/actions/UserOTP/Generate/invoke`;
+      },
+      cache: false
+    },
+
+    /**
+      * Validate OTP URL
+      * {@link config.credentials.validateOtpUrl}
+      * @type {string}
+      */
+    validateOtpUrl: {
+      deps: ['idbroker.url'],
+      fn() {
+        return `${this.idbroker.url || 'https://idbroker.webex.com'}/idb/token/v1/actions/UserOTP/Validate/invoke`;
+      },
+      cache: false
+    },
+
     // TODO does hydra also have an access_token endpoint?
     /**
       * Token URL used for token refresh and auth code exchange


### PR DESCRIPTION
If there is any authorization error, Client can leverage CI User One Time Login APIs to provide user with an option to do One Time login using a 6 digit PIN.
For social sign in flow webapp requires new functions for generating and validating one time passwords. 
Wiki links for both apis are:
https://wiki.cisco.com/display/IDENTITY/API+-+Generate+UserOTP
https://wiki.cisco.com/display/IDENTITY/API+-+Validate+UserOTP
Added generateOTP and validateOTP for the above and also added relevant integration and unittests.
Fixes #[INSERT LINK TO ISSUE NUMBER]
SPARK-260835
---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
