### PR TITLE
fix: set unique debugId for media connections

### DIFF
--- a/packages/@webex/plugin-meetings/src/media/index.js
+++ b/packages/@webex/plugin-meetings/src/media/index.js
@@ -118,29 +118,30 @@ Media.getLocalMedia = (options, config) => {
 
 /**
  * creates a webrtc media connection with provided tracks and mediaDirection configuration
- * @param {Object} mediaProperties only applicable to non-multistream connections, contains mediaDirection and local tracks:
- *                                 audioTrack, videoTrack and shareTrack
+ *
+ * @param {boolean} isMultistream
+ * @param {string} debugId string useful for debugging (will appear in media connection logs)
  * @param {Object} options
- * @param {boolean} options.isMultistream
+ * @param {Object} [options.mediaProperties] only applicable to non-multistream connections, contains mediaDirection and local tracks:
+ *                                 audioTrack, videoTrack and shareTrack
  * @param {string} [options.remoteQualityLevel] LOW|MEDIUM|HIGH applicable only to non-multistream connections
  * @param {boolean} [options.enableRtx] applicable only to non-multistream connections
  * @param {boolean} [options.enableExtmap] applicable only to non-multistream connections
  * @param {Object} [options.turnServerInfo]
  * @returns {RoapMediaConnection}
  */
-Media.createMediaConnection = (mediaProperties, {
+Media.createMediaConnection = (
   isMultistream,
-  remoteQualityLevel,
-  enableRtx,
-  enableExtmap,
-  turnServerInfo
-}) => {
+  debugId,
+  options
+) => {
   const {
-    mediaDirection,
-    audioTrack,
-    videoTrack,
-    shareTrack
-  } = mediaProperties;
+    mediaProperties,
+    remoteQualityLevel,
+    enableRtx,
+    enableExtmap,
+    turnServerInfo
+  } = options;
 
   const iceServers = [];
 
@@ -155,8 +156,20 @@ Media.createMediaConnection = (mediaProperties, {
   if (isMultistream) {
     return new MultistreamRoapMediaConnection({
       iceServers,
-    }, 'mc');
+    }, debugId);
   }
+
+  if (!mediaProperties) {
+    throw new Error('mediaProperties have to be provided for non-multistream media connections');
+  }
+
+  const {
+    mediaDirection,
+    audioTrack,
+    videoTrack,
+    shareTrack
+  } = mediaProperties;
+
 
   return new RoapMediaConnection({
     iceServers,
@@ -186,7 +199,7 @@ Media.createMediaConnection = (mediaProperties, {
       screenShareVideo: mediaDirection.receiveShare,
       remoteQualityLevel
     }
-  }, 'mc');
+  }, debugId);
 };
 
 /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/@webex/plugin-meetings/src/meeting/index.js
@@ -4436,14 +4436,17 @@ export default class Meeting extends StatelessWebexPlugin {
   };
 
   createMediaConnection(turnServerInfo) {
-    const mc = Media.createMediaConnection(this.mediaProperties, {
-      isMultistream: this.isMultistream,
-      meetingId: this.id,
-      remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
-      enableRtx: this.config.enableRtx,
-      enableExtmap: this.config.enableExtmap,
-      turnServerInfo
-    });
+    const mc = Media.createMediaConnection(
+      this.isMultistream,
+      `MC-${this.id.substring(0, 4)}`,
+      {
+        mediaProperties: this.mediaProperties,
+        remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
+        enableRtx: this.config.enableRtx,
+        enableExtmap: this.config.enableExtmap,
+        turnServerInfo
+      }
+    );
 
     this.mediaProperties.setMediaPeerConnection(mc);
     this.setupMediaConnectionListeners();

--- a/packages/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/@webex/plugin-meetings/src/meeting/index.js
@@ -4435,10 +4435,14 @@ export default class Meeting extends StatelessWebexPlugin {
     });
   };
 
+  getMediaConnectionDebugId() {
+    return `MC-${this.id.substring(0, 4)}`;
+  }
+
   createMediaConnection(turnServerInfo) {
     const mc = Media.createMediaConnection(
       this.isMultistream,
-      `MC-${this.id.substring(0, 4)}`,
+      this.getMediaConnectionDebugId(),
       {
         mediaProperties: this.mediaProperties,
         remoteQualityLevel: this.mediaProperties.remoteQualityLevel,

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
@@ -29,8 +29,8 @@ describe('createMediaConnection', () => {
     const ENABLE_EXTMAP = false;
     const ENABLE_RTX = true;
 
-    Media.createMediaConnection(
-      {
+    Media.createMediaConnection(false, 'some debug id', {
+      mediaProperties: {
         mediaDirection: {
           sendAudio: true,
           sendVideo: true,
@@ -43,18 +43,15 @@ describe('createMediaConnection', () => {
         videoTrack: fakeVideoTrack,
         shareTrack: null,
       },
-      {
-        isMultistream: false,
-        remoteQualityLevel: 'HIGH',
-        enableRtx: ENABLE_RTX,
-        enableExtmap: ENABLE_EXTMAP,
-        turnServerInfo: {
-          url: 'turn server url',
-          username: 'turn username',
-          password: 'turn password',
-        },
-      }
-    );
+      remoteQualityLevel: 'HIGH',
+      enableRtx: ENABLE_RTX,
+      enableExtmap: ENABLE_EXTMAP,
+      turnServerInfo: {
+        url: 'turn server url',
+        username: 'turn username',
+        password: 'turn password',
+      },
+    });
     assert.calledOnce(roapMediaConnectionConstructorStub);
     assert.calledWith(
       roapMediaConnectionConstructorStub,
@@ -94,7 +91,7 @@ describe('createMediaConnection', () => {
           remoteQualityLevel: 'HIGH',
         },
       },
-      'mc'
+      'some debug id'
     );
   });
 
@@ -103,17 +100,13 @@ describe('createMediaConnection', () => {
       .stub(internalMediaModule, 'MultistreamRoapMediaConnection')
       .returns(fakeRoapMediaConnection);
 
-    Media.createMediaConnection(
-      {},
-      {
-        isMultistream: true,
-        turnServerInfo: {
-          url: 'turn server url',
-          username: 'turn username',
-          password: 'turn password',
-        },
-      }
-    );
+    Media.createMediaConnection(true, 'some debug id', {
+      turnServerInfo: {
+        url: 'turn server url',
+        username: 'turn username',
+        password: 'turn password',
+      },
+    });
     assert.calledOnce(multistreamRoapMediaConnectionConstructorStub);
     assert.calledWith(
       multistreamRoapMediaConnectionConstructorStub,
@@ -126,7 +119,7 @@ describe('createMediaConnection', () => {
           },
         ],
       },
-      'mc'
+      'some debug id'
     );
   });
 
@@ -135,20 +128,14 @@ describe('createMediaConnection', () => {
       .stub(internalMediaModule, 'MultistreamRoapMediaConnection')
       .returns(fakeRoapMediaConnection);
 
-    Media.createMediaConnection(
-      {},
-      {
-        isMultistream: true,
-        turnServerInfo: undefined,
-      }
-    );
+    Media.createMediaConnection(true, 'debug string', {});
     assert.calledOnce(multistreamRoapMediaConnectionConstructorStub);
     assert.calledWith(
       multistreamRoapMediaConnectionConstructorStub,
       {
         iceServers: [],
       },
-      'mc'
+      'debug string'
     );
   });
 
@@ -162,8 +149,8 @@ describe('createMediaConnection', () => {
     const ENABLE_EXTMAP = false;
     const ENABLE_RTX = true;
 
-    Media.createMediaConnection(
-      {
+    Media.createMediaConnection(false, 'some debug id', {
+      mediaProperties: {
         mediaDirection: {
           sendAudio: true,
           sendVideo: true,
@@ -176,14 +163,11 @@ describe('createMediaConnection', () => {
         videoTrack: null,
         shareTrack: fakeVideoTrack,
       },
-      {
-        isMultistream: false,
-        remoteQualityLevel: 'HIGH',
-        enableRtx: ENABLE_RTX,
-        enableExtmap: ENABLE_EXTMAP,
-        turnServerInfo: undefined,
-      }
-    );
+      remoteQualityLevel: 'HIGH',
+      enableRtx: ENABLE_RTX,
+      enableExtmap: ENABLE_EXTMAP,
+      turnServerInfo: undefined,
+    });
     assert.calledOnce(roapMediaConnectionConstructorStub);
     assert.calledWith(
       roapMediaConnectionConstructorStub,
@@ -217,7 +201,7 @@ describe('createMediaConnection', () => {
           remoteQualityLevel: 'HIGH',
         },
       },
-      'mc'
+      'some debug id'
     );
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1105,7 +1105,7 @@ describe('plugin-meetings', () => {
           assert.calledWith(meeting.roap.doTurnDiscovery, meeting, false);
           assert.calledOnce(meeting.mediaProperties.setMediaDirection);
           assert.calledOnce(Media.createMediaConnection);
-          assert.calledWith(Media.createMediaConnection, false, `MC-${meeting.id.substring(0, 4)}`, sinon.match({turnServerInfo: undefined}));
+          assert.calledWith(Media.createMediaConnection, false, meeting.getMediaConnectionDebugId(), sinon.match({turnServerInfo: undefined}));
           assert.calledOnce(meeting.setMercuryListener);
           assert.calledOnce(fakeMediaConnection.initiateOffer);
           /* statsAnalyzer is initiated inside of addMedia so there isn't
@@ -1139,7 +1139,7 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.roap.doTurnDiscovery);
           assert.calledWith(meeting.roap.doTurnDiscovery, meeting, false);
           assert.calledOnce(Media.createMediaConnection);
-          assert.calledWith(Media.createMediaConnection, false, `MC-${meeting.id.substring(0, 4)}`, sinon.match({
+          assert.calledWith(Media.createMediaConnection, false, meeting.getMediaConnectionDebugId(), sinon.match({
             turnServerInfo: {
               url: FAKE_TURN_URL,
               username: FAKE_TURN_USER,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1105,7 +1105,7 @@ describe('plugin-meetings', () => {
           assert.calledWith(meeting.roap.doTurnDiscovery, meeting, false);
           assert.calledOnce(meeting.mediaProperties.setMediaDirection);
           assert.calledOnce(Media.createMediaConnection);
-          assert.calledWith(Media.createMediaConnection, sinon.match.any, sinon.match({turnServerInfo: undefined}));
+          assert.calledWith(Media.createMediaConnection, false, `MC-${meeting.id.substring(0, 4)}`, sinon.match({turnServerInfo: undefined}));
           assert.calledOnce(meeting.setMercuryListener);
           assert.calledOnce(fakeMediaConnection.initiateOffer);
           /* statsAnalyzer is initiated inside of addMedia so there isn't
@@ -1139,7 +1139,7 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.roap.doTurnDiscovery);
           assert.calledWith(meeting.roap.doTurnDiscovery, meeting, false);
           assert.calledOnce(Media.createMediaConnection);
-          assert.calledWith(Media.createMediaConnection, sinon.match.any, sinon.match({
+          assert.calledWith(Media.createMediaConnection, false, `MC-${meeting.id.substring(0, 4)}`, sinon.match({
             turnServerInfo: {
               url: FAKE_TURN_URL,
               username: FAKE_TURN_USER,


### PR DESCRIPTION
Changed Media.createMediaConnection() to take a value for debugId that's passed to the roap media connection, so that we can set it to be unique per meeting - this is especially useful when looking at logs from integration test runs where we have multiple test users and meetings happening at the same time in same browser tab.

While I was there, I've reorganised the arguments of Media.createMediaConnection() and put things that are optional in options and things that are not optional as separate args.