### PR TITLE
fix: add metrics to fetchMeetingInfo and fix tests

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.js
@@ -164,7 +164,7 @@ export default class MeetingInfoV2 {
             stack: err.stack
           }
         );
-        throw new MeetingInfoV2AdhocMeetingError(err.body?.code, err.body?.message);
+        throw err;
       });
   }
 

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -968,6 +968,10 @@ export default class Meeting extends StatelessWebexPlugin {
         EVENT_TRIGGERS.MEETING_INFO_AVAILABLE
       );
 
+      Metrics.sendBehavioralMetric(
+        BEHAVIORAL_METRICS.VERIFY_PASSWORD_SUCCESS
+      );
+
       return Promise.resolve();
     }
     catch (err) {
@@ -987,6 +991,10 @@ export default class Meeting extends StatelessWebexPlugin {
           await this.refreshCaptcha();
         }
 
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.VERIFY_PASSWORD_ERROR
+        );
+
         throw (new PasswordError());
       }
       else if (err instanceof MeetingInfoV2CaptchaError) {
@@ -999,6 +1007,10 @@ export default class Meeting extends StatelessWebexPlugin {
         if (err.isPasswordRequired) {
           this.passwordStatus = PASSWORD_STATUS.REQUIRED;
         }
+
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.VERIFY_CAPTCHA_ERROR
+        );
 
         this.requiredCaptcha = err.captchaInfo;
         throw (new CaptchaError());
@@ -1023,13 +1035,12 @@ export default class Meeting extends StatelessWebexPlugin {
     return this.fetchMeetingInfo({
       password, captchaCode
     })
-      .then(() => {
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.VERIFY_PASSWORD_SUCCESS
-        );
+      .then(() =>
+      // Metrics.sendBehavioralMetric(
+      //   BEHAVIORAL_METRICS.VERIFY_PASSWORD_SUCCESS
+      // );
 
-        return {isPasswordValid: true, requiredCaptcha: null, failureReason: MEETING_INFO_FAILURE_REASON.NONE};
-      })
+        ({isPasswordValid: true, requiredCaptcha: null, failureReason: MEETING_INFO_FAILURE_REASON.NONE}))
       .catch((error) => {
         if (error instanceof PasswordError || error instanceof CaptchaError) {
           return {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1420,7 +1420,7 @@ describe('plugin-meetings', () => {
 
             sandbox.stub(meeting.mediaProperties, 'peerConnection').value({shareTransceiver: true});
             sandbox.stub(MeetingUtil, 'getTrack').returns({videoTrack: true});
-            sandbox.stub(MeetingUtil, 'validateOptions').resolves(true);
+            MeetingUtil.validateOptions = sinon.stub().resolves(true);
             sandbox.stub(meeting, 'canUpdateMedia').returns(true);
             sandbox.stub(meeting, 'setLocalShareTrack');
 
@@ -1493,9 +1493,10 @@ describe('plugin-meetings', () => {
             sandbox.stub(MeetingUtil, 'getTrack').returns({videoTrack: null});
             sandbox.stub(meeting, 'setLocalShareTrack');
             sandbox.stub(meeting, 'unsetLocalShareTrack');
-            sandbox.stub(MeetingUtil, 'validateOptions').resolves(true);
+            MeetingUtil.validateOptions = sinon.stub().resolves(true);
             sandbox.stub(meeting, 'checkForStopShare').returns(false);
-            sandbox.stub(MeetingUtil, 'updateTransceiver').resolves(true);
+            MeetingUtil.updateTransceiver = sinon.stub().resolves(true);
+
             sandbox.stub(meeting, 'isLocalShareLive').value(false);
             sandbox.stub(meeting, 'handleShareTrackEnded');
             sandbox.stub(meeting.mediaProperties, 'peerConnection').value({


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #<[SPARK-353036](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-353036)>

## This pull request addresses

Adds missing metrics and fixes unit tests except BNR tests

## by making the following changes

All the unit tests for plugin-meetings passes except the BNR tests which is fixed in another PR #2396

### Screenshot
<img width="1274" alt="Screenshot 2022-08-11 at 8 37 53 PM" src="https://user-images.githubusercontent.com/16598065/184166400-4fa5f3b8-cc87-4ac1-84f9-8a1a5fdb73d6.png">

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
