### PR TITLE
chore(eslint): ignore max line length

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,12 +57,7 @@
       }
     ],
     "class-methods-use-this": "warn",
-    "max-len": [
-      "warn",
-      {
-        "ignoreComments": true
-      }
-    ],
+    "max-len":  "off",
     "no-multi-assign": "warn",
     "no-param-reassign": "warn",
     "no-shadow": "warn",


### PR DESCRIPTION
## This pull request addresses

There are yellow linter lines all over due to the 80 character line limit that is only a warning. It is clear that nobody wants this, otherwise all the lines would be smaller.

As it is right now it interferes with the ability to read the code and to spot other warnings.

## by making the following changes

Changing eslint to ignore the line length

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
