### PR TITLE
fix(meetings): move voicea transcription triggers under meetings

### DIFF
--- a/packages/@webex/internal-plugin-voicea/README.md
+++ b/packages/@webex/internal-plugin-voicea/README.md
@@ -37,9 +37,7 @@ webex.internal.voicea.registerAndConnect(locusUrl, datachannelUrl);
 Toggle Transcribing
 
 * Enable/Disable Transcribing in a meeting
-* Automatically activates Closed Captions(CC) if enabled.
-* Triggers voicea:transcribingOn / voicea:transcribingOff
-  
+* Automatically activates Closed Captions(CC) if enabled.  
 ```js
 await webex.internal.voicea.toggleTranscribing(true);
 await webex.internal.voicea.toggleTranscribing(false);

--- a/packages/@webex/internal-plugin-voicea/src/constants.ts
+++ b/packages/@webex/internal-plugin-voicea/src/constants.ts
@@ -3,12 +3,9 @@ export const EVENT_TRIGGERS = {
   CAPTION_LANGUAGE_UPDATE: 'voicea:captionLanguageUpdate',
   SPOKEN_LANGUAGE_UPDATE: 'voicea:spokenLanguageUpdate',
   CAPTIONS_TURNED_ON: 'voicea:captionOn',
-  TRANSCRIBING_ON: 'voicea:transcribingOn',
-  TRANSCRIBING_OFF: 'voicea:transcribingOff',
-
   NEW_CAPTION: 'voicea:newCaption',
   EVA_COMMAND: 'voicea:wxa',
-  HIGHLIGHT_CREATED: 'voicea:highlightCreated'
+  HIGHLIGHT_CREATED: 'voicea:highlightCreated',
 };
 
 export const VOICEA_RELAY_TYPES = {
@@ -16,7 +13,7 @@ export const VOICEA_RELAY_TYPES = {
   CLIENT_ANNOUNCEMENT: 'client.annc',
   TRANSLATION_REQUEST: 'voicea.transl.req',
   TRANSLATION_RESPONSE: 'voicea.transl.rsp',
-  TRANSCRIPTION: 'voicea.transcription'
+  TRANSCRIPTION: 'voicea.transcription',
 };
 
 export const TRANSCRIPTION_TYPE = {
@@ -26,7 +23,7 @@ export const TRANSCRIPTION_TYPE = {
   EVA_CANCEL: 'eva_cancel',
   HIGHLIGHT_CREATED: 'highlight_created',
   TRANSCRIPT_INTERIM_RESULTS: 'transcript_interim_results',
-  TRANSCRIPT_FINAL_RESULT: 'transcript_final_result'
+  TRANSCRIPT_FINAL_RESULT: 'transcript_final_result',
 };
 
 export const VOICEA = 'voicea';

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -354,14 +354,6 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
         transcribe: {transcribing: activate},
       },
     }).then(() => {
-      Trigger.trigger(
-        this,
-        {
-          file: 'voicea',
-          function: 'toggleTranscribing',
-        },
-        activate ? EVENT_TRIGGERS.TRANSCRIBING_ON : EVENT_TRIGGERS.TRANSCRIBING_OFF
-      );
       this.isTranscribingEnabled = activate;
       if (activate && !this.areCaptionsEnabled && !this.hasVoiceaJoined) this.turnOnCaptions();
     });

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -263,9 +263,6 @@ describe('plugin-voicea', () => {
           data: {relayType: 'voicea.annc', voiceaPayload: {}},
         });
 
-        const triggerSpy = sinon.spy();
-
-        voiceaService.on(EVENT_TRIGGERS.TRANSCRIBING_ON, triggerSpy);
         voiceaService.listenToEvents();
 
         await voiceaService.toggleTranscribing(true);
@@ -278,16 +275,12 @@ describe('plugin-voicea', () => {
           })
         );
 
-        assert.calledOnce(triggerSpy);
         assert.notCalled(announcementSpy);
       });
 
       it('turns on transcribing with CC disabled', async () => {
         const announcementSpy = sinon.spy(voiceaService, 'sendAnnouncement');
 
-        const triggerSpy = sinon.spy();
-
-        voiceaService.on(EVENT_TRIGGERS.TRANSCRIBING_ON, triggerSpy);
         voiceaService.listenToEvents();
 
         await voiceaService.toggleTranscribing(true);
@@ -300,7 +293,6 @@ describe('plugin-voicea', () => {
           })
         );
 
-        assert.calledOnce(triggerSpy);
         assert.calledOnce(announcementSpy);
       });
 
@@ -309,9 +301,6 @@ describe('plugin-voicea', () => {
 
         const announcementSpy = sinon.spy(voiceaService, 'sendAnnouncement');
 
-        const triggerSpy = sinon.spy();
-
-        voiceaService.on(EVENT_TRIGGERS.TRANSCRIBING_OFF, triggerSpy);
         voiceaService.listenToEvents();
 
         await voiceaService.toggleTranscribing(false);
@@ -324,20 +313,15 @@ describe('plugin-voicea', () => {
           })
         );
 
-        assert.calledOnce(triggerSpy);
         assert.notCalled(announcementSpy);
       });
 
       it("doesn't call API on same value", async () => {
         await voiceaService.toggleTranscribing(true);
-        const triggerSpy = sinon.spy();
         const announcementSpy = sinon.spy(voiceaService, 'sendAnnouncement');
-
-        voiceaService.on(EVENT_TRIGGERS.TRANSCRIBING_OFF, triggerSpy);
 
         await voiceaService.toggleTranscribing(true);
 
-        assert.notCalled(triggerSpy);
         assert.notCalled(announcementSpy);
 
         assert.calledTwice(voiceaService.request);

--- a/packages/@webex/plugin-meetings/README.md
+++ b/packages/@webex/plugin-meetings/README.md
@@ -923,6 +923,8 @@ meeting.on(...)
 | `meeting:recording:resumed`            | Fired when member resumes recording                                                               |
 | `meeting:receiveTranscription:started` | Fired when transcription is received                                                              |
 | `meeting:receiveTranscription:stopped` | Fired when transcription has stopped from being received                                          |
+| `voicea:transcribing:on` | Fired when transcription is turned on in locus data                                                              |
+| `voicea:transcribing:off` | Fired when transcription is turned off in locus data                                                              |
 | `meeting:meetingContainer:update`      | Fired when the meetingContainerUrl is updated                                                     |
 | ---                                    | ---                                                                                               |
 

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1,4 +1,4 @@
-import { hydraTypes } from '@webex/common';
+import {hydraTypes} from '@webex/common';
 
 // *********** LOWERCASE / CAMELCASE STRINGS ************
 
@@ -135,14 +135,14 @@ export const _MOVE_MEDIA_ = 'MOVE_MEDIA';
 export const PARTICIPANT_DELTAS = {
   TARGETS: {
     AUDIO: 'audio',
-    VIDEO: 'video'
+    VIDEO: 'video',
   },
   STATES: {
     DISABLED: 'disabled',
     MUTED: 'muted',
     UNKNOWN: 'unknown',
-    UNMUTED: 'unmuted'
-  }
+    UNMUTED: 'unmuted',
+  },
 };
 
 // *********** STRING HELPERS ***********
@@ -200,21 +200,26 @@ export const DIALER_REGEX = {
   // modified from https://github.com/kirm/sip.js base
   // and with https://tools.ietf.org/html/rfc3261
   // requires the @ symbol
-  SIP_ADDRESS: /^(sips?)?:?(?:([^\s>:@]+)(?::([^\s@>]+))?@)([\w\-.]+)(?::(\d+))?((?:;[^\s=?>;]+(?:=[^\s?;]+)?)*)(?:\?(([^\s&=>]+=[^\s&=>]+)(&[^\s&=>]+=[^\s&=>]+)*))?$/,
+  SIP_ADDRESS:
+    /^(sips?)?:?(?:([^\s>:@]+)(?::([^\s@>]+))?@)([\w\-.]+)(?::(\d+))?((?:;[^\s=?>;]+(?:=[^\s?;]+)?)*)(?:\?(([^\s&=>]+=[^\s&=>]+)(&[^\s&=>]+=[^\s&=>]+)*))?$/,
   // standard telephony num regex
-  PHONE_NUMBER: /^(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$/,
-  E164_FORMAT: /^\+[1-9]\d{1,14}$/
+  PHONE_NUMBER:
+    /^(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$/,
+  E164_FORMAT: /^\+[1-9]\d{1,14}$/,
 };
 
 // eslint-disable-next-line max-len
 export const IPV4_REGEX = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}|.local/g;
 
-export const VALID_EMAIL_ADDRESS = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-export const VALID_PMR_ADDRESS = /([a-z0-9][-a-z0-9, '.']{0,62})@([a-z0-9][-a-z0-9, '.']{0,62})\.webex\.com/i;
-export const VALID_PMR_LINK = /(https:\/\/)?([a-z0-9][-a-z0-9, '.']{0,62})\.webex\.com\/(meet|join)\/([a-z0-9][-a-z0-9, '.']{0,62})\/?/i;
+export const VALID_EMAIL_ADDRESS =
+  /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+export const VALID_PMR_ADDRESS =
+  /([a-z0-9][-a-z0-9, '.']{0,62})@([a-z0-9][-a-z0-9, '.']{0,62})\.webex\.com/i;
+export const VALID_PMR_LINK =
+  /(https:\/\/)?([a-z0-9][-a-z0-9, '.']{0,62})\.webex\.com\/(meet|join)\/([a-z0-9][-a-z0-9, '.']{0,62})\/?/i;
 export const VALID_PIN = /([0-9]{4,6})/;
-export const UUID_REG = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
+export const UUID_REG =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 // ******************** OBJECTS ********************
 // Please alphabetize, and keep objects organized
@@ -222,7 +227,7 @@ export const UUID_REG = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f
 // TODO:  move all api params to API section
 export const API = {
   CALLIOPEDISCOVERY: 'calliopeDiscovery',
-  LOCUS: 'locus'
+  LOCUS: 'locus',
 };
 
 export const CALENDAR_EVENTS = {
@@ -230,26 +235,38 @@ export const CALENDAR_EVENTS = {
   UPDATE: 'event:calendar.meeting.update',
   CREATE_MINIMAL: 'event:calendar.meeting.create.minimal',
   UPDATE_MINIMAL: 'event:calendar.meeting.update.minimal',
-  DELETE: 'event:calendar.meeting.delete'
+  DELETE: 'event:calendar.meeting.delete',
 };
 
 export const DEFAULT_GET_STATS_FILTER = {
-  types: ['track', 'transport', 'candidate-pair', 'outbound-rtp', 'outboundrtp', 'inbound-rtp', 'inboundrtp', 'remote-inbound-rtp', 'remote-outbound-rtp', 'remote-candidate', 'local-candidate', 'media-source']
+  types: [
+    'track',
+    'transport',
+    'candidate-pair',
+    'outbound-rtp',
+    'outboundrtp',
+    'inbound-rtp',
+    'inboundrtp',
+    'remote-inbound-rtp',
+    'remote-outbound-rtp',
+    'remote-candidate',
+    'local-candidate',
+    'media-source',
+  ],
 };
-
 
 export const RECORDING_STATE = {
   RECORDING: 'recording',
   IDLE: 'idle',
   PAUSED: 'paused',
-  RESUMED: 'resumed'
+  RESUMED: 'resumed',
 };
 
 export const SHARE_STATUS = {
   NO_SHARE: 'no_share',
   REMOTE_SHARE_ACTIVE: 'remote_share_active',
   LOCAL_SHARE_ACTIVE: 'local_share_active',
-  WHITEBOARD_SHARE_ACTIVE: 'whiteboard_share_active'
+  WHITEBOARD_SHARE_ACTIVE: 'whiteboard_share_active',
 };
 
 // TODO: do we want to scope by meeting, members when they come off those objects themselves?
@@ -311,7 +328,9 @@ export const EVENT_TRIGGERS = {
   MEETINGS_NETWORK_CONNECTED: 'network:connected',
   MEETING_SELF_LEFT: 'meeting:self:left',
   NETWORK_QUALITY: 'network:quality',
-  MEDIA_NEGOTIATED: 'media:negotiated'
+  MEDIA_NEGOTIATED: 'media:negotiated',
+  TRANSCRIBING_ON: 'voicea:transcribing:on',
+  TRANSCRIBING_OFF: 'voicea:transcribing:off',
 };
 
 export const EVENT_TYPES = {
@@ -323,7 +342,7 @@ export const EVENT_TYPES = {
   REMOTE_VIDEO: 'remoteVideo',
   REMOTE_SHARE: 'remoteShare',
   LOCAL_SHARE: 'localShare',
-  ERROR: 'error'
+  ERROR: 'error',
 };
 
 // Handles the reason when meeting gets destroyed
@@ -337,7 +356,7 @@ export const MEETING_REMOVED_REASON = {
   CLIENT_LEAVE_REQUEST: 'CLIENT_LEAVE_REQUEST', // You triggered leave meeting
   USER_ENDED_SHARE_STREAMS: 'USER_ENDED_SHARE_STREAMS', // user triggered stop share
   NO_MEETINGS_TO_SYNC: 'NO_MEETINGS_TO_SYNC', // After the syncMeeting no meeting exists
-  MEETING_CONNECTION_FAILED: 'MEETING_CONNECTION_FAILED' // meeting failed to connect due to ice failures or firewall issue
+  MEETING_CONNECTION_FAILED: 'MEETING_CONNECTION_FAILED', // meeting failed to connect due to ice failures or firewall issue
 };
 
 // One one one calls ends for the following reasons
@@ -346,12 +365,12 @@ export const MEETING_REMOVED_REASON = {
 export const CALL_REMOVED_REASON = {
   CALL_INACTIVE: 'CALL_INACTIVE', // partner and you leave the call
   PARTNER_LEFT: 'PARTNER_LEFT', // partner left the call
-  SELF_LEFT: 'SELF_LEFT'// you left/declined the call
+  SELF_LEFT: 'SELF_LEFT', // you left/declined the call
 };
 
 export const SHARE_STOPPED_REASON = {
   SELF_STOPPED: 'SELF_STOPPED',
-  MEETING_REJOIN: 'MEETING_REJOIN'
+  MEETING_REJOIN: 'MEETING_REJOIN',
 };
 
 export const EVENTS = {
@@ -371,66 +390,70 @@ export const EVENTS = {
   LOCUS_INFO_UPDATE_SELF: 'LOCUS_INFO_UPDATE_SELF',
   LOCUS_INFO_UPDATE_URL: 'LOCUS_INFO_UPDATE_URL',
   LOCUS_INFO_CAN_ASSIGN_HOST: 'LOCUS_INFO_CAN_ASSIGN_HOST',
-  DISCONNECT_DUE_TO_INACTIVITY: 'DISCONNECT_DUE_TO_INACTIVITY'
+  DISCONNECT_DUE_TO_INACTIVITY: 'DISCONNECT_DUE_TO_INACTIVITY',
 };
 
 export const MEDIA_STATE = {
   active: 'active',
-  inactive: 'inactive'
+  inactive: 'inactive',
 };
 
 export const ERROR_DICTIONARY = {
   PARAMETER: {
     NAME: 'ParameterError',
-    MESSAGE: 'The parameters passed to the function, or object properties needed in the function were null, missing where required, or otherwise incorrect.',
-    CODE: 0
+    MESSAGE:
+      'The parameters passed to the function, or object properties needed in the function were null, missing where required, or otherwise incorrect.',
+    CODE: 0,
   },
   INTENT_TO_JOIN: {
     NAME: 'IntentToJoinError',
-    MESSAGE: 'The meeting is locked. This is expected behavior. Call #join again with pin and/or moderator option',
-    CODE: 1
+    MESSAGE:
+      'The meeting is locked. This is expected behavior. Call #join again with pin and/or moderator option',
+    CODE: 1,
   },
   JOIN_MEETING: {
     NAME: 'JoinMeetingError',
     MESSAGE: 'There was an issue joining the meeting, meeting could be in a bad state.',
-    CODE: 2
+    CODE: 2,
   },
   RECONNECTION: {
     NAME: 'ReconnectionError',
-    MESSAGE: 'There was an error in the reconnection flow, the meeting may not reconnect, disconnect and dial again.',
-    CODE: 3
+    MESSAGE:
+      'There was an error in the reconnection flow, the meeting may not reconnect, disconnect and dial again.',
+    CODE: 3,
   },
   MEDIA: {
     NAME: 'MediaError',
     MESSAGE: 'There was an error with media, the meeting may not have live audio, video or share.',
-    CODE: 4
+    CODE: 4,
   },
   PERMISSION: {
     NAME: 'PermissionError',
-    MESSAGE: 'Not allowed to execute the function, some properties on server, or local client state do not allow you to complete this action.',
-    CODE: 5
+    MESSAGE:
+      'Not allowed to execute the function, some properties on server, or local client state do not allow you to complete this action.',
+    CODE: 5,
   },
   STATS: {
     NAME: 'StatsError',
     MESSAGE: 'An error occurred with getStats, stats may not continue for this data stream.',
-    CODE: 6
+    CODE: 6,
   },
   PASSWORD: {
     NAME: 'PasswordError',
     MESSAGE: 'Password is required, please use verifyPassword()',
-    CODE: 7
+    CODE: 7,
   },
   CAPTCHA: {
     NAME: 'CaptchaError',
     MESSAGE: 'Captcha is required.',
-    CODE: 8
-  }
+    CODE: 8,
+  },
 };
 
 export const FLOOR_ACTION = {
   GRANTED: 'GRANTED',
   RELEASED: 'RELEASED',
-  ACCEPTED: 'ACCEPTED'
+  ACCEPTED: 'ACCEPTED',
 };
 
 export const FULL_STATE = {
@@ -438,21 +461,21 @@ export const FULL_STATE = {
   INACTIVE: 'INACTIVE',
   ACTIVE: 'ACTIVE',
   TERMINATING: 'TERMINATING',
-  UNKNOWN: 'UNKNOWN'
+  UNKNOWN: 'UNKNOWN',
 };
 
 export const HTTP_VERBS = {
   PUT: 'PUT',
   POST: 'POST',
   GET: 'GET',
-  PATCH: 'PATCH'
+  PATCH: 'PATCH',
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceGatheringState
 export const ICE_GATHERING_STATE = {
   NEW: 'new',
   GATHERING: 'gathering',
-  COMPLETE: 'complete'
+  COMPLETE: 'complete',
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState
@@ -462,7 +485,7 @@ export const ICE_STATE = {
   CLOSED: 'closed',
   COMPLETED: 'completed',
   FAILED: 'failed',
-  DISCONNECTED: 'disconnected'
+  DISCONNECTED: 'disconnected',
 };
 
 export const CONNECTION_STATE = {
@@ -471,14 +494,14 @@ export const CONNECTION_STATE = {
   CONNECTED: 'connected',
   CLOSED: 'closed',
   FAILED: 'failed',
-  DISCONNECTED: 'disconnected'
+  DISCONNECTED: 'disconnected',
 };
 
 export const LOCUS = {
   STATE: {
     INACTIVE: 'INACTIVE',
     ENDED: 'ENDED',
-    INITIALIZING: 'INITIALIZING'
+    INITIALIZING: 'INITIALIZING',
   },
   SEQUENCE: {
     UN_DEF: 'undef',
@@ -486,9 +509,9 @@ export const LOCUS = {
     DEF: 'def',
     NA: 'na',
     RANGE_START: 'rangeStart',
-    RANGE_END: 'rangeEnd'
+    RANGE_END: 'rangeEnd',
   },
-  SYNCDEBUG: 'sync_debug'
+  SYNCDEBUG: 'sync_debug',
 };
 
 export const LOCUSINFO = {
@@ -517,7 +540,7 @@ export const LOCUSINFO = {
     EMBEDDED_APPS_UPDATED: 'EMBEDDED_APPS_UPDATED',
     SELF_CANNOT_VIEW_PARTICIPANT_LIST_CHANGE: 'SELF_CANNOT_VIEW_PARTICIPANT_LIST_CHANGE',
     SELF_IS_SHARING_BLOCKED_CHANGE: 'SELF_IS_SHARING_BLOCKED_CHANGE',
-  }
+  },
 };
 
 export const LOCUSEVENT = {
@@ -552,7 +575,7 @@ export const LOCUSEVENT = {
   RECORDING_START_FAILED: 'locus.recording_start_failed',
   RECORDING_STOPPED: 'locus.recording_stopped',
 
-  SELF_CHANGED: 'locus.self_changed'
+  SELF_CHANGED: 'locus.self_changed',
 };
 
 export const MEDIA_TRACK_CONSTRAINT = {
@@ -562,8 +585,8 @@ export const MEDIA_TRACK_CONSTRAINT = {
     // The cursor should only be visible while moving, then removed.
     MOTION: 'motion',
     // The cursor should never be visible in the generated stream.
-    NEVER: 'never'
-  }
+    NEVER: 'never',
+  },
 };
 
 export const MEETING_ERRORS = {
@@ -586,7 +609,8 @@ export const MEETING_ERRORS = {
   INVALID_LOCUS_ID: 'INVALID_LOCUS_ID',
   EMPTY_SCHEDULED_MEETING_START_TIME: 'EMPTY_SCHEDULED_MEETING_START_TIME',
   INVALID_SCHEDULED_MEETING_DURATION_MINUTES: 'INVALID_SCHEDULED_MEETING_DURATION_MINUTES',
-  INVALID_SCHEDULED_MEETING_REMINDER_DURATION_MINUTES: 'INVALID_SCHEDULED_MEETING_REMINDER_DURATION_MINUTES',
+  INVALID_SCHEDULED_MEETING_REMINDER_DURATION_MINUTES:
+    'INVALID_SCHEDULED_MEETING_REMINDER_DURATION_MINUTES',
   EMPTY_SCHEDULED_MEETING_ORGANIZER: 'EMPTY_SCHEDULED_MEETING_ORGANIZER',
   INVALID_MEETING_ID_FORMAT: 'INVALID_MEETING_ID_FORMAT',
   INVALID_SIP_URL_FORMAT: 'INVALID_SIP_URL_FORMAT',
@@ -667,13 +691,12 @@ export const MEETING_ERRORS = {
   SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
 
   SOCKET_TIMEOUT: 'SOCKET_TIMEOUT',
-  NO_HTTP_RESPONSE: 'NO_HTTP_RESPONSE'
+  NO_HTTP_RESPONSE: 'NO_HTTP_RESPONSE',
 };
-
 
 export const MEETING_END_REASON = {
   INACTIVE: 'INACTIVE',
-  MEDIA_RELEASED: 'MEDIA_RELEASED'
+  MEDIA_RELEASED: 'MEDIA_RELEASED',
 };
 
 export const DISPLAY_HINTS = {
@@ -705,7 +728,7 @@ export const DISPLAY_HINTS = {
 
 export const SELF_ROLES = {
   COHOST: 'COHOST',
-  MODERATOR: 'MODERATOR'
+  MODERATOR: 'MODERATOR',
 };
 
 export const MEETING_STATE = {
@@ -720,8 +743,8 @@ export const MEETING_STATE = {
     TERMINATING: 'TERMINATING',
     LEFT: 'LEFT',
     ENDED: 'ENDED',
-    ERROR: 'ERROR'
-  }
+    ERROR: 'ERROR',
+  },
 };
 
 export const MEETING_STATE_MACHINE = {
@@ -733,7 +756,7 @@ export const MEETING_STATE_MACHINE = {
     DECLINE: 'decline',
     LEAVE: 'leave',
     END: 'end',
-    RESET: 'reset'
+    RESET: 'reset',
   },
   STATES: {
     ERROR: 'ERROR',
@@ -742,35 +765,35 @@ export const MEETING_STATE_MACHINE = {
     DECLINED: 'DECLINED',
     RINGING: 'RINGING',
     JOINED: 'JOINED',
-    ANSWERED: 'ANSWERED'
-  }
+    ANSWERED: 'ANSWERED',
+  },
 };
 
 export const MEETING_AUDIO_STATE_MACHINE = {
   TRANSITIONS: {
     TOGGLE: 'toggle',
-    INIT: 'init'
+    INIT: 'init',
   },
   STATES: {
     MUTE_SELF: 'SELF_AUDIO_OFF',
-    UNMUTE_SELF: 'SELF_AUDIO_ON'
-  }
+    UNMUTE_SELF: 'SELF_AUDIO_ON',
+  },
 };
 
 export const MEETING_VIDEO_STATE_MACHINE = {
   TRANSITIONS: {
     TOGGLE: 'toggle',
-    INIT: 'init'
+    INIT: 'init',
   },
   STATES: {
     MUTE_SELF: 'SELF_VIDEO_OFF',
-    UNMUTE_SELF: 'SELF_VIDEO_ON'
-  }
+    UNMUTE_SELF: 'SELF_VIDEO_ON',
+  },
 };
 
 export const PEER_CONNECTION_STATE = {
   CLOSED: 'closed',
-  FAILED: 'failed'
+  FAILED: 'failed',
 };
 
 export const RECONNECTION = {
@@ -779,23 +802,23 @@ export const RECONNECTION = {
     COMPLETE: 'COMPLETE',
     FAILURE: 'FAILURE',
     DEFAULT_TRY_COUNT: 0,
-    DEFAULT_STATUS: ''
-  }
+    DEFAULT_STATUS: '',
+  },
 };
 
 export const RESOURCE = {
   CLUSTERS: 'clusters',
   REACHABILITY: 'reachability',
-  LOCI: 'loci'
+  LOCI: 'loci',
 };
 
 export const REACHABILITY = {
-  localStorage: 'reachability.result'
+  localStorage: 'reachability.result',
 };
 
 export const ROAP = {
   ROAP_TRANSITIONS: {
-    STEP: 'step'
+    STEP: 'step',
   },
   ROAP_TYPES: {
     OFFER: 'OFFER',
@@ -818,7 +841,7 @@ export const ROAP = {
     IDLE_LOCAL_OFFER: 'IDLE_LOCAL_OFFER',
     IDLE_REMOTE_OFFER: 'IDLE_REMOTE_OFFER',
     GLARE: 'GLARE',
-    ERROR: 'ERROR'
+    ERROR: 'ERROR',
   },
   ROAP_SIGNAL: {
     RX_OFFER: 'RX_OFFER',
@@ -827,7 +850,7 @@ export const ROAP = {
     TX_ANSWER: 'TX_ANSWER',
     RX_OK: 'RX_OK',
     TX_OK: 'TX_OK',
-    GLARE_RESOLVED: 'GLARE_RESOLVED'
+    GLARE_RESOLVED: 'GLARE_RESOLVED',
   },
   RECEIVE_ROAP_MSG: 'RECEIVE_ROAP_MSG',
   SEND_ROAP_MSG: 'SEND_ROAP_MSG',
@@ -837,12 +860,12 @@ export const ROAP = {
   ROAP_MERCURY: 'event:locus.message.roap',
   ROAP_VERSION: '2',
   RX_: 'RX_',
-  TX_: 'TX_'
+  TX_: 'TX_',
 };
 
 export const MediaContent = {
   main: 'main',
-  slides: 'slides'
+  slides: 'slides',
 };
 
 export const SDP = {
@@ -858,20 +881,20 @@ export const SDP = {
   // Edonus repeated key frames request
   PERIODIC_KEYFRAME: 'a=periodic-keyframes:20',
   CARRIAGE_RETURN: '\r\n',
-  BAD_MEDIA_PORTS: [0]
+  BAD_MEDIA_PORTS: [0],
 };
 
 export const NETWORK_STATUS = {
   DISCONNECTED: 'DISCONNECTED',
   RECONNECTING: 'RECONNECTING',
-  CONNECTED: 'CONNECTED'
+  CONNECTED: 'CONNECTED',
 };
 
 export const NETWORK_TYPE = {
   VPN: 'vpn',
   UNKNOWN: 'unknown',
   WIFI: 'wifi',
-  ETHERNET: 'ethernet'
+  ETHERNET: 'ethernet',
 };
 
 export const STATS = {
@@ -895,7 +918,7 @@ export const MQA_STATS = {
         isMain: false, // always true for share sender
         mariFecEnabled: false, // unavailable
         mariQosEnabled: false, // unavailable
-        multistreamEnabled: false // unavailable
+        multistreamEnabled: false, // unavailable
       },
       availableBitrate: 0,
       dtlsBitrate: 0, // unavailable
@@ -914,7 +937,7 @@ export const MQA_STATS = {
       rtpPackets: 0,
       stunBitrate: 0, // unavailable
       stunPackets: 0, // unavailable
-      transportType: 'UDP' // TODO: parse the transport type from the SDP and save globally
+      transportType: 'UDP', // TODO: parse the transport type from the SDP and save globally
     },
     streams: [
       {
@@ -926,7 +949,7 @@ export const MQA_STATS = {
           rtpPackets: 0,
           ssci: 0, // unavailable
           transmittedBitrate: 0,
-          transmittedFrameRate: 0
+          transmittedFrameRate: 0,
         },
         h264CodecProfile: 'BP', // TODO: parse the profile level from h264 in the SDP and save globally
         localConfigurationChanges: 0, // unavailable
@@ -936,9 +959,9 @@ export const MQA_STATS = {
         transmittedFrameSize: 0, // unavailable
         transmittedHeight: 0,
         transmittedKeyFrames: 0,
-        transmittedWidth: 0
-      }
-    ]
+        transmittedWidth: 0,
+      },
+    ],
   },
   intervalMetadata: {
     memoryUsage: {
@@ -949,14 +972,14 @@ export const MQA_STATS = {
       processMaximumMemoryBytes: 0,
       processMaximumMemoryUsage: 0,
       systemAverageMemoryUsage: 0,
-      systemMaximumMemoryUsage: 0
+      systemMaximumMemoryUsage: 0,
     },
     peerReflexiveIP: 'NULL', // TODO: save after ice trickling completes and use as a global variable
     processAverageCPU: 0,
     processMaximumCPU: 0,
     systemAverageCPU: 0,
-    systemMaximumCPU: 0
-  }
+    systemMaximumCPU: 0,
+  },
 };
 
 // ****** MEDIA QUALITY CONSTANTS ****** //
@@ -971,56 +994,55 @@ export const QUALITY_LEVELS = {
   '1080p': '1080p',
 };
 
-
 export const AVAILABLE_RESOLUTIONS = {
   '360p': {
     video: {
       width: {
         max: 640,
-        ideal: 640
+        ideal: 640,
       },
       height: {
         max: 360,
-        ideal: 360
-      }
-    }
+        ideal: 360,
+      },
+    },
   },
   '480p': {
     video: {
       width: {
         max: 640,
-        ideal: 640
+        ideal: 640,
       },
       height: {
         max: 480,
-        ideal: 480
-      }
-    }
+        ideal: 480,
+      },
+    },
   },
   '720p': {
     video: {
       width: {
         max: 1280,
-        ideal: 1280
+        ideal: 1280,
       },
       height: {
         max: 720,
-        ideal: 720
-      }
-    }
+        ideal: 720,
+      },
+    },
   },
   '1080p': {
     video: {
       width: {
         max: 1920,
-        ideal: 1920
+        ideal: 1920,
       },
       height: {
         max: 1080,
-        ideal: 1080
-      }
-    }
-  }
+        ideal: 1080,
+      },
+    },
+  },
 };
 
 export const VIDEO_RESOLUTIONS = {
@@ -1041,21 +1063,20 @@ export const REMOTE_VIDEO_CONSTRAINTS = {
   MAX_FS: {
     [QUALITY_LEVELS.LOW]: 1620,
     [QUALITY_LEVELS.MEDIUM]: 3600,
-    [QUALITY_LEVELS.HIGH]: 8192
-  }
+    [QUALITY_LEVELS.HIGH]: 8192,
+  },
 };
 
 /*
-*  mqa Interval for sending stats metrics
-*/
+ *  mqa Interval for sending stats metrics
+ */
 
 export const MQA_INTEVAL = 60000; // mqa analyzer interval its fixed to 60000
-
 
 export const MEDIA_DEVICES = {
   MICROPHONE: 'microphone',
   SPEAKER: 'speaker',
-  CAMERA: 'camera'
+  CAMERA: 'camera',
 };
 
 export const METRICS_JOIN_TIMES_MAX_DURATION = 1200000;
@@ -1066,31 +1087,31 @@ export const PSTN_STATUS = {
   LEFT: 'LEFT', // user has disconnected from the pstn device
   TRANSFERRING: 'TRANSFERRING', // usually happens in dial-out after the CONNECTED state
   SUCCESS: 'SUCCESS', // happens after the transfer (TRANSFERRING) is successful
-  UNKNOWN: '' // placeholder if we haven't been told what the status is
+  UNKNOWN: '', // placeholder if we haven't been told what the status is
 };
 
 export const PASSWORD_STATUS = {
   NOT_REQUIRED: 'NOT_REQUIRED', // password is not required to join the meeting
   REQUIRED: 'REQUIRED', // client needs to provide the password by calling verifyPassword() before calling join()
   UNKNOWN: 'UNKNOWN', // we are waiting for information from the backend if password is required or not
-  VERIFIED: 'VERIFIED' // client has already provided the password and it has been verified, client can proceed to call join()
+  VERIFIED: 'VERIFIED', // client has already provided the password and it has been verified, client can proceed to call join()
 };
 
 export const MEETING_INFO_FAILURE_REASON = {
   NONE: 'NONE', // meeting info was retrieved succesfully
   WRONG_PASSWORD: 'WRONG_PASSWORD', // meeting requires password and no password or wrong one was provided
   WRONG_CAPTCHA: 'WRONG_CAPTCHA', // wbxappapi requires a captcha code or a wrong captcha code was provided
-  OTHER: 'OTHER' // any other error (network, etc)
+  OTHER: 'OTHER', // any other error (network, etc)
 };
 
 export const BNR_STATUS = {
   SHOULD_ENABLE: 'SHOULD_ENABLE',
   ENABLED: 'ENABLED',
   SHOULD_DISABLE: 'SHOULD_DISABLE',
-  NOT_ENABLED: 'NOT_ENABLED'
+  NOT_ENABLED: 'NOT_ENABLED',
 };
 
 export const EMBEDDED_APP_TYPES = {
   SLIDO: 'SLIDO',
-  OTHER: 'OTHER'
+  OTHER: 'OTHER',
 };

--- a/packages/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/@webex/plugin-meetings/src/meeting/index.js
@@ -4,8 +4,12 @@ import {StatelessWebexPlugin} from '@webex/webex-core';
 import {Media as WebRTCMedia} from '@webex/internal-media-core';
 
 import {
-  MeetingNotActiveError, createMeetingsError, UserInLobbyError,
-  NoMediaEstablishedYetError, UserNotJoinedError, InvalidSdpError
+  MeetingNotActiveError,
+  createMeetingsError,
+  UserInLobbyError,
+  NoMediaEstablishedYetError,
+  UserNotJoinedError,
+  InvalidSdpError,
 } from '../common/errors/webex-errors';
 import {StatsAnalyzer, EVENTS as StatsAnalyzerEvents} from '../statsAnalyzer';
 import NetworkQualityMonitor from '../networkQualityMonitor';
@@ -68,17 +72,19 @@ import {
   VIDEO_RESOLUTIONS,
   VIDEO,
   BNR_STATUS,
-  HTTP_VERBS
+  HTTP_VERBS,
 } from '../constants';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import ParameterError from '../common/errors/parameter';
 import MediaError from '../common/errors/media';
-import {MeetingInfoV2PasswordError, MeetingInfoV2CaptchaError} from '../meeting-info/meeting-info-v2';
+import {
+  MeetingInfoV2PasswordError,
+  MeetingInfoV2CaptchaError,
+} from '../meeting-info/meeting-info-v2';
 import BrowserDetection from '../common/browser-detection';
 import RoapCollection from '../roap/collection';
 
 import InMeetingActions from './in-meeting-actions';
-
 
 const {isBrowser} = BrowserDetection();
 
@@ -101,7 +107,7 @@ export const MEDIA_UPDATE_TYPE = {
   ALL: 'ALL',
   AUDIO: 'AUDIO',
   VIDEO: 'VIDEO',
-  SHARE: 'SHARE'
+  SHARE: 'SHARE',
 };
 
 /**
@@ -117,21 +123,21 @@ export const MEDIA_UPDATE_TYPE = {
  */
 
 /**
-  * AudioVideo
-  * @typedef {Object} AudioVideo
-  * @property {Object} audio
-  * @property {String} audio.deviceId
-  * @property {Object} video
-  * @property {String} video.deviceId
-  * @property {String} video.localVideoQuality // [240p, 360p, 480p, 720p, 1080p]
-  */
+ * AudioVideo
+ * @typedef {Object} AudioVideo
+ * @property {Object} audio
+ * @property {String} audio.deviceId
+ * @property {Object} video
+ * @property {String} video.deviceId
+ * @property {String} video.localVideoQuality // [240p, 360p, 480p, 720p, 1080p]
+ */
 
 /**
-   * SharePreferences
-   * @typedef {Object} SharePreferences
-   * @property {Object} [shareConstraints]
-   * @property {Boolean} [highFrameRate]
-   */
+ * SharePreferences
+ * @typedef {Object} SharePreferences
+ * @property {Object} [shareConstraints]
+ * @property {Boolean} [highFrameRate]
+ */
 
 /**
  * JoinOptions
@@ -161,36 +167,36 @@ export const MEDIA_UPDATE_TYPE = {
  */
 
 /**
-  * Meeting State Change Event
-  * Emitted when ever there is a meeting state change
-  * @event meeting:stateChange
-  * @instance
-  * @type {Object}
-  * @property {String} currentState current state of the meeting
-  * @property {String} previousState previous state of the meeting
-  * @memberof Meeting
-  */
+ * Meeting State Change Event
+ * Emitted when ever there is a meeting state change
+ * @event meeting:stateChange
+ * @instance
+ * @type {Object}
+ * @property {String} currentState current state of the meeting
+ * @property {String} previousState previous state of the meeting
+ * @memberof Meeting
+ */
 
 /**
-  * Media Ready Event
-  * Emitted when a stream is ready to be rendered
-  * @event media:ready
-  * @instance
-  * @type {Object}
-  * @property {MediaStream} stream the media stream
-  * @property {String} type what type of stream, remote, local
-  * @memberof Meeting
-  */
+ * Media Ready Event
+ * Emitted when a stream is ready to be rendered
+ * @event media:ready
+ * @instance
+ * @type {Object}
+ * @property {MediaStream} stream the media stream
+ * @property {String} type what type of stream, remote, local
+ * @memberof Meeting
+ */
 
 /**
-  * Media Stopped Event
-  * Emitted when a stream has stopped sending
-  * @event media:stopped
-  * @instance
-  * @type {Object}
-  * @property {String} type what type of stream, remote, local
-  * @memberof Meeting
-  */
+ * Media Stopped Event
+ * Emitted when a stream has stopped sending
+ * @event media:stopped
+ * @instance
+ * @type {Object}
+ * @property {String} type what type of stream, remote, local
+ * @memberof Meeting
+ */
 
 /**
  * Meeting Ringing Event
@@ -317,7 +323,6 @@ export const MEDIA_UPDATE_TYPE = {
  * @memberof Meeting
  */
 
-
 /**
  * Meeting Self Guest Admitted Event
  * Emitted when a joined user get admitted to the meeting by another member or host
@@ -349,42 +354,42 @@ export const MEDIA_UPDATE_TYPE = {
  */
 
 /**
-  * Reconnection Starting Event
-  * Emitted when reconnection of media to the active meeting was successful
-  * @event meeting:reconnectionStarting
-  * @instance
-  * @memberof Meeting
-  */
+ * Reconnection Starting Event
+ * Emitted when reconnection of media to the active meeting was successful
+ * @event meeting:reconnectionStarting
+ * @instance
+ * @memberof Meeting
+ */
 
 /**
-  * Reconnection Success Event
-  * Emitted when reconnection of media to the active meeting was successful
-  * @event meeting:reconnectionSuccess
-  * @instance
-  * @type {Object}
-  * @property {Object} reconnect
-  * @memberof Meeting
-  */
+ * Reconnection Success Event
+ * Emitted when reconnection of media to the active meeting was successful
+ * @event meeting:reconnectionSuccess
+ * @instance
+ * @type {Object}
+ * @property {Object} reconnect
+ * @memberof Meeting
+ */
 
 /**
-  * Reconnection Failure Event
-  * Emitted when reconnection of media to the active meeting was successful
-  * @event meeting:reconnectionFailure
-  * @instance
-  * @type {Object}
-  * @property {Error} error
-  * @memberof Meeting
-  */
+ * Reconnection Failure Event
+ * Emitted when reconnection of media to the active meeting was successful
+ * @event meeting:reconnectionFailure
+ * @instance
+ * @type {Object}
+ * @property {Error} error
+ * @memberof Meeting
+ */
 
 /**
-  * Meeting network quality event
-  * Emitted on each interval of retrieving stats Analyzer data
-  * @event network:quality
-  * @type {Object}
-  * @property {string} mediaType {video|audio}
-  * @property {number} networkQualityScore - {1|0} 1 indicates acceptable uplink 0 indicates unacceptable uplink based on threshold
-  * @memberof Meeting
-  */
+ * Meeting network quality event
+ * Emitted on each interval of retrieving stats Analyzer data
+ * @event network:quality
+ * @type {Object}
+ * @property {string} mediaType {video|audio}
+ * @property {number} networkQualityScore - {1|0} 1 indicates acceptable uplink 0 indicates unacceptable uplink based on threshold
+ * @memberof Meeting
+ */
 
 /**
  * @description Meeting is the crux of the plugin
@@ -399,7 +404,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @param {Object} options
    * @constructor
    * @memberof Meeting
-  */
+   */
   constructor(attrs, options) {
     super({}, options);
     /**
@@ -492,7 +497,7 @@ export default class Meeting extends StatelessWebexPlugin {
      * @public
      * @memberof Meeting
      */
-    this.members = new Members({locusUrl: (attrs.locus && attrs.locus.url)}, {parent: this.webex});
+    this.members = new Members({locusUrl: attrs.locus && attrs.locus.url}, {parent: this.webex});
     /**
      * @instance
      * @type {Roap}
@@ -675,7 +680,7 @@ export default class Meeting extends StatelessWebexPlugin {
      * @type {InMeetingActions}
      * @public
      * @memberof Meeting
-    */
+     */
     this.inMeetingActions = new InMeetingActions();
     /**
      * This is deprecated, please use shareStatus instead.
@@ -716,7 +721,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
         return false;
       },
-      configurable: true
+      configurable: true,
     });
     /**
      * @instance
@@ -910,31 +915,47 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    * @returns {Promise}
    */
-  async fetchMeetingInfo({
-    password = null, captchaCode = null
-  }) {
+  async fetchMeetingInfo({password = null, captchaCode = null}) {
     // when fetch meeting info is called directly by the client, we want to clear out the random timer for sdk to do it
     if (this.fetchMeetingInfoTimeoutId) {
       clearTimeout(this.fetchMeetingInfoTimeoutId);
       this.fetchMeetingInfoTimeoutId = undefined;
     }
     if (captchaCode && !this.requiredCaptcha) {
-      return Promise.reject(new Error('fetchMeetingInfo() called with captchaCode when captcha was not required'));
+      return Promise.reject(
+        new Error('fetchMeetingInfo() called with captchaCode when captcha was not required')
+      );
     }
-    if (password && (this.passwordStatus !== PASSWORD_STATUS.REQUIRED && this.passwordStatus !== PASSWORD_STATUS.UNKNOWN)) {
-      return Promise.reject(new Error('fetchMeetingInfo() called with password when password was not required'));
+    if (
+      password &&
+      this.passwordStatus !== PASSWORD_STATUS.REQUIRED &&
+      this.passwordStatus !== PASSWORD_STATUS.UNKNOWN
+    ) {
+      return Promise.reject(
+        new Error('fetchMeetingInfo() called with password when password was not required')
+      );
     }
 
     try {
-      const captchaInfo = captchaCode ? {code: captchaCode, id: this.requiredCaptcha.captchaId} : null;
+      const captchaInfo = captchaCode ?
+        {code: captchaCode, id: this.requiredCaptcha.captchaId} :
+        null;
 
-      const info = await this.attrs.meetingInfoProvider.fetchMeetingInfo(this.destination, this.destinationType, password, captchaInfo);
+      const info = await this.attrs.meetingInfoProvider.fetchMeetingInfo(
+        this.destination,
+        this.destinationType,
+        password,
+        captchaInfo
+      );
 
       this.parseMeetingInfo(info, this.destination);
       this.meetingInfo = info ? info.body : null;
       this.meetingInfoFailureReason = MEETING_INFO_FAILURE_REASON.NONE;
       this.requiredCaptcha = null;
-      if ((this.passwordStatus === PASSWORD_STATUS.REQUIRED) || (this.passwordStatus === PASSWORD_STATUS.VERIFIED)) {
+      if (
+        this.passwordStatus === PASSWORD_STATUS.REQUIRED ||
+        this.passwordStatus === PASSWORD_STATUS.VERIFIED
+      ) {
         this.passwordStatus = PASSWORD_STATUS.VERIFIED;
       }
       else {
@@ -945,7 +966,7 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meetings',
-          function: 'fetchMeetingInfo'
+          function: 'fetchMeetingInfo',
         },
         EVENT_TRIGGERS.MEETING_INFO_AVAILABLE
       );
@@ -954,7 +975,9 @@ export default class Meeting extends StatelessWebexPlugin {
     }
     catch (err) {
       if (err instanceof MeetingInfoV2PasswordError) {
-        LoggerProxy.logger.info(`Meeting:index#fetchMeetingInfo --> Info Unable to fetch meeting info for ${this.destination} - password required (code=${err?.body?.code}).`);
+        LoggerProxy.logger.info(
+          `Meeting:index#fetchMeetingInfo --> Info Unable to fetch meeting info for ${this.destination} - password required (code=${err?.body?.code}).`
+        );
 
         // when wbxappapi requires password it still populates partial meeting info in the response
         if (err.meetingInfo) {
@@ -969,12 +992,14 @@ export default class Meeting extends StatelessWebexPlugin {
           await this.refreshCaptcha();
         }
 
-        throw (new PasswordError());
+        throw new PasswordError();
       }
       else if (err instanceof MeetingInfoV2CaptchaError) {
-        LoggerProxy.logger.info(`Meeting:index#fetchMeetingInfo --> Info Unable to fetch meeting info for ${this.destination} - captcha required (code=${err?.body?.code}).`);
+        LoggerProxy.logger.info(
+          `Meeting:index#fetchMeetingInfo --> Info Unable to fetch meeting info for ${this.destination} - captcha required (code=${err?.body?.code}).`
+        );
 
-        this.meetingInfoFailureReason = (this.requiredCaptcha) ?
+        this.meetingInfoFailureReason = this.requiredCaptcha ?
           MEETING_INFO_FAILURE_REASON.WRONG_CAPTCHA :
           MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD;
 
@@ -983,11 +1008,11 @@ export default class Meeting extends StatelessWebexPlugin {
         }
 
         this.requiredCaptcha = err.captchaInfo;
-        throw (new CaptchaError());
+        throw new CaptchaError();
       }
       else {
         this.meetingInfoFailureReason = MEETING_INFO_FAILURE_REASON.OTHER;
-        throw (err);
+        throw err;
       }
     }
   }
@@ -1003,24 +1028,27 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   verifyPassword(password, captchaCode) {
     return this.fetchMeetingInfo({
-      password, captchaCode
+      password,
+      captchaCode,
     })
       .then(() => {
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.VERIFY_PASSWORD_SUCCESS
-        );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.VERIFY_PASSWORD_SUCCESS);
 
-        return {isPasswordValid: true, requiredCaptcha: null, failureReason: MEETING_INFO_FAILURE_REASON.NONE};
+        return {
+          isPasswordValid: true,
+          requiredCaptcha: null,
+          failureReason: MEETING_INFO_FAILURE_REASON.NONE,
+        };
       })
       .catch((error) => {
         if (error instanceof PasswordError || error instanceof CaptchaError) {
           return {
             isPasswordValid: this.passwordStatus === PASSWORD_STATUS.VERIFIED,
             requiredCaptcha: this.requiredCaptcha,
-            failureReason: this.meetingInfoFailureReason
+            failureReason: this.meetingInfoFailureReason,
           };
         }
-        throw (error);
+        throw error;
       });
   }
 
@@ -1040,18 +1068,21 @@ export default class Meeting extends StatelessWebexPlugin {
     // we have to pass the wbxappapi hostname as the siteFullName parameter
     const {hostname} = new URL(this.requiredCaptcha.refreshURL);
 
-    return this.meetingRequest.refreshCaptcha({
-      captchaRefreshUrl: `${this.requiredCaptcha.refreshURL}&siteFullName=${hostname}`,
-      captchaId: this.requiredCaptcha.captchaId
-    })
+    return this.meetingRequest
+      .refreshCaptcha({
+        captchaRefreshUrl: `${this.requiredCaptcha.refreshURL}&siteFullName=${hostname}`,
+        captchaId: this.requiredCaptcha.captchaId,
+      })
       .then((response) => {
         this.requiredCaptcha.captchaId = response.body.captchaID;
         this.requiredCaptcha.verificationImageURL = response.body.verificationImageURL;
         this.requiredCaptcha.verificationAudioURL = response.body.verificationAudioURL;
       })
       .catch((error) => {
-        LoggerProxy.logger.error(`Meeting:index#refreshCaptcha --> Error Unable to refresh captcha for ${this.destination} - ${error}`);
-        throw (error);
+        LoggerProxy.logger.error(
+          `Meeting:index#refreshCaptcha --> Error Unable to refresh captcha for ${this.destination} - ${error}`
+        );
+        throw error;
       });
   }
 
@@ -1079,7 +1110,6 @@ export default class Meeting extends StatelessWebexPlugin {
     this.setUpLocusInfoMediaInactiveListener();
   }
 
-
   /**
    * Set up the locus info listener for meetings disconnected due to inactivity
    * @returns {undefined}
@@ -1092,13 +1122,10 @@ export default class Meeting extends StatelessWebexPlugin {
       // https:// jira-eng-gpk2.cisco.com/jira/browse/SPARK-240520
       // TODO: send custom parameter explaining why the inactivity happened
       // refresh , no media or network got dsconnected or something else
-      Metrics.sendBehavioralMetric(
-        BEHAVIORAL_METRICS.DISCONNECT_DUE_TO_INACTIVITY,
-        {
-          correlation_id: this.correlationId,
-          locus_id: this.locusId
-        }
-      );
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.DISCONNECT_DUE_TO_INACTIVITY, {
+        correlation_id: this.correlationId,
+        locus_id: this.locusId,
+      });
 
       // Upload logs on media inactivity
       // Normally media should not be inactive
@@ -1106,13 +1133,15 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meeting/index',
-          function: 'setUpLocusInfoMediaInactiveListener'
+          function: 'setUpLocusInfoMediaInactiveListener',
         },
         EVENTS.REQUEST_UPLOAD_LOGS,
         this
       );
 
-      LoggerProxy.logger.error(`Meeting:index#setUpLocusInfoMediaInactiveListener --> Meeting disconnected due to inactivity: ${res.reason}`);
+      LoggerProxy.logger.error(
+        `Meeting:index#setUpLocusInfoMediaInactiveListener --> Meeting disconnected due to inactivity: ${res.reason}`
+      );
 
       if (this.config.reconnection.autoRejoin) {
         this.reconnect();
@@ -1122,7 +1151,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'setUpLocusInfoMediaInactiveListener'
+            function: 'setUpLocusInfoMediaInactiveListener',
           },
           EVENT_TRIGGERS.MEETING_SELF_LEFT,
           res.reason
@@ -1148,7 +1177,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'setUpLocusInfoAssignHostListener'
+            function: 'setUpLocusInfoAssignHostListener',
           },
           EVENT_TRIGGERS.MEETING_ACTIONS_UPDATE,
           this.inMeetingActions.get()
@@ -1169,11 +1198,11 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meeting/index',
-          function: 'setUpLocusFullStateListener'
+          function: 'setUpLocusFullStateListener',
         },
         EVENT_TRIGGERS.MEETING_STATE_CHANGE,
         {
-          payload
+          payload,
         }
       );
     });
@@ -1196,14 +1225,14 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   getAnalyzerMetricsPrePayload(options) {
     if (options) {
-      const {
-        event,
-        trackingId,
-        mediaConnections
-      } = options;
+      const {event, trackingId, mediaConnections} = options;
 
       if (!event) {
-        LoggerProxy.logger.error('Meeting:index#getAnalyzerMetricsPrePayload --> Error [Call Analyzer Event', event || '', `]: invalid identifers or event type! ${this.correlationId}`);
+        LoggerProxy.logger.error(
+          'Meeting:index#getAnalyzerMetricsPrePayload --> Error [Call Analyzer Event',
+          event || '',
+          `]: invalid identifers or event type! ${this.correlationId}`
+        );
 
         return null;
       }
@@ -1213,13 +1242,14 @@ export default class Meeting extends StatelessWebexPlugin {
         userId: this.userId,
         deviceId: this.deviceUrl,
         orgId: this.orgId,
-        locusUrl: this.webex.internal.services.get('locus')
+        locusUrl: this.webex.internal.services.get('locus'),
       };
 
       if (this.locusUrl && this.locusInfo.fullState) {
         identifiers.locusUrl = this.locusUrl;
         identifiers.locusId = this.locusUrl && this.locusUrl.split('/').pop();
-        identifiers.locusStartTime = this.locusInfo.fullState && this.locusInfo.fullState.lastActive;
+        identifiers.locusStartTime =
+          this.locusInfo.fullState && this.locusInfo.fullState.lastActive;
       }
 
       // Check if mediaConnections has been passed in or else use this.mediaConnections
@@ -1244,7 +1274,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
       if (joinRespRxStartAudio) {
         options.audioSetupDelay = {
-          joinRespRxStart: joinRespRxStartAudio
+          joinRespRxStart: joinRespRxStartAudio,
         };
       }
 
@@ -1252,7 +1282,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
       if (joinRespRxStartAudio) {
         options.videoSetupDelay = {
-          joinRespRxStart: joinRespRxStartVideo
+          joinRespRxStart: joinRespRxStartVideo,
         };
       }
 
@@ -1261,7 +1291,7 @@ export default class Meeting extends StatelessWebexPlugin {
       if (joinRespTxStartAudio) {
         options.audioSetupDelay = {
           ...options.audioSetupDelay,
-          joinRespTxStart: joinRespTxStartAudio
+          joinRespTxStart: joinRespTxStartAudio,
         };
       }
 
@@ -1270,7 +1300,7 @@ export default class Meeting extends StatelessWebexPlugin {
       if (joinRespTxStartVideo) {
         options.videoSetupDelay = {
           ...options.videoSetupDelay,
-          joinRespTxStart: joinRespTxStartVideo
+          joinRespTxStart: joinRespTxStartVideo,
         };
       }
 
@@ -1279,7 +1309,7 @@ export default class Meeting extends StatelessWebexPlugin {
       if (localSDPGenRemoteSDPRecv) {
         options.joinTimes = {
           ...options.joinTimes,
-          localSDPGenRemoteSDPRecv
+          localSDPGenRemoteSDPRecv,
         };
       }
 
@@ -1288,7 +1318,7 @@ export default class Meeting extends StatelessWebexPlugin {
       if (callInitiateJoinReq) {
         options.joinTimes = {
           ...options.joinTimes,
-          callInitiateJoinReq
+          callInitiateJoinReq,
         };
       }
 
@@ -1297,7 +1327,7 @@ export default class Meeting extends StatelessWebexPlugin {
       if (joinReqResp) {
         options.joinTimes = {
           ...options.joinTimes,
-          joinReqResp
+          joinReqResp,
         };
       }
 
@@ -1306,7 +1336,7 @@ export default class Meeting extends StatelessWebexPlugin {
       if (getTotalJmt) {
         options.joinTimes = {
           ...options.joinTimes,
-          getTotalJmt
+          getTotalJmt,
         };
       }
 
@@ -1337,7 +1367,7 @@ export default class Meeting extends StatelessWebexPlugin {
   sendCallAnalyzerMetrics(options) {
     const payload = this.getAnalyzerMetricsPrePayload({
       ...pick(this.config.metrics, ['clientType', 'subClientType']),
-      ...options
+      ...options,
     });
 
     return this.webex.internal.metrics.submitCallDiagnosticEvents(payload);
@@ -1357,7 +1387,7 @@ export default class Meeting extends StatelessWebexPlugin {
     const payload = this.getAnalyzerMetricsPrePayload({
       type: MQA_STATS.CA_TYPE,
       ...pick(this.config.metrics, ['clientType', 'subClientType']),
-      ...options
+      ...options,
     });
 
     return this.webex.internal.metrics.submitCallDiagnosticEvents(payload);
@@ -1376,19 +1406,22 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meeting/index',
-          function: 'setNetworkStatus'
+          function: 'setNetworkStatus',
         },
-        EVENT_TRIGGERS.MEETINGS_NETWORK_DISCONNECTED,
+        EVENT_TRIGGERS.MEETINGS_NETWORK_DISCONNECTED
       );
     }
-    else if (networkStatus === NETWORK_STATUS.CONNECTED && this.networkStatus === NETWORK_STATUS.DISCONNECTED) {
+    else if (
+      networkStatus === NETWORK_STATUS.CONNECTED &&
+      this.networkStatus === NETWORK_STATUS.DISCONNECTED
+    ) {
       Trigger.trigger(
         this,
         {
           file: 'meeting/index',
-          function: 'setNetworkStatus'
+          function: 'setNetworkStatus',
         },
-        EVENT_TRIGGERS.MEETINGS_NETWORK_CONNECTED,
+        EVENT_TRIGGERS.MEETINGS_NETWORK_CONNECTED
       );
     }
 
@@ -1410,8 +1443,9 @@ export default class Meeting extends StatelessWebexPlugin {
 
       // If user moved to a JOINED state and there is a pending floor grant trigger it
       if (this.floorGrantPending && payload.newSelf.state === MEETING_STATE.STATES.JOINED) {
-        this.share()
-          .then(() => { this.floorGrantPending = false; });
+        this.share().then(() => {
+          this.floorGrantPending = false;
+        });
       }
     });
   }
@@ -1425,8 +1459,12 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   pstnUpdate(payload) {
     if (this.locusInfo.self) {
-      const dialInPstnDevice = payload.newSelf?.pstnDevices.find((device) => device.url === this.dialInUrl);
-      const dialOutPstnDevice = payload.newSelf?.pstnDevices.find((device) => device.url === this.dialOutUrl);
+      const dialInPstnDevice = payload.newSelf?.pstnDevices.find(
+        (device) => device.url === this.dialInUrl
+      );
+      const dialOutPstnDevice = payload.newSelf?.pstnDevices.find(
+        (device) => device.url === this.dialOutUrl
+      );
       let changed = false;
 
       if (dialInPstnDevice) {
@@ -1452,18 +1490,18 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'setUpLocusSelfListener'
+            function: 'setUpLocusSelfListener',
           },
           EVENT_TRIGGERS.MEETING_SELF_PHONE_AUDIO_UPDATE,
           {
             dialIn: {
               status: this.dialInDeviceStatus,
-              attendeeId: dialInPstnDevice?.attendeeId
+              attendeeId: dialInPstnDevice?.attendeeId,
             },
             dialOut: {
               status: this.dialOutDeviceStatus,
-              attendeeId: dialOutPstnDevice?.attendeeId
-            }
+              attendeeId: dialOutPstnDevice?.attendeeId,
+            },
           }
         );
       }
@@ -1498,7 +1536,6 @@ export default class Meeting extends StatelessWebexPlugin {
     });
   }
 
-
   /**
    * Set up the locus info recording update listener
    * update recording value for the meeting
@@ -1518,7 +1555,36 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   setupLocusControlsListener() {
-    this.locusInfo.on(LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
+    this.locusInfo.on(
+      LOCUSINFO.EVENTS.CONTROLS_MEETING_TRANSCRIBE_UPDATED,
+      ({caption, transcribing}) => {
+        if (transcribing && this.transcription && this.config.receiveTranscription) {
+          this.receiveTranscription();
+        }
+        else if (!transcribing && this.transcription) {
+          Trigger.trigger(
+            this,
+            {
+              file: 'meeting/index',
+              function: 'setupLocusControlsListener',
+            },
+            EVENT_TRIGGERS.MEETING_STOPPED_RECEIVING_TRANSCRIPTION,
+            {caption, transcribing}
+          );
+        }
+        Trigger.trigger(
+          this,
+          {
+            file: 'meeting/index',
+            function: 'setupLocusControlsListener',
+          },
+          transcribing ? EVENT_TRIGGERS.TRANSCRIBING_ON : EVENT_TRIGGERS.TRANSCRIBING_OFF
+        );
+      }
+    );
+
+    this.locusInfo.on(
+      LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
       ({state, modifiedBy, lastModified}) => {
         let event;
 
@@ -1544,63 +1610,47 @@ export default class Meeting extends StatelessWebexPlugin {
         this.recording = {
           state: state === RECORDING_STATE.RESUMED ? RECORDING_STATE.RECORDING : state,
           modifiedBy,
-          lastModified
+          lastModified,
         };
 
         Trigger.trigger(
           this,
           {
             file: 'meeting/index',
-            function: 'setupLocusControlsListener'
+            function: 'setupLocusControlsListener',
           },
           event,
           this.recording
         );
-      });
+      }
+    );
 
-    this.locusInfo.on(LOCUSINFO.EVENTS.CONTROLS_MEETING_CONTAINER_UPDATED,
+    this.locusInfo.on(
+      LOCUSINFO.EVENTS.CONTROLS_MEETING_CONTAINER_UPDATED,
       ({meetingContainerUrl}) => {
         Trigger.trigger(
           this,
           {
             file: 'meeting/index',
-            function: 'setupLocusControlsListener'
+            function: 'setupLocusControlsListener',
           },
           EVENT_TRIGGERS.MEETING_MEETING_CONTAINER_UPDATE,
           {meetingContainerUrl}
         );
-      });
+      }
+    );
 
-    this.locusInfo.on(LOCUSINFO.EVENTS.CONTROLS_MEETING_TRANSCRIBE_UPDATED,
-      ({caption, transcribing}) => {
-        if (transcribing && this.transcription && this.config.receiveTranscription) {
-          this.receiveTranscription();
-        }
-        else if (!transcribing && this.transcription) {
-          Trigger.trigger(
-            this,
-            {
-              file: 'meeting/index',
-              function: 'setupLocusControlsListener'
-            },
-            EVENT_TRIGGERS.MEETING_STOPPED_RECEIVING_TRANSCRIPTION,
-            {caption, transcribing}
-          );
-        }
-      });
-
-    this.locusInfo.on(LOCUSINFO.EVENTS.CONTROLS_ENTRY_EXIT_TONE_UPDATED,
-      ({entryExitTone}) => {
-        Trigger.trigger(
-          this,
-          {
-            file: 'meeting/index',
-            function: 'setupLocusControlsListener'
-          },
-          EVENT_TRIGGERS.MEETING_ENTRY_EXIT_TONE_UPDATE,
-          {entryExitTone}
-        );
-      });
+    this.locusInfo.on(LOCUSINFO.EVENTS.CONTROLS_ENTRY_EXIT_TONE_UPDATED, ({entryExitTone}) => {
+      Trigger.trigger(
+        this,
+        {
+          file: 'meeting/index',
+          function: 'setupLocusControlsListener',
+        },
+        EVENT_TRIGGERS.MEETING_ENTRY_EXIT_TONE_UPDATE,
+        {entryExitTone}
+      );
+    });
   }
 
   /**
@@ -1619,11 +1669,11 @@ export default class Meeting extends StatelessWebexPlugin {
       const previousWhiteboardShare = payload.previous?.whiteboard;
 
       if (
-        (contentShare.beneficiaryId === previousContentShare?.beneficiaryId &&
-          contentShare.disposition === previousContentShare?.disposition) &&
-        (whiteboardShare.beneficiaryId === previousWhiteboardShare?.beneficiaryId &&
-          whiteboardShare.disposition === previousWhiteboardShare?.disposition &&
-          whiteboardShare.resourceUrl === previousWhiteboardShare?.resourceUrl)
+        contentShare.beneficiaryId === previousContentShare?.beneficiaryId &&
+        contentShare.disposition === previousContentShare?.disposition &&
+        whiteboardShare.beneficiaryId === previousWhiteboardShare?.beneficiaryId &&
+        whiteboardShare.disposition === previousWhiteboardShare?.disposition &&
+        whiteboardShare.resourceUrl === previousWhiteboardShare?.resourceUrl
       ) {
         // nothing changed, so ignore
         // (this happens when we steal presentation from remote)
@@ -1647,11 +1697,13 @@ export default class Meeting extends StatelessWebexPlugin {
       ) {
         if (this.mediaProperties.shareTrack?.readyState === 'ended') {
           this.stopShare({
-            skipSignalingCheck: true
-          })
-            .catch((error) => {
-              LoggerProxy.logger.log('Meeting:index#setUpLocusMediaSharesListener --> Error stopping share: ', error);
-            });
+            skipSignalingCheck: true,
+          }).catch((error) => {
+            LoggerProxy.logger.log(
+              'Meeting:index#setUpLocusMediaSharesListener --> Error stopping share: ',
+              error
+            );
+          });
         }
         else {
           // CONTENT - sharing content local
@@ -1667,10 +1719,10 @@ export default class Meeting extends StatelessWebexPlugin {
       }
       // or if content share is either released or null and whiteboard share is either released or null, no one is sharing
       else if (
-        (previousContentShare &&
-          (contentShare.disposition === FLOOR_ACTION.RELEASED) || (contentShare.disposition === null)) &&
-        (previousWhiteboardShare &&
-          (whiteboardShare.disposition === FLOOR_ACTION.RELEASED) || (whiteboardShare.disposition === null))
+        ((previousContentShare && contentShare.disposition === FLOOR_ACTION.RELEASED) ||
+          contentShare.disposition === null) &&
+        ((previousWhiteboardShare && whiteboardShare.disposition === FLOOR_ACTION.RELEASED) ||
+          whiteboardShare.disposition === null)
       ) {
         newShareStatus = SHARE_STATUS.NO_SHARE;
       }
@@ -1688,7 +1740,7 @@ export default class Meeting extends StatelessWebexPlugin {
               this,
               {
                 file: 'meetings/index',
-                function: 'remoteShare'
+                function: 'remoteShare',
               },
               EVENT_TRIGGERS.MEETING_STOPPED_SHARING_REMOTE
             );
@@ -1699,11 +1751,11 @@ export default class Meeting extends StatelessWebexPlugin {
               this,
               {
                 file: 'meeting/index',
-                function: 'stopFloorRequest'
+                function: 'stopFloorRequest',
               },
               EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
               {
-                reason: SHARE_STOPPED_REASON.SELF_STOPPED
+                reason: SHARE_STOPPED_REASON.SELF_STOPPED,
               }
             );
             break;
@@ -1713,7 +1765,7 @@ export default class Meeting extends StatelessWebexPlugin {
               this,
               {
                 file: 'meeting/index',
-                function: 'stopWhiteboardShare'
+                function: 'stopWhiteboardShare',
               },
               EVENT_TRIGGERS.MEETING_STOPPED_SHARING_WHITEBOARD
             );
@@ -1735,27 +1787,29 @@ export default class Meeting extends StatelessWebexPlugin {
                 this,
                 {
                   file: 'meetings/index',
-                  function: 'remoteShare'
+                  function: 'remoteShare',
                 },
                 EVENT_TRIGGERS.MEETING_STARTED_SHARING_REMOTE,
                 {
-                  memberId: contentShare.beneficiaryId
+                  memberId: contentShare.beneficiaryId,
                 }
               );
             };
 
             // if a remote participant is stealing the presentation from us
-            if (!this.mediaProperties.mediaDirection?.sendShare || oldShareStatus === SHARE_STATUS.WHITEBOARD_SHARE_ACTIVE) {
+            if (
+              !this.mediaProperties.mediaDirection?.sendShare ||
+              oldShareStatus === SHARE_STATUS.WHITEBOARD_SHARE_ACTIVE
+            ) {
               sendStartedSharingRemote();
             }
             else {
               this.updateShare({
                 sendShare: false,
-                receiveShare: this.mediaProperties.mediaDirection.receiveShare
-              })
-                .finally(() => {
-                  sendStartedSharingRemote();
-                });
+                receiveShare: this.mediaProperties.mediaDirection.receiveShare,
+              }).finally(() => {
+                sendStartedSharingRemote();
+              });
             }
             break;
           }
@@ -1765,9 +1819,9 @@ export default class Meeting extends StatelessWebexPlugin {
               this,
               {
                 file: 'meeting/index',
-                function: 'share'
+                function: 'share',
               },
-              EVENT_TRIGGERS.MEETING_STARTED_SHARING_LOCAL,
+              EVENT_TRIGGERS.MEETING_STARTED_SHARING_LOCAL
             );
             Metrics.postEvent({event: eventType.LOCAL_SHARE_FLOOR_GRANTED, meeting: this});
             break;
@@ -1777,19 +1831,19 @@ export default class Meeting extends StatelessWebexPlugin {
               this,
               {
                 file: 'meeting/index',
-                function: 'startWhiteboardShare'
+                function: 'startWhiteboardShare',
               },
               EVENT_TRIGGERS.MEETING_STARTED_SHARING_WHITEBOARD,
               {
                 resourceUrl: whiteboardShare.resourceUrl,
-                memberId: whiteboardShare.beneficiaryId
+                memberId: whiteboardShare.beneficiaryId,
               }
             );
             Metrics.postEvent({event: eventType.WHITEBOARD_SHARE_FLOOR_GRANTED, meeting: this});
             break;
 
           case SHARE_STATUS.NO_SHARE:
-          // nothing to do
+            // nothing to do
             break;
 
           default:
@@ -1805,11 +1859,11 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meetings/index',
-            function: 'remoteShare'
+            function: 'remoteShare',
           },
           EVENT_TRIGGERS.MEETING_STARTED_SHARING_REMOTE,
           {
-            memberId: contentShare.beneficiaryId
+            memberId: contentShare.beneficiaryId,
           }
         );
         this.members.locusMediaSharesUpdate(payload);
@@ -1821,12 +1875,12 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'startWhiteboardShare'
+            function: 'startWhiteboardShare',
           },
           EVENT_TRIGGERS.MEETING_STARTED_SHARING_WHITEBOARD,
           {
             resourceUrl: whiteboardShare.resourceUrl,
-            memberId: whiteboardShare.beneficiaryId
+            memberId: whiteboardShare.beneficiaryId,
           }
         );
         Metrics.postEvent({event: eventType.WHITEBOARD_SHARE_FLOOR_GRANTED, meeting: this});
@@ -1863,11 +1917,11 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'setUpLocusInfoMeetingInfoListener'
+            function: 'setUpLocusInfoMeetingInfoListener',
           },
           EVENT_TRIGGERS.MEETING_LOCKED,
           {
-            payload
+            payload,
           }
         );
       }
@@ -1878,11 +1932,11 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'setUpLocusInfoMeetingInfoListener'
+            function: 'setUpLocusInfoMeetingInfoListener',
           },
           EVENT_TRIGGERS.MEETING_UNLOCKED,
           {
-            payload
+            payload,
           }
         );
       }
@@ -1890,7 +1944,9 @@ export default class Meeting extends StatelessWebexPlugin {
     this.locusInfo.on(LOCUSINFO.EVENTS.MEETING_INFO_UPDATED, (payload) => {
       if (payload && payload.info) {
         const changed = this.inMeetingActions.set({
-          canInviteNewParticipants: MeetingUtil.canInviteNewParticipants(payload.info.userDisplayHints),
+          canInviteNewParticipants: MeetingUtil.canInviteNewParticipants(
+            payload.info.userDisplayHints
+          ),
           canAdmitParticipant: MeetingUtil.canAdmitParticipant(payload.info.userDisplayHints),
           canLock: MeetingUtil.canUserLock(payload.info.userDisplayHints),
           canUnlock: MeetingUtil.canUserUnlock(payload.info.userDisplayHints),
@@ -1900,16 +1956,24 @@ export default class Meeting extends StatelessWebexPlugin {
           canResumeRecording: MeetingUtil.canUserResume(payload.info.userDisplayHints),
           canRaiseHand: MeetingUtil.canUserRaiseHand(payload.info.userDisplayHints),
           canLowerAllHands: MeetingUtil.canUserLowerAllHands(payload.info.userDisplayHints),
-          canLowerSomeoneElsesHand: MeetingUtil.canUserLowerSomeoneElsesHand(payload.info.userDisplayHints),
-          bothLeaveAndEndMeetingAvailable: MeetingUtil.bothLeaveAndEndMeetingAvailable(payload.info.userDisplayHints),
+          canLowerSomeoneElsesHand: MeetingUtil.canUserLowerSomeoneElsesHand(
+            payload.info.userDisplayHints
+          ),
+          bothLeaveAndEndMeetingAvailable: MeetingUtil.bothLeaveAndEndMeetingAvailable(
+            payload.info.userDisplayHints
+          ),
           canEnableClosedCaption: MeetingUtil.canEnableClosedCaption(payload.info.userDisplayHints),
           canStartTranscribing: MeetingUtil.canStartTranscribing(payload.info.userDisplayHints),
           canStopTranscribing: MeetingUtil.canStopTranscribing(payload.info.userDisplayHints),
           isClosedCaptionActive: MeetingUtil.isClosedCaptionActive(payload.info.userDisplayHints),
           isWebexAssistantActive: MeetingUtil.isWebexAssistantActive(payload.info.userDisplayHints),
           canViewCaptionPanel: MeetingUtil.canViewCaptionPanel(payload.info.userDisplayHints),
-          isRealTimeTranslationEnabled: MeetingUtil.isRealTimeTranslationEnabled(payload.info.userDisplayHints),
-          canSelectSpokenLanguages: MeetingUtil.canSelectSpokenLanguages(payload.info.userDisplayHints),
+          isRealTimeTranslationEnabled: MeetingUtil.isRealTimeTranslationEnabled(
+            payload.info.userDisplayHints
+          ),
+          canSelectSpokenLanguages: MeetingUtil.canSelectSpokenLanguages(
+            payload.info.userDisplayHints
+          ),
           waitingForOthersToJoin: MeetingUtil.waitingForOthersToJoin(payload.info.userDisplayHints),
         });
 
@@ -1918,7 +1982,7 @@ export default class Meeting extends StatelessWebexPlugin {
             this,
             {
               file: 'meeting/index',
-              function: 'setUpLocusInfoMeetingInfoListener'
+              function: 'setUpLocusInfoMeetingInfoListener',
             },
             EVENT_TRIGGERS.MEETING_ACTIONS_UPDATE,
             this.inMeetingActions.get()
@@ -1941,7 +2005,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'setUpLocusEmbeddedAppsListener'
+            function: 'setUpLocusEmbeddedAppsListener',
           },
           EVENT_TRIGGERS.MEETING_EMBEDDED_APPS_UPDATE,
           embeddedApps
@@ -1964,11 +2028,11 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'setUpLocusInfoSelfListener'
+            function: 'setUpLocusInfoSelfListener',
           },
           EVENT_TRIGGERS.MEETING_SELF_UNMUTED_BY_OTHERS,
           {
-            payload
+            payload,
           }
         );
       }
@@ -1981,17 +2045,19 @@ export default class Meeting extends StatelessWebexPlugin {
         // with "mute on entry" server will send us remote mute even if we don't have media configured,
         // so if being muted by others, always send the notification,
         // but if being unmuted, only send it if we are also locally unmuted
-        if (payload.muted || (!this.audio?.isMuted())) {
+        if (payload.muted || !this.audio?.isMuted()) {
           Trigger.trigger(
             this,
             {
               file: 'meeting/index',
-              function: 'setUpLocusInfoSelfListener'
+              function: 'setUpLocusInfoSelfListener',
             },
-            payload.muted ? EVENT_TRIGGERS.MEETING_SELF_MUTED_BY_OTHERS : EVENT_TRIGGERS.MEETING_SELF_UNMUTED_BY_OTHERS,
+            payload.muted ?
+              EVENT_TRIGGERS.MEETING_SELF_MUTED_BY_OTHERS :
+              EVENT_TRIGGERS.MEETING_SELF_UNMUTED_BY_OTHERS,
             {
-              payload
-            },
+              payload,
+            }
           );
         }
       }
@@ -2001,11 +2067,11 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meeting/index',
-          function: 'setUpLocusInfoSelfListener'
+          function: 'setUpLocusInfoSelfListener',
         },
         EVENT_TRIGGERS.MEETING_SELF_REQUESTED_TO_UNMUTE,
         {
-          payload
+          payload,
         }
       );
     });
@@ -2017,17 +2083,17 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'setUpLocusInfoSelfListener'
+            function: 'setUpLocusInfoSelfListener',
           },
           EVENT_TRIGGERS.MEETING_SELF_LOBBY_WAITING,
           {
-            payload
+            payload,
           }
         );
 
         Metrics.postEvent({
           event: eventType.LOBBY_ENTERED,
-          meeting: this
+          meeting: this,
         });
       }
     });
@@ -2039,29 +2105,26 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'setUpLocusInfoSelfListener'
+            function: 'setUpLocusInfoSelfListener',
           },
           EVENT_TRIGGERS.MEETING_SELF_GUEST_ADMITTED,
           {
-            payload
+            payload,
           }
         );
 
         Metrics.postEvent({
           event: eventType.LOBBY_EXITED,
-          meeting: this
+          meeting: this,
         });
       }
     });
 
     this.locusInfo.on(LOCUSINFO.EVENTS.MEDIA_INACTIVITY, () => {
-      Metrics.sendBehavioralMetric(
-        BEHAVIORAL_METRICS.MEETING_MEDIA_INACTIVE,
-        {
-          correlation_id: this.correlationId,
-          locus_id: this.locusId
-        }
-      );
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_MEDIA_INACTIVE, {
+        correlation_id: this.correlationId,
+        locus_id: this.locusId,
+      });
       this.reconnect();
     });
 
@@ -2079,8 +2142,8 @@ export default class Meeting extends StatelessWebexPlugin {
             sendShare: this.mediaProperties.mediaDirection?.sendShare,
             receiveAudio: this.mediaProperties.mediaDirection?.receiveAudio,
             receiveVideo: this.mediaProperties.mediaDirection?.receiveVideo,
-            receiveShare: this.mediaProperties.mediaDirection?.receiveShare
-          }
+            receiveShare: this.mediaProperties.mediaDirection?.receiveShare,
+          },
         });
       }
     });
@@ -2090,11 +2153,11 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meeting/index',
-          function: 'setUpLocusInfoSelfListener'
+          function: 'setUpLocusInfoSelfListener',
         },
         EVENT_TRIGGERS.MEETING_SELF_CANNOT_VIEW_PARTICIPANT_LIST,
         {
-          payload
+          payload,
         }
       );
     });
@@ -2104,11 +2167,11 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meeting/index',
-          function: 'setUpLocusInfoSelfListener'
+          function: 'setUpLocusInfoSelfListener',
         },
         EVENT_TRIGGERS.MEETING_SELF_IS_SHARING_BLOCKED,
         {
-          payload
+          payload,
         }
       );
     });
@@ -2125,11 +2188,17 @@ export default class Meeting extends StatelessWebexPlugin {
       this.meetingFiniteStateMachine.remote(payload);
 
       if (payload.remoteDeclined) {
-        this.leave({reason: payload.reason}).then(() => {
-          LoggerProxy.logger.info('Meeting:index#setUpLocusInfoMeetingListener --> REMOTE_RESPONSE. Attempting to leave meeting.');
-        }).catch((error) => {
-          LoggerProxy.logger.error(`Meeting:index#setUpLocusInfoMeetingListener --> REMOTE_RESPONSE. Issue with leave for meeting, meeting still in collection: ${this.meeting}, error: ${error}`);
-        });
+        this.leave({reason: payload.reason})
+          .then(() => {
+            LoggerProxy.logger.info(
+              'Meeting:index#setUpLocusInfoMeetingListener --> REMOTE_RESPONSE. Attempting to leave meeting.'
+            );
+          })
+          .catch((error) => {
+            LoggerProxy.logger.error(
+              `Meeting:index#setUpLocusInfoMeetingListener --> REMOTE_RESPONSE. Issue with leave for meeting, meeting still in collection: ${this.meeting}, error: ${error}`
+            );
+          });
       }
     });
     this.locusInfo.on(EVENTS.DESTROY_MEETING, (payload) => {
@@ -2153,26 +2222,35 @@ export default class Meeting extends StatelessWebexPlugin {
       if (payload.shouldLeave) {
         // TODO:  We should do cleaning of meeting object if the shouldLeave: false because there might be meeting object which we are not cleaning
 
-        this.leave({reason: payload.reason}).then(() => {
-          LoggerProxy.logger.warn('Meeting:index#setUpLocusInfoMeetingListener --> DESTROY_MEETING. The meeting has been left, but has not been destroyed, you should see a later event for leave.');
-        }).catch((error) => {
-          LoggerProxy.logger.error(`Meeting:index#setUpLocusInfoMeetingListener --> DESTROY_MEETING. Issue with leave for meeting, meeting still in collection: ${this.meeting}, error: ${error}`);
-        });
+        this.leave({reason: payload.reason})
+          .then(() => {
+            LoggerProxy.logger.warn(
+              'Meeting:index#setUpLocusInfoMeetingListener --> DESTROY_MEETING. The meeting has been left, but has not been destroyed, you should see a later event for leave.'
+            );
+          })
+          .catch((error) => {
+            LoggerProxy.logger.error(
+              `Meeting:index#setUpLocusInfoMeetingListener --> DESTROY_MEETING. Issue with leave for meeting, meeting still in collection: ${this.meeting}, error: ${error}`
+            );
+          });
       }
       else {
-        LoggerProxy.logger.info('Meeting:index#setUpLocusInfoMeetingListener --> MEETING_REMOVED_REASON', payload.reason);
+        LoggerProxy.logger.info(
+          'Meeting:index#setUpLocusInfoMeetingListener --> MEETING_REMOVED_REASON',
+          payload.reason
+        );
 
         MeetingUtil.cleanUp(this);
         Trigger.trigger(
           this,
           {
             file: 'meeting/index',
-            function: 'setUpLocusInfoMeetingListener'
+            function: 'setUpLocusInfoMeetingListener',
           },
           EVENTS.DESTROY_MEETING,
           {
             reason: payload.reason,
-            meetingId: this.id
+            meetingId: this.id,
           }
         );
       }
@@ -2365,15 +2443,30 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     // MeetingInfo will be undefined for 1:1 calls
-    if (locusMeetingObject || (webexMeetingInfo && !(meetingInfo?.errors && meetingInfo?.errors.length > 0))) {
-      this.conversationUrl = locusMeetingObject?.conversationUrl || webexMeetingInfo?.conversationUrl || this.conversationUrl;
+    if (
+      locusMeetingObject ||
+      (webexMeetingInfo && !(meetingInfo?.errors && meetingInfo?.errors.length > 0))
+    ) {
+      this.conversationUrl =
+        locusMeetingObject?.conversationUrl ||
+        webexMeetingInfo?.conversationUrl ||
+        this.conversationUrl;
       this.locusUrl = locusMeetingObject?.url || webexMeetingInfo?.locusUrl || this.locusUrl;
-      this.setSipUri(this.config.experimental.enableUnifiedMeetings ? locusMeetingObject?.info.sipUri || webexMeetingInfo?.sipUrl : locusMeetingObject?.info.sipUri || webexMeetingInfo?.sipMeetingUri || this.sipUri);
+      this.setSipUri(
+        this.config.experimental.enableUnifiedMeetings ?
+          locusMeetingObject?.info.sipUri || webexMeetingInfo?.sipUrl :
+          locusMeetingObject?.info.sipUri || webexMeetingInfo?.sipMeetingUri || this.sipUri
+      );
       if (this.config.experimental.enableUnifiedMeetings) {
-        this.meetingNumber = locusMeetingObject?.info.webExMeetingId || webexMeetingInfo?.meetingNumber;
+        this.meetingNumber =
+          locusMeetingObject?.info.webExMeetingId || webexMeetingInfo?.meetingNumber;
         this.meetingJoinUrl = webexMeetingInfo?.meetingJoinUrl;
       }
-      this.owner = locusMeetingObject?.info.owner || webexMeetingInfo?.owner || webexMeetingInfo?.hostId || this.owner;
+      this.owner =
+        locusMeetingObject?.info.owner ||
+        webexMeetingInfo?.owner ||
+        webexMeetingInfo?.hostId ||
+        this.owner;
       this.permissionToken = webexMeetingInfo?.permissionToken;
     }
   }
@@ -2479,17 +2572,18 @@ export default class Meeting extends StatelessWebexPlugin {
       // so we might need to either
       // A) wait until we have media flowing
       // B) trigger a second event when video is flowing
-      LoggerProxy.logger.log(`Meeting:index#setRemoteStream --> ontrack event received for peerConnection: ${event}`);
+      LoggerProxy.logger.log(
+        `Meeting:index#setRemoteStream --> ontrack event received for peerConnection: ${event}`
+      );
 
       const MEDIA_ID = {
         AUDIO_TRACK: '0',
         VIDEO_TRACK: '1',
-        SHARE_TRACK: '2'
+        SHARE_TRACK: '2',
       };
       let eventType = null;
       const mediaTrack = event.track;
       let trackMediaID = null;
-
 
       // In case of safari some time the transceiver is not present for specific os version
       // sdk tries to determine the transceive using the track id present
@@ -2503,26 +2597,20 @@ export default class Meeting extends StatelessWebexPlugin {
         if (mediaTrack.id === audioTransceiver.receiver.track.id) {
           trackMediaID = '0';
         }
-        else
-        if (mediaTrack.id === videoTransceiver.receiver.track.id) {
+        else if (mediaTrack.id === videoTransceiver.receiver.track.id) {
           trackMediaID = '1';
         }
-        else
-        if (mediaTrack.id === shareTransceiver.receiver.track.id) {
+        else if (mediaTrack.id === shareTransceiver.receiver.track.id) {
           trackMediaID = '2';
         }
         else {
           trackMediaID = null;
-          Metrics.sendBehavioralMetric(
-            BEHAVIORAL_METRICS.MUTE_AUDIO_FAILURE,
-            {
-              correlation_id: this.correlationId,
-              locus_id: this.locusUrl.split('/').pop()
-            }
-          );
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MUTE_AUDIO_FAILURE, {
+            correlation_id: this.correlationId,
+            locus_id: this.locusUrl.split('/').pop(),
+          });
         }
       }
-
 
       switch (trackMediaID) {
         case MEDIA_ID.AUDIO_TRACK:
@@ -2553,12 +2641,12 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'setRemoteStream:pc.ontrack'
+            function: 'setRemoteStream:pc.ontrack',
           },
           EVENT_TRIGGERS.MEDIA_READY,
           {
             type: eventType,
-            stream: MediaUtil.createMediaStream([mediaTrack])
+            stream: MediaUtil.createMediaStream([mediaTrack]),
           }
         );
       }
@@ -2573,14 +2661,8 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   uploadLogs(options = {file: 'meeting/index', function: 'uploadLogs'}) {
-    Trigger.trigger(
-      this,
-      options,
-      EVENTS.REQUEST_UPLOAD_LOGS,
-      this
-    );
+    Trigger.trigger(this, options, EVENTS.REQUEST_UPLOAD_LOGS, this);
   }
-
 
   /**
    * Removes remote audio and video stream on the class instance and triggers an event
@@ -2591,7 +2673,9 @@ export default class Meeting extends StatelessWebexPlugin {
    * @deprecated after v1.89.3
    */
   unsetRemoteStream() {
-    LoggerProxy.logger.warn('Meeting:index#unsetRemoteStream --> [DEPRECATION WARNING]: unsetRemoteStream has been deprecated after v1.89.3');
+    LoggerProxy.logger.warn(
+      'Meeting:index#unsetRemoteStream --> [DEPRECATION WARNING]: unsetRemoteStream has been deprecated after v1.89.3'
+    );
     this.mediaProperties.unsetRemoteMedia();
   }
 
@@ -2612,7 +2696,9 @@ export default class Meeting extends StatelessWebexPlugin {
    * @deprecated after v1.89.3
    */
   closeRemoteStream() {
-    LoggerProxy.logger.warn('Meeting:index#closeRemoteStream --> [DEPRECATION WARNING]: closeRemoteStream has been deprecated after v1.89.3');
+    LoggerProxy.logger.warn(
+      'Meeting:index#closeRemoteStream --> [DEPRECATION WARNING]: closeRemoteStream has been deprecated after v1.89.3'
+    );
     this.closeRemoteTracks();
   }
 
@@ -2623,11 +2709,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   closeRemoteTracks() {
-    const {
-      remoteAudioTrack,
-      remoteVideoTrack,
-      remoteShare
-    } = this.mediaProperties;
+    const {remoteAudioTrack, remoteVideoTrack, remoteShare} = this.mediaProperties;
 
     /**
      * Triggers an event to the developer
@@ -2640,11 +2722,11 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meeting/index',
-          function: 'closeRemoteTracks'
+          function: 'closeRemoteTracks',
         },
         EVENT_TRIGGERS.MEDIA_STOPPED,
         {
-          type: mediaType
+          type: mediaType,
         }
       );
     };
@@ -2658,24 +2740,25 @@ export default class Meeting extends StatelessWebexPlugin {
      */
     // eslint-disable-next-line arrow-body-style
     const stopTrack = (track, type) => {
-      return Media.stopTracks(track)
-        .then(() => {
-          const isTrackStopped = track && track.readyState === ENDED;
-          const isWrongReadyState = track && !isTrackStopped;
+      return Media.stopTracks(track).then(() => {
+        const isTrackStopped = track && track.readyState === ENDED;
+        const isWrongReadyState = track && !isTrackStopped;
 
-          if (isTrackStopped) {
-            triggerMediaStoppedEvent(type);
-          }
-          else if (isWrongReadyState) {
-            LoggerProxy.logger.warn(`Meeting:index#closeRemoteTracks --> Error: MediaStreamTrack.readyState is ${track.readyState} for ${type}`);
-          }
-        });
+        if (isTrackStopped) {
+          triggerMediaStoppedEvent(type);
+        }
+        else if (isWrongReadyState) {
+          LoggerProxy.logger.warn(
+            `Meeting:index#closeRemoteTracks --> Error: MediaStreamTrack.readyState is ${track.readyState} for ${type}`
+          );
+        }
+      });
     };
 
     return Promise.all([
       stopTrack(remoteAudioTrack, EVENT_TYPES.REMOTE_AUDIO),
       stopTrack(remoteVideoTrack, EVENT_TYPES.REMOTE_VIDEO),
-      stopTrack(remoteShare, EVENT_TYPES.REMOTE_SHARE)
+      stopTrack(remoteShare, EVENT_TYPES.REMOTE_SHARE),
     ]);
   }
 
@@ -2690,12 +2773,15 @@ export default class Meeting extends StatelessWebexPlugin {
       this,
       {
         file: 'meeting/index',
-        function: 'setLocalTracks'
+        function: 'setLocalTracks',
       },
       EVENT_TRIGGERS.MEDIA_READY,
       {
         type: EVENT_TYPES.LOCAL,
-        stream: MediaUtil.createMediaStream([this.mediaProperties.audioTrack, this.mediaProperties.videoTrack])
+        stream: MediaUtil.createMediaStream([
+          this.mediaProperties.audioTrack,
+          this.mediaProperties.videoTrack,
+        ]),
       }
     );
   }
@@ -2714,10 +2800,13 @@ export default class Meeting extends StatelessWebexPlugin {
 
       this.mediaProperties.setMediaSettings('audio', {
         echoCancellation: settings.echoCancellation,
-        noiseSuppression: settings.noiseSuppression
+        noiseSuppression: settings.noiseSuppression,
       });
 
-      LoggerProxy.logger.log('Meeting:index#setLocalAudioTrack --> Audio settings.', JSON.stringify(this.mediaProperties.mediaSettings.audio));
+      LoggerProxy.logger.log(
+        'Meeting:index#setLocalAudioTrack --> Audio settings.',
+        JSON.stringify(this.mediaProperties.mediaSettings.audio)
+      );
       this.mediaProperties.setLocalAudioTrack(audioTrack);
       if (this.audio) this.audio.applyClientStateLocally(this);
     }
@@ -2744,7 +2833,8 @@ export default class Meeting extends StatelessWebexPlugin {
       const {localQualityLevel} = this.mediaProperties;
 
       if (Number(localQualityLevel.slice(0, -1)) > height) {
-        LoggerProxy.logger.warn(`Meeting:index#setLocalVideoTrack --> Local video quality of ${localQualityLevel} not supported,
+        LoggerProxy.logger
+          .warn(`Meeting:index#setLocalVideoTrack --> Local video quality of ${localQualityLevel} not supported,
          downscaling to highest possible resolution of ${height}p`);
 
         this.mediaProperties.setLocalQualityLevel(`${height}p`);
@@ -2754,13 +2844,19 @@ export default class Meeting extends StatelessWebexPlugin {
       if (this.video) this.video.applyClientStateLocally(this);
 
       this.mediaProperties.setMediaSettings('video', {
-        aspectRatio, frameRate, height, width
+        aspectRatio,
+        frameRate,
+        height,
+        width,
       });
       // store and save the selected video input device
       if (deviceId) {
         this.mediaProperties.setVideoDeviceId(deviceId);
       }
-      LoggerProxy.logger.log('Meeting:index#setLocalVideoTrack --> Video settings.', JSON.stringify(this.mediaProperties.mediaSettings.video));
+      LoggerProxy.logger.log(
+        'Meeting:index#setLocalVideoTrack --> Video settings.',
+        JSON.stringify(this.mediaProperties.mediaSettings.video)
+      );
     }
 
     if (emitEvent) {
@@ -2808,9 +2904,12 @@ export default class Meeting extends StatelessWebexPlugin {
           height: settings.height,
           width: settings.width,
           displaySurface: settings.displaySurface,
-          cursor: settings.cursor
+          cursor: settings.cursor,
         });
-        LoggerProxy.logger.log('Meeting:index#setLocalShareTrack --> Screen settings.', JSON.stringify(this.mediaProperties.mediaSettings.screen));
+        LoggerProxy.logger.log(
+          'Meeting:index#setLocalShareTrack --> Screen settings.',
+          JSON.stringify(this.mediaProperties.mediaSettings.screen)
+        );
       }
 
       contentTracks.onended = () => this.handleShareTrackEnded(localShare);
@@ -2819,12 +2918,12 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meeting/index',
-          function: 'setLocalShareTrack'
+          function: 'setLocalShareTrack',
         },
         EVENT_TRIGGERS.MEDIA_READY,
         {
           type: EVENT_TYPES.LOCAL_SHARE,
-          stream: localShare
+          stream: localShare,
         }
       );
     }
@@ -2852,15 +2951,18 @@ export default class Meeting extends StatelessWebexPlugin {
             this,
             {
               file: 'meeting/index',
-              function: 'closeLocalStream'
+              function: 'closeLocalStream',
             },
-            EVENT_TRIGGERS.MEDIA_STOPPED, {
-              type: EVENT_TYPES.LOCAL
+            EVENT_TRIGGERS.MEDIA_STOPPED,
+            {
+              type: EVENT_TYPES.LOCAL,
             }
           );
         }
         else if (audioTrack || videoTrack) {
-          LoggerProxy.logger.warn('Meeting:index#closeLocalStream --> Warning: track might already been ended or unavaliable.');
+          LoggerProxy.logger.warn(
+            'Meeting:index#closeLocalStream --> Warning: track might already been ended or unavaliable.'
+          );
         }
       });
   }
@@ -2881,16 +2983,19 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'closeLocalShare'
+            function: 'closeLocalShare',
           },
-          EVENT_TRIGGERS.MEDIA_STOPPED, {
-            type: EVENT_TYPES.LOCAL_SHARE
+          EVENT_TRIGGERS.MEDIA_STOPPED,
+          {
+            type: EVENT_TYPES.LOCAL_SHARE,
           }
         );
       }
       else if (track) {
         // Track exists but with wrong readyState
-        LoggerProxy.logger.warn(`Meeting:index#closeLocalShare --> Error: MediaStreamTrack.readyState is ${track.readyState} for localShare`);
+        LoggerProxy.logger.warn(
+          `Meeting:index#closeLocalShare --> Error: MediaStreamTrack.readyState is ${track.readyState} for localShare`
+        );
       }
     });
   }
@@ -2931,14 +3036,11 @@ export default class Meeting extends StatelessWebexPlugin {
       if (!this.hasWebsocketConnected) {
         Metrics.postEvent({
           event: eventType.MERCURY_CONNECTION_RESTORED,
-          meeting: this
+          meeting: this,
         });
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.MERCURY_CONNECTION_RESTORED,
-          {
-            correlation_id: this.correlationId
-          }
-        );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MERCURY_CONNECTION_RESTORED, {
+          correlation_id: this.correlationId,
+        });
       }
       this.hasWebsocketConnected = true;
     });
@@ -2947,14 +3049,11 @@ export default class Meeting extends StatelessWebexPlugin {
       LoggerProxy.logger.error('Meeting:index#setMercuryListener --> Web socket offline');
       Metrics.postEvent({
         event: eventType.MERCURY_CONNECTION_LOST,
-        meeting: this
+        meeting: this,
       });
-      Metrics.sendBehavioralMetric(
-        BEHAVIORAL_METRICS.MERCURY_CONNECTION_FAILURE,
-        {
-          correlation_id: this.correlationId
-        }
-      );
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MERCURY_CONNECTION_FAILURE, {
+        correlation_id: this.correlationId,
+      });
     });
   }
 
@@ -3018,32 +3117,33 @@ export default class Meeting extends StatelessWebexPlugin {
     const LOG_HEADER = 'Meeting:index#muteAudio -->';
 
     // First, stop sending the local audio media
-    return logRequest(this.audio.handleClientRequest(this, true)
-      .then(() => {
-        MeetingUtil.handleAudioLogging(this.mediaProperties.audioTrack);
-        Metrics.postEvent({
-          event: eventType.MUTED,
-          meeting: this,
-          data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.AUDIO}
-        });
-      }).catch((error) => {
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.MUTE_AUDIO_FAILURE,
-          {
+    return logRequest(
+      this.audio
+        .handleClientRequest(this, true)
+        .then(() => {
+          MeetingUtil.handleAudioLogging(this.mediaProperties.audioTrack);
+          Metrics.postEvent({
+            event: eventType.MUTED,
+            meeting: this,
+            data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.AUDIO},
+          });
+        })
+        .catch((error) => {
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MUTE_AUDIO_FAILURE, {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
             reason: error.message,
-            stack: error.stack
-          }
-        );
+            stack: error.stack,
+          });
 
-        throw error;
-      }),
-    {
-      header: `${LOG_HEADER} muting audio`,
-      success: `${LOG_HEADER} muted audio successfully`,
-      failure: `${LOG_HEADER} muting audio failed, `
-    });
+          throw error;
+        }),
+      {
+        header: `${LOG_HEADER} muting audio`,
+        success: `${LOG_HEADER} muted audio successfully`,
+        failure: `${LOG_HEADER} muting audio failed, `,
+      }
+    );
   }
 
   /**
@@ -3069,32 +3169,33 @@ export default class Meeting extends StatelessWebexPlugin {
     const LOG_HEADER = 'Meeting:index#unmuteAudio -->';
 
     // First, send the control to unmute the participant on the server
-    return logRequest(this.audio.handleClientRequest(this, false)
-      .then(() => {
-        MeetingUtil.handleAudioLogging(this.mediaProperties.audioTrack);
-        Metrics.postEvent({
-          event: eventType.UNMUTED,
-          meeting: this,
-          data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.AUDIO}
-        });
-      }).catch((error) => {
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.UNMUTE_AUDIO_FAILURE,
-          {
+    return logRequest(
+      this.audio
+        .handleClientRequest(this, false)
+        .then(() => {
+          MeetingUtil.handleAudioLogging(this.mediaProperties.audioTrack);
+          Metrics.postEvent({
+            event: eventType.UNMUTED,
+            meeting: this,
+            data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.AUDIO},
+          });
+        })
+        .catch((error) => {
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.UNMUTE_AUDIO_FAILURE, {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
             reason: error.message,
-            stack: error.stack
-          }
-        );
+            stack: error.stack,
+          });
 
-        throw error;
-      }),
-    {
-      header: `${LOG_HEADER} unmuting audio`,
-      success: `${LOG_HEADER} unmuted audio successfully`,
-      failure: `${LOG_HEADER} unmuting audio failed, `
-    });
+          throw error;
+        }),
+      {
+        header: `${LOG_HEADER} unmuting audio`,
+        success: `${LOG_HEADER} unmuted audio successfully`,
+        failure: `${LOG_HEADER} unmuting audio failed, `,
+      }
+    );
   }
 
   /**
@@ -3119,32 +3220,33 @@ export default class Meeting extends StatelessWebexPlugin {
 
     const LOG_HEADER = 'Meeting:index#muteVideo -->';
 
-    return logRequest(this.video.handleClientRequest(this, true)
-      .then(() => {
-        MeetingUtil.handleVideoLogging(this.mediaProperties.videoTrack);
-        Metrics.postEvent({
-          event: eventType.MUTED,
-          meeting: this,
-          data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.VIDEO}
-        });
-      }).catch((error) => {
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.MUTE_VIDEO_FAILURE,
-          {
+    return logRequest(
+      this.video
+        .handleClientRequest(this, true)
+        .then(() => {
+          MeetingUtil.handleVideoLogging(this.mediaProperties.videoTrack);
+          Metrics.postEvent({
+            event: eventType.MUTED,
+            meeting: this,
+            data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.VIDEO},
+          });
+        })
+        .catch((error) => {
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MUTE_VIDEO_FAILURE, {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
             reason: error.message,
-            stack: error.stack
-          }
-        );
+            stack: error.stack,
+          });
 
-        throw error;
-      }),
-    {
-      header: `${LOG_HEADER} muting video`,
-      success: `${LOG_HEADER} muted video successfully`,
-      failure: `${LOG_HEADER} muting video failed, `
-    });
+          throw error;
+        }),
+      {
+        header: `${LOG_HEADER} muting video`,
+        success: `${LOG_HEADER} muted video successfully`,
+        failure: `${LOG_HEADER} muting video failed, `,
+      }
+    );
   }
 
   /**
@@ -3169,32 +3271,33 @@ export default class Meeting extends StatelessWebexPlugin {
 
     const LOG_HEADER = 'Meeting:index#unmuteVideo -->';
 
-    return logRequest(this.video.handleClientRequest(this, false)
-      .then(() => {
-        MeetingUtil.handleVideoLogging(this.mediaProperties.videoTrack);
-        Metrics.postEvent({
-          event: eventType.UNMUTED,
-          meeting: this,
-          data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.VIDEO}
-        });
-      }).catch((error) => {
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.UNMUTE_VIDEO_FAILURE,
-          {
+    return logRequest(
+      this.video
+        .handleClientRequest(this, false)
+        .then(() => {
+          MeetingUtil.handleVideoLogging(this.mediaProperties.videoTrack);
+          Metrics.postEvent({
+            event: eventType.UNMUTED,
+            meeting: this,
+            data: {trigger: trigger.USER_INTERACTION, mediaType: mediaType.VIDEO},
+          });
+        })
+        .catch((error) => {
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.UNMUTE_VIDEO_FAILURE, {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
             reason: error.message,
-            stack: error.stack
-          }
-        );
+            stack: error.stack,
+          });
 
-        throw error;
-      }),
-    {
-      header: `${LOG_HEADER} unmuting video`,
-      success: `${LOG_HEADER} unmuted video successfully`,
-      failure: `${LOG_HEADER} unmuting video failed, `
-    });
+          throw error;
+        }),
+      {
+        header: `${LOG_HEADER} unmuting video`,
+        success: `${LOG_HEADER} unmuted video successfully`,
+        failure: `${LOG_HEADER} unmuting video failed, `,
+      }
+    );
   }
 
   /**
@@ -3232,11 +3335,11 @@ export default class Meeting extends StatelessWebexPlugin {
           this.addMedia({
             mediaSettings,
             localShare,
-            localStream
+            localStream,
           }).then((mediaResponse) => ({
             join: joinResponse,
             media: mediaResponse,
-            local: [localStream, localShare]
+            local: [localStream, localShare],
           }))))
       .catch((error) => {
         LoggerProxy.logger.error('Meeting:index#joinWithMedia --> ', error);
@@ -3247,10 +3350,10 @@ export default class Meeting extends StatelessWebexPlugin {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
             reason: error.message,
-            stack: error.stack
+            stack: error.stack,
           },
           {
-            type: error.name
+            type: error.name,
           }
         );
 
@@ -3267,14 +3370,20 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   reconnect(options) {
-    LoggerProxy.logger.log(`Meeting:index#reconnect --> attempting to reconnect meeting ${this.id}`);
+    LoggerProxy.logger.log(
+      `Meeting:index#reconnect --> attempting to reconnect meeting ${this.id}`
+    );
 
     if (!this.reconnectionManager || !this.reconnectionManager.reconnect) {
-      return Promise.reject(new ParameterError('Cannot reconnect, ReconnectionManager must first be defined.'));
+      return Promise.reject(
+        new ParameterError('Cannot reconnect, ReconnectionManager must first be defined.')
+      );
     }
 
     if (!MeetingUtil.isMediaEstablished(this.currentMediaStatus)) {
-      return Promise.reject(new ParameterError('Cannot reconnect, Media has not established to reconnect'));
+      return Promise.reject(
+        new ParameterError('Cannot reconnect, Media has not established to reconnect')
+      );
     }
 
     try {
@@ -3284,7 +3393,9 @@ export default class Meeting extends StatelessWebexPlugin {
     catch (error) {
       // Unable to reconnect this call
       if (error instanceof ReconnectInProgress) {
-        LoggerProxy.logger.info('Meeting:index#reconnect --> Unable to reconnect, reconnection in progress.');
+        LoggerProxy.logger.info(
+          'Meeting:index#reconnect --> Unable to reconnect, reconnection in progress.'
+        );
       }
       else {
         LoggerProxy.logger.log('Meeting:index#reconnect --> Unable to reconnect.', error);
@@ -3297,11 +3408,10 @@ export default class Meeting extends StatelessWebexPlugin {
       this,
       {
         file: 'meeting/index',
-        function: 'reconnect'
+        function: 'reconnect',
       },
       EVENT_TRIGGERS.MEETING_RECONNECTION_STARTING
     );
-
 
     return this.reconnectionManager
       .reconnect(options)
@@ -3310,7 +3420,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'reconnect'
+            function: 'reconnect',
           },
           EVENT_TRIGGERS.MEETING_RECONNECTION_SUCCESS
         );
@@ -3321,29 +3431,26 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'reconnect'
+            function: 'reconnect',
           },
           EVENT_TRIGGERS.MEETING_RECONNECTION_FAILURE,
           {
-            error: new ReconnectionError('Reconnection failure event', error)
+            error: new ReconnectionError('Reconnection failure event', error),
           }
         );
 
         LoggerProxy.logger.error('Meeting:index#reconnect --> Meeting reconnect failed', error);
 
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.MEETING_RECONNECT_FAILURE,
-          {
-            correlation_id: this.correlationId,
-            locus_id: this.locusUrl.split('/').pop(),
-            reason: error.message,
-            stack: error.stack
-          }
-        );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_RECONNECT_FAILURE, {
+          correlation_id: this.correlationId,
+          locus_id: this.locusUrl.split('/').pop(),
+          reason: error.message,
+          stack: error.stack,
+        });
 
         this.uploadLogs({
           file: 'meeting/index',
-          function: 'reconnect'
+          function: 'reconnect',
         });
 
         return Promise.reject(new ReconnectionError('Reconnection failure event', error));
@@ -3397,14 +3504,11 @@ export default class Meeting extends StatelessWebexPlugin {
 
       this.triggerStopReceivingTranscriptionEvent();
 
-      Metrics.sendBehavioralMetric(
-        BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE,
-        {
-          correlation_id: this.correlationId,
-          reason: 'unexpected error: transcription LLM web socket connection error had occured.',
-          event
-        }
-      );
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE, {
+        correlation_id: this.correlationId,
+        reason: 'unexpected error: transcription LLM web socket connection error had occured.',
+        event,
+      });
     });
   }
 
@@ -3421,10 +3525,12 @@ export default class Meeting extends StatelessWebexPlugin {
 
     try {
       const {datachannelUrl} = this.locusInfo.info;
-      const {body: {webSocketUrl}} = await this.request({
+      const {
+        body: {webSocketUrl},
+      } = await this.request({
         method: HTTP_VERBS.POST,
         uri: datachannelUrl,
-        body: {deviceUrl: this.deviceUrl}
+        body: {deviceUrl: this.deviceUrl},
       });
 
       LoggerProxy.logger.info(
@@ -3432,11 +3538,7 @@ export default class Meeting extends StatelessWebexPlugin {
         Generated web socket url succesfully.`
       );
 
-      this.transcription = new Transcription(
-        webSocketUrl,
-        this.webex.sessionId,
-        this.members,
-      );
+      this.transcription = new Transcription(webSocketUrl, this.webex.sessionId, this.members);
 
       LoggerProxy.logger.info(
         `Meeting:index#receiveTranscription -->
@@ -3449,7 +3551,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'join'
+            function: 'join',
           },
           EVENT_TRIGGERS.MEETING_STARTED_RECEIVING_TRANSCRIPTION,
           payload
@@ -3461,14 +3563,11 @@ export default class Meeting extends StatelessWebexPlugin {
     }
     catch (error) {
       LoggerProxy.logger.error(`Meeting:index#receiveTranscription --> ${error}`);
-      Metrics.sendBehavioralMetric(
-        BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE,
-        {
-          correlation_id: this.correlationId,
-          reason: error.message,
-          stack: error.stack
-        }
-      );
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE, {
+        correlation_id: this.correlationId,
+        reason: error.message,
+        stack: error.stack,
+      });
     }
   }
 
@@ -3494,12 +3593,11 @@ export default class Meeting extends StatelessWebexPlugin {
       Meeting:index#stopReceivingTranscription -->
       closed transcription LLM web socket connection successfully.`);
 
-
     Trigger.trigger(
       this,
       {
         file: 'meeting',
-        function: 'triggerStopReceivingTranscriptionEvent'
+        function: 'triggerStopReceivingTranscriptionEvent',
       },
       EVENT_TRIGGERS.MEETING_STOPPED_RECEIVING_TRANSCRIPTION
     );
@@ -3547,8 +3645,12 @@ export default class Meeting extends StatelessWebexPlugin {
       this.hasJoinedOnce = true;
     }
     else {
-      LoggerProxy.logger.log(`Meeting:index#join --> Generating a new correlation id for meeting ${this.id}`);
-      LoggerProxy.logger.log(`Meeting:index#join --> Previous correlation id ${this.correlationId}`);
+      LoggerProxy.logger.log(
+        `Meeting:index#join --> Generating a new correlation id for meeting ${this.id}`
+      );
+      LoggerProxy.logger.log(
+        `Meeting:index#join --> Previous correlation id ${this.correlationId}`
+      );
       this.setCorrelationId(uuid.v4());
       LoggerProxy.logger.log(`Meeting:index#join --> New correlation id ${this.correlationId}`);
     }
@@ -3560,7 +3662,7 @@ export default class Meeting extends StatelessWebexPlugin {
     Metrics.postEvent({
       event: eventType.CALL_INITIATED,
       meeting: this,
-      data: {trigger: trigger.USER_INTERACTION, isRoapCallEnabled: true}
+      data: {trigger: trigger.USER_INTERACTION, isRoapCallEnabled: true},
     });
 
     LoggerProxy.logger.log('Meeting:index#join --> Joining a meeting');
@@ -3633,15 +3735,13 @@ export default class Meeting extends StatelessWebexPlugin {
       .then((join) => {
         joinSuccess(join);
         this.deferJoin = undefined;
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.JOIN_SUCCESS,
-          {
-            correlation_id: this.correlationId
-          }
-        );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.JOIN_SUCCESS, {
+          correlation_id: this.correlationId,
+        });
 
         return join;
-      }).then(async (join) => {
+      })
+      .then(async (join) => {
         if (isBrowser) {
           if (this.config.receiveTranscription || options.receiveTranscription) {
             if (this.isTranscriptionSupported()) {
@@ -3651,9 +3751,10 @@ export default class Meeting extends StatelessWebexPlugin {
           }
         }
         else {
-          LoggerProxy.logger.error('Meeting:index#join --> Receving transcription is not supported on this platform');
+          LoggerProxy.logger.error(
+            'Meeting:index#join --> Receving transcription is not supported on this platform'
+          );
         }
-
 
         return join;
       })
@@ -3666,28 +3767,23 @@ export default class Meeting extends StatelessWebexPlugin {
           meeting: this,
           meetingId: this.id,
           data: {
-            errors: [
-              Metrics.parseLocusError(error.error, true)
-            ]
-          }
+            errors: [Metrics.parseLocusError(error.error, true)],
+          },
         });
 
         // TODO:  change this to error codes and pre defined dictionary
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.JOIN_FAILURE,
-          {
-            correlation_id: this.correlationId,
-            reason: error.error?.message,
-            stack: error.stack
-          }
-        );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.JOIN_FAILURE, {
+          correlation_id: this.correlationId,
+          reason: error.error?.message,
+          stack: error.stack,
+        });
 
         // Upload logs on join Failure
         Trigger.trigger(
           this,
           {
             file: 'meeting/index',
-            function: 'join'
+            function: 'join',
           },
           EVENTS.REQUEST_UPLOAD_LOGS,
           this
@@ -3739,28 +3835,28 @@ export default class Meeting extends StatelessWebexPlugin {
 
     if (!this.dialInUrl) this.dialInUrl = `dialin:///${uuid.v4()}`;
 
-    return this.meetingRequest.dialIn({
-      correlationId,
-      dialInUrl: this.dialInUrl,
-      locusUrl,
-      clientUrl: this.deviceUrl
-    }).then((res) => {
-      this.locusInfo.onFullLocus(res.body.locus);
-    }).catch((error) => {
-      Metrics.sendBehavioralMetric(
-        BEHAVIORAL_METRICS.ADD_DIAL_IN_FAILURE,
-        {
+    return this.meetingRequest
+      .dialIn({
+        correlationId,
+        dialInUrl: this.dialInUrl,
+        locusUrl,
+        clientUrl: this.deviceUrl,
+      })
+      .then((res) => {
+        this.locusInfo.onFullLocus(res.body.locus);
+      })
+      .catch((error) => {
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_DIAL_IN_FAILURE, {
           correlation_id: this.correlationId,
           dial_in_url: this.dialInUrl,
           locus_id: locusUrl.split('/').pop(),
           client_url: this.deviceUrl,
           reason: error.error?.message,
-          stack: error.stack
-        }
-      );
+          stack: error.stack,
+        });
 
-      return Promise.reject(error);
-    });
+        return Promise.reject(error);
+      });
   }
 
   /**
@@ -3777,29 +3873,29 @@ export default class Meeting extends StatelessWebexPlugin {
 
     if (!this.dialOutUrl) this.dialOutUrl = `dialout:///${uuid.v4()}`;
 
-    return this.meetingRequest.dialOut({
-      correlationId,
-      dialOutUrl: this.dialOutUrl,
-      phoneNumber,
-      locusUrl,
-      clientUrl: this.deviceUrl
-    }).then((res) => {
-      this.locusInfo.onFullLocus(res.body.locus);
-    }).catch((error) => {
-      Metrics.sendBehavioralMetric(
-        BEHAVIORAL_METRICS.ADD_DIAL_OUT_FAILURE,
-        {
+    return this.meetingRequest
+      .dialOut({
+        correlationId,
+        dialOutUrl: this.dialOutUrl,
+        phoneNumber,
+        locusUrl,
+        clientUrl: this.deviceUrl,
+      })
+      .then((res) => {
+        this.locusInfo.onFullLocus(res.body.locus);
+      })
+      .catch((error) => {
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_DIAL_OUT_FAILURE, {
           correlation_id: this.correlationId,
           dial_out_url: this.dialOutUrl,
           locus_id: locusUrl.split('/').pop(),
           client_url: this.deviceUrl,
           reason: error.error?.message,
-          stack: error.stack
-        }
-      );
+          stack: error.stack,
+        });
 
-      return Promise.reject(error);
-    });
+        return Promise.reject(error);
+      });
   }
 
   /**
@@ -3816,7 +3912,7 @@ export default class Meeting extends StatelessWebexPlugin {
         Promise.resolve(),
       this.isPhoneProvisioned(this.dialOutDeviceStatus) ?
         MeetingUtil.disconnectPhoneAudio(this, this.dialOutUrl) :
-        Promise.resolve()
+        Promise.resolve(),
     ]);
   }
 
@@ -3842,17 +3938,17 @@ export default class Meeting extends StatelessWebexPlugin {
             share: true,
             share_audio: false,
             video: false,
-            whiteboard: false
+            whiteboard: false,
           },
           tx: {
             audio: false,
             share: false,
             share_audio: false,
             video: false,
-            whiteboard: false
-          }
-        }
-      }
+            whiteboard: false,
+          },
+        },
+      },
     });
 
     Metrics.postEvent({event: eventType.MOVE_MEDIA, meeting: this});
@@ -3871,8 +3967,8 @@ export default class Meeting extends StatelessWebexPlugin {
             sendAudio: false,
             receiveAudio: false,
             sendShare: false,
-            receiveShare: true
-          }
+            receiveShare: true,
+          },
         };
 
         // clean up the local tracks
@@ -3884,49 +3980,44 @@ export default class Meeting extends StatelessWebexPlugin {
 
         this.mediaProperties.unsetMediaTracks();
 
-
         // when a move to is intiated by the client , Locus delets the existing media node from the server as soon the DX answers the meeting
         // once the DX answers we establish connection back the media server with only receiveShare enabled
-        await this.reconnectionManager.reconnectMedia(mediaSettings)
-          .then(() => {
-            Metrics.sendBehavioralMetric(
-              BEHAVIORAL_METRICS.MOVE_TO_SUCCESS,
-            );
-          });
+        await this.reconnectionManager.reconnectMedia(mediaSettings).then(() => {
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_SUCCESS);
+        });
       }
       catch (error) {
         LoggerProxy.logger.error('Meeting:index#moveTo --> Failed to moveTo resourceId', error);
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.MOVE_TO_FAILURE,
-          {
-            correlation_id: this.correlationId,
-            locus_id: this.locusUrl.split('/').pop(),
-            reason: error.message,
-            stack: error.stack
-          }
-        );
-      }
-    });
-
-    LoggerProxy.logger.info('Meeting:index#moveTo --> Initated moved to using resourceId', resourceId);
-
-    return MeetingUtil.joinMeetingOptions(this, {resourceId, moveToResource: true}).then(() => {
-      this.meetingFiniteStateMachine.join();
-    }).catch((error) => {
-      this.meetingFiniteStateMachine.fail(error);
-      Metrics.sendBehavioralMetric(
-        BEHAVIORAL_METRICS.MOVE_TO_FAILURE,
-        {
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_FAILURE, {
           correlation_id: this.correlationId,
           locus_id: this.locusUrl.split('/').pop(),
           reason: error.message,
-          stack: error.stack
-        }
-      );
-      LoggerProxy.logger.error('Meeting:index#moveTo --> Failed to moveTo resourceId', error);
-
-      return Promise.reject(error);
+          stack: error.stack,
+        });
+      }
     });
+
+    LoggerProxy.logger.info(
+      'Meeting:index#moveTo --> Initated moved to using resourceId',
+      resourceId
+    );
+
+    return MeetingUtil.joinMeetingOptions(this, {resourceId, moveToResource: true})
+      .then(() => {
+        this.meetingFiniteStateMachine.join();
+      })
+      .catch((error) => {
+        this.meetingFiniteStateMachine.fail(error);
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_FAILURE, {
+          correlation_id: this.correlationId,
+          locus_id: this.locusUrl.split('/').pop(),
+          reason: error.message,
+          stack: error.stack,
+        });
+        LoggerProxy.logger.error('Meeting:index#moveTo --> Failed to moveTo resourceId', error);
+
+        return Promise.reject(error);
+      });
   }
 
   /**
@@ -3946,26 +4037,23 @@ export default class Meeting extends StatelessWebexPlugin {
     Metrics.postEvent({event: eventType.MOVE_MEDIA, meeting: this});
 
     return MeetingUtil.joinMeetingOptions(this)
-      .then(() => MeetingUtil.leaveMeeting(this, {
-        resourceId,
-        correlationId: oldCorrelationId,
-        moveMeeting: true
-      }).then(() => {
-        this.resourceId = '';
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.MOVE_FROM_SUCCESS,
-        );
-      })).catch((error) => {
+      .then(() =>
+        MeetingUtil.leaveMeeting(this, {
+          resourceId,
+          correlationId: oldCorrelationId,
+          moveMeeting: true,
+        }).then(() => {
+          this.resourceId = '';
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_FROM_SUCCESS);
+        }))
+      .catch((error) => {
         this.meetingFiniteStateMachine.fail(error);
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.MOVE_FROM_FAILURE,
-          {
-            correlation_id: this.correlationId,
-            locus_id: this.locusUrl.split('/').pop(),
-            reason: error.message,
-            stack: error.stack
-          }
-        );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_FROM_FAILURE, {
+          correlation_id: this.correlationId,
+          locus_id: this.locusUrl.split('/').pop(),
+          reason: error.message,
+          stack: error.stack,
+        });
         LoggerProxy.logger.error('Meeting:index#moveTo --> Failed to moveTo resourceId', error);
 
         return Promise.reject(error);
@@ -3990,26 +4078,27 @@ export default class Meeting extends StatelessWebexPlugin {
   ) => {
     if (
       mediaDirection &&
-      (
-        mediaDirection.sendAudio ||
-        mediaDirection.sendVideo ||
-        mediaDirection.sendShare
-      )
+      (mediaDirection.sendAudio || mediaDirection.sendVideo || mediaDirection.sendShare)
     ) {
-      if (mediaDirection &&
-        (
-          mediaDirection.sendAudio &&
-          mediaDirection.sendVideo &&
-          mediaDirection.sendShare
-        ) &&
+      if (
+        mediaDirection &&
+        mediaDirection.sendAudio &&
+        mediaDirection.sendVideo &&
+        mediaDirection.sendShare &&
         isBrowser('safari')
       ) {
-        LoggerProxy.logger.warn('Meeting:index#getMediaStreams --> Setting `sendShare` to FALSE, due to complications with Safari');
+        LoggerProxy.logger.warn(
+          'Meeting:index#getMediaStreams --> Setting `sendShare` to FALSE, due to complications with Safari'
+        );
 
         mediaDirection.sendShare = false;
 
-        LoggerProxy.logger.warn('Meeting:index#getMediaStreams --> Enabling `sendShare` along with `sendAudio` & `sendVideo`, on Safari, causes a failure while setting up a screen share at the same time as the camera+mic stream');
-        LoggerProxy.logger.warn('Meeting:index#getMediaStreams --> Please use `meeting.shareScreen()` to manually start the screen share after successfully joining the meeting');
+        LoggerProxy.logger.warn(
+          'Meeting:index#getMediaStreams --> Enabling `sendShare` along with `sendAudio` & `sendVideo`, on Safari, causes a failure while setting up a screen share at the same time as the camera+mic stream'
+        );
+        LoggerProxy.logger.warn(
+          'Meeting:index#getMediaStreams --> Please use `meeting.shareScreen()` to manually start the screen share after successfully joining the meeting'
+        );
       }
 
       if (audioVideo && isString(audioVideo)) {
@@ -4018,15 +4107,23 @@ export default class Meeting extends StatelessWebexPlugin {
           audioVideo = {video: VIDEO_RESOLUTIONS[audioVideo].video};
         }
         else {
-          throw new ParameterError(`${audioVideo} not supported. Either pass level from pre-defined resolutions or pass complete audioVideo object`);
+          throw new ParameterError(
+            `${audioVideo} not supported. Either pass level from pre-defined resolutions or pass complete audioVideo object`
+          );
         }
       }
 
       if (!audioVideo.video) {
-        audioVideo = {...audioVideo, video: {...audioVideo.video, ...VIDEO_RESOLUTIONS[this.mediaProperties.localQualityLevel].video}};
+        audioVideo = {
+          ...audioVideo,
+          video: {
+            ...audioVideo.video,
+            ...VIDEO_RESOLUTIONS[this.mediaProperties.localQualityLevel].video,
+          },
+        };
       }
       // extract deviceId if exists otherwise default to null.
-      const {deviceId: preferredVideoDevice} = (audioVideo && audioVideo.video || {deviceId: null});
+      const {deviceId: preferredVideoDevice} = (audioVideo && audioVideo.video) || {deviceId: null};
       const lastVideoDeviceId = this.mediaProperties.getVideoDeviceId();
 
       if (preferredVideoDevice) {
@@ -4041,56 +4138,58 @@ export default class Meeting extends StatelessWebexPlugin {
           ...audioVideo,
           video: {
             ...audioVideo.video,
-            deviceId: lastVideoDeviceId
-          }
+            deviceId: lastVideoDeviceId,
+          },
         };
       }
 
       return Media.getSupportedDevice({
         sendAudio: mediaDirection.sendAudio,
-        sendVideo: mediaDirection.sendVideo
+        sendVideo: mediaDirection.sendVideo,
       })
-        .catch((error) => Promise.reject(
-          new MediaError('Given constraints do not match permission set for either camera or microphone', error)
-        ))
+        .catch((error) =>
+          Promise.reject(
+            new MediaError(
+              'Given constraints do not match permission set for either camera or microphone',
+              error
+            )
+          ))
         .then((devicePermissions) =>
           Media.getUserMedia(
             {
               ...mediaDirection,
               sendAudio: devicePermissions.sendAudio,
               sendVideo: devicePermissions.sendVideo,
-              isSharing: this.shareStatus === SHARE_STATUS.LOCAL_SHARE_ACTIVE
+              isSharing: this.shareStatus === SHARE_STATUS.LOCAL_SHARE_ACTIVE,
             },
             audioVideo,
             sharePreferences,
             this.config
-          )
-            .catch((error) => {
-              // Whenever there is a failure when trying to access a user's device
-              // report it as an Behavioral metric
-              // This gives visibility into common errors and can help
-              // with further troubleshooting
-              const metricName = BEHAVIORAL_METRICS.GET_USER_MEDIA_FAILURE;
-              const data = {
-                correlation_id: this.correlationId,
-                locus_id: this.locusUrl?.split('/').pop(),
-                reason: error.message,
-                stack: error.stack
-              };
-              const metadata = {
-                type: error.name
-              };
+          ).catch((error) => {
+            // Whenever there is a failure when trying to access a user's device
+            // report it as an Behavioral metric
+            // This gives visibility into common errors and can help
+            // with further troubleshooting
+            const metricName = BEHAVIORAL_METRICS.GET_USER_MEDIA_FAILURE;
+            const data = {
+              correlation_id: this.correlationId,
+              locus_id: this.locusUrl?.split('/').pop(),
+              reason: error.message,
+              stack: error.stack,
+            };
+            const metadata = {
+              type: error.name,
+            };
 
-              Metrics.sendBehavioralMetric(metricName, data, metadata);
-              throw new MediaError('Unable to retrieve media streams', error);
-            }));
+            Metrics.sendBehavioralMetric(metricName, data, metadata);
+            throw new MediaError('Unable to retrieve media streams', error);
+          }));
     }
 
     return Promise.reject(
       new MediaError('At least one of the mediaDirection value should be true')
     );
   };
-
 
   /**
    * Checks if the machine has at least one audio or video device
@@ -4100,7 +4199,8 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {Object}
    * @memberof Meetings
    */
-  getSupportedDevices = ({sendAudio = true, sendVideo = true}) => Media.getSupportedDevice({sendAudio, sendVideo});
+  getSupportedDevices = ({sendAudio = true, sendVideo = true}) =>
+    Media.getSupportedDevice({sendAudio, sendVideo});
 
   /**
    * Get the devices from the Media module
@@ -4119,15 +4219,22 @@ export default class Meeting extends StatelessWebexPlugin {
     this.statsAnalyzer.on(StatsAnalyzerEvents.MEDIA_QUALITY, (options) => {
       // TODO:  might have to send the same event to the developer
       // Add ip address info if geo hint is present
-      options.data.intervalMetadata.peerReflexiveIP = this.webex.meetings.geoHintInfo?.clientAddress || options.data.intervalMetadata.peerReflexiveIP || MQA_STATS.DEFAULT_IP;
-      Metrics.postEvent({event: eventType.MEDIA_QUALITY, meeting: this, data: {intervalData: options.data, networkType: options.networkType}});
+      options.data.intervalMetadata.peerReflexiveIP =
+        this.webex.meetings.geoHintInfo?.clientAddress ||
+        options.data.intervalMetadata.peerReflexiveIP ||
+        MQA_STATS.DEFAULT_IP;
+      Metrics.postEvent({
+        event: eventType.MEDIA_QUALITY,
+        meeting: this,
+        data: {intervalData: options.data, networkType: options.networkType},
+      });
     });
     this.statsAnalyzer.on(StatsAnalyzerEvents.LOCAL_MEDIA_STARTED, (data) => {
       Trigger.trigger(
         this,
         {
           file: 'meeting/index',
-          function: 'addMedia'
+          function: 'addMedia',
         },
         EVENT_TRIGGERS.MEETING_MEDIA_LOCAL_STARTED,
         data
@@ -4136,8 +4243,8 @@ export default class Meeting extends StatelessWebexPlugin {
         event: eventType.SENDING_MEDIA_START,
         meeting: this,
         data: {
-          mediaType: data.type
-        }
+          mediaType: data.type,
+        },
       });
     });
     this.statsAnalyzer.on(StatsAnalyzerEvents.LOCAL_MEDIA_STOPPED, (data) => {
@@ -4145,8 +4252,8 @@ export default class Meeting extends StatelessWebexPlugin {
         event: eventType.SENDING_MEDIA_STOP,
         meeting: this,
         data: {
-          mediaType: data.type
-        }
+          mediaType: data.type,
+        },
       });
     });
     this.statsAnalyzer.on(StatsAnalyzerEvents.REMOTE_MEDIA_STARTED, (data) => {
@@ -4154,7 +4261,7 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meeting/index',
-          function: 'addMedia'
+          function: 'addMedia',
         },
         EVENT_TRIGGERS.MEETING_MEDIA_REMOTE_STARTED,
         data
@@ -4163,8 +4270,8 @@ export default class Meeting extends StatelessWebexPlugin {
         event: eventType.RECEIVING_MEDIA_START,
         meeting: this,
         data: {
-          mediaType: data.type
-        }
+          mediaType: data.type,
+        },
       });
     });
     this.statsAnalyzer.on(StatsAnalyzerEvents.REMOTE_MEDIA_STOPPED, (data) => {
@@ -4172,8 +4279,8 @@ export default class Meeting extends StatelessWebexPlugin {
         event: eventType.RECEIVING_MEDIA_STOP,
         meeting: this,
         data: {
-          mediaType: data.type
-        }
+          mediaType: data.type,
+        },
       });
     });
   };
@@ -4221,17 +4328,17 @@ export default class Meeting extends StatelessWebexPlugin {
             share: false,
             share_audio: false,
             video: false,
-            whiteboard: false
+            whiteboard: false,
           },
           tx: {
             audio: false,
             share: false,
             share_audio: false,
             video: false,
-            whiteboard: false
-          }
-        }
-      }
+            whiteboard: false,
+          },
+        },
+      },
     });
 
     return MeetingUtil.validateOptions(options)
@@ -4248,18 +4355,21 @@ export default class Meeting extends StatelessWebexPlugin {
 
         return this.preMedia(localStream, localShare, mediaSettings);
       })
-      .then(() => Media.attachMedia(this.mediaProperties, {
-        meetingId: this.id,
-        remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
-        enableRtx: this.config.enableRtx,
-        enableExtmap: this.config.enableExtmap,
-        setStartLocalSDPGenRemoteSDPRecvDelay: this.setStartLocalSDPGenRemoteSDPRecvDelay.bind(this)
-      }))
-      .then((peerConnection) => this.getDevices().then((devices) => {
-        MeetingUtil.handleDeviceLogging(devices);
+      .then(() =>
+        Media.attachMedia(this.mediaProperties, {
+          meetingId: this.id,
+          remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
+          enableRtx: this.config.enableRtx,
+          enableExtmap: this.config.enableExtmap,
+          setStartLocalSDPGenRemoteSDPRecvDelay:
+            this.setStartLocalSDPGenRemoteSDPRecvDelay.bind(this),
+        }))
+      .then((peerConnection) =>
+        this.getDevices().then((devices) => {
+          MeetingUtil.handleDeviceLogging(devices);
 
-        return peerConnection;
-      }))
+          return peerConnection;
+        }))
       .then((peerConnection) => {
         this.handleMediaLogging(this.mediaProperties);
         LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection Received from attachMedia `);
@@ -4270,64 +4380,70 @@ export default class Meeting extends StatelessWebexPlugin {
           this.networkQualityMonitor = new NetworkQualityMonitor(this.config.stats);
           this.statsAnalyzer = new StatsAnalyzer(this.config.stats, this.networkQualityMonitor);
           this.setupStatsAnalyzerEventHandlers();
-          this.networkQualityMonitor.on(EVENT_TRIGGERS.NETWORK_QUALITY, this.sendNetworkQualityEvent.bind(this));
+          this.networkQualityMonitor.on(
+            EVENT_TRIGGERS.NETWORK_QUALITY,
+            this.sendNetworkQualityEvent.bind(this)
+          );
         }
       })
       .catch((error) => {
-        LoggerProxy.logger.error(`${LOG_HEADER} Error adding media , setting up peerconnection, `, error);
-
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE,
-          {
-            correlation_id: this.correlationId,
-            locus_id: this.locusUrl.split('/').pop(),
-            reason: error.message,
-            stack: error.stack,
-            turnDiscoverySkippedReason,
-            turnServerUsed
-          }
+        LoggerProxy.logger.error(
+          `${LOG_HEADER} Error adding media , setting up peerconnection, `,
+          error
         );
+
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE, {
+          correlation_id: this.correlationId,
+          locus_id: this.locusUrl.split('/').pop(),
+          reason: error.message,
+          stack: error.stack,
+          turnDiscoverySkippedReason,
+          turnServerUsed,
+        });
 
         throw error;
       })
-      .then(() => new Promise((resolve, reject) => {
-        let timerCount = 0;
-
-        // eslint-disable-next-line func-names
-        // eslint-disable-next-line prefer-arrow-callback
-        if (this.type === _CALL_) {
-          resolve();
-        }
-        const joiningTimer = setInterval(() => {
-          timerCount += 1;
-          if (this.meetingState === FULL_STATE.ACTIVE) {
-            clearInterval(joiningTimer);
-            resolve();
-          }
-
-          if (timerCount === 4) {
-            clearInterval(joiningTimer);
-            reject(new Error('Meeting is still not active '));
-          }
-        }, 1000);
-      }))
-      .then(() =>
-        logRequest(this.roap
-          .sendRoapMediaRequest({
-            sdp: this.mediaProperties.peerConnection.sdp,
-            roapSeq: this.roapSeq,
-            meeting: this // or can pass meeting ID
-          }), {
-          header: `${LOG_HEADER} Send Roap Media Request.`,
-          success: `${LOG_HEADER} Successfully send roap media request`,
-          failure: `${LOG_HEADER} Error joining the call on send roap media request, `
-        }))
       .then(
-        () => this.mediaProperties.waitForIceConnectedState()
-          .catch(() => {
-            throw createMeetingsError(30202, 'Meeting connection failed');
+        () =>
+          new Promise((resolve, reject) => {
+            let timerCount = 0;
+
+            // eslint-disable-next-line func-names
+            // eslint-disable-next-line prefer-arrow-callback
+            if (this.type === _CALL_) {
+              resolve();
+            }
+            const joiningTimer = setInterval(() => {
+              timerCount += 1;
+              if (this.meetingState === FULL_STATE.ACTIVE) {
+                clearInterval(joiningTimer);
+                resolve();
+              }
+
+              if (timerCount === 4) {
+                clearInterval(joiningTimer);
+                reject(new Error('Meeting is still not active '));
+              }
+            }, 1000);
           })
       )
+      .then(() =>
+        logRequest(
+          this.roap.sendRoapMediaRequest({
+            sdp: this.mediaProperties.peerConnection.sdp,
+            roapSeq: this.roapSeq,
+            meeting: this, // or can pass meeting ID
+          }),
+          {
+            header: `${LOG_HEADER} Send Roap Media Request.`,
+            success: `${LOG_HEADER} Successfully send roap media request`,
+            failure: `${LOG_HEADER} Error joining the call on send roap media request, `,
+          }
+        ))
+      .then(() =>
+        this.mediaProperties.waitForIceConnectedState().catch(() => {
+          throw createMeetingsError(30202, 'Meeting connection failed');
+        }))
       .then(() => {
         LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection CONNECTED`);
 
@@ -4344,63 +4460,61 @@ export default class Meeting extends StatelessWebexPlugin {
       })
       .then(() => this.mediaProperties.getCurrentConnectionType())
       .then((connectionType) => {
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.ADD_MEDIA_SUCCESS,
-          {
-            correlation_id: this.correlationId,
-            locus_id: this.locusUrl.split('/').pop(),
-            connectionType
-          }
-        );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_MEDIA_SUCCESS, {
+          correlation_id: this.correlationId,
+          locus_id: this.locusUrl.split('/').pop(),
+          connectionType,
+        });
       })
       .catch((error) => {
         // Clean up stats analyzer, peer connection, and turn off listeners
-        const stopStatsAnalyzer = (this.statsAnalyzer) ? this.statsAnalyzer.stopAnalyzer() : Promise.resolve();
+        const stopStatsAnalyzer = this.statsAnalyzer ?
+          this.statsAnalyzer.stopAnalyzer() :
+          Promise.resolve();
 
-        return stopStatsAnalyzer
-          .then(() => {
-            this.statsAnalyzer = null;
+        return stopStatsAnalyzer.then(() => {
+          this.statsAnalyzer = null;
 
-            if (this.mediaProperties.peerConnection) {
-              this.closePeerConnections();
-              this.unsetPeerConnections();
-            }
+          if (this.mediaProperties.peerConnection) {
+            this.closePeerConnections();
+            this.unsetPeerConnections();
+          }
 
-            LoggerProxy.logger.error(`${LOG_HEADER} Error adding media failed to initiate PC and send request, `, error);
+          LoggerProxy.logger.error(
+            `${LOG_HEADER} Error adding media failed to initiate PC and send request, `,
+            error
+          );
 
-            Metrics.sendBehavioralMetric(
-              BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE,
-              {
-                correlation_id: this.correlationId,
-                locus_id: this.locusUrl.split('/').pop(),
-                reason: error.message,
-                stack: error.stack,
-                code: error.code,
-                turnDiscoverySkippedReason,
-                turnServerUsed
-              }
-            );
-
-            // Upload logs on error while adding media
-            Trigger.trigger(
-              this,
-              {
-                file: 'meeting/index',
-                function: 'addMedia'
-              },
-              EVENTS.REQUEST_UPLOAD_LOGS,
-              this
-            );
-
-            // If addMedia failes for not establishing connection then
-            // leave the meeting with reson connection failed as meeting anyways will end
-            // and cannot be connected unless network condition is checked for firewall
-            if (error.code === InvalidSdpError.CODE) {
-              this.leave({reason: MEETING_REMOVED_REASON.MEETING_CONNECTION_FAILED});
-            }
-
-            throw error;
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE, {
+            correlation_id: this.correlationId,
+            locus_id: this.locusUrl.split('/').pop(),
+            reason: error.message,
+            stack: error.stack,
+            code: error.code,
+            turnDiscoverySkippedReason,
+            turnServerUsed,
           });
+
+          // Upload logs on error while adding media
+          Trigger.trigger(
+            this,
+            {
+              file: 'meeting/index',
+              function: 'addMedia',
+            },
+            EVENTS.REQUEST_UPLOAD_LOGS,
+            this
+          );
+
+          // If addMedia failes for not establishing connection then
+          // leave the meeting with reson connection failed as meeting anyways will end
+          // and cannot be connected unless network condition is checked for firewall
+          if (error.code === InvalidSdpError.CODE) {
+            this.leave({reason: MEETING_REMOVED_REASON.MEETING_CONNECTION_FAILED});
+          }
+
+          throw error;
+        });
       });
   }
 
@@ -4409,7 +4523,10 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {Boolean}
    */
   canUpdateMedia() {
-    return this.mediaProperties.peerConnection.signalingState === SDP.STABLE && !RoapCollection.isBusy(this.correlationId);
+    return (
+      this.mediaProperties.peerConnection.signalingState === SDP.STABLE &&
+      !RoapCollection.isBusy(this.correlationId)
+    );
   }
 
   /**
@@ -4423,10 +4540,15 @@ export default class Meeting extends StatelessWebexPlugin {
   enqueueMediaUpdate(mediaUpdateType, options) {
     return new Promise((resolve, reject) => {
       const queueItem = {
-        pendingPromiseResolve: resolve, pendingPromiseReject: reject, mediaUpdateType, options
+        pendingPromiseResolve: resolve,
+        pendingPromiseReject: reject,
+        mediaUpdateType,
+        options,
       };
 
-      LoggerProxy.logger.log(`Meeting:index#enqueueMediaUpdate --> enqueuing media update type=${mediaUpdateType}`);
+      LoggerProxy.logger.log(
+        `Meeting:index#enqueueMediaUpdate --> enqueuing media update type=${mediaUpdateType}`
+      );
       this.queuedMediaUpdates.push(queueItem);
     });
   }
@@ -4444,9 +4566,9 @@ export default class Meeting extends StatelessWebexPlugin {
         this,
         {
           file: 'meeting/index',
-          function: 'mediaNegotiatedEvent'
+          function: 'mediaNegotiatedEvent',
         },
-        EVENT_TRIGGERS.MEDIA_NEGOTIATED,
+        EVENT_TRIGGERS.MEDIA_NEGOTIATED
       );
     }
   };
@@ -4459,12 +4581,15 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   processNextQueuedMediaUpdate = () => {
-    if (this.canUpdateMedia() && (this.queuedMediaUpdates.length > 0)) {
+    if (this.canUpdateMedia() && this.queuedMediaUpdates.length > 0) {
       const {
         pendingPromiseResolve, pendingPromiseReject, mediaUpdateType, options
-      } = this.queuedMediaUpdates.shift();
+      } =
+        this.queuedMediaUpdates.shift();
 
-      LoggerProxy.logger.log(`Meeting:index#processNextQueuedMediaUpdate --> performing delayed media update type=${mediaUpdateType}`);
+      LoggerProxy.logger.log(
+        `Meeting:index#processNextQueuedMediaUpdate --> performing delayed media update type=${mediaUpdateType}`
+      );
       switch (mediaUpdateType) {
         case MEDIA_UPDATE_TYPE.ALL:
           this.updateMedia(options).then(pendingPromiseResolve, pendingPromiseReject);
@@ -4479,7 +4604,9 @@ export default class Meeting extends StatelessWebexPlugin {
           this.updateShare(options).then(pendingPromiseResolve, pendingPromiseReject);
           break;
         default:
-          LoggerProxy.logger.error(`Peer-connection-manager:index#processNextQueuedMediaUpdate --> unsupported media update type ${mediaUpdateType} found in the queue`);
+          LoggerProxy.logger.error(
+            `Peer-connection-manager:index#processNextQueuedMediaUpdate --> unsupported media update type ${mediaUpdateType} found in the queue`
+          );
           break;
       }
     }
@@ -4503,65 +4630,64 @@ export default class Meeting extends StatelessWebexPlugin {
     if (!this.canUpdateMedia()) {
       return this.enqueueMediaUpdate(MEDIA_UPDATE_TYPE.ALL, options);
     }
-    const {
-      localStream, localShare, mediaSettings
-    } = options;
+    const {localStream, localShare, mediaSettings} = options;
 
     const previousSendShareStatus = this.mediaProperties.mediaDirection.sendShare;
 
     return MeetingUtil.validateOptions(options)
       .then(() => this.preMedia(localStream, localShare, mediaSettings))
-      .then(() => Media.updateMedia(this.mediaProperties, {
-        meetingId: this.id,
-        remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
-        enableRtx: this.config.enableRtx,
-        enableExtmap: this.config.enableExtmap,
-      })
-        .then((peerConnection) => {
-          LoggerProxy.logger.info(`${LOG_HEADER} PeerConnection received from updateMedia, ${peerConnection}`);
-          this.setRemoteStream(peerConnection);
-          if (mediaSettings.receiveShare || localShare) {
-            PeerConnectionManager.setContentSlides(peerConnection);
-          }
+      .then(() =>
+        Media.updateMedia(this.mediaProperties, {
+          meetingId: this.id,
+          remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
+          enableRtx: this.config.enableRtx,
+          enableExtmap: this.config.enableExtmap,
         })
-        .catch((error) => {
-          LoggerProxy.logger.error(`${LOG_HEADER} Error updatedMedia, `, error);
+          .then((peerConnection) => {
+            LoggerProxy.logger.info(
+              `${LOG_HEADER} PeerConnection received from updateMedia, ${peerConnection}`
+            );
+            this.setRemoteStream(peerConnection);
+            if (mediaSettings.receiveShare || localShare) {
+              PeerConnectionManager.setContentSlides(peerConnection);
+            }
+          })
+          .catch((error) => {
+            LoggerProxy.logger.error(`${LOG_HEADER} Error updatedMedia, `, error);
 
-          Metrics.sendBehavioralMetric(
-            BEHAVIORAL_METRICS.UPDATE_MEDIA_FAILURE,
-            {
+            Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.UPDATE_MEDIA_FAILURE, {
               correlation_id: this.correlationId,
               locus_id: this.locusUrl.split('/').pop(),
               reason: error.message,
-              stack: error.stack
+              stack: error.stack,
+            });
+
+            throw error;
+          })
+          .then(() =>
+            logRequest(
+              this.roap.sendRoapMediaRequest({
+                sdp: this.mediaProperties.peerConnection.sdp,
+                roapSeq: this.roapSeq,
+                meeting: this, // or can pass meeting ID
+              }),
+              {
+                header: `${LOG_HEADER} sendRoapMediaRequest being sent`,
+                success: `${LOG_HEADER} sendRoadMediaRequest successful`,
+                failure: `${LOG_HEADER} Error updateMedia on send roap media request, `,
+              }
+            ))
+          .then(() => this.checkForStopShare(mediaSettings.sendShare, previousSendShareStatus))
+          .then((startShare) => {
+            // This is a special case if we do an /floor grant followed by /media
+            // we actually get a OFFER from the server and a GLAR condition happens
+            if (startShare) {
+              // We are assuming that the clients are connected when doing an update
+              return this.share();
             }
-          );
 
-          throw error;
-        })
-        .then(() =>
-          logRequest(this.roap
-            .sendRoapMediaRequest({
-              sdp: this.mediaProperties.peerConnection.sdp,
-              roapSeq: this.roapSeq,
-              meeting: this, // or can pass meeting ID
-            }),
-          {
-            header: `${LOG_HEADER} sendRoapMediaRequest being sent`,
-            success: `${LOG_HEADER} sendRoadMediaRequest successful`,
-            failure: `${LOG_HEADER} Error updateMedia on send roap media request, `
-          }))
-        .then(() => this.checkForStopShare(mediaSettings.sendShare, previousSendShareStatus))
-        .then((startShare) => {
-          // This is a special case if we do an /floor grant followed by /media
-          // we actually get a OFFER from the server and a GLAR condition happens
-          if (startShare) {
-            // We are assuming that the clients are connected when doing an update
-            return this.share();
-          }
-
-          return Promise.resolve();
-        }));
+            return Promise.resolve();
+          }));
   }
 
   /**
@@ -4578,9 +4704,7 @@ export default class Meeting extends StatelessWebexPlugin {
     if (!this.canUpdateMedia()) {
       return this.enqueueMediaUpdate(MEDIA_UPDATE_TYPE.AUDIO, options);
     }
-    const {
-      sendAudio, receiveAudio, stream
-    } = options;
+    const {sendAudio, receiveAudio, stream} = options;
 
     const {audioTransceiver} = this.mediaProperties.peerConnection;
     let track = MeetingUtil.getTrack(stream).audioTrack;
@@ -4592,7 +4716,11 @@ export default class Meeting extends StatelessWebexPlugin {
     if (this.effects && this.effects.state) {
       const bnrEnabled = this.effects.state.bnr.enabled;
 
-      if (sendAudio && !this.isAudioMuted() && (bnrEnabled === BNR_STATUS.ENABLED || bnrEnabled === BNR_STATUS.SHOULD_ENABLE)) {
+      if (
+        sendAudio &&
+        !this.isAudioMuted() &&
+        (bnrEnabled === BNR_STATUS.ENABLED || bnrEnabled === BNR_STATUS.SHOULD_ENABLE)
+      ) {
         LoggerProxy.logger.info('Meeting:index#updateAudio. Calling WebRTC enable bnr method');
         track = await this.internal_enableBNR(track);
         LoggerProxy.logger.info('Meeting:index#updateAudio. WebRTC enable bnr request completed');
@@ -4606,7 +4734,7 @@ export default class Meeting extends StatelessWebexPlugin {
         if (this.mediaProperties.mediaDirection) {
           previousMediaDirection = {
             sendTrack: this.mediaProperties.mediaDirection.sendAudio,
-            receiveTrack: this.mediaProperties.mediaDirection.receiveAudio
+            receiveTrack: this.mediaProperties.mediaDirection.receiveAudio,
           };
         }
         else {
@@ -4621,12 +4749,12 @@ export default class Meeting extends StatelessWebexPlugin {
             track,
             transceiver: audioTransceiver,
             peerConnection: this.mediaProperties.peerConnection,
-            previousMediaDirection
+            previousMediaDirection,
           },
           {
             mediaProperties: this.mediaProperties,
             meeting: this,
-            id: this.id
+            id: this.id,
           }
         );
       })
@@ -4636,7 +4764,8 @@ export default class Meeting extends StatelessWebexPlugin {
         this.mediaProperties.mediaDirection.receiveAudio = receiveAudio;
 
         // audio state could be undefined if you have not sent audio before
-        this.audio = this.audio || createMuteState(AUDIO, this, this.mediaProperties.mediaDirection);
+        this.audio =
+          this.audio || createMuteState(AUDIO, this, this.mediaProperties.mediaDirection);
       });
   }
 
@@ -4663,30 +4792,34 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     return MeetingUtil.validateOptions({sendVideo, localStream: stream})
-      .then(() => MeetingUtil.updateTransceiver({
-        type: 'video',
-        sendTrack: options.sendVideo,
-        receiveTrack: options.receiveVideo,
-        track,
-        transceiver: videoTransceiver,
-        peerConnection: this.mediaProperties.peerConnection,
-        previousMediaDirection: {
-          sendTrack: this.mediaProperties.mediaDirection.sendVideo,
-          receiveTrack: this.mediaProperties.mediaDirection.receiveVideo
-        }
-      },
-      {
-        mediaProperties: this.mediaProperties,
-        meeting: this,
-        id: this.id
-      }))
+      .then(() =>
+        MeetingUtil.updateTransceiver(
+          {
+            type: 'video',
+            sendTrack: options.sendVideo,
+            receiveTrack: options.receiveVideo,
+            track,
+            transceiver: videoTransceiver,
+            peerConnection: this.mediaProperties.peerConnection,
+            previousMediaDirection: {
+              sendTrack: this.mediaProperties.mediaDirection.sendVideo,
+              receiveTrack: this.mediaProperties.mediaDirection.receiveVideo,
+            },
+          },
+          {
+            mediaProperties: this.mediaProperties,
+            meeting: this,
+            id: this.id,
+          }
+        ))
       .then(() => {
         this.setLocalVideoTrack(track);
         this.mediaProperties.mediaDirection.sendVideo = sendVideo;
         this.mediaProperties.mediaDirection.receiveVideo = receiveVideo;
 
         // video state could be undefined if you have not sent video before
-        this.video = this.video || createMuteState(VIDEO, this, this.mediaProperties.mediaDirection);
+        this.video =
+          this.video || createMuteState(VIDEO, this, this.mediaProperties.mediaDirection);
       });
   }
 
@@ -4706,8 +4839,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
     if (!sendShare && previousShareStatus) {
       // When user stops sharing
-      return this.stopFloorRequest()
-        .then(() => Promise.resolve(false));
+      return this.stopFloorRequest().then(() => Promise.resolve(false));
     }
 
     return Promise.resolve();
@@ -4739,24 +4871,26 @@ export default class Meeting extends StatelessWebexPlugin {
 
     return MeetingUtil.validateOptions({sendShare, localShare: stream})
       .then(() => this.checkForStopShare(sendShare, previousSendShareStatus))
-      .then((startShare) => MeetingUtil.updateTransceiver({
-        type: 'video',
-        sendTrack: sendShare,
-        receiveTrack: receiveShare,
-        track,
-        transceiver: shareTransceiver,
-        peerConnection: this.mediaProperties.peerConnection,
-        previousMediaDirection: {
-          sendTrack: this.mediaProperties.mediaDirection.sendShare,
-          receiveTrack: this.mediaProperties.mediaDirection.receiveShare
-        }
-      },
-      {
-        mediaProperties: this.mediaProperties,
-        meeting: this,
-        id: this.id
-      })
-        .then(() => {
+      .then((startShare) =>
+        MeetingUtil.updateTransceiver(
+          {
+            type: 'video',
+            sendTrack: sendShare,
+            receiveTrack: receiveShare,
+            track,
+            transceiver: shareTransceiver,
+            peerConnection: this.mediaProperties.peerConnection,
+            previousMediaDirection: {
+              sendTrack: this.mediaProperties.mediaDirection.sendShare,
+              receiveTrack: this.mediaProperties.mediaDirection.receiveShare,
+            },
+          },
+          {
+            mediaProperties: this.mediaProperties,
+            meeting: this,
+            id: this.id,
+          }
+        ).then(() => {
           if (startShare) {
             return this.share();
           }
@@ -4774,17 +4908,15 @@ export default class Meeting extends StatelessWebexPlugin {
       .finally(() => {
         const delay = 1e3;
         // Check to see if share was stopped natively before onended was assigned.
-        const sharingModeIsActive = this.mediaProperties.peerConnection.shareTransceiver.direction === SENDRECV;
+        const sharingModeIsActive =
+          this.mediaProperties.peerConnection.shareTransceiver.direction === SENDRECV;
         const isSharingOutOfSync = sharingModeIsActive && !this.isLocalShareLive;
 
         if (isSharingOutOfSync) {
           // Adding a delay to avoid a 409 from server
           // which results in user still appearing as if sharing.
           // Also delay give time for changes to peerConnection.
-          setTimeout(
-            () => this.handleShareTrackEnded(stream),
-            delay
-          );
+          setTimeout(() => this.handleShareTrackEnded(stream), delay);
         }
       });
   }
@@ -4827,7 +4959,7 @@ export default class Meeting extends StatelessWebexPlugin {
         .acknowledgeMeeting({
           locusUrl: this.locusUrl,
           deviceUrl: this.deviceUrl,
-          correlationId: this.correlationId
+          correlationId: this.correlationId,
         })
         .then((response) => Promise.resolve(response))
         .then((response) => {
@@ -4835,14 +4967,14 @@ export default class Meeting extends StatelessWebexPlugin {
           Metrics.postEvent({event: eventType.ALERT_DISPLAYED, meeting: this});
 
           return Promise.resolve({
-            response
+            response,
           });
         });
     }
 
     // TODO: outside of 1:1 incoming, and all outgoing calls
     return Promise.resolve({
-      message: 'noop'
+      message: 'noop',
     });
   }
 
@@ -4854,15 +4986,17 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   decline(reason) {
-    return MeetingUtil.declineMeeting(this, reason).then((decline) => {
-      this.meetingFiniteStateMachine.decline();
+    return MeetingUtil.declineMeeting(this, reason)
+      .then((decline) => {
+        this.meetingFiniteStateMachine.decline();
 
-      return Promise.resolve(decline);
-    }).catch((error) => {
-      this.meetingFiniteStateMachine.fail(error);
+        return Promise.resolve(decline);
+      })
+      .catch((error) => {
+        this.meetingFiniteStateMachine.fail(error);
 
-      return Promise.reject(error);
-    });
+        return Promise.reject(error);
+      });
   }
 
   /**
@@ -4874,7 +5008,11 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   leave(options = {}) {
-    Metrics.postEvent({event: eventType.LEAVE, meeting: this, data: {trigger: trigger.USER_INTERACTION, canProceed: false}});
+    Metrics.postEvent({
+      event: eventType.LEAVE,
+      meeting: this,
+      data: {trigger: trigger.USER_INTERACTION, canProceed: false},
+    });
     const leaveReason = options.reason || MEETING_REMOVED_REASON.CLIENT_LEAVE_REQUEST;
 
     LoggerProxy.logger.log('Meeting:index#leave --> Leaving a meeting');
@@ -4889,7 +5027,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'leave'
+            function: 'leave',
           },
           EVENTS.REQUEST_UPLOAD_LOGS,
           this
@@ -4902,19 +5040,20 @@ export default class Meeting extends StatelessWebexPlugin {
             this,
             {
               file: 'meeting/index',
-              function: 'leave'
+              function: 'leave',
             },
             EVENTS.DESTROY_MEETING,
             {
               reason: options.reason,
-              meetingId: this.id
+              meetingId: this.id,
             }
           );
         }
         LoggerProxy.logger.log('Meeting:index#leave --> LEAVE REASON ', leaveReason);
 
         return leave;
-      }).catch((error) => {
+      })
+      .catch((error) => {
         this.meetingFiniteStateMachine.fail(error);
         LoggerProxy.logger.error('Meeting:index#leave --> Failed to leave ', error);
         // upload logs on leave irrespective of meeting delete
@@ -4922,21 +5061,18 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'leave'
+            function: 'leave',
           },
           EVENTS.REQUEST_UPLOAD_LOGS,
           this
         );
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.MEETING_LEAVE_FAILURE,
-          {
-            correlation_id: this.correlationId,
-            locus_id: this.locusUrl.split('/').pop(),
-            reason: error.message,
-            stack: error.stack,
-            code: error.code
-          }
-        );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_LEAVE_FAILURE, {
+          correlation_id: this.correlationId,
+          locus_id: this.locusUrl.split('/').pop(),
+          reason: error.message,
+          stack: error.stack,
+          code: error.code,
+        });
 
         return Promise.reject(error);
       });
@@ -4965,14 +5101,15 @@ export default class Meeting extends StatelessWebexPlugin {
         personUrl: this.locusInfo.self.url,
         deviceUrl: this.deviceUrl,
         uri: whiteboard.url,
-        resourceUrl: channelUrl
+        resourceUrl: channelUrl,
       };
 
       if (resourceToken) {
         body.resourceToken = resourceToken;
       }
 
-      return this.meetingRequest.changeMeetingFloor(body)
+      return this.meetingRequest
+        .changeMeetingFloor(body)
         .then(() => {
           this.isSharing = false;
 
@@ -4981,16 +5118,13 @@ export default class Meeting extends StatelessWebexPlugin {
         .catch((error) => {
           LoggerProxy.logger.error('Meeting:index#startWhiteboardShare --> Error ', error);
 
-          Metrics.sendBehavioralMetric(
-            BEHAVIORAL_METRICS.MEETING_START_WHITEBOARD_SHARE_FAILURE,
-            {
-              correlation_id: this.correlationId,
-              locus_id: this.locusUrl.split('/').pop(),
-              reason: error.message,
-              stack: error.stack,
-              board: {channelUrl}
-            }
-          );
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_START_WHITEBOARD_SHARE_FAILURE, {
+            correlation_id: this.correlationId,
+            locus_id: this.locusUrl.split('/').pop(),
+            reason: error.message,
+            stack: error.stack,
+            board: {channelUrl},
+          });
 
           return Promise.reject(error);
         });
@@ -5012,30 +5146,27 @@ export default class Meeting extends StatelessWebexPlugin {
     if (whiteboard) {
       Metrics.postEvent({event: eventType.WHITEBOARD_SHARE_STOPPED, meeting: this});
 
-      return this.meetingRequest.changeMeetingFloor({
-        disposition: FLOOR_ACTION.RELEASED,
-        personUrl: this.locusInfo.self.url,
-        deviceUrl: this.deviceUrl,
-        uri: whiteboard.url
-      })
+      return this.meetingRequest
+        .changeMeetingFloor({
+          disposition: FLOOR_ACTION.RELEASED,
+          personUrl: this.locusInfo.self.url,
+          deviceUrl: this.deviceUrl,
+          uri: whiteboard.url,
+        })
         .catch((error) => {
           LoggerProxy.logger.error('Meeting:index#stopWhiteboardShare --> Error ', error);
 
-          Metrics.sendBehavioralMetric(
-            BEHAVIORAL_METRICS.STOP_WHITEBOARD_SHARE_FAILURE,
-            {
-              correlation_id: this.correlationId,
-              locus_id: this.locusUrl.split('/').pop(),
-              reason: error.message,
-              stack: error.stack,
-              board: {channelUrl}
-            }
-          );
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.STOP_WHITEBOARD_SHARE_FAILURE, {
+            correlation_id: this.correlationId,
+            locus_id: this.locusUrl.split('/').pop(),
+            reason: error.message,
+            stack: error.stack,
+            board: {channelUrl},
+          });
 
           return Promise.reject(error);
         })
-        .finally(() => {
-        });
+        .finally(() => {});
     }
 
     return Promise.reject(new ParameterError('Cannot stop share without whiteboard.'));
@@ -5050,16 +5181,17 @@ export default class Meeting extends StatelessWebexPlugin {
   share() {
     const content = this.locusInfo.mediaShares.find((element) => element.name === CONTENT);
 
-    if (content && (this.shareStatus !== SHARE_STATUS.LOCAL_SHARE_ACTIVE)) {
+    if (content && this.shareStatus !== SHARE_STATUS.LOCAL_SHARE_ACTIVE) {
       Metrics.postEvent({event: eventType.SHARE_INITIATED, meeting: this});
 
-      return this.meetingRequest.changeMeetingFloor({
-        disposition: FLOOR_ACTION.GRANTED,
-        personUrl: this.locusInfo.self.url,
-        deviceUrl: this.deviceUrl,
-        uri: content.url,
-        resourceUrl: this.resourceUrl
-      })
+      return this.meetingRequest
+        .changeMeetingFloor({
+          disposition: FLOOR_ACTION.GRANTED,
+          personUrl: this.locusInfo.self.url,
+          deviceUrl: this.deviceUrl,
+          uri: content.url,
+          resourceUrl: this.resourceUrl,
+        })
         .then(() => {
           this.isSharing = true;
 
@@ -5068,15 +5200,12 @@ export default class Meeting extends StatelessWebexPlugin {
         .catch((error) => {
           LoggerProxy.logger.error('Meeting:index#share --> Error ', error);
 
-          Metrics.sendBehavioralMetric(
-            BEHAVIORAL_METRICS.MEETING_SHARE_FAILURE,
-            {
-              correlation_id: this.correlationId,
-              locus_id: this.locusUrl.split('/').pop(),
-              reason: error.message,
-              stack: error.stack
-            }
-          );
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_SHARE_FAILURE, {
+            correlation_id: this.correlationId,
+            locus_id: this.locusUrl.split('/').pop(),
+            reason: error.message,
+            stack: error.stack,
+          });
 
           return Promise.reject(error);
         });
@@ -5097,7 +5226,7 @@ export default class Meeting extends StatelessWebexPlugin {
     return this.updateShare({
       sendShare: false,
       receiveShare: this.mediaProperties.mediaDirection.receiveShare,
-      ...options
+      ...options,
     });
   }
 
@@ -5110,7 +5239,7 @@ export default class Meeting extends StatelessWebexPlugin {
   stopFloorRequest() {
     const content = this.locusInfo.mediaShares.find((element) => element.name === CONTENT);
 
-    if (content && (this.mediaProperties.mediaDirection.sendShare)) {
+    if (content && this.mediaProperties.mediaDirection.sendShare) {
       Metrics.postEvent({event: eventType.SHARE_STOPPED, meeting: this});
       Media.stopTracks(this.mediaProperties.shareTrack);
 
@@ -5121,25 +5250,23 @@ export default class Meeting extends StatelessWebexPlugin {
         return Promise.resolve();
       }
 
-      return this.meetingRequest.changeMeetingFloor({
-        disposition: FLOOR_ACTION.RELEASED,
-        personUrl: this.locusInfo.self.url,
-        deviceUrl: this.deviceUrl,
-        uri: content.url,
-        resourceUrl: this.resourceUrl
-      })
+      return this.meetingRequest
+        .changeMeetingFloor({
+          disposition: FLOOR_ACTION.RELEASED,
+          personUrl: this.locusInfo.self.url,
+          deviceUrl: this.deviceUrl,
+          uri: content.url,
+          resourceUrl: this.resourceUrl,
+        })
         .catch((error) => {
           LoggerProxy.logger.error('Meeting:index#stopFloorRequest --> Error ', error);
 
-          Metrics.sendBehavioralMetric(
-            BEHAVIORAL_METRICS.STOP_FLOOR_REQUEST_FAILURE,
-            {
-              correlation_id: this.correlationId,
-              locus_id: this.locusUrl.split('/').pop(),
-              reason: error.message,
-              stack: error.stack
-            }
-          );
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.STOP_FLOOR_REQUEST_FAILURE, {
+            correlation_id: this.correlationId,
+            locus_id: this.locusUrl.split('/').pop(),
+            reason: error.message,
+            stack: error.stack,
+          });
 
           return Promise.reject(error);
         })
@@ -5234,18 +5361,21 @@ export default class Meeting extends StatelessWebexPlugin {
   sendDTMF(tones) {
     if (this.locusInfo && this.locusInfo.self) {
       if (this.locusInfo.self.enableDTMF) {
-        return this.meetingRequest
-          .sendDTMF({
-            locusUrl: this.locusInfo.self.url,
-            deviceUrl: this.deviceUrl,
-            tones
-          });
+        return this.meetingRequest.sendDTMF({
+          locusUrl: this.locusInfo.self.url,
+          deviceUrl: this.deviceUrl,
+          tones,
+        });
       }
 
-      return this.rejectWithErrorLog('Meeting:index#sendDTMF --> cannot send DTMF, meeting does not have DTMF enabled');
+      return this.rejectWithErrorLog(
+        'Meeting:index#sendDTMF --> cannot send DTMF, meeting does not have DTMF enabled'
+      );
     }
 
-    return this.rejectWithErrorLog('Meeting:index#sendDTMF --> cannot send DTMF, meeting does not have a connection to the "locus" call control service. Have you joined?');
+    return this.rejectWithErrorLog(
+      'Meeting:index#sendDTMF --> cannot send DTMF, meeting does not have a connection to the "locus" call control service. Have you joined?'
+    );
   }
 
   /**
@@ -5270,12 +5400,16 @@ export default class Meeting extends StatelessWebexPlugin {
 
     // TODO: We need a real time value for Audio, Video and Share send indicator
     if (mediaDirection.receiveVideo !== true || !remoteVideoTrack) {
-      return this.rejectWithErrorLog('Meeting:index#changeVideoLayout --> cannot change video layout, you are not recieving any video/share stream');
+      return this.rejectWithErrorLog(
+        'Meeting:index#changeVideoLayout --> cannot change video layout, you are not recieving any video/share stream'
+      );
     }
 
     if (layoutType) {
       if (!LAYOUT_TYPES.includes(layoutType)) {
-        this.rejectWithErrorLog('Meeting:index#changeVideoLayout --> cannot change video layout, invalid layoutType recieved.');
+        this.rejectWithErrorLog(
+          'Meeting:index#changeVideoLayout --> cannot change video layout, invalid layoutType recieved.'
+        );
       }
 
       layoutInfo.layoutType = layoutType;
@@ -5301,7 +5435,8 @@ export default class Meeting extends StatelessWebexPlugin {
         const contentHeight = Math.round(content.height);
 
         // Stop any "twitching" caused by very slight size changes
-        if (!this.lastVideoLayoutInfo.content ||
+        if (
+          !this.lastVideoLayoutInfo.content ||
           Math.abs(this.lastVideoLayoutInfo.content.height - contentHeight) > 2 ||
           Math.abs(this.lastVideoLayoutInfo.content.width - contentWidth) > 2
         ) {
@@ -5309,7 +5444,9 @@ export default class Meeting extends StatelessWebexPlugin {
         }
       }
       else {
-        return this.rejectWithErrorLog('Meeting:index#changeVideoLayout --> unable to send renderInfo for content, you are not receiving remote share');
+        return this.rejectWithErrorLog(
+          'Meeting:index#changeVideoLayout --> unable to send renderInfo for content, you are not receiving remote share'
+        );
       }
     }
 
@@ -5328,7 +5465,7 @@ export default class Meeting extends StatelessWebexPlugin {
         },
         EVENT_TRIGGERS.MEETING_CONTROLS_LAYOUT_UPDATE,
         {
-          layout: envelope.layout
+          layout: envelope.layout,
         }
       );
     });
@@ -5339,7 +5476,7 @@ export default class Meeting extends StatelessWebexPlugin {
         deviceUrl: this.deviceUrl,
         layoutType,
         main: layoutInfo.main,
-        content: layoutInfo.content
+        content: layoutInfo.content,
       })
       .then((response) => {
         if (response && response.body && response.body.locus) {
@@ -5366,12 +5503,16 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     if (!this.mediaProperties.mediaDirection.sendVideo) {
-      return this.rejectWithErrorLog('Meeting:index#setLocalVideoQuality --> unable to change video quality, sendVideo is disabled');
+      return this.rejectWithErrorLog(
+        'Meeting:index#setLocalVideoQuality --> unable to change video quality, sendVideo is disabled'
+      );
     }
 
     // If level is already the same, don't do anything
     if (level === this.mediaProperties.localQualityLevel) {
-      LoggerProxy.logger.warn(`Meeting:index#setLocalQualityLevel --> Quality already set to ${level}`);
+      LoggerProxy.logger.warn(
+        `Meeting:index#setLocalQualityLevel --> Quality already set to ${level}`
+      );
 
       return Promise.resolve();
     }
@@ -5382,7 +5523,7 @@ export default class Meeting extends StatelessWebexPlugin {
     const mediaDirection = {
       sendAudio: this.mediaProperties.mediaDirection.sendAudio,
       sendVideo: this.mediaProperties.mediaDirection.sendVideo,
-      sendShare: this.mediaProperties.mediaDirection.sendShare
+      sendShare: this.mediaProperties.mediaDirection.sendShare,
     };
 
     // When changing local video quality level
@@ -5391,16 +5532,17 @@ export default class Meeting extends StatelessWebexPlugin {
     // open bug link: https://bugs.chromium.org/p/chromium/issues/detail?id=943469
     if (isBrowser('chrome') && this.mediaProperties.videoTrack) Media.stopTracks(this.mediaProperties.videoTrack);
 
-    return this.getMediaStreams(mediaDirection, VIDEO_RESOLUTIONS[level])
-      .then(async ([localStream]) => {
+    return this.getMediaStreams(mediaDirection, VIDEO_RESOLUTIONS[level]).then(
+      async ([localStream]) => {
         await this.updateVideo({
           sendVideo: true,
           receiveVideo: true,
-          stream: localStream
+          stream: localStream,
         });
 
         return localStream;
-      });
+      }
+    );
   }
 
   /**
@@ -5412,16 +5554,25 @@ export default class Meeting extends StatelessWebexPlugin {
     LoggerProxy.logger.log(`Meeting:index#setRemoteQualityLevel --> Setting quality to ${level}`);
 
     if (!QUALITY_LEVELS[level]) {
-      return this.rejectWithErrorLog(`Meeting:index#setRemoteQualityLevel --> ${level} not defined`);
+      return this.rejectWithErrorLog(
+        `Meeting:index#setRemoteQualityLevel --> ${level} not defined`
+      );
     }
 
-    if (!this.mediaProperties.mediaDirection.receiveAudio && !this.mediaProperties.mediaDirection.receiveVideo) {
-      return this.rejectWithErrorLog('Meeting:index#setRemoteQualityLevel --> unable to change remote quality, receiveVideo and receiveAudio is disabled');
+    if (
+      !this.mediaProperties.mediaDirection.receiveAudio &&
+      !this.mediaProperties.mediaDirection.receiveVideo
+    ) {
+      return this.rejectWithErrorLog(
+        'Meeting:index#setRemoteQualityLevel --> unable to change remote quality, receiveVideo and receiveAudio is disabled'
+      );
     }
 
     // If level is already the same, don't do anything
     if (level === this.mediaProperties.remoteQualityLevel) {
-      LoggerProxy.logger.warn(`Meeting:index#setRemoteQualityLevel --> Quality already set to ${level}`);
+      LoggerProxy.logger.warn(
+        `Meeting:index#setRemoteQualityLevel --> Quality already set to ${level}`
+      );
 
       return Promise.resolve();
     }
@@ -5447,7 +5598,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
     const previousLevel = {
       local: this.mediaProperties.localQualityLevel,
-      remote: this.mediaProperties.remoteQualityLevel
+      remote: this.mediaProperties.remoteQualityLevel,
     };
 
     // If level is already the same, don't do anything
@@ -5455,7 +5606,9 @@ export default class Meeting extends StatelessWebexPlugin {
       level === this.mediaProperties.localQualityLevel &&
       level === this.mediaProperties.remoteQualityLevel
     ) {
-      LoggerProxy.logger.warn(`Meeting:index#setMeetingQuality --> Quality already set to ${level}`);
+      LoggerProxy.logger.warn(
+        `Meeting:index#setMeetingQuality --> Quality already set to ${level}`
+      );
 
       return Promise.resolve();
     }
@@ -5465,9 +5618,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
     return (sendVideo ? this.setLocalVideoQuality(level) : Promise.resolve())
       .then(() =>
-        ((receiveAudio || receiveVideo) ?
-          this.setRemoteQualityLevel(level) :
-          Promise.resolve()))
+        (receiveAudio || receiveVideo ? this.setRemoteQualityLevel(level) : Promise.resolve()))
       .catch((error) => {
         // From troubleshooting it seems that the stream itself doesn't change the max-fs if the peer connection isn't stable
         this.mediaProperties.setLocalQualityLevel(previousLevel.local);
@@ -5481,10 +5632,10 @@ export default class Meeting extends StatelessWebexPlugin {
             correlation_id: this.correlationId,
             locus_id: this.locusUrl.split('/').pop(),
             reason: error.message,
-            stack: error.stack
+            stack: error.stack,
           },
           {
-            type: error.name
+            type: error.name,
           }
         );
 
@@ -5493,30 +5644,31 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
-  * @param {Object} options parameter
-  * @param {Boolean} options.sendAudio send audio from the display share
-  * @param {Boolean} options.sendShare send video from the display share
-  * @param {Object} options.sharePreferences
-  * @param {MediaTrackConstraints} options.sharePreferences.shareConstraints constraints to apply to video
-  *   @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints}
-  * @param {Boolean} options.sharePreferences.highFrameRate if shareConstraints isn't provided, set default values based off of this boolean
-  * @returns {Promise}
-  */
+   * @param {Object} options parameter
+   * @param {Boolean} options.sendAudio send audio from the display share
+   * @param {Boolean} options.sendShare send video from the display share
+   * @param {Object} options.sharePreferences
+   * @param {MediaTrackConstraints} options.sharePreferences.shareConstraints constraints to apply to video
+   *   @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints}
+   * @param {Boolean} options.sharePreferences.highFrameRate if shareConstraints isn't provided, set default values based off of this boolean
+   * @returns {Promise}
+   */
   shareScreen(options = {}) {
     LoggerProxy.logger.log('Meeting:index#shareScreen --> Getting local share');
 
     const shareConstraints = {
       sendShare: true,
       sendAudio: false,
-      ...options
+      ...options,
     };
 
     return Media.getDisplayMedia(shareConstraints, this.config)
-      .then((shareStream) => this.updateShare({
-        sendShare: true,
-        receiveShare: this.mediaProperties.mediaDirection.receiveShare,
-        stream: shareStream
-      }))
+      .then((shareStream) =>
+        this.updateShare({
+          sendShare: true,
+          receiveShare: this.mediaProperties.mediaDirection.receiveShare,
+          stream: shareStream,
+        }))
       .catch((error) => {
         // Whenever there is a failure when trying to access a user's display
         // report it as an Behavioral metric
@@ -5530,10 +5682,10 @@ export default class Meeting extends StatelessWebexPlugin {
           correlation_id: this.correlationId,
           locus_id: this.locusUrl.split('/').pop(),
           reason: error.message,
-          stack: error.stack
+          stack: error.stack,
         };
         const metadata = {
-          type: error.name
+          type: error.name,
         };
 
         Metrics.sendBehavioralMetric(metricName, data, metadata);
@@ -5556,23 +5708,25 @@ export default class Meeting extends StatelessWebexPlugin {
       // Skip checking for a stable peerConnection
       // to allow immediately stopping screenshare
       this.stopShare({
-        skipSignalingCheck: true
-      })
-        .catch((error) => {
-          LoggerProxy.logger.log('Meeting:index#handleShareTrackEnded --> Error stopping share: ', error);
-        });
+        skipSignalingCheck: true,
+      }).catch((error) => {
+        LoggerProxy.logger.log(
+          'Meeting:index#handleShareTrackEnded --> Error stopping share: ',
+          error
+        );
+      });
     }
 
     Trigger.trigger(
       this,
       {
         file: 'meeting/index',
-        function: 'handleShareTrackEnded'
+        function: 'handleShareTrackEnded',
       },
       EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
       {
         type: EVENT_TYPES.LOCAL_SHARE,
-        stream: localShare
+        stream: localShare,
       }
     );
   }
@@ -5593,12 +5747,12 @@ export default class Meeting extends StatelessWebexPlugin {
       this,
       {
         file: 'meeting/index',
-        function: 'addMedia'
+        function: 'addMedia',
       },
       EVENT_TRIGGERS.NETWORK_QUALITY,
       {
         networkQualityScore: res.networkQualityScore,
-        mediaType: res.mediaType
+        mediaType: res.mediaType,
       }
     );
   }
@@ -5640,7 +5794,7 @@ export default class Meeting extends StatelessWebexPlugin {
     const start = this[`startSetupDelay${typeMedia}`];
     const end = this[`endSetupDelay${typeMedia}`];
 
-    return (start && end) ? end - start : undefined;
+    return start && end ? end - start : undefined;
   }
 
   /**
@@ -5668,7 +5822,7 @@ export default class Meeting extends StatelessWebexPlugin {
     const start = this[`startSendingMediaDelay${typeMedia}`];
     const end = this[`endSendingMediaDelay${typeMedia}`];
 
-    return (start && end) ? end - start : undefined;
+    return start && end ? end - start : undefined;
   }
 
   /**
@@ -5703,9 +5857,7 @@ export default class Meeting extends StatelessWebexPlugin {
     if (start && end) {
       const calculatedDelay = end - start;
 
-      return calculatedDelay > METRICS_JOIN_TIMES_MAX_DURATION ?
-        undefined :
-        calculatedDelay;
+      return calculatedDelay > METRICS_JOIN_TIMES_MAX_DURATION ? undefined : calculatedDelay;
     }
 
     return undefined;
@@ -5739,9 +5891,7 @@ export default class Meeting extends StatelessWebexPlugin {
     if (start && end) {
       const calculatedDelay = end - start;
 
-      return calculatedDelay > METRICS_JOIN_TIMES_MAX_DURATION ?
-        undefined :
-        calculatedDelay;
+      return calculatedDelay > METRICS_JOIN_TIMES_MAX_DURATION ? undefined : calculatedDelay;
     }
 
     return undefined;
@@ -5775,9 +5925,7 @@ export default class Meeting extends StatelessWebexPlugin {
     if (start && end) {
       const calculatedDelay = end - start;
 
-      return calculatedDelay > METRICS_JOIN_TIMES_MAX_DURATION ?
-        undefined :
-        calculatedDelay;
+      return calculatedDelay > METRICS_JOIN_TIMES_MAX_DURATION ? undefined : calculatedDelay;
     }
 
     return undefined;
@@ -5791,9 +5939,8 @@ export default class Meeting extends StatelessWebexPlugin {
     const start = this.startCallInitiateJoinReq;
     const end = this.endJoinReqResp;
 
-    return (start && end) ? end - start : undefined;
+    return start && end ? end - start : undefined;
   }
-
 
   /**
    * End the current meeting for all
@@ -5802,16 +5949,17 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   endMeetingForAll() {
-    Metrics.postEvent({event: eventType.LEAVE, meeting: this, data: {trigger: trigger.USER_INTERACTION, canProceed: false}});
+    Metrics.postEvent({
+      event: eventType.LEAVE,
+      meeting: this,
+      data: {trigger: trigger.USER_INTERACTION, canProceed: false},
+    });
 
     LoggerProxy.logger.log('Meeting:index#endMeetingForAll --> End meeting for All');
-    Metrics.sendBehavioralMetric(
-      BEHAVIORAL_METRICS.MEETING_END_ALL_INITIATED,
-      {
-        correlation_id: this.correlationId,
-        locus_id: this.locusId
-      }
-    );
+    Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_END_ALL_INITIATED, {
+      correlation_id: this.correlationId,
+      locus_id: this.locusId,
+    });
 
     return MeetingUtil.endMeetingForAll(this)
       .then((end) => {
@@ -5823,36 +5971,37 @@ export default class Meeting extends StatelessWebexPlugin {
           this,
           {
             file: 'meeting/index',
-            function: 'endMeetingForAll'
+            function: 'endMeetingForAll',
           },
           EVENTS.REQUEST_UPLOAD_LOGS,
           this
         );
 
         return end;
-      }).catch((error) => {
+      })
+      .catch((error) => {
         this.meetingFiniteStateMachine.fail(error);
-        LoggerProxy.logger.error('Meeting:index#endMeetingForAll --> Failed to end meeting ', error);
+        LoggerProxy.logger.error(
+          'Meeting:index#endMeetingForAll --> Failed to end meeting ',
+          error
+        );
         // upload logs on leave irrespective of meeting delete
         Trigger.trigger(
           this,
           {
             file: 'meeting/index',
-            function: 'endMeetingForAll'
+            function: 'endMeetingForAll',
           },
           EVENTS.REQUEST_UPLOAD_LOGS,
           this
         );
-        Metrics.sendBehavioralMetric(
-          BEHAVIORAL_METRICS.MEETING_END_ALL_FAILURE,
-          {
-            correlation_id: this.correlationId,
-            locus_id: this.locusUrl.split('/').pop(),
-            reason: error.message,
-            stack: error.stack,
-            code: error.code
-          }
-        );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_END_ALL_FAILURE, {
+          correlation_id: this.correlationId,
+          locus_id: this.locusUrl.split('/').pop(),
+          reason: error.message,
+          stack: error.stack,
+          code: error.code,
+        });
 
         return Promise.reject(error);
       });
@@ -5902,7 +6051,9 @@ export default class Meeting extends StatelessWebexPlugin {
       LoggerProxy.logger.info('Meeting:index#internal_enableBNR. Internal enable BNR called');
       const bnrAudioTrack = await WebRTCMedia.Effects.BNR.enableBNR(audioTrack);
 
-      LoggerProxy.logger.info('Meeting:index#internal_enableBNR. BNR enabled track obtained from WebRTC & returned as stream');
+      LoggerProxy.logger.info(
+        'Meeting:index#internal_enableBNR. BNR enabled track obtained from WebRTC & returned as stream'
+      );
 
       return bnrAudioTrack;
     }
@@ -5919,7 +6070,10 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   enableBNR() {
-    if (typeof this.mediaProperties === 'undefined' || typeof this.mediaProperties.audioTrack === 'undefined') {
+    if (
+      typeof this.mediaProperties === 'undefined' ||
+      typeof this.mediaProperties.audioTrack === 'undefined'
+    ) {
       return Promise.reject(new Error("Meeting doesn't have an audioTrack attached"));
     }
 
@@ -5931,20 +6085,23 @@ export default class Meeting extends StatelessWebexPlugin {
 
     const LOG_HEADER = 'Meeting:index#enableBNR -->';
 
-    return logRequest(this.effects.handleClientRequest(true, this)
-      .then((res) => {
-        LoggerProxy.logger.info('Meeting:index#enableBNR. Enable bnr completed');
+    return logRequest(
+      this.effects
+        .handleClientRequest(true, this)
+        .then((res) => {
+          LoggerProxy.logger.info('Meeting:index#enableBNR. Enable bnr completed');
 
-        return res;
-      })
-      .catch((error) => {
-        throw error;
-      }),
-    {
-      header: `${LOG_HEADER} enable bnr`,
-      success: `${LOG_HEADER} enable bnr success`,
-      failure: `${LOG_HEADER} enable bnr failure, `
-    });
+          return res;
+        })
+        .catch((error) => {
+          throw error;
+        }),
+      {
+        header: `${LOG_HEADER} enable bnr`,
+        success: `${LOG_HEADER} enable bnr success`,
+        failure: `${LOG_HEADER} enable bnr failure, `,
+      }
+    );
   }
 
   /**
@@ -5954,7 +6111,10 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   disableBNR() {
-    if (typeof this.mediaProperties === 'undefined' || typeof this.mediaProperties.audioTrack === 'undefined') {
+    if (
+      typeof this.mediaProperties === 'undefined' ||
+      typeof this.mediaProperties.audioTrack === 'undefined'
+    ) {
       return Promise.reject(new Error("Meeting doesn't have an audioTrack attached"));
     }
 
@@ -5966,20 +6126,23 @@ export default class Meeting extends StatelessWebexPlugin {
 
     const LOG_HEADER = 'Meeting:index#disableBNR -->';
 
-    return logRequest(this.effects.handleClientRequest(false, this)
-      .then((res) => {
-        LoggerProxy.logger.info('Meeting:index#disableBNR. Disable bnr completed');
+    return logRequest(
+      this.effects
+        .handleClientRequest(false, this)
+        .then((res) => {
+          LoggerProxy.logger.info('Meeting:index#disableBNR. Disable bnr completed');
 
-        return res;
-      })
-      .catch((error) => {
-        throw error;
-      }),
-    {
-      header: `${LOG_HEADER} disable bnr`,
-      success: `${LOG_HEADER} disable bnr success`,
-      failure: `${LOG_HEADER} disable bnr failure, `
-    });
+          return res;
+        })
+        .catch((error) => {
+          throw error;
+        }),
+      {
+        header: `${LOG_HEADER} disable bnr`,
+        success: `${LOG_HEADER} disable bnr success`,
+        failure: `${LOG_HEADER} disable bnr failure, `,
+      }
+    );
   }
 
   /**
@@ -5990,22 +6153,30 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   startKeepAlive = () => {
     if (this.keepAliveTimerId) {
-      LoggerProxy.logger.warn('Meeting:index#startKeepAlive --> keepAlive not started: keepAliveTimerId already exists');
+      LoggerProxy.logger.warn(
+        'Meeting:index#startKeepAlive --> keepAlive not started: keepAliveTimerId already exists'
+      );
 
       return;
     }
     if (!this.joinedWith?.keepAliveUrl) {
-      LoggerProxy.logger.warn('Meeting:index#startKeepAlive --> keepAlive not started: no keepAliveUrl');
+      LoggerProxy.logger.warn(
+        'Meeting:index#startKeepAlive --> keepAlive not started: no keepAliveUrl'
+      );
 
       return;
     }
     if (!this.joinedWith?.keepAliveSecs) {
-      LoggerProxy.logger.warn('Meeting:index#startKeepAlive --> keepAlive not started: no keepAliveSecs');
+      LoggerProxy.logger.warn(
+        'Meeting:index#startKeepAlive --> keepAlive not started: no keepAliveSecs'
+      );
 
       return;
     }
     if (this.joinedWith.keepAliveSecs <= 1) {
-      LoggerProxy.logger.warn('Meeting:index#startKeepAlive --> keepAlive not started: keepAliveSecs <= 1');
+      LoggerProxy.logger.warn(
+        'Meeting:index#startKeepAlive --> keepAlive not started: keepAliveSecs <= 1'
+      );
 
       return;
     }
@@ -6013,13 +6184,12 @@ export default class Meeting extends StatelessWebexPlugin {
     const keepAliveInterval = (this.joinedWith.keepAliveSecs - 1) * 750; // taken from UCF
 
     this.keepAliveTimerId = setInterval(() => {
-      this.meetingRequest.keepAlive({keepAliveUrl})
-        .catch((error) => {
-          LoggerProxy.logger.warn(
-            `Meeting:index#startKeepAlive --> Stopping sending keepAlives to ${keepAliveUrl} after error ${error}`
-          );
-          this.stopKeepAlive();
-        });
+      this.meetingRequest.keepAlive({keepAliveUrl}).catch((error) => {
+        LoggerProxy.logger.warn(
+          `Meeting:index#startKeepAlive --> Stopping sending keepAlives to ${keepAliveUrl} after error ${error}`
+        );
+        this.stopKeepAlive();
+      });
     }, keepAliveInterval);
   };
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -49,7 +49,7 @@ import {
   UserNotJoinedError,
   MeetingNotActiveError,
   UserInLobbyError,
-  NoMediaEstablishedYetError
+  NoMediaEstablishedYetError,
 } from '../../../../src/common/errors/webex-errors';
 import WebExMeetingsErrors from '../../../../src/common/errors/webex-meetings-error';
 import ParameterError from '../../../../src/common/errors/parameter';
@@ -58,11 +58,12 @@ import CaptchaError from '../../../../src/common/errors/captcha-error';
 import IntentToJoinError from '../../../../src/common/errors/intent-to-join';
 import DefaultSDKConfig from '../../../../src/config';
 import testUtils from '../../../utils/testUtils';
-import {MeetingInfoV2CaptchaError, MeetingInfoV2PasswordError} from '../../../../src/meeting-info/meeting-info-v2';
+import {
+  MeetingInfoV2CaptchaError,
+  MeetingInfoV2PasswordError,
+} from '../../../../src/meeting-info/meeting-info-v2';
 
-const {
-  getBrowserName
-} = BrowserDetection();
+const {getBrowserName} = BrowserDetection();
 
 // Non-stubbed function
 const {getDisplayMedia} = Media;
@@ -74,7 +75,7 @@ describe('plugin-meetings', () => {
     error: () => {},
     warn: () => {},
     trace: () => {},
-    debug: () => {}
+    debug: () => {},
   };
 
   beforeEach(() => {
@@ -86,44 +87,48 @@ describe('plugin-meetings', () => {
 
   before(() => {
     const MediaStream = {
-      getVideoTracks: () => [{
-        applyConstraints: () => { }
-      }]
+      getVideoTracks: () => [
+        {
+          applyConstraints: () => {},
+        },
+      ],
     };
 
     Object.defineProperty(global.window.navigator, 'mediaDevices', {
       writable: true,
       value: {
         getDisplayMedia: sinon.stub().returns(Promise.resolve(MediaStream)),
-        enumerateDevices: sinon.stub().returns(Promise.resolve([
-          {
-            deviceId: '',
-            kind: 'audioinput',
-            label: '',
-            groupId: '29d9339cc77bffdd24cb69ee80f6d3200481099bcd0f29267558672de0430777',
-          },
-          {
-            deviceId: '',
-            kind: 'videoinput',
-            label: '',
-            groupId: '08d4f8200e7e4a3425ecf75b7edea9ae4acd934019f2a52217554bcc8e46604d',
-          },
-          {
-            deviceId: '',
-            kind: 'audiooutput',
-            label: '',
-            groupId: '29d9339cc77bffdd24cb69ee80f6d3200481099bcd0f29267558672de0430777',
-          }
-        ])),
+        enumerateDevices: sinon.stub().returns(
+          Promise.resolve([
+            {
+              deviceId: '',
+              kind: 'audioinput',
+              label: '',
+              groupId: '29d9339cc77bffdd24cb69ee80f6d3200481099bcd0f29267558672de0430777',
+            },
+            {
+              deviceId: '',
+              kind: 'videoinput',
+              label: '',
+              groupId: '08d4f8200e7e4a3425ecf75b7edea9ae4acd934019f2a52217554bcc8e46604d',
+            },
+            {
+              deviceId: '',
+              kind: 'audiooutput',
+              label: '',
+              groupId: '29d9339cc77bffdd24cb69ee80f6d3200481099bcd0f29267558672de0430777',
+            },
+          ])
+        ),
         getSupportedConstraints: sinon.stub().returns({
-          sampleRate: true
-        })
+          sampleRate: true,
+        }),
       },
     });
 
     Object.defineProperty(global.window, 'MediaStream', {
       writable: true,
-      value: MediaStream
+      value: MediaStream,
     });
     LoggerConfig.set({verboseEvents: true, enable: false});
     LoggerProxy.set(logger);
@@ -148,32 +153,31 @@ describe('plugin-meetings', () => {
       children: {
         meetings: Meetings,
         credentials: Credentials,
-        support: Support
+        support: Support,
       },
       config: {
         credentials: {
-          client_id: 'mock-client-id'
+          client_id: 'mock-client-id',
         },
         meetings: {
           reconnection: {
-            enabled: false
+            enabled: false,
           },
           mediaSettings: {},
           metrics: {},
           stats: {},
-          experimental: {enableUnifiedMeetings: true}
+          experimental: {enableUnifiedMeetings: true},
         },
         metrics: {
-          type: ['behavioral']
-        }
-      }
+          type: ['behavioral'],
+        },
+      },
     });
 
     webex.internal.support.submitLogs = sinon.stub().returns(Promise.resolve());
     webex.credentials.getOrgId = sinon.stub().returns('fake-org-id');
     webex.internal.metrics.submitClientMetrics = sinon.stub().returns(Promise.resolve());
     webex.meetings.uploadLogs = sinon.stub().returns(Promise.resolve());
-
 
     TriggerProxy.trigger = sinon.stub().returns(true);
     Metrics.postEvent = sinon.stub();
@@ -203,7 +207,7 @@ describe('plugin-meetings', () => {
         destinationType: _MEETING_ID_,
       },
       {
-        parent: webex
+        parent: webex,
       }
     );
 
@@ -433,7 +437,6 @@ describe('plugin-meetings', () => {
           it('should return a promise resolution', async () => {
             meeting.audio = {handleClientRequest};
 
-
             const audio = meeting.unmuteAudio();
 
             assert.exists(audio.then);
@@ -450,8 +453,8 @@ describe('plugin-meetings', () => {
           readyState: 'live',
           enabled: true,
           getSettings: () => ({
-            sampleRate: 48000
-          })
+            sampleRate: 48000,
+          }),
         });
 
         beforeEach(() => {
@@ -459,7 +462,7 @@ describe('plugin-meetings', () => {
           sinon.replace(meeting, 'addMedia', () => {
             sinon.stub(meeting.mediaProperties, 'audioTrack').value(fakeMediaTrack());
             sinon.stub(meeting.mediaProperties, 'mediaDirection').value({
-              receiveAudio: true
+              receiveAudio: true,
             });
           });
         });
@@ -471,7 +474,7 @@ describe('plugin-meetings', () => {
           describe('before audio attached to meeting', () => {
             it('should throw no audio error', async () => {
               await meeting.enableBNR().catch((err) => {
-                assert.equal(err.toString(), 'Error: Meeting doesn\'t have an audioTrack attached');
+                assert.equal(err.toString(), "Error: Meeting doesn't have an audioTrack attached");
               });
             });
           });
@@ -519,7 +522,7 @@ describe('plugin-meetings', () => {
 
             it('should throw no audio error', async () => {
               await meeting.disableBNR().catch((err) => {
-                assert.equal(err.toString(), 'Error: Meeting doesn\'t have an audioTrack attached');
+                assert.equal(err.toString(), "Error: Meeting doesn't have an audioTrack attached");
               });
             });
           });
@@ -651,7 +654,10 @@ describe('plugin-meetings', () => {
       });
       describe('#getMediaStreams', () => {
         beforeEach(() => {
-          sinon.stub(Media, 'getSupportedDevice').callsFake((options) => Promise.resolve({sendAudio: options.sendAudio, sendVideo: options.sendVideo}));
+          sinon
+            .stub(Media, 'getSupportedDevice')
+            .callsFake((options) =>
+              Promise.resolve({sendAudio: options.sendAudio, sendVideo: options.sendVideo}));
           sinon.stub(Media, 'getUserMedia').returns(Promise.resolve(['stream1', 'stream2']));
         });
         afterEach(() => {
@@ -675,17 +681,20 @@ describe('plugin-meetings', () => {
           sinon.stub(meeting.mediaProperties, 'localQualityLevel').value('480p');
           await meeting.getMediaStreams(mediaDirection, audioVideoSettings);
 
-          assert.calledWith(Media.getUserMedia, {
-            ...mediaDirection,
-            isSharing: false
-          },
-          {
-            video: {
-              width: {max: 640, ideal: 640},
-              height: {max: 480, ideal: 480},
-              deviceId: videoDevice
+          assert.calledWith(
+            Media.getUserMedia,
+            {
+              ...mediaDirection,
+              isSharing: false,
+            },
+            {
+              video: {
+                width: {max: 640, ideal: 640},
+                height: {max: 480, ideal: 480},
+                deviceId: videoDevice,
+              },
             }
-          });
+          );
         });
         it('will set a new preferred video input device if passed in', async () => {
           // if audioVideo settings parameter specifies a new video device it
@@ -710,23 +719,26 @@ describe('plugin-meetings', () => {
             video: {
               width: {
                 max: 400,
-                ideal: 400
+                ideal: 400,
               },
               height: {
                 max: 200,
-                ideal: 200
-              }
-            }
+                ideal: 200,
+              },
+            },
           };
 
           sinon.stub(meeting.mediaProperties, 'localQualityLevel').value('200p');
           await meeting.getMediaStreams(mediaDirection, customAudioVideoSettings);
 
-          assert.calledWith(Media.getUserMedia, {
-            ...mediaDirection,
-            isSharing: false
-          },
-          customAudioVideoSettings);
+          assert.calledWith(
+            Media.getUserMedia,
+            {
+              ...mediaDirection,
+              isSharing: false,
+            },
+            customAudioVideoSettings
+          );
         });
         it('should not access camera if sendVideo is false ', async () => {
           await meeting.getMediaStreams({sendAudio: true, sendVideo: false});
@@ -774,7 +786,7 @@ describe('plugin-meetings', () => {
       describe('#stopReceivingTranscription', () => {
         it('should get invoked', () => {
           meeting.transcription = {
-            closeSocket: sinon.stub()
+            closeSocket: sinon.stub(),
           };
 
           meeting.stopReceivingTranscription();
@@ -809,7 +821,10 @@ describe('plugin-meetings', () => {
           it('should join the meeting and return promise', async () => {
             const join = meeting.join();
 
-            assert.calledWithMatch(Metrics.postEvent, {event: eventType.CALL_INITIATED, data: {trigger: trigger.USER_INTERACTION, isRoapCallEnabled: true}});
+            assert.calledWithMatch(Metrics.postEvent, {
+              event: eventType.CALL_INITIATED,
+              data: {trigger: trigger.USER_INTERACTION, isRoapCallEnabled: true},
+            });
 
             assert.exists(join.then);
             await join;
@@ -906,7 +921,7 @@ describe('plugin-meetings', () => {
       describe('#addMedia', () => {
         const muteStateStub = {
           handleClientRequest: sinon.stub().returns(Promise.resolve(true)),
-          applyClientStateLocally: sinon.stub().returns(Promise.resolve(true))
+          applyClientStateLocally: sinon.stub().returns(Promise.resolve(true)),
         };
 
         beforeEach(() => {
@@ -919,11 +934,16 @@ describe('plugin-meetings', () => {
           meeting.setMercuryListener = sinon.stub().returns(true);
           meeting.setRemoteStream = sinon.stub().returns(true);
           meeting.setMercuryListener = sinon.stub();
-          meeting.roap.sendRoapMediaRequest = sinon.stub().returns(new Promise((resolve) => {
-            meeting.mediaProperties.peerConnection.connectionState = CONSTANTS.CONNECTION_STATE.CONNECTED;
-            resolve();
-          }));
-          meeting.roap.doTurnDiscovery = sinon.stub().resolves({turnServerInfo: {}, turnDiscoverySkippedReason: undefined});
+          meeting.roap.sendRoapMediaRequest = sinon.stub().returns(
+            new Promise((resolve) => {
+              meeting.mediaProperties.peerConnection.connectionState =
+                CONSTANTS.CONNECTION_STATE.CONNECTED;
+              resolve();
+            })
+          );
+          meeting.roap.doTurnDiscovery = sinon
+            .stub()
+            .resolves({turnServerInfo: {}, turnDiscoverySkippedReason: undefined});
           PeerConnectionManager.setContentSlides = sinon.stub().returns(true);
         });
 
@@ -965,38 +985,34 @@ describe('plugin-meetings', () => {
             assert.exists(err);
             assert.isNull(meeting.statsAnalyzer);
             assert(Metrics.sendBehavioralMetric.calledOnce);
-            assert.calledWith(
-              Metrics.sendBehavioralMetric,
-              BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE, {
-                correlation_id: meeting.correlationId,
-                locus_id: meeting.locusUrl.split('/').pop(),
-                reason: err.message,
-                stack: err.stack,
-                code: err.code,
-                turnDiscoverySkippedReason: undefined,
-                turnServerUsed: true
-              }
-            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE, {
+              correlation_id: meeting.correlationId,
+              locus_id: meeting.locusUrl.split('/').pop(),
+              reason: err.message,
+              stack: err.stack,
+              code: err.code,
+              turnDiscoverySkippedReason: undefined,
+              turnServerUsed: true,
+            });
           });
         });
 
         it('checks metrics called with skipped reason config', async () => {
-          meeting.roap.doTurnDiscovery = sinon.stub().resolves({turnServerInfo: undefined, turnDiscoverySkippedReason: 'config'});
+          meeting.roap.doTurnDiscovery = sinon
+            .stub()
+            .resolves({turnServerInfo: undefined, turnDiscoverySkippedReason: 'config'});
           meeting.meetingState = 'ACTIVE';
           await meeting.addMedia().catch((err) => {
             assert.exists(err);
             assert(Metrics.sendBehavioralMetric.calledOnce);
-            assert.calledWith(
-              Metrics.sendBehavioralMetric,
-              BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE, {
-                correlation_id: meeting.correlationId,
-                locus_id: meeting.locusUrl.split('/').pop(),
-                reason: err.message,
-                stack: err.stack,
-                turnDiscoverySkippedReason: 'config',
-                turnServerUsed: false
-              }
-            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE, {
+              correlation_id: meeting.correlationId,
+              locus_id: meeting.locusUrl.split('/').pop(),
+              reason: err.message,
+              stack: err.stack,
+              turnDiscoverySkippedReason: 'config',
+              turnServerUsed: false,
+            });
           });
         });
 
@@ -1007,17 +1023,14 @@ describe('plugin-meetings', () => {
             assert.exists(err);
             assert.isNull(meeting.mediaProperties.peerConnection);
             assert(Metrics.sendBehavioralMetric.calledOnce);
-            assert.calledWith(
-              Metrics.sendBehavioralMetric,
-              BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE, {
-                correlation_id: meeting.correlationId,
-                locus_id: meeting.locusUrl.split('/').pop(),
-                reason: err.message,
-                stack: err.stack,
-                turnDiscoverySkippedReason: undefined,
-                turnServerUsed: true
-              }
-            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE, {
+              correlation_id: meeting.correlationId,
+              locus_id: meeting.locusUrl.split('/').pop(),
+              reason: err.message,
+              stack: err.stack,
+              turnDiscoverySkippedReason: undefined,
+              turnServerUsed: true,
+            });
           });
         });
 
@@ -1034,7 +1047,7 @@ describe('plugin-meetings', () => {
 
           try {
             await meeting.addMedia({
-              mediaSettings: {}
+              mediaSettings: {},
             });
           }
           catch (err) {
@@ -1044,12 +1057,15 @@ describe('plugin-meetings', () => {
 
         it('if an error occurs after media request has already been sent, and the user waits until the server kicks them out, a UserNotJoinedError should be thrown when attempting to addMedia again', async () => {
           meeting.meetingState = 'ACTIVE';
-          meeting.roap.sendRoapMediaRequest = sinon.stub().returns(new Promise((resolve) => {
-            meeting.mediaProperties.peerConnection.connectionState = CONSTANTS.CONNECTION_STATE.CONNECTED;
-            resolve();
-          }).then(() => {
-            throw new Error('sample error thrown');
-          }));
+          meeting.roap.sendRoapMediaRequest = sinon.stub().returns(
+            new Promise((resolve) => {
+              meeting.mediaProperties.peerConnection.connectionState =
+                CONSTANTS.CONNECTION_STATE.CONNECTED;
+              resolve();
+            }).then(() => {
+              throw new Error('sample error thrown');
+            })
+          );
           await meeting.addMedia().catch((err) => {
             assert.exists(err);
           });
@@ -1062,33 +1078,41 @@ describe('plugin-meetings', () => {
 
         it('if an error occurs after media request has already been sent, and the user does NOT wait until the server kicks them out, the user should be able to addMedia successfully', async () => {
           meeting.meetingState = 'ACTIVE';
-          meeting.roap.sendRoapMediaRequest = sinon.stub().returns(new Promise((resolve) => {
-            meeting.mediaProperties.peerConnection.connectionState = CONSTANTS.CONNECTION_STATE.CONNECTED;
-            resolve();
-          }).then(() => {
-            throw new Error('sample error thrown');
-          }));
+          meeting.roap.sendRoapMediaRequest = sinon.stub().returns(
+            new Promise((resolve) => {
+              meeting.mediaProperties.peerConnection.connectionState =
+                CONSTANTS.CONNECTION_STATE.CONNECTED;
+              resolve();
+            }).then(() => {
+              throw new Error('sample error thrown');
+            })
+          );
           await meeting.addMedia().catch((err) => {
             assert.exists(err);
           });
 
           meeting.mediaProperties.peerConnection = {};
-          meeting.roap.sendRoapMediaRequest = sinon.stub().returns(new Promise((resolve) => {
-            meeting.mediaProperties.peerConnection.connectionState = CONSTANTS.CONNECTION_STATE.CONNECTED;
-            resolve();
-          }));
+          meeting.roap.sendRoapMediaRequest = sinon.stub().returns(
+            new Promise((resolve) => {
+              meeting.mediaProperties.peerConnection.connectionState =
+                CONSTANTS.CONNECTION_STATE.CONNECTED;
+              resolve();
+            })
+          );
           await meeting.addMedia().catch((err) => {
             assert.fail('No error should appear: ', err);
           });
         });
 
         it('should attach the media and return promise', async () => {
-          meeting.roap.doTurnDiscovery = sinon.stub().resolves({turnServerInfo: undefined, turnDiscoverySkippedReason: undefined});
+          meeting.roap.doTurnDiscovery = sinon
+            .stub()
+            .resolves({turnServerInfo: undefined, turnDiscoverySkippedReason: undefined});
 
           meeting.meetingState = 'ACTIVE';
           MediaUtil.createPeerConnection.resetHistory();
           const media = meeting.addMedia({
-            mediaSettings: {}
+            mediaSettings: {},
           });
 
           assert.exists(media);
@@ -1103,8 +1127,8 @@ describe('plugin-meetings', () => {
           assert.calledOnce(MediaUtil.createPeerConnection);
           assert.calledWith(MediaUtil.createPeerConnection, undefined);
           /* statsAnalyzer is initiated inside of addMedia so there isn't
-          * a good way to mock it without mocking the constructor
-          */
+           * a good way to mock it without mocking the constructor
+           */
         });
 
         it('should pass the turn server info to the peer connection', async () => {
@@ -1115,17 +1139,16 @@ describe('plugin-meetings', () => {
           meeting.meetingState = 'ACTIVE';
           MediaUtil.createPeerConnection.resetHistory();
 
-
           meeting.roap.doTurnDiscovery = sinon.stub().resolves({
             turnServerInfo: {
               url: FAKE_TURN_URL,
               username: FAKE_TURN_USER,
-              password: FAKE_TURN_PASSWORD
+              password: FAKE_TURN_PASSWORD,
             },
-            turnServerSkippedReason: undefined
+            turnServerSkippedReason: undefined,
           });
           const media = meeting.addMedia({
-            mediaSettings: {}
+            mediaSettings: {},
           });
 
           assert.exists(media);
@@ -1136,16 +1159,18 @@ describe('plugin-meetings', () => {
           assert.calledWith(MediaUtil.createPeerConnection, {
             url: FAKE_TURN_URL,
             username: FAKE_TURN_USER,
-            password: FAKE_TURN_PASSWORD
+            password: FAKE_TURN_PASSWORD,
           });
         });
 
         it('should attach the media and return promise', async () => {
-          meeting.roap.doTurnDiscovery = sinon.stub().resolves({turnServerInfo: undefined, turnDiscoverySkippedReason: undefined});
+          meeting.roap.doTurnDiscovery = sinon
+            .stub()
+            .resolves({turnServerInfo: undefined, turnDiscoverySkippedReason: undefined});
           meeting.meetingState = 'ACTIVE';
           meeting.mediaProperties.peerConnection.connectionState = 'DISCONNECTED';
           const media = meeting.addMedia({
-            mediaSettings: {}
+            mediaSettings: {},
           });
 
           assert.exists(media);
@@ -1160,9 +1185,10 @@ describe('plugin-meetings', () => {
 
           let errorThrown = false;
 
-          await meeting.addMedia({
-            mediaSettings: {}
-          })
+          await meeting
+            .addMedia({
+              mediaSettings: {},
+            })
             .catch((error) => {
               assert.equal(error.code, IceGatheringFailed.CODE);
               errorThrown = true;
@@ -1174,19 +1200,15 @@ describe('plugin-meetings', () => {
         it('should send ADD_MEDIA_SUCCESS metrics', async () => {
           meeting.meetingState = 'ACTIVE';
           await meeting.addMedia({
-            mediaSettings: {}
+            mediaSettings: {},
           });
 
           assert.calledOnce(Metrics.sendBehavioralMetric);
-          assert.calledWith(
-            Metrics.sendBehavioralMetric,
-            BEHAVIORAL_METRICS.ADD_MEDIA_SUCCESS,
-            {
-              correlation_id: meeting.correlationId,
-              locus_id: meeting.locusUrl.split('/').pop(),
-              connectionType: 'udp'
-            }
-          );
+          assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.ADD_MEDIA_SUCCESS, {
+            correlation_id: meeting.correlationId,
+            locus_id: meeting.locusUrl.split('/').pop(),
+            connectionType: 'udp',
+          });
         });
 
         describe('handles StatsAnalyzer events', () => {
@@ -1204,7 +1226,7 @@ describe('plugin-meetings', () => {
             sinon.stub(StatsAnalyzerModule, 'StatsAnalyzer').returns(statsAnalyzerStub);
 
             await meeting.addMedia({
-              mediaSettings: {}
+              mediaSettings: {},
             });
           });
 
@@ -1213,51 +1235,79 @@ describe('plugin-meetings', () => {
           });
 
           it('LOCAL_MEDIA_STARTED triggers "meeting:media:local:start" event and sends metrics', async () => {
-            statsAnalyzerStub.emit({file: 'test', function: 'test'}, StatsAnalyzerModule.EVENTS.LOCAL_MEDIA_STARTED, {type: 'audio'});
+            statsAnalyzerStub.emit(
+              {file: 'test', function: 'test'},
+              StatsAnalyzerModule.EVENTS.LOCAL_MEDIA_STARTED,
+              {type: 'audio'}
+            );
 
             assert.calledWith(
               TriggerProxy.trigger,
               sinon.match.instanceOf(Meeting),
               {
                 file: 'meeting/index',
-                function: 'addMedia'
+                function: 'addMedia',
               },
               EVENT_TRIGGERS.MEETING_MEDIA_LOCAL_STARTED,
               {
-                type: 'audio'
+                type: 'audio',
               }
             );
-            assert.calledWithMatch(Metrics.postEvent, {event: eventType.SENDING_MEDIA_START, data: {mediaType: 'audio'}});
+            assert.calledWithMatch(Metrics.postEvent, {
+              event: eventType.SENDING_MEDIA_START,
+              data: {mediaType: 'audio'},
+            });
           });
 
           it('LOCAL_MEDIA_STOPPED triggers the right metrics', async () => {
-            statsAnalyzerStub.emit({file: 'test', function: 'test'}, StatsAnalyzerModule.EVENTS.LOCAL_MEDIA_STOPPED, {type: 'video'});
+            statsAnalyzerStub.emit(
+              {file: 'test', function: 'test'},
+              StatsAnalyzerModule.EVENTS.LOCAL_MEDIA_STOPPED,
+              {type: 'video'}
+            );
 
-            assert.calledWithMatch(Metrics.postEvent, {event: eventType.SENDING_MEDIA_STOP, data: {mediaType: 'video'}});
+            assert.calledWithMatch(Metrics.postEvent, {
+              event: eventType.SENDING_MEDIA_STOP,
+              data: {mediaType: 'video'},
+            });
           });
 
           it('REMOTE_MEDIA_STARTED triggers "meeting:media:remote:start" event and sends metrics', async () => {
-            statsAnalyzerStub.emit({file: 'test', function: 'test'}, StatsAnalyzerModule.EVENTS.REMOTE_MEDIA_STARTED, {type: 'video'});
+            statsAnalyzerStub.emit(
+              {file: 'test', function: 'test'},
+              StatsAnalyzerModule.EVENTS.REMOTE_MEDIA_STARTED,
+              {type: 'video'}
+            );
 
             assert.calledWith(
               TriggerProxy.trigger,
               sinon.match.instanceOf(Meeting),
               {
                 file: 'meeting/index',
-                function: 'addMedia'
+                function: 'addMedia',
               },
               EVENT_TRIGGERS.MEETING_MEDIA_REMOTE_STARTED,
               {
-                type: 'video'
+                type: 'video',
               }
             );
-            assert.calledWithMatch(Metrics.postEvent, {event: eventType.RECEIVING_MEDIA_START, data: {mediaType: 'video'}});
+            assert.calledWithMatch(Metrics.postEvent, {
+              event: eventType.RECEIVING_MEDIA_START,
+              data: {mediaType: 'video'},
+            });
           });
 
           it('REMOTE_MEDIA_STOPPED triggers the right metrics', async () => {
-            statsAnalyzerStub.emit({file: 'test', function: 'test'}, StatsAnalyzerModule.EVENTS.REMOTE_MEDIA_STOPPED, {type: 'audio'});
+            statsAnalyzerStub.emit(
+              {file: 'test', function: 'test'},
+              StatsAnalyzerModule.EVENTS.REMOTE_MEDIA_STOPPED,
+              {type: 'audio'}
+            );
 
-            assert.calledWithMatch(Metrics.postEvent, {event: eventType.RECEIVING_MEDIA_STOP, data: {mediaType: 'audio'}});
+            assert.calledWithMatch(Metrics.postEvent, {
+              event: eventType.RECEIVING_MEDIA_STOP,
+              data: {mediaType: 'audio'},
+            });
           });
 
           it('MEDIA_QUALITY triggers the right metrics', async () => {
@@ -1269,7 +1319,10 @@ describe('plugin-meetings', () => {
               {data: fakeData, networkType: 'wifi'}
             );
 
-            assert.calledWithMatch(Metrics.postEvent, {event: eventType.MEDIA_QUALITY, data: {intervalData: fakeData, networkType: 'wifi'}});
+            assert.calledWithMatch(Metrics.postEvent, {
+              event: eventType.MEDIA_QUALITY,
+              data: {intervalData: fakeData, networkType: 'wifi'},
+            });
           });
         });
       });
@@ -1332,7 +1385,9 @@ describe('plugin-meetings', () => {
           sandbox = sinon.createSandbox();
           meeting.meetingFiniteStateMachine.ring();
           meeting.meetingFiniteStateMachine.join();
-          meeting.meetingRequest.leaveMeeting = sinon.stub().returns(Promise.resolve({body: 'test'}));
+          meeting.meetingRequest.leaveMeeting = sinon
+            .stub()
+            .returns(Promise.resolve({body: 'test'}));
           meeting.locusInfo.onFullLocus = sinon.stub().returns(true);
           // the 3 need to be promises because we do closeLocalStream.then(closeLocalShare.then) etc in the src code
           meeting.closeLocalStream = sinon.stub().returns(Promise.resolve());
@@ -1403,7 +1458,7 @@ describe('plugin-meetings', () => {
             correlationId: meeting.correlationId,
             selfId: meeting.selfId,
             resourceId: null,
-            deviceUrl: meeting.deviceUrl
+            deviceUrl: meeting.deviceUrl,
           });
         });
         it('should leave the meeting on the resource', async () => {
@@ -1416,7 +1471,7 @@ describe('plugin-meetings', () => {
             correlationId: meeting.correlationId,
             selfId: meeting.selfId,
             resourceId: meeting.resourceId,
-            deviceUrl: meeting.deviceUrl
+            deviceUrl: meeting.deviceUrl,
           });
         });
       });
@@ -1443,7 +1498,9 @@ describe('plugin-meetings', () => {
 
         beforeEach(() => {
           _mediaDirection = meeting.mediaProperties.mediaDirection || {};
-          sinon.stub(meeting.mediaProperties, 'mediaDirection').value({sendAudio: true, sendVideo: true, sendShare: false});
+          sinon
+            .stub(meeting.mediaProperties, 'mediaDirection')
+            .value({sendAudio: true, sendVideo: true, sendShare: false});
         });
 
         afterEach(() => {
@@ -1480,7 +1537,11 @@ describe('plugin-meetings', () => {
           it('properly assigns default values', async () => {
             await meeting.shareScreen({sharePreferences: {highFrameRate: true}});
 
-            assert.calledWith(Media.getDisplayMedia, {sendShare: true, sendAudio: false, sharePreferences: {highFrameRate: true}});
+            assert.calledWith(Media.getDisplayMedia, {
+              sendShare: true,
+              sendAudio: false,
+              sharePreferences: {highFrameRate: true},
+            });
           });
         });
 
@@ -1505,10 +1566,10 @@ describe('plugin-meetings', () => {
                   track: {
                     get readyState() {
                       return _trackReadyState;
-                    }
-                  }
-                }
-              }
+                    },
+                  },
+                },
+              },
             });
           });
 
@@ -1566,18 +1627,17 @@ describe('plugin-meetings', () => {
               sendShare,
               receiveShare,
               stream,
-              skipSignalingCheck: true
+              skipSignalingCheck: true,
             });
 
             assert.notCalled(meeting.canUpdateMedia);
           });
 
-
           it('skips canUpdateMedia() check on contentTracks.onended', () => {
             const {mediaProperties} = meeting;
             const fakeTrack = {
               getSettings: sinon.stub().returns({}),
-              onended: sinon.stub()
+              onended: sinon.stub(),
             };
 
             sandbox.stub(mediaProperties, 'setLocalShareTrack');
@@ -1591,12 +1651,11 @@ describe('plugin-meetings', () => {
             assert.calledWith(meeting.stopShare, {skipSignalingCheck: true});
           });
 
-
           it('stopShare accepts and passes along optional parameters', () => {
             const args = {
               abc: 123,
               receiveShare: false,
-              sendShare: false
+              sendShare: false,
             };
 
             sandbox.stub(meeting, 'updateShare').returns(Promise.resolve());
@@ -1639,8 +1698,8 @@ describe('plugin-meetings', () => {
             sandbox.stub(meeting, 'handleShareTrackEnded');
             sandbox.stub(meeting.mediaProperties, 'peerConnection').value({
               shareTransceiver: {
-                direction: SENDRECV
-              }
+                direction: SENDRECV,
+              },
             });
             sandbox.useFakeTimers();
 
@@ -1648,7 +1707,7 @@ describe('plugin-meetings', () => {
               sendShare,
               receiveShare,
               stream,
-              skipSignalingCheck: true
+              skipSignalingCheck: true,
             });
             // simulate the setTimeout in code
             sandbox.clock.tick(delay);
@@ -1669,12 +1728,12 @@ describe('plugin-meetings', () => {
               sinon.match.instanceOf(Meeting),
               {
                 file: 'meeting/index',
-                function: 'handleShareTrackEnded'
+                function: 'handleShareTrackEnded',
               },
               EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
               {
                 stream,
-                type: EVENT_TYPES.LOCAL_SHARE
+                type: EVENT_TYPES.LOCAL_SHARE,
               }
             );
           });
@@ -1687,20 +1746,22 @@ describe('plugin-meetings', () => {
         const {resolution} = config;
         const shareOptions = {
           sendShare: true,
-          sendAudio: false
+          sendAudio: false,
         };
         const fireFoxOptions = {
           audio: false,
           video: {
             audio: shareOptions.sendAudio,
-            video: shareOptions.sendShare
-          }
+            video: shareOptions.sendShare,
+          },
         };
 
         const MediaStream = {
-          getVideoTracks: () => [{
-            applyConstraints: () => {}
-          }]
+          getVideoTracks: () => [
+            {
+              applyConstraints: () => {},
+            },
+          ],
         };
 
         const MediaConstraint = {
@@ -1708,7 +1769,7 @@ describe('plugin-meetings', () => {
           aspectRatio: config.aspectRatio,
           frameRate: config.screenFrameRate,
           width: null,
-          height: null
+          height: null,
         };
 
         const browserConditionalValue = (value) => {
@@ -1724,31 +1785,23 @@ describe('plugin-meetings', () => {
           if (!global.navigator) {
             global.navigator = {
               mediaDevices: {
-                getDisplayMedia: null
-              }
+                getDisplayMedia: null,
+              },
             };
           }
           _getDisplayMedia = global.navigator.mediaDevices.getDisplayMedia;
-          Object.defineProperty(
-            global.navigator.mediaDevices,
-            'getDisplayMedia',
-            {
-              value: sinon.stub().returns(Promise.resolve(MediaStream)),
-              writable: true
-            }
-          );
+          Object.defineProperty(global.navigator.mediaDevices, 'getDisplayMedia', {
+            value: sinon.stub().returns(Promise.resolve(MediaStream)),
+            writable: true,
+          });
         });
 
         after(() => {
           // clean up for browser
-          Object.defineProperty(
-            global.navigator.mediaDevices,
-            'getDisplayMedia',
-            {
-              value: _getDisplayMedia,
-              writable: true
-            }
-          );
+          Object.defineProperty(global.navigator.mediaDevices, 'getDisplayMedia', {
+            value: _getDisplayMedia,
+            writable: true,
+          });
         });
 
         // eslint-disable-next-line max-len
@@ -1760,39 +1813,48 @@ describe('plugin-meetings', () => {
             maxWidth: SHARE_WIDTH,
             maxHeight: SHARE_HEIGHT,
             idealWidth: SHARE_WIDTH,
-            idealHeight: SHARE_HEIGHT
+            idealHeight: SHARE_HEIGHT,
           };
 
           // If sharePreferences.shareConstraints is defined it ignores
           // default SDK config settings
-          getDisplayMedia({
-            ...shareOptions,
-            sharePreferences: {shareConstraints}
-          }, config);
+          getDisplayMedia(
+            {
+              ...shareOptions,
+              sharePreferences: {shareConstraints},
+            },
+            config
+          );
 
           // eslint-disable-next-line no-undef
-          assert.calledWith(navigator.mediaDevices.getDisplayMedia,
+          assert.calledWith(
+            global.navigator.mediaDevices.getDisplayMedia,
             browserConditionalValue({
               default: {
-                video: {...shareConstraints}
+                video: {...shareConstraints},
               },
               // Firefox is being handled differently
-              firefox: fireFoxOptions
-            }));
+              firefox: fireFoxOptions,
+            })
+          );
         });
 
         // eslint-disable-next-line max-len
         it('will use default resolution if shareConstraints is undefined and highFrameRate is defined', () => {
           // If highFrameRate is defined it ignores default SDK config settings
-          getDisplayMedia({
-            ...shareOptions,
-            sharePreferences: {
-              highFrameRate: true
-            }
-          }, config);
+          getDisplayMedia(
+            {
+              ...shareOptions,
+              sharePreferences: {
+                highFrameRate: true,
+              },
+            },
+            config
+          );
 
           // eslint-disable-next-line no-undef
-          assert.calledWith(navigator.mediaDevices.getDisplayMedia,
+          assert.calledWith(
+            global.navigator.mediaDevices.getDisplayMedia,
             browserConditionalValue({
               default: {
                 video: {
@@ -1803,11 +1865,12 @@ describe('plugin-meetings', () => {
                   maxWidth: resolution.maxWidth,
                   maxHeight: resolution.maxHeight,
                   idealWidth: resolution.idealWidth,
-                  idealHeight: resolution.idealHeight
-                }
+                  idealHeight: resolution.idealHeight,
+                },
               },
-              firefox: fireFoxOptions
-            }));
+              firefox: fireFoxOptions,
+            })
+          );
         });
 
         // eslint-disable-next-line max-len
@@ -1816,17 +1879,19 @@ describe('plugin-meetings', () => {
           const {screenResolution} = config;
 
           // eslint-disable-next-line no-undef
-          assert.calledWith(navigator.mediaDevices.getDisplayMedia,
+          assert.calledWith(
+            global.navigator.mediaDevices.getDisplayMedia,
             browserConditionalValue({
               default: {
                 video: {
                   ...MediaConstraint,
                   width: screenResolution.idealWidth,
-                  height: screenResolution.idealHeight
-                }
+                  height: screenResolution.idealHeight,
+                },
               },
-              firefox: fireFoxOptions
-            }));
+              firefox: fireFoxOptions,
+            })
+          );
         });
 
         // Test screenResolution
@@ -1839,14 +1904,15 @@ describe('plugin-meetings', () => {
               maxWidth: SHARE_WIDTH,
               maxHeight: SHARE_HEIGHT,
               idealWidth: SHARE_WIDTH,
-              idealHeight: SHARE_HEIGHT
-            }
+              idealHeight: SHARE_HEIGHT,
+            },
           };
 
           getDisplayMedia(shareOptions, customConfig);
 
           // eslint-disable-next-line no-undef
-          assert.calledWith(navigator.mediaDevices.getDisplayMedia,
+          assert.calledWith(
+            global.navigator.mediaDevices.getDisplayMedia,
             browserConditionalValue({
               default: {
                 video: {
@@ -1856,11 +1922,12 @@ describe('plugin-meetings', () => {
                   maxWidth: SHARE_WIDTH,
                   maxHeight: SHARE_HEIGHT,
                   idealWidth: SHARE_WIDTH,
-                  idealHeight: SHARE_HEIGHT
-                }
+                  idealHeight: SHARE_HEIGHT,
+                },
               },
-              firefox: fireFoxOptions
-            }));
+              firefox: fireFoxOptions,
+            })
+          );
         });
 
         // Test screenFrameRate
@@ -1873,14 +1940,15 @@ describe('plugin-meetings', () => {
               maxWidth: SHARE_WIDTH,
               maxHeight: SHARE_HEIGHT,
               idealWidth: SHARE_WIDTH,
-              idealHeight: SHARE_HEIGHT
-            }
+              idealHeight: SHARE_HEIGHT,
+            },
           };
 
           getDisplayMedia(shareOptions, customConfig);
 
           // eslint-disable-next-line no-undef
-          assert.calledWith(navigator.mediaDevices.getDisplayMedia,
+          assert.calledWith(
+            global.navigator.mediaDevices.getDisplayMedia,
             browserConditionalValue({
               default: {
                 video: {
@@ -1891,11 +1959,12 @@ describe('plugin-meetings', () => {
                   maxWidth: SHARE_WIDTH,
                   maxHeight: SHARE_HEIGHT,
                   idealWidth: SHARE_WIDTH,
-                  idealHeight: SHARE_HEIGHT
-                }
+                  idealHeight: SHARE_HEIGHT,
+                },
               },
-              firefox: fireFoxOptions
-            }));
+              firefox: fireFoxOptions,
+            })
+          );
         });
       });
 
@@ -1931,12 +2000,15 @@ describe('plugin-meetings', () => {
                 MeetingUtil.updateTransceiver = sinon.stub();
               });
 
-              it('sets previousMediaDirection to an empty object', () => meeting.updateAudio({
-                sendAudio: true,
-                receiveAudio: true
-              }).then(() => {
-                assert.calledOnce(MeetingUtil.updateTransceiver);
-              }));
+              it('sets previousMediaDirection to an empty object', () =>
+                meeting
+                  .updateAudio({
+                    sendAudio: true,
+                    receiveAudio: true,
+                  })
+                  .then(() => {
+                    assert.calledOnce(MeetingUtil.updateTransceiver);
+                  }));
             });
           });
         });
@@ -1954,7 +2026,7 @@ describe('plugin-meetings', () => {
 
           meeting.locusInfo.self = {
             enableDTMF: true,
-            url: url2
+            url: url2,
           };
 
           await meeting.sendDTMF(tones);
@@ -1962,7 +2034,7 @@ describe('plugin-meetings', () => {
           assert.calledWith(meeting.meetingRequest.sendDTMF, {
             locusUrl: meeting.locusInfo.self.url,
             deviceUrl: meeting.deviceUrl,
-            tones
+            tones,
           });
         });
 
@@ -1976,7 +2048,7 @@ describe('plugin-meetings', () => {
           it('should throw an error', () => {
             meeting.locusInfo.self = {
               enableDTMF: false,
-              url: url2
+              url: url2,
             };
 
             assert.isRejected(meeting.sendDTMF('123'));
@@ -2007,7 +2079,7 @@ describe('plugin-meetings', () => {
             receiveVideo: true,
             sendShare: true,
             receiveShare: true,
-            isSharing: true
+            isSharing: true,
           };
 
           sandbox.stub(meeting, 'canUpdateMedia').returns(false);
@@ -2015,11 +2087,12 @@ describe('plugin-meetings', () => {
 
           let myPromiseResolved = false;
 
-          meeting.updateMedia({
-            localStream: mockLocalStream,
-            localShare: mockLocalShare,
-            mediaSettings
-          })
+          meeting
+            .updateMedia({
+              localStream: mockLocalStream,
+              localShare: mockLocalShare,
+              mediaSettings,
+            })
             .then(() => {
               myPromiseResolved = true;
             });
@@ -2036,7 +2109,11 @@ describe('plugin-meetings', () => {
           await testUtils.flushPromises();
 
           // and check that meeting.updateMedia is called with the original args
-          assert.calledWith(meeting.updateMedia, {localStream: mockLocalStream, localShare: mockLocalShare, mediaSettings});
+          assert.calledWith(meeting.updateMedia, {
+            localStream: mockLocalStream,
+            localShare: mockLocalShare,
+            mediaSettings,
+          });
           assert.isTrue(myPromiseResolved);
         });
       });
@@ -2051,17 +2128,21 @@ describe('plugin-meetings', () => {
               sendAudio: true,
               sendVideo: true,
               sendShare: false,
-              receiveVideo: true
+              receiveVideo: true,
             };
             meeting.getMediaStreams = sinon.stub().returns(Promise.resolve([]));
             meeting.updateVideo = sinon.stub().returns(Promise.resolve());
             meeting.mediaProperties.mediaDirection = mediaDirection;
-            meeting.mediaProperties.remoteVideoTrack = sinon.stub().returns({mockTrack: 'mockTrack'});
+            meeting.mediaProperties.remoteVideoTrack = sinon
+              .stub()
+              .returns({mockTrack: 'mockTrack'});
 
-            meeting.meetingRequest.changeVideoLayoutDebounced = sinon.stub().returns(Promise.resolve());
+            meeting.meetingRequest.changeVideoLayoutDebounced = sinon
+              .stub()
+              .returns(Promise.resolve());
 
             meeting.locusInfo.self = {
-              url: url2
+              url: url2,
             };
           });
 
@@ -2090,11 +2171,11 @@ describe('plugin-meetings', () => {
               deviceUrl: meeting.deviceUrl,
               layoutType,
               main: undefined,
-              content: undefined
+              content: undefined,
             });
           });
 
-          it('doesn\'t have layoutType which exists in the list of allowed layoutTypes should throw an error', async () => {
+          it("doesn't have layoutType which exists in the list of allowed layoutTypes should throw an error", async () => {
             const layoutType = 'Invalid Layout';
 
             assert.isRejected(meeting.changeVideoLayout(layoutType));
@@ -2108,12 +2189,14 @@ describe('plugin-meetings', () => {
               deviceUrl: meeting.deviceUrl,
               layoutType: undefined,
               main: {width: 100, height: 200},
-              content: undefined
+              content: undefined,
             });
           });
 
           it('throws if trying to send renderInfo for content when not receiving content', async () => {
-            assert.isRejected(meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1280, height: 720}}));
+            assert.isRejected(
+              meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1280, height: 720}})
+            );
           });
 
           it('calls changeVideoLayoutDebounced with renderInfo for main and content', async () => {
@@ -2125,7 +2208,7 @@ describe('plugin-meetings', () => {
               deviceUrl: meeting.deviceUrl,
               layoutType: layoutTypeSingle,
               main: {width: 100, height: 200},
-              content: undefined
+              content: undefined,
             });
 
             meeting.mediaProperties.mediaDirection.receiveShare = true;
@@ -2139,18 +2222,21 @@ describe('plugin-meetings', () => {
               deviceUrl: meeting.deviceUrl,
               layoutType: layoutTypeSingle,
               main: {width: 100, height: 200},
-              content: {width: 500, height: 600}
+              content: {width: 500, height: 600},
             });
 
             // and now call with both
-            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 300, height: 400}, content: {width: 700, height: 800}});
+            await meeting.changeVideoLayout(layoutTypeSingle, {
+              main: {width: 300, height: 400},
+              content: {width: 700, height: 800},
+            });
 
             assert.calledWith(meeting.meetingRequest.changeVideoLayoutDebounced, {
               locusUrl: meeting.locusInfo.self.url,
               deviceUrl: meeting.deviceUrl,
               layoutType: layoutTypeSingle,
               main: {width: 300, height: 400},
-              content: {width: 700, height: 800}
+              content: {width: 700, height: 800},
             });
 
             // and now set just the layoutType, the previous main and content values should be used
@@ -2163,7 +2249,7 @@ describe('plugin-meetings', () => {
               deviceUrl: meeting.deviceUrl,
               layoutType,
               main: {width: 300, height: 400},
-              content: {width: 700, height: 800}
+              content: {width: 700, height: 800},
             });
           });
 
@@ -2175,7 +2261,7 @@ describe('plugin-meetings', () => {
               deviceUrl: meeting.deviceUrl,
               layoutType: layoutTypeSingle,
               main: {width: 1024, height: 768},
-              content: undefined
+              content: undefined,
             });
             meeting.meetingRequest.changeVideoLayoutDebounced.resetHistory();
 
@@ -2197,28 +2283,39 @@ describe('plugin-meetings', () => {
             meeting.mediaProperties.mediaDirection.receiveShare = true;
             meeting.mediaProperties.remoteShare = sinon.stub().returns({mockTrack: 'mockTrack'});
 
-            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 500, height: 510}, content: {width: 1024, height: 768}});
+            await meeting.changeVideoLayout(layoutTypeSingle, {
+              main: {width: 500, height: 510},
+              content: {width: 1024, height: 768},
+            });
 
             assert.calledWith(meeting.meetingRequest.changeVideoLayoutDebounced, {
               locusUrl: meeting.locusInfo.self.url,
               deviceUrl: meeting.deviceUrl,
               layoutType: layoutTypeSingle,
               main: {width: 500, height: 510},
-              content: {width: 1024, height: 768}
+              content: {width: 1024, height: 768},
             });
             meeting.meetingRequest.changeVideoLayoutDebounced.resetHistory();
 
             // now send main with width/height different by just 2px - it should be ignored
-            await meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1026, height: 768}});
+            await meeting.changeVideoLayout(layoutTypeSingle, {
+              content: {width: 1026, height: 768},
+            });
             assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
 
-            await meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1022, height: 768}});
+            await meeting.changeVideoLayout(layoutTypeSingle, {
+              content: {width: 1022, height: 768},
+            });
             assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
 
-            await meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1024, height: 770}});
+            await meeting.changeVideoLayout(layoutTypeSingle, {
+              content: {width: 1024, height: 770},
+            });
             assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
 
-            await meeting.changeVideoLayout(layoutTypeSingle, {content: {width: 1024, height: 766}});
+            await meeting.changeVideoLayout(layoutTypeSingle, {
+              content: {width: 1024, height: 766},
+            });
             assert.notCalled(meeting.meetingRequest.changeVideoLayoutDebounced);
           });
 
@@ -2226,14 +2323,17 @@ describe('plugin-meetings', () => {
             meeting.mediaProperties.mediaDirection.receiveShare = true;
             meeting.mediaProperties.remoteShare = sinon.stub().returns({mockTrack: 'mockTrack'});
 
-            await meeting.changeVideoLayout(layoutTypeSingle, {main: {width: 500.5, height: 510.09}, content: {width: 1024.2, height: 768.85}});
+            await meeting.changeVideoLayout(layoutTypeSingle, {
+              main: {width: 500.5, height: 510.09},
+              content: {width: 1024.2, height: 768.85},
+            });
 
             assert.calledWith(meeting.meetingRequest.changeVideoLayoutDebounced, {
               locusUrl: meeting.locusInfo.self.url,
               deviceUrl: meeting.deviceUrl,
               layoutType: layoutTypeSingle,
               main: {width: 501, height: 510},
-              content: {width: 1024, height: 769}
+              content: {width: 1024, height: 769},
             });
           });
         });
@@ -2245,7 +2345,7 @@ describe('plugin-meetings', () => {
             sendAudio: true,
             sendVideo: true,
             sendShare: false,
-            receiveVideo: true
+            receiveVideo: true,
           };
 
           meeting.mediaProperties.mediaDirection = mediaDirection;
@@ -2259,7 +2359,7 @@ describe('plugin-meetings', () => {
             sendAudio: true,
             sendVideo: true,
             sendShare: false,
-            receiveVideo: false
+            receiveVideo: false,
           };
 
           meeting.mediaProperties.mediaDirection = mediaDirection;
@@ -2273,8 +2373,8 @@ describe('plugin-meetings', () => {
 
         const fakeTrack = {getSettings: () => ({height: 720})};
         const USER_AGENT_CHROME_MAC =
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
-        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36';
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
+          'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36';
 
         beforeEach(() => {
           mediaDirection = {sendAudio: true, sendVideo: true, sendShare: false};
@@ -2290,34 +2390,36 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.setLocalVideoQuality);
         });
 
-        it('should call getMediaStreams with the proper level', () => meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
-          delete mediaDirection.receiveVideo;
-          assert.calledWith(meeting.getMediaStreams,
-            mediaDirection,
-            CONSTANTS.VIDEO_RESOLUTIONS[CONSTANTS.QUALITY_LEVELS.LOW]);
-        }));
+        it('should call getMediaStreams with the proper level', () =>
+          meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
+            delete mediaDirection.receiveVideo;
+            assert.calledWith(
+              meeting.getMediaStreams,
+              mediaDirection,
+              CONSTANTS.VIDEO_RESOLUTIONS[CONSTANTS.QUALITY_LEVELS.LOW]
+            );
+          }));
 
         it('when browser is chrome then it should stop previous video track', () => {
           meeting.mediaProperties.videoTrack = fakeTrack;
-          assert.equal(
-            BrowserDetection(USER_AGENT_CHROME_MAC).getBrowserName(),
-            'Chrome'
-          );
-          meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS.LOW)
-            .then(() => {
-              assert.calledWith(Media.stopTracks, fakeTrack);
-            });
+          assert.equal(BrowserDetection(USER_AGENT_CHROME_MAC).getBrowserName(), 'Chrome');
+          meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
+            assert.calledWith(Media.stopTracks, fakeTrack);
+          });
         });
 
-        it('should set mediaProperty with the proper level', () => meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
-          assert.equal(meeting.mediaProperties.localQualityLevel, CONSTANTS.QUALITY_LEVELS.LOW);
-        }));
+        it('should set mediaProperty with the proper level', () =>
+          meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
+            assert.equal(meeting.mediaProperties.localQualityLevel, CONSTANTS.QUALITY_LEVELS.LOW);
+          }));
 
         it('when device does not support 1080p then it should set localQualityLevel with highest possible resolution', () => {
-          meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS['1080p'])
-            .then(() => {
-              assert.equal(meeting.mediaProperties.localQualityLevel, CONSTANTS.QUALITY_LEVELS['720p']);
-            });
+          meeting.setLocalVideoQuality(CONSTANTS.QUALITY_LEVELS['1080p']).then(() => {
+            assert.equal(
+              meeting.mediaProperties.localQualityLevel,
+              CONSTANTS.QUALITY_LEVELS['720p']
+            );
+          });
         });
 
         it('should error if set to a invalid level', () => {
@@ -2343,13 +2445,15 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.setRemoteQualityLevel);
         });
 
-        it('should set mediaProperty with the proper level', () => meeting.setRemoteQualityLevel(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
-          assert.equal(meeting.mediaProperties.remoteQualityLevel, CONSTANTS.QUALITY_LEVELS.LOW);
-        }));
+        it('should set mediaProperty with the proper level', () =>
+          meeting.setRemoteQualityLevel(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
+            assert.equal(meeting.mediaProperties.remoteQualityLevel, CONSTANTS.QUALITY_LEVELS.LOW);
+          }));
 
-        it('should call updateMedia', () => meeting.setRemoteQualityLevel(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
-          assert.calledOnce(meeting.updateMedia);
-        }));
+        it('should call updateMedia', () =>
+          meeting.setRemoteQualityLevel(CONSTANTS.QUALITY_LEVELS.LOW).then(() => {
+            assert.calledOnce(meeting.updateMedia);
+          }));
 
         it('should error if set to a invalid level', () => {
           assert.isRejected(meeting.setRemoteQualityLevel('invalid'));
@@ -2363,8 +2467,12 @@ describe('plugin-meetings', () => {
 
       describe('#usePhoneAudio', () => {
         beforeEach(() => {
-          meeting.meetingRequest.dialIn = sinon.stub().returns(Promise.resolve({body: {locus: 'testData'}}));
-          meeting.meetingRequest.dialOut = sinon.stub().returns(Promise.resolve({body: {locus: 'testData'}}));
+          meeting.meetingRequest.dialIn = sinon
+            .stub()
+            .returns(Promise.resolve({body: {locus: 'testData'}}));
+          meeting.meetingRequest.dialOut = sinon
+            .stub()
+            .returns(Promise.resolve({body: {locus: 'testData'}}));
           meeting.locusInfo.onFullLocus = sinon.stub().returns(Promise.resolve());
         });
 
@@ -2376,7 +2484,7 @@ describe('plugin-meetings', () => {
             correlationId: meeting.correlationId,
             dialInUrl: DIAL_IN_URL,
             locusUrl: meeting.locusUrl,
-            clientUrl: meeting.deviceUrl
+            clientUrl: meeting.deviceUrl,
           });
           assert.calledWith(meeting.locusInfo.onFullLocus, 'testData');
           assert.notCalled(meeting.meetingRequest.dialOut);
@@ -2391,7 +2499,7 @@ describe('plugin-meetings', () => {
             correlationId: meeting.correlationId,
             dialInUrl: DIAL_IN_URL,
             locusUrl: meeting.locusUrl,
-            clientUrl: meeting.deviceUrl
+            clientUrl: meeting.deviceUrl,
           });
           assert.calledWith(meeting.locusInfo.onFullLocus, 'testData');
           assert.notCalled(meeting.meetingRequest.dialOut);
@@ -2408,7 +2516,7 @@ describe('plugin-meetings', () => {
             dialOutUrl: DIAL_OUT_URL,
             locusUrl: meeting.locusUrl,
             clientUrl: meeting.deviceUrl,
-            phoneNumber
+            phoneNumber,
           });
           assert.calledWith(meeting.locusInfo.onFullLocus, 'testData');
           assert.notCalled(meeting.meetingRequest.dialIn);
@@ -2424,7 +2532,7 @@ describe('plugin-meetings', () => {
             dialOutUrl: DIAL_OUT_URL,
             locusUrl: meeting.locusUrl,
             clientUrl: meeting.deviceUrl,
-            phoneNumber
+            phoneNumber,
           });
           assert.calledWith(meeting.locusInfo.onFullLocus, 'testData');
           assert.notCalled(meeting.meetingRequest.dialIn);
@@ -2435,11 +2543,14 @@ describe('plugin-meetings', () => {
 
           meeting.meetingRequest.dialIn = sinon.stub().returns(Promise.reject(error));
 
-          return meeting.usePhoneAudio().then(() => Promise.reject(new Error('Promise resolved when it should have rejected'))).catch((e) => {
-            assert.equal(e, error);
+          return meeting
+            .usePhoneAudio()
+            .then(() => Promise.reject(new Error('Promise resolved when it should have rejected')))
+            .catch((e) => {
+              assert.equal(e, error);
 
-            return Promise.resolve();
-          });
+              return Promise.resolve();
+            });
         });
 
         it('rejects if the request failed (dial out)', async () => {
@@ -2447,11 +2558,14 @@ describe('plugin-meetings', () => {
 
           meeting.meetingRequest.dialOut = sinon.stub().returns(Promise.reject(error));
 
-          return meeting.usePhoneAudio('+441234567890').then(() => Promise.reject(new Error('Promise resolved when it should have rejected'))).catch((e) => {
-            assert.equal(e, error);
+          return meeting
+            .usePhoneAudio('+441234567890')
+            .then(() => Promise.reject(new Error('Promise resolved when it should have rejected')))
+            .catch((e) => {
+              assert.equal(e, error);
 
-            return Promise.resolve();
-          });
+              return Promise.resolve();
+            });
         });
       });
 
@@ -2470,34 +2584,42 @@ describe('plugin-meetings', () => {
           locusUrl: 'some_locus_url',
           sipUrl: 'some_sip_url', // or sipMeetingUri
           meetingNumber: '123456', // this.config.experimental.enableUnifiedMeetings
-          hostId: 'some_host_id' // this.owner;
+          hostId: 'some_host_id', // this.owner;
         };
         const FAKE_SDK_CAPTCHA_INFO = {
           captchaId: FAKE_CAPTCHA_ID,
           verificationImageURL: FAKE_CAPTCHA_IMAGE_URL,
           verificationAudioURL: FAKE_CAPTCHA_AUDIO_URL,
-          refreshURL: FAKE_CAPTCHA_REFRESH_URL
+          refreshURL: FAKE_CAPTCHA_REFRESH_URL,
         };
         const FAKE_WBXAPPAPI_CAPTCHA_INFO = {
           captchaID: `${FAKE_CAPTCHA_ID}-2`,
           verificationImageURL: `${FAKE_CAPTCHA_IMAGE_URL}-2`,
           verificationAudioURL: `${FAKE_CAPTCHA_AUDIO_URL}-2`,
-          refreshURL: `${FAKE_CAPTCHA_REFRESH_URL}-2`
+          refreshURL: `${FAKE_CAPTCHA_REFRESH_URL}-2`,
         };
 
-
         it('calls meetingInfoProvider with all the right parameters and parses the result', async () => {
-          meeting.attrs.meetingInfoProvider = {fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO})};
+          meeting.attrs.meetingInfoProvider = {
+            fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO}),
+          };
           meeting.requiredCaptcha = FAKE_SDK_CAPTCHA_INFO;
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
           meeting.parseMeetingInfo = sinon.stub().returns(undefined);
 
           await meeting.fetchMeetingInfo({
-            password: FAKE_PASSWORD, captchaCode: FAKE_CAPTCHA_CODE
+            password: FAKE_PASSWORD,
+            captchaCode: FAKE_CAPTCHA_CODE,
           });
 
-          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, FAKE_PASSWORD, {code: FAKE_CAPTCHA_CODE, id: FAKE_CAPTCHA_ID});
+          assert.calledWith(
+            meeting.attrs.meetingInfoProvider.fetchMeetingInfo,
+            FAKE_DESTINATION,
+            FAKE_TYPE,
+            FAKE_PASSWORD,
+            {code: FAKE_CAPTCHA_CODE, id: FAKE_CAPTCHA_ID}
+          );
 
           assert.calledWith(meeting.parseMeetingInfo, {body: FAKE_MEETING_INFO}, FAKE_DESTINATION);
           assert.deepEqual(meeting.meetingInfo, FAKE_MEETING_INFO);
@@ -2505,11 +2627,18 @@ describe('plugin-meetings', () => {
           assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.NONE);
           assert.equal(meeting.requiredCaptcha, null);
           assert.calledTwice(TriggerProxy.trigger);
-          assert.calledWith(TriggerProxy.trigger, meeting, {file: 'meetings', function: 'fetchMeetingInfo'}, 'meeting:meetingInfoAvailable');
+          assert.calledWith(
+            TriggerProxy.trigger,
+            meeting,
+            {file: 'meetings', function: 'fetchMeetingInfo'},
+            'meeting:meetingInfoAvailable'
+          );
         });
 
         it('calls meetingInfoProvider with all the right parameters and parses the result when random delay is applied', async () => {
-          meeting.attrs.meetingInfoProvider = {fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO})};
+          meeting.attrs.meetingInfoProvider = {
+            fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO}),
+          };
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
           meeting.parseMeetingInfo = sinon.stub().returns(undefined);
@@ -2526,7 +2655,13 @@ describe('plugin-meetings', () => {
           assert.isUndefined(meeting.fetchMeetingInfoTimeoutId);
 
           // meeting info provider
-          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, null, null);
+          assert.calledWith(
+            meeting.attrs.meetingInfoProvider.fetchMeetingInfo,
+            FAKE_DESTINATION,
+            FAKE_TYPE,
+            null,
+            null
+          );
 
           // parseMeeting info
           assert.calledWith(meeting.parseMeetingInfo, {body: FAKE_MEETING_INFO}, FAKE_DESTINATION);
@@ -2537,31 +2672,48 @@ describe('plugin-meetings', () => {
           assert.equal(meeting.passwordStatus, PASSWORD_STATUS.NOT_REQUIRED);
 
           assert.calledTwice(TriggerProxy.trigger);
-          assert.calledWith(TriggerProxy.trigger, meeting, {file: 'meetings', function: 'fetchMeetingInfo'}, 'meeting:meetingInfoAvailable');
+          assert.calledWith(
+            TriggerProxy.trigger,
+            meeting,
+            {file: 'meetings', function: 'fetchMeetingInfo'},
+            'meeting:meetingInfoAvailable'
+          );
         });
 
         it('fails if captchaCode is provided when captcha not needed', async () => {
-          meeting.attrs.meetingInfoProvider = {fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO})};
+          meeting.attrs.meetingInfoProvider = {
+            fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO}),
+          };
           meeting.requiredCaptcha = null;
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
 
-          await assert.isRejected(meeting.fetchMeetingInfo({
-            captchaCode: FAKE_CAPTCHA_CODE
-          }), Error, 'fetchMeetingInfo() called with captchaCode when captcha was not required');
+          await assert.isRejected(
+            meeting.fetchMeetingInfo({
+              captchaCode: FAKE_CAPTCHA_CODE,
+            }),
+            Error,
+            'fetchMeetingInfo() called with captchaCode when captcha was not required'
+          );
 
           assert.notCalled(meeting.attrs.meetingInfoProvider.fetchMeetingInfo);
         });
 
         it('fails if password is provided when not required', async () => {
-          meeting.attrs.meetingInfoProvider = {fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO})};
+          meeting.attrs.meetingInfoProvider = {
+            fetchMeetingInfo: sinon.stub().resolves({body: FAKE_MEETING_INFO}),
+          };
           meeting.passwordStatus = PASSWORD_STATUS.NOT_REQUIRED;
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
 
-          await assert.isRejected(meeting.fetchMeetingInfo({
-            password: FAKE_PASSWORD
-          }), Error, 'fetchMeetingInfo() called with password when password was not required');
+          await assert.isRejected(
+            meeting.fetchMeetingInfo({
+              password: FAKE_PASSWORD,
+            }),
+            Error,
+            'fetchMeetingInfo() called with password when password was not required'
+          );
 
           assert.notCalled(meeting.attrs.meetingInfoProvider.fetchMeetingInfo);
         });
@@ -2570,15 +2722,26 @@ describe('plugin-meetings', () => {
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
           meeting.attrs.meetingInfoProvider = {
-            fetchMeetingInfo: sinon.stub().throws(new MeetingInfoV2PasswordError(403004, FAKE_MEETING_INFO))
+            fetchMeetingInfo: sinon
+              .stub()
+              .throws(new MeetingInfoV2PasswordError(403004, FAKE_MEETING_INFO)),
           };
 
           await assert.isRejected(meeting.fetchMeetingInfo({}), PasswordError);
 
-          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, null, null);
+          assert.calledWith(
+            meeting.attrs.meetingInfoProvider.fetchMeetingInfo,
+            FAKE_DESTINATION,
+            FAKE_TYPE,
+            null,
+            null
+          );
 
           assert.deepEqual(meeting.meetingInfo, FAKE_MEETING_INFO);
-          assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD);
+          assert.equal(
+            meeting.meetingInfoFailureReason,
+            MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD
+          );
           assert.equal(meeting.requiredCaptcha, null);
           assert.equal(meeting.passwordStatus, PASSWORD_STATUS.REQUIRED);
         });
@@ -2587,25 +2750,38 @@ describe('plugin-meetings', () => {
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
           meeting.attrs.meetingInfoProvider = {
-            fetchMeetingInfo: sinon.stub().throws(new MeetingInfoV2CaptchaError(423005, FAKE_SDK_CAPTCHA_INFO))
+            fetchMeetingInfo: sinon
+              .stub()
+              .throws(new MeetingInfoV2CaptchaError(423005, FAKE_SDK_CAPTCHA_INFO)),
           };
           meeting.requiredCaptcha = null;
 
-          await assert.isRejected(meeting.fetchMeetingInfo({
-            password: 'aaa'
-          }), CaptchaError);
+          await assert.isRejected(
+            meeting.fetchMeetingInfo({
+              password: 'aaa',
+            }),
+            CaptchaError
+          );
 
-          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, 'aaa', null);
-
+          assert.calledWith(
+            meeting.attrs.meetingInfoProvider.fetchMeetingInfo,
+            FAKE_DESTINATION,
+            FAKE_TYPE,
+            'aaa',
+            null
+          );
 
           assert.deepEqual(meeting.meetingInfo, {});
-          assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD);
+          assert.equal(
+            meeting.meetingInfoFailureReason,
+            MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD
+          );
           assert.equal(meeting.passwordStatus, PASSWORD_STATUS.REQUIRED);
           assert.deepEqual(meeting.requiredCaptcha, {
             captchaId: FAKE_CAPTCHA_ID,
             verificationImageURL: FAKE_CAPTCHA_IMAGE_URL,
             verificationAudioURL: FAKE_CAPTCHA_AUDIO_URL,
-            refreshURL: FAKE_CAPTCHA_REFRESH_URL
+            refreshURL: FAKE_CAPTCHA_REFRESH_URL,
           });
         });
 
@@ -2613,15 +2789,27 @@ describe('plugin-meetings', () => {
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
           meeting.attrs.meetingInfoProvider = {
-            fetchMeetingInfo: sinon.stub().throws(new MeetingInfoV2CaptchaError(423005, FAKE_SDK_CAPTCHA_INFO))
+            fetchMeetingInfo: sinon
+              .stub()
+              .throws(new MeetingInfoV2CaptchaError(423005, FAKE_SDK_CAPTCHA_INFO)),
           };
           meeting.requiredCaptcha = FAKE_SDK_CAPTCHA_INFO;
 
-          await assert.isRejected(meeting.fetchMeetingInfo({
-            password: 'aaa', captchaCode: 'bbb'
-          }), CaptchaError);
+          await assert.isRejected(
+            meeting.fetchMeetingInfo({
+              password: 'aaa',
+              captchaCode: 'bbb',
+            }),
+            CaptchaError
+          );
 
-          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, 'aaa', {code: 'bbb', id: FAKE_CAPTCHA_ID});
+          assert.calledWith(
+            meeting.attrs.meetingInfoProvider.fetchMeetingInfo,
+            FAKE_DESTINATION,
+            FAKE_TYPE,
+            'aaa',
+            {code: 'bbb', id: FAKE_CAPTCHA_ID}
+          );
 
           assert.deepEqual(meeting.meetingInfo, {});
           assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.WRONG_CAPTCHA);
@@ -2633,20 +2821,24 @@ describe('plugin-meetings', () => {
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
           meeting.attrs.meetingInfoProvider = {
-            fetchMeetingInfo: sinon.stub().resolves(
-              {
-                statusCode: 200,
-                body: FAKE_MEETING_INFO
-              }
-            )
+            fetchMeetingInfo: sinon.stub().resolves({
+              statusCode: 200,
+              body: FAKE_MEETING_INFO,
+            }),
           };
           meeting.passwordStatus = PASSWORD_STATUS.REQUIRED;
 
           await meeting.fetchMeetingInfo({
-            password: 'aaa'
+            password: 'aaa',
           });
 
-          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, 'aaa', null);
+          assert.calledWith(
+            meeting.attrs.meetingInfoProvider.fetchMeetingInfo,
+            FAKE_DESTINATION,
+            FAKE_TYPE,
+            'aaa',
+            null
+          );
 
           assert.deepEqual(meeting.meetingInfo, FAKE_MEETING_INFO);
           assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.NONE);
@@ -2660,36 +2852,50 @@ describe('plugin-meetings', () => {
           const refreshedCaptcha = {
             captchaID: FAKE_WBXAPPAPI_CAPTCHA_INFO.captchaID,
             verificationImageURL: FAKE_WBXAPPAPI_CAPTCHA_INFO.verificationImageURL,
-            verificationAudioURL: FAKE_WBXAPPAPI_CAPTCHA_INFO.verificationAudioURL
+            verificationAudioURL: FAKE_WBXAPPAPI_CAPTCHA_INFO.verificationAudioURL,
           };
 
           meeting.attrs.meetingInfoProvider = {
-            fetchMeetingInfo: sinon.stub().throws(new MeetingInfoV2PasswordError(403004, FAKE_MEETING_INFO))
+            fetchMeetingInfo: sinon
+              .stub()
+              .throws(new MeetingInfoV2PasswordError(403004, FAKE_MEETING_INFO)),
           };
-          meeting.meetingRequest.refreshCaptcha = sinon.stub().returns(Promise.resolve(
-            {
-              body: refreshedCaptcha
-            }
-          ));
+          meeting.meetingRequest.refreshCaptcha = sinon.stub().returns(
+            Promise.resolve({
+              body: refreshedCaptcha,
+            })
+          );
           meeting.passwordStatus = PASSWORD_STATUS.REQUIRED;
           meeting.requiredCaptcha = FAKE_SDK_CAPTCHA_INFO;
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
 
-          await assert.isRejected(meeting.fetchMeetingInfo({
-            password: 'aaa', captchaCode: 'bbb'
-          }));
+          await assert.isRejected(
+            meeting.fetchMeetingInfo({
+              password: 'aaa',
+              captchaCode: 'bbb',
+            })
+          );
 
-          assert.calledWith(meeting.attrs.meetingInfoProvider.fetchMeetingInfo, FAKE_DESTINATION, FAKE_TYPE, 'aaa', {code: 'bbb', id: FAKE_CAPTCHA_ID});
+          assert.calledWith(
+            meeting.attrs.meetingInfoProvider.fetchMeetingInfo,
+            FAKE_DESTINATION,
+            FAKE_TYPE,
+            'aaa',
+            {code: 'bbb', id: FAKE_CAPTCHA_ID}
+          );
 
           assert.deepEqual(meeting.meetingInfo, FAKE_MEETING_INFO);
-          assert.equal(meeting.meetingInfoFailureReason, MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD);
+          assert.equal(
+            meeting.meetingInfoFailureReason,
+            MEETING_INFO_FAILURE_REASON.WRONG_PASSWORD
+          );
           assert.equal(meeting.passwordStatus, PASSWORD_STATUS.REQUIRED);
           assert.deepEqual(meeting.requiredCaptcha, {
             captchaId: refreshedCaptcha.captchaID,
             verificationImageURL: refreshedCaptcha.verificationImageURL,
             verificationAudioURL: refreshedCaptcha.verificationAudioURL,
-            refreshURL: FAKE_SDK_CAPTCHA_INFO.refreshURL // refresh url doesn't change
+            refreshURL: FAKE_SDK_CAPTCHA_INFO.refreshURL, // refresh url doesn't change
           });
         });
       });
@@ -2699,48 +2905,56 @@ describe('plugin-meetings', () => {
           assert.isRejected(meeting.refreshCaptcha(), Error);
         });
         it('sends correct request to captcha service refresh url', async () => {
-          const REFRESH_URL = 'https://something.webex.com/captchaservice/v1/captchas/refresh?blablabla=something&captchaID=xxx';
-          const EXPECTED_REFRESH_URL = 'https://something.webex.com/captchaservice/v1/captchas/refresh?blablabla=something&captchaID=xxx&siteFullName=something.webex.com';
+          const REFRESH_URL =
+            'https://something.webex.com/captchaservice/v1/captchas/refresh?blablabla=something&captchaID=xxx';
+          const EXPECTED_REFRESH_URL =
+            'https://something.webex.com/captchaservice/v1/captchas/refresh?blablabla=something&captchaID=xxx&siteFullName=something.webex.com';
 
           const FAKE_SDK_CAPTCHA_INFO = {
             captchaId: 'some id',
             verificationImageURL: 'some image url',
             verificationAudioURL: 'some audio url',
-            refreshURL: REFRESH_URL
+            refreshURL: REFRESH_URL,
           };
 
           const FAKE_REFRESHED_CAPTCHA = {
             captchaID: 'some id',
             verificationImageURL: 'some image url',
-            verificationAudioURL: 'some audio url'
+            verificationAudioURL: 'some audio url',
           };
 
           // setup the meeting so that a captcha is required
           meeting.attrs.meetingInfoProvider = {
-            fetchMeetingInfo: sinon.stub().throws(new MeetingInfoV2CaptchaError(423005, FAKE_SDK_CAPTCHA_INFO))
+            fetchMeetingInfo: sinon
+              .stub()
+              .throws(new MeetingInfoV2CaptchaError(423005, FAKE_SDK_CAPTCHA_INFO)),
           };
 
-          await assert.isRejected(meeting.fetchMeetingInfo({
-            password: ''
-          }), CaptchaError);
+          await assert.isRejected(
+            meeting.fetchMeetingInfo({
+              password: '',
+            }),
+            CaptchaError
+          );
 
           assert.deepEqual(meeting.requiredCaptcha, FAKE_SDK_CAPTCHA_INFO);
-          meeting.meetingRequest.refreshCaptcha = sinon.stub().returns(Promise.resolve({body: FAKE_REFRESHED_CAPTCHA}));
+          meeting.meetingRequest.refreshCaptcha = sinon
+            .stub()
+            .returns(Promise.resolve({body: FAKE_REFRESHED_CAPTCHA}));
 
           // test the captcha refresh
           await meeting.refreshCaptcha();
 
-          assert.calledWith(meeting.meetingRequest.refreshCaptcha,
-            {
-              captchaRefreshUrl: EXPECTED_REFRESH_URL,
-              captchaId: FAKE_SDK_CAPTCHA_INFO.captchaId
-            });
+          assert.calledWith(meeting.meetingRequest.refreshCaptcha, {
+            captchaRefreshUrl: EXPECTED_REFRESH_URL,
+            captchaId: FAKE_SDK_CAPTCHA_INFO.captchaId,
+          });
 
           assert.deepEqual(meeting.requiredCaptcha, {
             captchaId: FAKE_REFRESHED_CAPTCHA.captchaID,
             verificationImageURL: FAKE_REFRESHED_CAPTCHA.verificationImageURL,
             verificationAudioURL: FAKE_REFRESHED_CAPTCHA.verificationAudioURL,
-            refreshURL: FAKE_SDK_CAPTCHA_INFO.refreshURL // refresh url doesn't change
+            refreshURL: FAKE_SDK_CAPTCHA_INFO.refreshURL, // refresh url doesn't change
           });
         });
       });
@@ -2754,7 +2968,7 @@ describe('plugin-meetings', () => {
           assert(Metrics.sendBehavioralMetric.calledOnce);
           assert.calledWith(
             Metrics.sendBehavioralMetric,
-            BEHAVIORAL_METRICS.VERIFY_PASSWORD_SUCCESS,
+            BEHAVIORAL_METRICS.VERIFY_PASSWORD_SUCCESS
           );
           assert.equal(result.isPasswordValid, true);
           assert.equal(result.requiredCaptcha, null);
@@ -2829,7 +3043,9 @@ describe('plugin-meetings', () => {
           sandbox = sinon.createSandbox();
           meeting.meetingFiniteStateMachine.ring();
           meeting.meetingFiniteStateMachine.join();
-          meeting.meetingRequest.endMeetingForAll = sinon.stub().returns(Promise.resolve({body: 'test'}));
+          meeting.meetingRequest.endMeetingForAll = sinon
+            .stub()
+            .returns(Promise.resolve({body: 'test'}));
           meeting.locusInfo.onFullLocus = sinon.stub().returns(true);
           meeting.closeLocalStream = sinon.stub().returns(Promise.resolve());
           meeting.closeLocalShare = sinon.stub().returns(Promise.resolve());
@@ -2883,7 +3099,11 @@ describe('plugin-meetings', () => {
           sandbox.stub(meeting.mediaProperties, 'unsetMediaTracks');
 
           sandbox.stub(meeting.reconnectionManager, 'reconnectMedia').returns(Promise.resolve());
-          sandbox.stub(MeetingUtil, 'joinMeeting').returns(Promise.resolve(MeetingUtil.parseLocusJoin({body: {locus, mediaConnections: []}})));
+          sandbox
+            .stub(MeetingUtil, 'joinMeeting')
+            .returns(
+              Promise.resolve(MeetingUtil.parseLocusJoin({body: {locus, mediaConnections: []}}))
+            );
         });
 
         afterEach(() => {
@@ -2912,17 +3132,17 @@ describe('plugin-meetings', () => {
                   share: true,
                   share_audio: false,
                   video: false,
-                  whiteboard: false
+                  whiteboard: false,
                 },
                 tx: {
                   audio: false,
                   share: false,
                   share_audio: false,
                   video: false,
-                  whiteboard: false
-                }
-              }
-            }
+                  whiteboard: false,
+                },
+              },
+            },
           });
           assert.calledWithMatch(Metrics.postEvent, {event: eventType.MOVE_MEDIA});
         });
@@ -2931,17 +3151,19 @@ describe('plugin-meetings', () => {
           sinon.spy(MeetingUtil, 'joinMeetingOptions');
           await meeting.moveTo('resourceId');
 
-          assert.calledWith(MeetingUtil.joinMeetingOptions, meeting, {resourceId: 'resourceId', moveToResource: true});
+          assert.calledWith(MeetingUtil.joinMeetingOptions, meeting, {
+            resourceId: 'resourceId',
+            moveToResource: true,
+          });
         });
 
         it('should reconnectMedia after DX joins after moveTo', async () => {
           await meeting.moveTo('resourceId');
 
-
           await meeting.locusInfo.emitScoped(
             {
               file: 'locus-info',
-              function: 'updateSelf'
+              function: 'updateSelf',
             },
             'SELF_OBSERVING'
           );
@@ -2957,17 +3179,16 @@ describe('plugin-meetings', () => {
           assert.called(meeting.mediaProperties.setMediaDirection);
           assert.called(meeting.mediaProperties.unsetMediaTracks);
 
-          assert.calledWith(meeting.reconnectionManager.reconnectMedia,
-            {
-              mediaDirection: {
-                sendVideo: false,
-                receiveVideo: false,
-                sendAudio: false,
-                receiveAudio: false,
-                sendShare: false,
-                receiveShare: true
-              }
-            });
+          assert.calledWith(meeting.reconnectionManager.reconnectMedia, {
+            mediaDirection: {
+              sendVideo: false,
+              receiveVideo: false,
+              sendAudio: false,
+              receiveAudio: false,
+              sendShare: false,
+              receiveShare: true,
+            },
+          });
         });
 
         it('should throw an error if moveTo call fails', async () => {
@@ -2977,16 +3198,12 @@ describe('plugin-meetings', () => {
           }
           catch {
             assert.calledOnce(Metrics.sendBehavioralMetric);
-            assert.calledWith(
-              Metrics.sendBehavioralMetric,
-              BEHAVIORAL_METRICS.MOVE_TO_FAILURE,
-              {
-                correlation_id: meeting.correlationId,
-                locus_id: meeting.locusUrl.split('/').pop(),
-                reason: sinon.match.any,
-                stack: sinon.match.any
-              }
-            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.MOVE_TO_FAILURE, {
+              correlation_id: meeting.correlationId,
+              locus_id: meeting.locusUrl.split('/').pop(),
+              reason: sinon.match.any,
+              stack: sinon.match.any,
+            });
           }
           Metrics.sendBehavioralMetric.reset();
           meeting.reconnectionManager.reconnectMedia = sinon.stub().returns(Promise.reject());
@@ -2996,23 +3213,19 @@ describe('plugin-meetings', () => {
             await meeting.locusInfo.emitScoped(
               {
                 file: 'locus-info',
-                function: 'updateSelf'
+                function: 'updateSelf',
               },
               'SELF_OBSERVING'
             );
           }
           catch {
             assert.calledOnce(Metrics.sendBehavioralMetric);
-            assert.calledWith(
-              Metrics.sendBehavioralMetric,
-              BEHAVIORAL_METRICS.MOVE_TO_FAILURE,
-              {
-                correlation_id: meeting.correlationId,
-                locus_id: meeting.locusUrl.split('/').pop(),
-                reason: sinon.match.any,
-                stack: sinon.match.any
-              }
-            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.MOVE_TO_FAILURE, {
+              correlation_id: meeting.correlationId,
+              locus_id: meeting.locusUrl.split('/').pop(),
+              reason: sinon.match.any,
+              stack: sinon.match.any,
+            });
           }
         });
       });
@@ -3022,7 +3235,11 @@ describe('plugin-meetings', () => {
 
         beforeEach(() => {
           sandbox = sinon.createSandbox();
-          sandbox.stub(MeetingUtil, 'joinMeeting').returns(Promise.resolve(MeetingUtil.parseLocusJoin({body: {locus, mediaConnections: []}})));
+          sandbox
+            .stub(MeetingUtil, 'joinMeeting')
+            .returns(
+              Promise.resolve(MeetingUtil.parseLocusJoin({body: {locus, mediaConnections: []}}))
+            );
           sandbox.stub(MeetingUtil, 'leaveMeeting').returns(Promise.resolve());
         });
 
@@ -3056,14 +3273,11 @@ describe('plugin-meetings', () => {
           assert.calledWith(MeetingUtil.leaveMeeting, meeting, {
             resourceId: 'resourceId',
             correlationId: meeting.correlationId,
-            moveMeeting: true
+            moveMeeting: true,
           });
 
           assert.calledOnce(Metrics.sendBehavioralMetric);
-          assert.calledWith(
-            Metrics.sendBehavioralMetric,
-            BEHAVIORAL_METRICS.MOVE_FROM_SUCCESS,
-          );
+          assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.MOVE_FROM_SUCCESS);
         });
 
         it('should throw an error if moveFrom call fails', async () => {
@@ -3073,16 +3287,12 @@ describe('plugin-meetings', () => {
           }
           catch {
             assert.calledOnce(Metrics.sendBehavioralMetric);
-            assert.calledWith(
-              Metrics.sendBehavioralMetric,
-              BEHAVIORAL_METRICS.MOVE_FROM_FAILURE,
-              {
-                correlation_id: meeting.correlationId,
-                locus_id: meeting.locusUrl.split('/').pop(),
-                reason: sinon.match.any,
-                stack: sinon.match.any
-              }
-            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.MOVE_FROM_FAILURE, {
+              correlation_id: meeting.correlationId,
+              locus_id: meeting.locusUrl.split('/').pop(),
+              reason: sinon.match.any,
+              stack: sinon.match.any,
+            });
           }
         });
       });
@@ -3151,7 +3361,9 @@ describe('plugin-meetings', () => {
             meeting.config.reconnection.enabled = true;
             meeting.currentMediaStatus = {audio: true};
             meeting.reconnectionManager = new ReconnectionManager(meeting);
-            meeting.reconnectionManager.reconnect = sinon.stub().returns(Promise.reject(new Error()));
+            meeting.reconnectionManager.reconnect = sinon
+              .stub()
+              .returns(Promise.reject(new Error()));
             meeting.reconnectionManager.reset = sinon.stub().returns(true);
           });
 
@@ -3176,7 +3388,7 @@ describe('plugin-meetings', () => {
                 correlation_id: meeting.correlationId,
                 locus_id: meeting.locusUrl.split('/').pop(),
                 reason: sinon.match.any,
-                stack: sinon.match.any
+                stack: sinon.match.any,
               }
             );
           });
@@ -3188,7 +3400,7 @@ describe('plugin-meetings', () => {
               sinon.match.instanceOf(Meeting),
               {file: 'meeting/index', function: 'reconnect'},
               EVENTS.REQUEST_UPLOAD_LOGS,
-              sinon.match.instanceOf(Meeting),
+              sinon.match.instanceOf(Meeting)
             );
           });
 
@@ -3272,8 +3484,8 @@ describe('plugin-meetings', () => {
               height: 1980,
               width: 1080,
               displaySurface: true,
-              cursor: true
-            })
+              cursor: true,
+            }),
           };
           const getVideoTracks = sinon.stub().returns([track]);
 
@@ -3305,21 +3517,36 @@ describe('plugin-meetings', () => {
           meeting.setRemoteStream(pc);
           pc.ontrack({track: 'track', transceiver: {mid: '0'}});
           assert.equal(TriggerProxy.trigger.getCall(1).args[2], 'media:ready');
-          assert.deepEqual(TriggerProxy.trigger.getCall(1).args[3], {type: 'remoteAudio', stream: true});
+          assert.deepEqual(TriggerProxy.trigger.getCall(1).args[3], {
+            type: 'remoteAudio',
+            stream: true,
+          });
 
           pc.ontrack({track: 'track', transceiver: {mid: '1'}});
           assert.equal(TriggerProxy.trigger.getCall(2).args[2], 'media:ready');
-          assert.deepEqual(TriggerProxy.trigger.getCall(2).args[3], {type: 'remoteVideo', stream: true});
+          assert.deepEqual(TriggerProxy.trigger.getCall(2).args[3], {
+            type: 'remoteVideo',
+            stream: true,
+          });
 
           pc.ontrack({transceiver: {mid: '2'}, track: 'track'});
           assert.equal(TriggerProxy.trigger.getCall(3).args[2], 'media:ready');
-          assert.deepEqual(TriggerProxy.trigger.getCall(3).args[3], {type: 'remoteShare', stream: true});
-
+          assert.deepEqual(TriggerProxy.trigger.getCall(3).args[3], {
+            type: 'remoteShare',
+            stream: true,
+          });
 
           // special case for safari
-          pc.ontrack({target: {audioTransceiver: {receiver: {track: {id: 'trackId'}}}}, transceiver: {}, track: {id: 'trackId'}});
+          pc.ontrack({
+            target: {audioTransceiver: {receiver: {track: {id: 'trackId'}}}},
+            transceiver: {},
+            track: {id: 'trackId'},
+          });
           assert.equal(TriggerProxy.trigger.getCall(1).args[2], 'media:ready');
-          assert.deepEqual(TriggerProxy.trigger.getCall(1).args[3], {type: 'remoteAudio', stream: true});
+          assert.deepEqual(TriggerProxy.trigger.getCall(1).args[3], {
+            type: 'remoteAudio',
+            stream: true,
+          });
         });
       });
       describe('#setUpLocusInfoSelfListener', () => {
@@ -3359,11 +3586,12 @@ describe('plugin-meetings', () => {
 
           meeting.members = {locusUrlUpdate: sinon.stub().returns(Promise.resolve(test1))};
 
-          meeting.locusInfo.emit({function: 'test', file: 'test'}, 'LOCUS_INFO_UPDATE_URL', newLocusUrl);
-          assert.calledWith(
-            meeting.members.locusUrlUpdate,
+          meeting.locusInfo.emit(
+            {function: 'test', file: 'test'},
+            'LOCUS_INFO_UPDATE_URL',
             newLocusUrl
           );
+          assert.calledWith(meeting.members.locusUrlUpdate, newLocusUrl);
           assert.equal(meeting.locusUrl, newLocusUrl);
           assert(meeting.locusId, '12345');
           done();
@@ -3372,7 +3600,11 @@ describe('plugin-meetings', () => {
       describe('#setUpLocusInfoMediaInactiveListener', () => {
         it('listens to disconnect due to un activity ', (done) => {
           TriggerProxy.trigger.reset();
-          meeting.locusInfo.emit({function: 'test', file: 'test'}, EVENTS.DISCONNECT_DUE_TO_INACTIVITY, {reason: 'inactive'});
+          meeting.locusInfo.emit(
+            {function: 'test', file: 'test'},
+            EVENTS.DISCONNECT_DUE_TO_INACTIVITY,
+            {reason: 'inactive'}
+          );
           assert.calledTwice(TriggerProxy.trigger);
 
           assert.calledWith(
@@ -3399,7 +3631,11 @@ describe('plugin-meetings', () => {
           sinon.stub(meeting, 'reconnect');
 
           meeting.config.reconnection.autoRejoin = true;
-          meeting.locusInfo.emit({function: 'test', file: 'test'}, EVENTS.DISCONNECT_DUE_TO_INACTIVITY, {reason: 'inactive'});
+          meeting.locusInfo.emit(
+            {function: 'test', file: 'test'},
+            EVENTS.DISCONNECT_DUE_TO_INACTIVITY,
+            {reason: 'inactive'}
+          );
           assert.calledOnce(TriggerProxy.trigger);
 
           assert.calledWith(
@@ -3424,7 +3660,10 @@ describe('plugin-meetings', () => {
           sinon.stub(meeting.reconnectionManager, 'cleanUp');
           sinon.spy(MeetingUtil, 'cleanUp');
 
-          meeting.locusInfo.emit({function: 'test', file: 'test'}, EVENTS.DESTROY_MEETING, {shouldLeave: false, reason: 'ended'});
+          meeting.locusInfo.emit({function: 'test', file: 'test'}, EVENTS.DESTROY_MEETING, {
+            shouldLeave: false,
+            reason: 'ended',
+          });
           assert.calledOnce(TriggerProxy.trigger);
           assert.calledOnce(MeetingUtil.cleanUp);
           assert.calledWith(
@@ -3432,12 +3671,12 @@ describe('plugin-meetings', () => {
             meeting,
             {
               file: 'meeting/index',
-              function: 'setUpLocusInfoMeetingListener'
+              function: 'setUpLocusInfoMeetingListener',
             },
             EVENTS.DESTROY_MEETING,
             {
               reason: 'ended',
-              meetingId: meeting.id
+              meetingId: meeting.id,
             }
           );
           done();
@@ -3554,8 +3793,8 @@ describe('plugin-meetings', () => {
               permissionToken: 'abc',
               sipMeetingUri: test1,
               sipUrl: test1,
-              owner: test2
-            }
+              owner: test2,
+            },
           };
 
           meeting.parseMeetingInfo(FAKE_MEETING_INFO);
@@ -3566,7 +3805,7 @@ describe('plugin-meetings', () => {
             meetingNumber: '12345',
             meetingJoinUrl: url2,
             owner: test2,
-            permissionToken: 'abc'
+            permissionToken: 'abc',
           };
 
           checkParseMeetingInfo(expectedInfoToParse);
@@ -3580,8 +3819,8 @@ describe('plugin-meetings', () => {
             info: {
               webExMeetingId: 'locusMeetingId',
               sipUri: 'locusSipUri',
-              owner: 'locusOwner'
-            }
+              owner: 'locusOwner',
+            },
           };
           const FAKE_MEETING_INFO = {
             body: {
@@ -3592,8 +3831,8 @@ describe('plugin-meetings', () => {
               permissionToken: 'abc',
               sipMeetingUri: test1,
               sipUrl: test1,
-              owner: test2
-            }
+              owner: test2,
+            },
           };
 
           meeting.parseMeetingInfo(FAKE_MEETING_INFO, FAKE_LOCUS_MEETING);
@@ -3604,7 +3843,7 @@ describe('plugin-meetings', () => {
             meetingNumber: 'locusMeetingId',
             meetingJoinUrl: url2,
             owner: 'locusOwner',
-            permissionToken: 'abc'
+            permissionToken: 'abc',
           };
 
           checkParseMeetingInfo(expectedInfoToParse);
@@ -3621,8 +3860,8 @@ describe('plugin-meetings', () => {
               permissionToken: 'abc',
               sipMeetingUri: test1,
               sipUrl: test1,
-              owner: test2
-            }
+              owner: test2,
+            },
           };
 
           meeting.parseMeetingInfo(FAKE_MEETING_INFO);
@@ -3633,7 +3872,7 @@ describe('plugin-meetings', () => {
             meetingNumber: '12345',
             meetingJoinUrl: url2,
             owner: test2,
-            permissionToken: 'abc'
+            permissionToken: 'abc',
           };
 
           checkParseMeetingInfo(expectedInfoToParse);
@@ -3651,8 +3890,8 @@ describe('plugin-meetings', () => {
               permissionToken: 'abc',
               sipMeetingUri: test1,
               sipUrl: test1,
-              owner: test2
-            }
+              owner: test2,
+            },
           };
 
           meeting.parseMeetingInfo(FAKE_MEETING_INFO, FAKE_STRING_DESTINATION);
@@ -3663,7 +3902,7 @@ describe('plugin-meetings', () => {
             meetingNumber: '12345',
             meetingJoinUrl: url2,
             owner: test2,
-            permissionToken: 'abc'
+            permissionToken: 'abc',
           };
 
           checkParseMeetingInfo(expectedInfoToParse);
@@ -3679,7 +3918,11 @@ describe('plugin-meetings', () => {
             meeting.type = 'CALL';
             meeting.parseLocus({url: url1, participants: [{id: uuid1}], self: {id: uuid2}});
             assert.calledOnce(meeting.setLocus);
-            assert.calledWith(meeting.setLocus, {url: url1, participants: [{id: uuid1}], self: {id: uuid2}});
+            assert.calledWith(meeting.setLocus, {
+              url: url1,
+              participants: [{id: uuid1}],
+              self: {id: uuid2},
+            });
             assert.calledOnce(MeetingUtil.getLocusPartner);
             assert.calledWith(MeetingUtil.getLocusPartner, [{id: uuid1}], {id: uuid2});
             assert.deepEqual(meeting.partner, {person: {sipUrl: uuid3}});
@@ -3699,6 +3942,53 @@ describe('plugin-meetings', () => {
           assert.ok(meeting.correlationId);
           meeting.setCorrelationId(uuid1);
           assert.equal(meeting.correlationId, uuid1);
+        });
+      });
+      describe('#setupLocusControlsListener', () => {
+        let locusInfoOnSpy;
+
+        beforeEach(() => {
+          locusInfoOnSpy = sinon.spy(meeting.locusInfo, 'on');
+        });
+
+        afterEach(() => {
+          locusInfoOnSpy.restore();
+        });
+
+        it('registers the correct event', () => {
+          meeting.setupLocusControlsListener();
+
+          assert.equal(locusInfoOnSpy.firstCall.args[0], 'CONTROLS_MEETING_TRANSCRIBE_UPDATED');
+          const callback = locusInfoOnSpy.firstCall.args[1];
+
+          let payload = {caption: true, transcribing: true};
+
+          callback(payload);
+
+          assert.calledWith(
+            TriggerProxy.trigger,
+            meeting,
+            {
+              file: 'meeting/index',
+              function: 'setupLocusControlsListener',
+            },
+            'voicea:transcribing:on'
+          );
+
+          TriggerProxy.trigger.resetHistory();
+
+          payload = {caption: true, transcribing: false};
+          callback(payload);
+
+          assert.calledWith(
+            TriggerProxy.trigger,
+            meeting,
+            {
+              file: 'meeting/index',
+              function: 'setupLocusControlsListener',
+            },
+            'voicea:transcribing:off'
+          );
         });
       });
 
@@ -3735,7 +4025,7 @@ describe('plugin-meetings', () => {
             meeting,
             {
               file: 'meeting/index',
-              function: 'setUpLocusInfoAssignHostListener'
+              function: 'setUpLocusInfoAssignHostListener',
             },
             'meeting:actionsUpdate',
             meeting.inMeetingActions.get()
@@ -3775,7 +4065,10 @@ describe('plugin-meetings', () => {
           inMeetingActionsSetSpy = sinon.spy(meeting.inMeetingActions, 'set');
           canUserRaiseHandSpy = sinon.spy(MeetingUtil, 'canUserRaiseHand');
           canUserLowerAllHandsSpy = sinon.spy(MeetingUtil, 'canUserLowerAllHands');
-          bothLeaveAndEndMeetingAvailableSpy = sinon.spy(MeetingUtil, 'bothLeaveAndEndMeetingAvailable');
+          bothLeaveAndEndMeetingAvailableSpy = sinon.spy(
+            MeetingUtil,
+            'bothLeaveAndEndMeetingAvailable'
+          );
           canUserLowerSomeoneElsesHandSpy = sinon.spy(MeetingUtil, 'canUserLowerSomeoneElsesHand');
           waitingForOthersToJoinSpy = sinon.spy(MeetingUtil, 'waitingForOthersToJoin');
         });
@@ -3785,7 +4078,6 @@ describe('plugin-meetings', () => {
           inMeetingActionsSetSpy.restore();
           waitingForOthersToJoinSpy.restore();
         });
-
 
         it('registers the correct MEETING_INFO_UPDATED event', () => {
           meeting.setUpLocusInfoMeetingInfoListener();
@@ -3799,8 +4091,8 @@ describe('plugin-meetings', () => {
 
           const payload = {
             info: {
-              userDisplayHints: ['LOCK_CONTROL_UNLOCK']
-            }
+              userDisplayHints: ['LOCK_CONTROL_UNLOCK'],
+            },
           };
 
           callback(payload);
@@ -3822,7 +4114,7 @@ describe('plugin-meetings', () => {
             meeting,
             {
               file: 'meeting/index',
-              function: 'setUpLocusInfoMeetingInfoListener'
+              function: 'setUpLocusInfoMeetingInfoListener',
             },
             'meeting:actionsUpdate',
             meeting.inMeetingActions.get()
@@ -3847,7 +4139,7 @@ describe('plugin-meetings', () => {
             locusId: uuid1,
             selfId: uuid2,
             mediaId: uuid3,
-            host: {id: uuid4}
+            host: {id: uuid4},
           });
           assert.calledOnce(meeting.locusInfo.initialSetup);
           assert.calledWith(meeting.locusInfo.initialSetup, {
@@ -3856,7 +4148,7 @@ describe('plugin-meetings', () => {
             locusId: uuid1,
             selfId: uuid2,
             mediaId: uuid3,
-            host: {id: uuid4}
+            host: {id: uuid4},
           });
           assert.equal(meeting.mediaConnections, test1);
           assert.equal(meeting.locusUrl, url1);
@@ -3905,7 +4197,7 @@ describe('plugin-meetings', () => {
           });
           it('should send the whiteboard share', async () => {
             const whiteboardShare = meeting.startWhiteboardShare({
-              channelUrl: url2
+              channelUrl: url2,
             });
 
             assert.exists(whiteboardShare.then);
@@ -3945,18 +4237,35 @@ describe('plugin-meetings', () => {
           const USER_IDS = {
             ME: '9528d952-e4de-46cf-8157-fd4823b98377',
             REMOTE_A: '5be7e7b0-b304-48da-8083-83bd72b5300d',
-            REMOTE_B: 'd4d102a1-17ce-4e17-9b08-bded3de467e4'
+            REMOTE_B: 'd4d102a1-17ce-4e17-9b08-bded3de467e4',
           };
 
           const RESOURCE_URLS = {
-            WHITEBOARD_A: 'https://board-a.wbx2.com/board/api/v1/channels/49cfb550-5517-11eb-a2af-1b9e4bc3da13',
-            WHITEBOARD_B: 'https://board-a.wbx2.com/board/api/v1/channels/977a7330-54f4-11eb-b1ef-91f5eefc7bf3'
+            WHITEBOARD_A:
+              'https://board-a.wbx2.com/board/api/v1/channels/49cfb550-5517-11eb-a2af-1b9e4bc3da13',
+            WHITEBOARD_B:
+              'https://board-a.wbx2.com/board/api/v1/channels/977a7330-54f4-11eb-b1ef-91f5eefc7bf3',
           };
 
-          const generateContent = (beneficiaryId = null, disposition = null) => ({beneficiaryId, disposition});
-          const generateWhiteboard = (beneficiaryId = null, disposition = null, resourceUrl = null) => ({beneficiaryId, disposition, resourceUrl});
+          const generateContent = (beneficiaryId = null, disposition = null) => ({
+            beneficiaryId,
+            disposition,
+          });
+          const generateWhiteboard = (
+            beneficiaryId = null,
+            disposition = null,
+            resourceUrl = null
+          ) => ({beneficiaryId, disposition, resourceUrl});
 
-          const generateData = (payload, isGranting, isContent, beneficiaryId, resourceUrl, isAccepting, otherBeneficiaryId) => {
+          const generateData = (
+            payload,
+            isGranting,
+            isContent,
+            beneficiaryId,
+            resourceUrl,
+            isAccepting,
+            otherBeneficiaryId
+          ) => {
             const newPayload = cloneDeep(payload);
 
             newPayload.previous = cloneDeep(payload.current);
@@ -3967,15 +4276,15 @@ describe('plugin-meetings', () => {
                 eventName: EVENT_TRIGGERS.MEMBERS_CONTENT_UPDATE,
                 eventPayload: {
                   activeSharingId: null,
-                  endedSharingId: null
-                }
-              }
+                  endedSharingId: null,
+                },
+              },
             };
 
             let shareStatus = null;
             const activeSharingId = {
               whiteboard: null,
-              content: null
+              content: null,
             };
 
             if (isGranting) {
@@ -3992,48 +4301,53 @@ describe('plugin-meetings', () => {
                       newPayload.current.whiteboard.disposition = FLOOR_ACTION.RELEASED;
                       eventTrigger.share.push({
                         eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_WHITEBOARD,
-                        functionName: 'stopWhiteboardShare'
+                        functionName: 'stopWhiteboardShare',
                       });
-                      eventTrigger.member.eventPayload.endedSharingId = newPayload.current.whiteboard.beneficiaryId;
+                      eventTrigger.member.eventPayload.endedSharingId =
+                        newPayload.current.whiteboard.beneficiaryId;
                     }
                   }
 
                   if (newPayload.previous.content.beneficiaryId) {
-                    if (newPayload.previous.content.beneficiaryId !== newPayload.current.content.beneficiaryId) {
+                    if (
+                      newPayload.previous.content.beneficiaryId !==
+                      newPayload.current.content.beneficiaryId
+                    ) {
                       if (newPayload.previous.content.beneficiaryId === USER_IDS.ME) {
                         eventTrigger.share.push({
                           eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
-                          functionName: 'stopFloorRequest'
+                          functionName: 'stopFloorRequest',
                         });
                       }
                       else if (newPayload.current.content.beneficiaryId === USER_IDS.ME) {
                         eventTrigger.share.push({
                           eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_REMOTE,
-                          functionName: 'remoteShare'
+                          functionName: 'remoteShare',
                         });
                       }
-                      eventTrigger.member.eventPayload.endedSharingId = newPayload.previous.content.beneficiaryId;
+                      eventTrigger.member.eventPayload.endedSharingId =
+                        newPayload.previous.content.beneficiaryId;
                     }
                   }
 
                   if (isAccepting) {
                     eventTrigger.share.push({
                       eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_WHITEBOARD,
-                      functionName: 'stopWhiteboardShare'
+                      functionName: 'stopWhiteboardShare',
                     });
                   }
 
                   if (beneficiaryId === USER_IDS.ME) {
                     eventTrigger.share.push({
                       eventName: EVENT_TRIGGERS.MEETING_STARTED_SHARING_LOCAL,
-                      functionName: 'share'
+                      functionName: 'share',
                     });
                   }
                   else {
                     eventTrigger.share.push({
                       eventName: EVENT_TRIGGERS.MEETING_STARTED_SHARING_REMOTE,
                       functionName: 'remoteShare',
-                      eventPayload: {memberId: beneficiaryId}
+                      eventPayload: {memberId: beneficiaryId},
                     });
                   }
                 }
@@ -4046,7 +4360,11 @@ describe('plugin-meetings', () => {
                 }
               }
               else {
-                newPayload.current.whiteboard = generateWhiteboard(beneficiaryId, FLOOR_ACTION.GRANTED, resourceUrl);
+                newPayload.current.whiteboard = generateWhiteboard(
+                  beneficiaryId,
+                  FLOOR_ACTION.GRANTED,
+                  resourceUrl
+                );
 
                 if (newPayload.current.content.beneficiaryId) {
                   if (newPayload.current.content.disposition === FLOOR_ACTION.GRANTED) {
@@ -4054,41 +4372,50 @@ describe('plugin-meetings', () => {
                     if (newPayload.current.content.beneficiaryId === USER_IDS.ME) {
                       eventTrigger.share.push({
                         eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
-                        functionName: 'stopFloorRequest'
+                        functionName: 'stopFloorRequest',
                       });
                     }
                     else {
                       eventTrigger.share.push({
                         eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_REMOTE,
-                        functionName: 'remoteShare'
+                        functionName: 'remoteShare',
                       });
                     }
 
-                    eventTrigger.member.eventPayload.endedSharingId = newPayload.current.content.beneficiaryId;
+                    eventTrigger.member.eventPayload.endedSharingId =
+                      newPayload.current.content.beneficiaryId;
                   }
                 }
 
                 if (newPayload.previous.content.beneficiaryId) {
-                  if (newPayload.previous.content.beneficiaryId !== newPayload.current.content.beneficiaryId) {
+                  if (
+                    newPayload.previous.content.beneficiaryId !==
+                    newPayload.current.content.beneficiaryId
+                  ) {
                     if (newPayload.previous.content.beneficiaryId === USER_IDS.ME) {
                       eventTrigger.share.push({
                         eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
-                        functionName: 'stopFloorRequest'
+                        functionName: 'stopFloorRequest',
                       });
                     }
                     else if (newPayload.current.content.beneficiaryId === USER_IDS.ME) {
                       eventTrigger.share.push({
                         eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_REMOTE,
-                        functionName: 'remoteShare'
+                        functionName: 'remoteShare',
                       });
                     }
-                    eventTrigger.member.eventPayload.endedSharingId = newPayload.previous.content.beneficiaryId;
+                    eventTrigger.member.eventPayload.endedSharingId =
+                      newPayload.previous.content.beneficiaryId;
                   }
                 }
 
                 if (newPayload.previous.whiteboard.beneficiaryId) {
-                  if (newPayload.previous.whiteboard.beneficiaryId !== newPayload.current.whiteboard.beneficiaryId) {
-                    eventTrigger.member.eventPayload.endedSharingId = newPayload.previous.whiteboard.beneficiaryId;
+                  if (
+                    newPayload.previous.whiteboard.beneficiaryId !==
+                    newPayload.current.whiteboard.beneficiaryId
+                  ) {
+                    eventTrigger.member.eventPayload.endedSharingId =
+                      newPayload.previous.whiteboard.beneficiaryId;
                   }
                 }
 
@@ -4097,7 +4424,7 @@ describe('plugin-meetings', () => {
                 eventTrigger.share.push({
                   eventName: EVENT_TRIGGERS.MEETING_STARTED_SHARING_WHITEBOARD,
                   functionName: 'startWhiteboardShare',
-                  eventPayload: {resourceUrl, memberId: beneficiaryId}
+                  eventPayload: {resourceUrl, memberId: beneficiaryId},
                 });
 
                 shareStatus = SHARE_STATUS.WHITEBOARD_SHARE_ACTIVE;
@@ -4116,13 +4443,13 @@ describe('plugin-meetings', () => {
                 if (beneficiaryId === USER_IDS.ME) {
                   eventTrigger.share.push({
                     eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_LOCAL,
-                    functionName: 'stopFloorRequest'
+                    functionName: 'stopFloorRequest',
                   });
                 }
                 else {
                   eventTrigger.share.push({
                     eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_REMOTE,
-                    functionName: 'remoteShare'
+                    functionName: 'remoteShare',
                   });
                 }
 
@@ -4138,7 +4465,7 @@ describe('plugin-meetings', () => {
                   eventTrigger.share.push({
                     eventName: EVENT_TRIGGERS.MEETING_STARTED_SHARING_WHITEBOARD,
                     functionName: 'startWhiteboardShare',
-                    eventPayload: {resourceUrl, memberId: beneficiaryId}
+                    eventPayload: {resourceUrl, memberId: beneficiaryId},
                   });
 
                   shareStatus = SHARE_STATUS.WHITEBOARD_SHARE_ACTIVE;
@@ -4146,7 +4473,7 @@ describe('plugin-meetings', () => {
                 else {
                   eventTrigger.share.push({
                     eventName: EVENT_TRIGGERS.MEETING_STOPPED_SHARING_WHITEBOARD,
-                    functionName: 'stopWhiteboardShare'
+                    functionName: 'stopWhiteboardShare',
                   });
 
                   shareStatus = SHARE_STATUS.NO_SHARE;
@@ -4155,21 +4482,23 @@ describe('plugin-meetings', () => {
             }
 
             return {
-              payload: newPayload, eventTrigger, shareStatus, activeSharingId
+              payload: newPayload,
+              eventTrigger,
+              shareStatus,
+              activeSharingId,
             };
           };
 
           const blankPayload = {
             previous: {
               content: generateContent(),
-              whiteboard: generateWhiteboard()
+              whiteboard: generateWhiteboard(),
             },
             current: {
               content: generateContent(),
-              whiteboard: generateWhiteboard()
-            }
+              whiteboard: generateWhiteboard(),
+            },
           };
-
 
           const payloadTestHelper = (data) => {
             assert.equal(meeting.shareStatus, SHARE_STATUS.NO_SHARE);
@@ -4178,22 +4507,32 @@ describe('plugin-meetings', () => {
             let callCounter = 1;
 
             data.forEach((d, index) => {
-              meeting.locusInfo.emit({function: 'test', file: 'test'}, EVENTS.LOCUS_INFO_UPDATE_MEDIA_SHARES, d.payload);
+              meeting.locusInfo.emit(
+                {function: 'test', file: 'test'},
+                EVENTS.LOCUS_INFO_UPDATE_MEDIA_SHARES,
+                d.payload
+              );
 
               assert.equal(meeting.shareStatus, data[index].shareStatus);
 
-              callCounter += data[index].eventTrigger.share.length + (data[index].eventTrigger.member ? 1 : 0);
+              callCounter +=
+                data[index].eventTrigger.share.length + (data[index].eventTrigger.member ? 1 : 0);
 
               assert.callCount(TriggerProxy.trigger, callCounter);
 
-              assert.equal(meeting.members.mediaShareWhiteboardId, data[index].activeSharingId.whiteboard);
-              assert.equal(meeting.members.mediaShareContentId, data[index].activeSharingId.content);
+              assert.equal(
+                meeting.members.mediaShareWhiteboardId,
+                data[index].activeSharingId.whiteboard
+              );
+              assert.equal(
+                meeting.members.mediaShareContentId,
+                data[index].activeSharingId.content
+              );
             });
 
             assert.callCount(TriggerProxy.trigger, callCounter);
 
             // Start with 1 to ignore members:update trigger
-
 
             let i = 1;
             let offset = 2;
@@ -4206,13 +4545,13 @@ describe('plugin-meetings', () => {
               for (let idx = 0; idx < share.length; idx += 1) {
                 const shareCallArgs = TriggerProxy.trigger.getCall(i + idx).args;
                 const {functionName, eventName, eventPayload} = share[idx];
-                const fileName = functionName === 'remoteShare' ? 'meetings/index' : 'meeting/index';
+                const fileName =
+                  functionName === 'remoteShare' ? 'meetings/index' : 'meeting/index';
 
                 assert.deepEqual(shareCallArgs[1], {
                   file: fileName,
-                  function: functionName
+                  function: functionName,
                 });
-
 
                 assert.equal(shareCallArgs[2], eventName);
 
@@ -4220,7 +4559,10 @@ describe('plugin-meetings', () => {
                   assert.deepEqual(shareCallArgs[3], eventPayload);
                 }
 
-                if (functionName === 'remoteShare' && eventName === EVENT_TRIGGERS.MEETING_STARTED_SHARING_REMOTE) {
+                if (
+                  functionName === 'remoteShare' &&
+                  eventName === EVENT_TRIGGERS.MEETING_STARTED_SHARING_REMOTE
+                ) {
                   assert.deepEqual(shareCallArgs[3], eventPayload);
                 }
               }
@@ -4231,7 +4573,7 @@ describe('plugin-meetings', () => {
 
                 assert.deepEqual(memberCallArgs[1], {
                   file: 'members',
-                  function: 'locusMediaSharesUpdate'
+                  function: 'locusMediaSharesUpdate',
                 });
                 assert.equal(memberCallArgs[2], member.eventName);
 
@@ -4247,7 +4589,7 @@ describe('plugin-meetings', () => {
                 offset = (offset + share.length + 1) / 2;
               }
               else if (share.length + 1 < offset) {
-                offset = (share.length + 1) + 0.5;
+                offset = share.length + 1 + 0.5;
               }
             }
           };
@@ -4258,40 +4600,100 @@ describe('plugin-meetings', () => {
 
           describe('Whiteboard A --> Whiteboard B', () => {
             it('Scenario #1: you share both whiteboards', () => {
-              const data1 = generateData(blankPayload, true, false, USER_IDS.ME, RESOURCE_URLS.WHITEBOARD_A);
-              const data2 = generateData(data1.payload, true, false, USER_IDS.ME, RESOURCE_URLS.WHITEBOARD_B);
+              const data1 = generateData(
+                blankPayload,
+                true,
+                false,
+                USER_IDS.ME,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
+              const data2 = generateData(
+                data1.payload,
+                true,
+                false,
+                USER_IDS.ME,
+                RESOURCE_URLS.WHITEBOARD_B
+              );
               const data3 = generateData(data2.payload, false, false, USER_IDS.ME);
 
               payloadTestHelper([data1, data2, data3]);
             });
 
             it('Scenario #2: you share whiteboard A and remote person A shares whiteboard B', () => {
-              const data1 = generateData(blankPayload, true, false, USER_IDS.ME, RESOURCE_URLS.WHITEBOARD_A);
-              const data2 = generateData(data1.payload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_B);
+              const data1 = generateData(
+                blankPayload,
+                true,
+                false,
+                USER_IDS.ME,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
+              const data2 = generateData(
+                data1.payload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_B
+              );
               const data3 = generateData(data2.payload, false, false, USER_IDS.REMOTE_A);
 
               payloadTestHelper([data1, data2, data3]);
             });
 
             it('Scenario #3: remote person A shares whiteboard A and you share whiteboard B', () => {
-              const data1 = generateData(blankPayload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A);
-              const data2 = generateData(data1.payload, true, false, USER_IDS.ME, RESOURCE_URLS.WHITEBOARD_B);
+              const data1 = generateData(
+                blankPayload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
+              const data2 = generateData(
+                data1.payload,
+                true,
+                false,
+                USER_IDS.ME,
+                RESOURCE_URLS.WHITEBOARD_B
+              );
               const data3 = generateData(data2.payload, false, false, USER_IDS.ME);
 
               payloadTestHelper([data1, data2, data3]);
             });
 
             it('Scenario #4: remote person A shares both whiteboards', () => {
-              const data1 = generateData(blankPayload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A);
-              const data2 = generateData(data1.payload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_B);
+              const data1 = generateData(
+                blankPayload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
+              const data2 = generateData(
+                data1.payload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_B
+              );
               const data3 = generateData(data2.payload, false, false, USER_IDS.REMOTE_A);
 
               payloadTestHelper([data1, data2, data3]);
             });
 
             it('Scenario #5: remote person A shares whiteboard A and remote person B shares whiteboard B', () => {
-              const data1 = generateData(blankPayload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A);
-              const data2 = generateData(data1.payload, true, false, USER_IDS.REMOTE_B, RESOURCE_URLS.WHITEBOARD_B);
+              const data1 = generateData(
+                blankPayload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
+              const data2 = generateData(
+                data1.payload,
+                true,
+                false,
+                USER_IDS.REMOTE_B,
+                RESOURCE_URLS.WHITEBOARD_B
+              );
               const data3 = generateData(data2.payload, false, false, USER_IDS.REMOTE_B);
 
               payloadTestHelper([data1, data2, data3]);
@@ -4300,45 +4702,155 @@ describe('plugin-meetings', () => {
 
           describe('Whiteboard A --> Desktop', () => {
             it('Scenario #1: you share whiteboard and then share desktop', () => {
-              const data1 = generateData(blankPayload, true, false, USER_IDS.ME, RESOURCE_URLS.WHITEBOARD_A);
-              const data2 = generateData(data1.payload, false, false, USER_IDS.ME, RESOURCE_URLS.WHITEBOARD_A, true, USER_IDS.ME);
-              const data3 = generateData(data2.payload, true, true, USER_IDS.ME, undefined, true, USER_IDS.ME);
+              const data1 = generateData(
+                blankPayload,
+                true,
+                false,
+                USER_IDS.ME,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
+              const data2 = generateData(
+                data1.payload,
+                false,
+                false,
+                USER_IDS.ME,
+                RESOURCE_URLS.WHITEBOARD_A,
+                true,
+                USER_IDS.ME
+              );
+              const data3 = generateData(
+                data2.payload,
+                true,
+                true,
+                USER_IDS.ME,
+                undefined,
+                true,
+                USER_IDS.ME
+              );
               const data4 = generateData(data3.payload, false, true, USER_IDS.ME);
 
               payloadTestHelper([data1, data2, data3, data4]);
             });
 
             it('Scenario #2: you share whiteboard A and remote person A shares desktop', () => {
-              const data1 = generateData(blankPayload, true, false, USER_IDS.ME, RESOURCE_URLS.WHITEBOARD_A);
-              const data2 = generateData(data1.payload, false, false, USER_IDS.ME, RESOURCE_URLS.WHITEBOARD_A, true, USER_IDS.REMOTE_A);
-              const data3 = generateData(data2.payload, true, true, USER_IDS.REMOTE_A, undefined, true, USER_IDS.ME);
+              const data1 = generateData(
+                blankPayload,
+                true,
+                false,
+                USER_IDS.ME,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
+              const data2 = generateData(
+                data1.payload,
+                false,
+                false,
+                USER_IDS.ME,
+                RESOURCE_URLS.WHITEBOARD_A,
+                true,
+                USER_IDS.REMOTE_A
+              );
+              const data3 = generateData(
+                data2.payload,
+                true,
+                true,
+                USER_IDS.REMOTE_A,
+                undefined,
+                true,
+                USER_IDS.ME
+              );
               const data4 = generateData(data3.payload, false, true, USER_IDS.REMOTE_A);
 
               payloadTestHelper([data1, data2, data3, data4]);
             });
 
             it('Scenario #3: remote person A shares whiteboard and you share desktop', () => {
-              const data1 = generateData(blankPayload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A);
-              const data2 = generateData(data1.payload, false, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A, true, USER_IDS.ME);
-              const data3 = generateData(data2.payload, true, true, USER_IDS.ME, undefined, true, USER_IDS.REMOTE_A);
+              const data1 = generateData(
+                blankPayload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
+              const data2 = generateData(
+                data1.payload,
+                false,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A,
+                true,
+                USER_IDS.ME
+              );
+              const data3 = generateData(
+                data2.payload,
+                true,
+                true,
+                USER_IDS.ME,
+                undefined,
+                true,
+                USER_IDS.REMOTE_A
+              );
               const data4 = generateData(data3.payload, false, true, USER_IDS.ME);
 
               payloadTestHelper([data1, data2, data3, data4]);
             });
 
             it('Scenario #4: remote person A shares whiteboard and then shares desktop', () => {
-              const data1 = generateData(blankPayload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A);
-              const data2 = generateData(data1.payload, false, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A, true, USER_IDS.REMOTE_A);
-              const data3 = generateData(data2.payload, true, true, USER_IDS.REMOTE_A, undefined, true, USER_IDS.REMOTE_A);
+              const data1 = generateData(
+                blankPayload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
+              const data2 = generateData(
+                data1.payload,
+                false,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A,
+                true,
+                USER_IDS.REMOTE_A
+              );
+              const data3 = generateData(
+                data2.payload,
+                true,
+                true,
+                USER_IDS.REMOTE_A,
+                undefined,
+                true,
+                USER_IDS.REMOTE_A
+              );
               const data4 = generateData(data3.payload, false, true, USER_IDS.REMOTE_A);
 
               payloadTestHelper([data1, data2, data3, data4]);
             });
 
             it('Scenario #5: remote person A shares whiteboard and remote person B shares desktop', () => {
-              const data1 = generateData(blankPayload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A);
-              const data2 = generateData(data1.payload, false, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A, true, USER_IDS.REMOTE_B);
-              const data3 = generateData(data2.payload, true, true, USER_IDS.REMOTE_B, undefined, true, USER_IDS.REMOTE_A);
+              const data1 = generateData(
+                blankPayload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
+              const data2 = generateData(
+                data1.payload,
+                false,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A,
+                true,
+                USER_IDS.REMOTE_B
+              );
+              const data3 = generateData(
+                data2.payload,
+                true,
+                true,
+                USER_IDS.REMOTE_B,
+                undefined,
+                true,
+                USER_IDS.REMOTE_A
+              );
               const data4 = generateData(data3.payload, false, true, USER_IDS.REMOTE_B);
 
               payloadTestHelper([data1, data2, data3, data4]);
@@ -4348,7 +4860,13 @@ describe('plugin-meetings', () => {
           describe('Desktop --> Whiteboard A', () => {
             it('Scenario #1: you share desktop and then share whiteboard', () => {
               const data1 = generateData(blankPayload, true, true, USER_IDS.ME);
-              const data2 = generateData(data1.payload, true, false, USER_IDS.ME, RESOURCE_URLS.WHITEBOARD_A);
+              const data2 = generateData(
+                data1.payload,
+                true,
+                false,
+                USER_IDS.ME,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
               const data3 = generateData(data2.payload, false, false, USER_IDS.ME);
 
               payloadTestHelper([data1, data2, data3]);
@@ -4356,7 +4874,13 @@ describe('plugin-meetings', () => {
 
             it('Scenario #2: you share desktop and remote person A shares whiteboard', () => {
               const data1 = generateData(blankPayload, true, true, USER_IDS.ME);
-              const data2 = generateData(data1.payload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A);
+              const data2 = generateData(
+                data1.payload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
               const data3 = generateData(data2.payload, false, false, USER_IDS.REMOTE_A);
 
               payloadTestHelper([data1, data2, data3]);
@@ -4364,7 +4888,13 @@ describe('plugin-meetings', () => {
 
             it('Scenario #3: remote person A shares desktop and you share whiteboard', () => {
               const data1 = generateData(blankPayload, true, true, USER_IDS.REMOTE_A);
-              const data2 = generateData(data1.payload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A);
+              const data2 = generateData(
+                data1.payload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
               const data3 = generateData(data2.payload, false, false, USER_IDS.REMOTE_A);
 
               payloadTestHelper([data1, data2, data3]);
@@ -4372,7 +4902,13 @@ describe('plugin-meetings', () => {
 
             it('Scenario #4: remote person A shares desktop and then shares whiteboard', () => {
               const data1 = generateData(blankPayload, true, true, USER_IDS.REMOTE_A);
-              const data2 = generateData(data1.payload, true, false, USER_IDS.ME, RESOURCE_URLS.WHITEBOARD_A);
+              const data2 = generateData(
+                data1.payload,
+                true,
+                false,
+                USER_IDS.ME,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
               const data3 = generateData(data2.payload, false, false, USER_IDS.ME);
 
               payloadTestHelper([data1, data2, data3]);
@@ -4380,7 +4916,13 @@ describe('plugin-meetings', () => {
 
             it('Scenario #5: remote person A shares desktop and remote person B shares whiteboard', () => {
               const data1 = generateData(blankPayload, true, true, USER_IDS.REMOTE_A);
-              const data2 = generateData(data1.payload, true, false, USER_IDS.REMOTE_A, RESOURCE_URLS.WHITEBOARD_A);
+              const data2 = generateData(
+                data1.payload,
+                true,
+                false,
+                USER_IDS.REMOTE_A,
+                RESOURCE_URLS.WHITEBOARD_A
+              );
               const data3 = generateData(data2.payload, false, false, USER_IDS.REMOTE_A);
 
               payloadTestHelper([data1, data2, data3]);
@@ -4456,17 +4998,21 @@ describe('plugin-meetings', () => {
           assert.isNull(meeting.keepAliveTimerId);
           meeting.joinedWith = {
             keepAliveUrl: defaultKeepAliveUrl,
-            keepAliveSecs: defaultKeepAliveSecs
+            keepAliveSecs: defaultKeepAliveSecs,
           };
           meeting.startKeepAlive();
           assert.isNumber(meeting.keepAliveTimerId.id);
           await testUtils.flushPromises();
           assert.notCalled(meeting.meetingRequest.keepAlive);
           await progressTime(defaultExpectedInterval);
-          assert.calledOnceWithExactly(meeting.meetingRequest.keepAlive, {keepAliveUrl: defaultKeepAliveUrl});
+          assert.calledOnceWithExactly(meeting.meetingRequest.keepAlive, {
+            keepAliveUrl: defaultKeepAliveUrl,
+          });
           await progressTime(defaultExpectedInterval);
           assert.calledTwice(meeting.meetingRequest.keepAlive);
-          assert.alwaysCalledWithExactly(meeting.meetingRequest.keepAlive, {keepAliveUrl: defaultKeepAliveUrl});
+          assert.alwaysCalledWithExactly(meeting.meetingRequest.keepAlive, {
+            keepAliveUrl: defaultKeepAliveUrl,
+          });
         });
         it('startKeepAlive handles existing keepAliveTimerId', async () => {
           meeting.meetingRequest.keepAlive = sinon.stub().returns(Promise.resolve());
@@ -4475,7 +5021,7 @@ describe('plugin-meetings', () => {
           meeting.keepAliveTimerId = 7;
           meeting.joinedWith = {
             keepAliveUrl: defaultKeepAliveUrl,
-            keepAliveSecs: defaultKeepAliveSecs
+            keepAliveSecs: defaultKeepAliveSecs,
           };
           meeting.startKeepAlive();
           assert.equal(meeting.keepAliveTimerId, 7);
@@ -4488,7 +5034,7 @@ describe('plugin-meetings', () => {
 
           assert.isNull(meeting.keepAliveTimerId);
           meeting.joinedWith = {
-            keepAliveSecs: defaultKeepAliveSecs
+            keepAliveSecs: defaultKeepAliveSecs,
           };
           meeting.startKeepAlive();
           assert.isNull(meeting.keepAliveTimerId);
@@ -4501,7 +5047,7 @@ describe('plugin-meetings', () => {
 
           assert.isNull(meeting.keepAliveTimerId);
           meeting.joinedWith = {
-            keepAliveUrl: defaultKeepAliveUrl
+            keepAliveUrl: defaultKeepAliveUrl,
           };
           meeting.startKeepAlive();
           assert.isNull(meeting.keepAliveTimerId);
@@ -4515,7 +5061,7 @@ describe('plugin-meetings', () => {
           assert.isNull(meeting.keepAliveTimerId);
           meeting.joinedWith = {
             keepAliveUrl: defaultKeepAliveUrl,
-            keepAliveSecs: 1
+            keepAliveSecs: 1,
           };
           meeting.startKeepAlive();
           assert.isNull(meeting.keepAliveTimerId);
@@ -4528,14 +5074,16 @@ describe('plugin-meetings', () => {
           assert.isNull(meeting.keepAliveTimerId);
           meeting.joinedWith = {
             keepAliveUrl: defaultKeepAliveUrl,
-            keepAliveSecs: defaultKeepAliveSecs
+            keepAliveSecs: defaultKeepAliveSecs,
           };
           meeting.startKeepAlive();
           assert.isNumber(meeting.keepAliveTimerId.id);
           await testUtils.flushPromises();
           assert.notCalled(meeting.meetingRequest.keepAlive);
           await progressTime(defaultExpectedInterval);
-          assert.calledOnceWithExactly(meeting.meetingRequest.keepAlive, {keepAliveUrl: defaultKeepAliveUrl});
+          assert.calledOnceWithExactly(meeting.meetingRequest.keepAlive, {
+            keepAliveUrl: defaultKeepAliveUrl,
+          });
           assert.isNull(meeting.keepAliveTimerId);
           await progressTime(defaultExpectedInterval);
           assert.calledOnce(meeting.meetingRequest.keepAlive);
@@ -4565,12 +5113,14 @@ describe('plugin-meetings', () => {
           assert.isNull(meeting.keepAliveTimerId);
           meeting.joinedWith = {
             keepAliveUrl: defaultKeepAliveUrl,
-            keepAliveSecs: defaultKeepAliveSecs
+            keepAliveSecs: defaultKeepAliveSecs,
           };
           meeting.startKeepAlive();
           assert.isNumber(meeting.keepAliveTimerId.id);
           await progressTime(defaultExpectedInterval);
-          assert.calledOnceWithExactly(meeting.meetingRequest.keepAlive, {keepAliveUrl: defaultKeepAliveUrl});
+          assert.calledOnceWithExactly(meeting.meetingRequest.keepAlive, {
+            keepAliveUrl: defaultKeepAliveUrl,
+          });
 
           meeting.stopKeepAlive();
           assert.isNull(meeting.keepAliveTimerId);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1826,9 +1826,9 @@ describe('plugin-meetings', () => {
             config
           );
 
-          // eslint-disable-next-line no-undef
           assert.calledWith(
-            global.navigator.mediaDevices.getDisplayMedia,
+            // eslint-disable-next-line no-undef
+            navigator.mediaDevices.getDisplayMedia,
             browserConditionalValue({
               default: {
                 video: {...shareConstraints},
@@ -1852,9 +1852,9 @@ describe('plugin-meetings', () => {
             config
           );
 
-          // eslint-disable-next-line no-undef
           assert.calledWith(
-            global.navigator.mediaDevices.getDisplayMedia,
+            // eslint-disable-next-line no-undef
+            navigator.mediaDevices.getDisplayMedia,
             browserConditionalValue({
               default: {
                 video: {
@@ -1878,9 +1878,9 @@ describe('plugin-meetings', () => {
           getDisplayMedia(shareOptions);
           const {screenResolution} = config;
 
-          // eslint-disable-next-line no-undef
           assert.calledWith(
-            global.navigator.mediaDevices.getDisplayMedia,
+            // eslint-disable-next-line no-undef
+            navigator.mediaDevices.getDisplayMedia,
             browserConditionalValue({
               default: {
                 video: {
@@ -1910,9 +1910,9 @@ describe('plugin-meetings', () => {
 
           getDisplayMedia(shareOptions, customConfig);
 
-          // eslint-disable-next-line no-undef
           assert.calledWith(
-            global.navigator.mediaDevices.getDisplayMedia,
+            // eslint-disable-next-line no-undef
+            navigator.mediaDevices.getDisplayMedia,
             browserConditionalValue({
               default: {
                 video: {
@@ -1946,9 +1946,9 @@ describe('plugin-meetings', () => {
 
           getDisplayMedia(shareOptions, customConfig);
 
-          // eslint-disable-next-line no-undef
           assert.calledWith(
-            global.navigator.mediaDevices.getDisplayMedia,
+            // eslint-disable-next-line no-undef
+            navigator.mediaDevices.getDisplayMedia,
             browserConditionalValue({
               default: {
                 video: {


### PR DESCRIPTION

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >

Currently, voicea triggers notification for transcribing on and off, only when user has used toggleTranscribing with the SDK. But if the value has changed from other apps like desktop client,  then clients depending on the triggers might not maintain the right state.

## by making the following changes

< DESCRIBE YOUR CHANGES >
Remove triggers from voicea plugin, and add them under meetings plugin for locus state change.
new trigger event name is changed as per convention.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
