### PR TITLE
fix(credentials): may not have orgId when sending metrics

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-metrics/src/metrics.js
+++ b/packages/node_modules/@webex/internal-plugin-metrics/src/metrics.js
@@ -68,7 +68,6 @@ const Metrics = WebexPlugin.extend({
     payload.tags = {
       ...props.tags,
       browser: getBrowserName(),
-      org_id: this.webex.credentials.getOrgId(),
       os: getOSName(),
 
       // Node does not like this so we need to check if it exists or not
@@ -77,6 +76,13 @@ const Metrics = WebexPlugin.extend({
       client_id: this.webex.credentials.config.client_id,
       user_id: this.webex.internal.device.userId
     };
+
+    try {
+      payload.tags.org_id = this.webex.credentials.getOrgId();
+    }
+    catch {
+      this.logger.info('metrics: unable to get orgId');
+    }
 
 
     payload.fields = {

--- a/packages/node_modules/@webex/webex-core/src/lib/credentials/credentials.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/credentials/credentials.js
@@ -154,7 +154,13 @@ const Credentials = WebexPlugin.extend({
         'credentials: attempting to extract OrgId from user token'
       );
 
-      return this.extractOrgIdFromUserToken(this.supertoken.access_token);
+      try {
+        return this.extractOrgIdFromUserToken(this.supertoken?.access_token);
+      }
+      catch (f) {
+        this.logger.info('credentials: could not extract OrgId from user token');
+        throw f;
+      }
     }
   },
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # 

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-317526

## This pull request addresses

There may not be a supertoken when trying to send a metric. This results in the extraction of orgId failing.

## by making the following changes

Propagate the correct error through the credentials plugin and catch in the error in metrics. Only send the org id when it is defined.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
