### PR TITLE
fix(plugin-meetings): add new error codes for password flow

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -185,7 +185,7 @@ export const MODERATOR_FALSE = false;
 
 // ******************** NUMBERS ********************
 
-export const INTENT_TO_JOIN = 2423005;
+export const INTENT_TO_JOIN = [2423005, 2423006, 2423016, 2423017, 2423018];
 export const ICE_TIMEOUT = 2000;
 export const ICE_FAIL_TIMEOUT = 3000;
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -72,13 +72,7 @@ MeetingUtil.hasOwner = (info) => info && info.owner;
 
 MeetingUtil.isOwnerSelf = (owner, selfId) => owner === selfId;
 
-MeetingUtil.isPinOrGuest = (err) => {
-  if (err && err.body && err.body.errorCode === INTENT_TO_JOIN) {
-    return true;
-  }
-
-  return false;
-};
+MeetingUtil.isPinOrGuest = (err) => err?.body?.errorCode && INTENT_TO_JOIN.includes(err.body.errorCode);
 
 MeetingUtil.joinMeeting = (meeting, options) => {
   if (!meeting) {
@@ -263,14 +257,6 @@ MeetingUtil.joinMeetingOptions = (meeting, options = {}) => {
     .catch((err) => {
       // joining a claimed PMR that is not my own, scenario B
       if (MeetingUtil.isPinOrGuest(err)) {
-        if (MeetingUtil.hasOwner(meeting.meetingInfo)) {
-          return MeetingUtil.joinMeeting(meeting, options).then((response) => {
-            meeting.setLocus(response);
-
-            return Promise.resolve();
-          });
-        }
-
         Metrics.postEvent({
           event: eventType.PIN_PROMPT,
           meeting


### PR DESCRIPTION
Server team is going to add new error codes for password flow . adding that as part of the this PR 
https://confluence-eng-gpk2.cisco.com/conf/pages/viewpage.action?spaceKey=LOCUS&title=Webex+Meeting+Password
Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
