### PR TITLE
fix(plugin-meetings): fix extmap config boolean

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
@@ -324,7 +324,7 @@ pc.setRemoteSessionDetails = (
   if (peerConnection.signalingState === SDP.HAVE_LOCAL_OFFER || (peerConnection.signalingState === SDP.STABLE && typeStr === SDP.OFFER)) {
     sdp = setStartBitrateOnRemoteSdp(sdp);
 
-    if (peerConnection.enableExtmap) {
+    if (!peerConnection.enableExtmap) {
       sdp = sdp.replace(/\na=extmap.*/g, '');
     }
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/peerconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/peerconnection-manager/index.js
@@ -21,7 +21,7 @@ describe('Peerconnection Manager', () => {
       };
     });
     describe('setRemoteSessionDetails', () => {
-      it('change the start bitrate on remoteSDP', async () => {
+      it('change the start bitrate on remoteSDP and remove extmap', async () => {
         StaticConfig.set({bandwidth: {audio: 50, video: 500, startBitrate: 2000}});
         let result = null;
         const setRemoteDescription = sinon.stub().callsFake((args) => {
@@ -33,17 +33,18 @@ describe('Peerconnection Manager', () => {
         'm=video 5004 UDP/TLS/RTP/SAVPF 102 127 97 99\r\n' +
         'a=fmtp:102 profile-level-id=42e016;packetization-mode=1;max-mbps=244800;max-fs=8160;max-fps=3000;max-dpb=12240;max-rcmd-nalu-size=196608;level-asymmetry-allowed=1\r\n' +
         'a=rtpmap:127 H264/90000\r\n' +
+        'a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\n' +
         'a=fmtp:127 profile-level-id=42e016;max-mbps=244800;max-fs=8160;max-fps=3000;max-dpb=12240;max-rcmd-nalu-size=196608;level-asymmetry-allowed=1\r\n';
 
         const resultSdp = 'v=0\r\n' +
         'm=video 5004 UDP/TLS/RTP/SAVPF 102 127 97 99\r\n' +
         'a=fmtp:102 profile-level-id=42e016;packetization-mode=1;max-mbps=244800;max-fs=8160;max-fps=3000;max-dpb=12240;max-rcmd-nalu-size=196608;level-asymmetry-allowed=1;x-google-start-bitrate=2000\r\n' +
-        'a=rtpmap:127 H264/90000\r\n' +
+        'a=rtpmap:127 H264/90000\r\r\n' +
         'a=fmtp:127 profile-level-id=42e016;max-mbps=244800;max-fs=8160;max-fps=3000;max-dpb=12240;max-rcmd-nalu-size=196608;level-asymmetry-allowed=1;x-google-start-bitrate=2000\r\n';
         const peerConnection = {
           signalingState: 'have-local-offer',
-          setRemoteDescription
-
+          setRemoteDescription,
+          enableExtmap: false
         };
 
         await PeerConnectionManager.setRemoteSessionDetails(peerConnection, 'answer', remoteSdp, {});
@@ -68,7 +69,6 @@ describe('Peerconnection Manager', () => {
         const peerConnection = {
           signalingState: 'have-local-offer',
           setRemoteDescription
-
         };
 
         await PeerConnectionManager.setRemoteSessionDetails(peerConnection, 'answer', remoteSdp, {});


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-306113 ](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-306113)>

## This pull request addresses

Currently the sdk offers transport cc using the config value enableExtmap which will make sure we send 
`a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01`

as an offer to the server and server responds back with an answer 

In cases remote screen share the server offers the same 

`a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01`

in the remote SDP but the client initially has disabled transport cc 


So we need to make sure we remove the extmap line not only in the offer from client but also offer from the server


## by making the following changes

remove extmap based on toggle in peerconnection manager

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
Manual test was performed

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
