### PR TITLE
fix: added stopped event to RemoteMedia

### DIFF
--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -7,6 +7,7 @@ import {CSI, ReceiveSlot, ReceiveSlotEvents} from './receiveSlot';
 
 export const RemoteMediaEvents = {
   SourceUpdate: ReceiveSlotEvents.SourceUpdate,
+  Stopped: 'stopped',
 };
 
 export type RemoteVideoResolution =
@@ -112,6 +113,14 @@ export class RemoteMedia extends EventsScope {
     this.cancelMediaRequest(commit);
     this.receiveSlot?.removeAllListeners();
     this.receiveSlot = undefined;
+    this.emit(
+      {
+        file: 'multistream/remoteMedia',
+        function: 'stop',
+      },
+      RemoteMediaEvents.Stopped,
+      {}
+    );
   }
 
   /**
@@ -164,7 +173,7 @@ export class RemoteMedia extends EventsScope {
   private setupEventListeners() {
     if (this.receiveSlot) {
       const scope = {
-        file: 'meeting/remoteMedia',
+        file: 'multistream/remoteMedia',
         function: 'setupEventListeners',
       };
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -184,7 +184,15 @@ describe('RemoteMedia', () => {
     it('cancels media request, unsets the receive slot and removes all the listeners from it', () => {
       const cancelMediaRequestSpy = sinon.spy(remoteMedia, 'cancelMediaRequest');
 
+      let stoppedListenerCalled = false;
+
+      remoteMedia.on(RemoteMediaEvents.Stopped, () => {
+        stoppedListenerCalled = true;
+      });
+
       remoteMedia.stop(true);
+
+      assert.isTrue(stoppedListenerCalled);
 
       assert.calledOnce(cancelMediaRequestSpy);
       assert.calledWith(cancelMediaRequestSpy, true);


### PR DESCRIPTION

# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-392487

## This pull request addresses

Client app had no explicit API to know when a RemoteMedia instance was no longer useable. It had to assume that when a layout changes, the old RemoteMedia instance are stopped or that when we leave the meeting they are all stopped.

## by making the following changes

Added a "stopped" event to RemoteMediaEvents, which is emitted from RemoteMedia.stop()

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
