### PR TITLE
test(plugin-meetings): added test for hydra roomId on new meetingInfo Api

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
@@ -68,13 +68,18 @@ skipInNode(describe)('plugin-meetings', () => {
 
     // Enable this test when we are going to enable the unified space meeeting .
     // We cannot change the config on load as the meetingInfo function loads dynamically
-    xit('Should fetch meeting Info using the new api', async () => {
-      alice.webex.meetings.config.experimental.enableUnifiedMeetings = true;
+    xit('Should fetch meeting info using room hydra id with the new api', () => alice.webex.rooms.create({title: 'sample'})
+      .then((room) => alice.webex.meetings.meetingInfo.fetchMeetingInfo(room.id))
+      .then((res) => {
+        assert.exists(res.body.meetingNumber);
+      }));
+
+    // Enable this test when we are going to enable the unified space meeeting .
+    // We cannot change the config on load as the meetingInfo function loads dynamically
+    xit('Should fetch meeting info using space url with the new api', async () => {
       const res = await alice.webex.meetings.meetingInfo.fetchMeetingInfo(space.url, 'CONVERSATION_URL');
 
-      assert.exists(res.meetingNumber);
-
-      alice.webex.meetings.config.experimental.enableUnifiedMeetings = false;
+      assert.exists(res.body.meetingNumber);
     });
 
     xit('Bob fetches meeting Info with SIP URI before joining', async () => {

--- a/packages/node_modules/@webex/plugin-meetings/test/utils/webex-test-users.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/utils/webex-test-users.js
@@ -12,6 +12,7 @@ require('@webex/internal-plugin-user');
 require('@webex/internal-plugin-device');
 require('@webex/internal-plugin-conversation');
 require('@webex/internal-plugin-support');
+require('@webex/plugin-rooms');
 require('@webex/plugin-meetings');
 
 const generateTestUsers = (options) => testUser.create({count: options.count})


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-260888

at the time of this writing: the test works when using v2, but other existing tests (16) fail when using v2