### PR TITLE
fix(meetings): move meetingInfo instantiation to onReady callback

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -116,15 +116,7 @@ export default class Meetings extends WebexPlugin {
      */
     constructor(...args) {
       super(...args);
-      /**
-       * The MeetingInfo object to interact with server
-       * @instance
-       * @type {Object}
-       * @private
-       * @memberof Meetings
-       */
 
-      this.meetingInfo = null;
       /**
        * The Meetings request to interact with server
        * @instance
@@ -381,6 +373,15 @@ export default class Meetings extends WebexPlugin {
         LoggerConfig.set(this.config.logging);
         LoggerProxy.set(this.webex.logger);
 
+        /**
+       * The MeetingInfo object to interact with server
+       * @instance
+       * @type {Object}
+       * @private
+       * @memberof Meetings
+       */
+        this.meetingInfo = this.config.experimental.enableUnifiedMeetings ? new MeetingInfoV2(this.webex) : new MeetingInfo(this.webex);
+
         Trigger.trigger(
           this,
           {
@@ -406,8 +407,6 @@ export default class Meetings extends WebexPlugin {
 
         return Promise.reject(new Error('SDK cannot authorize'));
       }
-
-      this.meetingInfo = this.config.experimental.enableUnifiedMeetings ? new MeetingInfoV2(this.webex) : new MeetingInfo(this.webex);
 
 
       if (this.registered) {


### PR DESCRIPTION
Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-280998
---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
