### PR TITLE
feat: avoid unnecessary turn request

### DIFF
--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -202,6 +202,28 @@ export default class TurnDiscovery {
    * @returns {Promise}
    */
   doTurnDiscovery(meeting, isReconnecting) {
+    const reachabilityData = window.localStorage.getItem(REACHABILITY.localStorage);
+    if (reachabilityData) {
+      try {
+        const reachabilityResult = JSON.parse(reachabilityData);
+
+        const reachable = Object.values(reachabilityResult).some((result: {udp: {reachable: 'true'| 'false'}, tcp: {reachable: 'true'| 'false'}}) => {
+          if (result.udp.reachable === 'true' || result.tcp.reachable === 'true') {
+            LoggerProxy.logger.info('Roap:turnDiscovery#doTurnDiscovery --> reachability has not failed, skipping it');
+            return true;
+          }
+        });
+
+        if (reachable) {
+          return Promise.resolve(undefined);
+        }
+
+      }
+      catch (e) {
+        LoggerProxy.logger.error(`Roap:request#attachReachabilityData --> Error in parsing reachability data: ${e}`);
+      }
+    }
+
     if (!meeting.config.experimental.enableTurnDiscovery) {
       LoggerProxy.logger.info('Roap:turnDiscovery#doTurnDiscovery --> TURN discovery disabled in config, skipping it');
 


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-380070
## This pull request addresses
 Not doing the TURN discovery step if reachability checks result in at least 1 successful connection to any cluster. 
< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
