### PR TITLE
fix: turn discovery - initial version (with console logs)

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/constants.ts
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.ts
@@ -754,9 +754,6 @@ export const PEER_CONNECTION_STATE = {
   FAILED: 'failed'
 };
 
-export const RTC_CONFIGURATION_FIREFOX = {iceServers: [], bundlePolicy: 'max-compat'};
-export const RTC_CONFIGURATION = {iceServers: []};
-
 export const RECONNECTION = {
   STATE: {
     IN_PROGRESS: 'IN_PROGRESS',
@@ -787,7 +784,9 @@ export const ROAP = {
     OK: 'OK',
     ERROR: 'ERROR',
     SHUTDOWN: 'SHUTDOWN',
-    OFFER_REQUEST: 'OFFER_REQUEST'
+    OFFER_REQUEST: 'OFFER_REQUEST',
+    TURN_DISCOVERY_REQUEST: 'TURN_DISCOVERY_REQUEST',
+    TURN_DISCOVERY_RESPONSE: 'TURN_DISCOVERY_RESPONSE',
   },
   ROAP_STATE: {
     INIT: 'INIT',

--- a/packages/node_modules/@webex/plugin-meetings/src/media/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/util.js
@@ -2,19 +2,30 @@
 import window from 'global/window';
 
 import BrowserDetection from '../common/browser-detection';
-import {
-  RTC_CONFIGURATION,
-  RTC_CONFIGURATION_FIREFOX
-} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
 
 const {isBrowser} = BrowserDetection();
 
 const MediaUtil = {};
 
-MediaUtil.createPeerConnection = () => new window.RTCPeerConnection(
-  isBrowser('firefox') ? RTC_CONFIGURATION_FIREFOX : RTC_CONFIGURATION
-);
+MediaUtil.createPeerConnection = (turnServerInfo) => {
+  const config = {iceServers: []};
+
+  if (turnServerInfo) {
+    config.iceServers.push({
+      urls: turnServerInfo.url,
+      username: turnServerInfo.username || '',
+      credential: turnServerInfo.password || ''
+    });
+  }
+  if (isBrowser('firefox')) {
+    config.bundlePolicy = 'max-compat';
+  }
+  console.log(`marcin: creating RTCPeerConnection with config: ${JSON.stringify(config)}`);
+
+  return new window.RTCPeerConnection(config);
+};
+
 
 MediaUtil.createMediaStream = (tracks) => {
   if (!tracks) {

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -4124,8 +4124,9 @@ export default class Meeting extends StatelessWebexPlugin {
     });
 
     return MeetingUtil.validateOptions(options)
-      .then(() => {
-        this.mediaProperties.setMediaPeerConnection(MediaUtil.createPeerConnection());
+      .then(() => this.roap.doTurnDiscovery({meeting: this, seq: this.roapSeq}))
+      .then((turnServerInfo) => {
+        this.mediaProperties.setMediaPeerConnection(MediaUtil.createPeerConnection(turnServerInfo));
         this.setMercuryListener();
         PeerConnectionManager.setPeerConnectionEvents(this);
 

--- a/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
@@ -26,7 +26,7 @@ import BEHAVIORAL_METRICS from '../metrics/constants';
 import {error, eventType} from '../metrics/config';
 import MediaError from '../common/errors/media';
 import ParameterError from '../common/errors/parameter';
-import {InvalidSdpError, IceGatheringFailed} from '../common/errors/webex-errors';
+import {InvalidSdpError} from '../common/errors/webex-errors';
 import BrowserDetection from '../common/browser-detection';
 
 import PeerConnectionUtils from './util';
@@ -227,8 +227,7 @@ pc.iceCandidate = (peerConnection, {remoteQualityLevel}) =>
     };
 
     peerConnection.onicecandidateerror = (event) => {
-      LoggerProxy.logger.error('PeerConnectionManager:index#onicecandidateerror --> Failed to gather ice candidate.', event);
-      reject(new IceGatheringFailed());
+      LoggerProxy.logger.error('PeerConnectionManager:index#onicecandidateerror --> ignoring ice error:', event);
     };
   });
 

--- a/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
@@ -327,6 +327,8 @@ pc.setRemoteSessionDetails = (
       sdp = sdp.replace(/\na=extmap.*/g, '');
     }
 
+    console.log('marcin: removing xtls candidates from the sdp...');
+    sdp = sdp.replace(/^a=candidate:.*xTLS.*\r\n/gim, '');
 
     return peerConnection.setRemoteDescription(
       new window.RTCSessionDescription({

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/index.js
@@ -394,7 +394,7 @@ export default class Roap extends StatelessWebexPlugin {
     console.log(`marcin: handling TURN_DISCOVERY_RESPONSE with headers=${JSON.stringify(headers)}`);
 
     const expectedHeaders = [
-      {headerName: 'x-cisco-turn-fqdn', field: 'url'},
+      {headerName: 'x-cisco-turn-url', field: 'url'},
       {headerName: 'x-cisco-turn-username', field: 'username'},
     ];
 
@@ -442,7 +442,6 @@ export default class Roap extends StatelessWebexPlugin {
 
     const roapMessage = {
       messageType: ROAP.ROAP_TYPES.TURN_DISCOVERY_REQUEST,
-      sdps: [],
       version: ROAP.ROAP_VERSION,
       seq,
     };
@@ -513,8 +512,14 @@ export default class Roap extends StatelessWebexPlugin {
         return {
           url: this.turnDiscovery.url,
           username: this.turnDiscovery.username,
-          password: this.turnDiscovery.username // todo: for now we use username as password
+          password: 'fwprTkcKDE', // todo: this is a temp hack until Linus gives us the password
         };
+      })
+      .catch((e) => {
+        // we catch any errors and resolve with no turn information so that the normal call join flow can continue without TURN
+        console.log('marcin: turn discovery failed:', e);
+
+        return Promise.resolve(undefined);
       });
   }
 }

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/index.js
@@ -1,4 +1,5 @@
 import {StatelessWebexPlugin} from '@webex/webex-core';
+import {Defer} from '@webex/common';
 
 import {ROAP} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
@@ -75,6 +76,13 @@ export default class Roap extends StatelessWebexPlugin {
      * @memberof Roap
      */
     this.lastRoapOffer = {};
+
+    this.turnDiscovery = {
+      defer: null,
+      url: undefined,
+      username: undefined,
+      password: undefined,
+    };
   }
 
   /**
@@ -89,11 +97,20 @@ export default class Roap extends StatelessWebexPlugin {
     const {correlationId} = data;
 
     LoggerProxy.logger.log(`Roap:index#roapEvent --> Received Roap Message [${JSON.stringify(msg, null, 2)}]`);
-    this.roapHandler.submit({
-      type: ROAP.RECEIVE_ROAP_MSG,
-      msg,
-      correlationId
-    });
+
+    console.log('marcin: roapEvent msq=', msg);
+    if (msg.messageType === ROAP.ROAP_TYPES.TURN_DISCOVERY_RESPONSE) {
+      // turn discovery is not part of normal roap protocol and so we are not handling it
+      // through the usual roap statemachine
+      this.handleTurnDiscoveryResponse(msg);
+    }
+    else {
+      this.roapHandler.submit({
+        type: ROAP.RECEIVE_ROAP_MSG,
+        msg,
+        correlationId
+      });
+    }
   }
 
   /**
@@ -346,5 +363,158 @@ export default class Roap extends StatelessWebexPlugin {
     if (!RoapCollection.isBusy(correlationId)) {
       meeting.processNextQueuedMediaUpdate();
     }
+  }
+
+  /**
+   * waits for turn discovery response
+   * @returns {Promise}
+   * @private
+   * @memberof Roap
+   */
+  waitForTurnDiscoveryResponse() {
+    console.log('marcin: waiting for turn discovery response');
+    if (this.turnDiscovery.defer === null) {
+      LoggerProxy.logger.warn('Roap:index#waitForTurnDiscoveryResponse --> TURN discovery is not in progress');
+    }
+
+    return this.turnDiscovery.defer.promise;
+  }
+
+  /**
+   * handles turn discovery response roap message
+   * @returns {void}
+   * @public
+   * @memberof Roap
+   */
+  handleTurnDiscoveryResponse({headers}) {
+    if (this.turnDiscovery.defer === null) {
+      LoggerProxy.logger.warn('Roap:index#handleTurnDiscoveryResponse --> unexpected TURN discovery response');
+    }
+
+    console.log(`marcin: handling TURN_DISCOVERY_RESPONSE with headers=${JSON.stringify(headers)}`);
+
+    const expectedHeaders = [
+      {headerName: 'x-cisco-turn-fqdn', field: 'url'},
+      {headerName: 'x-cisco-turn-username', field: 'username'},
+    ];
+
+    let foundHeaders = 0;
+
+    headers.forEach((receivedHeader) => {
+      // check if it matches any of our expected headers
+      expectedHeaders.forEach((expectedHeader) => {
+        if (receivedHeader.startsWith(`${expectedHeader.headerName}=`)) {
+          this.turnDiscovery[expectedHeader.field] = receivedHeader.substring(expectedHeader.headerName.length + 1);
+          foundHeaders += 1;
+        }
+      });
+    });
+
+    if (foundHeaders !== expectedHeaders.length) {
+      LoggerProxy.logger.warn(`Roap:index#handleTurnDiscoveryResponse --> missing some headers, received: ${JSON.stringify(headers)}`);
+      this.turnDiscovery.defer.reject(new Error('missing some headers in turn discovery response'));
+    }
+    else {
+      console.log('marcin: happy with the response ');
+      this.turnDiscovery.defer.resolve();
+    }
+  }
+
+  /**
+   * sends a roap media request
+   * @param {RoapOptions} options
+   * @returns {Promise}
+   * @private
+   * @memberof Roap
+   */
+  sendRoapTurnDiscoveryRequest(options) {
+    const {
+      meeting,
+    } = options;
+
+    const seq = options.seq + 1;
+
+    if (this.turnDiscovery.defer) {
+      LoggerProxy.logger.warn('Roap:index#sendRoapTurnDiscoveryRequest --> already in progress');
+    }
+
+    this.turnDiscovery.defer = new Defer();
+
+    const roapMessage = {
+      messageType: ROAP.ROAP_TYPES.TURN_DISCOVERY_REQUEST,
+      sdps: [],
+      version: ROAP.ROAP_VERSION,
+      seq,
+    };
+
+    console.log(`marcin: sending TURN_DISCOVERY_REQUEST with seq=${seq}`);
+
+    return this.roapRequest
+      .sendRoap({
+        roapMessage,
+        correlationId: meeting.correlationId,
+        locusSelfUrl: meeting.selfUrl,
+        mediaId: meeting.mediaId,
+        audioMuted: meeting.isAudioMuted(),
+        videoMuted: meeting.isVideoMuted(),
+        meetingId: meeting.id
+      })
+      .then(() => {
+        meeting.setRoapSeq(seq);
+      });
+    // todo: code that sends roap offer was also doing this: (not sure if we need it here)
+    // .then(({locus, mediaConnections}) => {
+    //   if (mediaConnections) {
+    //     meeting.updateMediaConnections(mediaConnections);
+    //   }
+    //   return locus;
+    // });
+  }
+
+  /**
+   * Retrieves TURN server information from the backend by doing
+   * a roap message exchange:
+   * TURN_DISCOVERY_REQUEST, TURN_DISCOVERY_RESPONSE, OK
+   *
+   * @param {*} options
+   * @returns {Promise}
+   */
+  doTurnDiscovery(options) {
+    console.log('marcin: starting turn discovery');
+    const {
+      meeting,
+    } = options;
+
+    return this.sendRoapTurnDiscoveryRequest(options)
+      .then(() => this.waitForTurnDiscoveryResponse())
+      .then(() => {
+        console.log('marcin: sending turn discovery OK');
+
+        return this.roapRequest
+          .sendRoap({
+            roapMessage: {
+              messageType: ROAP.ROAP_TYPES.OK,
+              version: ROAP.ROAP_VERSION,
+              seq: meeting.roapSeq
+            },
+            locusSelfUrl: meeting.selfUrl,
+            mediaId: meeting.mediaId,
+            correlationId: meeting.correlationId,
+            audioMuted: meeting.isAudioMuted(),
+            videoMuted: meeting.isVideoMuted(),
+            meetingId: meeting.id
+          });
+      })
+      .then(() => {
+        this.turnDiscovery.defer = null;
+
+        console.log(`marcin: turn discovery done: url=${this.turnDiscovery.url}, username=${this.turnDiscovery.username} password=${this.turnDiscovery.password}`);
+
+        return {
+          url: this.turnDiscovery.url,
+          username: this.turnDiscovery.username,
+          password: this.turnDiscovery.username // todo: for now we use username as password
+        };
+      });
   }
 }


### PR DESCRIPTION
This PR contains changes for e2e testing with Linus for the "TURN TLS" feature.

When adding media, first we are doing this new flow:
1. Send a TURN_DISCOVERY_REQUEST roap message
2. Wait for TURN_DISCOVERY_RESPONSE roap message
3. Parse the headers from the response to get the TURN url, username, password
4. Send OK roap message 
Then create RTCPeerConnection as usual, but with the obtained TURN server information in the config.

Additional change: 
We also ignore ice candidate errors, because we can get them when TURN server doesn't reply correctly and that should not stop the connection attempt.

PR contains console logs starting with "marcin:" for easier debugging.