### PR TITLE
fix: check joined display hints

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/index.js
@@ -801,8 +801,8 @@ export default class LocusInfo extends EventsScope {
   updateMeetingInfo(info, self) {
     if (info && (!isEqual(this.info, info))) {
       const roles = self ? SelfUtils.getRoles(self) : this.parsedLocus.self?.roles || [];
-
-      const parsedInfo = InfoUtils.getInfos(this.parsedLocus.info, info, roles);
+      const isJoined = SelfUtils.isJoined(self || this.parsedLocus.self);
+      const parsedInfo = InfoUtils.getInfos(this.parsedLocus.info, info, roles, isJoined);
 
       this.emitScoped(
         {

--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/infoUtils.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/infoUtils.js
@@ -3,14 +3,14 @@ import {SELF_ROLES, DISPLAY_HINTS} from '../constants';
 
 const InfoUtils = {};
 
-InfoUtils.parse = (info, roles) => {
+InfoUtils.parse = (info, roles, isJoined = true) => {
   const parsed = {
     policy: InfoUtils.parsePolicy(info),
     moderator: InfoUtils.parseModerator(info),
     coHost: InfoUtils.parseCoHost(info),
   };
 
-  let userDisplayHints = {...parsed.policy};
+  let userDisplayHints = isJoined ? {...parsed.policy} : {};
 
   if (roles.includes(SELF_ROLES.COHOST)) {
     userDisplayHints = {...userDisplayHints, ...parsed.coHost};
@@ -63,13 +63,13 @@ InfoUtils.isLocked = (policy) => policy.LOCK_STATUS_LOCKED || false;
 
 InfoUtils.isUnlocked = (policy) => policy.LOCK_STATUS_UNLOCKED || false;
 
-InfoUtils.getInfos = (oldInfo, newInfo, roles) => {
+InfoUtils.getInfos = (oldInfo, newInfo, roles, isJoined) => {
   let previous = null;
 
   if (oldInfo) {
     previous = oldInfo;
   }
-  const current = newInfo && InfoUtils.parse(newInfo, roles);
+  const current = newInfo && InfoUtils.parse(newInfo, roles, isJoined);
   const updates = {};
 
   if (current) {

--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/selfUtils.js
@@ -98,6 +98,14 @@ SelfUtils.getSelves = (oldSelf, newSelf, deviceId) => {
   };
 };
 
+/**
+ * Checks if user has joined the meeting
+ * @param {Object} self
+ * @returns {boolean} isJoined
+*/
+SelfUtils.isJoined = (self) => self?.state === _JOINED_;
+
+
 SelfUtils.isMediaInactive = (previous, current) => {
   if (
     previous &&

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -652,6 +652,7 @@ describe('plugin-meetings', () => {
       let meetingInfo;
       let getInfosSpy;
       let getRolesSpy;
+      let isJoinedSpy;
 
       beforeEach('setup meeting info', () => {
         meetingInfo = {
@@ -662,11 +663,13 @@ describe('plugin-meetings', () => {
         };
         getInfosSpy = sinon.spy(InfoUtils, 'getInfos');
         getRolesSpy = sinon.spy(SelfUtils, 'getRoles');
+        isJoinedSpy = sinon.spy(SelfUtils, 'isJoined');
       });
 
       afterEach(() => {
         getRolesSpy.restore();
         getInfosSpy.restore();
+        isJoinedSpy.restore();
       });
 
       it('should trigger MEETING_LOCKED/UNLOCKED when meeting gets locked/unlocked', () => {
@@ -770,7 +773,7 @@ describe('plugin-meetings', () => {
         const parsedLocusInfo = cloneDeep(locusInfo.parsedLocus.info);
 
         locusInfo.updateMeetingInfo(initialInfo);
-
+        assert.calledWith(isJoinedSpy, locusInfo.parsedLocus.self);
         assert.neverCalledWith(getRolesSpy, self);
         assert.calledWith(
           getInfosSpy,

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/infoUtils.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/infoUtils.js
@@ -59,6 +59,22 @@ describe('plugin-meetings', () => {
           userDisplayHints: ['HINT_3']
         });
       });
+
+      it('only gives includes display hints when user has joined the meeting role', () => {
+        assert.deepEqual(InfoUtils.parse(info, ['MODERATOR'], false), {
+          policy: {HINT_3: true},
+          moderator: {HINT_1: true, HINT_2: true, LOWER_SOMEONE_ELSES_HAND: true},
+          coHost: {HINT_4: true, LOWER_SOMEONE_ELSES_HAND: true},
+          userDisplayHints: ['HINT_1', 'HINT_2', 'LOWER_SOMEONE_ELSES_HAND']
+        });
+
+        assert.deepEqual(InfoUtils.parse(info, ['MODERATOR'], true), {
+          policy: {HINT_3: true},
+          moderator: {HINT_1: true, HINT_2: true, LOWER_SOMEONE_ELSES_HAND: true},
+          coHost: {HINT_4: true, LOWER_SOMEONE_ELSES_HAND: true},
+          userDisplayHints: ['HINT_3', 'HINT_1', 'HINT_2', 'LOWER_SOMEONE_ELSES_HAND']
+        });
+      });
     });
 
     describe('parseDisplayHintsSection', () => {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
@@ -40,4 +40,24 @@ describe('plugin-meetings', () => {
       });
     });
   });
+
+  describe('isJoined', () => {
+    it(' returns true if state is joined', () => {
+      assert.deepEqual(SelfUtils.isJoined(self), true);
+    });
+
+    it(' returns true if state is not joined', () => {
+      const customSelf = {...self, state: 'NOT_JOINED'};
+
+      assert.deepEqual(SelfUtils.isJoined(customSelf), false);
+    });
+
+    it(' returns true if state is empty', () => {
+      const customSelf = {...self};
+
+      delete customSelf.state;
+
+      assert.deepEqual(SelfUtils.isJoined(customSelf), false);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-354097

This pull request addresses
< DESCRIBE THE CONTEXT OF THE ISSUE >
meeting display hints are set to true even when one has joined the meeting.

by making the following changes
< DESCRIBE YOUR CHANGES >
Added a check to see if participant is in the meeting.



### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
