### PR TITLE
send full hd

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -1191,15 +1191,23 @@ async function stopScreenShare() {
   }
 }
 
+function updateLocalVideoStream(localStream) {
+  const [currLocalStream, currLocalShare] = currentMediaStreams;
+  currentMediaStreams = [localStream || currLocalStream, currLocalShare];
+
+  meetingStreamsLocalVideo.srcObject = new MediaStream(localStream.getVideoTracks());
+  meetingStreamsLocalAudio.srcObject = new MediaStream(localStream.getAudioTracks());
+}
+
 function setLocalMeetingQuality() {
   const meeting = getCurrentMeeting();
   const level = localResolutionInp.value;
 
   meeting.setLocalVideoQuality(level)
-    .then(() => {
+    .then((localStream) => {
       toggleSourcesQualityStatus.innerText = `Local meeting quality level set to ${level}!`;
+      updateLocalVideoStream(localStream)
       console.log('MeetingControls#setLocalMeetingQuality() :: Meeting quality level set successfully!');
-
       getLocalMediaSettings();
     })
     .catch((error) => {

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -2657,6 +2657,15 @@ export default class Meeting extends StatelessWebexPlugin {
         aspectRatio, frameRate, height, width, deviceId
       } = videoTrack.getSettings();
 
+      const {localQualityLevel} = this.mediaProperties;
+
+      if (Number(localQualityLevel.slice(0, -1)) > height) {
+        LoggerProxy.logger.error(`Meeting:index#setLocalVideoTrack --> Local video quality of ${localQualityLevel} not supported,
+         downscaling to highest possible resolution of ${height}p`);
+
+        this.mediaProperties.setLocalQualityLevel(`${height}p`);
+      }
+
       this.mediaProperties.setLocalVideoTrack(videoTrack);
       if (this.video) this.video.applyClientStateLocally(this);
 
@@ -5257,7 +5266,7 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * Sets the quality of the local video stream
    * @param {String} level {LOW|MEDIUM|HIGH}
-   * @returns {Promise}
+   * @returns {Promise<MediaStream>} localStream
    */
   setLocalVideoQuality(level) {
     LoggerProxy.logger.log(`Meeting:index#setLocalVideoQuality --> Setting quality to ${level}`);
@@ -5286,13 +5295,22 @@ export default class Meeting extends StatelessWebexPlugin {
       sendShare: this.mediaProperties.mediaDirection.sendShare
     };
 
+    // When changing local video quality level
+    // Need to stop current track first as chrome doesn't support resolution upscaling(for eg. changing 480p to 720p)
+    // Without feeding it a new track
+    // open bug link: https://bugs.chromium.org/p/chromium/issues/detail?id=943469
+    if (isBrowser('chrome') && this.mediaProperties.videoTrack) Media.stopTracks(this.mediaProperties.videoTrack);
+
     return this.getMediaStreams(mediaDirection, VIDEO_RESOLUTIONS[level])
-      .then(([localStream]) =>
-        this.updateVideo({
+      .then(async ([localStream]) => {
+        await this.updateVideo({
           sendVideo: true,
           receiveVideo: true,
           stream: localStream
-        }));
+        });
+
+        return localStream;
+      });
   }
 
   /**

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2109,11 +2109,18 @@ describe('plugin-meetings', () => {
       describe('#setLocalVideoQuality', () => {
         let mediaDirection;
 
+        const fakeTrack = {getSettings: () => ({height: 720})};
+        const USER_AGENT_CHROME_MAC =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36';
+
         beforeEach(() => {
           mediaDirection = {sendAudio: true, sendVideo: true, sendShare: false};
           meeting.getMediaStreams = sinon.stub().returns(Promise.resolve([]));
-          meeting.updateVideo = sinon.stub().returns(Promise.resolve());
           meeting.mediaProperties.mediaDirection = mediaDirection;
+          meeting.canUpdateMedia = sinon.stub().returns(true);
+          MeetingUtil.validateOptions = sinon.stub().returns(Promise.resolve());
+          MeetingUtil.updateTransceiver = sinon.stub().returns(Promise.resolve());
         });
 
         it('should have #setLocalVideoQuality', () => {
@@ -2121,14 +2128,34 @@ describe('plugin-meetings', () => {
         });
 
         it('should call getMediaStreams with the proper level', () => meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
+          delete mediaDirection.receiveVideo;
           assert.calledWith(meeting.getMediaStreams,
             mediaDirection,
             CONSTANTS.VIDEO_RESOLUTIONS[CONSTANTS.QUALITY_LEVELS.LOW]);
         }));
 
+        it('when browser is chrome then it should stop previous video track', () => {
+          meeting.mediaProperties.videoTrack = fakeTrack;
+          assert.equal(
+            BrowserDetection(USER_AGENT_CHROME_MAC).getBrowserName(),
+            'Chrome'
+          );
+          meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS.LOW)
+            .then(() => {
+              assert.calledWith(Media.stopTracks, fakeTrack);
+            });
+        });
+
         it('should set mediaProperty with the proper level', () => meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
           assert.equal(meeting.mediaProperties.localQualityLevel, CONSTANTS.QUALITY_LEVELS.LOW);
         }));
+
+        it('when device does not support 1080p then it should set localQualityLevel with highest possible resolution', () => {
+          meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS['1080p'])
+            .then(() => {
+              assert.equal(meeting.mediaProperties.localQualityLevel, CONSTANTS.QUALITY_LEVELS['720p']);
+            });
+        });
 
         it('should error if set to a invalid level', () => {
           assert.isRejected(meeting.setLocalVideoQuality('invalid'));


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-351407](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-351407) >

## This pull request addresses

This change is for sending FULL HD i.e. 1080p video(local video).

## by making the following changes

1. Updated samples app.js to accomodate new FULL HD track when user selects local resolution as 1080p.
2. Updated `setLocalVideoQuality` of meeting to check if browser is chrome then stop the current track(open [bug link](https://bugs.chromium.org/p/chromium/issues/detail?id=943469)) and sets local resolution to 1080p.
3. Checked the behaviour on all 3 browsers i.e. Chrome, Safari and firefox.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
