### PR TITLE
feat(plugin-meetins: add adhoc meetings support

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -84,7 +84,13 @@ function initWebex(e) {
         reconnection: {
           enabled: true
         },
-        enableRtx: true
+        enableRtx: true,
+        experimental: {
+          enableMediaNegotiatedEvent: false,
+          enableUnifiedMeetings: true,
+          enableAdhocMeetings: true
+        }
+
       }
       // Any other sdk config we need
     },

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -572,7 +572,8 @@ const Conversation = WebexPlugin.extend({
         activitiesLimit: 0,
         includeConvWithDeletedUserUUID: false,
         includeParticipants: false
-      }, omit(options, 'id', 'user', 'url'))
+      }, omit(options, 'id', 'user', 'url')),
+      disableTransform: options.disableTransform
     };
 
     // Default behavior is to set includeParticipants=false,

--- a/packages/node_modules/@webex/plugin-meetings/src/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/config.js
@@ -89,7 +89,8 @@ export default {
     enableExtmap: false,
     experimental: {
       enableMediaNegotiatedEvent: false,
-      enableUnifiedMeetings: false
+      enableUnifiedMeetings: false,
+      enableAdhocMeetings: false
     }
   }
 };

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
@@ -1,10 +1,11 @@
 
-import {HTTP_VERBS} from '../constants';
+import {HTTP_VERBS, _CONVERSATION_URL_} from '../constants';
 
 import MeetingInfoUtil from './utilv2';
 
 const PASSWORD_ERROR_DEFAULT_MESSAGE = 'Password required. Call fetchMeetingInfo() with password argument';
 const CAPTCHA_ERROR_DEFAULT_MESSAGE = 'Captcha required. Call fetchMeetingInfo() with captchaInfo argument';
+const ADHOC_MEETING_DEFAULT_ERROR = 'Failed starting the adhoc meeting, Please contact support team ';
 
 /**
  * Error to indicate that wbxappapi requires a password
@@ -28,7 +29,27 @@ export class MeetingInfoV2PasswordError extends Error {
 }
 
 /**
-   * Error to indicate that wbxappapi requires a captcha
+ * Error generating a adhoc space meeting
+ */
+export class MeetingInfoV2AdhocMeetingError extends Error {
+  /**
+    *
+    * @constructor
+    * @param {Number} [wbxAppApiErrorCode]
+    * @param {String} [message]
+    */
+  constructor(wbxAppApiErrorCode, message = ADHOC_MEETING_DEFAULT_ERROR) {
+    super(`${message}, code=${wbxAppApiErrorCode}`);
+    this.name = 'MeetingInfoV2AdhocMeetingError';
+    this.sdkMessage = message;
+    this.stack = (new Error()).stack;
+    this.wbxAppApiCode = wbxAppApiErrorCode;
+  }
+}
+
+
+/**
+   * Error to indicate that preferred webex site not present to start adhoc meeting
    */
 export class MeetingInfoV2CaptchaError extends Error {
   /**
@@ -65,7 +86,7 @@ export default class MeetingInfoV2 {
      * converts hydra id into conversation url and persons Id
      * @param {String} destination one of many different types of destinations to look up info for
      * @param {String} [type] to match up with the destination value
-     * @returns {Promise} returns destination and type
+     * @returns {Promise} destination and type
      * @public
      * @memberof MeetingInfo
      */
@@ -75,6 +96,59 @@ export default class MeetingInfoV2 {
       type,
       webex: this.webex
     });
+  }
+
+  /**
+     * Creates adhoc space meetings for a space by fetching the conversation infomation
+     * @param {String} conversationUrl conversationUrl to start adhoc meeting on
+     * @returns {Promise} returns a meeting info object
+     * @public
+     * @memberof MeetingInfo
+     */
+  async createAdhocSpaceMeeting(conversationUrl) {
+    if (!this.webex.meetings.preferredWebexSite) {
+      throw Error('No preferred webex site found');
+    }
+    const getInvitees = (particpants = []) => {
+      const invitees = [];
+
+      if (particpants) {
+        particpants.forEach((participant) => {
+          invitees.push({
+            email: participant.emailAddress,
+            ciUserUuid: participant.entryUUID
+          });
+        });
+      }
+
+      return invitees;
+    };
+
+    return this.webex.internal.conversation.get(
+      {url: conversationUrl},
+      {includeParticipants: true, disableTransform: true}
+    )
+      .then((conversation) => {
+        const body = {
+          title: conversation.displayName,
+          spaceUrl: conversation.url,
+          keyUrl: conversation.encryptionKeyUrl,
+          kroUrl: conversation.kmsResourceObjectUrl,
+          invitees: getInvitees(conversation.participants?.items)
+        };
+
+        const uri = this.webex.meetings.preferredWebexSite ?
+          `https://${this.webex.meetings.preferredWebexSite}/wbxappapi/v2/meetings/spaceInstant` : '';
+
+        return this.webex.request({
+          method: HTTP_VERBS.POST,
+          uri,
+          body
+        })
+          .catch((err) => {
+            throw new MeetingInfoV2AdhocMeetingError(err.body?.code, err.body?.message);
+          });
+      });
   }
 
   /**
@@ -95,6 +169,11 @@ export default class MeetingInfoV2 {
       type,
       webex: this.webex
     });
+
+    if (destinationType.type === _CONVERSATION_URL_ && this.webex.config.meetings.experimental.enableAdhocMeetings) {
+      return this.createAdhocSpaceMeeting(destinationType.destination);
+    }
+
     const body = await MeetingInfoUtil.getRequestBody({...destinationType, password, captchaInfo});
 
     const options = {

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -3,6 +3,7 @@
 */
 
 import '@webex/internal-plugin-mercury';
+import '@webex/internal-plugin-conversation';
 import {WebexPlugin} from '@webex/webex-core';
 
 import 'webrtc-adapter';
@@ -162,6 +163,15 @@ export default class Meetings extends WebexPlugin {
        * @memberof Meetings
        */
       this.registered = false;
+
+      /**
+       * This values indicates the preferred webex site the user will start there meeting, getsits value from {@link Meetings#register}
+       * @instance
+       * @type {String}
+       * @private
+       * @memberof Meetings
+       */
+      this.preferredWebexSite = '';
 
       /**
        * The public interface for the internal Media util files. These are helpful to expose outside the context
@@ -408,6 +418,22 @@ export default class Meetings extends WebexPlugin {
     }
 
     /**
+     * API to toggle starting adhoc meeting
+     * @param {Boolean} changeState
+     * @private
+     * @memberof Meetings
+     * @returns {undefined}
+    */
+    _toggleAdhocMeetings(changeState) {
+      if (typeof changeState !== 'boolean') {
+        return;
+      }
+      if (this.config?.experimental?.enableAdhocMeetings !== changeState) {
+        this.config.experimental.enableAdhocMeetings = changeState;
+      }
+    }
+
+    /**
      * Explicitly sets up the meetings plugin by registering
      * the device, connecting to mercury, and listening for locus events.
      *
@@ -430,6 +456,7 @@ export default class Meetings extends WebexPlugin {
       }
 
       return Promise.all([
+        this.fetchUserPreferredWebexSite(),
         this.getGeoHint(),
         this.startReachability().catch((error) => {
           LoggerProxy.logger.error(`Meetings:index#register --> GDM error, ${error.message}`);
@@ -605,11 +632,27 @@ export default class Meetings extends WebexPlugin {
     }
 
     /**
+     * Fetch user preferred webex site information
+     * This also has other infomation about the user
+     * @returns {Promise}
+     * @private
+     * @memberof Meetings
+     */
+    fetchUserPreferredWebexSite() {
+      return this.request.fetchLoginUserInformation().then((res) => {
+        this.preferredWebexSite = MeetingsUtil.parseUserPreferences(res.userPreferences);
+        console.error(this.preferredWebexSite);
+      });
+    }
+
+
+    /**
      * gets the personal meeting room instance, for saved PMR values for this user
      * @returns {PersonalMeetingRoom}
      * @public
      * @memberof Meetings
      */
+
     getPersonalMeetingRoom() {
       return this.personalMeetingRoom;
     }

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js
@@ -12,9 +12,9 @@ import {
  */
 export default class MeetingRequest extends StatelessWebexPlugin {
   /**
-     *  get all the active meetings for the user
-     * @returns {Array} return locus array
-    */
+   *  get all the active meetings for the user
+   * @returns {Array} return locus array
+  */
   getActiveMeetings() {
     return this.request({
       api: API.LOCUS,
@@ -27,12 +27,21 @@ export default class MeetingRequest extends StatelessWebexPlugin {
   }
 
   /**
-     *  fetch geoHit for the user
-     * @returns {Promise<object>} geoHintInfo
-    */
+   *  fetch geoHit for the user
+   * @returns {Promise<object>} geoHintInfo
+   */
   fetchGeoHint() {
     return this.webex.internal.services.fetchClientRegionInfo();
   }
+
+  /**
+   *  fetch login user information
+   * @returns {Promise<object>} loginUserInformation
+  */
+  fetchLoginUserInformation() {
+    return this.webex.internal.services.fetchLoginUserInformation();
+  }
+
 
   // locus federation, determines and populate locus if the responseBody has remote URLs to fetch locus details
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js
@@ -64,6 +64,25 @@ MeetingsUtil.checkForCorrelationId = (deviceUrl, locus) => {
   return false;
 };
 
+MeetingsUtil.parseUserPreferences = (userPreferences) => {
+  let webexSite = null;
+
+  userPreferences.find((item) => {
+    // eslint-disable-next-line no-useless-escape
+    const regex = /"preferredWebExSite\":\"(\S+)\"/;
+    const preferredSite = item.match(regex);
+
+    if (preferredSite) {
+      webexSite = preferredSite[1];
+
+      return true;
+    }
+
+    return false;
+  });
+
+  return webexSite;
+};
 
 /**
  * Will check to see if the H.264 media codec is supported.

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -10,12 +10,34 @@ import Mercury from '@webex/internal-plugin-mercury';
 import Meetings from '@webex/plugin-meetings/src/meetings';
 import {
   _MEETING_ID_,
-  _PERSONAL_ROOM_
+  _PERSONAL_ROOM_,
+  _CONVERSATION_URL_
 } from '@webex/plugin-meetings/src/constants';
-import MeetingInfo, {MeetingInfoV2PasswordError, MeetingInfoV2CaptchaError} from '@webex/plugin-meetings/src/meeting-info/meeting-info-v2';
+import MeetingInfo, {MeetingInfoV2PasswordError, MeetingInfoV2CaptchaError, MeetingInfoV2AdhocMeetingError} from '@webex/plugin-meetings/src/meeting-info/meeting-info-v2';
 import MeetingInfoUtil from '@webex/plugin-meetings/src/meeting-info/utilv2';
 
 describe('plugin-meetings', () => {
+  const conversation = {
+    displayName: 'displayName',
+    url: 'conversationUrl',
+    encryptionKeyUrl: 'encryptionKeyUrl',
+    kmsResourceObjectUrl: 'kmsResourceObjectUrl',
+    participants: {
+      items: [
+        {
+          id: '344ea183-9d5d-4e77-aed',
+          emailAddress: 'testUser1@cisco.com',
+          entryUUID: '344ea183-9d5d-4e77-'
+
+        },
+        {
+          id: '40b446fe-175c-4628-8a9d',
+          emailAddress: 'testUser2@cisco.com',
+          entryUUID: '40b446fe-175c-4628'
+        }
+      ]
+    }
+  };
   let webex;
   let meetingInfo = null;
 
@@ -29,6 +51,9 @@ describe('plugin-meetings', () => {
         }
       });
 
+      webex.meetings.preferredWebexSite = 'go.webex.com';
+      webex.config.meetings = {experimental: {enableUnifiedMeetings: true, enableAdhocMeetings: true}};
+
       Object.assign(webex.internal, {
         device: {
           deviceType: 'FAKE_DEVICE',
@@ -41,6 +66,9 @@ describe('plugin-meetings', () => {
           disconnect: sinon.stub().returns(Promise.resolve()),
           on: () => {},
           off: () => {}
+        },
+        conversation: {
+          get: sinon.stub().returns(Promise.resolve(conversation))
         }
       });
 
@@ -98,6 +126,40 @@ describe('plugin-meetings', () => {
         });
       });
 
+      it('create adhoc meeting when conversationUrl passed with enableAdhocMeetings toggle', async () => {
+        sinon.stub(meetingInfo, 'createAdhocSpaceMeeting').returns(Promise.resolve());
+        await meetingInfo.fetchMeetingInfo('conversationUrl', _CONVERSATION_URL_);
+
+        assert.calledWith(meetingInfo.createAdhocSpaceMeeting, 'conversationUrl');
+        assert.notCalled(webex.request);
+        meetingInfo.createAdhocSpaceMeeting.restore();
+      });
+
+      it('should not call createAdhocSpaceMeeting if enableAdhocMeetings toggle is off', async () => {
+        webex.config.meetings.experimental.enableAdhocMeetings = false;
+        sinon.stub(meetingInfo, 'createAdhocSpaceMeeting').returns(Promise.resolve());
+
+        await meetingInfo.fetchMeetingInfo('conversationUrl', _CONVERSATION_URL_);
+
+        assert.notCalled(meetingInfo.createAdhocSpaceMeeting);
+        assert.called(webex.request);
+        meetingInfo.createAdhocSpaceMeeting.restore();
+      });
+
+      it('should throw an error MeetingInfoV2AdhocMeetingError if not able to start adhoc meeting for a conversation', async () => {
+        webex.config.meetings.experimental.enableAdhocMeetings = true;
+
+        webex.request = sinon.stub().rejects({statusCode: 403, body: {code: 400000, message: 'Input is invalid'}});
+        try {
+          await meetingInfo.createAdhocSpaceMeeting('conversationUrl');
+        }
+        catch (err) {
+          assert.instanceOf(err, MeetingInfoV2AdhocMeetingError);
+          assert.deepEqual(err.message, 'Input is invalid, code=400000');
+          assert.equal(err.wbxAppApiCode, 400000);
+        }
+      });
+
       it('should throw MeetingInfoV2PasswordError for 403 response', async () => {
         const FAKE_MEETING_INFO = {blablabla: 'some_fake_meeting_info'};
 
@@ -151,6 +213,41 @@ describe('plugin-meetings', () => {
 
         it('should throw MeetingInfoV2CaptchaError for 423 response (wbxappapi code 423001)', async () => {
           await runTest(423001, false);
+        });
+      });
+    });
+
+
+    describe('createAdhocSpaceMeeting', () => {
+      it('Make a request to /instantSpace when conversationUrl', async () => {
+        const conversationUrl = 'https://conversationUrl/xxx';
+        const invitee = [];
+
+        invitee.push({
+          email: conversation.participants.items[0].emailAddress,
+          ciUserUuid: conversation.participants.items[0].entryUUID
+        });
+
+        invitee.push({
+          email: conversation.participants.items[1].emailAddress,
+          ciUserUuid: conversation.participants.items[1].entryUUID
+        });
+
+        await meetingInfo.createAdhocSpaceMeeting(conversationUrl);
+
+        assert.calledWith(webex.internal.conversation.get, {url: conversationUrl},
+          {includeParticipants: true, disableTransform: true});
+
+        assert.calledWith(webex.request, {
+          method: 'POST',
+          uri: 'https://go.webex.com/wbxappapi/v2/meetings/spaceInstant',
+          body: {
+            title: conversation.displayName,
+            spaceUrl: conversation.url,
+            keyUrl: conversation.encryptionKeyUrl,
+            kroUrl: conversation.kmsResourceObjectUrl,
+            invitees: invitee
+          }
         });
       });
     });

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -28,7 +28,6 @@ import {
   ROAP
 } from '../../../../src/constants';
 
-
 describe('plugin-meetings', () => {
   const logger = {
     log: () => {},
@@ -74,6 +73,11 @@ describe('plugin-meetings', () => {
         }
       });
 
+
+      Object.assign(webex, {
+        logging: logger
+      });
+
       Object.assign(webex.meetings.config, {
         bandwidth: {
           // please note, these are the maximum bandwidth values
@@ -86,13 +90,17 @@ describe('plugin-meetings', () => {
           enableUnifiedMeetings: true
         },
         logging: {
-          enable: false,
+          enable: true,
           verboseEvents: true
         }
       });
 
       Object.assign(webex, {
         logger
+      });
+
+      Object.assign(webex.meetings, {
+        startReachability: sinon.stub().returns(Promise.resolve())
       });
 
       Object.assign(webex.internal, {
@@ -162,17 +170,36 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#_toggleAdhocMeetings', () => {
+      it('should have toggleAdhocMeetings', () => {
+        assert.equal(typeof webex.meetings._toggleAdhocMeetings, 'function');
+      });
+
+      describe('success', () => {
+        it('should update meetings to start  adhoc meeting', () => {
+          webex.meetings._toggleAdhocMeetings(false);
+          assert.equal(webex.meetings.config.experimental.enableAdhocMeetings, false);
+        });
+      });
+
+      describe('failure', () => {
+        it('should not accept non boolean input', () => {
+          const currentEnableAdhocMeetings = webex.meetings.config.experimental.enableAdhocMeetings;
+
+          webex.meetings._toggleAdhocMeetings('test');
+          assert.equal(webex.meetings.config.experimental.enableAdhocMeetings, currentEnableAdhocMeetings);
+        });
+      });
+    });
+
+
     describe('Public API Contracts', () => {
       describe('#register', () => {
-        it('emits an event and resolves when register succeeds', (done) => {
+        it('emits an event and resolves when register succeeds', async () => {
           webex.canAuthorize = true;
-          webex.meetings.register().then(() => {
-            assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meetings), {
-              file: 'meetings', function: 'register'
-            }, 'meetings:registered');
-            assert.isTrue(webex.meetings.registered);
-            done();
-          });
+          await webex.meetings.register();
+          assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meetings), {file: 'meetings', function: 'register'}, 'meetings:registered');
+          assert.isTrue(webex.meetings.registered);
         });
 
         it('rejects when SDK canAuthorize is false', () => {
@@ -192,15 +219,24 @@ describe('plugin-meetings', () => {
           assert.isRejected(webex.meetings.register());
         });
 
-        it('resolves immediately if already registered', (done) => {
+        it('resolves immediately if already registered', async () => {
           webex.canAuthorize = true;
           webex.meetings.registered = true;
-          webex.meetings.register().then(() => {
-            assert.notCalled(webex.internal.device.register);
-            assert.notCalled(webex.internal.mercury.connect);
-            assert.isTrue(webex.meetings.registered);
-            done();
-          });
+          await webex.meetings.register();
+          assert.notCalled(webex.internal.device.register);
+          assert.notCalled(webex.internal.mercury.connect);
+          assert.isTrue(webex.meetings.registered);
+        });
+
+        it('on register makes sure following functions are called ', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+          await webex.meetings.register();
+          assert.called(webex.internal.device.register);
+          assert.called(webex.internal.services.fetchLoginUserInformation);
+          assert.called(webex.internal.services.fetchClientRegionInfo);
+          assert.called(webex.internal.mercury.connect);
+          assert.isTrue(webex.meetings.registered);
         });
       });
 
@@ -766,6 +802,15 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meetings.handleMercuryOffline);
           assert.calledOnce(TriggerProxy.trigger);
           assert.calledWith(TriggerProxy.trigger, webex.internal.mercury, SCOPE, EVENT);
+        });
+      });
+
+      describe('#fetchUserPreferredWebexSite', () => {
+        it('should call request.fetchLoginUserInformation to get the preferred webex site ', async () => {
+          assert.isDefined(webex.meetings.preferredWebexSite);
+          await webex.meetings.fetchUserPreferredWebexSite();
+
+          assert.equal(webex.meetings.preferredWebexSite, 'go.webex.com');
         });
       });
     });

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
@@ -1,0 +1,18 @@
+import {assert} from '@webex/test-helper-chai';
+import MeetingsUtil from '@webex/plugin-meetings/src/meetings/util';
+
+describe('plugin-meetings', () => {
+  describe('Meetings utils function', () => {
+    describe('#parseUserPreferences', () => {
+      it('parsed the prefered webesite from userPreferences', async () => {
+        const res = MeetingsUtil.parseUserPreferences([
+          'SparkTOSAccept',
+          '"preferredWebExSite":"go.webex.com"'
+        ]);
+
+        assert.equal(res, 'go.webex.com');
+      });
+    });
+  });
+});
+

--- a/packages/node_modules/@webex/webex-core/src/interceptors/payload-transformer.js
+++ b/packages/node_modules/@webex/webex-core/src/interceptors/payload-transformer.js
@@ -36,6 +36,10 @@ export default class PayloadTransformerInterceptor extends Interceptor {
    * @returns {Object}
    */
   onResponse(options, response) {
+    if (options.disableTransform) {
+      return response;
+    }
+
     return this.webex.transform('inbound', response);
   }
 

--- a/packages/node_modules/@webex/webex-core/src/lib/services/services.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/services.js
@@ -366,6 +366,27 @@ const Services = WebexPlugin.extend({
   },
 
   /**
+   * Fetch login user infomation (preferred webex site).
+   *
+   * @returns {object} - User Information including user preferrences .
+   */
+  fetchLoginUserInformation() {
+    return this.request({
+      method: 'GET',
+      service: 'identity',
+      resource: 'identity/scim/v1/Users/me?showAllTypes=true'
+    }).then((res) => {
+      this.logger.info('services: received user region info');
+
+      return res.body;
+    }).catch((err) => {
+      this.logger.info('services: was not able to fetch user login information', err);
+      // resolve successfully even if request failed
+    });
+  },
+
+
+  /**
    * Fetches client region info such as countryCode and timezone.
    *
    * @returns {object} - The region info object.

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/services.js
@@ -4,8 +4,8 @@
 
 import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
-import {Services, ServiceRegistry, ServiceState} from '@webex/webex-core';
 import sinon from 'sinon';
+import {Services, ServiceRegistry, ServiceState} from '@webex/webex-core';
 
 /* eslint-disable no-underscore-dangle */
 describe('webex-core', () => {
@@ -97,6 +97,37 @@ describe('webex-core', () => {
           .then((r) => {
             assert.isUndefined(r);
           });
+      });
+    });
+
+    describe('#fetchLoginUserInformation', () => {
+      it('Fetch login users information ', async () => {
+        const userPreferences = {userPreferences: 'userPreferences'};
+
+        webex.request = sinon.stub().returns(Promise.resolve({body: userPreferences}));
+
+        const res = await services.fetchLoginUserInformation();
+
+        assert.calledWith(webex.request, {
+          method: 'GET',
+          service: 'identity',
+          resource: 'identity/scim/v1/Users/me?showAllTypes=true'
+        });
+        assert.isDefined(res);
+        assert.equal(res, userPreferences);
+      });
+
+      it('Resolve fetchLoginUserInformation if the api request fails ', async () => {
+        webex.request = sinon.stub().returns(Promise.reject());
+
+        const res = await services.fetchLoginUserInformation();
+
+        assert.calledWith(webex.request, {
+          method: 'GET',
+          service: 'identity',
+          resource: 'identity/scim/v1/Users/me?showAllTypes=true'
+        });
+        assert.isUndefined(res);
       });
     });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-290078

## This pull request addresses

All the new adhoc webex meetings will use the new instantspace api for there webex meetings 

As part of the api we need to fetch the conversation then make a api call to instant-space with the invite 

## by making the following changes

use the Following api for instant meetings 
 https://confluence-eng-gpk2.cisco.com/conf/display/WMT/WebexAppAPI+API+Document

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Did manual testing to join a adhoc meeting and also checked if the obtp is being received 

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
