### PR TITLE
Imc chat events

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -1078,6 +1078,16 @@ const Conversation = WebexPlugin.extend({
   },
 
   /**
+   * Handles incoming conversation.inmeetingchat.activity mercury messages
+   * @param {Event} event
+   * @returns {Promise}
+   */
+  processInmeetingchatEvent(event) {
+    return this.webex.transform('inbound', event)
+      .then(() => event);
+  },
+
+  /**
    * Removes all mute-related tags
    * @param {Conversation~ConversationObject} conversation
    * @param {Conversation~ActivityObject} activity

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/encryption-transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/encryption-transforms.js
@@ -80,7 +80,7 @@ export const transforms = toArray('outbound', {
 
   encryptActivity(ctx, key, activity) {
     // Activity is already encrypted
-    if (activity.encryptionKeyUrl || activity.object.created === 'True') {
+    if (activity.encryptionKeyUrl || activity.object?.created === 'True') {
       return Promise.resolve();
     }
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/encryption-transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/encryption-transforms.js
@@ -80,7 +80,7 @@ export const transforms = toArray('outbound', {
 
   encryptActivity(ctx, key, activity) {
     // Activity is already encrypted
-    if (activity.encryptionKeyUrl) {
+    if (activity.encryptionKeyUrl || activity.object.created === 'True') {
       return Promise.resolve();
     }
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -5,6 +5,7 @@
 import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import sinon from 'sinon';
+
 import Conversation from '@webex/internal-plugin-conversation';
 
 import {rootActivityManager, getLoopCounterFailsafe, noMoreActivitiesManager, bookendManager, activityManager} from '../../../src/activity-thread-ordering';
@@ -26,6 +27,27 @@ describe('plugin-conversation', () => {
       webex.internal.services = {};
       webex.internal.services.get = sinon.stub().returns(Promise.resolve(convoUrl));
       webex.internal.services.getServiceFromClusterId = sinon.stub().returns({url: convoUrl});
+    });
+
+    describe('processInmeetingchatEvent()', () => {
+      beforeEach(() => {
+        webex.transform = sinon.stub().callsFake((obj) => Promise.resolve(obj));
+      });
+
+      it('calls transform with correct arguments', async () => {
+        const event = {name: 'test-event'};
+
+        await webex.internal.conversation.processInmeetingchatEvent(event);
+
+        assert.calledWith(webex.transform, 'inbound', event);
+      });
+
+      it('calls transform and returns event', async () => {
+        const event = {name: 'test-event'};
+        const returnValue = await webex.internal.conversation.processInmeetingchatEvent(event);
+
+        assert.equal(event, returnValue);
+      });
     });
 
     describe('#_inferConversationUrl', () => {

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/encryption-transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/encryption-transforms.js
@@ -1,0 +1,59 @@
+/*!
+ * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import sinon from 'sinon';
+import {assert} from '@webex/test-helper-chai';
+
+import {transforms} from '@webex/internal-plugin-conversation/src/encryption-transforms';
+
+
+describe('plugin-conversation', () => {
+  describe('encryption transforms', () => {
+    describe('encryptActivity()', () => {
+      it('does not call transfom when created is True', () => {
+        const transform = transforms.find((t) => t.name === 'encryptActivity');
+
+        const ctx = {
+          transform
+        };
+        const key = null;
+        const activity = {
+          object: {
+            created: 'True'
+          },
+          objectType: 'activity',
+          verb: 'update'
+        };
+
+        // should just resolve immediately and return nothing
+        transform.fn(ctx, key, activity).then((result) => {
+          assert.equal(undefined, result, 'should just return nothing');
+        }).catch(() => {
+          assert.equal(false, true, 'something unexpected happened');
+        });
+      });
+
+      it('does transfom when created is not True', async () => {
+        const transform = transforms.find((t) => t.name === 'encryptActivity');
+        const transformStub = sinon.stub().resolves();
+
+        const ctx = {
+          transform: transformStub
+        };
+        const key = null;
+        const activity = {
+          object: {
+            created: 'false'
+          },
+          objectType: 'activity',
+          verb: 'update'
+        };
+
+        // should go through the promise chain and last thing called is prepareActivityKmsMessage
+        await transform.fn(ctx, key, activity);
+        assert.equal(transformStub.lastCall.args[0], 'prepareActivityKmsMessage', key, activity);
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. added support for incoming meeting chat activity events
2. do not encrypt payload sent to meeting-container service to create convo (check `created: 'True'`)