### PR TITLE
feat(plugin-meetings): added metrics for bnr functionality

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -5767,9 +5767,21 @@ export default class Meeting extends StatelessWebexPlugin {
       });
       this.isBnrEnabled = true;
       isSuccess = true;
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.ENABLE_BNR_SUCCESS,
+      );
     }
     catch (error) {
       LoggerProxy.logger.error(`Meeting:index#enableBNR. ${error}`);
+
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.ENABLE_BNR_FAILURE,
+        {
+          reason: error.message,
+          stack: error.stack
+        }
+      );
+
       throw error;
     }
 
@@ -5801,9 +5813,22 @@ export default class Meeting extends StatelessWebexPlugin {
       });
       this.isBnrEnabled = false;
       isSuccess = true;
+
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.DISABLE_BNR_SUCCESS
+      );
     }
     catch (error) {
       LoggerProxy.logger.error(`Meeting:index#disableBNR. ${error}`);
+
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.DISABLE_BNR_FAILURE,
+        {
+          reason: error.message,
+          stack: error.stack
+        }
+      );
+
       throw error;
     }
 

--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/constants.js
@@ -40,7 +40,11 @@ const BEHAVIORAL_METRICS = {
   PEERCONNECTION_FAILURE: 'js_sdk_peerConnection_failures',
   INVALID_ICE_CANDIDATE: 'js_sdk_invalid_ice_candidate',
   UPLOAD_LOGS_FAILURE: 'js_sdk_upload_logs_failure',
-  RECEIVE_TRANSCRIPTION_FAILURE: 'js_sdk_receive_transcription_failure'
+  RECEIVE_TRANSCRIPTION_FAILURE: 'js_sdk_receive_transcription_failure',
+  ENABLE_BNR_SUCCESS: 'js_sdk_enable_bnr_success',
+  ENABLE_BNR_FAILURE: 'js_sdk_enable_bnr_failure',
+  DISABLE_BNR_SUCCESS: 'js_sdk_disable_bnr_success',
+  DISABLE_BNR_FAILURE: 'js_sdk_disable_bnr_failure'
 };
 
 

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -74,6 +74,13 @@ describe('plugin-meetings', () => {
     debug: () => {}
   };
 
+  beforeEach(() => {
+    sinon.stub(Metrics, 'sendBehavioralMetric');
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
+
   before(() => {
     const MediaStream = {
       getVideoTracks: () => [{
@@ -577,7 +584,7 @@ describe('plugin-meetings', () => {
               assert.equal(response, true);
             });
 
-            it('should throw error for inappropriate sample rate', async () => {
+            it('should throw error for inappropriate sample rate and send error metrics', async () => {
               const fakeMediaTrack = () => ({
                 stop: () => {},
                 readyState: 'live',
@@ -588,8 +595,27 @@ describe('plugin-meetings', () => {
 
               sinon.stub(meeting.mediaProperties, 'audioTrack').value(fakeMediaTrack());
               await meeting.enableBNR().catch((err) => {
+                assert(Metrics.sendBehavioralMetric.calledOnce);
+                assert.calledWith(
+                  Metrics.sendBehavioralMetric,
+                  BEHAVIORAL_METRICS.ENABLE_BNR_FAILURE, {
+                    reason: err.message,
+                    stack: err.stack
+                  }
+                );
                 assert.equal(err.message, 'Sample rate of 49000 is not supported.');
               });
+            });
+
+            it('should send metrics for enable bnr success', async () => {
+              const response = await meeting.enableBNR();
+
+              assert(Metrics.sendBehavioralMetric.calledOnce);
+              assert.calledWith(
+                Metrics.sendBehavioralMetric,
+                BEHAVIORAL_METRICS.ENABLE_BNR_SUCCESS,
+              );
+              assert.equal(response, true);
             });
           });
         });
@@ -605,8 +631,13 @@ describe('plugin-meetings', () => {
             assert.equal(response, true);
           });
 
-          it('should throw error if bnr is not enabled before disabling', async () => {
+          it('should throw error if bnr is not enabled before disabling and send error metrics', async () => {
             await meeting.disableBNR().catch((err) => {
+              assert(Metrics.sendBehavioralMetric.calledOnce);
+              assert.calledWith(
+                Metrics.sendBehavioralMetric,
+                BEHAVIORAL_METRICS.DISABLE_BNR_FAILURE,
+              );
               assert.equal(err.message, 'Can not disable as BNR is not enabled');
             });
           });
@@ -2773,7 +2804,6 @@ describe('plugin-meetings', () => {
           });
 
           it('should send metrics on reconnect failure', async () => {
-            sandbox.stub(Metrics, 'sendBehavioralMetric');
             await assert.isRejected(meeting.reconnect());
             assert(Metrics.sendBehavioralMetric.calledOnce);
             assert.calledWith(


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-323844](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-323844) >

## This pull request addresses

Behavioural metrics for enable and disable BNR functionality.

## by making the following changes

Added behavioural metrics for enable and disable BNR functionality to track the usage and any corresponding errors.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
