### PR TITLE
Swapped descriptions for auth methods

### DIFF
--- a/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js
+++ b/packages/node_modules/@webex/plugin-authorization-browser/src/authorization.js
@@ -134,7 +134,7 @@ const Authorization = WebexPlugin.extend({
 
   @whileInFlight('isAuthorizing')
   /**
-   * Kicks off the Authorization Code grant flow. Typically called via
+   * Kicks off the Implicit Code grant flow. Typically called via
    * {@link AuthorizationBrowser#initiateLogin}
    * @instance
    * @memberof AuthorizationBrowser
@@ -150,7 +150,7 @@ const Authorization = WebexPlugin.extend({
 
   @whileInFlight('isAuthorizing')
   /**
-   * Kicks off the Implicit Code grant flow. Typically called via
+   * Kicks off the Authorization Code grant flow. Typically called via
    * {@link AuthorizationBrowser#initiateLogin}
    * @instance
    * @memberof AuthorizationBrowser


### PR DESCRIPTION
This PR fixes a minor documentation issue where the descriptions of the implicit and auth code grant flows were in the wrong places.