### PR TITLE
feat(conversation): add support for delete-mcs

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -363,11 +363,23 @@ const Conversation = WebexPlugin.extend({
       return Promise.reject(new Error('`object` must be an object'));
     }
 
-    return this.prepare(activity, {
+    const request = {
       verb: 'delete',
       target: this.prepareConversation(convoWithUrl),
-      object: pick(object, 'id', 'url', 'objectType')
-    })
+      object: pick(object, 'id', 'url', 'objectType'),
+    };
+
+    // Deleting meeting container requires KMS message
+    if (object.object.objectType === 'meetingContainer') {
+      // It's building a string uri + "/authorizations?authId=" + id, where uri is the meeting container's KRO URL, and id is the conversation's KRO URL.
+      request.target.kmsResourceObjectUrl = object.object.kmsResourceObjectUrl;
+      request.kmsMessage = {
+        method: 'delete',
+        uri: `<KRO>/authorizations?${querystring.stringify({authId: convoWithUrl.kmsResourceObjectUrl})}`
+      };
+    }
+
+    return this.prepare(activity, request)
       .then((a) => this.submit(a));
   },
 

--- a/packages/node_modules/@webex/internal-plugin-conversation/src/encryption-transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/encryption-transforms.js
@@ -151,6 +151,10 @@ export const transforms = toArray('outbound', {
 
   prepareActivityKmsMessage(ctx, key, activity) {
     if (activity.kmsMessage) {
+      if (!key && activity.verb === 'delete') {
+        key = get(activity, 'target.defaultActivityEncryptionKeyUrl');
+      }
+
       if (!key && activity.verb === 'updateKey' && has(activity, 'object.defaultActivityEncryptionKeyUrl')) {
         key = get(activity, 'object.defaultActivityEncryptionKeyUrl');
       }

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -707,5 +707,67 @@ describe('plugin-conversation', () => {
         }
       });
     });
+
+    describe('delete()', () => {
+      const testConvo = {
+        id: 'id1',
+        url: 'https://example.com',
+      };
+
+      it('should reject if provided param is not an object', () => {
+        const request = webex.internal.conversation.delete(testConvo, 'hello');
+
+        return request.then(() => {
+          assert.equal(true, false, 'should have rejected');
+        })
+          .catch(() => {
+            assert.equal(true, true, 'object is not type object, rejects as expected');
+          });
+      });
+      it('deletes a non-meeting container activity', () => {
+        webex.internal.conversation.prepare = sinon.stub().callsFake((activity, request) => Promise.resolve({activity, request}));
+        webex.internal.conversation.submit = sinon.stub().callsFake((p) => Promise.resolve(p));
+
+        // fix this to look like below
+        const request = webex.internal.conversation.delete(testConvo, {
+          id: 'activity-id-1',
+          url: 'https://example.com/activity1',
+          object: {objectType: 'activity'}
+        },
+        {
+          object:
+          {objectType: 'activity'}
+        });
+
+        return request.then(({request}) => {
+          assert.isUndefined(request.kmsMessage);
+        });
+      });
+      it('deletes a meeting container activity', () => {
+        webex.internal.conversation.prepare = sinon.stub().callsFake((activity, request) => Promise.resolve({activity, request}));
+        webex.internal.conversation.submit = sinon.stub().callsFake((p) => Promise.resolve(p));
+
+        const request = webex.internal.conversation.delete(testConvo, {
+          id: 'activity-id-2',
+          url: 'https://example.com/activity2',
+          object: {
+            kmsResourceObjectUrl: 'kms://example',
+            objectType: 'meetingContainer'
+          }
+        },
+        {
+          object: {
+            objectType: 'meetingContainer'
+          }
+        });
+
+
+        return request.then(({request}) => {
+          assert.equal(request.kmsMessage.method, 'delete');
+          assert.equal(request.kmsMessage.uri, '<KRO>/authorizations?authId=');
+          assert.equal(request.target.kmsResourceObjectUrl, 'kms://example');
+        });
+      });
+    });
   });
 });

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/encryption-transforms.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/unit/spec/encryption-transforms.js
@@ -55,5 +55,32 @@ describe('plugin-conversation', () => {
         assert.equal(transformStub.lastCall.args[0], 'prepareActivityKmsMessage', key, activity);
       });
     });
+    it('does not have key and has verb delete', async () => {
+      const transform = transforms.find((t) => t.name === 'prepareActivityKmsMessage');
+
+      const ctx = {
+        transform
+      };
+      const key = null;
+      const activity = {
+        object: {
+          created: 'false'
+        },
+        target: {
+          defaultActivityEncryptionKeyUrl: 'fakeEncryptionKey',
+          kmsResourceObjectUrl: 'meetingContainerKRO'
+        },
+        objectType: 'activity',
+        verb: 'delete',
+        kmsMessage: {
+          uri: '<KRO>/authorizations?authId=123',
+          method: 'delete'
+        }
+      };
+
+      transform.fn(ctx, key, activity);
+
+      assert.equal(activity.kmsMessage.uri, 'meetingContainerKRO/authorizations?authId=123', 'did not properly transform KRO for delete meeting container activity');
+    });
   });
 });


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-336425

## This pull request addresses
Changes the delete method on conversation to generate a KMS message when the activity contains a meeting container.

## by making the following changes
Conversation Plugin --> added conditional to handle meeting container activities
encryption transform --> no-op for meeting container activities, otherwise it stripes the KMS message from the request and the request fails

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
