### PR TITLE
fix(embedded-apps): parsed apps now stored in meeting, fixed similari…

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/embeddedAppsUtils.js
+++ b/packages/@webex/plugin-meetings/src/locus-info/embeddedAppsUtils.js
@@ -30,11 +30,18 @@ EmbeddedAppsUtils.parseApp = (embeddedApp) => {
  * @returns {boolean} true if the arrays are different
  */
 EmbeddedAppsUtils.areSimilar = (apps1, apps2) => {
+  if (!apps1 || !apps2) {
+    return apps1 === apps2;
+  }
+
   if (apps1?.length !== apps2?.length) {
     return false;
   }
-  if (apps1?.[0]?.state !== apps2?.[0]?.state) {
-    return false;
+
+  for (let i = 0; i < apps1.length; i += 1) {
+    if (apps1[i].state !== apps2[i].state) {
+      return false;
+    }
   }
 
   return true;
@@ -45,7 +52,7 @@ EmbeddedAppsUtils.areSimilar = (apps1, apps2) => {
  * @param {array} embeddedApps
  * @returns {array} result - new array of parsed embedded app objects
  */
-EmbeddedAppsUtils.parse = (embeddedApps) => embeddedApps && embeddedApps.map(EmbeddedAppsUtils.parseApp);
-
+EmbeddedAppsUtils.parse = (embeddedApps) =>
+  embeddedApps && embeddedApps.map(EmbeddedAppsUtils.parseApp);
 
 export default EmbeddedAppsUtils;

--- a/packages/@webex/plugin-meetings/src/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.js
@@ -15,7 +15,7 @@ import {
   _LEFT_,
   MEETING_REMOVED_REASON,
   CALL_REMOVED_REASON,
-  RECORDING_STATE
+  RECORDING_STATE,
 } from '../constants';
 import Metrics from '../metrics';
 import {eventType} from '../metrics/config';
@@ -28,7 +28,6 @@ import EmbeddedAppsUtils from '../locus-info/embeddedAppsUtils';
 import MediaSharesUtils from '../locus-info/mediaSharesUtils';
 import LocusDeltaParser from '../locus-info/parser';
 
-
 /**
  * @description LocusInfo extends ChildEmitter to convert locusInfo info a private emitter to parent object
  * @export
@@ -39,7 +38,7 @@ export default class LocusInfo extends EventsScope {
   constructor(updateMeeting, webex, meetingId) {
     super();
     this.parsedLocus = {
-      states: []
+      states: [],
     };
     this.webex = webex;
     this.emitChange = false;
@@ -48,7 +47,6 @@ export default class LocusInfo extends EventsScope {
     this.updateMeeting = updateMeeting;
     this.locusParser = new LocusDeltaParser();
   }
-
 
   /**
    * Apply locus delta data to meeting
@@ -69,21 +67,24 @@ export default class LocusInfo extends EventsScope {
         meeting.needToGetFullLocus = false;
         break;
       case DESYNC:
-        meeting.meetingRequest.getFullLocus({
-          desync: true,
-          locusUrl: meeting.locusUrl
-        }).then((res) => {
-          meeting.locusInfo.onFullLocus(res.body);
-          // Notify parser to resume processing delta events
-          // now that we have full locus from DESYNC.
-          this.locusParser.resume();
-        });
+        meeting.meetingRequest
+          .getFullLocus({
+            desync: true,
+            locusUrl: meeting.locusUrl,
+          })
+          .then((res) => {
+            meeting.locusInfo.onFullLocus(res.body);
+            // Notify parser to resume processing delta events
+            // now that we have full locus from DESYNC.
+            this.locusParser.resume();
+          });
         break;
       default:
-        LoggerProxy.logger.info(`Locus-info:index#applyLocusDeltaData --> Unknown locus delta action: ${action}`);
+        LoggerProxy.logger.info(
+          `Locus-info:index#applyLocusDeltaData --> Unknown locus delta action: ${action}`
+        );
     }
   }
-
 
   /**
    * Adds locus delta to parser's queue
@@ -105,7 +106,6 @@ export default class LocusInfo extends EventsScope {
     // queue delta event with parser
     this.locusParser.onDeltaEvent(locus);
   }
-
 
   /**
    * @param {Locus} locus
@@ -230,7 +230,9 @@ export default class LocusInfo extends EventsScope {
    */
   onFullLocus(locus, eventType) {
     if (!locus) {
-      LoggerProxy.logger.error('Locus-info:index#onFullLocus --> object passed as argument was invalid, continuing.');
+      LoggerProxy.logger.error(
+        'Locus-info:index#onFullLocus --> object passed as argument was invalid, continuing.'
+      );
     }
     this.updateParticipantDeltas(locus.participants);
     this.scheduledMeeting = locus.meeting || null;
@@ -239,6 +241,7 @@ export default class LocusInfo extends EventsScope {
     this.updateParticipants(locus.participants);
     this.isMeetingActive();
     this.handleOneOnOneEvent(eventType);
+    this.updateEmbeddedApps(locus.embeddedApps);
     // set current (working copy) for parser
     this.locusParser.workingCopy = locus;
   }
@@ -250,34 +253,37 @@ export default class LocusInfo extends EventsScope {
    * @memberof LocusInfo
    */
   handleOneOnOneEvent(eventType) {
-    if (this.parsedLocus.fullState.type === _CALL_ || this.parsedLocus.fullState.type === _SIP_BRIDGE_) {
-    // for 1:1 bob calls alice and alice declines, notify the meeting state
+    if (
+      this.parsedLocus.fullState.type === _CALL_ ||
+      this.parsedLocus.fullState.type === _SIP_BRIDGE_
+    ) {
+      // for 1:1 bob calls alice and alice declines, notify the meeting state
       if (eventType === LOCUSEVENT.PARTICIPANT_DECLINED) {
-      // trigger the event for stop ringing
+        // trigger the event for stop ringing
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'handleOneonOneEvent'
+            function: 'handleOneonOneEvent',
           },
           EVENTS.REMOTE_RESPONSE,
           {
             remoteDeclined: true,
-            remoteAnswered: false
+            remoteAnswered: false,
           }
         );
       }
       // for 1:1 bob calls alice and alice answers, notify the meeting state
       if (eventType === LOCUSEVENT.PARTICIPANT_JOIN) {
-      // trigger the event for stop ringing
+        // trigger the event for stop ringing
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'handleOneonOneEvent'
+            function: 'handleOneonOneEvent',
           },
           EVENTS.REMOTE_RESPONSE,
           {
             remoteDeclined: false,
-            remoteAnswered: true
+            remoteAnswered: true,
           }
         );
       }
@@ -333,9 +339,14 @@ export default class LocusInfo extends EventsScope {
       return null;
     }
 
-    return participants.find((participant) =>
-      (self && participant.identity !== self.identity) &&
-  (participants.length <= 2 || (participant.type === _USER_ && !participant.removed))) || this.partner;
+    return (
+      participants.find(
+        (participant) =>
+          self &&
+          participant.identity !== self.identity &&
+          (participants.length <= 2 || (participant.type === _USER_ && !participant.removed))
+      ) || this.partner
+    );
   }
 
   // TODO: all the leave states need to be checked
@@ -344,7 +355,10 @@ export default class LocusInfo extends EventsScope {
    * @memberof LocusInfo
    */
   isMeetingActive() {
-    if ((this.parsedLocus.fullState.type === _CALL_) || (this.parsedLocus.fullState.type === _SIP_BRIDGE_)) {
+    if (
+      this.parsedLocus.fullState.type === _CALL_ ||
+      this.parsedLocus.fullState.type === _SIP_BRIDGE_
+    ) {
       const partner = this.getLocusPartner(this.participants, this.self);
 
       this.updateMeeting({partner});
@@ -358,104 +372,110 @@ export default class LocusInfo extends EventsScope {
 
       if (this.fullState && this.fullState.state === LOCUS.STATE.INACTIVE) {
         // TODO: update the meeting state
-        LoggerProxy.logger.warn('Locus-info:index#isMeetingActive --> Call Ended, locus state is inactive.');
+        LoggerProxy.logger.warn(
+          'Locus-info:index#isMeetingActive --> Call Ended, locus state is inactive.'
+        );
         Metrics.postEvent({
           event: eventType.REMOTE_ENDED,
-          meetingId: this.meetingId
+          meetingId: this.meetingId,
         });
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'isMeetingActive'
+            function: 'isMeetingActive',
           },
           EVENTS.DESTROY_MEETING,
           {
             reason: CALL_REMOVED_REASON.CALL_INACTIVE,
-            shouldLeave: false
+            shouldLeave: false,
           }
         );
-      }
-      else
-      if (partner.state === MEETING_STATE.STATES.LEFT &&
+      } else if (
+        partner.state === MEETING_STATE.STATES.LEFT &&
         this.parsedLocus.self &&
         (this.parsedLocus.self.state === MEETING_STATE.STATES.DECLINED ||
-        this.parsedLocus.self.state === MEETING_STATE.STATES.NOTIFIED ||
-        this.parsedLocus.self.state === MEETING_STATE.STATES.JOINED)) {
+          this.parsedLocus.self.state === MEETING_STATE.STATES.NOTIFIED ||
+          this.parsedLocus.self.state === MEETING_STATE.STATES.JOINED)
+      ) {
         Metrics.postEvent({
           event: eventType.REMOTE_ENDED,
-          meetingId: this.meetingId
+          meetingId: this.meetingId,
         });
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'isMeetingActive'
+            function: 'isMeetingActive',
           },
           EVENTS.DESTROY_MEETING,
           {
             reason: CALL_REMOVED_REASON.PARTNER_LEFT,
-            shouldLeave: this.parsedLocus.self.joinedWith && this.parsedLocus.self.joinedWith.state !== _LEFT_
+            shouldLeave:
+              this.parsedLocus.self.joinedWith && this.parsedLocus.self.joinedWith.state !== _LEFT_,
           }
         );
-      }
-      else
-      if (this.parsedLocus.self &&
+      } else if (
+        this.parsedLocus.self &&
         this.parsedLocus.self.state === MEETING_STATE.STATES.LEFT &&
-      (partner.state === MEETING_STATE.STATES.LEFT ||
-      partner.state === MEETING_STATE.STATES.DECLINED ||
-      partner.state === MEETING_STATE.STATES.NOTIFIED ||
-      partner.state === MEETING_STATE.STATES.IDLE) // Happens when user just joins and adds no Media
+        (partner.state === MEETING_STATE.STATES.LEFT ||
+          partner.state === MEETING_STATE.STATES.DECLINED ||
+          partner.state === MEETING_STATE.STATES.NOTIFIED ||
+          partner.state === MEETING_STATE.STATES.IDLE) // Happens when user just joins and adds no Media
       ) {
         Metrics.postEvent({
           event: eventType.REMOTE_ENDED,
-          meetingId: this.meetingId
+          meetingId: this.meetingId,
         });
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'isMeetingActive'
+            function: 'isMeetingActive',
           },
           EVENTS.DESTROY_MEETING,
           {
             reason: CALL_REMOVED_REASON.SELF_LEFT,
-            shouldLeave: false
+            shouldLeave: false,
           }
         );
       }
-    }
-    else if (this.parsedLocus.fullState.type === _MEETING_) {
-      if (this.fullState && (this.fullState.state === LOCUS.STATE.INACTIVE || this.fullState.state === LOCUS.STATE.TERMINATING)) {
-        LoggerProxy.logger.warn('Locus-info:index#isMeetingActive --> Meeting is ending due to inactive or terminating');
+    } else if (this.parsedLocus.fullState.type === _MEETING_) {
+      if (
+        this.fullState &&
+        (this.fullState.state === LOCUS.STATE.INACTIVE ||
+          this.fullState.state === LOCUS.STATE.TERMINATING)
+      ) {
+        LoggerProxy.logger.warn(
+          'Locus-info:index#isMeetingActive --> Meeting is ending due to inactive or terminating'
+        );
         Metrics.postEvent({
           event: eventType.REMOTE_ENDED,
-          meetingId: this.meetingId
+          meetingId: this.meetingId,
         });
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'isMeetingActive'
+            function: 'isMeetingActive',
           },
           EVENTS.DESTROY_MEETING,
           {
             reason: MEETING_REMOVED_REASON.MEETING_INACTIVE_TERMINATING,
-            shouldLeave: false
+            shouldLeave: false,
           }
         );
-      }
-      else if (this.fullState && this.fullState.removed) {
+      } else if (this.fullState && this.fullState.removed) {
         // user has been dropped from a meeting
         Metrics.postEvent({
           event: eventType.REMOTE_ENDED,
-          meetingId: this.meetingId
+          meetingId: this.meetingId,
         });
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'isMeetingActive'
+            function: 'isMeetingActive',
           },
           EVENTS.DESTROY_MEETING,
           {
             reason: MEETING_REMOVED_REASON.FULLSTATE_REMOVED,
-            shouldLeave: false
+            shouldLeave: false,
           }
         );
       }
@@ -466,17 +486,16 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'isMeetingActive'
+            function: 'isMeetingActive',
           },
           EVENTS.DESTROY_MEETING,
           {
             reason: MEETING_REMOVED_REASON.SELF_REMOVED,
-            shouldLeave: false
+            shouldLeave: false,
           }
         );
       }
-    }
-    else {
+    } else {
       LoggerProxy.logger.warn('Locus-info:index#isMeetingActive --> Meeting Type is unknown.');
     }
   }
@@ -490,7 +509,10 @@ export default class LocusInfo extends EventsScope {
   compareAndUpdate() {
     // TODO: check with locus team on host and moderator doc
     // use host as a validator if needed
-    if (this.compareAndUpdateFlags.compareSelfAndHost || this.compareAndUpdateFlags.compareHostAndSelf) {
+    if (
+      this.compareAndUpdateFlags.compareSelfAndHost ||
+      this.compareAndUpdateFlags.compareHostAndSelf
+    ) {
       this.compareSelfAndHost();
     }
   }
@@ -502,27 +524,29 @@ export default class LocusInfo extends EventsScope {
    */
   compareSelfAndHost() {
     // In some cases the host info is not present but the moderator values changes from null to false so it triggers an update
-    if ((this.parsedLocus.self.selfIdentity === this.parsedLocus.host?.hostId) && this.parsedLocus.self.moderator) {
+    if (
+      this.parsedLocus.self.selfIdentity === this.parsedLocus.host?.hostId &&
+      this.parsedLocus.self.moderator
+    ) {
       this.emitScoped(
         {
           file: 'locus-info',
-          function: 'compareSelfAndHost'
+          function: 'compareSelfAndHost',
         },
         EVENTS.LOCUS_INFO_CAN_ASSIGN_HOST,
         {
-          canAssignHost: true
+          canAssignHost: true,
         }
       );
-    }
-    else {
+    } else {
       this.emitScoped(
         {
           file: 'locus-info',
-          function: 'compareSelfAndHost'
+          function: 'compareSelfAndHost',
         },
         EVENTS.LOCUS_INFO_CAN_ASSIGN_HOST,
         {
-          canAssignHost: false
+          canAssignHost: false,
         }
       );
     }
@@ -546,42 +570,35 @@ export default class LocusInfo extends EventsScope {
       const deltas = {
         audioStatus: prevState.audioStatus !== newState.audioStatus,
         videoSlidesStatus: prevState.videoSlidesStatus !== newState.videoSlidesStatus,
-        videoStatus: prevState.videoStatus !== newState.videoStatus
+        videoStatus: prevState.videoStatus !== newState.videoStatus,
       };
 
       // Clean the object
-      Object.keys(deltas).forEach(
-        (key) => {
-          if (deltas[key] !== true) {
-            delete deltas[key];
-          }
+      Object.keys(deltas).forEach((key) => {
+        if (deltas[key] !== true) {
+          delete deltas[key];
         }
-      );
+      });
 
       return deltas;
     };
 
-    this.deltaParticipants = participants.reduce(
-      (collection, participant) => {
-        const existingParticipant = findParticipant(
-          participant,
-          this.participants || []
-        ) || {};
+    this.deltaParticipants = participants.reduce((collection, participant) => {
+      const existingParticipant = findParticipant(participant, this.participants || []) || {};
 
-        const delta = generateDelta(existingParticipant.status, participant.status);
+      const delta = generateDelta(existingParticipant.status, participant.status);
 
-        const changed = (Object.keys(delta).length > 0);
+      const changed = Object.keys(delta).length > 0;
 
-        if (changed) {
-          collection.push({
-            person: participant.person,
-            delta
-          });
-        }
+      if (changed) {
+        collection.push({
+          person: participant.person,
+          delta,
+        });
+      }
 
-        return collection;
-      }, []
-    );
+      return collection;
+    }, []);
   }
 
   /**
@@ -595,7 +612,7 @@ export default class LocusInfo extends EventsScope {
     this.emitScoped(
       {
         file: 'locus-info',
-        function: 'updateParticipants'
+        function: 'updateParticipants',
       },
       EVENTS.LOCUS_INFO_UPDATE_PARTICIPANTS,
       {
@@ -603,7 +620,7 @@ export default class LocusInfo extends EventsScope {
         recordingId: this.parsedLocus.controls && this.parsedLocus.controls.record?.modifiedBy,
         selfIdentity: this.parsedLocus.self && this.parsedLocus.self.selfIdentity,
         selfId: this.parsedLocus.self && this.parsedLocus.self.selfId,
-        hostId: this.parsedLocus.host && this.parsedLocus.host.hostId
+        hostId: this.parsedLocus.host && this.parsedLocus.host.hostId,
       }
     );
   }
@@ -621,9 +638,9 @@ export default class LocusInfo extends EventsScope {
           hasRecordingChanged,
           hasRecordingPausedChanged,
           hasMeetingContainerChanged,
-          hasTranscribeChanged
+          hasTranscribeChanged,
         },
-        current
+        current,
       } = ControlsUtils.getControls(this.controls, controls);
 
       if (hasRecordingChanged || hasRecordingPausedChanged) {
@@ -632,26 +649,24 @@ export default class LocusInfo extends EventsScope {
         if (hasRecordingPausedChanged) {
           if (current.record.paused) {
             state = RECORDING_STATE.PAUSED;
-          }
-          else {
+          } else {
             // state will be `IDLE` if the recording is not active, even when there is a `pause` status change.
             state = current.record.recording ? RECORDING_STATE.RESUMED : RECORDING_STATE.IDLE;
           }
-        }
-        else if (hasRecordingChanged) {
+        } else if (hasRecordingChanged) {
           state = current.record.recording ? RECORDING_STATE.RECORDING : RECORDING_STATE.IDLE;
         }
 
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateControls'
+            function: 'updateControls',
           },
           LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
           {
             state,
             modifiedBy: current.record.modifiedBy,
-            lastModified: current.record.lastModified
+            lastModified: current.record.lastModified,
           }
         );
       }
@@ -662,11 +677,11 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateControls'
+            function: 'updateControls',
           },
           LOCUSINFO.EVENTS.CONTROLS_MEETING_CONTAINER_UPDATED,
           {
-            meetingContainerUrl
+            meetingContainerUrl,
           }
         );
       }
@@ -677,11 +692,12 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateControls'
+            function: 'updateControls',
           },
           LOCUSINFO.EVENTS.CONTROLS_MEETING_TRANSCRIBE_UPDATED,
           {
-            transcribing, caption
+            transcribing,
+            caption,
           }
         );
       }
@@ -700,8 +716,11 @@ export default class LocusInfo extends EventsScope {
     if (conversationUrl && !isEqual(this.conversationUrl, conversationUrl)) {
       this.conversationUrl = conversationUrl;
       this.updateMeeting({conversationUrl});
-    }
-    else if (info && info.conversationUrl && !isEqual(this.conversationUrl, info.conversationUrl)) {
+    } else if (
+      info &&
+      info.conversationUrl &&
+      !isEqual(this.conversationUrl, info.conversationUrl)
+    ) {
       this.conversationUrl = info.conversationUrl;
       this.updateMeeting({conversationUrl: info.conversationUrl});
     }
@@ -718,7 +737,6 @@ export default class LocusInfo extends EventsScope {
     }
   }
 
-
   /**
    * @param {Object} fullState
    * @returns {undefined}
@@ -734,12 +752,12 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateFullState'
+            function: 'updateFullState',
           },
           LOCUSINFO.EVENTS.FULL_STATE_MEETING_STATE_CHANGE,
           {
             previousState: result.previous && result.previous.meetingState,
-            currentState: result.current.meetingState
+            currentState: result.current.meetingState,
           }
         );
       }
@@ -748,11 +766,11 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateFullState'
+            function: 'updateFullState',
           },
           LOCUSINFO.EVENTS.FULL_STATE_TYPE_UPDATE,
           {
-            type: result.current.type
+            type: result.current.type,
           }
         );
       }
@@ -779,18 +797,17 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateHostInfo'
+            function: 'updateHostInfo',
           },
           EVENTS.LOCUS_INFO_UPDATE_HOST,
           {
             newHost: parsedHosts.current,
-            oldHost: parsedHosts.previous
+            oldHost: parsedHosts.previous,
           }
         );
       }
       this.host = host;
-    }
-    else {
+    } else {
       this.compareAndUpdateFlags.compareSelfAndHost = false;
     }
   }
@@ -802,7 +819,7 @@ export default class LocusInfo extends EventsScope {
    * @memberof LocusInfo
    */
   updateMeetingInfo(info, self) {
-    if (info && (!isEqual(this.info, info))) {
+    if (info && !isEqual(this.info, info)) {
       const roles = self ? SelfUtils.getRoles(self) : this.parsedLocus.self?.roles || [];
       const isJoined = SelfUtils.isJoined(self || this.parsedLocus.self);
       const parsedInfo = InfoUtils.getInfos(this.parsedLocus.info, info, roles, isJoined);
@@ -810,7 +827,7 @@ export default class LocusInfo extends EventsScope {
       this.emitScoped(
         {
           file: 'locus-info',
-          function: 'updateMeetingInfo'
+          function: 'updateMeetingInfo',
         },
         LOCUSINFO.EVENTS.MEETING_INFO_UPDATED,
         {info: parsedInfo.current, self}
@@ -820,7 +837,7 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateMeetingInfo'
+            function: 'updateMeetingInfo',
           },
           LOCUSINFO.EVENTS.MEETING_LOCKED,
           info
@@ -830,7 +847,7 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateMeetingInfo'
+            function: 'updateMeetingInfo',
           },
           LOCUSINFO.EVENTS.MEETING_UNLOCKED,
           info
@@ -855,15 +872,17 @@ export default class LocusInfo extends EventsScope {
       return;
     }
 
-    this.parsedLocus.embeddedApps = EmbeddedAppsUtils.parse(embeddedApps);
+    const parsedEmbeddedApps = EmbeddedAppsUtils.parse(embeddedApps);
+
+    this.updateMeeting({embeddedApps: parsedEmbeddedApps});
 
     this.emitScoped(
       {
         file: 'locus-info',
-        function: 'updateEmbeddedApps'
+        function: 'updateEmbeddedApps',
       },
       LOCUSINFO.EVENTS.EMBEDDED_APPS_UPDATED,
-      embeddedApps
+      parsedEmbeddedApps
     );
     this.embeddedApps = embeddedApps;
   }
@@ -883,12 +902,12 @@ export default class LocusInfo extends EventsScope {
       this.emitScoped(
         {
           file: 'locus-info',
-          function: 'updateMediaShares'
+          function: 'updateMediaShares',
         },
         EVENTS.LOCUS_INFO_UPDATE_MEDIA_SHARES,
         {
           current: parsedMediaShares.current,
-          previous: parsedMediaShares.previous
+          previous: parsedMediaShares.previous,
         }
       );
       this.parsedLocus.mediaShares = parsedMediaShares.current;
@@ -941,7 +960,11 @@ export default class LocusInfo extends EventsScope {
 
       // TODO: check if we need to save the sipUri here as well
       // this.emit(LOCUSINFO.EVENTS.MEETING_UPDATE, SelfUtils.getSipUrl(this.getLocusPartner(participants, self), this.parsedLocus.fullState.type, this.parsedLocus.info.sipUri));
-      const result = SelfUtils.getSipUrl(this.getLocusPartner(participants, self), this.parsedLocus.fullState.type, this.parsedLocus.info.sipUri);
+      const result = SelfUtils.getSipUrl(
+        this.getLocusPartner(participants, self),
+        this.parsedLocus.fullState.type,
+        this.parsedLocus.info.sipUri
+      );
 
       if (result.sipUri) {
         this.updateMeeting(result);
@@ -949,8 +972,7 @@ export default class LocusInfo extends EventsScope {
 
       if (parsedSelves.updates.moderatorChanged) {
         this.compareAndUpdateFlags.compareHostAndSelf = true;
-      }
-      else {
+      } else {
         this.compareAndUpdateFlags.compareHostAndSelf = false;
       }
 
@@ -958,7 +980,7 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.CONTROLS_MEETING_LAYOUT_UPDATED,
           {layout: parsedSelves.current.layout}
@@ -969,7 +991,7 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.DISCONNECT_DUE_TO_INACTIVITY,
           {reason: self.reason}
@@ -980,7 +1002,7 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.SELF_MODERATOR_CHANGED,
           self
@@ -990,12 +1012,12 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUIRED,
           {
             muted: parsedSelves.current.remoteMuted,
-            unmuteAllowed: parsedSelves.current.unmuteAllowed
+            unmuteAllowed: parsedSelves.current.unmuteAllowed,
           }
         );
       }
@@ -1003,12 +1025,12 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
           {
             muted: parsedSelves.current.remoteMuted,
-            unmuteAllowed: parsedSelves.current.unmuteAllowed
+            unmuteAllowed: parsedSelves.current.unmuteAllowed,
           }
         );
       }
@@ -1016,7 +1038,7 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUESTED,
           {}
@@ -1026,7 +1048,7 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.SELF_UNADMITTED_GUEST,
           self
@@ -1036,7 +1058,7 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.SELF_ADMITTED_GUEST,
           self
@@ -1047,24 +1069,28 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.MEDIA_INACTIVITY,
           SelfUtils.getMediaStatus(self.mediaSessions)
         );
       }
 
-      if (parsedSelves.updates.audioStateChange || parsedSelves.updates.videoStateChange || parsedSelves.updates.shareStateChange) {
+      if (
+        parsedSelves.updates.audioStateChange ||
+        parsedSelves.updates.videoStateChange ||
+        parsedSelves.updates.shareStateChange
+      ) {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.MEDIA_STATUS_CHANGE,
           {
             audioStatus: parsedSelves.current.currentMediaStatus?.audio,
             videoStatus: parsedSelves.current.currentMediaStatus?.video,
-            shareStatus: parsedSelves.current.currentMediaStatus?.share
+            shareStatus: parsedSelves.current.currentMediaStatus?.share,
           }
         );
       }
@@ -1073,28 +1099,26 @@ export default class LocusInfo extends EventsScope {
         this.emitScoped(
           {
             file: 'locus-info',
-            function: 'updateSelf'
+            function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.SELF_OBSERVING
         );
       }
 
-
       this.emitScoped(
         {
           file: 'locus-info',
-          function: 'updateSelf'
+          function: 'updateSelf',
         },
         EVENTS.LOCUS_INFO_UPDATE_SELF,
         {
           oldSelf: parsedSelves.previous,
-          newSelf: parsedSelves.current
+          newSelf: parsedSelves.current,
         }
       );
       this.parsedLocus.self = parsedSelves.current;
       this.self = self;
-    }
-    else {
+    } else {
       this.compareAndUpdateFlags.compareHostAndSelf = false;
     }
   }
@@ -1112,7 +1136,7 @@ export default class LocusInfo extends EventsScope {
       this.emitScoped(
         {
           file: 'locus-info',
-          function: 'updateLocusUrl'
+          function: 'updateLocusUrl',
         },
         EVENTS.LOCUS_INFO_UPDATE_URL,
         url

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -3,11 +3,11 @@ import sinon from 'sinon';
 import {cloneDeep} from 'lodash';
 import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
-
 import Meetings from '@webex/plugin-meetings';
 import LocusInfo from '@webex/plugin-meetings/src/locus-info';
 import SelfUtils from '@webex/plugin-meetings/src/locus-info/selfUtils';
 import InfoUtils from '@webex/plugin-meetings/src/locus-info/infoUtils';
+import EmbeddedAppsUtils from '@webex/plugin-meetings/src/locus-info/embeddedAppsUtils';
 import LocusDeltaParser from '@webex/plugin-meetings/src/locus-info/parser';
 
 import {
@@ -15,28 +15,34 @@ import {
   RECORDING_STATE,
   LOCUSEVENT,
   EVENTS,
-  DISPLAY_HINTS
+  DISPLAY_HINTS,
 } from '../../../../src/constants';
 
 import {self, selfWithInactivity} from './selfConstant';
 
 describe('plugin-meetings', () => {
   describe('LocusInfo index', () => {
-    const updateMeeting = () => {};
+    let mockMeeting;
+    const updateMeeting = (object) => {
+      if (mockMeeting && object && Object.keys(object).length) {
+        Object.keys(object).forEach((key) => {
+          mockMeeting[key] = object[key];
+        });
+      }
+    };
     const locus = {};
-    const meetingId = 'meedingId';
+    const meetingId = 'meetingId';
     let locusInfo;
 
     const webex = new MockWebex({
       children: {
-        meetings: Meetings
-      }
+        meetings: Meetings,
+      },
     });
 
     beforeEach(() => {
-      locusInfo = new LocusInfo(
-        updateMeeting, webex, meetingId
-      );
+      mockMeeting = {};
+      locusInfo = new LocusInfo(updateMeeting, webex, meetingId);
 
       locusInfo.init(locus);
 
@@ -49,9 +55,9 @@ describe('plugin-meetings', () => {
           isLocked: false,
           displayHints: {
             joined: ['ROSTER_IN_MEETING', 'LOCK_STATUS_UNLOCKED'],
-            moderator: []
-          }
-        }
+            moderator: [],
+          },
+        },
       };
     });
 
@@ -67,14 +73,14 @@ describe('plugin-meetings', () => {
             paused: false,
             meta: {
               lastModified: 'TODAY',
-              modifiedBy: 'George Kittle'
-            }
+              modifiedBy: 'George Kittle',
+            },
           },
           shareControl: {},
           transcribe: {},
           meetingContainer: {
-            meetingContainerUrl: 'http://new-url.com'
-          }
+            meetingContainerUrl: 'http://new-url.com',
+          },
         };
       });
 
@@ -106,25 +112,28 @@ describe('plugin-meetings', () => {
             paused: false,
             meta: {
               lastModified: 'TODAY',
-              modifiedBy: 'George Kittle'
-            }
+              modifiedBy: 'George Kittle',
+            },
           },
           shareControl: {},
-          transcribe: {}
+          transcribe: {},
         };
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateControls(newControls);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateControls'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
-        {
-          state: RECORDING_STATE.IDLE,
-          modifiedBy: 'George Kittle',
-          lastModified: 'TODAY'
-        });
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateControls',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
+          {
+            state: RECORDING_STATE.IDLE,
+            modifiedBy: 'George Kittle',
+            lastModified: 'TODAY',
+          }
+        );
       });
 
       it('should update the recording state to `RECORDING`', () => {
@@ -136,26 +145,29 @@ describe('plugin-meetings', () => {
             paused: false,
             meta: {
               lastModified: 'TODAY',
-              modifiedBy: 'George Kittle'
-            }
+              modifiedBy: 'George Kittle',
+            },
           },
           shareControl: {},
-          transcribe: {}
+          transcribe: {},
         };
         newControls.record.recording = true;
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateControls(newControls);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateControls'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
-        {
-          state: RECORDING_STATE.RECORDING,
-          modifiedBy: 'George Kittle',
-          lastModified: 'TODAY'
-        });
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateControls',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
+          {
+            state: RECORDING_STATE.RECORDING,
+            modifiedBy: 'George Kittle',
+            lastModified: 'TODAY',
+          }
+        );
       });
 
       it('should update the recording state to `PAUSED`', () => {
@@ -168,26 +180,29 @@ describe('plugin-meetings', () => {
             paused: false,
             meta: {
               lastModified: 'TODAY',
-              modifiedBy: 'George Kittle'
-            }
+              modifiedBy: 'George Kittle',
+            },
           },
           shareControl: {},
-          transcribe: {}
+          transcribe: {},
         };
         newControls.record.paused = true;
         newControls.record.recording = true;
         locusInfo.updateControls(newControls);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateControls'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
-        {
-          state: RECORDING_STATE.PAUSED,
-          modifiedBy: 'George Kittle',
-          lastModified: 'TODAY'
-        });
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateControls',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
+          {
+            state: RECORDING_STATE.PAUSED,
+            modifiedBy: 'George Kittle',
+            lastModified: 'TODAY',
+          }
+        );
       });
 
       it('should update the recording state to `RESUMED`', () => {
@@ -200,27 +215,30 @@ describe('plugin-meetings', () => {
             paused: true,
             meta: {
               lastModified: 'TODAY',
-              modifiedBy: 'George Kittle'
-            }
+              modifiedBy: 'George Kittle',
+            },
           },
           shareControl: {},
-          transcribe: {}
+          transcribe: {},
         };
         // there must be a recording to be paused/resumed
         newControls.record.recording = true;
         newControls.record.paused = false;
         locusInfo.updateControls(newControls);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateControls'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
-        {
-          state: RECORDING_STATE.RESUMED,
-          modifiedBy: 'George Kittle',
-          lastModified: 'TODAY'
-        });
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateControls',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
+          {
+            state: RECORDING_STATE.RESUMED,
+            modifiedBy: 'George Kittle',
+            lastModified: 'TODAY',
+          }
+        );
       });
 
       it('should update the recording state to `IDLE` even if `pause`status changes', () => {
@@ -233,26 +251,29 @@ describe('plugin-meetings', () => {
             paused: true,
             meta: {
               lastModified: 'TODAY',
-              modifiedBy: 'George Kittle'
-            }
+              modifiedBy: 'George Kittle',
+            },
           },
           shareControl: {},
-          transcribe: {}
+          transcribe: {},
         };
         newControls.record.recording = false;
         newControls.record.paused = false;
         locusInfo.updateControls(newControls);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateControls'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
-        {
-          state: RECORDING_STATE.IDLE,
-          modifiedBy: 'George Kittle',
-          lastModified: 'TODAY'
-        });
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateControls',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
+          {
+            state: RECORDING_STATE.IDLE,
+            modifiedBy: 'George Kittle',
+            lastModified: 'TODAY',
+          }
+        );
       });
 
       it('should update the transcript state', () => {
@@ -265,28 +286,32 @@ describe('plugin-meetings', () => {
             paused: true,
             meta: {
               lastModified: 'TODAY',
-              modifiedBy: 'George Kittle'
-            }
+              modifiedBy: 'George Kittle',
+            },
           },
           shareControl: {},
           transcribe: {
             transcribing: false,
-            caption: false
-          }
+            caption: false,
+          },
         };
         newControls.transcribe.transcribing = true;
         newControls.transcribe.caption = true;
 
         locusInfo.updateControls(newControls);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateControls'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_MEETING_TRANSCRIBE_UPDATED,
-        {
-          transcribing: true, caption: true
-        });
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateControls',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_MEETING_TRANSCRIBE_UPDATED,
+          {
+            transcribing: true,
+            caption: true,
+          }
+        );
       });
 
       it('should update the meetingContainerURL from null', () => {
@@ -297,12 +322,15 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateControls(newControls);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateControls'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_MEETING_CONTAINER_UPDATED,
-        {meetingContainerUrl: 'http://new-url.com'});
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateControls',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_MEETING_CONTAINER_UPDATED,
+          {meetingContainerUrl: 'http://new-url.com'}
+        );
       });
 
       it('should update the meetingContainerURL from not null', () => {
@@ -313,12 +341,15 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateControls(newControls);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateControls'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_MEETING_CONTAINER_UPDATED,
-        {meetingContainerUrl: 'http://new-url.com'});
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateControls',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_MEETING_CONTAINER_UPDATED,
+          {meetingContainerUrl: 'http://new-url.com'}
+        );
       });
 
       it('should update the meetingContainerURL from missing', () => {
@@ -327,12 +358,15 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateControls(newControls);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateControls'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_MEETING_CONTAINER_UPDATED,
-        {meetingContainerUrl: 'http://new-url.com'});
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateControls',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_MEETING_CONTAINER_UPDATED,
+          {meetingContainerUrl: 'http://new-url.com'}
+        );
       });
     });
 
@@ -343,14 +377,14 @@ describe('plugin-meetings', () => {
         newParticipants = [
           {
             person: {
-              id: 1234
+              id: 1234,
             },
             status: {
               audioStatus: 'testValue',
               videoSlidesStatus: 'testValue',
-              videoStatus: 'testValue'
-            }
-          }
+              videoStatus: 'testValue',
+            },
+          },
         ];
       });
 
@@ -358,26 +392,27 @@ describe('plugin-meetings', () => {
         locusInfo.parsedLocus = {
           controls: {
             record: {
-              modifiedBy: '1'
-            }
+              modifiedBy: '1',
+            },
           },
           self: {
             selfIdentity: '123',
-            selfId: '2'
+            selfId: '2',
           },
           host: {
-            hostId: '3'
-          }
+            hostId: '3',
+          },
         };
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateParticipants({});
 
         // if this assertion fails, double-check the attributes used in
         // the updateParticipants function in locus-info/index.js
-        assert.calledWith(locusInfo.emitScoped,
+        assert.calledWith(
+          locusInfo.emitScoped,
           {
             file: 'locus-info',
-            function: 'updateParticipants'
+            function: 'updateParticipants',
           },
           EVENTS.LOCUS_INFO_UPDATE_PARTICIPANTS,
           {
@@ -385,8 +420,9 @@ describe('plugin-meetings', () => {
             recordingId: '1',
             selfIdentity: '123',
             selfId: '2',
-            hostId: '3'
-          });
+            hostId: '3',
+          }
+        );
         // note: in a real use case, recordingId, selfId, and hostId would all be the same
         // for this specific test, we are double-checking that each of the id's
         // are being correctly grabbed from locusInfo.parsedLocus within updateParticipants
@@ -434,19 +470,24 @@ describe('plugin-meetings', () => {
         locusInfo.self = undefined;
         const selfWithLayoutChanged = cloneDeep(self);
 
-        selfWithLayoutChanged.controls.layouts = [{
-          type: layoutType,
-        }];
+        selfWithLayoutChanged.controls.layouts = [
+          {
+            type: layoutType,
+          },
+        ];
 
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateSelf(selfWithLayoutChanged, []);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_MEETING_LAYOUT_UPDATED,
-        {layout: layoutType});
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_MEETING_LAYOUT_UPDATED,
+          {layout: layoutType}
+        );
       });
 
       it('should not trigger CONTROLS_MEETING_LAYOUT_UPDATED when the meeting layout controls did not change', () => {
@@ -455,9 +496,11 @@ describe('plugin-meetings', () => {
         locusInfo.self = undefined;
         const selfWithLayoutChanged = cloneDeep(self);
 
-        selfWithLayoutChanged.controls.layouts = [{
-          type: layoutType,
-        }];
+        selfWithLayoutChanged.controls.layouts = [
+          {
+            type: layoutType,
+          },
+        ];
 
         // Set the layout prior to stubbing to validate it does not change.
         locusInfo.updateSelf(selfWithLayoutChanged, []);
@@ -466,12 +509,15 @@ describe('plugin-meetings', () => {
 
         locusInfo.updateSelf(selfWithLayoutChanged, []);
 
-        assert.neverCalledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.CONTROLS_MEETING_LAYOUT_UPDATED,
-        {layout: layoutType});
+        assert.neverCalledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.CONTROLS_MEETING_LAYOUT_UPDATED,
+          {layout: layoutType}
+        );
       });
 
       it('should trigger MEDIA_INACTIVITY on server media inactivity', () => {
@@ -481,12 +527,15 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateSelf(selfWithInactivity, []);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.MEDIA_INACTIVITY,
-        SelfUtils.getMediaStatus(selfWithInactivity.mediaSessions));
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.MEDIA_INACTIVITY,
+          SelfUtils.getMediaStatus(selfWithInactivity.mediaSessions)
+        );
       });
 
       it('should trigger SELF_REMOTE_MUTE_STATUS_UPDATED when muted on entry', () => {
@@ -500,24 +549,30 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateSelf(selfWithMutedByOthers, []);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
-        {muted: true, unmuteAllowed: true});
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
+          {muted: true, unmuteAllowed: true}
+        );
 
         // but sometimes "previous self" is defined, but without controls.audio.muted, so we test this here:
         locusInfo.self = cloneDeep(self);
         locusInfo.self.controls.audio = {};
 
         locusInfo.updateSelf(selfWithMutedByOthers, []);
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
-        {muted: true, unmuteAllowed: true});
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
+          {muted: true, unmuteAllowed: true}
+        );
       });
 
       it('should not trigger SELF_REMOTE_MUTE_STATUS_UPDATED when not muted on entry', () => {
@@ -568,12 +623,15 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateSelf(selfWithMutedByOthers, []);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
-        {muted: true, unmuteAllowed: true});
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
+          {muted: true, unmuteAllowed: true}
+        );
       });
 
       it('should trigger SELF_REMOTE_MUTE_STATUS_UPDATED if muted and disallowUnmute changed', () => {
@@ -588,12 +646,15 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateSelf(selfWithMutedByOthersAndDissalowUnmute, []);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
-        {muted: true, unmuteAllowed: false});
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
+          {muted: true, unmuteAllowed: false}
+        );
 
         // now change only disallowUnmute
         const selfWithMutedByOthers = cloneDeep(self);
@@ -603,12 +664,15 @@ describe('plugin-meetings', () => {
 
         locusInfo.updateSelf(selfWithMutedByOthers, []);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
-        {muted: true, unmuteAllowed: true});
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
+          {muted: true, unmuteAllowed: true}
+        );
       });
 
       it('should trigger LOCAL_UNMUTE_REQUIRED on localAudioUnmuteRequired', () => {
@@ -622,15 +686,18 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateSelf(selfWithLocalUnmuteRequired, []);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUIRED,
-        {
-          muted: false,
-          unmuteAllowed: true
-        });
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUIRED,
+          {
+            muted: false,
+            unmuteAllowed: true,
+          }
+        );
       });
 
       it('should trigger LOCAL_UNMUTE_REQUESTED when receiving requestedToUnmute=true', () => {
@@ -643,12 +710,15 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateSelf(selfWithRequestedToUnmute, []);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUESTED,
-        {});
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUESTED,
+          {}
+        );
 
         // now change requestedToUnmute back to false -> it should NOT trigger LOCAL_UNMUTE_REQUESTED
         const selfWithoutRequestedToUnmute = cloneDeep(selfWithRequestedToUnmute);
@@ -658,14 +728,16 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped.resetHistory();
         locusInfo.updateSelf(selfWithoutRequestedToUnmute, []);
 
-        assert.neverCalledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUESTED,
-        {});
+        assert.neverCalledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUESTED,
+          {}
+        );
       });
-
 
       it('should trigger SELF_OBSERVING when moving meeting to DX', () => {
         locusInfo.self = self;
@@ -686,11 +758,14 @@ describe('plugin-meetings', () => {
 
         locusInfo.updateSelf(selfAfterDxJoins, []);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateSelf'
-        },
-        LOCUSINFO.EVENTS.SELF_OBSERVING);
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.SELF_OBSERVING
+        );
       });
     });
 
@@ -704,8 +779,8 @@ describe('plugin-meetings', () => {
         meetingInfo = {
           displayHints: {
             joined: ['ROSTER_IN_MEETING', 'LOCK_STATUS_UNLOCKED'],
-            moderator: []
-          }
+            moderator: [],
+          },
         };
         getInfosSpy = sinon.spy(InfoUtils, 'getInfos');
         getRolesSpy = sinon.spy(SelfUtils, 'getRoles');
@@ -731,38 +806,46 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped = sinon.stub();
         locusInfo.updateMeetingInfo(meetingInfoLocked, self);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateMeetingInfo'
-        },
-        LOCUSINFO.EVENTS.MEETING_LOCKED,
-        meetingInfoLocked);
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateMeetingInfo',
+          },
+          LOCUSINFO.EVENTS.MEETING_LOCKED,
+          meetingInfoLocked
+        );
 
         // now unlock the meeting and verify that we get the right event
         const meetingInfoUnlocked = cloneDeep(meetingInfo); // meetingInfo already is "unlocked"
 
         locusInfo.updateMeetingInfo(meetingInfoUnlocked, self);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateMeetingInfo'
-        },
-        LOCUSINFO.EVENTS.MEETING_UNLOCKED,
-        meetingInfoUnlocked);
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateMeetingInfo',
+          },
+          LOCUSINFO.EVENTS.MEETING_UNLOCKED,
+          meetingInfoUnlocked
+        );
       });
 
       const checkMeetingInfoUpdatedCalled = (expected) => {
-        const expectedArgs = [locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateMeetingInfo'
-        },
-        LOCUSINFO.EVENTS.MEETING_INFO_UPDATED,
-        {info: locusInfo.parsedLocus.info, self}];
+        const expectedArgs = [
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateMeetingInfo',
+          },
+          LOCUSINFO.EVENTS.MEETING_INFO_UPDATED,
+          {info: locusInfo.parsedLocus.info, self},
+        ];
 
         if (expected) {
           assert.calledWith(...expectedArgs);
-        }
-        else {
+        } else {
           assert.neverCalledWith(...expectedArgs);
         }
         locusInfo.emitScoped.resetHistory();
@@ -803,17 +886,14 @@ describe('plugin-meetings', () => {
         locusInfo.updateMeetingInfo(initialInfo, self);
 
         assert.calledWith(getRolesSpy, self);
-        assert.calledWith(
-          getInfosSpy,
-          parsedLocusInfo, initialInfo, ['PRESENTER']
-        );
+        assert.calledWith(getInfosSpy, parsedLocusInfo, initialInfo, ['PRESENTER']);
       });
 
       it('gets roles from parsedLocus if self not passed in', () => {
         const initialInfo = cloneDeep(meetingInfo);
 
         locusInfo.parsedLocus.self = {
-          roles: ['MODERATOR', 'COHOST']
+          roles: ['MODERATOR', 'COHOST'],
         };
 
         const parsedLocusInfo = cloneDeep(locusInfo.parsedLocus.info);
@@ -821,36 +901,38 @@ describe('plugin-meetings', () => {
         locusInfo.updateMeetingInfo(initialInfo);
         assert.calledWith(isJoinedSpy, locusInfo.parsedLocus.self);
         assert.neverCalledWith(getRolesSpy, self);
-        assert.calledWith(
-          getInfosSpy,
-          parsedLocusInfo, initialInfo, ['MODERATOR', 'COHOST']
-        );
+        assert.calledWith(getInfosSpy, parsedLocusInfo, initialInfo, ['MODERATOR', 'COHOST']);
       });
     });
 
     describe('#updateEmbeddedApps()', () => {
-      const newEmbeddedApps = [{
-        url: 'https://hecate-b.wbx2.com/apps/api/v1/locus/7a4994a7',
-        sequence: 138849877016800000,
-        appId: 'Y2lzY29zcGFyazovL3VzL0FQUExJQ0FUSU9OLzQxODc1MGQ0LTM3ZDctNGY2MC1hOWE3LWEwZTE1NDFhNjRkNg',
-        instanceInfo: {
-          appInstanceUrl: 'https://webex.sli.do/participant/event/mFKKjcYxzx9h31eyWgngFS?clusterId=eu1',
-          externalAppInstanceUrl: '',
-          title: 'Active session'
+      const newEmbeddedApps = [
+        {
+          url: 'https://hecate-b.wbx2.com/apps/api/v1/locus/7a4994a7',
+          sequence: 138849877016800000,
+          appId:
+            'Y2lzY29zcGFyazovL3VzL0FQUExJQ0FUSU9OLzQxODc1MGQ0LTM3ZDctNGY2MC1hOWE3LWEwZTE1NDFhNjRkNg',
+          instanceInfo: {
+            appInstanceUrl:
+              'https://webex.sli.do/participant/event/mFKKjcYxzx9h31eyWgngFS?clusterId=eu1',
+            externalAppInstanceUrl: '',
+            title: 'Active session',
+          },
+          state: 'STARTED',
+          lastModified: '2022-10-13T21:01:41.680Z',
         },
-        state: 'STARTED',
-        lastModified: '2022-10-13T21:01:41.680Z'
-      }];
+      ];
 
-      it('updates the embeddedApps object', () => {
-        const prev = locusInfo.embeddedApps;
+      it('properly updates the meeting embeddedApps', () => {
+        const prev = mockMeeting.embeddedApps;
 
         locusInfo.updateEmbeddedApps(newEmbeddedApps);
 
-        assert.notEqual(locusInfo.embeddedApps, prev);
+        assert.notEqual(mockMeeting.embeddedApps, prev);
+        assert.isNotNull(mockMeeting.embeddedApps?.[0].type);
       });
 
-      it('does not emit EMBEDDED_APPS_UPDATED when apps didn\'t change', () => {
+      it("does not emit EMBEDDED_APPS_UPDATED when apps didn't change", () => {
         locusInfo.updateEmbeddedApps(newEmbeddedApps);
 
         locusInfo.emitScoped = sinon.stub();
@@ -870,15 +952,19 @@ describe('plugin-meetings', () => {
         const clonedApps = cloneDeep(newEmbeddedApps);
 
         clonedApps[0].state = 'STOPPED';
+        const expectedApps = EmbeddedAppsUtils.parse(clonedApps);
 
         locusInfo.updateEmbeddedApps(clonedApps);
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'updateEmbeddedApps'
-        },
-        LOCUSINFO.EVENTS.EMBEDDED_APPS_UPDATED,
-        clonedApps);
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateEmbeddedApps',
+          },
+          LOCUSINFO.EVENTS.EMBEDDED_APPS_UPDATED,
+          expectedApps
+        );
       });
     });
 
@@ -894,7 +980,7 @@ describe('plugin-meetings', () => {
 
         fakeLocus = {
           meeting: true,
-          participants: true
+          participants: true,
         };
       });
 
@@ -903,13 +989,12 @@ describe('plugin-meetings', () => {
         sandbox = null;
       });
 
-
       it('handles locus delta events', () => {
         sandbox.stub(locusInfo, 'handleLocusDelta');
 
         const data = {
           eventType: LOCUSEVENT.DIFFERENCE,
-          locus: fakeLocus
+          locus: fakeLocus,
         };
 
         locusInfo.parse(fakeMeeting, data);
@@ -917,13 +1002,12 @@ describe('plugin-meetings', () => {
         assert.calledWith(locusInfo.handleLocusDelta, fakeLocus, fakeMeeting);
       });
 
-
       it('should queue delta event with internal locus parser', () => {
         sandbox.stub(locusParser, 'onDeltaEvent');
 
         const data = {
           eventType: LOCUSEVENT.DIFFERENCE,
-          locus: fakeLocus
+          locus: fakeLocus,
         };
 
         locusInfo.parse(fakeMeeting, data);
@@ -931,7 +1015,6 @@ describe('plugin-meetings', () => {
         // queues locus delta event
         assert.calledWith(locusParser.onDeltaEvent, fakeLocus);
       });
-
 
       it('should assign a function to onDeltaAction', () => {
         sandbox.stub(locusParser, 'onDeltaEvent');
@@ -941,7 +1024,6 @@ describe('plugin-meetings', () => {
 
         assert.isFunction(locusParser.onDeltaAction);
       });
-
 
       it('onFullLocus() updates the working-copy of locus parser', () => {
         const eventType = 'fakeEvent';
@@ -957,7 +1039,6 @@ describe('plugin-meetings', () => {
         assert.equal(fakeLocus, locusParser.workingCopy);
       });
 
-
       it('onDeltaAction applies locus delta data to meeting', () => {
         const action = 'fake action';
         const parsedLoci = 'fake loci';
@@ -971,13 +1052,12 @@ describe('plugin-meetings', () => {
         assert.calledWith(locusInfo.applyLocusDeltaData, action, parsedLoci, fakeMeeting);
       });
 
-
       it('applyLocusDeltaData handles USE_INCOMING action correctly', () => {
         const {USE_INCOMING} = LocusDeltaParser.loci;
         const meeting = {
           locusInfo: {
-            onDeltaLocus: sandbox.stub()
-          }
+            onDeltaLocus: sandbox.stub(),
+          },
         };
 
         locusInfo.applyLocusDeltaData(USE_INCOMING, fakeLocus, meeting);
@@ -985,16 +1065,15 @@ describe('plugin-meetings', () => {
         assert.calledWith(meeting.locusInfo.onDeltaLocus, fakeLocus);
       });
 
-
       it('applyLocusDeltaData gets full locus on DESYNC action', () => {
         const {DESYNC} = LocusDeltaParser.loci;
         const meeting = {
           meetingRequest: {
-            getFullLocus: sandbox.stub().resolves(true)
+            getFullLocus: sandbox.stub().resolves(true),
           },
           locusInfo: {
-            onFullLocus: sandbox.stub()
-          }
+            onFullLocus: sandbox.stub(),
+          },
         };
 
         locusInfo.locusParser.resume = sandbox.stub();
@@ -1007,9 +1086,9 @@ describe('plugin-meetings', () => {
         const {DESYNC} = LocusDeltaParser.loci;
         const meeting = {
           meetingRequest: {
-            getFullLocus: sandbox.stub().resolves({body: true})
+            getFullLocus: sandbox.stub().resolves({body: true}),
           },
-          locusInfo
+          locusInfo,
         };
 
         locusInfo.onFullLocus = sandbox.stub();
@@ -1037,29 +1116,34 @@ describe('plugin-meetings', () => {
         locusInfo.parsedLocus.fullState.type = 'SIP_BRIDGE';
         locusInfo.handleOneOnOneEvent('locus.participant_declined');
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'handleOneonOneEvent'
-        },
-        'REMOTE_RESPONSE',
-        {
-          remoteDeclined: true,
-          remoteAnswered: false
-        });
-
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'handleOneonOneEvent',
+          },
+          'REMOTE_RESPONSE',
+          {
+            remoteDeclined: true,
+            remoteAnswered: false,
+          }
+        );
 
         locusInfo.parsedLocus.fullState.type = 'SIP_BRIDGE';
         locusInfo.handleOneOnOneEvent('locus.participant_joined');
 
-        assert.calledWith(locusInfo.emitScoped, {
-          file: 'locus-info',
-          function: 'handleOneonOneEvent'
-        },
-        'REMOTE_RESPONSE',
-        {
-          remoteDeclined: false,
-          remoteAnswered: true
-        });
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'handleOneonOneEvent',
+          },
+          'REMOTE_RESPONSE',
+          {
+            remoteDeclined: false,
+            remoteAnswered: true,
+          }
+        );
       });
     });
   });


### PR DESCRIPTION
# COMPLETES #

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-374954

## This pull request addresses

A few changes to embedded app events.

## by making the following changes

* Changed updateEmbeddedApps() to store the apps on the meeting object instead of meeting.locusInfo
* Updated areSimilar() to ignore order of arrays
* new lint rules adjusted quite a few lines

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Updated unit tests.  Manually tested with in-progress cantina changes.

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
