### PR TITLE
fix(plugin-meetings): added timeout for ICE candidate gathering

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -186,8 +186,7 @@ export const MODERATOR_FALSE = false;
 // ******************** NUMBERS ********************
 
 export const INTENT_TO_JOIN = [2423005, 2423006, 2423016, 2423017, 2423018];
-export const ICE_TIMEOUT = 2000;
-export const ICE_FAIL_TIMEOUT = 3000;
+export const ICE_GATHERING_TIMEOUT = 5000;
 
 export const RETRY_TIMEOUT = 3000;
 export const ROAP_SEQ_PRE = -1;


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

I've seen cases where Chrome never called us back with gathering state "complete" or null ice candidate even though we got a lot of (possibly all?) ICE candidates. This fix adds a timeout to ensure we don't get stuck.

## by making the following changes

Added a timeout for ICE candidate gathering. After the timer expires, we check if we have enough candidates and continue or fail.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

manual tests with sample app, existing automatic tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
