### PR TITLE
fix(plugin-meetings): move meetingInfo setup to constructor

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -380,7 +380,7 @@ export default class Meetings extends WebexPlugin {
         StaticConfig.set(this.config);
         LoggerConfig.set(this.config.logging);
         LoggerProxy.set(this.webex.logger);
-
+        this.meetingInfo = this.config.experimental.enableUnifiedMeetings ? new MeetingInfoV2(this.webex) : new MeetingInfo(this.webex);
         Trigger.trigger(
           this,
           {
@@ -406,8 +406,6 @@ export default class Meetings extends WebexPlugin {
 
         return Promise.reject(new Error('SDK cannot authorize'));
       }
-
-      this.meetingInfo = this.config.experimental.enableUnifiedMeetings ? new MeetingInfoV2(this.webex) : new MeetingInfo(this.webex);
 
 
       if (this.registered) {


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-282036

Moving meetingInfo logic to constructor

Fixes #[INSERT LINK TO ISSUE NUMBER]

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
