### PR TITLE
fix(guest join): send keepalives when in lobby

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -888,6 +888,15 @@ export default class Meeting extends StatelessWebexPlugin {
      */
     this.meetingInfoFailureReason = undefined;
 
+    /**
+     * Repeating timer used to send keepAlives when in lobby
+     * @instance
+     * @type {String}
+     * @private
+     * @memberof Meeting
+     */
+    this.keepAliveTimerId = null;
+
     this.setUpLocusInfoListeners();
     this.locusInfo.init(attrs.locus ? attrs.locus : {});
     this.hasJoinedOnce = false;
@@ -1989,6 +1998,8 @@ export default class Meeting extends StatelessWebexPlugin {
     });
     this.locusInfo.on(LOCUSINFO.EVENTS.SELF_UNADMITTED_GUEST, (payload) => {
       if (payload) {
+        this.startKeepAlive();
+
         Trigger.trigger(
           this,
           {
@@ -2008,6 +2019,8 @@ export default class Meeting extends StatelessWebexPlugin {
       }
     });
     this.locusInfo.on(LOCUSINFO.EVENTS.SELF_ADMITTED_GUEST, (payload) => {
+      this.stopKeepAlive();
+
       if (payload) {
         Trigger.trigger(
           this,
@@ -5902,4 +5915,59 @@ export default class Meeting extends StatelessWebexPlugin {
       failure: `${LOG_HEADER} disable bnr failure, `
     });
   }
+
+  /**
+   * starts keepAlives being sent
+   * @returns {void}
+   * @private
+   * @memberof Meeting
+   */
+  startKeepAlive = () => {
+    if (this.keepAliveTimerId) {
+      LoggerProxy.logger.warn('Meeting:index#startKeepAlive --> keepAlive not started: keepAliveTimerId already exists');
+
+      return;
+    }
+    if (!this.joinedWith?.keepAliveUrl) {
+      LoggerProxy.logger.warn('Meeting:index#startKeepAlive --> keepAlive not started: no keepAliveUrl');
+
+      return;
+    }
+    if (!this.joinedWith?.keepAliveSecs) {
+      LoggerProxy.logger.warn('Meeting:index#startKeepAlive --> keepAlive not started: no keepAliveSecs');
+
+      return;
+    }
+    if (this.joinedWith.keepAliveSecs <= 1) {
+      LoggerProxy.logger.warn('Meeting:index#startKeepAlive --> keepAlive not started: keepAliveSecs <= 1');
+
+      return;
+    }
+    const {keepAliveUrl} = this.joinedWith;
+    const keepAliveInterval = (this.joinedWith.keepAliveSecs - 1) * 750; // taken from UCF
+
+    this.keepAliveTimerId = setInterval(() => {
+      this.meetingRequest.keepAlive({keepAliveUrl})
+        .catch((error) => {
+          LoggerProxy.logger.warn(
+            `Meeting:index#startKeepAlive --> Stopping sending keepAlives to ${keepAliveUrl} after error ${error}`
+          );
+          this.stopKeepAlive();
+        });
+    }, keepAliveInterval);
+  };
+
+  /**
+   * stops keepAlives being sent
+   * @returns {void}
+   * @private
+   * @memberof Meeting
+   */
+  stopKeepAlive = () => {
+    if (!this.keepAliveTimerId) {
+      return;
+    }
+    clearInterval(this.keepAliveTimerId);
+    this.keepAliveTimerId = null;
+  };
 }

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
@@ -665,4 +665,19 @@ export default class MeetingRequest extends StatelessWebexPlugin {
       uri
     });
   }
+
+  /**
+   * Send a locus keepAlive (used in lobby)
+   * @param {Object} options
+   * @param {Url} options.keepAliveUrl
+   * @returns {Promise}
+   */
+  keepAlive({
+    keepAliveUrl,
+  }) {
+    return this.request({
+      method: HTTP_VERBS.GET,
+      uri: keepAliveUrl
+    });
+  }
 }

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -130,7 +130,8 @@ MeetingUtil.cleanUp = (meeting) => {
       meeting.unsetPeerConnections();
       meeting.reconnectionManager.cleanUp();
     })
-    .then(() => meeting.roap.stop(meeting.correlationId, meeting.roapSeq));
+    .then(() => meeting.roap.stop(meeting.correlationId, meeting.roapSeq))
+    .then(() => meeting.stopKeepAlive());
 };
 
 MeetingUtil.disconnectPhoneAudio = (meeting, phoneUrl) => {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -3227,7 +3227,9 @@ describe('plugin-meetings', () => {
       });
       describe('#setUpLocusInfoSelfListener', () => {
         it('listens to the self unadmitted guest event', (done) => {
+          meeting.startKeepAlive = sinon.stub();
           meeting.locusInfo.emit({function: 'test', file: 'test'}, 'SELF_UNADMITTED_GUEST', test1);
+          assert.calledOnceWithExactly(meeting.startKeepAlive);
           assert.calledTwice(TriggerProxy.trigger);
           assert.calledWith(
             TriggerProxy.trigger,
@@ -3239,7 +3241,9 @@ describe('plugin-meetings', () => {
           done();
         });
         it('listens to the self admitted guest event', (done) => {
+          meeting.stopKeepAlive = sinon.stub();
           meeting.locusInfo.emit({function: 'test', file: 'test'}, 'SELF_ADMITTED_GUEST', test1);
+          assert.calledOnceWithExactly(meeting.stopKeepAlive);
           assert.calledTwice(TriggerProxy.trigger);
           assert.calledWith(
             TriggerProxy.trigger,
@@ -4326,6 +4330,157 @@ describe('plugin-meetings', () => {
               payloadTestHelper([data1, data2, data3]);
             });
           });
+        });
+      });
+
+      describe('#startKeepAlive', () => {
+        let clock;
+        const defaultKeepAliveUrl = 'keep.alive.url';
+        const defaultKeepAliveSecs = 23;
+        const defaultExpectedInterval = (defaultKeepAliveSecs - 1) * 750;
+
+        beforeEach(() => {
+          clock = sinon.useFakeTimers();
+        });
+        afterEach(() => {
+          clock.restore();
+        });
+
+        const progressTime = async (interval) => {
+          await clock.tickAsync(interval);
+          await testUtils.flushPromises();
+        };
+
+        it('startKeepAlive starts the keep alive', async () => {
+          meeting.meetingRequest.keepAlive = sinon.stub().returns(Promise.resolve());
+
+          assert.isNull(meeting.keepAliveTimerId);
+          meeting.joinedWith = {
+            keepAliveUrl: defaultKeepAliveUrl,
+            keepAliveSecs: defaultKeepAliveSecs
+          };
+          meeting.startKeepAlive();
+          assert.isNumber(meeting.keepAliveTimerId.id);
+          await testUtils.flushPromises();
+          assert.notCalled(meeting.meetingRequest.keepAlive);
+          await progressTime(defaultExpectedInterval);
+          assert.calledOnceWithExactly(meeting.meetingRequest.keepAlive, {keepAliveUrl: defaultKeepAliveUrl});
+          await progressTime(defaultExpectedInterval);
+          assert.calledTwice(meeting.meetingRequest.keepAlive);
+          assert.alwaysCalledWithExactly(meeting.meetingRequest.keepAlive, {keepAliveUrl: defaultKeepAliveUrl});
+        });
+        it('startKeepAlive handles existing keepAliveTimerId', async () => {
+          meeting.meetingRequest.keepAlive = sinon.stub().returns(Promise.resolve());
+          logger.warn = sinon.spy();
+
+          meeting.keepAliveTimerId = 7;
+          meeting.joinedWith = {
+            keepAliveUrl: defaultKeepAliveUrl,
+            keepAliveSecs: defaultKeepAliveSecs
+          };
+          meeting.startKeepAlive();
+          assert.equal(meeting.keepAliveTimerId, 7);
+          await progressTime(defaultExpectedInterval);
+          assert.notCalled(meeting.meetingRequest.keepAlive);
+        });
+        it('startKeepAlive handles missing keepAliveUrl', async () => {
+          meeting.meetingRequest.keepAlive = sinon.stub().returns(Promise.resolve());
+          logger.warn = sinon.spy();
+
+          assert.isNull(meeting.keepAliveTimerId);
+          meeting.joinedWith = {
+            keepAliveSecs: defaultKeepAliveSecs
+          };
+          meeting.startKeepAlive();
+          assert.isNull(meeting.keepAliveTimerId);
+          await progressTime(defaultExpectedInterval);
+          assert.notCalled(meeting.meetingRequest.keepAlive);
+        });
+        it('startKeepAlive handles missing keepAliveSecs', async () => {
+          meeting.meetingRequest.keepAlive = sinon.stub().returns(Promise.resolve());
+          logger.warn = sinon.spy();
+
+          assert.isNull(meeting.keepAliveTimerId);
+          meeting.joinedWith = {
+            keepAliveUrl: defaultKeepAliveUrl
+          };
+          meeting.startKeepAlive();
+          assert.isNull(meeting.keepAliveTimerId);
+          await progressTime(1);
+          assert.notCalled(meeting.meetingRequest.keepAlive);
+        });
+        it('startKeepAlive handles too low keepAliveSecs', async () => {
+          meeting.meetingRequest.keepAlive = sinon.stub().returns(Promise.resolve());
+          logger.warn = sinon.spy();
+
+          assert.isNull(meeting.keepAliveTimerId);
+          meeting.joinedWith = {
+            keepAliveUrl: defaultKeepAliveUrl,
+            keepAliveSecs: 1
+          };
+          meeting.startKeepAlive();
+          assert.isNull(meeting.keepAliveTimerId);
+          await progressTime(1);
+          assert.notCalled(meeting.meetingRequest.keepAlive);
+        });
+        it('failed keepAlive stops the keep alives', async () => {
+          meeting.meetingRequest.keepAlive = sinon.stub().returns(Promise.reject());
+
+          assert.isNull(meeting.keepAliveTimerId);
+          meeting.joinedWith = {
+            keepAliveUrl: defaultKeepAliveUrl,
+            keepAliveSecs: defaultKeepAliveSecs
+          };
+          meeting.startKeepAlive();
+          assert.isNumber(meeting.keepAliveTimerId.id);
+          await testUtils.flushPromises();
+          assert.notCalled(meeting.meetingRequest.keepAlive);
+          await progressTime(defaultExpectedInterval);
+          assert.calledOnceWithExactly(meeting.meetingRequest.keepAlive, {keepAliveUrl: defaultKeepAliveUrl});
+          assert.isNull(meeting.keepAliveTimerId);
+          await progressTime(defaultExpectedInterval);
+          assert.calledOnce(meeting.meetingRequest.keepAlive);
+        });
+      });
+      describe('#stopKeepAlive', () => {
+        let clock;
+        const defaultKeepAliveUrl = 'keep.alive.url';
+        const defaultKeepAliveSecs = 23;
+        const defaultExpectedInterval = (defaultKeepAliveSecs - 1) * 750;
+
+        beforeEach(() => {
+          clock = sinon.useFakeTimers();
+        });
+        afterEach(() => {
+          clock.restore();
+        });
+
+        const progressTime = async (interval) => {
+          await clock.tickAsync(interval);
+          await testUtils.flushPromises();
+        };
+
+        it('stopKeepAlive stops the keep alive', async () => {
+          meeting.meetingRequest.keepAlive = sinon.stub().returns(Promise.resolve());
+
+          assert.isNull(meeting.keepAliveTimerId);
+          meeting.joinedWith = {
+            keepAliveUrl: defaultKeepAliveUrl,
+            keepAliveSecs: defaultKeepAliveSecs
+          };
+          meeting.startKeepAlive();
+          assert.isNumber(meeting.keepAliveTimerId.id);
+          await progressTime(defaultExpectedInterval);
+          assert.calledOnceWithExactly(meeting.meetingRequest.keepAlive, {keepAliveUrl: defaultKeepAliveUrl});
+
+          meeting.stopKeepAlive();
+          assert.isNull(meeting.keepAliveTimerId);
+          await progressTime(defaultExpectedInterval);
+          assert.calledOnce(meeting.meetingRequest.keepAlive);
+        });
+        it('stopKeepAlive handles missing keepAliveTimerId', async () => {
+          assert.isNull(meeting.keepAliveTimerId);
+          meeting.stopKeepAlive();
         });
       });
     });

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/request.js
@@ -264,5 +264,19 @@ describe('plugin-meetings', () => {
         assert.equal(requestParams.uri, `${locusUrl}/end`);
       });
     });
+
+    describe('#keepAlive', () => {
+      it('sends request to keepAlive', async () => {
+        const keepAliveUrl = 'keepAliveURL';
+
+        await meetingsRequest.keepAlive({
+          keepAliveUrl,
+        });
+        const requestParams = meetingsRequest.request.getCall(0).args[0];
+
+        assert.equal(requestParams.method, 'GET');
+        assert.equal(requestParams.uri, keepAliveUrl);
+      });
+    });
   });
 });

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -43,6 +43,7 @@ describe('plugin-meetings', () => {
       meeting.unsetPeerConnections = sinon.stub();
       meeting.reconnectionManager = {cleanUp: sinon.stub()};
       meeting.roap = {stop: sinon.stub()};
+      meeting.stopKeepAlive = sinon.stub();
     });
 
     afterEach(() => {
@@ -64,6 +65,7 @@ describe('plugin-meetings', () => {
         assert.calledOnce(meeting.unsetPeerConnections);
         assert.calledOnce(meeting.reconnectionManager.cleanUp);
         assert.calledOnce(meeting.roap.stop);
+        assert.calledOnce(meeting.stopKeepAlive);
       });
     });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-362664

## This pull request addresses

When in the meeting lobby, we aren't sending or receiving media, which causes the call to timeout. We should be sending locus keepAlives to keep the call alive.

## by making the following changes

I have added a repeating timer to send locus keepAlives, based on the thick client code https://sqbu-github.cisco.com/WebExSquared/spark-client-framework/blob/71d7176dd4591e92859c06c4ee6e3198ee162455/spark-client-framework/Services/TelephonyService/LocusManager.cpp#L2629

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
