### PR TITLE
fix(plugin-meetings): isRecording shows which member started recording

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
@@ -605,7 +605,7 @@ export default class LocusInfo extends EventsScope {
       EVENTS.LOCUS_INFO_UPDATE_PARTICIPANTS,
       {
         participants,
-        recordingId: this.parsedLocus.controls && this.parsedLocus.controls.modifiedBy,
+        recordingId: this.parsedLocus.controls && this.parsedLocus.controls.record?.modifiedBy,
         selfIdentity: this.parsedLocus.self && this.parsedLocus.self.selfIdentity,
         selfId: this.parsedLocus.self && this.parsedLocus.self.selfId,
         hostId: this.parsedLocus.host && this.parsedLocus.host.hostId

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -10,7 +10,8 @@ import LocusDeltaParser from '@webex/plugin-meetings/src/locus-info/parser';
 import {
   LOCUSINFO,
   RECORDING_STATE,
-  LOCUSEVENT
+  LOCUSEVENT,
+  EVENTS
 } from '../../../../src/constants';
 
 import {self, selfWithInactivity} from './selfConstant';
@@ -265,6 +266,44 @@ describe('plugin-meetings', () => {
             }
           }
         ];
+      });
+
+      it('should assert that the correct recordingId, selfIdentity, selfId, and hostId are being set and emitted from updateParticipants', () => {
+        locusInfo.parsedLocus = {
+          controls: {
+            record: {
+              modifiedBy: '1'
+            }
+          },
+          self: {
+            selfIdentity: '123',
+            selfId: '2'
+          },
+          host: {
+            hostId: '3'
+          }
+        };
+        locusInfo.emitScoped = sinon.stub();
+        locusInfo.updateParticipants({});
+
+        // if this assertion fails, double-check the attributes used in
+        // the updateParticipants function in locus-info/index.js
+        assert.calledWith(locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateParticipants'
+          },
+          EVENTS.LOCUS_INFO_UPDATE_PARTICIPANTS,
+          {
+            participants: {},
+            recordingId: '1',
+            selfIdentity: '123',
+            selfId: '2',
+            hostId: '3'
+          });
+        // note: in a real use case, recordingId, selfId, and hostId would all be the same
+        // for this specific test, we are double-checking that each of the id's
+        // are being correctly grabbed from locusInfo.parsedLocus within updateParticipants
       });
 
       it('should update the deltaParticipants object', () => {


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-189023?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&showAll=tr

Previously `this.parsedLocus.controls.modifiedBy` was being used to get the `recordingId`, but that doesn't exist (always `undefined`, and thus the reason why `isRecording` is always `false` when comparing id's). Changed it to the correct reference `this.parsedLocus.controls.record.modifiedBy` and now it correctly gets the id

![Screen Shot 2021-09-29 at 12 33 57 PM](https://user-images.githubusercontent.com/22531461/135320126-ba9de23e-a439-4531-a83a-f9571deba599.png)
![Screen Shot 2021-09-29 at 1 55 51 PM](https://user-images.githubusercontent.com/22531461/135323052-948bedb6-8d55-4364-a510-83bef79cd0a6.png)
