### PR TITLE
feat(samples): sample app provide option to select the resolution & UI adjustments

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -199,6 +199,7 @@ function register() {
       toggleUnifiedMeetings.removeAttribute('disabled');
       unregisterElm.disabled = false;
       unregisterElm.classList.add('btn--red');
+      meetingsResolutionCheckInterval();
     })
     .catch((error) => {
       console.warn('Authentication#register() :: error registering', error);
@@ -388,7 +389,7 @@ meetingsListElm.onclick = (e) => {
     document.getElementById('btn-join').disabled = true;
     document.getElementById('btn-join-media').disabled = true;
   }
-  else if (meeting.passwordStatus === 'UNKNOWN') {
+  else if (meeting && meeting.passwordStatus === 'UNKNOWN') {
     meetingsJoinPinElm.disabled = true;
     verifyPasswordElm.disabled = true;
     document.getElementById('btn-join').disabled = true;
@@ -1255,33 +1256,33 @@ function clearMediaDeviceList() {
 
 function getLocalMediaSettings() {
   const meeting = getCurrentMeeting();
-  const videoSettings = meeting.mediaProperties.videoTrack.getSettings();
-
-  const {frameRate, height} = videoSettings;
-
-  localVideoResElm.innerText = `${height}p ${Math.round(frameRate)}fps`;
+  if(meeting && meeting.mediaProperties.videoTrack) {
+    const videoSettings = meeting.mediaProperties.videoTrack.getSettings();
+    const {frameRate, height} = videoSettings;
+    localVideoResElm.innerText = `${height}p ${Math.round(frameRate)}fps`;
+  }
 }
 
 function getRemoteMediaSettings() {
   const meeting = getCurrentMeeting();
-  const videoSettings = meeting.mediaProperties.remoteVideoTrack.getSettings();
-
-  const {frameRate, height} = videoSettings;
-
-  remoteVideoResElm.innerText = `${height}p ${Math.round(frameRate)}fps`;
+  if(meeting && meeting.mediaProperties.remoteVideoTrack){
+      const videoSettings = meeting.mediaProperties.remoteVideoTrack.getSettings();
+      const {frameRate, height} = videoSettings;
+      remoteVideoResElm.innerText = `${height}p ${Math.round(frameRate)}fps`;
+  }
 }
 
 let resolutionInterval;
 const INTERVAL_TIME = 3000;
 
-function startResolutionCheckInterval() {
+function meetingsResolutionCheckInterval() {
   resolutionInterval = setInterval(() => {
     getLocalMediaSettings();
     getRemoteMediaSettings();
   }, INTERVAL_TIME);
 }
 
-function clearResolutionCheckInterval() {
+function clearMeetingsResolutionCheckInterval() {
   localVideoResElm.innerText = '';
   remoteVideoResElm.innerText = '';
 
@@ -1330,8 +1331,6 @@ function addMedia() {
 
   // Wait for media in order to show video/share
   meeting.on('media:ready', (media) => {
-    startResolutionCheckInterval();
-
     // eslint-disable-next-line default-case
     switch (media.type) {
       case 'remoteVideo':
@@ -1352,7 +1351,7 @@ function addMedia() {
 
   // remove stream if media stopped
   meeting.on('media:stopped', (media) => {
-    clearResolutionCheckInterval();
+    clearMeetingsResolutionCheckInterval();
 
     // eslint-disable-next-line default-case
     switch (media.type) {
@@ -1385,7 +1384,7 @@ function changeLayout() {
 
   currentMeeting.changeVideoLayout(layoutVal, {main: {height, width}})
     .then(() => {
-      console.log('Remote Layout changed successfully');
+      console.log('Remote Video Layout changed successfully');
     })
     .catch((err) => {
       console.error(err);

--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -496,19 +496,21 @@
                 </div>
 
                 <fieldset>
-                  <legend>Set Resolution (Experimental)</legend>
-                  <select name="layout" id="layout-type">
-                    <option value="Single">Single</option>
-                    <option value="Equal" selected="selected">Equal</option>
-                    <option value="ActivePresence">Active Presence</option>
-                    <option value="Prominent">Prominent</option>
-                    <option value="OnePlusN">One+N</option>
-                  </select>
-                  <div class="flex u-mt u-mb" style="align-items: center; gap:10px">
-                    <label for="width">Width</label>
-                    <input type="number" name="width" id="layout-width" />
-                    <label for="height">Height</label>
-                    <input type="number" name='height' id="layout-height" />
+                  <legend>Set Resolution</legend>
+                  <div class="u-mv">
+                    <div class="flex" style="align-items: center; gap:10px">
+                      <select name="layout" id="layout-type">
+                        <option value="Single">Single</option>
+                        <option value="Equal" selected="selected">Equal</option>
+                        <option value="ActivePresence">Active Presence</option>
+                        <option value="Prominent">Prominent</option>
+                        <option value="OnePlusN">One+N</option>
+                      </select>
+                      <label for="width">Width</label>
+                      <input type="number" name="width" id="layout-width" />
+                      <label for="height">Height</label>
+                      <input type="number" name='height' id="layout-height" />
+                    </div>
                   </div>
                   <button type="submit" name="submit" id="layout-submit" onclick="changeLayout()">Submit</button>
                 </fieldset>

--- a/docs/samples/browser-plugin-meetings/style.css
+++ b/docs/samples/browser-plugin-meetings/style.css
@@ -223,6 +223,10 @@ button.btn-code {
   width: 23rem;
 }
 
+h2 {
+  color: #0052bf;
+}
+
 legend {
   font-size: 1.15rem;
   color: #1a73e8;
@@ -232,16 +236,13 @@ legend {
   position: relative;
 }
 
-.video-el {
-  height: 100%;
-  width: 100%;
-}
-
 .video-resolution {
   position: absolute;
-  right: 1rem;
-  top: 1rem;
+  left: 0.5rem;
+  top: 0.5rem;
   opacity: 0.75;
   user-select: none;
-  color: #20f020;
+  color: #083f88;
+  background-color: rgb(255 255 255);
+  padding: 0.3rem;
 }


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [#< SPARK-360345>](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-360345)

## This pull request addresses

Worked on Samples -
Added the height and width parameter to the remote screenShare layout - Removed
Some UI adjustment
Updating video element code for UI
show the current resolution and fps using the getSettings on the video track every 3 seconds

<img width="1711" alt="Screenshot 2022-09-15 at 8 01 55 PM" src="https://user-images.githubusercontent.com/3918217/190572374-a6d71832-4272-46eb-af5b-5ad2e0ecf059.png">
<img width="1309" alt="Screenshot 2022-09-15 at 8 01 19 PM" src="https://user-images.githubusercontent.com/3918217/190572382-d2e857b9-cb46-4c99-aad5-b7db6814b05e.png">
<img width="1315" alt="Screenshot 2022-09-15 at 8 00 55 PM" src="https://user-images.githubusercontent.com/3918217/190572387-2ca96d32-dba4-4087-8082-a35564dc278e.png">


## by making the following changes

< DESCRIBE YOUR CHANGES >

Changes in samples code - 
docs/samples/browser-plugin-meetings/app.js
docs/samples/browser-plugin-meetings/index.html

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.

### Open Question

- [x] Check with Edonus team about the status of what they support for renderInfo inside changeVideoLayout method, they support video need to check if they suppot content (remoteShare).
- [x] Testing with valid values

