### PR TITLE
test(plugin-meetings): add spec for conversation

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -164,6 +164,40 @@ skipInNode(describe)('plugin-meetings', () => {
         }));
     });
 
+    describe('Conversation URL', () => {
+      describe('Successful 1:1 meeting', () => {
+        it('Fetch meeting information with a conversation URL for a 1:1 space', async () => {
+          assert.equal(Object.keys(bob.webex.meetings.getAllMeetings()), 0);
+          assert.equal(Object.keys(chris.webex.meetings.getAllMeetings()), 0);
+
+          const conversation = await chris.webex.internal.conversation.create({participants: [bob]});
+
+          await chris.webex.internal.conversation.post(conversation, {displayName: 'hello world how are you '});
+
+          await Promise.all([
+            testUtils.delayedPromise(chris.webex.meetings.create(conversation.url, 'CONVERSATION_URL')),
+            testUtils.waitForEvents([{scope: chris.webex.meetings, event: 'meeting:added', user: chris}])
+          ])
+            .then(function chrisJoinsMeeting() {
+              return Promise.all([
+                testUtils.delayedPromise(chris.meeting.join()),
+                testUtils.waitForEvents([{scope: bob.webex.meetings, event: 'meeting:added', user: bob},
+                  {scope: chris.meeting, event: 'meeting:stateChange', user: chris}])
+                  .then((response) => {
+                    assert.equal(response[0].result.payload.currentState, 'ACTIVE');
+                  })
+              ]);
+            });
+        });
+
+        it('Fetch meeting information with invalid conversation URL and throws error', () => {
+          chris.webex.meetings.meetingInfo.fetchMeetingInfo('http://some-invalid.com', 'CONVERSATION_URL').then((response) => {
+            assert(response.result === '404');
+          });
+        });
+      });
+    });
+
     describe('Successful 1:1 meeting (including Guest)', function () {
       before(() => {
         // Workaround since getDisplayMedia requires a user gesture to be activated, and this is a integration tests

--- a/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -164,7 +164,8 @@ skipInNode(describe)('plugin-meetings', () => {
         }));
     });
 
-    describe('Conversation URL', () => {
+    // Enabled when config.enableUnifiedMeetings = true
+    xdescribe('Conversation URL', () => {
       describe('Successful 1:1 meeting', () => {
         it('Fetch meeting information with a conversation URL for a 1:1 space', async () => {
           assert.equal(Object.keys(bob.webex.meetings.getAllMeetings()), 0);


### PR DESCRIPTION
Added spec for:

- Fetch meeting information with a conversation URL for a 1:1 space
- Invalid conversation URL and asserting that fetchMeetingInfo returns an error.

### Test Results 
The following is the test results when `config.enableUnifiedMeetings = true`
![Screen Shot 2021-12-01 at 10 04 12 AM](https://user-images.githubusercontent.com/320490/144289359-cf30faf4-8b11-499b-9f29-565482fa1a61.png)
