### PR TITLE
SPARK-238602 Decrypt space information for eDiscovery

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/transforms.js
@@ -190,30 +190,31 @@ class Transforms {
 
         // add warning properties to the activity - these will be recorded in the downloader
         if (container.warning) {
-          activity.spaceWarning = container.warning; // Depreciate this property
+          activity.spaceWarning = container.warning; // Remove this property once all clients are using the content container model
           activity.containerWarning = container.warning;
         }
 
         // set space name and participants on activity
         if (container.containerName) {
-          activity.spaceName = container.containerName; // Depreciate this property
+          activity.spaceName = container.containerName; // Remove this property once all clients are using the content container model
           activity.containerName = container.containerName;
         }
         else if (container.isOneOnOne) {
           const displayNames = (container.participants || []).concat(container.formerParticipants || []).map((p) => p.displayName).join(' & ');
 
           // One to One spaces have no space name, use participant names as 'Subject' instead
-          activity.spaceName = displayNames; // Depreciate this property
+          activity.spaceName = displayNames; // Remove this property once all clients are using the content container model
           activity.containerName = displayNames;
         }
         else {
-          activity.spaceName = ''; // Depreciate this property
+          activity.spaceName = ''; // Remove this property once all clients are using the content container model
           activity.containerName = '';
         }
 
         // post and share activities have content which needs to be decrypted
-        // as do meeting and recording activities
-        if (!['post', 'share'].includes(activity.verb) && !activity.meeting && !activity.recording && !(activity.extension && activity.extension.extensionType === 'customApp')) {
+        // as do meeting, recording activities, customApp extensions, and space information updates
+        if (!['post', 'share'].includes(activity.verb) && !activity.meeting && !activity.recording && !(activity.extension && activity.extension.extensionType === 'customApp') &&
+          !activity.spaceInfo?.name && !activity.spaceInfo?.description) {
           return Promise.resolve(object);
         }
 
@@ -243,6 +244,47 @@ class Transforms {
             .catch((reason) => {
               ctx.webex.logger.error(`Decrypt message error for activity ${activity.activityId} in container ${activity.targetId}: ${reason}`);
               // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+              activity.error = reason;
+
+              return Promise.resolve(object);
+            }));
+        }
+
+        // If the activity is a space information update, decrypt the name and description if present
+        if (activity.spaceInfo?.name) {
+          promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
+            [activity.encryptionKeyUrl, activity.spaceInfo.name, {onBehalfOf: container.onBehalfOfUser}])
+            .then((decryptedMessage) => {
+              activity.spaceInfo.name = decryptedMessage;
+            })
+            .catch((reason) => {
+              ctx.webex.logger.error(`Decrypt activity.spaceInfo.name error for activity ${activity.activityId} in container ${activity.targetId}: ${reason}`);
+              activity.error = reason;
+
+              return Promise.resolve(object);
+            }));
+        }
+        if (activity.spaceInfo?.description) {
+          promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
+            [activity.encryptionKeyUrl, activity.spaceInfo.description, {onBehalfOf: container.onBehalfOfUser}])
+            .then((decryptedMessage) => {
+              activity.spaceInfo.description = decryptedMessage;
+            })
+            .catch((reason) => {
+              ctx.webex.logger.error(`Decrypt activity.spaceInfo.description error for activity ${activity.activityId} in container ${activity.targetId}: ${reason}`);
+              activity.error = reason;
+
+              return Promise.resolve(object);
+            }));
+        }
+        if (activity.spaceInfo?.previousName && activity.spaceInfo.previousEncryptionKeyUrl) {
+          promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
+            [activity.spaceInfo.previousEncryptionKeyUrl, activity.spaceInfo.previousName, {onBehalfOf: container.onBehalfOfUser}])
+            .then((decryptedMessage) => {
+              activity.spaceInfo.previousName = decryptedMessage;
+            })
+            .catch((reason) => {
+              ctx.webex.logger.error(`Decrypt activity.spaceInfo.previousName error for activity ${activity.activityId} in container ${activity.targetId}: ${reason}`);
               activity.error = reason;
 
               return Promise.resolve(object);
@@ -445,7 +487,7 @@ class Transforms {
 
   /**
    * This function is used to decrypt encrypted properties on the containers that are returned from the eDiscovery Service getContentContainer API
-   * @param {Object} ctx - An object containg a webex instance and a transform
+   * @param {Object} ctx - An object containing a webex instance and a transform
    * @param {Object} object - Generic object that you want to decrypt some property on based on the type
    * @returns {Promise} - Returns a transform promise
    */
@@ -473,6 +515,21 @@ class Transforms {
       container.error = reason;
 
       return Promise.resolve(object);
+    }
+
+    // decrypt description if present with a descriptionEncryptionKeyUrl
+    if (container.description && container.descriptionEncryptionKeyUrl) {
+      requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
+        [container.descriptionEncryptionKeyUrl, container.description, {onBehalfOf: container.onBehalfOfUser}])
+        .then((decryptedContainerDescription) => {
+          container.description = decryptedContainerDescription;
+        })
+        .catch((reason) => {
+          ctx.webex.logger.error(`Decrypt container description error for ${container.containerType} container ${container.containerId}: ${reason}`);
+          // add warn property to container info - this warning will be recorded in the downloader
+          container.warning = reason;
+          // don't return, attempt to decrypt the name first
+        });
     }
 
     return requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/test/unit/spec/transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/test/unit/spec/transforms.js
@@ -364,6 +364,58 @@ describe('EDiscovery Transform Tests', () => {
 
         return result;
       });
+
+      it('Calls the correct decrypt functions when transforming activity.spaceInfo.name', () => {
+        object.body.verb = 'update';
+        object.body.spaceInfo = {name: 'Encrypted Name'};
+        object.body.objectDisplayName = undefined;
+        const result = Transforms.decryptReportContent(ctx, object, reportId)
+          .then(() => {
+            assert.callCount(ctx.webex.internal.encryption.decryptText, 1);
+            assert.equal(activity.error, undefined);
+          });
+
+        return result;
+      });
+
+      it('Calls the correct decrypt functions when transforming activity.spaceInfo.name with previousValue', () => {
+        object.body.verb = 'update';
+        object.body.spaceInfo = {name: 'Encrypted Name', previousName: 'Previous Name', previousEncryptionKeyUrl: keyUri};
+        object.body.objectDisplayName = undefined;
+        const result = Transforms.decryptReportContent(ctx, object, reportId)
+          .then(() => {
+            assert.callCount(ctx.webex.internal.encryption.decryptText, 2);
+            assert.equal(activity.error, undefined);
+          });
+
+        return result;
+      });
+
+      it('Calls the correct decrypt functions when transforming activity.spaceInfo.description', () => {
+        object.body.verb = 'update';
+        object.body.spaceInfo = {description: 'Encrypted Description'};
+        object.body.objectDisplayName = undefined;
+        const result = Transforms.decryptReportContent(ctx, object, reportId)
+          .then(() => {
+            assert.callCount(ctx.webex.internal.encryption.decryptText, 1);
+            assert.equal(activity.error, undefined);
+          });
+
+        return result;
+      });
+
+      it('Calls the correct decrypt functions when transforming both activity.spaceInfo.name and activity.spaceInfo.description', () => {
+        object.body.verb = 'update';
+        object.body.spaceInfo = {name: 'Encrypted Name', description: 'Encrypted description'};
+        object.body.objectDisplayName = undefined;
+        const result = Transforms.decryptReportContent(ctx, object, reportId)
+          .then(() => {
+            assert.callCount(ctx.webex.internal.encryption.decryptText, 2);
+            assert.equal(activity.error, undefined);
+          });
+
+        return result;
+      });
     });
   });
 });


### PR DESCRIPTION
eDiscovery will be handling new activities which contain space information (name, description etc.) that must be decrypted so that the end user will be able to read it.

Fixes #[https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-238602]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
