### PR TITLE
BNR Phase 1 PR review comments

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -5756,8 +5756,8 @@ export default class Meeting extends StatelessWebexPlugin {
       if (typeof this.mediaProperties === 'undefined' || typeof this.mediaProperties.audioTrack === 'undefined') {
         throw new Error("Meeting doesn't have an audioTrack attached");
       }
-      this.mediaProperties.audioTrack = await WebRTCMedia.Effects.BNR.enableBNR(this.mediaProperties.audioTrack);
-      const audioStream = MediaUtil.createMediaStream([this.mediaProperties.audioTrack]);
+      const bnrEnabledTrack = await WebRTCMedia.Effects.BNR.enableBNR(this.mediaProperties.audioTrack);
+      const audioStream = MediaUtil.createMediaStream([bnrEnabledTrack]);
 
       LoggerProxy.logger.info('Meeting:index#enableBNR. BNR enabled track obtained from WebRTC & sent to updateAudio');
       await this.updateAudio({
@@ -5790,8 +5790,8 @@ export default class Meeting extends StatelessWebexPlugin {
       if (typeof this.mediaProperties === 'undefined' || typeof this.mediaProperties.audioTrack === 'undefined') {
         throw new Error("Meeting doesn't have an audioTrack attached");
       }
-      this.mediaProperties.audioTrack = WebRTCMedia.Effects.BNR.disableBNR(this.mediaProperties.audioTrack);
-      const audioStream = MediaUtil.createMediaStream([this.mediaProperties.audioTrack]);
+      const bnrDisabledTrack = WebRTCMedia.Effects.BNR.disableBNR(this.mediaProperties.audioTrack);
+      const audioStream = MediaUtil.createMediaStream([bnrDisabledTrack]);
 
       LoggerProxy.logger.info('Meeting:index#disableBNR. Raw media track obtained from WebRTC & sent to updateAudio');
       await this.updateAudio({

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -5762,7 +5762,7 @@ export default class Meeting extends StatelessWebexPlugin {
       LoggerProxy.logger.info('Meeting:index#enableBNR. BNR enabled track obtained from WebRTC & sent to updateAudio');
       await this.updateAudio({
         sendAudio: true,
-        receiveAudio: true,
+        receiveAudio: this.mediaProperties.mediaDirection.receiveAudio,
         stream: audioStream
       });
       this.isBnrEnabled = true;
@@ -5796,7 +5796,7 @@ export default class Meeting extends StatelessWebexPlugin {
       LoggerProxy.logger.info('Meeting:index#disableBNR. Raw media track obtained from WebRTC & sent to updateAudio');
       await this.updateAudio({
         sendAudio: true,
-        receiveAudio: true,
+        receiveAudio: this.mediaProperties.mediaDirection.receiveAudio,
         stream: audioStream
       });
       this.isBnrEnabled = false;

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -544,6 +544,7 @@ describe('plugin-meetings', () => {
           const fakeMediaTrack = () => ({
             stop: () => {},
             readyState: 'live',
+            enabled: true,
             getSettings: () => ({
               sampleRate: 48000
             })
@@ -552,9 +553,10 @@ describe('plugin-meetings', () => {
           meeting.getMediaStreams = sinon.stub().returns(Promise.resolve());
           sinon.replace(meeting, 'addMedia', () => {
             sinon.stub(meeting.mediaProperties, 'audioTrack').value(fakeMediaTrack());
+            sinon.stub(meeting.mediaProperties, 'mediaDirection').value({
+              receiveAudio: true
+            });
           });
-          await meeting.getMediaStreams();
-          await meeting.addMedia();
         });
 
         describe('#enableBNR', () => {
@@ -571,6 +573,11 @@ describe('plugin-meetings', () => {
           });
 
           describe('after audio attached to meeting', () => {
+            beforeEach(async () => {
+              await meeting.getMediaStreams();
+              await meeting.addMedia();
+            });
+
             it('should return true for appropriate sample rate', async () => {
               const response = await meeting.enableBNR();
 
@@ -595,6 +602,11 @@ describe('plugin-meetings', () => {
         });
 
         describe('#disableBNR', () => {
+          beforeEach(async () => {
+            await meeting.getMediaStreams();
+            await meeting.addMedia();
+          });
+
           it('should have #disableBnr', () => {
             assert.exists(meeting.disableBNR);
           });
@@ -609,6 +621,40 @@ describe('plugin-meetings', () => {
             await meeting.disableBNR().catch((err) => {
               assert.equal(err.message, 'Can not disable as BNR is not enabled');
             });
+          });
+        });
+
+        describe('#mute & #BNR', () => {
+          let handleClientRequest;
+
+          beforeEach(async () => {
+            await meeting.getMediaStreams();
+            await meeting.addMedia();
+            handleClientRequest = (meeting, mute) => {
+              meeting.mediaProperties.audioTrack.enabled = !mute;
+
+              return Promise.resolve();
+            };
+            sinon.stub().returns(Promise.resolve());
+            meeting.mediaId = 'mediaId';
+            meeting.audio = {handleClientRequest};
+            meeting.locusInfo.parsedLocus = {self: {state: 'JOINED'}};
+            await meeting.muteAudio();
+          });
+
+          it('should be muted on enableBNR if already muted', async () => {
+            const response = await meeting.enableBNR();
+
+            assert.equal(response, true);
+            assert.equal(meeting.mediaProperties.audioTrack.enabled, false);
+          });
+
+          it('should be muted on disableBNR if already muted', async () => {
+            await meeting.enableBNR();
+            const response = await meeting.disableBNR();
+
+            assert.equal(response, true);
+            assert.equal(meeting.mediaProperties.audioTrack.enabled, false);
           });
         });
       });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES 
- [SPARK-345985 - WebEx JS SDK - Incorporate PR comment on BNR Phase 1](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-345985)

## This pull request addresses

The review comments on the pull request #2381 

## by making the following changes

- updateMedia call's receiveAudio is set from meeting.mediaDirections rather than hardcoding.
- BNR enabled audio track is disabled if meeting audio is muted by the user

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- Ensured muted audio track is still muted upon enabling BNR

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
