### PR TITLE
fix: version of @webex dependencies

### DIFF
--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:^",
-    "@webex/internal-media-core": "^0.0.7-beta",
+    "@webex/internal-media-core": "0.0.7-beta",
     "@webex/internal-plugin-conversation": "workspace:^",
     "@webex/internal-plugin-device": "workspace:^",
     "@webex/internal-plugin-mercury": "workspace:^",
@@ -50,7 +50,7 @@
     "@webex/internal-plugin-user": "workspace:^",
     "@webex/plugin-people": "workspace:^",
     "@webex/plugin-rooms": "workspace:^",
-    "@webex/ts-sdp": "^1.0.1",
+    "@webex/ts-sdp": "1.0.1",
     "@webex/webex-core": "workspace:^",
     "bowser": "^2.11.0",
     "btoa": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4012,7 +4012,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:^0.0.7-beta":
+"@webex/internal-media-core@npm:0.0.7-beta":
   version: 0.0.7-beta
   resolution: "@webex/internal-media-core@npm:0.0.7-beta"
   dependencies:
@@ -4591,7 +4591,7 @@ __metadata:
   resolution: "@webex/plugin-meetings@workspace:packages/@webex/plugin-meetings"
   dependencies:
     "@webex/common": "workspace:^"
-    "@webex/internal-media-core": "npm:^0.0.7-beta"
+    "@webex/internal-media-core": "npm:0.0.7-beta"
     "@webex/internal-plugin-conversation": "workspace:^"
     "@webex/internal-plugin-device": "workspace:^"
     "@webex/internal-plugin-mercury": "workspace:^"
@@ -4606,7 +4606,7 @@ __metadata:
     "@webex/test-helper-mock-webex": "workspace:^"
     "@webex/test-helper-retry": "workspace:^"
     "@webex/test-helper-test-users": "workspace:^"
-    "@webex/ts-sdp": "npm:^1.0.1"
+    "@webex/ts-sdp": "npm:1.0.1"
     "@webex/webex-core": "workspace:^"
     bowser: "npm:^2.11.0"
     btoa: "npm:^1.2.1"
@@ -4976,7 +4976,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/ts-sdp@npm:^1.0.1":
+"@webex/ts-sdp@npm:1.0.1, @webex/ts-sdp@npm:^1.0.1":
   version: 1.0.1
   resolution: "@webex/ts-sdp@npm:1.0.1"
   checksum: 8be36b8e379972aa333026e09b6f2bf6507fff4282b71ec0354ad8c0c9856b9c7976976d3021c9b3e871e51fa48af61b8065ea329011b066295fcd80bcfabca8


### PR DESCRIPTION
## This pull request addresses

ts-sdp lib has introduced an API breaking change in version 1.3.1 so we don't want to use ^ in the version designation in package.json, because we can accidentally bring in the new version that breaks SDK

## by making the following changes

Removed ^ from the @webex/ts-sdp version. Also removed it for @webex/internal-media-core, because this lib is often changing rapidly and may have API breakages in minor versions too.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

automatic tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
