### PR TITLE
fix: use correct TURN TLS information when reconnecting

### DIFF
--- a/packages/@webex/plugin-meetings/src/reconnection-manager/index.js
+++ b/packages/@webex/plugin-meetings/src/reconnection-manager/index.js
@@ -474,9 +474,9 @@ export default class ReconnectionManager {
     await this.meeting.closePeerConnections();
     this.meeting.mediaProperties.unsetPeerConnection();
 
-    const turnServerInfo = await this.meeting.roap.doTurnDiscovery(this.meeting, true);
+    const turnServerResult = await this.meeting.roap.doTurnDiscovery(this.meeting, true);
 
-    const mc = this.meeting.createMediaConnection(turnServerInfo);
+    const mc = this.meeting.createMediaConnection(turnServerResult.turnServerInfo);
 
     this.meeting.statsAnalyzer.updateMediaConnection(mc);
 


### PR DESCRIPTION
There was a recent change on master to the output of `doTurnDiscovery()` function, so after merge from latest master the TURN server information was not properly passed to `createMediaConnection()` resulting in browser failing to create the RTCPeerConnection.


Similar fix will be required on master, although the code is slightly different there.