### PR TITLE
Spark 379747 [CDR Compliance] add encrypted text to decryption flows

### DIFF
--- a/packages/@webex/internal-plugin-ediscovery/src/transforms.js
+++ b/packages/@webex/internal-plugin-ediscovery/src/transforms.js
@@ -214,7 +214,7 @@ class Transforms {
         // post and share activities have content which needs to be decrypted
         // as do meeting, recording activities, customApp extensions, and space information updates
         if (!['post', 'share'].includes(activity.verb) && !activity.meeting && !activity.recording && !(activity.extension && activity.extension.extensionType === 'customApp') &&
-          !activity.spaceInfo?.name && !activity.spaceInfo?.description) {
+          !activity.spaceInfo?.name && !activity.spaceInfo?.description && !activity.encryptedTextKeyValues) {
           return Promise.resolve(object);
         }
 
@@ -362,8 +362,8 @@ class Transforms {
         }
 
         // Decrypt encrypted text map if present
-        if (activity.encryptedTextKeyValues) {
-          for (let [key, value] of Object.entries(activity.encryptedTextKeyValues)) {
+        if (activity.encryptedTextKeyValues !== undefined) {
+          for (let [value] of activity.encryptedTextKeyValues.values()) {
             promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
               [activity.encryptionKeyUrl, value])
               .then((decryptedMessage) => {

--- a/packages/@webex/internal-plugin-ediscovery/src/transforms.js
+++ b/packages/@webex/internal-plugin-ediscovery/src/transforms.js
@@ -361,6 +361,23 @@ class Transforms {
           }
         }
 
+        // Decrypt encrypted text map if present
+        if (activity.encryptedTextKeyValues) {
+          for (let [key, value] of Object.entries(activity.encryptedTextKeyValues)) {
+            promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,
+              [activity.encryptionKeyUrl, value])
+              .then((decryptedMessage) => {
+                value = decryptedMessage;
+              })
+              .catch((reason) => {
+                ctx.webex.logger.error(`Decrypt activity.encryptedTextKeyValues error for activity ${activity.activityId} in container ${activity.targetId}: ${reason}`);
+                activity.error = reason;
+
+                return Promise.resolve(object);
+              }));
+          }
+        }
+
         // Decrypt meeting title if present
         if (activity?.meeting?.title) {
           promises.push(requestWithRetries(ctx.webex.internal.encryption, ctx.webex.internal.encryption.decryptText,

--- a/packages/@webex/internal-plugin-ediscovery/test/unit/spec/transforms.js
+++ b/packages/@webex/internal-plugin-ediscovery/test/unit/spec/transforms.js
@@ -416,6 +416,22 @@ describe('EDiscovery Transform Tests', () => {
 
         return result;
       });
+
+      it('Calls the correct decrypt functions when transforming activity.encryptedTextKeyValues', () => {
+        object.body.verb = 'add';
+        object.body.objectDisplayName = undefined;
+        object.body.encryptedTextKeyValues = new Map();
+        object.body.encryptedTextKeyValues.set('CallingLineId', 'Encrypted Phone Number 1');
+        object.body.encryptedTextKeyValues.set('CallingNumber', 'Encrypted Phone Number 2');
+        object.body.encryptedTextKeyValues.set('RedirectingNumber', 'Encrypted Phone Number 3');
+        const result = Transforms.decryptReportContent(ctx, object, reportId)
+          .then(() => {
+            assert.callCount(ctx.webex.internal.encryption.decryptText, object.body.encryptedTextKeyValues.size);
+            assert.equal(activity.error, undefined);
+          });
+
+        return result;
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-383474

## This pull request addresses
Calling compliance for eDiscovery has to decrypt new content.
< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
