### PR TITLE
fix(internal-plugin-conversation): add hint when uploading space avatars

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -1115,6 +1115,8 @@ const Conversation = WebexPlugin.extend({
    * @returns {Promise<Activity>}
    */
   assign(conversation, avatar) {
+    const uploadOptions = {role:'spaceAvatar'};
+
     if ((avatar.size || avatar.length) > 1024 * 1024) {
       return Promise.reject(new Error('Room avatars must be less than 1MB'));
     }
@@ -1129,7 +1131,7 @@ const Conversation = WebexPlugin.extend({
         const activity = ShareActivity.create(conversation, null, this.webex);
 
         activity.enableThumbnails = false;
-        activity.add(avatar);
+        activity.add(avatar,uploadOptions);
 
         return this.prepare(activity, {
           target: this.prepareConversation(convoWithUrl)

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -1115,7 +1115,7 @@ const Conversation = WebexPlugin.extend({
    * @returns {Promise<Activity>}
    */
   assign(conversation, avatar) {
-    const uploadOptions = {role:'spaceAvatar'};
+    const uploadOptions = {role: 'spaceAvatar'};
 
     if ((avatar.size || avatar.length) > 1024 * 1024) {
       return Promise.reject(new Error('Room avatars must be less than 1MB'));
@@ -1131,7 +1131,7 @@ const Conversation = WebexPlugin.extend({
         const activity = ShareActivity.create(conversation, null, this.webex);
 
         activity.enableThumbnails = false;
-        activity.add(avatar,uploadOptions);
+        activity.add(avatar, uploadOptions);
 
         return this.prepare(activity, {
           target: this.prepareConversation(convoWithUrl)

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -265,7 +265,9 @@ const ShareActivity = WebexPlugin.extend({
         transcode: true
       },
       phases: {
-        initialize: {fileSize},
+        initialize: {
+          body:{fileSize,role:'spaceAvatar'}
+        },
         upload: {
           $url(session) {
             return session.uploadUrl;
@@ -393,6 +395,7 @@ const ShareActivity = WebexPlugin.extend({
  * @returns {ShareActivity}
  */
 ShareActivity.create = function create(conversation, object, webex) {
+  console.log(conversation, object, webex);
   if (object instanceof ShareActivity) {
     return object;
   }

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -79,11 +79,11 @@ const ShareActivity = WebexPlugin.extend({
           return url;
         }));
       this.hiddenSpaceUrl = Promise.resolve(attrs.conversation._hiddenSpaceUrl || this._retrieveSpaceUrl(`${attrs.conversation.url}/space/hidden`)
-      .then((url) => {
-        attrs.conversation._hiddenSpaceUrl = url;
+        .then((url) => {
+          attrs.conversation._hiddenSpaceUrl = url;
 
-        return url;
-      }));
+          return url;
+        }));
     }
   },
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -189,7 +189,7 @@ const ShareActivity = WebexPlugin.extend({
             return Promise.all([cdata, this.spaceUrl]);
           })
           .then(([cdata, spaceUrl]) => {
-            const uploadPromise = this._upload(cdata, `${spaceUrl}/upload_sessions`);
+            const uploadPromise = this._upload(cdata, `${spaceUrl}/upload_sessions`, options);
 
             transferEvents('progress', uploadPromise, emitter);
 
@@ -254,9 +254,11 @@ const ShareActivity = WebexPlugin.extend({
    * @private
    * @returns {Promise}
    */
-  _upload(file, uri) {
+  _upload(file, uri, uploadOptions) {
     const fileSize = file.length || file.size || file.byteLength;
     const fileHash = sha256(file).toString();
+    const role = uploadOptions?.role;  
+    const initializeBody = role !== undefined ? {fileSize,role} : {fileSize};
 
     return this.webex.upload({
       uri,
@@ -266,7 +268,7 @@ const ShareActivity = WebexPlugin.extend({
       },
       phases: {
         initialize: {
-          body:{fileSize,role:'spaceAvatar'}
+          body:initializeBody
         },
         upload: {
           $url(session) {
@@ -395,7 +397,6 @@ const ShareActivity = WebexPlugin.extend({
  * @returns {ShareActivity}
  */
 ShareActivity.create = function create(conversation, object, webex) {
-  console.log(conversation, object, webex);
   if (object instanceof ShareActivity) {
     return object;
   }

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -77,8 +77,7 @@ const ShareActivity = WebexPlugin.extend({
           attrs.conversation._spaceUrl = url;
 
           return url;
-        }));
-        
+        }));  
       this.hiddenSpaceUrl = Promise.resolve(attrs.conversation._hiddenSpaceUrl || this._retrieveSpaceUrl(`${attrs.conversation.url}/space/hidden`)
         .then((url) => {
           attrs.conversation._hiddenSpaceUrl = url;

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -78,12 +78,12 @@ const ShareActivity = WebexPlugin.extend({
 
           return url;
         }));
-        this.hiddenSpaceUrl = Promise.resolve(attrs.conversation._hiddenSpaceUrl || this._retrieveSpaceUrl(`${attrs.conversation.url}/space/hidden`)
-        .then((url) => {
-          attrs.conversation._hiddenSpaceUrl = url;
+      this.hiddenSpaceUrl = Promise.resolve(attrs.conversation._hiddenSpaceUrl || this._retrieveSpaceUrl(`${attrs.conversation.url}/space/hidden`)
+      .then((url) => {
+        attrs.conversation._hiddenSpaceUrl = url;
 
-          return url;
-        }));
+        return url;
+      }));
     }
   },
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -77,8 +77,8 @@ const ShareActivity = WebexPlugin.extend({
           attrs.conversation._spaceUrl = url;
 
           return url;
-        }));  
-      this.hiddenSpaceUrl = Promise.resolve(attrs.conversation._hiddenSpaceUrl || this._retrieveSpaceUrl(`${attrs.conversation.url}/space/hidden`)
+        }));
+        this.hiddenSpaceUrl = Promise.resolve(attrs.conversation._hiddenSpaceUrl || this._retrieveSpaceUrl(`${attrs.conversation.url}/space/hidden`)
         .then((url) => {
           attrs.conversation._hiddenSpaceUrl = url;
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -78,7 +78,7 @@ const ShareActivity = WebexPlugin.extend({
 
           return url;
         }));
-
+        
       this.hiddenSpaceUrl = Promise.resolve(attrs.conversation._hiddenSpaceUrl || this._retrieveSpaceUrl(`${attrs.conversation.url}/space/hidden`)
         .then((url) => {
           attrs.conversation._hiddenSpaceUrl = url;
@@ -258,8 +258,8 @@ const ShareActivity = WebexPlugin.extend({
   _upload(file, uri, uploadOptions) {
     const fileSize = file.length || file.size || file.byteLength;
     const fileHash = sha256(file).toString();
-    const role = uploadOptions?.role;  
-    const initializeBody = role !== undefined ? {fileSize, role} : {fileSize};
+    const role = uploadOptions ? uploadOptions.role : undefined;
+    const initializeBody = role ? {fileSize, role} : {fileSize};
 
     return this.webex.upload({
       uri,

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -251,6 +251,7 @@ const ShareActivity = WebexPlugin.extend({
   /**
    * @param {File} file
    * @param {string} uri
+   * @param {Object} uploadOptions
    * @private
    * @returns {Promise}
    */
@@ -258,7 +259,7 @@ const ShareActivity = WebexPlugin.extend({
     const fileSize = file.length || file.size || file.byteLength;
     const fileHash = sha256(file).toString();
     const role = uploadOptions?.role;  
-    const initializeBody = role !== undefined ? {fileSize,role} : {fileSize};
+    const initializeBody = role !== undefined ? {fileSize, role} : {fileSize};
 
     return this.webex.upload({
       uri,
@@ -268,7 +269,7 @@ const ShareActivity = WebexPlugin.extend({
       },
       phases: {
         initialize: {
-          body:initializeBody
+          body: initializeBody
         },
         upload: {
           $url(session) {

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/share-activity.js
@@ -120,7 +120,7 @@ describe('plugin-conversation', () => {
         const inputData = {
           phases: {
             initialize: {
-              body:{fileSize,role:'spaceAvatar'}
+              body: {fileSize, role: 'spaceAvatar'}
             },
             finalize: {
               body: {

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/share-activity.js
@@ -111,6 +111,30 @@ describe('plugin-conversation', () => {
 
         assert.isTrue(spy.calledWith(inputData));
       });
+
+      it('checks whether property role:spaceAvatar is sent in body while making a call to /finish API', () => {
+        const spy = sinon.spy(webex.upload);
+        const fileSize = 3333;
+        const fileHash = sha256(fakeURL).toString();
+
+        const inputData = {
+          phases: {
+            initialize: {
+              body:{fileSize,role:'spaceAvatar'}
+            },
+            finalize: {
+              body: {
+                fileSize,
+                fileHash
+              }
+            }
+          }
+        };
+
+        spy(inputData);
+
+        assert.isTrue(spy.calledWith(inputData));
+      });
     });
 
     describe('#addGif', () => {


### PR DESCRIPTION

When uploading a space avatar, the client begins by uploading the proposed image file to the Files Service, using a POST request. This story is to add the property "role":"spaceAvatar" to that request body. Doing so will allow Files to bypass its normal file share blocking rules.

Fixes #SPARK-239726