### PR TITLE
fix(plugin-meetings): Using new reachability timeout values (1s for video mesh, 3s for the rest)

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js
@@ -15,6 +15,9 @@ import {
 
 import ReachabilityRequest from './request';
 
+const DEFAULT_TIMEOUT = 5000;
+const VIDEO_MESH_TIMEOUT = 1000;
+
 /**
  * @class Reachability
  * @export
@@ -77,6 +80,8 @@ export default class Reachability {
 
       window.localStorage.setItem(REACHABILITY.localStorage, JSON.stringify(results));
 
+      LoggerProxy.logger.log('Reachability:index#gatherReachability --> Reachability checks completed');
+
       return results;
     }
     catch (getClusterError) {
@@ -132,7 +137,7 @@ export default class Reachability {
       return peerConnection;
     }
     catch (peerConnectionError) {
-      LoggerProxy.logger.log(`Reachability:index#getLocalSDPForClusters --> Error creating peerConnection: ${peerConnectionError}`);
+      LoggerProxy.logger.log(`Reachability:index#createPeerConnection --> Error creating peerConnection: ${peerConnectionError}`);
 
       return null;
     }
@@ -174,7 +179,7 @@ export default class Reachability {
       peerConnection.begin = Date.now();
       peerConnection.setLocalDescription(description);
 
-      return this.iceGatheringState(peerConnection)
+      return this.iceGatheringState(peerConnection, cluster.isVideoMesh ? VIDEO_MESH_TIMEOUT : DEFAULT_TIMEOUT)
         .catch((iceGatheringStateError) => {
           LoggerProxy.logger.log(`Reachability:index#getLocalSDPForClusters --> Error in getLocalSDP : ${iceGatheringStateError}`);
         });
@@ -256,18 +261,17 @@ export default class Reachability {
     };
   }
 
-
   /**
    * An event handler on an RTCPeerConnection when the state of the ICE
    * candidate gathering process changes. Used to measure connection
    * speed.
    * @private
    * @param {RTCPeerConnection} peerConnection
+   * @param {number} timeout
    * @returns {Promise}
    */
-  iceGatheringState(peerConnection) {
+  iceGatheringState(peerConnection, timeout) {
     const ELAPSED = 'elapsed';
-    const waitTime = 5e3;
 
     return new Promise((resolve) => {
       const peerConnectionProxy = new window.Proxy(peerConnection, {
@@ -300,13 +304,13 @@ export default class Reachability {
 
       // Set maximum timeout
       window.setTimeout(() => {
-        const CLOSED = {CONNECTION_STATE};
+        const {CLOSED} = CONNECTION_STATE;
 
         // Close any open peerConnections
         if (peerConnectionProxy.connectionState !== CLOSED) {
           this.setLatencyAndClose(peerConnectionProxy, null);
         }
-      }, waitTime);
+      }, timeout);
     });
   }
 
@@ -321,7 +325,7 @@ export default class Reachability {
     const list = this.getUnreachablClusters();
 
     list.forEach((cluster) => {
-      LoggerProxy.logger.log(`Reachability:index#getLocalSDPForClusters --> No ice candidate for ${cluster}.`);
+      LoggerProxy.logger.log(`Reachability:index#logUnreachableClusters --> No ice candidate for ${cluster}.`);
     });
   }
 

--- a/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/reachability/index.js
@@ -15,7 +15,7 @@ import {
 
 import ReachabilityRequest from './request';
 
-const DEFAULT_TIMEOUT = 5000;
+const DEFAULT_TIMEOUT = 3000;
 const VIDEO_MESH_TIMEOUT = 1000;
 
 /**

--- a/packages/node_modules/@webex/plugin-meetings/src/reachability/request.ts
+++ b/packages/node_modules/@webex/plugin-meetings/src/reachability/request.ts
@@ -5,14 +5,25 @@ import {
   API
 } from '../constants';
 
+export interface ClusterNode {
+  isVideoMesh: boolean;
+  udp: Array<string>;
+  tcp: Array<string>;
+  xtls: Array<string>;
+}
+
+export type ClusterList = {
+  [key:string]: ClusterNode;
+}
+
 /**
- * @class RechabilityRequest
+ * @class ReachabilityRequest
  */
-class RechabilityRequest {
+class ReachabilityRequest {
   /**
-   * Creates an instance of RechabilityRequest.
+   * Creates an instance of ReachabilityRequest.
    * @param {object} webex
-   * @memberof RechabilityRequest
+   * @memberof ReachabilityRequest
    */
   constructor(webex) {
     this.webex = webex;
@@ -20,9 +31,11 @@ class RechabilityRequest {
 
   /**
    * gets the cluster information
+   *
+   * @param {boolean} includeVideoMesh whether to include the video mesh clusters in the result or not
    * @returns {Promise}
    */
-  getClusters = () => this.webex.request({
+  getClusters = (): Promise<ClusterList> => this.webex.request({
     method: HTTP_VERBS.GET,
     shouldRefreshAccessToken: false,
     api: API.CALLIOPEDISCOVERY,
@@ -30,6 +43,10 @@ class RechabilityRequest {
   })
     .then((res) => {
       const {clusters} = res.body;
+
+      Object.keys(clusters).forEach((key) => {
+        clusters[key].isVideoMesh = res.body.clusterClasses?.hybridMedia?.includes(key);
+      });
 
       LoggerProxy.logger.log(`Reachability:request#getClusters --> get clusters successful:${JSON.stringify(clusters)}`);
 
@@ -55,4 +72,4 @@ class RechabilityRequest {
     });
 }
 
-export default RechabilityRequest;
+export default ReachabilityRequest;

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/reachability/request.ts
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/reachability/request.ts
@@ -38,7 +38,7 @@ describe('ReachabilityRequest', () => {
     reachabilityRequest = new ReachabilityRequest(webex);
   });
 
-  describe.only('getClusters', () => {
+  describe('getClusters', () => {
     beforeEach(() => {
       webex.request = sinon.fake.resolves({
         body: {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/reachability/request.ts
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/reachability/request.ts
@@ -1,0 +1,84 @@
+
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import ReachabilityRequest from '@webex/plugin-meetings/src/reachability/request';
+
+describe('ReachabilityRequest', () => {
+  let webex;
+  let reachabilityRequest;
+
+  const VIDEO_MESH_NODE_0 = '111-222-333-some-vmn';
+  const VIDEO_MESH_NODE_1 = '444-555-666-some-vmn';
+
+  const CLOUD_NODE_0 = 'some-public-node-1.somewhere';
+  const CLOUD_NODE_1 = 'some-public-node-2.somewhere';
+
+  const vmnClusterUrls = [{
+    tcp: ['some vmn node 0 tcp url', 'another vmn node 0 tcp url'],
+    udp: ['some vmn node 0 udp url', 'another vmn node 0 udp url']
+  }, {
+    tcp: ['some vmn node 1 tcp url', 'another vmn node 1 tcp url'],
+    udp: ['some vmn node 1 udp url', 'another vmn node 1 udp url']
+  }
+  ];
+
+  const cloudClusterUrls = [{
+    tcp: ['some public node 0 tcp url', 'another public node 0 tcp url'],
+    udp: ['some public node 0 udp url', 'another public node 0 udp url']
+  }, {
+    tcp: ['some public node 1 tcp url', 'another public node 1 tcp url'],
+    udp: ['some public node 1 udp url', 'another public node 1 udp url']
+  }
+  ];
+
+  beforeEach(() => {
+    webex = {
+      request: sinon.stub()
+    };
+    reachabilityRequest = new ReachabilityRequest(webex);
+  });
+
+  describe.only('getClusters', () => {
+    beforeEach(() => {
+      webex.request = sinon.fake.resolves({
+        body: {
+          clusterClasses: {
+            ocpCloud: [],
+            publicCloud: [],
+            hybridMedia: [VIDEO_MESH_NODE_0, VIDEO_MESH_NODE_1]
+          },
+          clusters: {
+            [VIDEO_MESH_NODE_0]: vmnClusterUrls[0],
+            [VIDEO_MESH_NODE_1]: vmnClusterUrls[1],
+            [CLOUD_NODE_0]: cloudClusterUrls[0],
+            [CLOUD_NODE_1]: cloudClusterUrls[1],
+          }
+        }
+      });
+    });
+
+    it('marks video mesh clusters correctly', async () => {
+      const clusters = await reachabilityRequest.getClusters(false);
+
+      assert.deepEqual(clusters, {
+        [VIDEO_MESH_NODE_0]: {
+          ...vmnClusterUrls[0],
+          isVideoMesh: true,
+        },
+        [VIDEO_MESH_NODE_1]: {
+          ...vmnClusterUrls[1],
+          isVideoMesh: true,
+        },
+        [CLOUD_NODE_0]: {
+          ...cloudClusterUrls[0],
+          isVideoMesh: false,
+        },
+        [CLOUD_NODE_1]: {
+          ...cloudClusterUrls[1],
+          isVideoMesh: false,
+        },
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-364898

## This pull request addresses
With the current design of reachability in JS-SDK, it will always fail if the cluster is on the same network as the client, which means that it will always fail for video mesh nodes if client is on the corporate network and it also always fails for the cisco cloud clusters if you are on cisco network (or cisco vpn). Cisco users always get some video mesh nodes in their cluster list, so that means that reachability always takes 5s for cisco users, because:
- if they're on Cisco VPN, the reachability checks for all clusters will fail, so they wait for the 5s timeout 
- if they're not on VPN, the reachability checks for cisco video mesh nodes fail, because they're only available on cisco network, so again the clients will have to wait for the 5s timeout

## by making the following changes
According to Orpheus metrics, only 1.7% of web clients report reachability values greater than 3s to any cluster. Therefore, we're reducing the overall timeout from 5s to 3s.

We are working on a solution to reachability issues for nodes running on the same network, but it may take months before the required changes are done in the backend so in the meantime we are reducing the timeout for video mesh to 1s.

Also fixed:
- some incorrect logs,
- typos
- a bug that was causing a log "Attempting to set latency of null on closed peerConnection" being displayed every time when reachability checks are done

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
manually tested with and without vpn

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
