### PR TITLE
fix: use the correct members request in raiseOrLowerHand

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/members/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/members/index.js
@@ -756,7 +756,7 @@ export default class Members extends StatelessWebexPlugin {
     }
     const options = MembersUtil.generateRaiseHandMemberOptions(memberId, raise, this.locusUrl);
 
-    return this.membersRequest.raiseLowerHandMember(options);
+    return this.membersRequest.raiseOrLowerHandMember(options);
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/members/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/members/index.js
@@ -10,8 +10,9 @@ import chaiAsPromised from 'chai-as-promised';
 import {Credentials} from '@webex/webex-core';
 import Support from '@webex/internal-plugin-support';
 import MockWebex from '@webex/test-helper-mock-webex';
-import Meetings from '@webex/plugin-meetings';
 
+import Meetings from '@webex/plugin-meetings';
+import ParameterError from '@webex/plugin-meetings/src/common/errors/parameter';
 import Members from '@webex/plugin-meetings/src/members';
 import MembersUtil from '@webex/plugin-meetings/src/members/util';
 
@@ -191,25 +192,72 @@ describe('plugin-meetings', () => {
       });
     });
 
-    describe('#raiseHand', () => {
-      it('should fire spies correctly when raiseOrLowerHand is called with valid params', async () => {
-        const members = createMembers({url: url1});
+    describe('#raiseOrLowerHand', () => {
+      const setup = (locusUrl) => {
+        const members = createMembers({url: locusUrl});
 
-        const {membersRequest} = members;
+        const spies = {
+          generateRaiseHandMemberOptions: sandbox.spy(MembersUtil, 'generateRaiseHandMemberOptions'),
+          raiseOrLowerHandMember: sandbox.spy(members.membersRequest, 'raiseOrLowerHandMember'),
+        };
 
-        const generateOptionsSpy = sandbox.spy(MembersUtil, 'generateRaiseHandMemberOptions');
-        const raiseOrLowerHandMemberSpy = sandbox.spy(membersRequest, 'raiseOrLowerHandMember');
+        return {members, spies};
+      };
 
-        await members.raiseOrLowerHand('test1', true);
+      const checkInvalid = async (resultPromise, expectedMessage, spies) => {
+        await assert.isRejected(resultPromise, ParameterError, expectedMessage);
+        assert.notCalled(spies.generateRaiseHandMemberOptions);
+        assert.notCalled(spies.raiseOrLowerHandMember);
+      };
 
-        assert.calledOnce(generateOptionsSpy);
-        assert.calledOnce(raiseOrLowerHandMemberSpy);
+      const checkValid = async (resultPromise, spies, expectedMemberId, expectedRaise, expectedLocusUrl) => {
+        await assert.isFulfilled(resultPromise);
+        assert.calledOnceWithExactly(spies.generateRaiseHandMemberOptions, expectedMemberId, expectedRaise, expectedLocusUrl);
+        assert.calledOnceWithExactly(spies.raiseOrLowerHandMember, {memberId: expectedMemberId, raised: expectedRaise, locusUrl: expectedLocusUrl});
+        assert.strictEqual(resultPromise, spies.raiseOrLowerHandMember.getCall(0).returnValue);
+      };
+
+      it('should not make a request if there is no member id', async () => {
+        const {members, spies} = setup(url1);
+
+        const resultPromise = members.raiseOrLowerHand();
+
+        await checkInvalid(resultPromise, 'The member id must be defined to raise/lower the hand of the member.', spies);
       });
 
-      it('should throw a rejection if there is no locus url', async () => {
-        const members = createMembers({url: false});
+      it('should not make a request if there is no locus url', async () => {
+        const {members, spies} = setup();
 
-        assert.isRejected(members.raiseOrLowerHand('test1', true));
+        const resultPromise = members.raiseOrLowerHand(uuid.v4());
+
+        await checkInvalid(resultPromise, 'The associated locus url for this meetings members object must be defined.', spies);
+      });
+
+      it('should make the correct request when called with raise as true', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1);
+
+        const resultPromise = members.raiseOrLowerHand(memberId, true);
+
+        await checkValid(resultPromise, spies, memberId, true, url1);
+      });
+
+      it('should make the correct request when called with raise as false', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1);
+
+        const resultPromise = members.raiseOrLowerHand(memberId, false);
+
+        await checkValid(resultPromise, spies, memberId, false, url1);
+      });
+
+      it('should make the correct request when called with raise as default', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1);
+
+        const resultPromise = members.raiseOrLowerHand(memberId);
+
+        await checkValid(resultPromise, spies, memberId, true, url1);
       });
     });
   });


### PR DESCRIPTION
## This pull request addresses

A small error in the name of the members request used when raising / lowering hand

## by making the following changes

Correcting the name and updating some tests

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

All paths through the method

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All related existing and new tests passed
- [x] I have updated the documentation accordingly