### PR TITLE
feat(plugin-meetings): send diagnostic error when join fails

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1154,6 +1154,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @param {String} options.trackingId
    * @param {Object} options.locus
    * @param {Array} options.mediaConnections
+   * @param {Object} options.errors
    * @returns {Object}
    * @memberof Meeting
    */
@@ -1292,6 +1293,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @param {String} options.event
    * @param {String} options.trackingId
    * @param {Object} options.locus
+   * @param {Object} options.errors
    * @returns {Promise}
    * @private
    * @memberof Meeting
@@ -3623,6 +3625,17 @@ export default class Meeting extends StatelessWebexPlugin {
       .catch((error) => {
         this.meetingFiniteStateMachine.fail(error);
         LoggerProxy.logger.error('Meeting:index#join --> Failed', error);
+
+        Metrics.postEvent({
+          event: eventType.LOCUS_JOIN_RESPONSE,
+          meeting: this,
+          meetingId: this.id,
+          data: {
+            errors: [
+              Metrics.parseLocusError(error.error, true)
+            ]
+          }
+        });
 
         // TODO:  change this to error codes and pre defined dictionary
         Metrics.sendBehavioralMetric(

--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
@@ -328,7 +328,11 @@ class Metrics {
   parseLocusError(err, showToUser) {
     let errorCode;
 
-    if (err && err.body && err.body.errorCode) {
+    if (err && err.statusCode && err.statusCode >= 500) {
+      errorCode = 1003;
+    }
+    else if (err && err.body && err.body.errorCode) {
+      // locus error codes: https://sqbu-github.cisco.com/WebExSquared/locus/blob/master/server/src/main/resources/locus-error-codes.properties
       switch (ERROR_CODE[err.body.errorCode]) {
         case MEETING_ERRORS.FREE_USER_MAX_PARTICIPANTS_EXCEEDED:
           errorCode = 3007;
@@ -450,6 +454,10 @@ class Metrics {
 
       if (err && err.body) {
         errorPayload.errorData = err.body;
+      }
+
+      if (err && err.statusCode) {
+        errorPayload.httpCode = err.statusCode;
       }
 
       return errorPayload;

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -27,6 +27,7 @@ import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
 import TriggerProxy from '@webex/plugin-meetings/src/common/events/trigger-proxy';
 import BrowserDetection from '@webex/plugin-meetings/src/common/browser-detection';
 import Metrics from '@webex/plugin-meetings/src/metrics';
+import {eventType} from '@webex/plugin-meetings/src/metrics/config';
 import {
   FLOOR_ACTION,
   SHARE_STATUS,
@@ -693,6 +694,11 @@ describe('plugin-meetings', () => {
               MeetingUtil.joinMeeting = sinon.stub().returns(Promise.resolve());
               await meeting.join({pin: '1234', moderator: false});
               assert.calledWith(MeetingUtil.joinMeeting, meeting, {moderator: false, pin: '1234'});
+            });
+          });
+          it('should post error event if failed', async () => {
+            await meeting.join().catch(() => {
+              assert.calledWithMatch(Metrics.postEvent, {event: eventType.LOCUS_JOIN_RESPONSE});
             });
           });
           it('should fail if password is required', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETE [SPARK-270186](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-270186)
## This pull request addresses
Attach an error payload when `meeting.join()` throws an error.

## by making the following changes

Catch and parse the Locus error and send a diagnostic-event.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
Manual test to see if error payload is attached when attempting to join an invalid meeting.
Automated test:
`npm test -- --packages @webex/package-meetings --node`

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
