### PR TITLE
feat(internal-plugin-conversation) send file extensions on file upload

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/share-activity.js
@@ -38,6 +38,7 @@ const ShareActivity = WebexPlugin.extend({
   },
 
   session: {
+    claimedFileType: 'string',
     conversation: {
       required: true,
       type: 'object'
@@ -150,6 +151,7 @@ const ShareActivity = WebexPlugin.extend({
    */
   add(file, options) {
     options = options || {};
+    options.claimedFileType = file.displayName.substring(file.displayName.lastIndexOf('.'));
     let upload = this.uploads.get(file);
 
     if (upload) {
@@ -257,8 +259,8 @@ const ShareActivity = WebexPlugin.extend({
   _upload(file, uri, uploadOptions) {
     const fileSize = file.length || file.size || file.byteLength;
     const fileHash = sha256(file).toString();
-    const {role} = uploadOptions ?? {};
-    const initializeBody = Object.assign({fileSize}, role && {role});
+    const {role, claimedFileType} = uploadOptions ?? {};
+    const initializeBody = Object.assign({fileSize}, {claimedFileType}, role && {role});
 
     return this.webex.upload({
       uri,

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/share-activity.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/share-activity.js
@@ -129,6 +129,20 @@ describe('plugin-conversation', () => {
 
         assert.match(actualResult, expectedResult);
       });
+
+      it('checks whether property claimedFileType is sent with file extension in body while making a call to /finish API', () => {
+        const fileSize = 100;
+        const mockFile = {size: fileSize};
+
+        const uploadOptions = {claimedFileType: '.zip'};
+
+        shareActivityUpload._upload(mockFile, fakeURL, uploadOptions);
+
+        const expectedResult = {fileSize, claimedFileType: '.zip'};
+        const actualResult = webex.upload.getCall(0).args[0].phases.initialize.body;
+
+        assert.match(actualResult, expectedResult);
+      });
     });
 
     describe('#addGif', () => {


### PR DESCRIPTION

# COMPLETES [SPARK-312937](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-312937)

## This pull request addresses

Working on restricting file upload/download based on file type requires the client to send file extension "claimedFileType" for every upload request.

## by making the following changes

I have added additional property "claimedFileType" inside file upload request. That property will be used to restrict file to be upload/download by file type extensions. 

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

Unit Test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
