### PR TITLE
fix(plugin-meetings): meeting stuck in error state

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -851,8 +851,7 @@ export const MEETING_STATE_MACHINE = {
     JOIN: 'join',
     DECLINE: 'decline',
     LEAVE: 'leave',
-    RESET: 'reset',
-    SAFE: 'SAFE'
+    RESET: 'reset'
   },
   STATES: {
     ERROR: 'ERROR',
@@ -861,8 +860,7 @@ export const MEETING_STATE_MACHINE = {
     DECLINED: 'DECLINED',
     RINGING: 'RINGING',
     JOINED: 'JOINED',
-    ANSWERED: 'ANSWERED',
-    SAFE: 'SAFE'
+    ANSWERED: 'ANSWERED'
   }
 };
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/state.js
@@ -24,20 +24,20 @@ const MeetingStateMachine = {
         // when ringing a meeting, it must be first IDLE, because all other states are invalid, it transitions to the RINGING state
         {
           name: MEETING_STATE_MACHINE.TRANSITIONS.RING,
-          from: [MEETING_STATE_MACHINE.STATES.IDLE, MEETING_STATE_MACHINE.STATES.SAFE, MEETING_STATE_MACHINE.STATES.JOINED],
+          from: [MEETING_STATE_MACHINE.STATES.IDLE, MEETING_STATE_MACHINE.STATES.ERROR, MEETING_STATE_MACHINE.STATES.JOINED],
           to: MEETING_STATE_MACHINE.STATES.RINGING
         },
         // when joining a meeting, it must be from the RINGING or IDLE state, transitions to JOINED state, 1:1 will go to RINGING,
         // others will go straight to JOINED with this transition
         {
           name: MEETING_STATE_MACHINE.TRANSITIONS.JOIN,
-          from: [MEETING_STATE_MACHINE.STATES.JOINED, MEETING_STATE_MACHINE.STATES.IDLE, MEETING_STATE_MACHINE.STATES.RINGING, MEETING_STATE_MACHINE.STATES.SAFE],
+          from: [MEETING_STATE_MACHINE.STATES.JOINED, MEETING_STATE_MACHINE.STATES.IDLE, MEETING_STATE_MACHINE.STATES.RINGING, MEETING_STATE_MACHINE.STATES.ERROR],
           to: MEETING_STATE_MACHINE.STATES.JOINED
         },
         // signify that ringing has stopped and somebody else answered, move state to DECLINED, ANSWERED
         {
           name: MEETING_STATE_MACHINE.TRANSITIONS.REMOTE,
-          from: [MEETING_STATE_MACHINE.STATES.JOINED, MEETING_STATE_MACHINE.STATES.SAFE],
+          from: [MEETING_STATE_MACHINE.STATES.JOINED, MEETING_STATE_MACHINE.STATES.ERROR],
           /**
          * @param {Object} remote
          * @param {Boolean} remote.remoteAnswered
@@ -67,15 +67,14 @@ const MeetingStateMachine = {
             MEETING_STATE_MACHINE.STATES.JOINED,
             MEETING_STATE_MACHINE.STATES.ANSWERED,
             MEETING_STATE_MACHINE.STATES.DECLINED,
-            MEETING_STATE_MACHINE.STATES.ERROR,
-            MEETING_STATE_MACHINE.STATES.SAFE
+            MEETING_STATE_MACHINE.STATES.ERROR
           ],
           to: MEETING_STATE_MACHINE.STATES.ENDED
         },
         // when declining an incoming meeting it must be from the ringing state, and it moves to DECLINED state
         {
           name: MEETING_STATE_MACHINE.TRANSITIONS.DECLINE,
-          from: [MEETING_STATE_MACHINE.STATES.RINGING, MEETING_STATE_MACHINE.STATES.SAFE],
+          from: [MEETING_STATE_MACHINE.STATES.RINGING, MEETING_STATE_MACHINE.STATES.ERROR],
           to: MEETING_STATE_MACHINE.STATES.ENDED
         },
         // transition from ANY state to ERROR state
@@ -83,11 +82,6 @@ const MeetingStateMachine = {
           name: MEETING_STATE_MACHINE.TRANSITIONS.FAIL,
           from: '*',
           to: MEETING_STATE_MACHINE.STATES.ERROR
-        },
-        {
-          name: MEETING_STATE_MACHINE.TRANSITIONS.SAFE,
-          from: MEETING_STATE_MACHINE.STATES.ERROR,
-          to: MEETING_STATE_MACHINE.STATES.SAFE
         },
         // fail safe, transition from ANY state to IDLE state
         {
@@ -148,16 +142,13 @@ const MeetingStateMachine = {
           }
         },
         /**
-         * handle the error transition stage
+         * handle the entry to error state
          * @param {Object} transition
          * @param {Error} error
          * @returns {Boolean}
          */
-        onBeforeError(transition, error) {
-          LoggerProxy.logger.error(`Meeting:state#onBeforeError --> state->onError#meeting.id: ${this.meeting.id} | Transition '${transition.transition}' : ${transition.from} -> ${transition.to} failed after last state transition, with error ${error}. Moving to a non-informative state. Last states: ${this.history}`);
-        },
-        onAfterError() {
-          this.safe();
+        onEnterError(transition, error) {
+          LoggerProxy.logger.error(`Meeting:state#onEnterError --> state->onEnterError#meeting.id: ${this.meeting.id} | Transition '${transition?.transition}' : ${transition?.from} -> ${transition?.to}, with error ${error}. Last states: ${this.history}`);
         },
         /**
          * After ANY transition occurs, we want to know what state the meeting moved to for debugging

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -48,6 +48,7 @@ import WebExMeetingsErrors from '../../../../src/common/errors/webex-meetings-er
 import ParameterError from '../../../../src/common/errors/parameter';
 import PasswordError from '../../../../src/common/errors/password-error';
 import CaptchaError from '../../../../src/common/errors/captcha-error';
+import IntentToJoinError from '../../../../src/common/errors/intent-to-join';
 import DefaultSDKConfig from '../../../../src/config';
 import testUtils from '../../../utils/testUtils';
 import {MeetingInfoV2CaptchaError, MeetingInfoV2PasswordError} from '../../../../src/meeting-info/meeting-info-v2';
@@ -661,6 +662,24 @@ describe('plugin-meetings', () => {
               await meeting.join().catch(() => {
                 assert.calledOnce(MeetingUtil.joinMeeting);
               });
+            });
+            it('should succeed when called again after IntentToJoinError error', async () => {
+              let joinSucceeded = false;
+
+              try {
+                await meeting.join();
+                joinSucceeded = true;
+              }
+              catch (e) {
+                assert.instanceOf(e, IntentToJoinError);
+              }
+              assert.isFalse(joinSucceeded);
+
+              // IntentToJoinError means that client should call join() again
+              // with moderator and pin explicitly set
+              MeetingUtil.joinMeeting = sinon.stub().returns(Promise.resolve());
+              await meeting.join({pin: '1234', moderator: false});
+              assert.calledWith(MeetingUtil.joinMeeting, meeting, {moderator: false, pin: '1234'});
             });
           });
           it('should fail if password is required', async () => {


### PR DESCRIPTION
# COMPLETES [#SPARK-297591](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-297591)

## This pull request addresses

When Locus requires host key or guest password, the first call to meeting.join() will fail and client is supposed to call it again with the moderator flag and pin parameters. The second call to join() currently always fails.

## by making the following changes

The meeting state machine was wrong - it seems like it was designed to always automatically go from "error" state into "safe" state and then allow calls like join() to work from the safe state, but this never worked, because onBeforeError() and onAfterError() handlers were never called. They were not called, because their names were wrong (error is a state not a transition so state entry/exit handlers should have been used instead of transition handlers). Anyway, this whole design of the state machine's "safe" state is flawed and the "safe" state is redundant, so I've removed it.
### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Joining meetings that require guest password or host key (manual test done with the webex web app)
SDK Unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
