### PR TITLE
feat(webex): add random delay to fetchmeetinginfo

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.js
@@ -40,6 +40,7 @@ export const LOCAL = 'local';
 export const LOCI = 'loci';
 export const LOCUS_URL = 'locusUrl';
 
+export const MAX_RANDOM_DELAY_FOR_MEETING_INFO = 3 * 60 * 1000;
 export const MEETINGINFO = 'meetingInfo';
 export const MEET = 'meet';
 export const MEET_M = 'm';
@@ -436,6 +437,7 @@ export const EVENT_TRIGGERS = {
   MEETING_RECONNECTION_FAILURE: 'meeting:reconnectionFailure',
   MEETING_UNLOCKED: 'meeting:unlocked',
   MEETING_LOCKED: 'meeting:locked',
+  MEETING_INFO_AVAILABLE: 'meeting:meetingInfoAvailable',
   MEETING_LOG_UPLOAD_SUCCESS: 'meeting:logUpload:success',
   MEETING_LOG_UPLOAD_FAILURE: 'meeting:logUpload:failure',
   MEETING_ACTIONS_UPDATE: 'meeting:actionsUpdate',

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -646,6 +646,18 @@ export default class Meeting extends StatelessWebexPlugin {
      * @memberof Meeting
      */
     this.mediaConnections = null;
+
+    /**
+     * Fetching meeting info can be done randomly 2-5 mins before meeting start
+     * In case it is done before the timer expires, this timeout id is reset to cancel the timer.
+     * @instance
+     * @type {Number}
+     * @readonly
+     * @private
+     * @memberof Meeting
+     */
+    this.fetchMeetingInfoTimeoutId = null;
+
     /**
      * Update the MediaConnections property with new information
      * @param {array} mediaConnections
@@ -908,15 +920,20 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * Fetches meeting information.
    * @param {Object} options
-   * @param {String} options.destination
-   * @param {String} options.type
-   * @private
+   * @param {String} [options.password] optional
+   * @param {String} [options.captchaCode] optional
+   * @public
    * @memberof Meeting
    * @returns {Promise}
    */
   async fetchMeetingInfo({
     password = null, captchaCode = null
   }) {
+    // when fetch meeting info is called directly by the client, we want to clear out the random timer for sdk to do it
+    if (this.fetchMeetingInfoTimeoutId) {
+      clearTimeout(this.fetchMeetingInfoTimeoutId);
+      this.fetchMeetingInfoTimeoutId = undefined;
+    }
     if (captchaCode && !this.requiredCaptcha) {
       return Promise.reject(new Error('fetchMeetingInfo() called with captchaCode when captcha was not required'));
     }
@@ -929,7 +946,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
       const info = await this.attrs.meetingInfoProvider.fetchMeetingInfo(this.destination, this.destinationType, password, captchaInfo);
 
-      this.parseMeetingInfo(info);
+      this.parseMeetingInfo(info, this.destination);
       this.meetingInfo = info ? info.body : null;
       this.meetingInfoFailureReason = MEETING_INFO_FAILURE_REASON.NONE;
       this.requiredCaptcha = null;
@@ -939,6 +956,15 @@ export default class Meeting extends StatelessWebexPlugin {
       else {
         this.passwordStatus = PASSWORD_STATUS.NOT_REQUIRED;
       }
+
+      Trigger.trigger(
+        this,
+        {
+          file: 'meetings',
+          function: 'fetchMeetingInfo'
+        },
+        EVENT_TRIGGERS.MEETING_INFO_AVAILABLE
+      );
 
       return Promise.resolve();
     }
@@ -2355,24 +2381,32 @@ export default class Meeting extends StatelessWebexPlugin {
    * @param {String} meetingInfo.body.locusUrl
    * @param {String} meetingInfo.body.sipUri
    * @param {Object} meetingInfo.body.owner
+   * @param {Object | String} destination locus object with meeting data or destination string (sip url, meeting link, etc)
    * @returns {undefined}
    * @private
    * @memberof Meeting
    */
-  parseMeetingInfo(meetingInfo) {
+  parseMeetingInfo(meetingInfo, destination = null) {
     const webexMeetingInfo = meetingInfo?.body;
+    // We try to use as much info from Locus meeting object, stored in destination
+
+    let locusMeetingObject;
+
+    if (destination) {
+      locusMeetingObject = typeof destination === 'object' ? destination : undefined;
+    }
 
     // MeetingInfo will be undefined for 1:1 calls
-    if (webexMeetingInfo && !(meetingInfo.errors && meetingInfo.errors.length > 0)) {
-      this.conversationUrl = webexMeetingInfo.conversationUrl || this.conversationUrl;
-      this.locusUrl = webexMeetingInfo.locusUrl || this.locusUrl;
-      this.setSipUri(this.config.experimental.enableUnifiedMeetings ? webexMeetingInfo.sipUrl : webexMeetingInfo.sipMeetingUri || this.sipUri);
+    if (locusMeetingObject || (webexMeetingInfo && !(meetingInfo?.errors && meetingInfo?.errors.length > 0))) {
+      this.conversationUrl = locusMeetingObject?.conversationUrl || webexMeetingInfo?.conversationUrl || this.conversationUrl;
+      this.locusUrl = locusMeetingObject?.url || webexMeetingInfo?.locusUrl || this.locusUrl;
+      this.setSipUri(this.config.experimental.enableUnifiedMeetings ? locusMeetingObject?.info.sipUri || webexMeetingInfo?.sipUrl : locusMeetingObject?.info.sipUri || webexMeetingInfo?.sipMeetingUri || this.sipUri);
       if (this.config.experimental.enableUnifiedMeetings) {
-        this.meetingNumber = webexMeetingInfo.meetingNumber;
-        this.meetingJoinUrl = webexMeetingInfo.meetingJoinUrl;
+        this.meetingNumber = locusMeetingObject?.info.webExMeetingId || webexMeetingInfo?.meetingNumber;
+        this.meetingJoinUrl = webexMeetingInfo?.meetingJoinUrl;
       }
-      this.owner = webexMeetingInfo.owner || webexMeetingInfo.hostId || this.owner;
-      this.permissionToken = webexMeetingInfo.permissionToken;
+      this.owner = locusMeetingObject?.info.owner || webexMeetingInfo?.owner || webexMeetingInfo?.hostId || this.owner;
+      this.permissionToken = webexMeetingInfo?.permissionToken;
     }
   }
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -21,6 +21,7 @@ import {
   READY,
   LOCUSEVENT,
   LOCUS_URL,
+  MAX_RANDOM_DELAY_FOR_MEETING_INFO,
   ROAP,
   ONLINE,
   OFFLINE,
@@ -193,12 +194,13 @@ export default class Meetings extends WebexPlugin {
      * @param {Object} data a locus event
      * @param {String} data.locusUrl
      * @param {Object} data.locus
+     * @param {Boolean} useRandomDelayForInfo whether a random delay should be added to fetching meeting info
      * @param {String} data.eventType
      * @returns {undefined}
      * @private
      * @memberof Meetings
      */
-  handleLocusEvent(data) {
+  handleLocusEvent(data, useRandomDelayForInfo = false) {
     let meeting = null;
 
     // getting meeting by correlationId. This will happen for the new event
@@ -255,7 +257,7 @@ export default class Meetings extends WebexPlugin {
         return;
       }
 
-      this.create(data.locus, _LOCUS_ID_).then((newMeeting) => {
+      this.create(data.locus, _LOCUS_ID_, useRandomDelayForInfo).then((newMeeting) => {
         meeting = newMeeting;
 
         // It's a new meeting so initialize the locus data
@@ -307,7 +309,7 @@ export default class Meetings extends WebexPlugin {
     const {eventType} = data;
 
     if (eventType && eventType !== LOCUSEVENT.MESSAGE_ROAP) {
-      this.handleLocusEvent(data);
+      this.handleLocusEvent(data, true);
     }
   }
 
@@ -684,11 +686,12 @@ export default class Meetings extends WebexPlugin {
      * Create a meeting.
      * @param {string} destination - sipURL, spaceId, phonenumber, or locus object}
      * @param {string} [type] - the optional specified type, such as locusId
+     * @param {Boolean} useRandomDelayForInfo - whether a random delay should be added to fetching meeting info
      * @returns {Promise<Meeting>} A new Meeting.
      * @public
      * @memberof Meetings
      */
-  create(destination, type = null) {
+  create(destination, type = null, useRandomDelayForInfo = false) {
     // TODO: type should be from a dictionary
 
     // Validate meeting information based on the provided destination and
@@ -726,11 +729,10 @@ export default class Meetings extends WebexPlugin {
           meeting = this.meetingCollection.getByKey(SIP_URI, targetDest);
         }
 
-
         // Validate if a meeting was found.
         if (!meeting) {
           // Create a meeting based on the normalized destination and type.
-          return this.createMeeting(targetDest, type)
+          return this.createMeeting(targetDest, type, useRandomDelayForInfo)
             .then((createdMeeting) => {
               // If the meeting was successfully created.
               if (createdMeeting && createdMeeting.on) {
@@ -779,11 +781,12 @@ export default class Meetings extends WebexPlugin {
   /**
      * @param {String} destination see create()
      * @param {String} type see create()
+     * @param {Boolean} useRandomDelayForInfo whether a random delay should be added to fetching meeting info
      * @returns {Promise} a new meeting instance complete with meeting info and destination
      * @private
      * @memberof Meetings
      */
-  async createMeeting(destination, type = null) {
+  async createMeeting(destination, type = null, useRandomDelayForInfo = false) {
     const meeting = new Meeting(
       {
         userId: this.webex.internal.device.userId,
@@ -803,7 +806,31 @@ export default class Meetings extends WebexPlugin {
     this.meetingCollection.set(meeting);
 
     try {
-      await meeting.fetchMeetingInfo({});
+      // if no participant has joined the scheduled meeting (meaning meeting is not active) and we get a locusEvent,
+      // it means the meeting will start in 5-6 min. In that case, we want to fetchMeetingInfo
+      // between 5 and 2 min (random between 3 minutes) before the meeting starts
+      // to avoid a spike in traffic to the wbxappi service
+      let waitingTime = 0;
+
+      if (destination.meeting) {
+        const {startTime} = destination.meeting;
+        const startTimeDate = new Date(startTime);
+        const startTimeDatestamp = startTimeDate.getTime();
+        const timeToStart = startTimeDatestamp - Date.now();
+        const maxWaitingTime = Math.max(Math.min(timeToStart, MAX_RANDOM_DELAY_FOR_MEETING_INFO), 0);
+
+        waitingTime = Math.round(Math.random() * maxWaitingTime);
+      }
+      const isMeetingActive = !!destination.fullState?.active;
+      const {enableUnifiedMeetings} = this.config.experimental;
+
+      if (enableUnifiedMeetings && !isMeetingActive && useRandomDelayForInfo && waitingTime > 0) {
+        meeting.fetchMeetingInfoTimeoutId = setTimeout(() => meeting.fetchMeetingInfo({}), waitingTime);
+        meeting.parseMeetingInfo(undefined, destination);
+      }
+      else {
+        await meeting.fetchMeetingInfo({});
+      }
     }
     catch (err) {
       if (!(err instanceof CaptchaError) && !(err instanceof PasswordError)) {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -10,6 +10,7 @@ import {assert} from '@webex/test-helper-chai';
 import {Credentials} from '@webex/webex-core';
 import Support from '@webex/internal-plugin-support';
 import MockWebex from '@webex/test-helper-mock-webex';
+
 import Meetings, {CONSTANTS} from '@webex/plugin-meetings';
 import Meeting from '@webex/plugin-meetings/src/meeting';
 import Members from '@webex/plugin-meetings/src/members';
@@ -228,6 +229,7 @@ describe('plugin-meetings', () => {
           assert.isNull(meeting.policy);
           assert.instanceOf(meeting.meetingRequest, MeetingRequest);
           assert.instanceOf(meeting.locusInfo, LocusInfo);
+          assert.equal(meeting.fetchMeetingInfoTimeoutId, undefined);
           assert.instanceOf(meeting.mediaProperties, MediaProperties);
           assert.equal(meeting.passwordStatus, PASSWORD_STATUS.UNKNOWN);
           assert.equal(meeting.requiredCaptcha, null);
@@ -2118,6 +2120,7 @@ describe('plugin-meetings', () => {
       describe('#fetchMeetingInfo', () => {
         const FAKE_DESTINATION = 'something@somecompany.com';
         const FAKE_TYPE = _SIP_URI_;
+        const FAKE_TIMEOUT_FETCHMEETINGINFO_ID = '123456';
         const FAKE_PASSWORD = '123abc';
         const FAKE_CAPTCHA_CODE = 'a1b2c3XYZ';
         const FAKE_CAPTCHA_ID = '987654321';
@@ -2150,6 +2153,7 @@ describe('plugin-meetings', () => {
           meeting.requiredCaptcha = FAKE_SDK_CAPTCHA_INFO;
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
+          meeting.parseMeetingInfo = sinon.stub().returns(undefined);
 
           await meeting.fetchMeetingInfo({
             password: FAKE_PASSWORD, captchaCode: FAKE_CAPTCHA_CODE
@@ -2157,10 +2161,45 @@ describe('plugin-meetings', () => {
 
           assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, FAKE_PASSWORD, {code: FAKE_CAPTCHA_CODE, id: FAKE_CAPTCHA_ID});
 
+          assert.calledWith(meeting.parseMeetingInfo, {body: FAKE_MEETING_INFO}, FAKE_DESTINATION);
           assert.deepEqual(meeting.meetingInfo, FAKE_MEETING_INFO);
           assert.equal(meeting.passwordStatus, PASSWORD_STATUS.NOT_REQUIRED);
           assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.NONE);
           assert.equal(meeting.requiredCaptcha, null);
+          assert.calledTwice(TriggerProxy.trigger);
+          assert.calledWith(TriggerProxy.trigger, meeting, {file: 'meetings', function: 'fetchMeetingInfo'}, 'meeting:meetingInfoAvailable');
+        });
+
+        it('calls meetingInfoProvider with all the right parameters and parses the result when random delay is applied', async () => {
+          meeting.attrs.meetingInfoProvider = {fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO})};
+          meeting.destination = FAKE_DESTINATION;
+          meeting.destinationType = FAKE_TYPE;
+          meeting.parseMeetingInfo = sinon.stub().returns(undefined);
+          meeting.fetchMeetingInfoTimeoutId = FAKE_TIMEOUT_FETCHMEETINGINFO_ID;
+
+          const clock = sinon.useFakeTimers();
+          const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
+
+          await meeting.fetchMeetingInfo({});
+
+          // clear timer
+          assert.calledWith(clearTimeoutSpy, FAKE_TIMEOUT_FETCHMEETINGINFO_ID);
+          clock.restore();
+          assert.isUndefined(meeting.fetchMeetingInfoTimeoutId);
+
+          // meeting info provider
+          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, null, null);
+
+          // parseMeeting info
+          assert.calledWith(meeting.parseMeetingInfo, {body: FAKE_MEETING_INFO}, FAKE_DESTINATION);
+
+          assert.deepEqual(meeting.meetingInfo, FAKE_MEETING_INFO);
+          assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.NONE);
+          assert.equal(meeting.requiredCaptcha, null);
+          assert.equal(meeting.passwordStatus, PASSWORD_STATUS.NOT_REQUIRED);
+
+          assert.calledTwice(TriggerProxy.trigger);
+          assert.calledWith(TriggerProxy.trigger, meeting, {file: 'meetings', function: 'fetchMeetingInfo'}, 'meeting:meetingInfoAvailable');
         });
 
         it('fails if captchaCode is provided when captcha not needed', async () => {
@@ -2879,21 +2918,141 @@ describe('plugin-meetings', () => {
         });
       });
       describe('#parseMeetingInfo', () => {
-        it('should parse meeting info, set values, and return null', () => {
-          meeting.config.experimental = {enableMediaNegotiatedEvent: true};
+        const checkParseMeetingInfo = (expectedInfoToParse) => {
+          assert.equal(meeting.conversationUrl, expectedInfoToParse.conversationUrl);
+          assert.equal(meeting.locusUrl, expectedInfoToParse.locusUrl);
+          assert.equal(meeting.sipUri, expectedInfoToParse.sipUri);
+          assert.equal(meeting.meetingNumber, expectedInfoToParse.meetingNumber);
+          assert.equal(meeting.meetingJoinUrl, expectedInfoToParse.meetingJoinUrl);
+          assert.equal(meeting.owner, expectedInfoToParse.owner);
+          assert.equal(meeting.permissionToken, expectedInfoToParse.permissionToken);
+        };
 
-          meeting.parseMeetingInfo({
+        it('should parse meeting info from api return when locus meeting object is not available, set values, and return null', () => {
+          meeting.config.experimental = {enableMediaNegotiatedEvent: true};
+          meeting.config.experimental.enableUnifiedMeetings = true;
+          const FAKE_MEETING_INFO = {
             body: {
               conversationUrl: uuid1,
               locusUrl: url1,
+              meetingJoinUrl: url2,
+              meetingNumber: '12345',
+              permissionToken: 'abc',
               sipMeetingUri: test1,
+              sipUrl: test1,
               owner: test2
             }
-          });
-          assert.equal(meeting.conversationUrl, uuid1);
-          assert.equal(meeting.locusUrl, url1);
-          assert.equal(meeting.sipUri, test1);
-          assert.equal(meeting.owner, test2);
+          };
+
+          meeting.parseMeetingInfo(FAKE_MEETING_INFO);
+          const expectedInfoToParse = {
+            conversationUrl: uuid1,
+            locusUrl: url1,
+            sipUri: test1,
+            meetingNumber: '12345',
+            meetingJoinUrl: url2,
+            owner: test2,
+            permissionToken: 'abc'
+          };
+
+          checkParseMeetingInfo(expectedInfoToParse);
+        });
+        it('should parse meeting info from locus meeting object if possible, else from api return, set values, and return null', () => {
+          meeting.config.experimental = {enableMediaNegotiatedEvent: true};
+          meeting.config.experimental.enableUnifiedMeetings = true;
+          const FAKE_LOCUS_MEETING = {
+            conversationUrl: 'locusConvURL',
+            url: 'locusUrl',
+            info: {
+              webExMeetingId: 'locusMeetingId',
+              sipUri: 'locusSipUri',
+              owner: 'locusOwner'
+            }
+          };
+          const FAKE_MEETING_INFO = {
+            body: {
+              conversationUrl: uuid1,
+              locusUrl: url1,
+              meetingJoinUrl: url2,
+              meetingNumber: '12345',
+              permissionToken: 'abc',
+              sipMeetingUri: test1,
+              sipUrl: test1,
+              owner: test2
+            }
+          };
+
+          meeting.parseMeetingInfo(FAKE_MEETING_INFO, FAKE_LOCUS_MEETING);
+          const expectedInfoToParse = {
+            conversationUrl: 'locusConvURL',
+            locusUrl: 'locusUrl',
+            sipUri: 'locusSipUri',
+            meetingNumber: 'locusMeetingId',
+            meetingJoinUrl: url2,
+            owner: 'locusOwner',
+            permissionToken: 'abc'
+          };
+
+          checkParseMeetingInfo(expectedInfoToParse);
+        });
+        it('should parse meeting info from api return, set values, and return null', () => {
+          meeting.config.experimental = {enableMediaNegotiatedEvent: true};
+          meeting.config.experimental.enableUnifiedMeetings = true;
+          const FAKE_MEETING_INFO = {
+            body: {
+              conversationUrl: uuid1,
+              locusUrl: url1,
+              meetingJoinUrl: url2,
+              meetingNumber: '12345',
+              permissionToken: 'abc',
+              sipMeetingUri: test1,
+              sipUrl: test1,
+              owner: test2
+            }
+          };
+
+          meeting.parseMeetingInfo(FAKE_MEETING_INFO);
+          const expectedInfoToParse = {
+            conversationUrl: uuid1,
+            locusUrl: url1,
+            sipUri: test1,
+            meetingNumber: '12345',
+            meetingJoinUrl: url2,
+            owner: test2,
+            permissionToken: 'abc'
+          };
+
+          checkParseMeetingInfo(expectedInfoToParse);
+        });
+        it('should parse meeting info, set values, and return null when destination is a string', () => {
+          meeting.config.experimental = {enableMediaNegotiatedEvent: true};
+          meeting.config.experimental.enableUnifiedMeetings = true;
+          const FAKE_STRING_DESTINATION = 'sipUrl';
+          const FAKE_MEETING_INFO = {
+            body: {
+              conversationUrl: uuid1,
+              locusUrl: url1,
+              meetingJoinUrl: url2,
+              meetingNumber: '12345',
+              permissionToken: 'abc',
+              sipMeetingUri: test1,
+              sipUrl: test1,
+              owner: test2
+            }
+          };
+
+          meeting.parseMeetingInfo(FAKE_MEETING_INFO, FAKE_STRING_DESTINATION);
+          const expectedInfoToParse = {
+            conversationUrl: uuid1,
+            locusUrl: url1,
+            sipUri: test1,
+            meetingNumber: '12345',
+            meetingJoinUrl: url2,
+            owner: test2,
+            permissionToken: 'abc'
+          };
+
+          checkParseMeetingInfo(expectedInfoToParse);
         });
       });
       describe('#parseLocus', () => {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -5,6 +5,11 @@ import 'jsdom-global/register';
 
 import Device from '@webex/internal-plugin-device';
 import Mercury from '@webex/internal-plugin-mercury';
+import {assert} from '@webex/test-helper-chai';
+import MockWebex from '@webex/test-helper-mock-webex';
+import sinon from 'sinon';
+import uuid from 'uuid';
+
 import StaticConfig from '@webex/plugin-meetings/src/common/config';
 import TriggerProxy from '@webex/plugin-meetings/src/common/events/trigger-proxy';
 import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
@@ -16,11 +21,8 @@ import MeetingCollection from '@webex/plugin-meetings/src/meetings/collection';
 import MeetingsUtil from '@webex/plugin-meetings/src/meetings/util';
 import PersonalMeetingRoom from '@webex/plugin-meetings/src/personal-meeting-room';
 import Reachability from '@webex/plugin-meetings/src/reachability';
-import {assert} from '@webex/test-helper-chai';
-import MockWebex from '@webex/test-helper-mock-webex';
-import sinon from 'sinon';
-import uuid from 'uuid';
 
+import testUtils from '../../../utils/testUtils';
 import {
   LOCUSEVENT,
   OFFLINE,
@@ -489,12 +491,13 @@ describe('plugin-meetings', () => {
           });
 
         it('calls createMeeting and returns its promise', async () => {
-          const create = webex.meetings.create(test1, test2);
+          const FAKE_USE_RANDOM_DELAY = true;
+          const create = webex.meetings.create(test1, test2, FAKE_USE_RANDOM_DELAY);
 
           assert.exists(create.then);
           await create;
           assert.calledOnce(webex.meetings.createMeeting);
-          assert.calledWith(webex.meetings.createMeeting, test1, test2);
+          assert.calledWith(webex.meetings.createMeeting, test1, test2, FAKE_USE_RANDOM_DELAY);
         });
 
         it('creates a new meeting when a scheduled meeting exists in the conversation', async () => {
@@ -582,7 +585,7 @@ describe('plugin-meetings', () => {
           assert.calledOnce(webex.meetings.handleLocusEvent);
           assert.calledWith(webex.meetings.handleLocusEvent, {
             eventType: test1
-          });
+          }, true);
         });
       });
       describe('#handleLocusEvent', () => {
@@ -753,43 +756,208 @@ describe('plugin-meetings', () => {
           TriggerProxy.trigger.reset();
         });
         describe('successful MeetingInfo.#fetchMeetingInfo', () => {
+          let clock, setTimeoutSpy, fakeMeetingStartTimeString, FAKE_TIME_TO_START;
+
           beforeEach(() => {
+            clock = sinon.useFakeTimers();
+            setTimeoutSpy = sinon.spy(clock, 'setTimeout');
             webex.meetings.meetingInfo.fetchMeetingInfo = sinon.stub().returns(Promise.resolve({
               body: {
                 permissionToken: 'PT', meetingJoinUrl: 'meetingJoinUrl'
               }
             }));
-          });
-          it('creates the meeting from a successful meeting info fetch promise testing', async () => {
-            const meeting = await webex.meetings.createMeeting('test destination', 'test type');
+            const nowTimeStamp = Date.now();
 
-            assert.calledOnce(webex.meetings.meetingInfo.fetchMeetingInfo);
-            assert.calledOnce(MeetingsUtil.getMeetingAddedType);
-            assert.calledTwice(TriggerProxy.trigger);
-            assert.calledWith(webex.meetings.meetingInfo.fetchMeetingInfo, 'test destination', 'test type');
-            assert.calledWith(MeetingsUtil.getMeetingAddedType, 'test type');
-            assert.equal(meeting.permissionToken, 'PT');
-            assert.equal(meeting.meetingJoinUrl, 'meetingJoinUrl');
-            assert.equal(meeting.destination, 'test destination');
-            assert.equal(meeting.destinationType, 'test type');
+            FAKE_TIME_TO_START = 0.1 * 60 * 1000;
+            const fakeMeetingStartTimeStamp = nowTimeStamp + FAKE_TIME_TO_START;
+            const fakeMeetingStartTimeDate = new Date(fakeMeetingStartTimeStamp);
+
+            fakeMeetingStartTimeString = fakeMeetingStartTimeDate.toISOString();
           });
 
-          it('creates the meeting from a successful meeting info fetch meeting resolve testing', async () => {
-            const meeting = await webex.meetings.createMeeting('test destination', 'test type');
+          afterEach(() => {
+            clock.restore();
+          });
 
-            assert.instanceOf(meeting, Meeting, 'createMeeting should eventually resolve to a Meeting Object');
+          const checkCreateWithoutDelay = (meeting, destination, type, expectedMeetingData = {}) => {
             assert.calledOnce(webex.meetings.meetingInfo.fetchMeetingInfo);
             assert.calledOnce(MeetingsUtil.getMeetingAddedType);
-            assert.calledTwice(TriggerProxy.trigger);
-            assert.calledWith(webex.meetings.meetingInfo.fetchMeetingInfo, 'test destination', 'test type');
+            assert.notCalled(setTimeoutSpy);
+            assert.calledThrice(TriggerProxy.trigger);
+            assert.calledWith(webex.meetings.meetingInfo.fetchMeetingInfo, destination, type);
             assert.calledWith(MeetingsUtil.getMeetingAddedType, 'test type');
+
+            if (expectedMeetingData.permissionToken) {
+              assert.equal(meeting.permissionToken, expectedMeetingData.permissionToken);
+            }
+            if (expectedMeetingData.meetingJoinUrl) {
+              assert.equal(meeting.meetingJoinUrl, expectedMeetingData.meetingJoinUrl);
+            }
+            assert.equal(meeting.destination, destination);
+            assert.equal(meeting.destinationType, type);
             assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meetings), {
               file: 'meetings', function: 'createMeeting'
             }, 'meeting:added', {
               meeting: sinon.match.instanceOf(Meeting), type: 'test meeting added type'
             });
+            assert.calledWith(TriggerProxy.trigger, meeting, {file: 'meetings', function: 'fetchMeetingInfo'}, 'meeting:meetingInfoAvailable');
+          };
+
+          it('creates the meeting from a successful meeting info fetch promise testing', async () => {
+            const meeting = await webex.meetings.createMeeting('test destination', 'test type');
+
+            const expectedMeetingData = {
+              permissionToken: 'PT',
+              meetingJoinUrl: 'meetingJoinUrl'
+            };
+
+            checkCreateWithoutDelay(meeting, 'test destination', 'test type', expectedMeetingData);
+          });
+
+          it('creates the meeting from a successful meeting info fetch meeting resolve testing', async () => {
+            const meeting = await webex.meetings.createMeeting('test destination', 'test type');
+            const expectedMeetingData = {
+              permissionToken: 'PT',
+              meetingJoinUrl: 'meetingJoinUrl'
+            };
+
+            assert.instanceOf(meeting, Meeting, 'createMeeting should eventually resolve to a Meeting Object');
+            checkCreateWithoutDelay(meeting, 'test destination', 'test type', expectedMeetingData);
+          });
+
+          it('creates the meeting from a successful meeting info fetch with random delay', async () => {
+            const FAKE_LOCUS_MEETING = {
+              conversationUrl: 'locusConvURL',
+              url: 'locusUrl',
+              info: {
+                webExMeetingId: 'locusMeetingId',
+                sipUri: 'locusSipUri',
+                owner: 'locusOwner'
+              },
+              meeting: {
+                startTime: fakeMeetingStartTimeString
+              },
+              fullState: {
+                active: false
+              }
+            };
+
+            const meeting = await webex.meetings.createMeeting(FAKE_LOCUS_MEETING, 'test type', true);
+
+            assert.instanceOf(meeting, Meeting, 'createMeeting should eventually resolve to a Meeting Object');
+            assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
+            assert.calledOnce(setTimeoutSpy);
+
+            // Parse meeting info with locus object
+            assert.equal(meeting.conversationUrl, 'locusConvURL');
+            assert.equal(meeting.locusUrl, 'locusUrl');
+            assert.equal(meeting.sipUri, 'locusSipUri');
+            assert.equal(meeting.meetingNumber, 'locusMeetingId');
+            assert.isUndefined(meeting.meetingJoinUrl);
+            assert.equal(meeting.owner, 'locusOwner');
+            assert.isUndefined(meeting.permissionToken);
+
+            // Add meeting and send trigger
+            assert.calledWith(MeetingsUtil.getMeetingAddedType, 'test type');
+            assert.calledTwice(TriggerProxy.trigger);
+            assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meetings), {
+              file: 'meetings', function: 'createMeeting'
+            }, 'meeting:added', {
+              meeting: sinon.match.instanceOf(Meeting), type: 'test meeting added type'
+            });
+
+            // When timer expires
+            clock.tick(FAKE_TIME_TO_START);
+            assert.calledWith(webex.meetings.meetingInfo.fetchMeetingInfo, FAKE_LOCUS_MEETING, 'test type');
+
+            // Parse meeting info is called again with new meeting info
+            await testUtils.flushPromises();
+            assert.equal(meeting.conversationUrl, 'locusConvURL');
+            assert.equal(meeting.locusUrl, 'locusUrl');
+            assert.equal(meeting.sipUri, 'locusSipUri');
+            assert.equal(meeting.meetingNumber, 'locusMeetingId');
+            assert.equal(meeting.meetingJoinUrl, 'meetingJoinUrl');
+            assert.equal(meeting.owner, 'locusOwner');
+            assert.equal(meeting.permissionToken, 'PT');
+
+            assert.calledWith(TriggerProxy.trigger, meeting, {file: 'meetings', function: 'fetchMeetingInfo'}, 'meeting:meetingInfoAvailable');
+          });
+
+          it('creates the meeting from a successful meeting info fetch that has no random delay because it is active', async () => {
+            const FAKE_LOCUS_MEETING = {
+              conversationUrl: 'locusConvURL',
+              url: 'locusUrl',
+              info: {
+                webExMeetingId: 'locusMeetingId',
+                sipUri: 'locusSipUri',
+                owner: 'locusOwner'
+              },
+              meeting: {
+                startTime: fakeMeetingStartTimeString
+              },
+              fullState: {
+                active: true
+              }
+            };
+
+            const meeting = await webex.meetings.createMeeting(FAKE_LOCUS_MEETING, 'test type', true);
+
+            assert.instanceOf(meeting, Meeting, 'createMeeting should eventually resolve to a Meeting Object');
+            checkCreateWithoutDelay(meeting, FAKE_LOCUS_MEETING, 'test type');
+          });
+
+          it('creates the meeting from a successful meeting info fetch that has no random delay because meeting start time is in the past', async () => {
+            const FAKE_LOCUS_MEETING = {
+              conversationUrl: 'locusConvURL',
+              url: 'locusUrl',
+              info: {
+                webExMeetingId: 'locusMeetingId',
+                sipUri: 'locusSipUri',
+                owner: 'locusOwner'
+              },
+              meeting: {
+                startTime: fakeMeetingStartTimeString - (1 * 60 * 60 * 1000)
+              },
+              fullState: {
+                active: false
+              }
+            };
+
+            const meeting = await webex.meetings.createMeeting(FAKE_LOCUS_MEETING, 'test type', true);
+
+            assert.instanceOf(meeting, Meeting, 'createMeeting should eventually resolve to a Meeting Object');
+            checkCreateWithoutDelay(meeting, FAKE_LOCUS_MEETING, 'test type');
+          });
+
+          it('creates the meeting from a successful meeting info fetch that has no random delay because enableUnifiedMeetings is disabled', async () => {
+            Object.assign(webex.meetings.config, {
+              experimental: {
+                enableUnifiedMeetings: false
+              }
+            });
+            const FAKE_LOCUS_MEETING = {
+              conversationUrl: 'locusConvURL',
+              url: 'locusUrl',
+              info: {
+                webExMeetingId: 'locusMeetingId',
+                sipUri: 'locusSipUri',
+                owner: 'locusOwner'
+              },
+              meeting: {
+                startTime: fakeMeetingStartTimeString
+              },
+              fullState: {
+                active: false
+              }
+            };
+
+            const meeting = await webex.meetings.createMeeting(FAKE_LOCUS_MEETING, 'test type', true);
+
+            assert.instanceOf(meeting, Meeting, 'createMeeting should eventually resolve to a Meeting Object');
+            checkCreateWithoutDelay(meeting, FAKE_LOCUS_MEETING, 'test type');
           });
         });
+
         describe('rejected MeetingInfo.#fetchMeetingInfo', () => {
           beforeEach(() => {
             console.error = sinon.stub().returns(false);


### PR DESCRIPTION
## DESCRIBE THE CONTEXT OF THE ISSUE

When a meeting is about to start in 5 minutes, we receive information about it from Locus and SDK creates a meeting object. At this time SDK fetches the meeting info for that object. This will cause a spike of traffic to the wbxappapi service - they have seen this problem with UCF and it has caused an outage of wbxappapi service on multiple occasions.

WbxAppAPI team have asked us to put a random delay for the call to meetinginfo api for OBTPs to avoid the spike in traffic. They've already agreed this solution with UCF team and UCF have already done this implementation - they add a random delay (up to 2-3 minutes) or fetch the meeting info immediately if the user presses the OBTP before the random delay is finished.

## DESCRIBE YOUR CHANGES

1. Change createMeeting() so that it doesn't call meeting.fetchMeetingInfo() immediately if createMeeting() was called as a result of a new meeting notification from Locus (see 
handleLocusEvent()) for a scheduled meeting that hasn't started yet
2. Make sure that some basic properties like sip url, meeting number, conversationUrl, locusUrl, owner are taken from the Locus DTO that came over Mercury connection as we now won't have the meeting info from which we normally take them 
3. Choose a random time between "now" and up to "now + 2 minutes" or "meeting scheduled start time" (whichever is sooner) and fetch meeting info at that random time
4. Allow the web app to trigger fetching meeting info immediately when needed (web app will call it when user presses the OBTP button before the random timer expires) - there is already existing meeting method called fetchMeetingInfo() that does this, but it's marked as "private"
5. Fetch the meeting info if it wasn't fetched before and meeting.join() was called.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
