### PR TITLE
spark-367050: SDP related metrics

### DIFF
--- a/packages/@webex/plugin-meetings/src/common/errors/webex-errors.js
+++ b/packages/@webex/plugin-meetings/src/common/errors/webex-errors.js
@@ -101,24 +101,6 @@ class UserInLobbyError extends WebexMeetingsError {
 export {UserInLobbyError};
 WebExMeetingsErrors[UserInLobbyError.CODE] = UserInLobbyError;
 
-/**
- * @class InvalidSdpError
- * @classdesc Raised whenever SDP generated via browser is invalid.
- * @extends WebexMeetingsError
- * @property {number} code - 30201
- * @property {string} message - 'user is still in the lobby or not joined'
- */
-class InvalidSdpError extends WebexMeetingsError {
-  static CODE = 30201;
-
-  constructor(message) {
-    super(InvalidSdpError.CODE, message || 'iceConnection: sdp generated is invalid');
-  }
-}
-
-export {InvalidSdpError};
-WebExMeetingsErrors[InvalidSdpError.CODE] = InvalidSdpError;
-
 
 /**
  * @class IceGatheringFailed


### PR DESCRIPTION
This is a PR for sdk_v3 branch. It makes sure we send the same kind of metrics related to SDP handling on the sdk_v3 branch as we have been sending on master.

This PR depends on webrtc-media lib changes from here: https://sqbu-github.cisco.com/WebExSquared/webrtc-media-core/pull/145 that have been released as "@webex/internal-media-core@0.0.14-beta"
