### PR TITLE
docs(): add a link to all the samples in the nav bar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,38 +43,9 @@
           </button>
         </div>
         <ul class="nav navbar-nav navbar-right">
-          <!-- <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Samples <span class="caret"></span></a>
-            <ul class="dropdown-menu">
-              <li>
-                <a href="/webex-js-sdk/samples/browser-auth-implicit/">Authentication - Implicit Grant Flow</a>
-              </li>
-              <li>
-                <a href="/webex-js-sdk/samples/browser-auth-jwt/">Authentication - Guest Users</a>
-              </li>
-              <li>
-                <a href="/webex-js-sdk/samples/browser-call-with-screenshare/">Local Screensharing</a>
-              </li>
-              <li>
-                <a href="/webex-js-sdk/samples/multi-party-cal/">Multi Party Calling</a>
-              </li>
-              <li>
-                <a href="/webex-js-sdk/samples/browser-plugin-meetings/">Meetings Plugin</a>
-              </li>
-              <li>
-                <a href="/webex-js-sdk/samples/browser-read-status/">Read Status</a>
-              </li>
-              <li>
-                <a href="/webex-js-sdk/samples/browser-single-party-call/">Single Party Call</a>
-              </li>
-              <li>
-                <a href="/webex-js-sdk/samples/browser-single-party-call-with-mute/">Local Mute/Unmute</a>
-              </li>
-              <li>
-                <a href="/webex-js-sdk/samples/browser-socket/">Socket</a>
-              </li>
-            </ul>
-          </li> -->
+          <li>
+            <a class="page-link" href="./samples/">Samples</a>
+          </li>
           <li>
             <a class="page-link" href="https://developer.webex.com/docs/sdks/browser#samples">Developer Portal</a>
           </li>
@@ -90,23 +61,23 @@
               Get started quickly with the Cisco Webex JS SDK with the following samples:
             </p>
             <div class="list-group">
-              <a href="/webex-js-sdk/samples/browser-auth-implicit/" class="list-group-item">Authentication - Implicit Grant Flow</a>
+              <a href="./samples/browser-auth-implicit/" class="list-group-item">Authentication - Implicit Grant Flow</a>
 
-              <a href="/webex-js-sdk/samples/browser-auth-jwt/" class="list-group-item">Authentication - Guest Users</a>
+              <a href="./samples/browser-auth-jwt/" class="list-group-item">Authentication - Guest Users</a>
 
-              <a href="/webex-js-sdk/samples/browser-call-with-screenshare/" class="list-group-item">Local Screensharing</a>
+              <a href="./samples/browser-call-with-screenshare/" class="list-group-item">Local Screensharing</a>
 
-              <a href="/webex-js-sdk/samples/multi-party-cal/" class="list-group-item">Multi Party Calling</a>
+              <a href="./samples/multi-party-cal/" class="list-group-item">Multi Party Calling</a>
 
-              <a href="/webex-js-sdk/samples/browser-plugin-meetings/" class="list-group-item">Meetings Plugin</a>
+              <a href="./samples/browser-plugin-meetings/" class="list-group-item">Meetings Plugin</a>
 
-              <a href="/webex-js-sdk/samples/browser-read-status/" class="list-group-item">Read Status</a>
+              <a href="./samples/browser-read-status/" class="list-group-item">Read Status</a>
 
-              <a href="/webex-js-sdk/samples/browser-single-party-call/" class="list-group-item">Single Party Call</a>
+              <a href="./samples/browser-single-party-call/" class="list-group-item">Single Party Call</a>
 
-              <a href="/webex-js-sdk/samples/browser-single-party-call-with-mute/" class="list-group-item">Local Mute/Unmute</a>
+              <a href="./samples/browser-single-party-call-with-mute/" class="list-group-item">Local Mute/Unmute</a>
 
-              <a href="/webex-js-sdk/samples/browser-socket/" class="list-group-item">Socket</a>
+              <a href="./samples/browser-socket/" class="list-group-item">Socket</a>
             </div>
           </div>
           <div class="col-md-4">
@@ -115,7 +86,7 @@
               See the full API Reference for more detailed information about the SDK:
             </p>
             <div class="list-group">
-              <a href="/webex-js-sdk/api" class="list-group-item">API Reference</a>
+              <a href="./api" class="list-group-item">API Reference</a>
             </div>
           </div>
           <div class="col-md-4">


### PR DESCRIPTION
This is a quick tweak to add a link to the samples/index.html in the navbar of the homepage

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [ x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ x] I discussed changes with code owners prior to submitting this pull request

- [ x] I have not skipped any automated checks
- [ x] All existing and new tests passed
- [ x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
