### PR TITLE
fix: use the meetings preferences api for webex site

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/index.js
@@ -638,9 +638,9 @@ export default class Meetings extends WebexPlugin {
      * @memberof Meetings
      */
   fetchUserPreferredWebexSite() {
-    return this.request.fetchLoginUserInformation().then((res) => {
-      if (res && res.userPreferences) {
-        this.preferredWebexSite = MeetingsUtil.parseUserPreferences(res?.userPreferences);
+    return this.request.getMeetingPreferences().then((res) => {
+      if (res) {
+        this.preferredWebexSite = MeetingsUtil.parseDefaultSiteFromMeetingPreferences(res);
       }
     });
   }

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/request.js
@@ -35,11 +35,11 @@ export default class MeetingRequest extends StatelessWebexPlugin {
   }
 
   /**
-   *  fetch login user information
-   * @returns {Promise<object>} loginUserInformation
+   * get user meeting preference information
+   * @returns {Promise<object>} getMeetingPreferences
   */
-  fetchLoginUserInformation() {
-    return this.webex.internal.services.fetchLoginUserInformation();
+  getMeetingPreferences() {
+    return this.webex.internal.services.getMeetingPreferences();
   }
 
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings/util.js
@@ -64,24 +64,18 @@ MeetingsUtil.checkForCorrelationId = (deviceUrl, locus) => {
   return false;
 };
 
-MeetingsUtil.parseUserPreferences = (userPreferences) => {
-  let webexSite = null;
+MeetingsUtil.parseDefaultSiteFromMeetingPreferences = (userPreferences) => {
+  let result = '';
 
-  userPreferences.find((item) => {
-    // eslint-disable-next-line no-useless-escape
-    const regex = /"preferredWebExSite\":\"(\S+)\"/;
-    const preferredSite = item.match(regex);
+  if (userPreferences && userPreferences.sites) {
+    const defaultSite = userPreferences.sites.find((site) => site.default);
 
-    if (preferredSite) {
-      webexSite = preferredSite[1];
-
-      return true;
+    if (defaultSite) {
+      result = defaultSite.siteUrl;
     }
+  }
 
-    return false;
-  });
-
-  return webexSite;
+  return result;
 };
 
 /**

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -118,11 +118,24 @@ describe('plugin-meetings', () => {
           off: () => {}
         },
         services: {
-          fetchLoginUserInformation: sinon.stub().returns(Promise.resolve({
-            userPreferences: [
-              'SparkTOSAccept',
-              // eslint-disable-next-line no-useless-escape
-              '\"preferredWebExSite\":"\go.webex.com\"'
+          getMeetingPreferences: sinon.stub().returns(Promise.resolve({
+            sites: [
+              {
+                siteUrl: 'site1-example.webex.com',
+                default: false
+              },
+              {
+                siteUrl: 'site2-example.webex.com',
+                default: false
+              },
+              {
+                siteUrl: 'site3-example.webex.com',
+                default: false
+              },
+              {
+                siteUrl: 'go.webex.com',
+                default: true
+              }
             ]
           })),
           fetchClientRegionInfo: sinon.stub().returns(Promise.resolve())
@@ -235,7 +248,7 @@ describe('plugin-meetings', () => {
           webex.meetings.registered = false;
           await webex.meetings.register();
           assert.called(webex.internal.device.register);
-          assert.called(webex.internal.services.fetchLoginUserInformation);
+          assert.called(webex.internal.services.getMeetingPreferences);
           assert.called(webex.internal.services.fetchClientRegionInfo);
           assert.called(webex.internal.mercury.connect);
           assert.isTrue(webex.meetings.registered);
@@ -1050,7 +1063,7 @@ describe('plugin-meetings', () => {
       });
 
       describe('#fetchUserPreferredWebexSite', () => {
-        it('should call request.fetchLoginUserInformation to get the preferred webex site ', async () => {
+        it('should call request.getMeetingPreferences to get the preferred webex site ', async () => {
           assert.isDefined(webex.meetings.preferredWebexSite);
           await webex.meetings.fetchUserPreferredWebexSite();
 
@@ -1060,7 +1073,7 @@ describe('plugin-meetings', () => {
         it('should not fail if UserPreferred info is not fetched ', async () => {
           Object.assign(webex.internal, {
             services: {
-              fetchLoginUserInformation: sinon.stub().returns(Promise.resolve({})),
+              getMeetingPreferences: sinon.stub().returns(Promise.resolve({})),
             },
 
           });

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
@@ -1,16 +1,62 @@
 import {assert} from '@webex/test-helper-chai';
+
 import MeetingsUtil from '@webex/plugin-meetings/src/meetings/util';
 
 describe('plugin-meetings', () => {
   describe('Meetings utils function', () => {
-    describe('#parseUserPreferences', () => {
-      it('parsed the prefered webesite from userPreferences', async () => {
-        const res = MeetingsUtil.parseUserPreferences([
-          'SparkTOSAccept',
-          '"preferredWebExSite":"go.webex.com"'
-        ]);
+    describe('#parseDefaultSiteFromMeetingPreferences', () => {
+      it('should return the default true site from user preferences', () => {
+        const userPreferences = {
+          sites: [
+            {
+              siteUrl: 'site1-example.webex.com',
+              default: false
+            },
+            {
+              siteUrl: 'site2-example.webex.com',
+              default: false
+            },
+            {
+              siteUrl: 'go.webex.com',
+              default: true
+            },
+            {
+              siteUrl: 'site3-example.webex.com',
+              default: false
+            }
+          ]
+        };
 
-        assert.equal(res, 'go.webex.com');
+        assert.equal(MeetingsUtil.parseDefaultSiteFromMeetingPreferences(userPreferences), 'go.webex.com');
+      });
+
+      it('should work fine if no default true site', () => {
+        const userPreferences = {
+          sites: [
+            {
+              siteUrl: 'site1-example.webex.com',
+              default: false
+            },
+            {
+              siteUrl: 'site2-example.webex.com',
+              default: false
+            },
+            {
+              siteUrl: 'site3-example.webex.com',
+              default: false
+            }
+          ],
+        };
+
+        assert.equal(MeetingsUtil.parseDefaultSiteFromMeetingPreferences(userPreferences), '');
+      });
+
+      it('should work fine if sites an empty array', () => {
+        const userPreferences = {
+          sites: [],
+        };
+
+        assert.equal(MeetingsUtil.parseDefaultSiteFromMeetingPreferences(userPreferences), '');
       });
     });
   });

--- a/packages/node_modules/@webex/webex-core/src/lib/services/constants.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/constants.js
@@ -1,5 +1,5 @@
 const NAMESPACE = 'services';
-
+const WEBEXAPI = 'https://webexapis.com/';
 const SERVICE_CATALOGS = [
   'discovery',
   'limited',
@@ -14,6 +14,7 @@ const SERVICE_CATALOGS_ENUM_TYPES = {
 };
 
 export {
+  WEBEXAPI,
   SERVICE_CATALOGS_ENUM_TYPES,
   NAMESPACE,
   SERVICE_CATALOGS

--- a/packages/node_modules/@webex/webex-core/src/lib/services/services.js
+++ b/packages/node_modules/@webex/webex-core/src/lib/services/services.js
@@ -9,7 +9,7 @@ import ServiceCatalog from './service-catalog';
 import ServiceRegistry from './service-registry';
 import ServiceState from './service-state';
 import fedRampServices from './service-fed-ramp';
-
+import {WEBEXAPI} from './constants';
 
 const trailingSlashes = /(?:^\/)|(?:\/$)/;
 
@@ -366,15 +366,14 @@ const Services = WebexPlugin.extend({
   },
 
   /**
-   * Fetch login user infomation (preferred webex site).
+   * Get user meeting preferences (preferred webex site).
    *
    * @returns {object} - User Information including user preferrences .
    */
-  fetchLoginUserInformation() {
+  getMeetingPreferences() {
     return this.request({
       method: 'GET',
-      service: 'identity',
-      resource: 'identity/scim/v1/Users/me?showAllTypes=true'
+      url: `${WEBEXAPI}v1/meetingPreferences`
     }).then((res) => {
       this.logger.info('services: received user region info');
 

--- a/packages/node_modules/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/node_modules/@webex/webex-core/test/unit/spec/services/services.js
@@ -5,7 +5,9 @@
 import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import sinon from 'sinon';
+
 import {Services, ServiceRegistry, ServiceState} from '@webex/webex-core';
+import {WEBEXAPI} from '@webex/webex-core/src/lib/services/constants';
 
 /* eslint-disable no-underscore-dangle */
 describe('webex-core', () => {
@@ -100,32 +102,30 @@ describe('webex-core', () => {
       });
     });
 
-    describe('#fetchLoginUserInformation', () => {
+    describe('#getMeetingPreferences', () => {
       it('Fetch login users information ', async () => {
         const userPreferences = {userPreferences: 'userPreferences'};
 
         webex.request = sinon.stub().returns(Promise.resolve({body: userPreferences}));
 
-        const res = await services.fetchLoginUserInformation();
+        const res = await services.getMeetingPreferences();
 
         assert.calledWith(webex.request, {
           method: 'GET',
-          service: 'identity',
-          resource: 'identity/scim/v1/Users/me?showAllTypes=true'
+          url: `${WEBEXAPI}v1/meetingPreferences`
         });
         assert.isDefined(res);
         assert.equal(res, userPreferences);
       });
 
-      it('Resolve fetchLoginUserInformation if the api request fails ', async () => {
+      it('Resolve getMeetingPreferences if the api request fails ', async () => {
         webex.request = sinon.stub().returns(Promise.reject());
 
-        const res = await services.fetchLoginUserInformation();
+        const res = await services.getMeetingPreferences();
 
         assert.calledWith(webex.request, {
           method: 'GET',
-          service: 'identity',
-          resource: 'identity/scim/v1/Users/me?showAllTypes=true'
+          url: `${WEBEXAPI}v1/meetingPreferences`
         });
         assert.isUndefined(res);
       });


### PR DESCRIPTION

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [SPARK-325626](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-325626) - Start Using the /meetings api for preferred webex site 

## This pull request addresses

JIRA Ticket - [SPARK-325626](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-325626) - Start Using the /meetings api for preferred webex site 

Started using the meetings API for the preferred Webex site
Changed the function name to getMeetingPreferences
Used the https://webexapis.com/v1/meetingPreferences and mention it in the constant file
Updated the util function to parse the site info and get the default Webex site from it
Unit Testing covered

## by making the following changes

I started using the meetings API for the preferred Webex site
Moved From using identity to fetch Preferred Webex site to https://developer.webex.com/docs/api/v1/meeting-preferences/get-meeting-preference-details
For fetch preferred Webex site information

Use the above api to fetch the preferred meeting site rather then using the identity

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
