### PR TITLE
feat(plugin-meetings): password and captcha support for unified space meetings

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/common/errors/captcha-error.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/common/errors/captcha-error.js
@@ -1,0 +1,21 @@
+import {ERROR_DICTIONARY} from '../../constants';
+
+/**
+ * Extended Error object to signify captcha related errors
+ */
+export default class CaptchaError extends Error {
+  /**
+  *
+  * @constructor
+  * @param {String} [message]
+  * @param {Object} [error]
+  */
+  constructor(message = ERROR_DICTIONARY.CAPTCHA.MESSAGE, error = null) {
+    super(message);
+    this.name = ERROR_DICTIONARY.CAPTCHA.NAME;
+    this.sdkMessage = ERROR_DICTIONARY.CAPTCHA.MESSAGE;
+    this.error = error;
+    this.stack = error ? error.stack : (new Error()).stack;
+    this.code = ERROR_DICTIONARY.CAPTCHA.CODE;
+  }
+}

--- a/packages/node_modules/@webex/plugin-meetings/src/common/errors/password-error.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/common/errors/password-error.js
@@ -1,0 +1,21 @@
+import {ERROR_DICTIONARY} from '../../constants';
+
+/**
+ * Extended Error object to signify password related errors
+ */
+export default class PasswordError extends Error {
+  /**
+  *
+  * @constructor
+  * @param {String} [message]
+  * @param {Object} [error]
+  */
+  constructor(message = ERROR_DICTIONARY.PASSWORD.MESSAGE, error = null) {
+    super(message);
+    this.name = ERROR_DICTIONARY.PASSWORD.NAME;
+    this.sdkMessage = ERROR_DICTIONARY.PASSWORD.MESSAGE;
+    this.error = error;
+    this.stack = error ? error.stack : (new Error()).stack;
+    this.code = ERROR_DICTIONARY.PASSWORD.CODE;
+  }
+}

--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -559,6 +559,16 @@ export const ERROR_DICTIONARY = {
     NAME: 'StatsError',
     MESSAGE: 'An error occurred with getStats, stats may not continue for this data stream.',
     CODE: 6
+  },
+  PASSWORD: {
+    NAME: 'PasswordError',
+    MESSAGE: 'Password is required, please use verifyPassword()',
+    CODE: 7
+  },
+  CAPTCHA: {
+    NAME: 'CaptchaError',
+    MESSAGE: 'Captcha is required.',
+    CODE: 8
   }
 };
 
@@ -1250,4 +1260,18 @@ export const PSTN_STATUS = {
   TRANSFERRING: 'TRANSFERRING', // usually happens in dial-out after the CONNECTED state
   SUCCESS: 'SUCCESS', // happens after the transfer (TRANSFERRING) is successful
   UNKNOWN: '' // placeholder if we haven't been told what the status is
+};
+
+export const PASSWORD_STATUS = {
+  NOT_REQUIRED: 'NOT_REQUIRED', // password is not required to join the meeting
+  REQUIRED: 'REQUIRED', // client needs to provide the password by calling verifyPassword() before calling join()
+  UNKNOWN: 'UNKNOWN', // we are waiting for information from the backend if password is required or not
+  VERIFIED: 'VERIFIED' // client has already provided the password and it has been verified, client can proceed to call join()
+};
+
+export const MEETING_INFO_FAILURE_REASON = {
+  NONE: 'NONE', // meeting info was retrieved succesfully
+  WRONG_PASSWORD: 'WRONG_PASSWORD', // meeting requires password and no password or wrong one was provided
+  WRONG_CAPTCHA: 'WRONG_CAPTCHA', // wbxappapi requires a captcha code or a wrong captcha code was provided
+  OTHER: 'OTHER' // any other error (network, etc)
 };

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
@@ -3,6 +3,52 @@ import {HTTP_VERBS} from '../constants';
 
 import MeetingInfoUtil from './utilv2';
 
+const PASSWORD_ERROR_DEFAULT_MESSAGE = 'Password required by WbxAppApi, fetchMeetingInfo() has to be called with the password parameter';
+const CAPTCHA_ERROR_DEFAULT_MESSAGE = 'Captcha required by WbxAppApi, fetchMeetingInfo() has to be called with the captchaInfo parameter';
+
+/**
+ * Error to indicate that wbxappapi requires a password
+ */
+export class MeetingInfoV2PasswordError extends Error {
+  /**
+    *
+    * @constructor
+    * @param {Number} [wbxAppApiErrorCode]
+    * @param {Object} [meetingInfo]
+    * @param {String} [message]
+    */
+  constructor(wbxAppApiErrorCode, meetingInfo, message = PASSWORD_ERROR_DEFAULT_MESSAGE) {
+    super(`${message}, code=${wbxAppApiErrorCode}`);
+    this.name = 'MeetingInfoV2PasswordError';
+    this.sdkMessage = message;
+    this.stack = (new Error()).stack;
+    this.wbxAppApiCode = wbxAppApiErrorCode;
+    this.meetingInfo = meetingInfo;
+  }
+}
+
+/**
+   * Error to indicate that wbxappapi requires a captcha
+   */
+export class MeetingInfoV2CaptchaError extends Error {
+  /**
+    *
+    * @constructor
+    * @param {Number} [wbxAppApiErrorCode]
+    * @param {Object} [captchaInfo]
+    * @param {String} [message]
+    */
+  constructor(wbxAppApiErrorCode, captchaInfo, message = CAPTCHA_ERROR_DEFAULT_MESSAGE) {
+    super(`${message}, code=${wbxAppApiErrorCode}`);
+    this.name = 'MeetingInfoV2PasswordError';
+    this.sdkMessage = message;
+    this.stack = (new Error()).stack;
+    this.wbxAppApiCode = wbxAppApiErrorCode;
+    this.isPasswordRequired = wbxAppApiErrorCode === 423005;
+    this.captchaInfo = captchaInfo;
+  }
+}
+
 /**
    * @class MeetingInfo
    */
@@ -35,24 +81,42 @@ export default class MeetingInfoV2 {
      * Fetches meeting info from the server
      * @param {String} destination one of many different types of destinations to look up info for
      * @param {String} [type] to match up with the destination value
+     * @param {String} password
+     * @param {Object} captchaInfo
+     * @param {String} captchaInfo.code
+     * @param {String} captchaInfo.id
      * @returns {Promise} returns a meeting info object
      * @public
      * @memberof MeetingInfo
      */
-  async fetchMeetingInfo(destination, type = null) {
+  async fetchMeetingInfo(destination, type = null, password = null, captchaInfo = null) {
     const destinationType = await MeetingInfoUtil.getDestinationType({
       destination,
       type,
       webex: this.webex
     });
-    const body = await MeetingInfoUtil.getRequestBody(destinationType);
+    const body = await MeetingInfoUtil.getRequestBody({...destinationType, password, captchaInfo});
 
     return this.webex.request({
       method: HTTP_VERBS.POST,
       service: 'webex-appapi-service',
       resource: 'meetingInfo',
       body
-    });
+    })
+      .catch((err) => {
+        if (err?.statusCode === 403) {
+          throw new MeetingInfoV2PasswordError(err.body?.code, err.body?.data?.meetingInfo);
+        }
+        if (err?.statusCode === 423) {
+          throw new MeetingInfoV2CaptchaError(err.body?.code, {
+            captchaId: err.body.captchaID,
+            verificationImageURL: err.body.verificationImageURL,
+            verificationAudioURL: err.body.verificationAudioURL,
+            refreshURL: err.body.refreshURL
+          });
+        }
+        throw err;
+      });
   }
 }
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
@@ -4,7 +4,7 @@ import {HTTP_VERBS} from '../constants';
 import MeetingInfoUtil from './utilv2';
 
 const PASSWORD_ERROR_DEFAULT_MESSAGE = 'Password required by WbxAppApi, fetchMeetingInfo() has to be called with the password parameter';
-const CAPTCHA_ERROR_DEFAULT_MESSAGE = 'Captcha required by WbxAppApi, fetchMeetingInfo() has to be called with the captchaInfo parameter';
+const CAPTCHA_ERROR_DEFAULT_MESSAGE = 'Captcha required. Call fetchMeetingInfo() with captchaInfo argument';
 
 /**
  * Error to indicate that wbxappapi requires a password

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
@@ -3,7 +3,7 @@ import {HTTP_VERBS} from '../constants';
 
 import MeetingInfoUtil from './utilv2';
 
-const PASSWORD_ERROR_DEFAULT_MESSAGE = 'Password required by WbxAppApi, fetchMeetingInfo() has to be called with the password parameter';
+const PASSWORD_ERROR_DEFAULT_MESSAGE = 'Password required. Call fetchMeetingInfo() with password argument';
 const CAPTCHA_ERROR_DEFAULT_MESSAGE = 'Captcha required. Call fetchMeetingInfo() with captchaInfo argument';
 
 /**

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/utilv2.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/utilv2.js
@@ -212,7 +212,9 @@ MeetingInfoUtil.getDestinationType = async (from) => {
  * @returns {Object} returns an object with {resource, method}
  */
 MeetingInfoUtil.getRequestBody = (options) => {
-  const {type, destination} = options;
+  const {
+    type, destination, password, captchaInfo
+  } = options;
   const body = {
     supportHostKey: true
   };
@@ -248,6 +250,15 @@ MeetingInfoUtil.getRequestBody = (options) => {
       break;
     }
     default:
+  }
+
+  if (password) {
+    body.password = password;
+  }
+
+  if (captchaInfo) {
+    body.captchaID = captchaInfo.id;
+    body.captchaVerifyCode = captchaInfo.code;
   }
 
   return body;

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -29,12 +29,15 @@ import WebRTCStats from '../stats/index';
 import StatsMetrics from '../stats/metrics';
 import StatsUtil from '../stats/util';
 import Transcription from '../transcription';
+import PasswordError from '../common/errors/password-error';
+import CaptchaError from '../common/errors/captcha-error';
 import ReconnectionError from '../common/errors/reconnection';
 import ReconnectInProgress from '../common/errors/reconnection-in-progress';
 import {
   _CALL_,
   _INCOMING_,
   _JOIN_,
+  _SIP_URI_,
   AUDIO,
   CONNECTION_STATE,
   CONTENT,
@@ -47,6 +50,7 @@ import {
   LAYOUT_TYPES,
   LIVE,
   LOCUSINFO,
+  MEETING_INFO_FAILURE_REASON,
   MEETING_REMOVED_REASON,
   MEETING_STATE_MACHINE,
   MEETING_STATE,
@@ -57,6 +61,7 @@ import {
   NETWORK_STATUS,
   ONLINE,
   OFFLINE,
+  PASSWORD_STATUS,
   PC_BAIL_TIMEOUT,
   PSTN_STATUS,
   QUALITY_LEVELS,
@@ -73,6 +78,7 @@ import {
 } from '../constants';
 import ParameterError from '../common/errors/parameter';
 import MediaError from '../common/errors/media';
+import {MeetingInfoV2PasswordError, MeetingInfoV2CaptchaError} from '../meeting-info/meeting-info-v2';
 import MQAProcessor from '../metrics/mqa-processor';
 import BrowserDetection from '../common/browser-detection';
 import RoapCollection from '../roap/collection';
@@ -846,9 +852,173 @@ export default class Meeting extends StatelessWebexPlugin {
      */
     this.transcription = undefined;
 
+    /**
+     * Password status. If it's PASSWORD_STATUS.REQUIRED then verifyPassword() needs to be called
+     * with the correct password before calling join()
+     * @instance
+     * @type {PASSWORD_STATUS}
+     * @public
+     * @memberof Meeting
+     */
+    this.passwordStatus = PASSWORD_STATUS.UNKNOWN;
+
+    /**
+     * Information about required captcha. If null, then no captcha is required. status. If it's PASSWORD_STATUS.REQUIRED then verifyPassword() needs to be called
+     * with the correct password before calling join()
+     * @instance
+     * @type {Object}
+     * @property {string} captchaId captcha id
+     * @property {string} verificationImageURL Url of the captcha image
+     * @property {string} verificationAudioURL Url of the captcha audio file
+     * @property {string} refreshURL Url used for refreshing the captcha (don't use it directly, call refreshCaptcha() instead)
+     * @public
+     * @memberof Meeting
+     */
+    this.requiredCaptcha = null;
+
+    /**
+     * Indicates the reason for last failure to obtain meeting.meetingInfo. MEETING_INFO_FAILURE_REASON.NONE if meeting info was
+     * retrieved successfully
+     * @instance
+     * @type {MEETING_INFO_FAILURE_REASON}
+     * @private
+     * @memberof Meeting
+     */
+    this.meetingInfoFailureReason = undefined;
+
     this.setUpLocusInfoListeners();
     this.locusInfo.init(attrs.locus ? attrs.locus : {});
     this.isCreated = true;
+  }
+
+  /**
+   * Fetches meeting information.
+   * @param {Object} options
+   * @param {String} options.destination
+   * @param {String} options.type
+   * @private
+   * @memberof Meeting
+   * @returns {Promise}
+   */
+  async fetchMeetingInfo({
+    destination, type, password = null, captchaCode = null
+  }) {
+    if (captchaCode && !this.requiredCaptcha) {
+      return Promise.reject(new Error('fetchMeetingInfo() called with captchaCode when captcha was not required'));
+    }
+    if (password && (this.passwordStatus !== PASSWORD_STATUS.REQUIRED && this.passwordStatus !== PASSWORD_STATUS.UNKNOWN)) {
+      return Promise.reject(new Error('fetchMeetingInfo() called with password when password was not required'));
+    }
+
+    try {
+      const captchaInfo = captchaCode ? {code: captchaCode, id: this.requiredCaptcha.captchaId} : null;
+
+      const info = await this.attrs.meetingInfoProvider.fetchMeetingInfo(destination, type, password, captchaInfo);
+
+      this.parseMeetingInfo(info);
+      this.meetingInfo = info ? info.body : null;
+      this.meetingInfoFailureReason = MEETING_INFO_FAILURE_REASON.NONE;
+      this.requiredCaptcha = null;
+      if ((this.passwordStatus === PASSWORD_STATUS.REQUIRED) || (this.passwordStatus === PASSWORD_STATUS.VERIFIED)) {
+        this.passwordStatus = PASSWORD_STATUS.VERIFIED;
+      }
+      else {
+        this.passwordStatus = PASSWORD_STATUS.NOT_REQUIRED;
+      }
+
+      return Promise.resolve();
+    }
+    catch (err) {
+      if (err instanceof MeetingInfoV2PasswordError) {
+        LoggerProxy.logger.info(`Meeting:index#fetchMeetingInfo --> Info Unable to fetch meeting info for ${destination} - password required (code=${err?.body?.code}).`);
+
+        // when wbxappapi requires password it still populates partial meeting info in the response
+        if (err.meetingInfo) {
+          this.meetingInfo = err.meetingInfo;
+          this.meetingNumber = err.meetingInfo.meetingNumber;
+        }
+
+        this.passwordStatus = PASSWORD_STATUS.REQUIRED;
+        this.meetingInfoFailureReason = MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD;
+        if (this.requiredCaptcha) {
+          // this is a workaround for captcha service bug, see WEBEX-224862
+          await this.refreshCaptcha();
+        }
+
+        throw (new PasswordError());
+      }
+      else if (err instanceof MeetingInfoV2CaptchaError) {
+        LoggerProxy.logger.info(`Meeting:index#fetchMeetingInfo --> Info Unable to fetch meeting info for ${destination} - captcha required (code=${err?.body?.code}).`);
+
+        this.meetingInfoFailureReason = (this.requiredCaptcha) ?
+          MEETING_INFO_FAILURE_REASON.WRONG_CAPTCHA :
+          MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD;
+
+        if (err.isPasswordRequired) {
+          this.passwordStatus = PASSWORD_STATUS.REQUIRED;
+        }
+
+        this.requiredCaptcha = err.captchaInfo;
+        throw (new CaptchaError());
+      }
+      else {
+        this.meetingInfoFailureReason = MEETING_INFO_FAILURE_REASON.OTHER;
+        throw (err);
+      }
+    }
+  }
+
+  /**
+   * Checks if the supplied password/host key is correct. It returns a promise with information whether the
+   * password and captcha code were correct or not.
+   * @param {String} password - this can be either a password or a host key, can be undefined if only captcha was required
+   * @param {String} captchaCode - can be undefined if captcha was not required by the server
+   * @public
+   * @memberof Meeting
+   * @returns {Promise<{isPasswordValid: boolean, requiredCaptcha: boolean, failureReason: MEETING_INFO_FAILURE_REASON}>}
+   */
+  verifyPassword(password, captchaCode) {
+    return this.fetchMeetingInfo({
+      destination: this.sipUri, type: _SIP_URI_, password, captchaCode
+    })
+      .then(() => ({isPasswordValid: true, requiredCaptcha: null, failureReason: MEETING_INFO_FAILURE_REASON.NONE}))
+      .catch((error) => {
+        if (error instanceof PasswordError || error instanceof CaptchaError) {
+          return {
+            isPasswordValid: this.passwordStatus === PASSWORD_STATUS.VERIFIED,
+            requiredCaptcha: this.requiredCaptcha,
+            failureReason: this.meetingInfoFailureReason
+          };
+        }
+        throw (error);
+      });
+  }
+
+  /**
+   * Refreshes the captcha. As a result the meeting will have new captcha id, image and audio.
+   * If the refresh operation fails, meeting remains with the old captcha properties.
+   * @public
+   * @memberof Meeting
+   * @returns {Promise}
+   */
+  refreshCaptcha() {
+    if (!this.requiredCaptcha) {
+      return Promise.reject(new Error('There is no captcha to refresh'));
+    }
+
+    // in order to get fully populated uris for captcha audio and image in response to refresh captcha request
+    // we have to pass the wbxappapi hostname as the siteFullName parameter
+    const {hostname} = new URL(this.requiredCaptcha.refreshURL);
+
+    return this.meetingRequest.refreshCaptcha({
+      captchaRefreshUrl: `${this.requiredCaptcha.refreshURL}&siteFullName=${hostname}`,
+      captchaId: this.requiredCaptcha.captchaId
+    })
+      .then((response) => {
+        this.requiredCaptcha.captchaId = response.body.captchaID;
+        this.requiredCaptcha.verificationImageURL = response.body.verificationImageURL;
+        this.requiredCaptcha.verificationAudioURL = response.body.verificationAudioURL;
+      });
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
@@ -141,6 +141,33 @@ export default class MeetingRequest extends StatelessWebexPlugin {
   }
 
   /**
+   * Send a request to refresh the captcha
+   * @param {Object} options
+   * @param {String} options.captchaRefreshUrl
+   * @param {String} options.captchaId
+   * @returns {Promise}
+   * @private
+   */
+  refreshCaptcha({
+    captchaRefreshUrl,
+    captchaId
+  }) {
+    const body = {
+      captchaId
+    };
+
+    return this.request({
+      method: HTTP_VERBS.POST,
+      uri: captchaRefreshUrl,
+      body
+    }).catch((err) => {
+      LoggerProxy.logger.error(`Meeting:request#refreshCaptcha --> Error: ${err}`);
+
+      throw err;
+    });
+  }
+
+  /**
    * Make a network request to add a dial in device
    * @param {Object} options
    * @param {String} options.correlationId

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -7,19 +7,23 @@ import {eventType, trigger, mediaType} from '../metrics/config';
 import Media from '../media';
 import LoggerProxy from '../common/logs/logger-proxy';
 import WebRTCStats from '../stats/index';
-import {INTENT_TO_JOIN,
+import {
+  INTENT_TO_JOIN,
   _LEFT_,
   _IDLE_,
   _JOINED_,
   STATS,
-  EVENT_TRIGGERS
-  , FULL_STATE} from '../constants';
+  EVENT_TRIGGERS,
+  FULL_STATE,
+  PASSWORD_STATUS
+} from '../constants';
 import Trigger from '../common/events/trigger-proxy';
 import IntentToJoinError from '../common/errors/intent-to-join';
 import JoinMeetingError from '../common/errors/join-meeting';
 import ParameterError from '../common/errors/parameter';
 import PermissionError from '../common/errors/permission';
-
+import PasswordError from '../common/errors/password-error';
+import CaptchaError from '../common/errors/captcha-error';
 
 const MeetingUtil = {};
 
@@ -239,6 +243,13 @@ MeetingUtil.isMediaEstablished = (currentMediaStatus) =>
 
 MeetingUtil.joinMeetingOptions = (meeting, options = {}) => {
   meeting.resourceId = meeting.resourceId || options.resourceId;
+
+  if (meeting.requiredCaptcha) {
+    return Promise.reject(new CaptchaError());
+  }
+  if (meeting.passwordStatus === PASSWORD_STATUS.REQUIRED) {
+    return Promise.reject(new PasswordError());
+  }
 
   if (options.pin) {
     Metrics.postEvent({

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -48,6 +48,8 @@ import Reachability from '../reachability';
 import Request from '../meetings/request';
 import StatsAnalyzer from '../analyzer/analyzer';
 import StatsCalculator from '../analyzer/calculator';
+import PasswordError from '../common/errors/password-error';
+import CaptchaError from '../common/errors/captcha-error';
 
 import MeetingCollection from './collection';
 import MeetingsUtil from './util';
@@ -716,7 +718,8 @@ export default class Meetings extends WebexPlugin {
           deviceUrl: this.webex.internal.device.url,
           orgId: this.webex.internal.device.orgId,
           roapSeq: 0,
-          locus: type === _LOCUS_ID_ ? destination : null // pass the locus object if present
+          locus: type === _LOCUS_ID_ ? destination : null, // pass the locus object if present
+          meetingInfoProvider: this.meetingInfo
         },
         {
           parent: this.webex
@@ -726,15 +729,14 @@ export default class Meetings extends WebexPlugin {
       this.meetingCollection.set(meeting);
 
       try {
-        const info = await this.meetingInfo.fetchMeetingInfo(destination, type);
-
-        meeting.parseMeetingInfo(info);
-        meeting.meetingInfo = info ? info.body : null;
+        await meeting.fetchMeetingInfo({destination, type});
       }
       catch (err) {
-        // if there is no meeting info we assume its a 1:1 call or wireless share
-        LoggerProxy.logger.info(`Meetings:index#createMeeting --> Info Unable to fetch meeting info for ${destination}.`);
-        LoggerProxy.logger.info('Meetings:index#createMeeting --> Info assuming this destination is a 1:1 or wireless share');
+        if (!(err instanceof CaptchaError) && !(err instanceof PasswordError)) {
+          // if there is no meeting info we assume its a 1:1 call or wireless share
+          LoggerProxy.logger.info(`Meetings:index#createMeeting --> Info Unable to fetch meeting info for ${destination}.`);
+          LoggerProxy.logger.info('Meetings:index#createMeeting --> Info assuming this destination is a 1:1 or wireless share');
+        }
         LoggerProxy.logger.debug(`Meetings:index#createMeeting --> Debug ${err} fetching /meetingInfo for creation.`);
         // We need to save this info for future reference
         meeting.destination = destination;

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -12,7 +12,7 @@ import {
   _MEETING_ID_,
   _PERSONAL_ROOM_
 } from '@webex/plugin-meetings/src/constants';
-import MeetingInfo from '@webex/plugin-meetings/src/meeting-info/meeting-info-v2';
+import MeetingInfo, {MeetingInfoV2PasswordError, MeetingInfoV2CaptchaError} from '@webex/plugin-meetings/src/meeting-info/meeting-info-v2';
 import MeetingInfoUtil from '@webex/plugin-meetings/src/meeting-info/utilv2';
 
 describe('plugin-meetings', () => {
@@ -79,6 +79,79 @@ describe('plugin-meetings', () => {
 
         MeetingInfoUtil.getDestinationType.restore();
         MeetingInfoUtil.getRequestBody.restore();
+      });
+
+      it('should fetch meeting info with provided password and captcha code', async () => {
+        await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, 'abc', {id: '999', code: 'aabbcc11'});
+
+        assert.calledWith(webex.request, {
+          method: 'POST',
+          service: 'webex-appapi-service',
+          resource: 'meetingInfo',
+          body: {
+            supportHostKey: true,
+            meetingKey: '1234323',
+            password: 'abc',
+            captchaID: '999',
+            captchaVerifyCode: 'aabbcc11'
+          }
+        });
+      });
+
+      it('should throw MeetingInfoV2PasswordError for 403 response', async () => {
+        const FAKE_MEETING_INFO = {blablabla: 'some_fake_meeting_info'};
+
+        webex.request = sinon.stub().rejects({statusCode: 403, body: {code: 403000, data: {meetingInfo: FAKE_MEETING_INFO}}});
+
+        try {
+          await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, 'abc', {id: '999', code: 'aabbcc11'});
+          assert.fail('fetchMeetingInfo should have thrown, but has not done that');
+        }
+        catch (err) {
+          assert.instanceOf(err, MeetingInfoV2PasswordError);
+          assert.deepEqual(err.meetingInfo, FAKE_MEETING_INFO);
+          assert.equal(err.wbxAppApiCode, 403000);
+        }
+      });
+
+      describe('should throw MeetingInfoV2CaptchaError for 423 response', () => {
+        const runTest = async (wbxAppApiCode, expectedIsPasswordRequired) => {
+          webex.request = sinon.stub().rejects(
+            {
+              statusCode: 423,
+              body: {
+                code: wbxAppApiCode,
+                captchaID: 'fake_captcha_id',
+                verificationImageURL: 'fake_image_url',
+                verificationAudioURL: 'fake_audio_url',
+                refreshURL: 'fake_refresh_url'
+              }
+            }
+          );
+          try {
+            await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, 'abc', {id: '999', code: 'aabbcc11'});
+            assert.fail('fetchMeetingInfo should have thrown, but has not done that');
+          }
+          catch (err) {
+            assert.instanceOf(err, MeetingInfoV2CaptchaError);
+            assert.deepEqual(err.captchaInfo, {
+              captchaId: 'fake_captcha_id',
+              verificationImageURL: 'fake_image_url',
+              verificationAudioURL: 'fake_audio_url',
+              refreshURL: 'fake_refresh_url'
+            });
+            assert.equal(err.wbxAppApiCode, wbxAppApiCode);
+            assert.equal(err.isPasswordRequired, expectedIsPasswordRequired);
+          }
+        };
+
+        it('should throw MeetingInfoV2CaptchaError for 423 response (wbxappapi code 423005)', async () => {
+          await runTest(423005, true);
+        });
+
+        it('should throw MeetingInfoV2CaptchaError for 423 response (wbxappapi code 423001)', async () => {
+          await runTest(423001, false);
+        });
       });
     });
   });

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -31,8 +31,11 @@ import {
   FLOOR_ACTION,
   SHARE_STATUS,
   METRICS_OPERATIONAL_MEASURES,
+  MEETING_INFO_FAILURE_REASON,
+  PASSWORD_STATUS,
   EVENTS,
-  EVENT_TRIGGERS
+  EVENT_TRIGGERS,
+  _SIP_URI_
 } from '@webex/plugin-meetings/src/constants';
 
 import {
@@ -43,8 +46,11 @@ import {
 } from '../../../../src/common/errors/webex-errors';
 import WebExMeetingsErrors from '../../../../src/common/errors/webex-meetings-error';
 import ParameterError from '../../../../src/common/errors/parameter';
+import PasswordError from '../../../../src/common/errors/password-error';
+import CaptchaError from '../../../../src/common/errors/captcha-error';
 import DefaultSDKConfig from '../../../../src/config';
 import testUtils from '../../../utils/testUtils';
+import {MeetingInfoV2CaptchaError, MeetingInfoV2PasswordError} from '../../../../src/meeting-info/meeting-info-v2';
 
 const {
   getBrowserName
@@ -98,7 +104,8 @@ describe('plugin-meetings', () => {
           },
           mediaSettings: {},
           metrics: {},
-          stats: {}
+          stats: {},
+          experimental: {enableUnifiedMeetings: true}
         }
       }
     });
@@ -173,6 +180,9 @@ describe('plugin-meetings', () => {
           assert.instanceOf(meeting.meetingRequest, MeetingRequest);
           assert.instanceOf(meeting.locusInfo, LocusInfo);
           assert.instanceOf(meeting.mediaProperties, MediaProperties);
+          assert.equal(meeting.passwordStatus, PASSWORD_STATUS.UNKNOWN);
+          assert.equal(meeting.requiredCaptcha, null);
+          assert.equal(meeting.meetingInfoFailureReason, undefined);
         });
       });
       describe('#invite', () => {
@@ -652,6 +662,14 @@ describe('plugin-meetings', () => {
                 assert.calledOnce(MeetingUtil.joinMeeting);
               });
             });
+          });
+          it('should fail if password is required', async () => {
+            meeting.passwordStatus = PASSWORD_STATUS.REQUIRED;
+            await assert.isRejected(meeting.join(), PasswordError);
+          });
+          it('should fail if captcha is required', async () => {
+            meeting.requiredCaptcha = {captchaId: 'aaa'};
+            await assert.isRejected(meeting.join(), CaptchaError);
           });
           describe('total failure', () => {
             beforeEach(() => {
@@ -2010,6 +2028,279 @@ describe('plugin-meetings', () => {
         });
       });
 
+      describe('#fetchMeetingInfo', () => {
+        const FAKE_DESTINATION = 'something@somecompany.com';
+        const FAKE_TYPE = _SIP_URI_;
+        const FAKE_PASSWORD = '123abc';
+        const FAKE_CAPTCHA_CODE = 'a1b2c3XYZ';
+        const FAKE_CAPTCHA_ID = '987654321';
+        const FAKE_CAPTCHA_IMAGE_URL = 'http://captchaimage';
+        const FAKE_CAPTCHA_AUDIO_URL = 'http://captchaaudio';
+        const FAKE_CAPTCHA_REFRESH_URL = 'http://captcharefresh';
+        const FAKE_MEETING_INFO = {
+          conversationUrl: 'some_convo_url',
+          locusUrl: 'some_locus_url',
+          sipUrl: 'some_sip_url', // or sipMeetingUri
+          meetingNumber: '123456', // this.config.experimental.enableUnifiedMeetings
+          hostId: 'some_host_id' // this.owner;
+        };
+        const FAKE_SDK_CAPTCHA_INFO = {
+          captchaId: FAKE_CAPTCHA_ID,
+          verificationImageURL: FAKE_CAPTCHA_IMAGE_URL,
+          verificationAudioURL: FAKE_CAPTCHA_AUDIO_URL,
+          refreshURL: FAKE_CAPTCHA_REFRESH_URL
+        };
+        const FAKE_WBXAPPAPI_CAPTCHA_INFO = {
+          captchaID: `${FAKE_CAPTCHA_ID}-2`,
+          verificationImageURL: `${FAKE_CAPTCHA_IMAGE_URL}-2`,
+          verificationAudioURL: `${FAKE_CAPTCHA_AUDIO_URL}-2`,
+          refreshURL: `${FAKE_CAPTCHA_REFRESH_URL}-2`
+        };
+
+
+        it('calls meetingInfoProvider with all the right parameters and parses the result', async () => {
+          meeting.attrs.meetingInfoProvider = {fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO})};
+          meeting.requiredCaptcha = FAKE_SDK_CAPTCHA_INFO;
+          await meeting.fetchMeetingInfo({
+            destination: FAKE_DESTINATION, type: FAKE_TYPE, password: FAKE_PASSWORD, captchaCode: FAKE_CAPTCHA_CODE
+          });
+
+          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, FAKE_PASSWORD, {code: FAKE_CAPTCHA_CODE, id: FAKE_CAPTCHA_ID});
+
+          assert.deepEqual(meeting.meetingInfo, FAKE_MEETING_INFO);
+          assert.equal(meeting.passwordStatus, PASSWORD_STATUS.NOT_REQUIRED);
+          assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.NONE);
+          assert.equal(meeting.requiredCaptcha, null);
+        });
+
+        it('fails if captchaCode is provided when captcha not needed', async () => {
+          meeting.attrs.meetingInfoProvider = {fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO})};
+          meeting.requiredCaptcha = null;
+
+          await assert.isRejected(meeting.fetchMeetingInfo({
+            destination: FAKE_DESTINATION, type: FAKE_TYPE, captchaCode: FAKE_CAPTCHA_CODE
+          }), Error, 'fetchMeetingInfo() called with captchaCode when captcha was not required');
+
+          assert.notCalled(meeting.attrs.meetingInfoProvider.fetchMeetingInfo);
+        });
+
+        it('fails if password is provided when not required', async () => {
+          meeting.attrs.meetingInfoProvider = {fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO})};
+          meeting.passwordStatus = PASSWORD_STATUS.NOT_REQUIRED;
+
+          await assert.isRejected(meeting.fetchMeetingInfo({
+            destination: FAKE_DESTINATION, type: FAKE_TYPE, password: FAKE_PASSWORD
+          }), Error, 'fetchMeetingInfo() called with password when password was not required');
+
+          assert.notCalled(meeting.attrs.meetingInfoProvider.fetchMeetingInfo);
+        });
+
+        it('handles meetingInfoProvider requiring password', async () => {
+          meeting.attrs.meetingInfoProvider = {
+            fetchMeetingInfo: sinon.stub().throws(new MeetingInfoV2PasswordError(403004, FAKE_MEETING_INFO))
+          };
+
+          await assert.isRejected(meeting.fetchMeetingInfo({
+            destination: FAKE_DESTINATION, type: FAKE_TYPE
+          }), PasswordError);
+
+          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, null, null);
+
+          assert.deepEqual(meeting.meetingInfo, FAKE_MEETING_INFO);
+          assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD);
+          assert.equal(meeting.requiredCaptcha, null);
+          assert.equal(meeting.passwordStatus, PASSWORD_STATUS.REQUIRED);
+        });
+
+        it('handles meetingInfoProvider requiring captcha because of wrong password', async () => {
+          meeting.attrs.meetingInfoProvider = {
+            fetchMeetingInfo: sinon.stub().throws(new MeetingInfoV2CaptchaError(423005, FAKE_SDK_CAPTCHA_INFO))
+          };
+          meeting.requiredCaptcha = null;
+
+          await assert.isRejected(meeting.fetchMeetingInfo({
+            destination: FAKE_DESTINATION, type: FAKE_TYPE, password: 'aaa'
+          }), CaptchaError);
+
+          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, 'aaa', null);
+
+          assert.deepEqual(meeting.meetingInfo, {});
+          assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD);
+          assert.equal(meeting.passwordStatus, PASSWORD_STATUS.REQUIRED);
+          assert.deepEqual(meeting.requiredCaptcha, {
+            captchaId: FAKE_CAPTCHA_ID,
+            verificationImageURL: FAKE_CAPTCHA_IMAGE_URL,
+            verificationAudioURL: FAKE_CAPTCHA_AUDIO_URL,
+            refreshURL: FAKE_CAPTCHA_REFRESH_URL
+          });
+        });
+
+        it('handles meetingInfoProvider requiring captcha because of wrong captcha', async () => {
+          meeting.attrs.meetingInfoProvider = {
+            fetchMeetingInfo: sinon.stub().throws(new MeetingInfoV2CaptchaError(423005, FAKE_SDK_CAPTCHA_INFO))
+          };
+          meeting.requiredCaptcha = FAKE_SDK_CAPTCHA_INFO;
+
+          await assert.isRejected(meeting.fetchMeetingInfo({
+            destination: FAKE_DESTINATION, type: FAKE_TYPE, password: 'aaa', captchaCode: 'bbb'
+          }), CaptchaError);
+
+          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, 'aaa', {code: 'bbb', id: FAKE_CAPTCHA_ID});
+
+          assert.deepEqual(meeting.meetingInfo, {});
+          assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.WRONG_CAPTCHA);
+          assert.equal(meeting.passwordStatus, PASSWORD_STATUS.REQUIRED);
+          assert.deepEqual(meeting.requiredCaptcha, FAKE_SDK_CAPTCHA_INFO);
+        });
+
+        it('handles successful response when good password is passed', async () => {
+          meeting.attrs.meetingInfoProvider = {
+            fetchMeetingInfo: sinon.stub().resolves(
+              {
+                statusCode: 200,
+                body: FAKE_MEETING_INFO
+              }
+            )
+          };
+          meeting.passwordStatus = PASSWORD_STATUS.REQUIRED;
+
+          await meeting.fetchMeetingInfo({
+            destination: FAKE_DESTINATION, type: FAKE_TYPE, password: 'aaa'
+          });
+
+          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, 'aaa', null);
+
+          assert.deepEqual(meeting.meetingInfo, FAKE_MEETING_INFO);
+          assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.NONE);
+          assert.equal(meeting.passwordStatus, PASSWORD_STATUS.VERIFIED);
+          assert.equal(meeting.requiredCaptcha, null);
+        });
+
+        it('refreshes captcha when captcha was required and we received 403 error code', async () => {
+          const refreshedCaptcha = {
+            captchaID: FAKE_WBXAPPAPI_CAPTCHA_INFO.captchaID,
+            verificationImageURL: FAKE_WBXAPPAPI_CAPTCHA_INFO.verificationImageURL,
+            verificationAudioURL: FAKE_WBXAPPAPI_CAPTCHA_INFO.verificationAudioURL
+          };
+
+          meeting.attrs.meetingInfoProvider = {
+            fetchMeetingInfo: sinon.stub().throws(new MeetingInfoV2PasswordError(403004, FAKE_MEETING_INFO))
+          };
+          meeting.meetingRequest.refreshCaptcha = sinon.stub().returns(Promise.resolve(
+            {
+              body: refreshedCaptcha
+            }
+          ));
+          meeting.passwordStatus = PASSWORD_STATUS.REQUIRED;
+          meeting.requiredCaptcha = FAKE_SDK_CAPTCHA_INFO;
+
+          await assert.isRejected(meeting.fetchMeetingInfo({
+            destination: FAKE_DESTINATION, type: FAKE_TYPE, password: 'aaa', captchaCode: 'bbb'
+          }));
+
+          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, 'aaa', {code: 'bbb', id: FAKE_CAPTCHA_ID});
+
+          assert.deepEqual(meeting.meetingInfo, FAKE_MEETING_INFO);
+          assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD);
+          assert.equal(meeting.passwordStatus, PASSWORD_STATUS.REQUIRED);
+          assert.deepEqual(meeting.requiredCaptcha, {
+            captchaId: refreshedCaptcha.captchaID,
+            verificationImageURL: refreshedCaptcha.verificationImageURL,
+            verificationAudioURL: refreshedCaptcha.verificationAudioURL,
+            refreshURL: FAKE_SDK_CAPTCHA_INFO.refreshURL // refresh url doesn't change
+          });
+        });
+      });
+
+      describe('#refreshCaptcha', () => {
+        it('fails if no captcha required', async () => {
+          assert.isRejected(meeting.refreshCaptcha(), Error);
+        });
+        it('sends correct request to captcha service refresh url', async () => {
+          const REFRESH_URL = 'https://something.webex.com/captchaservice/v1/captchas/refresh?blablabla=something&captchaID=xxx';
+          const EXPECTED_REFRESH_URL = 'https://something.webex.com/captchaservice/v1/captchas/refresh?blablabla=something&captchaID=xxx&siteFullName=something.webex.com';
+
+          const FAKE_SDK_CAPTCHA_INFO = {
+            captchaId: 'some id',
+            verificationImageURL: 'some image url',
+            verificationAudioURL: 'some audio url',
+            refreshURL: REFRESH_URL
+          };
+
+          const FAKE_REFRESHED_CAPTCHA = {
+            captchaID: 'some id',
+            verificationImageURL: 'some image url',
+            verificationAudioURL: 'some audio url'
+          };
+
+          // setup the meeting so that a captcha is required
+          meeting.attrs.meetingInfoProvider = {
+            fetchMeetingInfo: sinon.stub().throws(new MeetingInfoV2CaptchaError(423005, FAKE_SDK_CAPTCHA_INFO))
+          };
+
+          await assert.isRejected(meeting.fetchMeetingInfo({
+            destination: 'something@somecompany.com', type: _SIP_URI_, password: ''
+          }), CaptchaError);
+
+          assert.deepEqual(meeting.requiredCaptcha, FAKE_SDK_CAPTCHA_INFO);
+          meeting.meetingRequest.refreshCaptcha = sinon.stub().returns(Promise.resolve({body: FAKE_REFRESHED_CAPTCHA}));
+
+          // test the captcha refresh
+          await meeting.refreshCaptcha();
+
+          assert.calledWith(meeting.meetingRequest.refreshCaptcha,
+            {
+              captchaRefreshUrl: EXPECTED_REFRESH_URL,
+              captchaId: FAKE_SDK_CAPTCHA_INFO.captchaId
+            });
+
+          assert.deepEqual(meeting.requiredCaptcha, {
+            captchaId: FAKE_REFRESHED_CAPTCHA.captchaID,
+            verificationImageURL: FAKE_REFRESHED_CAPTCHA.verificationImageURL,
+            verificationAudioURL: FAKE_REFRESHED_CAPTCHA.verificationAudioURL,
+            refreshURL: FAKE_SDK_CAPTCHA_INFO.refreshURL // refresh url doesn't change
+          });
+        });
+      });
+
+      describe('#verifyPassword', () => {
+        it('calls fetchMeetingInfo() with the passed password and captcha code', async () => {
+          // simulate successful case
+          meeting.fetchMeetingInfo = sinon.stub().resolves();
+          const result = await meeting.verifyPassword('password', 'captcha id');
+
+          assert.equal(result.isPasswordValid, true);
+          assert.equal(result.requiredCaptcha, null);
+          assert.equal(result.failureReason, MEETING_INFO_FAILURE_REASON.NONE);
+        });
+        it('handles PasswordError returned by fetchMeetingInfo', async () => {
+          meeting.fetchMeetingInfo = sinon.stub().callsFake(() => {
+            meeting.meetingInfoFailureReason = MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD;
+
+            return Promise.reject(new PasswordError());
+          });
+          const result = await meeting.verifyPassword('password', 'captcha id');
+
+          assert.equal(result.isPasswordValid, false);
+          assert.equal(result.requiredCaptcha, null);
+          assert.equal(result.failureReason, MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD);
+        });
+        it('handles CaptchaError returned by fetchMeetingInfo', async () => {
+          const FAKE_CAPTCHA = {captchaId: 'some catcha id...'};
+
+          meeting.fetchMeetingInfo = sinon.stub().callsFake(() => {
+            meeting.meetingInfoFailureReason = MEETING_INFO_FAILURE_REASON.WRONG_CAPTCHA;
+            meeting.requiredCaptcha = FAKE_CAPTCHA;
+
+            return Promise.reject(new CaptchaError());
+          });
+          const result = await meeting.verifyPassword('password', 'captcha id');
+
+          assert.equal(result.isPasswordValid, false);
+          assert.deepEqual(result.requiredCaptcha, FAKE_CAPTCHA);
+          assert.equal(result.failureReason, MEETING_INFO_FAILURE_REASON.WRONG_CAPTCHA);
+        });
+      });
       describe('#mediaNegotiatedEvent', () => {
         it('should have #mediaNegotiatedEvent', () => {
           assert.exists(meeting.mediaNegotiatedEvent);


### PR DESCRIPTION
Initial draft of changes required to support password and captcha when talking with WbxAppApi

It's still got lots of todo comments, console logs, etc.

Tests need to be added/updated.
Some of the new code may be also be gated on the config setting for using wbxappapi. 