### PR TITLE
fix(plugin-meetings): for 423006 error code set password required true

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
@@ -6,6 +6,7 @@ import MeetingInfoUtil from './utilv2';
 const PASSWORD_ERROR_DEFAULT_MESSAGE = 'Password required. Call fetchMeetingInfo() with password argument';
 const CAPTCHA_ERROR_DEFAULT_MESSAGE = 'Captcha required. Call fetchMeetingInfo() with captchaInfo argument';
 const ADHOC_MEETING_DEFAULT_ERROR = 'Failed starting the adhoc meeting, Please contact support team ';
+const CAPTCHA_ERROR_REQUIRES_PASSWORD_CODES = [423005, 423006];
 
 /**
  * Error to indicate that wbxappapi requires a password
@@ -65,7 +66,7 @@ export class MeetingInfoV2CaptchaError extends Error {
     this.sdkMessage = message;
     this.stack = (new Error()).stack;
     this.wbxAppApiCode = wbxAppApiErrorCode;
-    this.isPasswordRequired = wbxAppApiErrorCode === 423005;
+    this.isPasswordRequired = CAPTCHA_ERROR_REQUIRES_PASSWORD_CODES.includes(wbxAppApiErrorCode);
     this.captchaInfo = captchaInfo;
   }
 }
@@ -204,4 +205,3 @@ export default class MeetingInfoV2 {
       });
   }
 }
-

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 import MockWebex from '@webex/test-helper-mock-webex';
 import Device from '@webex/internal-plugin-device';
 import Mercury from '@webex/internal-plugin-mercury';
+
 import Meetings from '@webex/plugin-meetings/src/meetings';
 import {
   _MEETING_ID_,
@@ -209,6 +210,10 @@ describe('plugin-meetings', () => {
 
         it('should throw MeetingInfoV2CaptchaError for 423 response (wbxappapi code 423005)', async () => {
           await runTest(423005, true);
+        });
+
+        it('should throw MeetingInfoV2CaptchaError for 423 response (wbxappapi code 423006)', async () => {
+          await runTest(423006, true);
         });
 
         it('should throw MeetingInfoV2CaptchaError for 423 response (wbxappapi code 423001)', async () => {


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >
SPARK-332360

## This pull request addresses
The appapi is responding with a 423006(too many requests, wrong password or host key) error code, when the sdk expects just a 423005 error code for the case where a captcha is required and a password is needed. This PR now checks for 423006 error code as well.
< DESCRIBE THE CONTEXT OF THE ISSUE >
At the moment it checks for the 423005 error code, which means that although it does report that it requires a captcha, it sets the password requirement to false.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
