### PR TITLE
test(plugin-meetings): add spec for conversation URL space

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/config.js
@@ -88,7 +88,7 @@ export default {
     enableExtmap: false,
     experimental: {
       enableMediaNegotiatedEvent: false,
-      enableUnifiedMeetings: false
+      enableUnifiedMeetings: true
     }
   }
 };

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -164,6 +164,41 @@ skipInNode(describe)('plugin-meetings', () => {
         }));
     });
 
+    describe('Conversation URL', () => {
+      describe('Successful 1:1 meeting', () => {
+        it('Fetch meeting information with a conversation URL for a 1:1 space', async () => {
+          assert.equal(Object.keys(bob.webex.meetings.getAllMeetings()), 0);
+          assert.equal(Object.keys(chris.webex.meetings.getAllMeetings()), 0);
+
+          const conversation = await chris.webex.internal.conversation.create({participants: [bob]});
+
+          await chris.webex.internal.conversation.post(conversation, {displayName: 'hello world how are you '});
+
+          await Promise.all([
+            testUtils.delayedPromise(chris.webex.meetings.create(conversation.url, 'CONVERSATION_URL')),
+            testUtils.waitForEvents([{scope: chris.webex.meetings, event: 'meeting:added', user: chris}])
+          ])
+            .then(function chrisJoinsMeeting() {
+              return Promise.all([
+                testUtils.delayedPromise(chris.meeting.join()),
+                testUtils.waitForEvents([{scope: bob.webex.meetings, event: 'meeting:added', user: bob},
+                  {scope: chris.meeting, event: 'meeting:stateChange', user: chris}])
+                  .then((response) => {
+                    assert.equal(response[0].result.payload.currentState, 'ACTIVE');
+                  })
+              ]);
+            });
+        });
+
+        it('Fetch meeting information with invalid conversation URL and throws error', () => {
+          chris.webex.meetings.meetingInfo.fetchMeetingInfo('http://some-invalid.com', 'CONVERSATION_URL').then((response) => {
+            assert(response.result === '404');
+          });
+        });
+      });
+    });
+
+
     describe('Successful 1:1 meeting (including Guest)', function () {
       before(() => {
         // Workaround since getDisplayMedia requires a user gesture to be activated, and this is a integration tests

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/space-meeting.js
@@ -77,14 +77,13 @@ skipInNode(describe)('plugin-meetings', () => {
       alice.webex.meetings.config.experimental.enableUnifiedMeetings = false;
     });
 
-    xit('Bob fetches meeting Info with SIP URI before joining', async () => {
+    it('Bob fetches meeting Info with SIP URI before joining', async () => {
       const {sipUri} = alice.meeting;
       const res = await bob.webex.meetings.meetingInfo.fetchMeetingInfo(sipUri, 'SIP_URI');
       const {meetingNumber} = res.body;
 
       assert(meetingNumber === alice.meeting.meetingNumber, 'meetingNumber matches alice meeting number');
     });
-
 
     it('Bob and chris joins space meeting', () => testUtils.waitForStateChange(alice.meeting, 'JOINED')
       .then(() => testUtils.waitForStateChange(bob.meeting, 'IDLE'))


### PR DESCRIPTION
Added spec for:

- Fetch meeting information with a conversation URL for a 1:1 space
- Invalid conversation URL and asserting that `fetchMeetingInfo` returns an error.