### PR TITLE
fix(plugin-meetings): fixed false firing of stop recording event

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/controlsUtils.js
@@ -46,12 +46,13 @@ ControlsUtils.getControls = (oldControls, newControls) => {
     previous,
     current,
     updates: {
-      hasRecordingPausedChanged: current?.record && !isEqual(
-        previous?.record?.paused, current.record.paused
-      ),
-      hasRecordingChanged: current?.record && !isEqual(
-        previous?.record?.recording, current?.record?.recording
-      )
+      hasRecordingPausedChanged: current?.record &&
+      !isEqual(previous?.record?.paused, current.record.paused) &&
+      (previous?.record?.recording || current?.record?.recording), // see comments directly below
+
+      hasRecordingChanged: current?.record &&
+      !isEqual(previous?.record?.recording, current?.record?.recording) && // upon first join, previous?.record?.recording = undefined; thus, never going to be equal and will always return true
+      (previous?.record?.recording || current?.record?.recording) // therefore, condition added to prevent false firings of #meeting:recording:stopped upon first joining a meeting
     }
   };
 };

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -81,6 +81,17 @@ describe('plugin-meetings', () => {
         assert.equal(locusInfo.controls, newControls);
       });
 
+      it('should not trigger the CONTROLS_RECORDING_UPDATED event', () => {
+        locusInfo.controls = {};
+        locusInfo.emitScoped = sinon.stub();
+        locusInfo.updateControls(newControls);
+
+        locusInfo.emitScoped.getCalls().forEach((x) => {
+          // check that no calls in emitScoped are for CONTROLS_RECORDING_UPDATED
+          assert.notEqual(x.args[1], LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED);
+        });
+      });
+
       it('should keep the recording state to `IDLE`', () => {
         locusInfo.controls = {
           record: {

--- a/packages/node_modules/samples/browser-call-with-screenshare/test/wdio/spec/normal-dialing.js
+++ b/packages/node_modules/samples/browser-call-with-screenshare/test/wdio/spec/normal-dialing.js
@@ -419,7 +419,7 @@ describe('Call With Screenshare', () => {
       browserFirefox.waitUntil(() =>
         (browserFirefox.$('#screenshare-tracks').getText() === 'SHARING'),
       {
-        timeout: 10000,
+        timeout: 20000,
         timeoutMsg: 'Timed-out waiting for screenshare to start'
       });
     });


### PR DESCRIPTION
this would occur upon joining a meeting that was created using the API

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-255479

Also noticed that there are some issues with the `current` and `previous` state (in ControlUtils) while I was trying to create tests for this pr. `current` is not the same in both cases and i think that is important to look into to properly make tests. will need to get more info on this. 

Top 2 logs are from *api created meeting*, bottom 2 are from *ui created meeting*, first in each section is `previous` and the other is `current`. can ignore `#meeting:recording` just using that to filter through logs 

![Screen Shot 2021-09-27 at 12 58 48 PM](https://user-images.githubusercontent.com/22531461/134953381-3b95ea06-d444-45b5-90bb-492a68f39788.png)

