### PR TITLE
fix(plugin-meetings): using the env for port in the web pack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = (env = {NODE_ENV: process.env.NODE_ENV || 'production'}) => ({
     'eval-cheap-module-source-map' : 'source-map',
   devServer: {
     https: true,
-    port: 8000,
+    port: process.env.PORT || 8000,
     static: './docs'
   },
   node: {


### PR DESCRIPTION

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[ SPARK-303051 ](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-303051)

## This pull request addresses

[SPARK-303051](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-303051) Thinkrite - JS SDK - sample slow on PORT 8080 

## by making the following changes

Using the .env for PORT in the web pack config
Screnshot added below -

<!-- You may include screenshots -->
<img width="1668" alt="Screenshot 2022-06-20 at 7 35 48 PM" src="https://user-images.githubusercontent.com/3918217/174656570-4f943f6f-347f-42e1-8078-a1ff9be37a63.png">


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
