### PR TITLE
fix(plugin-meetings): added missing orgId for v2 get meeting info requests

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
@@ -45,7 +45,7 @@ export default class MeetingInfoV2 {
       type,
       webex: this.webex
     });
-    const body = await MeetingInfoUtil.getRequestBody(destinationType);
+    const body = await MeetingInfoUtil.getRequestBody({...destinationType, webex: this.webex});
 
     return this.webex.request({
       method: HTTP_VERBS.POST,

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/utilv2.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/utilv2.js
@@ -189,10 +189,11 @@ MeetingInfoUtil.getDestinationType = async (from) => {
  * @param {Object} options type and value to fetch meeting info
  * @param {String} options.type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
  * @param {Object} options.destination ?? value.value
+ * @param {Object} options.webex Webex SDK instance
  * @returns {Object} returns an object with {resource, method}
  */
 MeetingInfoUtil.getRequestBody = (options) => {
-  const {type, destination} = options;
+  const {type, destination, webex} = options;
   const body = {};
 
   switch (type) {
@@ -201,7 +202,7 @@ MeetingInfoUtil.getRequestBody = (options) => {
       break;
     case _PERSONAL_ROOM_:
       body.userId = destination;
-      body.orgId = ''; // TODO: when to use the org iD (fetch others PMR)
+      body.orgId = webex.credentials.getOrgId(); // TODO: when to use the org iD (fetch others PMR)
       break;
     case _MEETING_ID_:
       body.meetingKey = destination;

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
@@ -14,6 +14,7 @@ import {
   _MEETING_UUID_
 } from '@webex/plugin-meetings/src/constants';
 import MeetingInfoUtil from '@webex/plugin-meetings/src/meeting-info/utilv2';
+import WebexCore from '@webex/webex-core';
 
 describe('plugin-meetings', () => {
   describe('Meeting Info Utils V2', () => {
@@ -72,12 +73,25 @@ describe('plugin-meetings', () => {
 
     describe('#getRequestBody', () => {
       it('for _PERSONAL_ROOM_', () => {
-        const res = MeetingInfoUtil.getRequestBody({
-          type: _PERSONAL_ROOM_,
-          destination: 'userId_1234'
+        const webex = new WebexCore({
+           /**
+            JWT payload: {
+            "sub": "1234567890",
+            "name": "John Doe",
+            "iat": 1516239022,
+            "realm": "my-realm"
+            }
+          */
+          credentials: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJyZWFsbSI6Im15LXJlYWxtIn0.U16gzUsaRW1VVikJA2VeXRHPX716tG1_B42oxzy1UMk'
         });
 
-        assert.equal(res.orgId, '');
+        const res = MeetingInfoUtil.getRequestBody({
+          type: _PERSONAL_ROOM_,
+          destination: 'userId_1234',
+          webex
+        });
+
+        assert.equal(res.orgId, 'my-realm');
         assert.equal(res.userId, 'userId_1234');
       });
 


### PR DESCRIPTION
Got from: https://github.com/webex/webex-js-sdk/pull/2206, seperated it so it would be it's own trackable pr. 

Ticket responsible for this pr: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-274567