### PR TITLE
test(plugin-meetings): check sipUrl in meetingInfo response

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
@@ -77,6 +77,15 @@ skipInNode(describe)('plugin-meetings', () => {
       alice.webex.meetings.config.experimental.enableUnifiedMeetings = false;
     });
 
+    xit('Bob fetches meeting Info with SIP URI before joining', async () => {
+      const {sipUri} = alice.meeting;
+      const res = await bob.webex.meetings.meetingInfo.fetchMeetingInfo(sipUri, 'SIP_URI');
+      const {meetingNumber} = res.body;
+
+      assert(meetingNumber === alice.meeting.meetingNumber, 'meetingNumber matches alice meeting number');
+    });
+
+
     it('Bob and chris joins space meeting', () => testUtils.waitForStateChange(alice.meeting, 'JOINED')
       .then(() => testUtils.waitForStateChange(bob.meeting, 'IDLE'))
       .then(() => testUtils.waitForStateChange(chris.meeting, 'IDLE'))


### PR DESCRIPTION
Added test case for checking sipUrl in response.

<img width="1072" alt="Screen Shot 2021-11-23 at 10 51 16 AM" src="https://user-images.githubusercontent.com/320490/143136964-f120f755-2940-4ae2-967a-31009aa56d3c.png">

<img width="839" alt="Screen Shot 2021-11-23 at 2 07 05 PM" src="https://user-images.githubusercontent.com/320490/143136976-2ef1bee0-9eea-48a3-ab0b-f741e69e2310.png">

