### PR TITLE
fix: karma tests fail to start in a real browser

### DIFF
--- a/karma-ng.conf.js
+++ b/karma-ng.conf.js
@@ -68,10 +68,10 @@ function makeConfig(packageName, argv) {
     browserify: {
       debug: true,
       watch: argv && argv.karmaDebug,
-      extensions: ['.ts', '.js', '.json'],
+      extensions: ['.ts', '.js'],
       transform: [
         ['babelify', {
-          extensions: ['.ts', '.js', '.json'],
+          extensions: ['.ts', '.js'],
           global: true,
           ignore: ['node_modules'],
         }],


### PR DESCRIPTION
# COMPLETES #

no jira

## This pull request addresses

When running tests like this:
```
npm test -- --packages @webex/plugin-meetings --unit --browser --karma-debug --browsers chrome
```
I get the following errors:
```
15 09 2022 09:07:47.714:ERROR [framework.browserify]: bundle error
15 09 2022 09:07:47.714:ERROR [framework.browserify]: SyntaxError: /home/mawojtcz/my-build/webex-js-sdk2/packages/node_modules/@webex/plugin-meetings/test/unit/spec/locus-info/lib/BasicSeqCmp.json: Missing semicolon. (2:15)

  1 | {
> 2 |   "comparisons": {
    |                ^
  3 |     "test_equals01_rev": {
  4 |       "current": "test_equals01_b",
  5 |       "new": "test_equals01_a",
15 09 2022 09:07:47.715:WARN [karma]: No captured browser, open http://localhost:8001/
```

## by making the following changes

Fixed karma config.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
