### PR TITLE
docs(readme): correcting the docs hyperlink

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,5 +1,5 @@
 # Documentation
 
-This directory contains the configuration and raw markdown for the [API docs](https://webex.github.io/webex-js-sdk/api/). The [docs](./docs) directory contains the jekyll site for the rest of the documentation.
+This directory contains the configuration and raw markdown for the [API docs](https://webex.github.io/webex-js-sdk/api/). The [docs](../docs) directory contains the jekyll site for the rest of the documentation.
 
 Use `npm run build:docs` to build the API documentation.


### PR DESCRIPTION
Noticed the docs hyperlink was broken
