### PR TITLE
fix(plugins-meetings): warn if H.264 codec is not detected

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js
@@ -84,7 +84,7 @@ MeetingsUtil.hasH264Codec = async () => {
     pc.close();
   }
   catch (error) {
-    LoggerProxy.logger.error('Meetings:util#hasH264Codec --> Error creating peerConnection for H.264 test.');
+    LoggerProxy.logger.warn('Meetings:util#hasH264Codec --> Error creating peerConnection for H.264 test.');
   }
 
   return hasCodec;


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [ SPARK-312420](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-312420)

## This pull request addresses
Avoiding showing an error message when H.264 is not detected in a Node environment.

## by making the following changes
Changing the error log to a warning log

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
Manual test to see warning instead of an error.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
