### PR TITLE
Spark 358527 custom video resolution

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -3928,8 +3928,9 @@ export default class Meeting extends StatelessWebexPlugin {
         LoggerProxy.logger.warn('Meeting:index#getMediaStreams --> Please use `meeting.shareScreen()` to manually start the screen share after successfully joining the meeting');
       }
 
-      audioVideo = {...audioVideo, video: {...audioVideo.video, ...VIDEO_RESOLUTIONS[this.mediaProperties.localQualityLevel].video}};
-
+      if (!audioVideo.video) {
+        audioVideo = {...audioVideo, video: {...audioVideo.video, ...VIDEO_RESOLUTIONS[this.mediaProperties.localQualityLevel].video}};
+      }
       // extract deviceId if exists otherwise default to null.
       const {deviceId: preferredVideoDevice} = (audioVideo && audioVideo.video || {deviceId: null});
       const lastVideoDeviceId = this.mediaProperties.getVideoDeviceId();

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -704,6 +704,30 @@ describe('plugin-meetings', () => {
           assert.calledWith(meeting.mediaProperties.setVideoDeviceId, newVideoDevice);
         });
 
+        it('uses the passed custom video resolution', async () => {
+          const mediaDirection = {sendAudio: true, sendVideo: true, sendShare: false};
+          const customAudioVideoSettings = {
+            video: {
+              width: {
+                max: 400,
+                ideal: 400
+              },
+              height: {
+                max: 200,
+                ideal: 200
+              }
+            }
+          };
+
+          sinon.stub(meeting.mediaProperties, 'localQualityLevel').value('200p');
+          await meeting.getMediaStreams(mediaDirection, customAudioVideoSettings);
+
+          assert.calledWith(Media.getUserMedia, {
+            ...mediaDirection,
+            isSharing: false
+          },
+          customAudioVideoSettings);
+        });
         it('should not access camera if sendVideo is false ', async () => {
           await meeting.getMediaStreams({sendAudio: true, sendVideo: false});
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-358527](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-358527) >

## This pull request addresses

Support for developers to pass their own custom video resolutions settings

## by making the following changes

`AudioVideo` parameter in `getMediaStreams` method will take custom resolution passed by user otherwise will take pre defined default resolution from constants file. For eg., in screenshot below, we passed custom video resolution as 
`{
            video: {
              width: {
                max: 400,
                ideal: 400
              },
              height: {
                max: 200,
                ideal: 200
              }
            }
          }`

<img width="865" alt="Screenshot 2022-10-12 at 6 23 23 PM" src="https://user-images.githubusercontent.com/41181764/195347828-7d199a5d-fcdb-4feb-bc54-4c809077e0f8.png">

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
