### PR TITLE
feat(plugin-meetings): added support for TURN discovery (under a config flag)

### DIFF
--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -39,6 +39,13 @@
                 <label for="enable-fedramp">Enable Fedramp</label>
               </div>
 
+              <div>
+                <legend>Meetings</legend>
+                <input type="checkbox" id="enable-turn-discovery">
+                <label for="enable-turn-discovery">Enable TURN discovery (experimental)</label>
+              </div>
+
+
               <form id="credentials">
                 <p class="note">
                   NOTE: Click <a href="https://developer.webex.com/docs/getting-started" target="_blank">here</a> for access token

--- a/packages/node_modules/@webex/plugin-meetings/src/common/errors/webex-errors.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/common/errors/webex-errors.js
@@ -119,7 +119,6 @@ class InvalidSdpError extends WebexMeetingsError {
 export {InvalidSdpError};
 WebExMeetingsErrors[InvalidSdpError.CODE] = InvalidSdpError;
 
-
 /**
  * @class IceGatheringFailed
  * @classdesc Raised whenever ice gathering fails.

--- a/packages/node_modules/@webex/plugin-meetings/src/common/logs/logger-proxy.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/common/logs/logger-proxy.js
@@ -1,13 +1,14 @@
+/* eslint-disable no-unused-vars */
 import LoggerConfig from './logger-config';
 
 const LoggerProxy = {
   logger: {
-    info: () => { console.error('LoggerProxy->info#NO LOGGER DEFINED'); },
-    log: () => { console.error('LoggerProxy->log#NO LOGGER DEFINED'); },
-    error: () => { console.error('LoggerProxy->error#NO LOGGER DEFINED'); },
-    warn: () => { console.error('LoggerProxy->warn#NO LOGGER DEFINED'); },
-    trace: () => { console.error('LoggerProxy->trace#NO LOGGER DEFINED'); },
-    debug: () => { console.error('LoggerProxy->debug#NO LOGGER DEFINED'); }
+    info: (args) => { console.error('LoggerProxy->info#NO LOGGER DEFINED'); },
+    log: (args) => { console.error('LoggerProxy->log#NO LOGGER DEFINED'); },
+    error: (args) => { console.error('LoggerProxy->error#NO LOGGER DEFINED'); },
+    warn: (args) => { console.error('LoggerProxy->warn#NO LOGGER DEFINED'); },
+    trace: (args) => { console.error('LoggerProxy->trace#NO LOGGER DEFINED'); },
+    debug: (args) => { console.error('LoggerProxy->debug#NO LOGGER DEFINED'); }
   }
 };
 

--- a/packages/node_modules/@webex/plugin-meetings/src/config.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/config.js
@@ -90,7 +90,8 @@ export default {
     experimental: {
       enableMediaNegotiatedEvent: false,
       enableUnifiedMeetings: false,
-      enableAdhocMeetings: false
+      enableAdhocMeetings: false,
+      enableTurnDiscovery: false,
     }
   }
 };

--- a/packages/node_modules/@webex/plugin-meetings/src/constants.ts
+++ b/packages/node_modules/@webex/plugin-meetings/src/constants.ts
@@ -754,9 +754,6 @@ export const PEER_CONNECTION_STATE = {
   FAILED: 'failed'
 };
 
-export const RTC_CONFIGURATION_FIREFOX = {iceServers: [], bundlePolicy: 'max-compat'};
-export const RTC_CONFIGURATION = {iceServers: []};
-
 export const RECONNECTION = {
   STATE: {
     IN_PROGRESS: 'IN_PROGRESS',
@@ -787,7 +784,9 @@ export const ROAP = {
     OK: 'OK',
     ERROR: 'ERROR',
     SHUTDOWN: 'SHUTDOWN',
-    OFFER_REQUEST: 'OFFER_REQUEST'
+    OFFER_REQUEST: 'OFFER_REQUEST',
+    TURN_DISCOVERY_REQUEST: 'TURN_DISCOVERY_REQUEST',
+    TURN_DISCOVERY_RESPONSE: 'TURN_DISCOVERY_RESPONSE',
   },
   ROAP_STATE: {
     INIT: 'INIT',

--- a/packages/node_modules/@webex/plugin-meetings/src/media/properties.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/properties.js
@@ -107,7 +107,7 @@ export default class MediaProperties {
   }
 
   reInitiatePeerconnection() {
-    this.peerConnection = MediaUtil.createPeerConnection();
+    this.peerConnection = MediaUtil.createPeerConnection(); // todo:
   }
 
   unsetLocalVideoTrack() {

--- a/packages/node_modules/@webex/plugin-meetings/src/media/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/media/util.js
@@ -2,19 +2,29 @@
 import window from 'global/window';
 
 import BrowserDetection from '../common/browser-detection';
-import {
-  RTC_CONFIGURATION,
-  RTC_CONFIGURATION_FIREFOX
-} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
 
 const {isBrowser} = BrowserDetection();
 
 const MediaUtil = {};
 
-MediaUtil.createPeerConnection = () => new window.RTCPeerConnection(
-  isBrowser('firefox') ? RTC_CONFIGURATION_FIREFOX : RTC_CONFIGURATION
-);
+MediaUtil.createPeerConnection = (turnServerInfo) => {
+  const config = {iceServers: []};
+
+  if (turnServerInfo) {
+    config.iceServers.push({
+      urls: turnServerInfo.url,
+      username: turnServerInfo.username || '',
+      credential: turnServerInfo.password || ''
+    });
+  }
+  if (isBrowser('firefox')) {
+    config.bundlePolicy = 'max-compat';
+  }
+
+  return new window.RTCPeerConnection(config);
+};
+
 
 MediaUtil.createMediaStream = (tracks) => {
   if (!tracks) {

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -4124,8 +4124,9 @@ export default class Meeting extends StatelessWebexPlugin {
     });
 
     return MeetingUtil.validateOptions(options)
-      .then(() => {
-        this.mediaProperties.setMediaPeerConnection(MediaUtil.createPeerConnection());
+      .then(() => this.roap.doTurnDiscovery(this))
+      .then((turnServerInfo) => {
+        this.mediaProperties.setMediaPeerConnection(MediaUtil.createPeerConnection(turnServerInfo));
         this.setMercuryListener();
         PeerConnectionManager.setPeerConnectionEvents(this);
 

--- a/packages/node_modules/@webex/plugin-meetings/src/metrics/constants.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/metrics/constants.js
@@ -55,7 +55,8 @@ const BEHAVIORAL_METRICS = {
   MOVE_TO_SUCCESS: 'js_sdk_move_to_success',
   MOVE_TO_FAILURE: 'js_sdk_move_to_failure',
   MOVE_FROM_SUCCESS: 'js_sdk_move_from_success',
-  MOVE_FROM_FAILURE: 'js_sdk_move_from_failure'
+  MOVE_FROM_FAILURE: 'js_sdk_move_from_failure',
+  TURN_DISCOVERY_FAILURE: 'js_sdk_turn_discovery_failure',
 };
 
 

--- a/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/peer-connection-manager/index.js
@@ -26,7 +26,7 @@ import BEHAVIORAL_METRICS from '../metrics/constants';
 import {error, eventType} from '../metrics/config';
 import MediaError from '../common/errors/media';
 import ParameterError from '../common/errors/parameter';
-import {InvalidSdpError, IceGatheringFailed} from '../common/errors/webex-errors';
+import {InvalidSdpError} from '../common/errors/webex-errors';
 import BrowserDetection from '../common/browser-detection';
 
 import PeerConnectionUtils from './util';
@@ -227,8 +227,9 @@ pc.iceCandidate = (peerConnection, {remoteQualityLevel}) =>
     };
 
     peerConnection.onicecandidateerror = (event) => {
-      LoggerProxy.logger.error('PeerConnectionManager:index#onicecandidateerror --> Failed to gather ice candidate.', event);
-      reject(new IceGatheringFailed());
+      // we can often get ICE candidate errors (for example when failing to communicate with a TURN server)
+      // they don't mean that the whole ICE connection will fail, so it's OK to ignore them
+      LoggerProxy.logger.error('PeerConnectionManager:index#onicecandidateerror --> ignoring ice error:', event);
     };
   });
 
@@ -328,6 +329,8 @@ pc.setRemoteSessionDetails = (
       sdp = sdp.replace(/\na=extmap.*/g, '');
     }
 
+    // remove any xtls candidates
+    sdp = sdp.replace(/^a=candidate:.*xTLS.*\r\n/gim, '');
 
     return peerConnection.setRemoteDescription(
       new window.RTCSessionDescription({

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/handler.js
@@ -102,8 +102,6 @@ export default class RoapHandler extends StatelessWebexPlugin {
           RoapUtil.updatePeerConnection(meeting, session)
             .then((answerSdps) => {
               this.roapAnswer({
-                locusId: meeting.locusId,
-                locusSelfId: meeting.locusInfo.self.id,
                 mediaId: meeting.mediaId,
                 sdps: answerSdps,
                 seq: session.OFFER.seq,

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/index.js
@@ -7,6 +7,7 @@ import MeetingUtil from '../meeting/util';
 import RoapHandler from './handler';
 import RoapRequest from './request';
 import RoapCollection from './collection';
+import TurnDiscovery from './turnDiscovery';
 
 /**
  * Roap options
@@ -75,6 +76,8 @@ export default class Roap extends StatelessWebexPlugin {
      * @memberof Roap
      */
     this.lastRoapOffer = {};
+
+    this.turnDiscovery = new TurnDiscovery(this.roapRequest);
   }
 
   /**
@@ -89,11 +92,19 @@ export default class Roap extends StatelessWebexPlugin {
     const {correlationId} = data;
 
     LoggerProxy.logger.log(`Roap:index#roapEvent --> Received Roap Message [${JSON.stringify(msg, null, 2)}]`);
-    this.roapHandler.submit({
-      type: ROAP.RECEIVE_ROAP_MSG,
-      msg,
-      correlationId
-    });
+
+    if (msg.messageType === ROAP.ROAP_TYPES.TURN_DISCOVERY_RESPONSE) {
+      // turn discovery is not part of normal roap protocol and so we are not handling it
+      // through the usual roap state machine
+      this.turnDiscovery.handleTurnDiscoveryResponse(msg);
+    }
+    else {
+      this.roapHandler.submit({
+        type: ROAP.RECEIVE_ROAP_MSG,
+        msg,
+        correlationId
+      });
+    }
   }
 
   /**
@@ -346,5 +357,17 @@ export default class Roap extends StatelessWebexPlugin {
     if (!RoapCollection.isBusy(correlationId)) {
       meeting.processNextQueuedMediaUpdate();
     }
+  }
+
+  /**
+   * Performs a TURN server discovery procedure, which involves exchanging
+   * some roap messages with the server. This exchange has to be done before
+   * any other roap messages are sent
+   *
+   * @param {Meeting} meeting
+   * @returns {Promise}
+   */
+  doTurnDiscovery(meeting) {
+    return this.turnDiscovery.doTurnDiscovery(meeting);
   }
 }

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/request.js
@@ -116,11 +116,13 @@ export default class RoapRequest extends StatelessWebexPlugin {
   /**
    * Sends a ROAP message
    * @param {Object} options
-   * @param {String} options.roapMessage
-   * @param {String} options.locusId
-   * @param {String} options.locusSelfId
+   * @param {Object} options.roapMessage
+   * @param {String} options.locusSelfUrl
    * @param {String} options.mediaId
    * @param {String} options.correlationId
+   * @param {Boolean} options.audioMuted
+   * @param {Boolean} options.videoMuted
+   * @param {String} options.meetingId
    * @returns {Promise} returns the response/failure of the request
    */
   sendRoap(options) {

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -1,0 +1,235 @@
+import {Defer} from '@webex/common';
+
+import Metrics from '../metrics';
+import BEHAVIORAL_METRICS from '../metrics/constants';
+import LoggerProxy from '../common/logs/logger-proxy';
+import {ROAP} from '../constants';
+
+import RoapRequest from './request';
+
+const TURN_DISCOVERY_TIMEOUT = 10; // in seconds
+
+/**
+ * Handles the process of finding out TURN server information from Linus.
+ * This is achieved by sending a TURN_DISCOVERY_REQUEST.
+ */
+export default class TurnDiscovery {
+  private roapRequest: RoapRequest;
+
+  private defer?: Defer; // used for waiting for the response
+
+  private turnInfo: {
+    url: string;
+    username: string;
+    password: string;
+  };
+
+  private responseTimer?: ReturnType<typeof setTimeout>;
+
+  /**
+   * Constructor
+   *
+   * @param {RoapRequest} roapRequest
+   */
+  constructor(roapRequest: RoapRequest) {
+    this.roapRequest = roapRequest;
+    this.turnInfo = {
+      url: '',
+      username: '',
+      password: '',
+    };
+  }
+
+
+  /**
+   * waits for TURN_DISCOVERY_RESPONSE message to arrive
+   *
+   * @returns {Promise}
+   * @private
+   * @memberof Roap
+   */
+  waitForTurnDiscoveryResponse() {
+    if (!this.defer) {
+      LoggerProxy.logger.warn('Roap:turnDiscovery#waitForTurnDiscoveryResponse --> TURN discovery is not in progress');
+
+      return Promise.reject(new Error('waitForTurnDiscoveryResponse() called before sendRoapTurnDiscoveryRequest()'));
+    }
+
+    const {defer} = this;
+
+    this.responseTimer = setTimeout(() => {
+      LoggerProxy.logger.warn(`Roap:turnDiscovery#waitForTurnDiscoveryResponse --> timeout! no response arrived within ${TURN_DISCOVERY_TIMEOUT} seconds`);
+
+      defer.reject(new Error('Timed out waiting for TURN_DISCOVERY_RESPONSE'));
+    }, TURN_DISCOVERY_TIMEOUT * 1000);
+
+    LoggerProxy.logger.info('Roap:turnDiscovery#waitForTurnDiscoveryResponse --> waiting for TURN_DISCOVERY_RESPONSE...');
+
+    return defer.promise;
+  }
+
+  /**
+   * handles TURN_DISCOVERY_RESPONSE roap message
+   *
+   * @param {Object} roapMessage
+   * @returns {void}
+   * @public
+   * @memberof Roap
+   */
+  handleTurnDiscoveryResponse(roapMessage) {
+    const {headers} = roapMessage;
+
+    if (!this.defer) {
+      LoggerProxy.logger.warn('Roap:turnDiscovery#handleTurnDiscoveryResponse --> unexpected TURN discovery response');
+
+      return;
+    }
+
+    const expectedHeaders = [
+      {headerName: 'x-cisco-turn-url', field: 'url'},
+      {headerName: 'x-cisco-turn-username', field: 'username'},
+      {headerName: 'x-cisco-turn-password', field: 'password'},
+    ];
+
+    let foundHeaders = 0;
+
+    headers?.forEach((receivedHeader) => {
+      // check if it matches any of our expected headers
+      expectedHeaders.forEach((expectedHeader) => {
+        if (receivedHeader.startsWith(`${expectedHeader.headerName}=`)) {
+          this.turnInfo[expectedHeader.field] = receivedHeader.substring(expectedHeader.headerName.length + 1);
+          foundHeaders += 1;
+        }
+      });
+    });
+
+    clearTimeout(this.responseTimer);
+    this.responseTimer = undefined;
+
+    if (foundHeaders !== expectedHeaders.length) {
+      LoggerProxy.logger.warn(`Roap:turnDiscovery#handleTurnDiscoveryResponse --> missing some headers, received: ${JSON.stringify(headers)}`);
+      this.defer.reject(new Error(`TURN_DISCOVERY_RESPONSE missing some headers: ${JSON.stringify(headers)}`));
+    }
+    else {
+      LoggerProxy.logger.info(`Roap:turnDiscovery#handleTurnDiscoveryResponse --> received a valid response, url=${this.turnInfo.url}`);
+      this.defer.resolve();
+    }
+  }
+
+  /**
+   * sends the TURN_DISCOVERY_REQUEST roap request
+   *
+   * @param {Meeting} meeting
+   * @returns {Promise}
+   * @private
+   * @memberof Roap
+   */
+  sendRoapTurnDiscoveryRequest(meeting) {
+    const seq = meeting.roapSeq + 1;
+
+    if (this.defer) {
+      LoggerProxy.logger.warn('Roap:turnDiscovery#sendRoapTurnDiscoveryRequest --> already in progress');
+
+      return Promise.resolve();
+    }
+
+    this.defer = new Defer();
+
+    const roapMessage = {
+      messageType: ROAP.ROAP_TYPES.TURN_DISCOVERY_REQUEST,
+      version: ROAP.ROAP_VERSION,
+      seq,
+    };
+
+    LoggerProxy.logger.info('Roap:turnDiscovery#sendRoapTurnDiscoveryRequest --> sending TURN_DISCOVERY_REQUEST');
+
+    return this.roapRequest
+      .sendRoap({
+        roapMessage,
+        correlationId: meeting.correlationId,
+        locusSelfUrl: meeting.selfUrl,
+        mediaId: meeting.mediaId,
+        audioMuted: meeting.isAudioMuted(),
+        videoMuted: meeting.isVideoMuted(),
+        meetingId: meeting.id
+      })
+      .then(({mediaConnections}) => {
+        meeting.setRoapSeq(seq);
+
+        if (mediaConnections) {
+          meeting.updateMediaConnections(mediaConnections);
+        }
+      });
+  }
+
+  /**
+   * Sends the OK message that server expects to receive
+   * after it sends us TURN_DISCOVERY_RESPONSE
+   *
+   * @param {Meeting} meeting
+   * @returns {Promise}
+   */
+  sendRoapOK(meeting) {
+    LoggerProxy.logger.info('Roap:turnDiscovery#sendRoapOK --> sending OK');
+
+    return this.roapRequest.sendRoap({
+      roapMessage: {
+        messageType: ROAP.ROAP_TYPES.OK,
+        version: ROAP.ROAP_VERSION,
+        seq: meeting.roapSeq
+      },
+      locusSelfUrl: meeting.selfUrl,
+      mediaId: meeting.mediaId,
+      correlationId: meeting.correlationId,
+      audioMuted: meeting.isAudioMuted(),
+      videoMuted: meeting.isVideoMuted(),
+      meetingId: meeting.id
+    });
+  }
+
+  /**
+   * Retrieves TURN server information from the backend by doing
+   * a roap message exchange:
+   * client                             server
+   *  | -----TURN_DISCOVERY_REQUEST-----> |
+   *  | <----TURN_DISCOVERY_RESPONSE----- |
+   *  | --------------OK----------------> |
+   *
+   * @param {Meeting} meeting
+   * @returns {Promise}
+   */
+  doTurnDiscovery(meeting) {
+    if (!meeting.config.experimental.enableTurnDiscovery) {
+      LoggerProxy.logger.info('Roap:turnDiscovery#doTurnDiscovery --> TURN discovery disabled in config, skipping it');
+
+      return Promise.resolve(undefined);
+    }
+
+    return this.sendRoapTurnDiscoveryRequest(meeting)
+      .then(() => this.waitForTurnDiscoveryResponse())
+      .then(() => this.sendRoapOK(meeting))
+      .then(() => {
+        this.defer = undefined;
+
+        LoggerProxy.logger.info('Roap:turnDiscovery#doTurnDiscovery --> TURN discovery completed');
+
+        return this.turnInfo;
+      })
+      .catch((e) => {
+        // we catch any errors and resolve with no turn information so that the normal call join flow can continue without TURN
+        LoggerProxy.logger.info(`Roap:turnDiscovery#doTurnDiscovery --> TURN discovery failed, continuing without TURN: ${e}`);
+
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.TURN_DISCOVERY_FAILURE,
+          {
+            correlation_id: meeting.correlationId,
+            locus_id: meeting.locusUrl.split('/').pop(),
+            reason: e.message,
+            stack: e.stack
+          }
+        );
+
+        return Promise.resolve(undefined);
+      });
+  }
+}

--- a/packages/node_modules/@webex/plugin-meetings/src/roap/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/roap/util.js
@@ -80,8 +80,6 @@ RoapUtil.setRemoteDescription = (meeting, session) => {
 
     return {
       seq: session.ANSWER.seq,
-      locusId: meeting.locusId,
-      locusSelfId: meeting.locusInfo.self.id,
       mediaId: meeting.mediaId,
       correlationId: meeting.correlationId
     };

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -893,6 +893,7 @@ describe('plugin-meetings', () => {
             meeting.mediaProperties.peerConnection.connectionState = CONSTANTS.CONNECTION_STATE.CONNECTED;
             resolve();
           }));
+          meeting.roap.doTurnDiscovery = sinon.stub().resolves();
           PeerConnectionManager.setContentSlides = sinon.stub().returns(true);
         });
 
@@ -1008,20 +1009,54 @@ describe('plugin-meetings', () => {
 
         it('should attach the media and return promise', async () => {
           meeting.meetingState = 'ACTIVE';
+          MediaUtil.createPeerConnection.resetHistory();
           const media = meeting.addMedia({
             mediaSettings: {}
           });
 
           assert.exists(media);
           await media;
+          assert.calledOnce(meeting.roap.doTurnDiscovery);
+          assert.calledWith(meeting.roap.doTurnDiscovery, meeting);
           assert.calledOnce(meeting.mediaProperties.setMediaDirection);
           assert.calledOnce(Media.attachMedia);
           assert.calledOnce(meeting.setMercuryListener);
           assert.calledOnce(meeting.setRemoteStream);
           assert.calledOnce(meeting.roap.sendRoapMediaRequest);
+          assert.calledOnce(MediaUtil.createPeerConnection);
+          assert.calledWith(MediaUtil.createPeerConnection, undefined);
           /* statsAnalyzer is initiated inside of addMedia so there isn't
           * a good way to mock it without mocking the constructor
           */
+        });
+
+        it('should pass the turn server info to the peer connection', async () => {
+          const FAKE_TURN_URL = 'turns:webex.com:3478';
+          const FAKE_TURN_USER = 'some-turn-username';
+          const FAKE_TURN_PASSWORD = 'some-password';
+
+          meeting.meetingState = 'ACTIVE';
+          MediaUtil.createPeerConnection.resetHistory();
+
+          meeting.roap.doTurnDiscovery = sinon.stub().resolves({
+            url: FAKE_TURN_URL,
+            username: FAKE_TURN_USER,
+            password: FAKE_TURN_PASSWORD
+          });
+          const media = meeting.addMedia({
+            mediaSettings: {}
+          });
+
+          assert.exists(media);
+          await media;
+          assert.calledOnce(meeting.roap.doTurnDiscovery);
+          assert.calledWith(meeting.roap.doTurnDiscovery, meeting);
+          assert.calledOnce(MediaUtil.createPeerConnection);
+          assert.calledWith(MediaUtil.createPeerConnection, {
+            url: FAKE_TURN_URL,
+            username: FAKE_TURN_USER,
+            password: FAKE_TURN_PASSWORD
+          });
         });
 
         it('should attach the media and return promise', async () => {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/peerconnection-manager/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/peerconnection-manager/index.js
@@ -1,9 +1,10 @@
 import 'jsdom-global/register';
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
+
 import PeerConnectionManager from '@webex/plugin-meetings/src/peer-connection-manager/index';
 import StaticConfig from '@webex/plugin-meetings/src/common/config';
-import {IceGatheringFailed, InvalidSdpError} from '@webex/plugin-meetings/src/common/errors/webex-errors';
+import {InvalidSdpError} from '@webex/plugin-meetings/src/common/errors/webex-errors';
 
 describe('Peerconnection Manager', () => {
   describe('Methods', () => {
@@ -85,6 +86,45 @@ describe('Peerconnection Manager', () => {
 
         assert.equal(result.sdp, remoteSdp);
       });
+
+      it('removes xTLS candidates from the remote sdp', async () => {
+        StaticConfig.set({bandwidth: {}});
+
+        const remoteSdpWithXtlsCandidates = 'v=0\r\n' +
+        'm=video 5004 UDP/TLS/RTP/SAVPF 102 127 97 99\r\n' +
+        'a=candidate:1 1 UDP 2130706175 18.206.82.54 9000 typ host\r\n' +
+        'a=candidate:2 1 TCP 1962934271 18.206.82.54 5004 typ host tcptype passive\r\n' +
+        'a=candidate:3 1 TCP 1962934015 18.206.82.54 9000 typ host tcptype passive\r\n' +
+        'a=candidate:4 1 xTLS 1795162111 external-media2.aintm-a-6.int.infra.webex.com 443 typ host tcptype passive fingerprint sha-1;55:B8:1D:94:BC:9D:B2:A5:5E:82:E7:84:C6:C8:10:AC:D3:FD:96:26\r\n' +
+        'a=rtpmap:127 H264/90000\r\n' +
+        'a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\n' +
+        'm=video 9000 UDP/TLS/RTP/SAVPF 102 127 97 99\r\n' +
+        'a=candidate:1 1 xTLS 1795162111 external-media2.aintm-a-6.int.infra.webex.com 443 typ host tcptype passive fingerprint sha-1;55:B8:1D:94:BC:9D:B2:A5:5E:82:E7:84:C6:C8:10:AC:D3:FD:96:26\r\n' +
+        'a=candidate:2 1 TCP 1962934271 18.206.82.54 5004 typ host tcptype passive\r\n' +
+        'a=fmtp:127 profile-level-id=42e016;max-mbps=244800;max-fs=8160;max-fps=3000;max-dpb=12240;max-rcmd-nalu-size=196608;level-asymmetry-allowed=1\r\n';
+
+        // same as remoteSdpWithXtlsCandidates but without the xtls candidates
+        const resultSdp = 'v=0\r\n' +
+        'm=video 5004 UDP/TLS/RTP/SAVPF 102 127 97 99\r\n' +
+        'a=candidate:1 1 UDP 2130706175 18.206.82.54 9000 typ host\r\n' +
+        'a=candidate:2 1 TCP 1962934271 18.206.82.54 5004 typ host tcptype passive\r\n' +
+        'a=candidate:3 1 TCP 1962934015 18.206.82.54 9000 typ host tcptype passive\r\n' +
+        'a=rtpmap:127 H264/90000\r\n' +
+        'a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\n' +
+        'm=video 9000 UDP/TLS/RTP/SAVPF 102 127 97 99\r\n' +
+        'a=candidate:2 1 TCP 1962934271 18.206.82.54 5004 typ host tcptype passive\r\n' +
+        'a=fmtp:127 profile-level-id=42e016;max-mbps=244800;max-fs=8160;max-fps=3000;max-dpb=12240;max-rcmd-nalu-size=196608;level-asymmetry-allowed=1\r\n';
+
+        const peerConnection = {
+          signalingState: 'have-local-offer',
+          setRemoteDescription: sinon.stub().resolves(),
+          enableExtmap: true
+        };
+
+        await PeerConnectionManager.setRemoteSessionDetails(peerConnection, 'answer', remoteSdpWithXtlsCandidates, '');
+
+        assert.calledWith(peerConnection.setRemoteDescription, new global.window.RTCSessionDescription({sdp: resultSdp, type: 'answer'}));
+      });
     });
 
     describe('iceCandidate', () => {
@@ -123,13 +163,16 @@ describe('Peerconnection Manager', () => {
           });
       });
 
-      it('should not generate sdp if onicecandidateerror errors out ', async () => {
+      it('should still generate sdp even if onicecandidateerror is called ', async () => {
         peerConnection.iceGatheringState = 'none';
         setTimeout(() => {
           peerConnection.onicecandidateerror();
+          peerConnection.onicecandidate({candidate: null});
         }, 1000);
-        await assert.isRejected(PeerConnectionManager.iceCandidate(peerConnection, {remoteQualityLevel: 'HIGH'}), IceGatheringFailed);
-        assert.equal(peerConnection.sdp, null);
+        await PeerConnectionManager.iceCandidate(peerConnection, {remoteQualityLevel: 'HIGH'})
+          .then(() => {
+            assert(peerConnection.sdp.search('max-fs:8192'), true);
+          });
       });
 
       it('should throw generated SDP does not have candidates ', async () => {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/roap/index.ts
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/roap/index.ts
@@ -1,0 +1,25 @@
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import TurnDiscovery from '@webex/plugin-meetings/src/roap/turnDiscovery';
+
+import Roap from '@webex/plugin-meetings/src/roap/';
+
+describe('Roap', () => {
+  describe('doTurnDiscovery', () => {
+    it('calls this.turnDiscovery.doTurnDiscovery()', async () => {
+      const RESULT = {something: 'some value'};
+      const meeting = {id: 'some meeting id'};
+
+      const doTurnDiscoveryStub = sinon.stub(TurnDiscovery.prototype, 'doTurnDiscovery').resolves(RESULT);
+
+      const roap = new Roap({}, {parent: 'fake'});
+
+      const result = await roap.doTurnDiscovery(meeting);
+
+      assert.calledOnceWithExactly(doTurnDiscoveryStub, meeting);
+      assert.deepEqual(result, RESULT);
+
+      sinon.restore();
+    });
+  });
+});

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -1,0 +1,300 @@
+import sinon from 'sinon';
+import {assert} from '@webex/test-helper-chai';
+import TurnDiscovery from '@webex/plugin-meetings/src/roap/turnDiscovery';
+
+import Metrics from '@webex/plugin-meetings/src/metrics';
+import BEHAVIORAL_METRICS from '@webex/plugin-meetings/src/metrics/constants';
+import RoapRequest from '@webex/plugin-meetings/src/roap/request';
+
+import testUtils from '../../../utils/testUtils';
+
+describe('TurnDiscovery', () => {
+  let clock;
+  let mockRoapRequest: RoapRequest;
+  let testMeeting: any;
+
+  const FAKE_TURN_URL = 'turns:fakeTurnServer.com:443?transport=tcp';
+  const FAKE_TURN_USERNAME = 'someUsernameFromServer';
+  const FAKE_TURN_PASSWORD = 'fakePasswordFromServer';
+  const FAKE_LOCUS_ID = '09493311-f5d5-3e58-b491-009cc628162e';
+  const FAKE_MEDIA_CONNECTIONS_FROM_LOCUS = [{mediaId: '464ff97f-4bda-466a-ad06-3a22184a2274'}];
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+
+    sinon.stub(Metrics, 'sendBehavioralMetric');
+
+    mockRoapRequest = {
+      sendRoap: sinon.fake.resolves({mediaConnections: FAKE_MEDIA_CONNECTIONS_FROM_LOCUS})
+    } as unknown as RoapRequest;
+
+    testMeeting = {
+      id: 'fake meeting id',
+      config: {
+        experimental: {
+          enableTurnDiscovery: true
+        }
+      },
+      correlationId: 'fake correlation id',
+      selfUrl: 'fake self url',
+      mediaId: 'fake media id',
+      locusUrl: `https://locus-a.wbx2.com/locus/api/v1/loci/${FAKE_LOCUS_ID}`,
+      roapSeq: -1,
+      isAudioMuted: () => true,
+      isVideoMuted: () => false,
+      setRoapSeq: sinon.fake((newSeq) => {
+        testMeeting.roapSeq = newSeq;
+      }),
+      updateMediaConnections: sinon.stub(),
+    };
+  });
+
+  afterEach(() => {
+    clock.restore();
+    sinon.restore();
+  });
+
+  const checkRoapMessageSent = async (messageType, seq) => {
+    await testUtils.flushPromises();
+
+    assert.calledOnce(mockRoapRequest.sendRoap);
+    assert.calledWith(mockRoapRequest.sendRoap, {
+      roapMessage: {
+        messageType,
+        version: '2',
+        seq,
+      },
+      correlationId: testMeeting.correlationId,
+      locusSelfUrl: testMeeting.selfUrl,
+      mediaId: testMeeting.mediaId,
+      audioMuted: testMeeting.isAudioMuted(),
+      videoMuted: testMeeting.isVideoMuted(),
+      meetingId: testMeeting.id
+    });
+
+    if (messageType === 'TURN_DISCOVERY_REQUEST') {
+      // check also that we've applied the media connections from the response
+      assert.calledOnce(testMeeting.updateMediaConnections);
+      assert.calledWith(testMeeting.updateMediaConnections, FAKE_MEDIA_CONNECTIONS_FROM_LOCUS);
+    }
+  };
+
+  const checkFailureMetricsSent = () => {
+    assert.calledOnce(Metrics.sendBehavioralMetric);
+    assert.calledWith(
+      Metrics.sendBehavioralMetric,
+      BEHAVIORAL_METRICS.TURN_DISCOVERY_FAILURE,
+      sinon.match({
+        correlation_id: testMeeting.correlationId,
+        locus_id: FAKE_LOCUS_ID,
+      })
+    );
+  };
+
+  describe('doTurnDiscovery', () => {
+    it('sends TURN_DISCOVERY_REQUEST, waits for response and sends OK', async () => {
+      const td = new TurnDiscovery(mockRoapRequest);
+
+      const result = td.doTurnDiscovery(testMeeting);
+
+      // check that TURN_DISCOVERY_REQUEST was sent
+      await checkRoapMessageSent('TURN_DISCOVERY_REQUEST', 0);
+
+      mockRoapRequest.sendRoap.resetHistory();
+
+      // simulate the response
+      td.handleTurnDiscoveryResponse({
+        headers: [
+          `x-cisco-turn-url=${FAKE_TURN_URL}`,
+          `x-cisco-turn-username=${FAKE_TURN_USERNAME}`,
+          `x-cisco-turn-password=${FAKE_TURN_PASSWORD}`,
+        ]
+      });
+
+      await testUtils.flushPromises();
+
+      // check that we've sent OK
+      await checkRoapMessageSent('OK', 0);
+
+      const turnInfo = await result;
+
+      assert.deepEqual(turnInfo, {
+        url: FAKE_TURN_URL,
+        username: FAKE_TURN_USERNAME,
+        password: FAKE_TURN_PASSWORD
+      });
+    });
+
+    it('ignores any extra, unexpected headers in the response', async () => {
+      const td = new TurnDiscovery(mockRoapRequest);
+      const result = td.doTurnDiscovery(testMeeting);
+
+      // check that TURN_DISCOVERY_REQUEST was sent
+      await checkRoapMessageSent('TURN_DISCOVERY_REQUEST', 0);
+
+      mockRoapRequest.sendRoap.resetHistory();
+
+      // simulate the response with some extra headers
+      td.handleTurnDiscoveryResponse({
+        headers: [
+          'x-cisco-turn-unexpected-header=xxx',
+          `x-cisco-turn-url=${FAKE_TURN_URL}`,
+          'x-cisco-some-other-header',
+          `x-cisco-turn-username=${FAKE_TURN_USERNAME}`,
+          `x-cisco-turn-password=${FAKE_TURN_PASSWORD}`,
+          'another-header-at-the-end=12345',
+        ]
+      });
+
+      await testUtils.flushPromises();
+
+      // check that we've sent OK and still parsed the headers we care about
+      await checkRoapMessageSent('OK', 0);
+
+      const turnInfo = await result;
+
+      assert.deepEqual(turnInfo, {
+        url: FAKE_TURN_URL,
+        username: FAKE_TURN_USERNAME,
+        password: FAKE_TURN_PASSWORD
+      });
+    });
+
+    it('resolves with undefined if turn discovery feature is disabled in config', async () => {
+      const prevConfigValue = testMeeting.config.experimental.enableTurnDiscovery;
+
+      testMeeting.config.experimental.enableTurnDiscovery = false;
+
+      const result = await new TurnDiscovery(mockRoapRequest).doTurnDiscovery(testMeeting);
+
+      assert.isUndefined(result);
+      assert.notCalled(mockRoapRequest.sendRoap);
+      assert.notCalled(Metrics.sendBehavioralMetric);
+
+      // restore previous config
+      testMeeting.config.experimental.enableTurnDiscovery = prevConfigValue;
+    });
+
+    it('resolves with undefined if sending the request fails', async () => {
+      const td = new TurnDiscovery(mockRoapRequest);
+
+      mockRoapRequest.sendRoap = sinon.fake.rejects(new Error('fake error'));
+
+      const result = await td.doTurnDiscovery(testMeeting);
+
+      assert.isUndefined(result);
+      checkFailureMetricsSent();
+    });
+
+    it('resolves with undefined if we don\'t get a response within 10s', async () => {
+      const td = new TurnDiscovery(mockRoapRequest);
+
+      const promise = td.doTurnDiscovery(testMeeting);
+
+      await clock.tickAsync(10 * 1000);
+      await testUtils.flushPromises();
+
+      const turnInfo = await promise;
+
+      assert.isUndefined(turnInfo);
+      checkFailureMetricsSent();
+    });
+
+    it('resolves with undefined if the response does not have all the headers we expect', async () => {
+      const td = new TurnDiscovery(mockRoapRequest);
+      const turnDiscoveryPromise = td.doTurnDiscovery(testMeeting);
+
+      // simulate the response without the password
+      td.handleTurnDiscoveryResponse({
+        headers: [
+          `x-cisco-turn-url=${FAKE_TURN_URL}`,
+          `x-cisco-turn-username=${FAKE_TURN_USERNAME}`,
+        ]
+      });
+      await testUtils.flushPromises();
+      const turnInfo = await turnDiscoveryPromise;
+
+      assert.isUndefined(turnInfo);
+      checkFailureMetricsSent();
+    });
+
+    it('resolves with undefined if the response does not have any headers', async () => {
+      const td = new TurnDiscovery(mockRoapRequest);
+      const turnDiscoveryPromise = td.doTurnDiscovery(testMeeting);
+
+      // simulate the response without the headers
+      td.handleTurnDiscoveryResponse({});
+
+      await testUtils.flushPromises();
+      const turnInfo = await turnDiscoveryPromise;
+
+      assert.isUndefined(turnInfo);
+      checkFailureMetricsSent();
+    });
+
+    it('resolves with undefined if the response has empty headers array', async () => {
+      const td = new TurnDiscovery(mockRoapRequest);
+      const turnDiscoveryPromise = td.doTurnDiscovery(testMeeting);
+
+      // simulate the response without the headers
+      td.handleTurnDiscoveryResponse({headers: []});
+
+      await testUtils.flushPromises();
+      const turnInfo = await turnDiscoveryPromise;
+
+      assert.isUndefined(turnInfo);
+      checkFailureMetricsSent();
+    });
+
+    it('resolves with undefined if failed to send OK', async () => {
+      const td = new TurnDiscovery(mockRoapRequest);
+
+      const turnDiscoveryPromise = td.doTurnDiscovery(testMeeting);
+
+      // check that TURN_DISCOVERY_REQUEST was sent
+      await checkRoapMessageSent('TURN_DISCOVERY_REQUEST', 0);
+
+      mockRoapRequest.sendRoap.resetHistory();
+
+      // setup the mock so that sending of OK fails
+      mockRoapRequest.sendRoap = sinon.fake.rejects(new Error('fake error'));
+
+      // simulate the response
+      td.handleTurnDiscoveryResponse({
+        headers: [
+          `x-cisco-turn-url=${FAKE_TURN_URL}`,
+          `x-cisco-turn-username=${FAKE_TURN_USERNAME}`,
+          `x-cisco-turn-password=${FAKE_TURN_PASSWORD}`,
+        ]
+      });
+
+      await testUtils.flushPromises();
+
+      // check that we've sent OK
+      await checkRoapMessageSent('OK', 0);
+
+      const turnInfo = await turnDiscoveryPromise;
+
+      assert.isUndefined(turnInfo);
+      checkFailureMetricsSent();
+    });
+  });
+
+  describe('handleTurnDiscoveryResponse', () => {
+    it('doesn\'t do anything if turn discovery was not started', () => {
+      const td = new TurnDiscovery(mockRoapRequest);
+
+      // there is not much we can check, but we mainly want to make
+      // sure that it doesn't crash
+      td.handleTurnDiscoveryResponse({
+        headers: [
+          `x-cisco-turn-url=${FAKE_TURN_URL}`,
+          `x-cisco-turn-username=${FAKE_TURN_USERNAME}`,
+          `x-cisco-turn-password=${FAKE_TURN_PASSWORD}`,
+        ]
+      });
+
+      assert.notCalled(mockRoapRequest.sendRoap);
+    });
+  });
+});


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-369983

## This pull request addresses
Adding ability to use Linus as a TURN server for TURN TLS connections, so that we can have media flowing in networks behind firewalls that block all UDP and TCP apart from TLS on 443.

## by making the following changes
Using new Roap messages to get TURN information from Linus and configuring RTCPeerConnection with that TURN server information. Also removing xTLS candidates from remote SDP as Linus now sends them to us when it's pretending to be a TURN server.

All changes are behind an experimental config flag. Added also a checkbox for it to the sample app.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
unit tests, manual e2e with a special Linus version

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
