### PR TITLE
fix(plugin-meetings): add validation for device registration

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -3575,6 +3575,15 @@ export default class Meeting extends StatelessWebexPlugin {
    * Scenario D: Joining any other way (sip, pstn, conversationUrl, link just need to specify resourceId)
    */
   join(options = {}) {
+    if (!this.webex.meetings.registered) {
+      const errorMessage = 'Meeting:index#join --> Device not registered';
+      const error = new Error(errorMessage);
+
+      LoggerProxy.logger.error(errorMessage);
+
+      return Promise.reject(error);
+    }
+
     // If a join request is being processed, refer to the deferred promise.
     if (this.deferJoin) {
       return this.deferJoin;

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -786,6 +786,7 @@ describe('plugin-meetings', () => {
         beforeEach(() => {
           meeting.setCorrelationId = sinon.stub().returns(true);
           meeting.setLocus = sinon.stub().returns(true);
+          webex.meetings.registered = true;
         });
         describe('successful', () => {
           beforeEach(() => {
@@ -854,6 +855,14 @@ describe('plugin-meetings', () => {
               assert.calledWith(MeetingUtil.joinMeeting, meeting, {moderator: false, pin: '1234'});
             });
           });
+
+          it('should throw error if device is not registered', async () => {
+            webex.meetings.registered = false;
+            await meeting.join().catch((error) => {
+              assert.equal(error.message, 'Meeting:index#join --> Device not registered');
+            });
+          });
+
           it('should post error event if failed', async () => {
             await meeting.join().catch(() => {
               assert.calledWithMatch(Metrics.postEvent, {event: eventType.LOCUS_JOIN_RESPONSE});


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #<[SPARK-238149](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-238149)>

## This pull request addresses

Missing validation for device registration before user joins a meeting

## by making the following changes

- Fixes the missing validation for device registration before user joins a meeting
- Adds unit test for the same

<!-- You may include screenshots -->

Screenshot
<img width="1711" alt="device registration validation error" src="https://user-images.githubusercontent.com/16598065/187155264-28f6995e-040b-4619-bd9e-42ab4ddc2e44.png">



### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
