### PR TITLE
fix(metrics): short-circuit HTTP request if no metrics are enqueued

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-metrics/src/call-diagnostic-events-batcher.js
+++ b/packages/node_modules/@webex/internal-plugin-metrics/src/call-diagnostic-events-batcher.js
@@ -31,6 +31,10 @@ const CallDiagnosticEventsBatcher = Batcher.extend({
   },
 
   submitHttpRequest(payload) {
+    if (payload && payload.length === 0) {
+      return Promise.resolve({}); // batcher.js expects a promise with a non-nullish object
+    }
+
     return this.webex.request({
       method: 'POST',
       service: 'metrics',


### PR DESCRIPTION
The metrics service rejects requests with empty metrics lists, causing
automated tests to fail in contexts that fail on unhandled promise rejections.