### PR TITLE
feat(plugin-meetings): start sending behavioral metrics to amplitude

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -1216,14 +1216,22 @@ export const MEDIA_DEVICES = {
 
 // Metrics constants ----------------------------------------------------------
 
-export const METRICS_OPERATIONAL_MEASURES = {
-  JOIN_ATTEMPT: 'js_sdk_join_attempt',
+export const BEHAVIORAL_METRICS = {
+  MEETINGS_REGISTRATION_FAILED: 'js_sdk_meetings_registration_failed',
+  MEETINGS_REGISTRATION_SUCCESS: 'js_sdk_meetings_registration_success',
+  MERCURY_CONNECTION_FAILURE: 'js_sdk_mercury_connection_failure',
+  MERCURY_CONNECTION_RESTORED: 'js_sdk_mercury_connection_restored',
+  JOIN_SUCCESS: 'js_sdk_join_success',
+  JOIN_FAILURE: 'js_sdk_join_failures',
+  ADD_MEDIA_SUCCESS: 'js_sdk_add_media_success',
   ADD_MEDIA_FAILURE: 'js_sdk_add_media_failures',
+  CONNECTION_SUCCESS: 'js_sdk_connection_success',
+  CONNECTION_FAILURE: 'js_sdk_connection_failures',
+  MEETING_LEAVE_FAILURE: 'js_sdk_meeting_leave_failure',
   GET_USER_MEDIA_FAILURE: 'js_sdk_get_user_media_failures',
   GET_DISPLAY_MEDIA_FAILURE: 'js_sdk_get_display_media_failures',
-  JOIN_FAILURE: 'js_sdk_join_failures',
   JOIN_WITH_MEDIA_FAILURE: 'js_sdk_join_with_media_failures',
-  MEETING_LEAVE_FAILURE: 'js_sdk_meeting_leave_failure',
+
   DISCONNECT_DUE_TO_INACTIVITY: 'js_sdk_disconnect_due_to_inactivity',
   MEETING_MEDIA_INACTIVE: 'js_sdk_meeting_media_inactive',
   MEETING_RECONNECT_FAILURE: 'js_sdk_meeting_reconnect_failures',
@@ -1243,9 +1251,7 @@ export const METRICS_OPERATIONAL_MEASURES = {
   ROAP_ANSWER_FAILURE: 'js_sdk_roap_answer_failures',
   ROAP_GLARE_CONDITION: 'js_sdk_roap_glar_condition',
   PEERCONNECTION_FAILURE: 'js_sdk_peerConnection_failures',
-  CONNECTION_FAILURE: 'js_sdk_connection_failures',
   INVALID_ICE_CANDIDATE: 'js_sdk_invalid_ice_candidate',
-  MERCURY_CONNECTION_FAILURE: 'js_sdk_mercury_connection_failure',
   UPLOAD_LOGS_FAILURE: 'js_sdk_upload_logs_failure',
   RECEIVE_TRANSCRIPTION_FAILURE: 'js_sdk_receive_transcription_failure'
 };

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -56,7 +56,7 @@ import {
   MEETING_STATE,
   MEETINGS,
   METRICS_JOIN_TIMES_MAX_DURATION,
-  METRICS_OPERATIONAL_MEASURES,
+  BEHAVIORAL_METRICS,
   MQA_STATS,
   NETWORK_STATUS,
   ONLINE,
@@ -1057,8 +1057,8 @@ export default class Meeting extends StatelessWebexPlugin {
       // https:// jira-eng-gpk2.cisco.com/jira/browse/SPARK-240520
       // TODO: send custom parameter explaining why the inactivity happened
       // refresh , no media or network got dsconnected or something else
-      Metrics.sendOperationalMetric(
-        METRICS_OPERATIONAL_MEASURES.DISCONNECT_DUE_TO_INACTIVITY,
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.DISCONNECT_DUE_TO_INACTIVITY,
         {
           correlation_id: this.correlationId,
           locus_id: this.locusId
@@ -1950,8 +1950,8 @@ export default class Meeting extends StatelessWebexPlugin {
     });
 
     this.locusInfo.on(LOCUSINFO.EVENTS.MEDIA_INACTIVITY, () => {
-      Metrics.sendOperationalMetric(
-        METRICS_OPERATIONAL_MEASURES.MEETING_MEDIA_INACTIVE,
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.MEETING_MEDIA_INACTIVE,
         {
           correlation_id: this.correlationId,
           locus_id: this.locusId
@@ -2495,8 +2495,8 @@ export default class Meeting extends StatelessWebexPlugin {
         }
         else {
           trackMediaID = null;
-          Metrics.sendOperationalMetric(
-            METRICS_OPERATIONAL_MEASURES.MUTE_AUDIO_FAILURE,
+          Metrics.sendBehavioralMetric(
+            BEHAVIORAL_METRICS.MUTE_AUDIO_FAILURE,
             {
               correlation_id: this.correlationId,
               locus_id: this.locusUrl.split('/').pop()
@@ -2905,6 +2905,12 @@ export default class Meeting extends StatelessWebexPlugin {
           event: eventType.MERCURY_CONNECTION_RESTORED,
           meeting: this
         });
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.MERCURY_CONNECTION_RESTORED,
+          {
+            correlation_id: this.correlationId
+          }
+        );
       }
       this.hasWebsocketConnected = true;
     });
@@ -2915,8 +2921,8 @@ export default class Meeting extends StatelessWebexPlugin {
         event: eventType.MERCURY_CONNECTION_LOST,
         meeting: this
       });
-      Metrics.sendOperationalMetric(
-        METRICS_OPERATIONAL_MEASURES.MERCURY_CONNECTION_FAILURE,
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.MERCURY_CONNECTION_FAILURE,
         {
           correlation_id: this.correlationId
         }
@@ -2993,8 +2999,8 @@ export default class Meeting extends StatelessWebexPlugin {
           data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.AUDIO}
         });
       }).catch((error) => {
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.MUTE_AUDIO_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.MUTE_AUDIO_FAILURE,
           {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
@@ -3044,8 +3050,8 @@ export default class Meeting extends StatelessWebexPlugin {
           data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.AUDIO}
         });
       }).catch((error) => {
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.UNMUTE_AUDIO_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.UNMUTE_AUDIO_FAILURE,
           {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
@@ -3094,8 +3100,8 @@ export default class Meeting extends StatelessWebexPlugin {
           data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.VIDEO}
         });
       }).catch((error) => {
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.MUTE_VIDEO_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.MUTE_VIDEO_FAILURE,
           {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
@@ -3144,8 +3150,8 @@ export default class Meeting extends StatelessWebexPlugin {
           data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.VIDEO}
         });
       }).catch((error) => {
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.UNMUTE_VIDEO_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.UNMUTE_VIDEO_FAILURE,
           {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
@@ -3207,8 +3213,8 @@ export default class Meeting extends StatelessWebexPlugin {
       .catch((error) => {
         LoggerProxy.logger.error('Meeting:index#joinWithMedia --> ', error);
 
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.JOIN_WITH_MEDIA_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
           {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
@@ -3297,8 +3303,8 @@ export default class Meeting extends StatelessWebexPlugin {
 
         LoggerProxy.logger.error('Meeting:index#reconnect --> Meeting reconnect failed', error);
 
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.MEETING_RECONNECT_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.MEETING_RECONNECT_FAILURE,
           {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
@@ -3363,8 +3369,8 @@ export default class Meeting extends StatelessWebexPlugin {
 
       this.triggerStopReceivingTranscriptionEvent();
 
-      Metrics.sendOperationalMetric(
-        METRICS_OPERATIONAL_MEASURES.RECEIVE_TRANSCRIPTION_FAILURE,
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE,
         {
           correlation_id: this.correlationId,
           reason: 'unexpected error: transcription LLM web socket connection error had occured.',
@@ -3427,8 +3433,8 @@ export default class Meeting extends StatelessWebexPlugin {
     }
     catch (error) {
       LoggerProxy.logger.error(`Meeting:index#receiveTranscription --> ${error}`);
-      Metrics.sendOperationalMetric(
-        METRICS_OPERATIONAL_MEASURES.RECEIVE_TRANSCRIPTION_FAILURE,
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE,
         {
           correlation_id: this.correlationId,
           reason: error.message,
@@ -3520,13 +3526,6 @@ export default class Meeting extends StatelessWebexPlugin {
       data: {trigger: trigger.USER_INTERACTION}
     });
 
-    Metrics.sendOperationalMetric(
-      METRICS_OPERATIONAL_MEASURES.JOIN_ATTEMPT,
-      {
-        correlation_id: this.correlationId
-      }
-    );
-
     LoggerProxy.logger.log('Meeting:index#join --> Joining a meeting');
 
     if (this.meetingFiniteStateMachine.state === MEETING_STATE_MACHINE.STATES.ENDED) {
@@ -3597,6 +3596,12 @@ export default class Meeting extends StatelessWebexPlugin {
       .then((join) => {
         joinSuccess(join);
         this.deferJoin = undefined;
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.JOIN_SUCCESS,
+          {
+            correlation_id: this.correlationId
+          }
+        );
 
         return join;
       }).then(async (join) => {
@@ -3620,8 +3625,8 @@ export default class Meeting extends StatelessWebexPlugin {
         LoggerProxy.logger.error('Meeting:index#join --> Failed', error);
 
         // TODO:  change this to error codes and pre defined dictionary
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.JOIN_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.JOIN_FAILURE,
           {
             correlation_id: this.correlationId,
             reason: error.error?.message,
@@ -3694,8 +3699,8 @@ export default class Meeting extends StatelessWebexPlugin {
     }).then((res) => {
       this.locusInfo.onFullLocus(res.body.locus);
     }).catch((error) => {
-      Metrics.sendOperationalMetric(
-        METRICS_OPERATIONAL_MEASURES.ADD_DIAL_IN_FAILURE,
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.ADD_DIAL_IN_FAILURE,
         {
           correlation_id: this.correlationId,
           dial_in_url: this.dialInUrl,
@@ -3733,8 +3738,8 @@ export default class Meeting extends StatelessWebexPlugin {
     }).then((res) => {
       this.locusInfo.onFullLocus(res.body.locus);
     }).catch((error) => {
-      Metrics.sendOperationalMetric(
-        METRICS_OPERATIONAL_MEASURES.ADD_DIAL_OUT_FAILURE,
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.ADD_DIAL_OUT_FAILURE,
         {
           correlation_id: this.correlationId,
           dial_out_url: this.dialOutUrl,
@@ -3960,10 +3965,10 @@ export default class Meeting extends StatelessWebexPlugin {
           )
             .catch((error) => {
               // Whenever there is a failure when trying to access a user's device
-              // report it as an operational metric
+              // report it as an Behavioral metric
               // This gives visibility into common errors and can help
               // with further troubleshooting
-              const metricName = METRICS_OPERATIONAL_MEASURES.GET_USER_MEDIA_FAILURE;
+              const metricName = BEHAVIORAL_METRICS.GET_USER_MEDIA_FAILURE;
               const data = {
                 correlation_id: this.correlationId,
                 locus_id: this.locusUrl?.split('/').pop(),
@@ -3974,7 +3979,7 @@ export default class Meeting extends StatelessWebexPlugin {
                 type: error.name
               };
 
-              Metrics.sendOperationalMetric(metricName, data, metadata);
+              Metrics.sendBehavioralMetric(metricName, data, metadata);
               throw new MediaError('Unable to retrieve media streams', error);
             }));
     }
@@ -4102,8 +4107,8 @@ export default class Meeting extends StatelessWebexPlugin {
         .catch((error) => {
           LoggerProxy.logger.error(`${LOG_HEADER} Error adding media , setting up peerconnection, `, error);
 
-          Metrics.sendOperationalMetric(
-            METRICS_OPERATIONAL_MEASURES.ADD_MEDIA_FAILURE,
+          Metrics.sendBehavioralMetric(
+            BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE,
             {
               correlation_id: this.correlationId,
               locus_id: this.locusUrl.split('/').pop(),
@@ -4186,6 +4191,14 @@ export default class Meeting extends StatelessWebexPlugin {
             this.floorGrantPending = true;
           }
 
+          Metrics.sendBehavioralMetric(
+            BEHAVIORAL_METRICS.ADD_MEDIA_SUCCESS,
+            {
+              correlation_id: this.correlationId,
+              locus_id: this.locusUrl.split('/').pop()
+            }
+          );
+
           return Promise.resolve();
         }))
       .catch((error) => {
@@ -4201,8 +4214,8 @@ export default class Meeting extends StatelessWebexPlugin {
 
         LoggerProxy.logger.error(`${LOG_HEADER} Error adding media failed to initiate PC and send request, `, error);
 
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.ADD_MEDIA_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE,
           {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
@@ -4355,8 +4368,8 @@ export default class Meeting extends StatelessWebexPlugin {
         .catch((error) => {
           LoggerProxy.logger.error(`${LOG_HEADER} Error updatedMedia, `, error);
 
-          Metrics.sendOperationalMetric(
-            METRICS_OPERATIONAL_MEASURES.UPDATE_MEDIA_FAILURE,
+          Metrics.sendBehavioralMetric(
+            BEHAVIORAL_METRICS.UPDATE_MEDIA_FAILURE,
             {
               correlation_id: this.correlationId,
               locus_id: this.locusUrl.split('/').pop(),
@@ -4754,8 +4767,8 @@ export default class Meeting extends StatelessWebexPlugin {
           EVENTS.REQUEST_UPLOAD_LOGS,
           this
         );
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.MEETING_LEAVE_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.MEETING_LEAVE_FAILURE,
           {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
@@ -4808,8 +4821,8 @@ export default class Meeting extends StatelessWebexPlugin {
         .catch((error) => {
           LoggerProxy.logger.error('Meeting:index#startWhiteboardShare --> Error ', error);
 
-          Metrics.sendOperationalMetric(
-            METRICS_OPERATIONAL_MEASURES.MEETING_START_WHITEBOARD_SHARE_FAILURE,
+          Metrics.sendBehavioralMetric(
+            BEHAVIORAL_METRICS.MEETING_START_WHITEBOARD_SHARE_FAILURE,
             {
               correlation_id: this.correlationId,
               locus_id: this.locusUrl.split('/').pop(),
@@ -4848,8 +4861,8 @@ export default class Meeting extends StatelessWebexPlugin {
         .catch((error) => {
           LoggerProxy.logger.error('Meeting:index#stopWhiteboardShare --> Error ', error);
 
-          Metrics.sendOperationalMetric(
-            METRICS_OPERATIONAL_MEASURES.STOP_WHITEBOARD_SHARE_FAILURE,
+          Metrics.sendBehavioralMetric(
+            BEHAVIORAL_METRICS.STOP_WHITEBOARD_SHARE_FAILURE,
             {
               correlation_id: this.correlationId,
               locus_id: this.locusUrl.split('/').pop(),
@@ -4895,8 +4908,8 @@ export default class Meeting extends StatelessWebexPlugin {
         .catch((error) => {
           LoggerProxy.logger.error('Meeting:index#share --> Error ', error);
 
-          Metrics.sendOperationalMetric(
-            METRICS_OPERATIONAL_MEASURES.MEETING_SHARE_FAILURE,
+          Metrics.sendBehavioralMetric(
+            BEHAVIORAL_METRICS.MEETING_SHARE_FAILURE,
             {
               correlation_id: this.correlationId,
               locus_id: this.locusUrl.split('/').pop(),
@@ -4958,8 +4971,8 @@ export default class Meeting extends StatelessWebexPlugin {
         .catch((error) => {
           LoggerProxy.logger.error('Meeting:index#stopFloorRequest --> Error ', error);
 
-          Metrics.sendOperationalMetric(
-            METRICS_OPERATIONAL_MEASURES.STOP_FLOOR_REQUEST_FAILURE,
+          Metrics.sendBehavioralMetric(
+            BEHAVIORAL_METRICS.STOP_FLOOR_REQUEST_FAILURE,
             {
               correlation_id: this.correlationId,
               locus_id: this.locusUrl.split('/').pop(),
@@ -5277,8 +5290,8 @@ export default class Meeting extends StatelessWebexPlugin {
 
         LoggerProxy.logger.error(`Meeting:index#setMeetingQuality --> ${error.message}`);
 
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.SET_MEETING_QUALITY_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.SET_MEETING_QUALITY_FAILURE,
           {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
@@ -5321,13 +5334,13 @@ export default class Meeting extends StatelessWebexPlugin {
       }))
       .catch((error) => {
         // Whenever there is a failure when trying to access a user's display
-        // report it as an operational metric
+        // report it as an Behavioral metric
         // This gives visibility into common errors and can help
         // with further troubleshooting
 
         // This metrics will get erros for getDisplayMedia and share errors for now
         // TODO: The getDisplayMedia errors need to be moved inside `media.getDisplayMedia`
-        const metricName = METRICS_OPERATIONAL_MEASURES.GET_DISPLAY_MEDIA_FAILURE;
+        const metricName = BEHAVIORAL_METRICS.GET_DISPLAY_MEDIA_FAILURE;
         const data = {
           correlation_id: this.correlationId,
           locus_id: this.locusUrl.split('/').pop(),
@@ -5338,7 +5351,7 @@ export default class Meeting extends StatelessWebexPlugin {
           type: error.name
         };
 
-        Metrics.sendOperationalMetric(metricName, data, metadata);
+        Metrics.sendBehavioralMetric(metricName, data, metadata);
         throw new MediaError('Unable to retrieve display media stream', error);
       });
   }

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -38,7 +38,7 @@ import {
   MEETING_REMOVED_REASON,
   _CONVERSATION_URL_,
   CONVERSATION_URL,
-  METRICS_OPERATIONAL_MEASURES
+  BEHAVIORAL_METRICS
 } from '../constants';
 import MeetingInfo from '../meeting-info';
 import MeetingInfoV2 from '../meeting-info/meeting-info-v2';
@@ -456,9 +456,20 @@ export default class Meetings extends WebexPlugin {
           EVENT_TRIGGERS.MEETINGS_REGISTERED
         );
         this.registered = true;
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_SUCCESS,
+        );
       })
         .catch((error) => {
           LoggerProxy.logger.error(`Meetings:index#register --> ERROR, Unable to register, ${error.message}`);
+
+          Metrics.sendBehavioralMetric(
+            BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_FAILED,
+            {
+              reason: error.message,
+              stack: error.stack
+            }
+          );
 
           return Promise.reject(error);
         });
@@ -542,8 +553,8 @@ export default class Meetings extends WebexPlugin {
             }
           );
 
-          Metrics.sendOperationalMetric(
-            METRICS_OPERATIONAL_MEASURES.UPLOAD_LOGS_FAILURE,
+          Metrics.sendBehavioralMetric(
+            BEHAVIORAL_METRICS.UPLOAD_LOGS_FAILURE,
             {
               meetingId: options.meetingsId,
               reason: uploadError.message,

--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/config.js
@@ -320,3 +320,4 @@ export const OS_NAME = {
 };
 
 export const CLIENT_NAME = 'webex-js-sdk';
+export const PLATFORM = 'Web';

--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
@@ -14,7 +14,7 @@ import BrowserDetection from '../common/browser-detection';
 
 import {
   error, eventType, errorCodes as ERROR_CODE, OS_NAME, UNKNOWN, CLIENT_NAME,
-  mediaType
+  mediaType, PLATFORM
 } from './config';
 
 const OSMap = {
@@ -489,11 +489,11 @@ class Metrics {
   }
 
   /**
-   * Uploads given metric to the Metrics service as an operational metric.
+   * Uploads given metric to the Metrics service as an Behavioral metric.
    * Metadata about the environment such as browser, OS, SDK and their versions
    * are automatically added when the metric is sent.
    *
-   * The Metrics service will send an operational metric to InfluxDB for
+   * The Metrics service will send an Behavioral metric to InfluxDB for
    * aggregation.
    * See https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Getting+started+with+Metrics+Service.
    *
@@ -503,12 +503,24 @@ class Metrics {
    *
    * @returns {void}
    */
-  sendOperationalMetric(metricName, metricFields = {}, metricTags = {}) {
+  sendBehavioralMetric(metricName, metricFields = {}, metricTags = {}) {
     const fields = {
       ...metricFields,
       browser_version: getBrowserVersion(),
       os_version: getOSVersion(),
-      sdk_version: this.webex.version
+      sdk_version: this.webex.version,
+      platform: PLATFORM
+    };
+
+    const context = {
+      app: {
+        version: this.webex.version
+      },
+      locale: 'en-US',
+      os: {
+        name: getOSName(),
+        version: getOSVersion()
+      }
     };
 
     const tags = {
@@ -517,17 +529,19 @@ class Metrics {
       org_id: this.webex.credentials.getOrgId(),
       os: getOSName(),
       domain: window.location.hostname,
-      client_id: this.webex.credentials.config.client_id
+      client_id: this.webex.credentials.config.client_id,
+      user_id: this.webex.internal.device.userId
     };
 
     if (!metricName) {
-      throw Error('Missing operational metric name. Please provide one');
+      throw Error('Missing behavioral metric name. Please provide one');
     }
 
     this.webex.internal.metrics.submitClientMetrics(metricName, {
-      type: ['operational'],
+      type: ['behavioral', 'operational'],
       fields,
-      tags
+      tags,
+      context
     });
   }
 }

--- a/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
@@ -21,7 +21,7 @@ import {
   OFFER,
   QUALITY_LEVELS,
   MAX_FRAMESIZES,
-  METRICS_OPERATIONAL_MEASURES
+  BEHAVIORAL_METRICS
 } from '../constants';
 import {error, eventType} from '../metrics/config';
 import MediaError from '../common/errors/media';
@@ -342,7 +342,7 @@ pc.setRemoteSessionDetails = (
         LoggerProxy.logger.error(`Peer-connection-manager:index#setRemoteDescription --> ${error} missing remotesdp`);
 
 
-        const metricName = METRICS_OPERATIONAL_MEASURES.PEERCONNECTION_FAILURE;
+        const metricName = BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE;
         const data = {
           correlation_id: meetingId,
           reason: error.message,
@@ -352,7 +352,7 @@ pc.setRemoteSessionDetails = (
           type: error.name
         };
 
-        Metrics.sendOperationalMetric(metricName, data, metadata);
+        Metrics.sendBehavioralMetric(metricName, data, metadata);
 
         return Metrics.postEvent({
           event: eventType.REMOTE_SDP_RECEIVED,
@@ -423,8 +423,8 @@ pc.createOffer = (peerConnection, {
     .catch((error) => {
       LoggerProxy.logger.error(`Peer-connection-manager:index#createOffer --> ${error}`);
       if (error instanceof InvalidSdpError) {
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.INVALID_ICE_CANDIDATE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.INVALID_ICE_CANDIDATE,
           {
             correlation_id: meetingId,
             code: error.code,
@@ -433,7 +433,7 @@ pc.createOffer = (peerConnection, {
         );
       }
       else {
-        const metricName = METRICS_OPERATIONAL_MEASURES.PEERCONNECTION_FAILURE;
+        const metricName = BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE;
         const data = {
           correlation_id: meetingId,
           reason: error.message,
@@ -443,7 +443,7 @@ pc.createOffer = (peerConnection, {
           type: error.name
         };
 
-        Metrics.sendOperationalMetric(metricName, data, metadata);
+        Metrics.sendBehavioralMetric(metricName, data, metadata);
       }
 
       Metrics.postEvent({
@@ -538,15 +538,15 @@ pc.createAnswer = (params, {meetingId, remoteQualityLevel}) => {
     })
     .catch((error) => {
       if (error instanceof InvalidSdpError) {
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.INVALID_ICE_CANDIDATE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.INVALID_ICE_CANDIDATE,
           {
             correlation_id: meetingId
           }
         );
       }
       else {
-        const metricName = METRICS_OPERATIONAL_MEASURES.PEERCONNECTION_FAILURE;
+        const metricName = BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE;
         const data = {
           correlation_id: meetingId,
           reason: error.message,
@@ -556,7 +556,7 @@ pc.createAnswer = (params, {meetingId, remoteQualityLevel}) => {
           type: error.name
         };
 
-        Metrics.sendOperationalMetric(metricName, data, metadata);
+        Metrics.sendBehavioralMetric(metricName, data, metadata);
       }
 
       LoggerProxy.logger.error(`PeerConnectionManager:index#setRemoteSessionDetails --> Error creating remote session, error: ${error}`);
@@ -619,8 +619,8 @@ pc.setPeerConnectionEvents = (meeting) => {
       function: 'connectionFailed'
     });
 
-    Metrics.sendOperationalMetric(
-      METRICS_OPERATIONAL_MEASURES.CONNECTION_FAILURE,
+    Metrics.sendBehavioralMetric(
+      BEHAVIORAL_METRICS.CONNECTION_FAILURE,
       {
         correlation_id: meeting.correlationId,
         locus_id: meeting.locusId
@@ -642,6 +642,13 @@ pc.setPeerConnectionEvents = (meeting) => {
         // Ice connection state goes to connected when both client and server sends STUN packets and
         // Established connected between them. Firefox does not trigger COMPLETED and only trigger CONNECTED
         Metrics.postEvent({event: eventType.ICE_END, meeting});
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.CONNECTION_SUCCESS,
+          {
+            correlation_id: meeting.correlationId,
+            locus_id: meeting.locusId
+          }
+        );
         meeting.setNetworkStatus(NETWORK_STATUS.CONNECTED);
         meeting.reconnectionManager.iceReconnected();
         LoggerProxy.logger.info('PeerConnectionManager:index#setPeerConnectionEvents --> ICE STATE CONNECTED.');

--- a/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -8,7 +8,7 @@ import LoggerProxy from '../common/logs/logger-proxy';
 import Trigger from '../common/events/trigger-proxy';
 import {
   EVENT_TRIGGERS,
-  METRICS_OPERATIONAL_MEASURES,
+  BEHAVIORAL_METRICS,
   RECONNECTION,
   SHARE_STATUS,
   SHARE_STOPPED_REASON,
@@ -424,8 +424,8 @@ export default class ReconnectionManager {
       }
       else {
         LoggerProxy.logger.error('ReconnectionManager:index#rejoinMeeting --> Unable to rejoin meeting after max attempts.', joinError);
-        Metrics.sendOperationalMetric(
-          METRICS_OPERATIONAL_MEASURES.MEETING_MAX_REJOIN_FAILURE,
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.MEETING_MAX_REJOIN_FAILURE,
           {
             locus_id: this.meeting.locusUrl.split('/').pop(),
             reason: joinError.message,

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js
@@ -2,7 +2,7 @@
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
 import LoggerProxy from '../common/logs/logger-proxy';
-import {ROAP, _OFFER_, METRICS_OPERATIONAL_MEASURES} from '../constants';
+import {ROAP, _OFFER_, BEHAVIORAL_METRICS} from '../constants';
 import Metrics from '../metrics';
 
 import RoapUtil from './util';
@@ -44,14 +44,14 @@ const handleSessionStep = ({
   if (session.OFFER && messageType === _OFFER_) {
     session.GLARE_OFFER = roap.msg;
     session.GLARE_OFFER.remote = !!roap.remote;
-    const metricName = METRICS_OPERATIONAL_MEASURES.ROAP_GLARE_CONDITION;
+    const metricName = BEHAVIORAL_METRICS.ROAP_GLARE_CONDITION;
     const data = {
       correlation_id: correlationId,
       locus_id: locusUrl.split('/').pop(),
       sequence: sequenceId
     };
 
-    Metrics.sendOperationalMetric(metricName, data);
+    Metrics.sendBehavioralMetric(metricName, data);
 
     LoggerProxy.logger.warn(`Roap:handler#handleSessionStep --> Glare condition occurred with new mercury event, sequenceId: ${sequenceId}`);
   }
@@ -112,7 +112,7 @@ export default class RoapHandler extends StatelessWebexPlugin {
               });
             })
             .catch((error) => {
-              const metricName = METRICS_OPERATIONAL_MEASURES.ROAP_ANSWER_FAILURE;
+              const metricName = BEHAVIORAL_METRICS.ROAP_ANSWER_FAILURE;
               const data = {
                 correlation_id: meeting.correlationId,
                 locus_id: meeting.locusUrl.split('/').pop(),
@@ -123,7 +123,7 @@ export default class RoapHandler extends StatelessWebexPlugin {
                 type: error.name
               };
 
-              Metrics.sendOperationalMetric(metricName, data, metadata);
+              Metrics.sendBehavioralMetric(metricName, data, metadata);
               LoggerProxy.logger.error(`Roap:handler#perform --> Error occured during wait receive answer, continuing, ${error}`);
             });
         }

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -30,7 +30,7 @@ import Metrics from '@webex/plugin-meetings/src/metrics';
 import {
   FLOOR_ACTION,
   SHARE_STATUS,
-  METRICS_OPERATIONAL_MEASURES,
+  BEHAVIORAL_METRICS,
   MEETING_INFO_FAILURE_REASON,
   PASSWORD_STATUS,
   EVENTS,
@@ -2433,12 +2433,12 @@ describe('plugin-meetings', () => {
           });
 
           it('should send metrics on reconnect failure', async () => {
-            sandbox.stub(Metrics, 'sendOperationalMetric');
+            sandbox.stub(Metrics, 'sendBehavioralMetric');
             await assert.isRejected(meeting.reconnect());
-            assert(Metrics.sendOperationalMetric.calledOnce);
+            assert(Metrics.sendBehavioralMetric.calledOnce);
             assert.calledWith(
-              Metrics.sendOperationalMetric,
-              METRICS_OPERATIONAL_MEASURES.MEETING_RECONNECT_FAILURE,
+              Metrics.sendBehavioralMetric,
+              BEHAVIORAL_METRICS.MEETING_RECONNECT_FAILURE,
               {
                 correlation_id: meeting.correlationId,
                 locus_id: meeting.locusUrl.split('/').pop(),

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/metrics/index.js
@@ -90,9 +90,9 @@ browserOnly(describe)('Meeting metrics', () => {
     });
   });
 
-  describe('#sendOperationalMetric', () => {
+  describe('#sendBehavioralMetric', () => {
     it('sends client metric via Metrics plugin', () => {
-      metrics.sendOperationalMetric('myMetric');
+      metrics.sendBehavioralMetric('myMetric');
 
       assert.calledOnce(mockSubmitMetric);
     });
@@ -101,13 +101,13 @@ browserOnly(describe)('Meeting metrics', () => {
       const data = {value: 567};
       const metadata = {test: true};
 
-      metrics.sendOperationalMetric('myMetric', data, metadata);
+      metrics.sendBehavioralMetric('myMetric', data, metadata);
 
       assert.calledWithMatch(
         mockSubmitMetric,
         'myMetric',
         {
-          type: ['operational'],
+          type: ['behavioral'],
           fields: {
             browser_version: getBrowserVersion(),
             os_version: getOSVersion(),
@@ -127,8 +127,8 @@ browserOnly(describe)('Meeting metrics', () => {
 
     it('throws error if no metric name is given', () => {
       assert.throws(
-        () => metrics.sendOperationalMetric(),
-        'Missing operational metric name. Please provide one'
+        () => metrics.sendBehavioralMetric(),
+        'Missing behavioral metric name. Please provide one'
       );
     });
   });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-302864](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-302864)

## This pull request addresses

We are changing the current operational metrics to behaviors metrics so that we can track the user activity flow 
which help identifying the user flow and issues 

## by making the following changes

We are changing the metrics values from "Operational" to "behavioral" and adding some user properties like userID , os information etc 

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
https://analytics.amplitude.com/cisco-cross-project/dashboard/48b3zev
 Did manual test where the data is been shown in the dashboard 

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
