### PR TITLE
fix: release to publish correct version number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,6 +376,9 @@ jobs:
       - run:
           name: "Publish to NPM"
           command: |
+            echo "replace yarn workspace environment variables "
+            yarn run deps:generate
+
             echo "Publish to NPM"
             npm run tooling -- exec --cmd bash -- -c 'npm publish --access public || true'
       - run:

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "srcdist": "find ./packages -name 'package.json' -print0 | xargs -0 sed -ibak 's#\"main\": \"src/index.js#\"main\": \"dist/index.js#' && find ./packages -name '*bak' -print0 | xargs -0 rimraf",
     "get-current-version": "node ./tooling/index.js version current",
     "get-next-version": "node ./tooling/index.js version next --alwaysIncrement --includeSamples",
-    "deps:generate": "node ./deps.js",
+    "deps:generate": "node ./tooling/dep2.js",
     "samples:build": "node ./tooling/index.js build --only-samples",
     "samples:serve": "webpack serve --color --env NODE_ENV=development",
     "samples:serve:integration": "webpack serve --color --env NODE_ENV=test",
@@ -217,8 +217,7 @@
     "scripts": {
       "postbump": "yarn run build --skip-samples && yarn run build:script && git add packages/webex/umd/*.js",
       "release": "git add packages/*/package.json  packages/@webex/*/package.json CHANGELOG.md && standard-version -a"
-    },
-    "packageManager": "yarn@4.0.0-rc.20"
+    }
   },
   "packageManager": "yarn@4.0.0-rc.22"
 }

--- a/tooling/dep2.js
+++ b/tooling/dep2.js
@@ -1,0 +1,22 @@
+
+const fs = require('fs');
+
+const glob = require('glob');
+
+// gets reference to all the package.json file
+glob('packages/**/package.json', {}, (er, files) => {
+  files.forEach((file) => {
+    const currentPackageJson = fs.readFileSync(file);
+
+    const parsedPackages = JSON.parse(currentPackageJson);
+
+    let stringified = JSON.stringify(parsedPackages, null, 2);
+
+
+    // replace all the version which 'workspace:^' to the SDK version
+    stringified = stringified.replaceAll('workspace:^', parsedPackages.version);
+
+    fs.writeFileSync(file, `${stringified}\n`);
+  });
+});
+


### PR DESCRIPTION
Fixes the issues with the release broken with yarn workspace, converts all the workspace reference to actual version number

![Screenshot 2022-11-01 at 4 12 48 PM](https://user-images.githubusercontent.com/3895486/199332907-99bae87e-0dc1-49e3-a33f-b8809b2a9761.png)

