### PR TITLE
fix(plugin-meetings): allow calling join() again after IntentToJoinError

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -7,6 +7,7 @@ import {
   MeetingNotActiveError, createMeetingsError, UserInLobbyError,
   NoMediaEstablishedYetError, UserNotJoinedError, InvalidSdpError
 } from '../common/errors/webex-errors';
+import IntentToJoinError from '../common/errors/intent-to-join';
 import StatsAnalyzer from '../statsAnalyzer';
 import NetworkQualityMonitor from '../networkQualityMonitor';
 import LoggerProxy from '../common/logs/logger-proxy';
@@ -3612,29 +3613,31 @@ export default class Meeting extends StatelessWebexPlugin {
         return join;
       })
       .catch((error) => {
-        this.meetingFiniteStateMachine.fail(error);
         LoggerProxy.logger.error('Meeting:index#join --> Failed', error);
+        if (!(error instanceof IntentToJoinError)) {
+          this.meetingFiniteStateMachine.fail(error);
 
-        // TODO:  change this to error codes and pre defined dictionary
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.JOIN_FAILURE,
-          {
-            correlation_id: this.correlationId,
-            reason: error.error?.message,
-            stack: error.stack
-          }
-        );
+          // TODO:  change this to error codes and pre defined dictionary
+          Metrics.sendOperationalMetric(
+            METRICS_OPERATIONAL_MEASURES.JOIN_FAILURE,
+            {
+              correlation_id: this.correlationId,
+              reason: error.error?.message,
+              stack: error.stack
+            }
+          );
 
-        // Upload logs on join Failure
-        Trigger.trigger(
-          this,
-          {
-            file: 'meeting/index',
-            function: 'join'
-          },
-          EVENTS.REQUEST_UPLOAD_LOGS,
-          this
-        );
+          // Upload logs on join Failure
+          Trigger.trigger(
+            this,
+            {
+              file: 'meeting/index',
+              function: 'join'
+            },
+            EVENTS.REQUEST_UPLOAD_LOGS,
+            this
+          );
+        }
 
         joinFailed(error);
         this.deferJoin = undefined;


### PR DESCRIPTION
When Locus returns one of the errors from the INTENT_TO_JOIN array, the web app is supposed to call join() again with the right pin and moderator flag set. However, this is failing because the meeting state machine is in error state and doesn't allow to call join() in that state.

Fixes #SPARK-290105
