### PR TITLE
fix(plugin-meetings): fail silently if webex site information not found

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -640,8 +640,9 @@ export default class Meetings extends WebexPlugin {
      */
     fetchUserPreferredWebexSite() {
       return this.request.fetchLoginUserInformation().then((res) => {
-        this.preferredWebexSite = MeetingsUtil.parseUserPreferences(res.userPreferences);
-        console.error(this.preferredWebexSite);
+        if (res && res.userPreferences) {
+          this.preferredWebexSite = MeetingsUtil.parseUserPreferences(res?.userPreferences);
+        }
       });
     }
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -812,6 +812,20 @@ describe('plugin-meetings', () => {
 
           assert.equal(webex.meetings.preferredWebexSite, 'go.webex.com');
         });
+
+        it('should not fail if UserPreferred info is not fetched ', async () => {
+          Object.assign(webex.internal, {
+            services: {
+              fetchLoginUserInformation: sinon.stub().returns(Promise.resolve({})),
+            },
+
+          });
+
+          await webex.meetings.fetchUserPreferredWebexSite()
+            .then(() => {
+              assert.equal(webex.meetings.preferredWebexSite, '');
+            });
+        });
       });
     });
   });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #BEMS01421092 [Open] DAVRA NETWORKS    Webex JS SDK Authentication / Meeting joining failure

## This pull request addresses

We were seeing issue where the Eu org an some specific domains are not able to get userPreferences information 

## by making the following changes

Silently fail the function 

<img width="1869" alt="Screen Shot 2022-04-15 at 1 14 02 PM" src="https://user-images.githubusercontent.com/3895486/163600536-2f9c114d-dce3-463a-af12-07f071e6235d.png">

https://pr-2332.d3m3l2kee0btzx.amplifyapp.com/samples/browser-plugin-meetings/

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
