### PR TITLE
fix: mask localNetworkPrefix in ipv6 format to CIDR/96

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/index.js
@@ -33,8 +33,9 @@ const {
   getBrowserVersion
 } = BrowserDetection();
 
-// Apply a CIDR /28 format to the IP address
-const anonymizeIPAddress = (localIp) => anonymize(localIp);
+// Apply a CIDR /28 format to the IPV4 and /96 to the IPV6 addresses
+// For reference : https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
+const anonymizeIPAddress = (localIp) => anonymize(localIp, 28, 96);
 
 const triggerTimers = ({event, meeting, data}) => {
   switch (event) {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/metrics/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/metrics/index.js
@@ -76,12 +76,12 @@ browserOnly(describe)('Meeting metrics', () => {
       metrics.initialSetup({}, webex);
       const payload = metrics.initPayload('myIPv6Metric', {}, {clientType: 'TEAMS_CLIENT'});
 
-      assert(payload.origin.clientInfo.localNetworkPrefix === '2001:d00::');
+      assert(payload.origin.clientInfo.localNetworkPrefix === '2001:db8:0:8d3::');
       assert(payload.event.name === 'myIPv6Metric');
 
       const payload2 = metrics.initMediaPayload('myIPv6Metric', {}, {clientType: 'TEAMS_CLIENT'});
 
-      assert(payload2.origin.clientInfo.localNetworkPrefix === '2001:d00::');
+      assert(payload2.origin.clientInfo.localNetworkPrefix === '2001:db8:0:8d3::');
     });
   });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-334545](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-334545) >

## This pull request addresses

The ipv6 address was not being masked with CIDR /96 for localNetworkPrefix. As a result, it was showing the ip address suffixed with `...0`.

## by making the following changes

The localNetworkPrefix is now being masked with CIDR /96 and same is getting sent to the `clientmetrics` API for `diagnostic-event` type event

<img width="1634" alt="localNetworkPrefix" src="https://user-images.githubusercontent.com/16598065/174792332-cfba79b4-d3a3-4770-91c1-aad9349988e6.png">

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
