### PR TITLE
fix: return the response from the meetingInfo API

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
@@ -205,10 +205,12 @@ export default class MeetingInfoV2 {
     if (directURI) options.directURI = directURI;
 
     return this.webex.request(options)
-      .then(() => {
+      .then((response) => {
         Metrics.sendBehavioralMetric(
           BEHAVIORAL_METRICS.FETCH_MEETING_INFO_V1_SUCCESS
         );
+
+        return response;
       })
       .catch((err) => {
         if (err?.statusCode === 403) {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -88,10 +88,14 @@ describe('plugin-meetings', () => {
 
     describe('#fetchMeetingInfo', () => {
       it('should fetch meeting info for the destination type', async () => {
-        sinon.stub(MeetingInfoUtil, 'getDestinationType').returns(Promise.resolve({type: 'MEETING_ID', destination: '123456'}));
-        sinon.stub(MeetingInfoUtil, 'getRequestBody').returns(Promise.resolve({meetingKey: '1234323'}));
+        const body = {meetingKey: '1234323'};
+        const requestResponse = {statusCode: 200, body};
 
-        await meetingInfo.fetchMeetingInfo({
+        sinon.stub(MeetingInfoUtil, 'getDestinationType').returns(Promise.resolve({type: 'MEETING_ID', destination: '123456'}));
+        sinon.stub(MeetingInfoUtil, 'getRequestBody').returns(Promise.resolve(body));
+        webex.request.resolves(requestResponse);
+
+        const result = await meetingInfo.fetchMeetingInfo({
           type: _MEETING_ID_,
           destination: '1234323'
         });
@@ -99,28 +103,39 @@ describe('plugin-meetings', () => {
         assert.calledWith(webex.request, {
           method: 'POST', service: 'webex-appapi-service', resource: 'meetingInfo', body: {meetingKey: '1234323'}
         });
+        assert.deepEqual(result, requestResponse);
 
         MeetingInfoUtil.getDestinationType.restore();
         MeetingInfoUtil.getRequestBody.restore();
       });
-      it('should fetch meeting info for the personal meeting room  type', async () => {
-        sinon.stub(MeetingInfoUtil, 'getDestinationType').returns(Promise.resolve({type: 'MEETING_ID', destination: '123456'}));
-        sinon.stub(MeetingInfoUtil, 'getRequestBody').returns(Promise.resolve({meetingKey: '1234323'}));
 
-        await meetingInfo.fetchMeetingInfo({
+      it('should fetch meeting info for the personal meeting room  type', async () => {
+        const body = {meetingKey: '1234323'};
+        const requestResponse = {statusCode: 200, body};
+
+        sinon.stub(MeetingInfoUtil, 'getDestinationType').returns(Promise.resolve({type: 'MEETING_ID', destination: '123456'}));
+        sinon.stub(MeetingInfoUtil, 'getRequestBody').returns(Promise.resolve(body));
+        webex.request.resolves(requestResponse);
+
+        const result = await meetingInfo.fetchMeetingInfo({
           type: _PERSONAL_ROOM_
         });
 
         assert.calledWith(webex.request, {
           method: 'POST', service: 'webex-appapi-service', resource: 'meetingInfo', body: {meetingKey: '1234323'}
         });
+        assert.deepEqual(result, requestResponse);
 
         MeetingInfoUtil.getDestinationType.restore();
         MeetingInfoUtil.getRequestBody.restore();
       });
 
       it('should fetch meeting info with provided password and captcha code', async () => {
-        await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, 'abc', {id: '999', code: 'aabbcc11'});
+        const requestResponse = {statusCode: 200, body: {meetingKey: '1234323'}};
+
+        webex.request.resolves(requestResponse);
+
+        const result = await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, 'abc', {id: '999', code: 'aabbcc11'});
 
         assert.calledWith(webex.request, {
           method: 'POST',
@@ -134,6 +149,7 @@ describe('plugin-meetings', () => {
             captchaVerifyCode: 'aabbcc11'
           }
         });
+        assert.deepEqual(result, requestResponse);
         assert(Metrics.sendBehavioralMetric.calledOnce);
         assert.calledWith(
           Metrics.sendBehavioralMetric,


### PR DESCRIPTION
## This pull request addresses

Fixes [SPARK-352626](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-352626)

## by making the following changes

In #2392 a change was made to the `fetchMeetingInfo` function which resulted in it not returning the meeting info... This should rectify that issue by actually returning the response from the request. This also improves upon existing tests which now ensure something is returned from the promise (currently it is `undefined`).

Note that there is one test that is still broken, but is unrelated to this change so I have opened [SPARK-353036](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-353036) to track it (since I think some logic in the actual implementation will want to be fixed also).

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- Unit tests added to ensure the request response is returned in the promise
- Checked meeting info on web client when using a build with this change in

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request
- [X] I have not skipped any automated checks
- [X] All relevant existing and new tests passed
- [X] I have updated the documentation accordingly
