### PR TITLE
fix(plugin-meetings): logger init before meeting's onready call

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -174,6 +174,8 @@ export default class Meetings extends WebexPlugin {
         getSupportedDevice: Media.getSupportedDevice
       };
 
+      LoggerProxy.set(this.webex.logger);
+
       this.onReady();
       MeetingsUtil.checkH264Support({disableNotifications: true});
       Metrics.initialSetup(this.meetingCollection, this.webex);
@@ -371,7 +373,6 @@ export default class Meetings extends WebexPlugin {
       this.webex.once(READY, () => {
         StaticConfig.set(this.config);
         LoggerConfig.set(this.config.logging);
-        LoggerProxy.set(this.webex.logger);
 
         /**
        * The MeetingInfo object to interact with server

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
@@ -14,8 +14,23 @@ import {
   _MEETING_UUID_
 } from '@webex/plugin-meetings/src/constants';
 import MeetingInfoUtil from '@webex/plugin-meetings/src/meeting-info/utilv2';
+import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
+import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
 
 describe('plugin-meetings', () => {
+  const logger = {
+    log: () => {},
+    error: () => {},
+    warn: () => {},
+    trace: () => {},
+    debug: () => {}
+  };
+
+  beforeEach(() => {
+    LoggerConfig.set({verboseEvents: true, enable: false});
+    LoggerProxy.set(logger);
+  });
+
   describe('Meeting Info Utils V2', () => {
     beforeEach(() => {
       MeetingInfoUtil.getHydraId = sinon.stub().returns(false);


### PR DESCRIPTION
Fixes [SPARK-263135](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-263135)

This happened in the [Webex Server](https://webex.github.io/webex-js-sdk/example/servers) usage and not in [browsers](https://webex.github.io//webex-js-sdk/guides/browsers/) because the plugin-meetings tries to create an object for [RTCPeerConnection](https://github.com/webex/webex-js-sdk/blob/master/packages/node_modules/%40webex/plugin-meetings/src/meetings/util.js#L78) which wouldn't be available in node.js (while checking if H264 codec is available). Basically browser creates this object whereas server wouldn't and the error gets caught.

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
