### PR TITLE
fix(internal-plugin-conversation): add new property to request body

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -1115,6 +1115,8 @@ const Conversation = WebexPlugin.extend({
    * @returns {Promise<Activity>}
    */
   assign(conversation, avatar) {
+    const uploadOptions = {role: 'spaceAvatar'};
+
     if ((avatar.size || avatar.length) > 1024 * 1024) {
       return Promise.reject(new Error('Room avatars must be less than 1MB'));
     }
@@ -1129,7 +1131,7 @@ const Conversation = WebexPlugin.extend({
         const activity = ShareActivity.create(conversation, null, this.webex);
 
         activity.enableThumbnails = false;
-        activity.add(avatar);
+        activity.add(avatar, uploadOptions);
 
         return this.prepare(activity, {
           target: this.prepareConversation(convoWithUrl)

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -78,7 +78,6 @@ const ShareActivity = WebexPlugin.extend({
 
           return url;
         }));
-
       this.hiddenSpaceUrl = Promise.resolve(attrs.conversation._hiddenSpaceUrl || this._retrieveSpaceUrl(`${attrs.conversation.url}/space/hidden`)
         .then((url) => {
           attrs.conversation._hiddenSpaceUrl = url;
@@ -189,7 +188,7 @@ const ShareActivity = WebexPlugin.extend({
             return Promise.all([cdata, this.spaceUrl]);
           })
           .then(([cdata, spaceUrl]) => {
-            const uploadPromise = this._upload(cdata, `${spaceUrl}/upload_sessions`);
+            const uploadPromise = this._upload(cdata, `${spaceUrl}/upload_sessions`, options);
 
             transferEvents('progress', uploadPromise, emitter);
 
@@ -251,12 +250,15 @@ const ShareActivity = WebexPlugin.extend({
   /**
    * @param {File} file
    * @param {string} uri
+   * @param {Object} uploadOptions
    * @private
    * @returns {Promise}
    */
-  _upload(file, uri) {
+  _upload(file, uri, uploadOptions) {
     const fileSize = file.length || file.size || file.byteLength;
     const fileHash = sha256(file).toString();
+    const {role} = uploadOptions ?? {};
+    const initializeBody = Object.assign({fileSize}, role && {role});
 
     return this.webex.upload({
       uri,
@@ -265,7 +267,9 @@ const ShareActivity = WebexPlugin.extend({
         transcode: true
       },
       phases: {
-        initialize: {fileSize},
+        initialize: {
+          body: initializeBody
+        },
         upload: {
           $url(session) {
             return session.uploadUrl;

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/share-activity.js
@@ -79,13 +79,18 @@ describe('plugin-conversation', () => {
       });
     });
     describe('#upload', () => {
+      let shareActivityUpload;
       let webex;
       const fakeURL = 'https://encryption-a.wbx2.com/encryption/api/v1/keys/8a7d3d78-ce75-48aa-a943-2e8acf63fbc9';
 
-      before(() => {
+      beforeEach(() => {
         webex = new MockWebex({
           upload: sinon.stub().returns(Promise.resolve({body: {downloadUrl: fakeURL}}))
         });
+
+        shareActivityUpload = new ShareActivity({}, {
+          parent: webex
+        }); 
       });
 
       it('checks whether filehash is sent in body while making a call to /finish API', () => {
@@ -108,8 +113,21 @@ describe('plugin-conversation', () => {
         };
 
         spy(inputData);
-
+        
         assert.isTrue(spy.calledWith(inputData));
+      });
+
+      it('checks whether property role:spaceAvatar is sent in body while making a call to /finish API', () => {
+        const fileSize = 100;
+        const mockFile = {size: fileSize};
+        const uploadOptions = {role: 'spaceAvatar'};
+        
+        shareActivityUpload._upload(mockFile, fakeURL, uploadOptions);
+
+        const expectedResult = {fileSize, role: 'spaceAvatar'};
+        const actualResult = webex.upload.getCall(0).args[0].phases.initialize.body;
+
+        assert.match(actualResult, expectedResult);
       });
     });
 


### PR DESCRIPTION
When uploading a space avatar, the client begins by uploading the proposed image file to the Files Service, using a POST request. This story is to add the property "role":"spaceAvatar" to that request body. Doing so will allow Files to bypass its normal file share blocking rules.

Fixes #SPARK-239726
