### PR TITLE
fix(plugin-meetings): Handle the roap state for sending answer

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js
@@ -192,8 +192,10 @@ export default class RoapHandler extends StatelessWebexPlugin {
   handleAction(session, action, meeting, correlationId) {
     let signal;
 
+
     switch (action.type) {
       case ROAP.RECEIVE_ROAP_MSG:
+        LoggerProxy.logger.log(`Roap:handler#handleAction --> RECEIVE_ROAP_MSG event captured, reciving a roap message : ${JSON.stringify(action)}`);
         if (compareWithLastRoapMessage(this.lastRoapMessage, action)) {
           LoggerProxy.logger.warn(`Roap:handler#handleAction --> duplicate roap offer from server: ${action.msg.seq}`);
         }
@@ -204,18 +206,15 @@ export default class RoapHandler extends StatelessWebexPlugin {
         }
         break;
       case ROAP.SEND_ROAP_MSG:
+        LoggerProxy.logger.log(`Roap:handler#handleAction --> SEND_ROAP_MSG event captured, sending roap message ${JSON.stringify(action)}`);
+
         action.local = true;
         this.execute(signal, session, action, meeting, ROAP.TX_);
         break;
       case ROAP.SEND_ROAP_MSG_SUCCESS:
-        // This means we got and answer and waiting for 200 ok for /participants
-        if (RoapCollection.getSessionSequence(correlationId, action.seq).ANSWER) {
-          signal = ROAP.ROAP_SIGNAL.RX_ANSWER;
-          // NOTE: When server send back an answer via mercury the
-          // remote SDP is already saved sent and ok message is sent back
-          // We dont have to indicate the roapHandler about the RX_ANSWER via SEND_ROAP_MSG_SUCCESS
-          // RoapHandler.transition(signal, session, meeting);
-        }
+        // NOTE: When server send back an answer via mercury the
+        // remote SDP is already saved sent and ok message is sent back
+        // We dont have to indicate the roapHandler about the RX_ANSWER via SEND_ROAP_MSG_SUCCESS
         break;
       case ROAP.RECEIVE_CALL_LEAVE:
         RoapCollection.deleteSession(correlationId);

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/index.js
@@ -174,6 +174,12 @@ export default class Roap extends StatelessWebexPlugin {
       seq: options.seq
     };
 
+    this.roapHandler.submit({
+      type: ROAP.SEND_ROAP_MSG,
+      msg: roapMessage,
+      correlationId: options.correlationId
+    });
+
     return this.roapRequest
       .sendRoap({
         roapMessage,
@@ -186,10 +192,11 @@ export default class Roap extends StatelessWebexPlugin {
       })
       .then(() => {
         meeting.setRoapSeq(options.seq);
+
         this.roapHandler.submit({
-          type: ROAP.SEND_ROAP_MSG,
-          msg: roapMessage,
-          correlationId: options.correlationId
+          type: ROAP.SEND_ROAP_MSG_SUCCESS,
+          seq: roapMessage.seq,
+          correlationId: meeting.correlationId
         });
       });
   }

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/state.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/state.js
@@ -25,6 +25,8 @@ const shouldStep = (roap, meeting) => {
 };
 
 const handleTransition = (value, signal, meeting) => {
+  LoggerProxy.logger.log(`Roap:state#handleTransition --> current ${value} to ${signal}`);
+
   switch (value) {
     case ROAP.ROAP_STATE.INIT:
       if (signal === ROAP.ROAP_SIGNAL.RX_OFFER) {

--- a/packages/node_modules/@webex/webex-core/src/interceptors/redirect.js
+++ b/packages/node_modules/@webex/webex-core/src/interceptors/redirect.js
@@ -74,6 +74,8 @@ export default class RedirectInterceptor extends Interceptor {
       response.body.errorCode === LOCUS_REDIRECT_ERROR &&
       response.body.location) {
       options = clone(options);
+
+      this.webex.logger.warn('redirect: url redirects needed from', options.uri);
       if (response.options && response.options.qs) { // for POST requests
         const newUrl = response.body.location.split('?');
 
@@ -82,6 +84,8 @@ export default class RedirectInterceptor extends Interceptor {
       else { // for GET requests
         options.uri = response.body.location;
       }
+
+      this.webex.logger.warn('redirect: url redirects needed to', options.uri);
       options.$redirectCount += 1;
       if (options.$redirectCount > this.webex.config.maxLocusRedirects) {
         return Promise.reject(new Error('Maximum redirects exceeded'));


### PR DESCRIPTION
There was a race condition  when we make a api for /media the response was coming back after the mercury message so the roap state was getting set later after mercury message so we assuming the request is send as soon the api call is made so that if the mercury message comes in then the state changes correctly if the response fails then state will be reset 

so we move the state change before the request then just log the success


https://sqbu-github.cisco.com/WebExSquared/cloud-apps/wiki/Locus---ROAP-callflow
https://sqbu-github.cisco.com/WebExSquared/linus/blob/master/components/protocols/roap/src/roap_session.cpp#L629
https://sqbu-github.cisco.com/Calliope/documentation/blob/master/apis/roap/api_v2.md

Fixes #[SPARK-272808](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-272808)

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
