### PR TITLE
fix: spark-325176 non-USM users see meetings with wrong participants

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -210,7 +210,7 @@ export default class Meetings extends WebexPlugin {
       meeting = this.meetingCollection.getByKey(LOCUS_URL, data.locusUrl) ||
       this.meetingCollection.getByKey(CORRELATION_ID, MeetingsUtil.checkForCorrelationId(this.webex.internal.device.url, data.locus)) ||
       this.meetingCollection.getByKey(SIP_URI, data.locus.self && data.locus.self.callbackInfo && data.locus.self.callbackInfo.callbackAddress) ||
-      (this.config.experimental.enableUnifiedMeetings ? undefined : this.meetingCollection.getByKey(CONVERSATION_URL, data.locus.conversationUrl));
+      (data.locus.info?.isUnifiedSpaceMeeting ? undefined : this.meetingCollection.getByKey(CONVERSATION_URL, data.locus.conversationUrl));
 
       // Special case when locus has got replaced, This only happend once if a replace locus exists
       // https://sqbu-github.cisco.com/WebExSquared/locus/wiki/Locus-changing-mid-call

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -396,7 +396,7 @@ describe('plugin-meetings', () => {
             it('tests the sync meeting calls for not existing meeting', async () => {
               await webex.meetings.syncMeetings();
               assert.calledOnce(webex.meetings.request.getActiveMeetings);
-              assert.callCount(webex.meetings.meetingCollection.getByKey, 3);
+              assert.callCount(webex.meetings.meetingCollection.getByKey, 4);
               assert.calledOnce(initialSetup);
               assert.calledOnce(webex.meetings.create);
               assert.calledWith(webex.meetings.request.getActiveMeetings);
@@ -641,7 +641,7 @@ describe('plugin-meetings', () => {
               eventType: 'locus.difference',
               locusUrl: url1
             });
-            assert.callCount(webex.meetings.meetingCollection.getByKey, 4);
+            assert.callCount(webex.meetings.meetingCollection.getByKey, 5);
             assert.calledWith(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
             assert.calledOnce(initialSetup);
             assert.calledWith(initialSetup, {
@@ -669,7 +669,7 @@ describe('plugin-meetings', () => {
               eventType: 'locus.difference',
               locusUrl: url1
             });
-            assert.callCount(webex.meetings.meetingCollection.getByKey, 3);
+            assert.callCount(webex.meetings.meetingCollection.getByKey, 4);
             assert.calledWith(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
             assert.calledOnce(initialSetup);
             assert.calledWith(initialSetup, {
@@ -694,7 +694,7 @@ describe('plugin-meetings', () => {
               eventType: test1,
               locusUrl: url1
             });
-            assert.callCount(webex.meetings.meetingCollection.getByKey, 3);
+            assert.callCount(webex.meetings.meetingCollection.getByKey, 4);
             assert.calledWith(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
             assert.calledOnce(initialSetup);
             assert.calledWith(initialSetup, {
@@ -705,6 +705,41 @@ describe('plugin-meetings', () => {
                 }
               }
             });
+          });
+
+          const generateFakeLocusData = (isUnifiedSpaceMeeting) => ({
+            locus: {
+              id: uuid1,
+              self: {
+                callbackInfo: {
+                  callbackAddress: uri1
+                }
+              },
+              info: {
+                isUnifiedSpaceMeeting
+              },
+              conversationUrl: 'fakeConvoUrl'
+            },
+            eventType: test1,
+            locusUrl: url1,
+          });
+
+          it('should not try to match USM meetings by conversation url', async () => {
+            await webex.meetings.handleLocusEvent(generateFakeLocusData(true));
+            assert.callCount(webex.meetings.meetingCollection.getByKey, 3);
+            assert.deepEqual(webex.meetings.meetingCollection.getByKey.getCall(0).args, ['locusUrl', url1]);
+            assert.deepEqual(webex.meetings.meetingCollection.getByKey.getCall(1).args, ['correlationId', false]);
+            assert.deepEqual(webex.meetings.meetingCollection.getByKey.getCall(2).args, ['sipUri', uri1]);
+            assert.calledOnce(initialSetup);
+          });
+          it('should try to match non-USM meetings by conversation url', async () => {
+            await webex.meetings.handleLocusEvent(generateFakeLocusData(false));
+            assert.callCount(webex.meetings.meetingCollection.getByKey, 4);
+            assert.deepEqual(webex.meetings.meetingCollection.getByKey.getCall(0).args, ['locusUrl', url1]);
+            assert.deepEqual(webex.meetings.meetingCollection.getByKey.getCall(1).args, ['correlationId', false]);
+            assert.deepEqual(webex.meetings.meetingCollection.getByKey.getCall(2).args, ['sipUri', uri1]);
+            assert.deepEqual(webex.meetings.meetingCollection.getByKey.getCall(3).args, ['conversationUrl', 'fakeConvoUrl']);
+            assert.calledOnce(initialSetup);
           });
         });
       });


### PR DESCRIPTION
# COMPLETES #SPARK-325176

## This pull request addresses

Users with config.experimental.enableUnifiedMeetings disabled see incorrect meeting information when they are in spaces with other users that have config.experimental.enableUnifiedMeetings enabled and start instant meetings that overlap with scheduled meetings.

## by making the following changes

SDK will now use conversation url to match incoming Locus event with existing meetings only for non-USM meetings irrespective of the configuration config.experimental.enableUnifiedMeetings

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

manual tests of steps described in spark-325176

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
