### PR TITLE
make sure webex.min.js is in the docs folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,6 +320,7 @@ jobs:
             # Check if there's anything to commit before committing
             if [ -n "$(git status --porcelain)" ]; then
               git add docs/
+              git add -f docs/samples/webex.min.js*
               git commit -m "docs(api): update docs [skip ci]"
               git push upstream HEAD:master
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ tasks/selenium
 .sauce
 .sauce.tid
 browsers.processed.js
-bundle.js
-bundle.js.map
 docs/samples/webex.min.js
 docs/samples/webex.min.js.map
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,6 @@ If you would like to contribute to this repository by adding features, enhanceme
         - [`[skip ci]`](#skip-ci)
     - [Submitting a Pull Request](#submitting-a-pull-request)
     - [Pull Request Checklist](#pull-request-checklist)
-  - [Updating the Documentation](#updating-the-documentation)
-    - [Set Up Environment (with Bundler)](#set-up-environment-with-bundler)
-    - [Compile and Serve Docs](#compile-and-serve-docs)
 
 ## Reporting Issues
 
@@ -440,24 +437,3 @@ Before you open that new pull request, make sure to have completed the following
 - I have added tests that prove my fix is effective or that my feature works
 - New and existing unit tests pass locally with my changes
 - Any dependent changes have been merged and published in downstream modules
-
-## Updating the Documentation
-
-To compile the documentation locally, make sure you have [Bundler](http://bundler.io/) or
-[Jekyll](https://jekyllrb.com/) installed then run the following:
-
-### Set Up Environment (with Bundler)
-
-```bash
-cd docs
-bundle install
-```
-
-### Compile and Serve Docs
-
-```bash
-cd docs
-npm run build:docs
-bundle exec jekyll serve --config=_config.yml,_config.local.yml
-```
-

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This is a monorepo containing all officially maintained Cisco Webex JS SDK modul
       - [_A note on browser usage_](#a-note-on-browser-usage)
       - [_Still using `webex/env` or `ciscospark/env`?_](#still-using-webexenv-or-ciscosparkenv)
   - [Samples](#samples)
+  - [FedRAMP Environment](#fedramp-environment)
+    - [Features that do not work in FedRAMP](#features-that-do-not-work-in-fedramp)
   - [Contribute](#contribute)
   - [Issues](#issues)
   - [License](#license)
@@ -83,7 +85,7 @@ We provide a built, minified version of the SDK, that includes `window.Webex`. Y
 <!-- jsdelivr -->
 <script crossorigin src="https://cdn.jsdelivr.net/npm/webex/umd/webex.min.js"></script>
 <!-- gitcdn -->
-<script crossorigin src="https://gitcdn.xyz/repo/webex/webex-js-sdk/master/packages/node_modules/webex/umd/webex.min.js"></script>
+<script crossorigin src="https://gitcdn.xyz/repo/webex/webex-js-sdk/master/docs/samples/webex.min.js"></script>
 ```
 
 If you're already using a bundler (like [Webpack](https://webpack.js.org/) or [Rollup](https://rollupjs.org/)) you can simply import/require the package and use the above snippet and assign the initialized `webex` variable to `window.webex`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
         </div>
         <ul class="nav navbar-nav navbar-right">
           <li>
-            <a class="page-link" href="./samples/">Samples</a>
+            <a class="page-link" href="/webex-js-sdk/samples/">Samples</a>
           </li>
           <li>
             <a class="page-link" href="https://developer.webex.com/docs/sdks/browser#samples">Developer Portal</a>
@@ -61,23 +61,23 @@
               Get started quickly with the Cisco Webex JS SDK with the following samples:
             </p>
             <div class="list-group">
-              <a href="./samples/browser-auth-implicit/" class="list-group-item">Authentication - Implicit Grant Flow</a>
+              <a href="/webex-js-sdk/samples/browser-auth-implicit/" class="list-group-item">Authentication - Implicit Grant Flow</a>
 
-              <a href="./samples/browser-auth-jwt/" class="list-group-item">Authentication - Guest Users</a>
+              <a href="/webex-js-sdk/samples/browser-auth-jwt/" class="list-group-item">Authentication - Guest Users</a>
 
-              <a href="./samples/browser-call-with-screenshare/" class="list-group-item">Local Screensharing</a>
+              <a href="/webex-js-sdk/samples/browser-call-with-screenshare/" class="list-group-item">Local Screensharing</a>
 
-              <a href="./samples/multi-party-cal/" class="list-group-item">Multi Party Calling</a>
+              <a href="/webex-js-sdk/samples/multi-party-cal/" class="list-group-item">Multi Party Calling</a>
 
-              <a href="./samples/browser-plugin-meetings/" class="list-group-item">Meetings Plugin</a>
+              <a href="/webex-js-sdk/samples/browser-plugin-meetings/" class="list-group-item">Meetings Plugin</a>
 
-              <a href="./samples/browser-read-status/" class="list-group-item">Read Status</a>
+              <a href="/webex-js-sdk/samples/browser-read-status/" class="list-group-item">Read Status</a>
 
-              <a href="./samples/browser-single-party-call/" class="list-group-item">Single Party Call</a>
+              <a href="/webex-js-sdk/samples/browser-single-party-call/" class="list-group-item">Single Party Call</a>
 
-              <a href="./samples/browser-single-party-call-with-mute/" class="list-group-item">Local Mute/Unmute</a>
+              <a href="/webex-js-sdk/samples/browser-single-party-call-with-mute/" class="list-group-item">Local Mute/Unmute</a>
 
-              <a href="./samples/browser-socket/" class="list-group-item">Socket</a>
+              <a href="/webex-js-sdk/samples/browser-socket/" class="list-group-item">Socket</a>
             </div>
           </div>
           <div class="col-md-4">
@@ -86,7 +86,7 @@
               See the full API Reference for more detailed information about the SDK:
             </p>
             <div class="list-group">
-              <a href="./api" class="list-group-item">API Reference</a>
+              <a href="/webex-js-sdk/api" class="list-group-item">API Reference</a>
             </div>
           </div>
           <div class="col-md-4">

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,5 +1,5 @@
 # Documentation
 
-This directory contains the configuration and raw markdown for the [API docs](https://webex.github.io/webex-js-sdk/api/). The [docs](../docs) directory contains the jekyll site for the rest of the documentation.
+This directory contains the configuration and raw markdown for the [API docs](https://webex.github.io/webex-js-sdk/api/) and the [Samples](https://webex.github.io/webex-js-sdk/samples/).
 
 Use `npm run build:docs` to build the API documentation.


### PR DESCRIPTION
`webex.min.js` is being uploaded to github pages because it's ignored
Force adding `webex.min.js*` when building docs on CI

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [ x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ x] I discussed changes with code owners prior to submitting this pull request

- [ x] I have not skipped any automated checks
- [x ] All existing and new tests passed
- [ x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
