### PR TITLE
feat(plugin-meetings): added connection type to "js_sdk_add_media_success" metric

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/@webex/plugin-meetings/src/meeting/index.js
@@ -36,7 +36,6 @@ import {
   _INCOMING_,
   _JOIN_,
   AUDIO,
-  CONNECTION_STATE,
   CONTENT,
   ENDED,
   EVENT_TRIGGERS,
@@ -58,7 +57,6 @@ import {
   ONLINE,
   OFFLINE,
   PASSWORD_STATUS,
-  PC_BAIL_TIMEOUT,
   PSTN_STATUS,
   QUALITY_LEVELS,
   RECORDING_STATE,
@@ -4246,129 +4244,110 @@ export default class Meeting extends StatelessWebexPlugin {
         enableRtx: this.config.enableRtx,
         enableExtmap: this.config.enableExtmap,
         setStartLocalSDPGenRemoteSDPRecvDelay: this.setStartLocalSDPGenRemoteSDPRecvDelay.bind(this)
+      }))
+      .then((peerConnection) => this.getDevices().then((devices) => {
+        MeetingUtil.handleDeviceLogging(devices);
+
+        return peerConnection;
+      }))
+      .then((peerConnection) => {
+        this.handleMediaLogging(this.mediaProperties);
+        LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection Received from attachMedia `);
+
+        this.setRemoteStream(peerConnection);
+        if (this.config.stats.enableStatsAnalyzer) {
+          // TODO: ** Dont re create StatsAnalyzer on reconnect or rejoin
+          this.networkQualityMonitor = new NetworkQualityMonitor(this.config.stats);
+          this.statsAnalyzer = new StatsAnalyzer(this.config.stats, this.networkQualityMonitor);
+          this.setupStatsAnalyzerEventHandlers();
+          this.networkQualityMonitor.on(EVENT_TRIGGERS.NETWORK_QUALITY, this.sendNetworkQualityEvent.bind(this));
+        }
       })
-        .then((peerConnection) => this.getDevices().then((devices) => {
-          MeetingUtil.handleDeviceLogging(devices);
+      .catch((error) => {
+        LoggerProxy.logger.error(`${LOG_HEADER} Error adding media , setting up peerconnection, `, error);
 
-          return peerConnection;
-        }))
-        .then((peerConnection) => {
-          this.handleMediaLogging(this.mediaProperties);
-          LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection Received from attachMedia `);
-
-          this.setRemoteStream(peerConnection);
-          if (this.config.stats.enableStatsAnalyzer) {
-            // TODO: ** Dont re create StatsAnalyzer on reconnect or rejoin
-            this.networkQualityMonitor = new NetworkQualityMonitor(this.config.stats);
-            this.statsAnalyzer = new StatsAnalyzer(this.config.stats, this.networkQualityMonitor);
-            this.setupStatsAnalyzerEventHandlers();
-            this.networkQualityMonitor.on(EVENT_TRIGGERS.NETWORK_QUALITY, this.sendNetworkQualityEvent.bind(this));
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE,
+          {
+            correlation_id: this.correlationId,
+            locus_id: this.locusUrl.split('/').pop(),
+            reason: error.message,
+            stack: error.stack,
+            turnDiscoverySkippedReason,
+            turnServerUsed
           }
-        })
-        .catch((error) => {
-          LoggerProxy.logger.error(`${LOG_HEADER} Error adding media , setting up peerconnection, `, error);
+        );
 
-          Metrics.sendBehavioralMetric(
-            BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE,
-            {
-              correlation_id: this.correlationId,
-              locus_id: this.locusUrl.split('/').pop(),
-              reason: error.message,
-              stack: error.stack,
-              turnDiscoverySkippedReason,
-              turnServerUsed
-            }
-          );
+        throw error;
+      })
+      .then(() => new Promise((resolve, reject) => {
+        let timerCount = 0;
 
-          throw error;
-        })
-        .then(() => new Promise((resolve, reject) => {
-          let timerCount = 0;
-
-          // eslint-disable-next-line func-names
-          // eslint-disable-next-line prefer-arrow-callback
-          if (this.type === _CALL_) {
+        // eslint-disable-next-line func-names
+        // eslint-disable-next-line prefer-arrow-callback
+        if (this.type === _CALL_) {
+          resolve();
+        }
+        const joiningTimer = setInterval(() => {
+          timerCount += 1;
+          if (this.meetingState === FULL_STATE.ACTIVE) {
+            clearInterval(joiningTimer);
             resolve();
           }
-          const joiningTimer = setInterval(() => {
-            timerCount += 1;
-            if (this.meetingState === FULL_STATE.ACTIVE) {
-              clearInterval(joiningTimer);
-              resolve();
-            }
 
-            if (timerCount === 4) {
-              clearInterval(joiningTimer);
-              reject(new Error('Meeting is still not active '));
-            }
-          }, 1000);
+          if (timerCount === 4) {
+            clearInterval(joiningTimer);
+            reject(new Error('Meeting is still not active '));
+          }
+        }, 1000);
+      }))
+      .then(() =>
+        logRequest(this.roap
+          .sendRoapMediaRequest({
+            sdp: this.mediaProperties.peerConnection.sdp,
+            roapSeq: this.roapSeq,
+            meeting: this // or can pass meeting ID
+          }), {
+          header: `${LOG_HEADER} Send Roap Media Request.`,
+          success: `${LOG_HEADER} Successfully send roap media request`,
+          failure: `${LOG_HEADER} Error joining the call on send roap media request, `
         }))
-        .then(() =>
-          logRequest(this.roap
-            .sendRoapMediaRequest({
-              sdp: this.mediaProperties.peerConnection.sdp,
-              roapSeq: this.roapSeq,
-              meeting: this // or can pass meeting ID
-            }), {
-            header: `${LOG_HEADER} Send Roap Media Request.`,
-            success: `${LOG_HEADER} Successfully send roap media request`,
-            failure: `${LOG_HEADER} Error joining the call on send roap media request, `
-          }))
-        .then(() => {
-          const {peerConnection} = this.mediaProperties;
+      .then(
+        () => this.mediaProperties.waitForIceConnectedState()
+          .catch(() => {
+            throw createMeetingsError(30202, 'Meeting connection failed');
+          })
+      )
+      .then(() => {
+        LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection CONNECTED`);
 
-          return new Promise((resolve, reject) => {
-            if (peerConnection.connectionState === CONNECTION_STATE.CONNECTED) {
-              LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection CONNECTED`);
-
-              resolve(peerConnection);
-
-              return;
-            }
-            // Check if Peer Connection is STABLE (connected)
-            const stabilityTimeout = setTimeout(() => {
-              if (peerConnection.connectionState !== CONNECTION_STATE.CONNECTED) {
-                // TODO: Fix this after the error code pr goes in
-                reject(createMeetingsError(30202, 'Meeting connection failed'));
-              }
-              else {
-                LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection CONNECTED`);
-                resolve(peerConnection);
-              }
-            }, PC_BAIL_TIMEOUT);
-
-            this.once(EVENT_TRIGGERS.MEDIA_READY, () => {
-              LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection CONNECTED, clearing stability timer.`);
-              clearTimeout(stabilityTimeout);
-              resolve(peerConnection);
-            });
-          });
-        })
-        .then(() => {
-          if (mediaSettings && mediaSettings.sendShare && localShare) {
-            if (this.state === MEETING_STATE.STATES.JOINED) {
-              return this.share();
-            }
-
-            // When the self state changes to JOINED then request the floor
-            this.floorGrantPending = true;
+        if (mediaSettings && mediaSettings.sendShare && localShare) {
+          if (this.state === MEETING_STATE.STATES.JOINED) {
+            return this.share();
           }
 
-          Metrics.sendBehavioralMetric(
-            BEHAVIORAL_METRICS.ADD_MEDIA_SUCCESS,
-            {
-              correlation_id: this.correlationId,
-              locus_id: this.locusUrl.split('/').pop()
-            }
-          );
+          // When the self state changes to JOINED then request the floor
+          this.floorGrantPending = true;
+        }
 
-          return Promise.resolve();
-        }))
+        return {};
+      })
+      .then(() => this.mediaProperties.getCurrentConnectionType())
+      .then((connectionType) => {
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.ADD_MEDIA_SUCCESS,
+          {
+            correlation_id: this.correlationId,
+            locus_id: this.locusUrl.split('/').pop(),
+            connectionType
+          }
+        );
+      })
       .catch((error) => {
         // Clean up stats analyzer, peer connection, and turn off listeners
         const stopStatsAnalyzer = (this.statsAnalyzer) ? this.statsAnalyzer.stopAnalyzer() : Promise.resolve();
 
-        stopStatsAnalyzer
+        return stopStatsAnalyzer
           .then(() => {
             this.statsAnalyzer = null;
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
@@ -1,0 +1,305 @@
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import MediaProperties from '@webex/plugin-meetings/src/media/properties';
+import MediaUtil from '@webex/plugin-meetings/src/media/util';
+import testUtils from '../../../utils/testUtils';
+import {PC_BAIL_TIMEOUT} from '@webex/plugin-meetings/src/constants';
+import {Defer} from '@webex/common';
+
+describe('MediaProperties', () => {
+  let mediaProperties;
+  let mockPc;
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+
+    mockPc = {
+      getStats: sinon.stub().resolves([]),
+      addEventListener: sinon.stub(),
+      removeEventListener: sinon.stub(),
+      iceConnectionState: 'connected',
+    };
+
+    sinon.stub(MediaUtil, 'createPeerConnection').returns(mockPc);
+
+    mediaProperties = new MediaProperties();
+  });
+
+  afterEach(() => {
+    clock.restore();
+    sinon.restore();
+  });
+  describe('waitForIceConnectedState', () => {
+    it('resolves immediately if ice state is connected', async () => {
+      mockPc.iceConnectionState = 'connected';
+
+      await mediaProperties.waitForIceConnectedState();
+    });
+    it('resolves immediately if ice state is completed', async () => {
+      mockPc.iceConnectionState = 'completed';
+
+      await mediaProperties.waitForIceConnectedState();
+    });
+    it('rejects after timeout if ice state does not reach connected/completed', async () => {
+      mockPc.iceConnectionState = 'connecting';
+
+      let promiseResolved = false;
+      let promiseRejected = false;
+
+      mediaProperties
+        .waitForIceConnectedState()
+        .then(() => {
+          promiseResolved = true;
+        })
+        .catch(() => {
+          promiseRejected = true;
+        });
+
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, false);
+
+      await clock.tickAsync(PC_BAIL_TIMEOUT);
+      await testUtils.flushPromises();
+
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, true);
+
+      // check that listener was registered and removed
+      assert.calledOnce(mockPc.addEventListener);
+      assert.equal(mockPc.addEventListener.getCall(0).args[0], 'iceconnectionstatechange');
+      const listener = mockPc.addEventListener.getCall(0).args[1];
+
+      assert.calledOnce(mockPc.removeEventListener);
+      assert.calledWith(mockPc.removeEventListener, 'iceconnectionstatechange', listener);
+    });
+
+    ['connected', 'completed'].forEach((successIceState) =>
+      it(`resolves when ice state reaches ${successIceState}`, async () => {
+        mockPc.iceConnectionState = 'connecting';
+
+        const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
+
+        let promiseResolved = false;
+        let promiseRejected = false;
+
+        mediaProperties
+          .waitForIceConnectedState()
+          .then(() => {
+            promiseResolved = true;
+          })
+          .catch(() => {
+            promiseRejected = true;
+          });
+
+        assert.equal(promiseResolved, false);
+        assert.equal(promiseRejected, false);
+
+        // check the right listener was registered
+        assert.calledOnce(mockPc.addEventListener);
+        assert.equal(mockPc.addEventListener.getCall(0).args[0], 'iceconnectionstatechange');
+        const listener = mockPc.addEventListener.getCall(0).args[1];
+
+        // call the listener and pretend we are now connected
+        mockPc.iceConnectionState = successIceState;
+        listener();
+        await testUtils.flushPromises();
+
+        assert.equal(promiseResolved, true);
+        assert.equal(promiseRejected, false);
+
+        // check that listener was removed
+        assert.calledOnce(mockPc.removeEventListener);
+        assert.calledWith(mockPc.removeEventListener, 'iceconnectionstatechange', listener);
+
+        assert.calledOnce(clearTimeoutSpy);
+      })
+    );
+  });
+
+  describe('getCurrentConnectionType', () => {
+    it('calls waitForIceConnectedState', async () => {
+      const spy = sinon.stub(mediaProperties, 'waitForIceConnectedState');
+
+      await mediaProperties.getCurrentConnectionType();
+
+      assert.calledOnce(spy);
+    });
+    it('calls getStats() only after waitForIceConnectedState resolves', async () => {
+      const waitForIceConnectedStateResult = new Defer();
+
+      const waitForIceConnectedStateStub = sinon
+        .stub(mediaProperties, 'waitForIceConnectedState')
+        .returns(waitForIceConnectedStateResult.promise);
+
+      const result = mediaProperties.getCurrentConnectionType();
+
+      await testUtils.flushPromises();
+
+      assert.called(waitForIceConnectedStateStub);
+      assert.notCalled(mockPc.getStats);
+
+      waitForIceConnectedStateResult.resolve();
+      await testUtils.flushPromises();
+
+      assert.called(mockPc.getStats);
+      await result;
+    });
+    it('rejects if waitForIceConnectedState rejects', async () => {
+      const waitForIceConnectedStateResult = new Defer();
+
+      const waitForIceConnectedStateStub = sinon
+        .stub(mediaProperties, 'waitForIceConnectedState')
+        .returns(waitForIceConnectedStateResult.promise);
+
+      const result = mediaProperties.getCurrentConnectionType();
+
+      await testUtils.flushPromises();
+
+      assert.called(waitForIceConnectedStateStub);
+
+      waitForIceConnectedStateResult.reject(new Error('fake error'));
+      await testUtils.flushPromises();
+
+      assert.notCalled(mockPc.getStats);
+
+      await assert.isRejected(result);
+    });
+    it('returns "unknown" if getStats() fails', async () => {
+      mockPc.getStats.rejects(new Error());
+
+      const connectionType = await mediaProperties.getCurrentConnectionType();
+      assert.equal(connectionType, 'unknown');
+    });
+
+    it('returns "unknown" if getStats() returns no candidate pairs', async () => {
+      mockPc.getStats.resolves([{type: 'something', id: '1234'}]);
+
+      const connectionType = await mediaProperties.getCurrentConnectionType();
+      assert.equal(connectionType, 'unknown');
+    });
+
+    it('returns "unknown" if getStats() returns no successful candidate pair', async () => {
+      mockPc.getStats.resolves([{type: 'candidate-pair', id: '1234', state: 'inprogress'}]);
+
+      const connectionType = await mediaProperties.getCurrentConnectionType();
+      assert.equal(connectionType, 'unknown');
+    });
+
+    it('returns "unknown" if getStats() returns a successful candidate pair but local candidate is missing', async () => {
+      mockPc.getStats.resolves([
+        {type: 'candidate-pair', id: '1234', state: 'succeeded', localCandidateId: 'wrong id'},
+      ]);
+
+      const connectionType = await mediaProperties.getCurrentConnectionType();
+      assert.equal(connectionType, 'unknown');
+    });
+
+    it('returns "UDP" if getStats() returns a successful candidate pair with udp local candidate', async () => {
+      mockPc.getStats.resolves([
+        {
+          type: 'candidate-pair',
+          id: 'some candidate pair id',
+          state: 'succeeded',
+          localCandidateId: 'local candidate id',
+        },
+        {type: 'local-candidate', id: 'some other candidate id', protocol: 'tcp'},
+        {type: 'local-candidate', id: 'local candidate id', protocol: 'udp'},
+      ]);
+
+      const connectionType = await mediaProperties.getCurrentConnectionType();
+      assert.equal(connectionType, 'UDP');
+    });
+
+    it('returns "TCP" if getStats() returns a successful candidate pair with tcp local candidate', async () => {
+      mockPc.getStats.resolves([
+        {
+          type: 'candidate-pair',
+          id: 'some candidate pair id',
+          state: 'succeeded',
+          localCandidateId: 'some candidate id',
+        },
+        {type: 'local-candidate', id: 'some other candidate id', protocol: 'udp'},
+        {type: 'local-candidate', id: 'some candidate id', protocol: 'tcp'},
+      ]);
+
+      const connectionType = await mediaProperties.getCurrentConnectionType();
+      assert.equal(connectionType, 'TCP');
+    });
+
+    [
+      {relayProtocol: 'tls', expectedConnectionType: 'TURN-TLS'},
+      {relayProtocol: 'tcp', expectedConnectionType: 'TURN-TCP'},
+      {relayProtocol: 'udp', expectedConnectionType: 'TURN-UDP'},
+    ].forEach(({relayProtocol, expectedConnectionType}) =>
+      it(`returns "${expectedConnectionType}" if getStats() returns a successful candidate pair with a local candidate with relayProtocol=${relayProtocol}`, async () => {
+        mockPc.getStats.resolves([
+          {
+            type: 'candidate-pair',
+            id: 'some candidate pair id',
+            state: 'succeeded',
+            localCandidateId: 'selected candidate id',
+          },
+          {
+            type: 'candidate-pair',
+            id: 'some other candidate pair id',
+            state: 'failed',
+            localCandidateId: 'some other candidate id 1',
+          },
+          {type: 'local-candidate', id: 'some other candidate id 1', protocol: 'udp'},
+          {type: 'local-candidate', id: 'some other candidate id 2', protocol: 'tcp'},
+          {
+            type: 'local-candidate',
+            id: 'selected candidate id',
+            protocol: 'udp',
+            relayProtocol,
+          },
+        ]);
+
+        const connectionType = await mediaProperties.getCurrentConnectionType();
+        assert.equal(connectionType, expectedConnectionType);
+      })
+    );
+
+    it('returns connection type of the first successful candidate pair', async () => {
+      // in real life this will never happen and all active candidate pairs will have same transport,
+      // but here we're simulating a situation where they have different transports and just checking
+      // that the code still works and just returns the first one
+      mockPc.getStats.resolves([
+        {
+          type: 'inbound-rtp',
+          id: 'whatever',
+        },
+        {
+          type: 'candidate-pair',
+          id: 'some candidate pair id',
+          state: 'succeeded',
+          localCandidateId: '1st selected candidate id',
+        },
+        {
+          type: 'candidate-pair',
+          id: 'some other candidate pair id',
+          state: 'succeeded',
+          localCandidateId: '2nd selected candidate id',
+        },
+        {type: 'local-candidate', id: 'some other candidate id 1', protocol: 'udp'},
+        {type: 'local-candidate', id: 'some other candidate id 2', protocol: 'tcp'},
+        {
+          type: 'local-candidate',
+          id: '1st selected candidate id',
+          protocol: 'udp',
+          relayProtocol: 'tls',
+        },
+        {
+          type: 'local-candidate',
+          id: '2nd selected candidate id',
+          protocol: 'udp',
+          relayProtocol: 'tcp',
+        },
+      ]);
+
+      const connectionType = await mediaProperties.getCurrentConnectionType();
+      assert.equal(connectionType, 'TURN-TLS');
+    });
+  });
+});


### PR DESCRIPTION
Added connectionType to BEHAVIORAL_METRICS.ADD_MEDIA_SUCCESS metric (this is part of the TURN TLS feature, so that we know how many clients connect using TURN).

jira: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-370008

There seems to be a bug in Firefox and Safari where they don't set the relayProtocol correctly for the local candidate when connecting using TURN. It works fine in Chrome/Edge.

There is an indentation change in addMedia() in meeting/index.js, because there were some `then()` calls that were unnecessarily nested, so it's best to view the diff with "hide whitespace" checkbox ticked. I've fixed it here, because this is also already fixed on sdk_v3 branch and is causing conflicts every time I merge latest master into sdk_v3, so fixed it now on master to make my life easier.