### PR TITLE
feat(reactions): add sendReaction on meeting plugin

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -470,7 +470,6 @@ export default class Meeting extends StatelessWebexPlugin {
   resourceUrl: string;
   selfId: string;
   state: any;
-
   namespace = MEETINGS;
 
   /**
@@ -1610,7 +1609,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @private
    * @memberof Meeting
    */
-  private setupLocusControlsListener() {
+   private setupLocusControlsListener() {
     this.locusInfo.on(LOCUSINFO.EVENTS.CONTROLS_RECORDING_UPDATED,
       ({state, modifiedBy, lastModified}) => {
         let event;
@@ -1706,7 +1705,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @private
    * @memberof Meeting
    */
-  private setUpLocusMediaSharesListener() {
+   private setUpLocusMediaSharesListener() {
     // Will get triggered on local and remote share
     this.locusInfo.on(EVENTS.LOCUS_INFO_UPDATE_MEDIA_SHARES, (payload) => {
       const {content: contentShare, whiteboard: whiteboardShare} = payload.current;
@@ -5853,7 +5852,7 @@ export default class Meeting extends StatelessWebexPlugin {
    *
    * @returns {undefined}
    */
-  setStartLocalSDPGenRemoteSDPRecvDelay() {
+   setStartLocalSDPGenRemoteSDPRecvDelay() {
     if (!this.startLocalSDPGenRemoteSDPRecvDelay) {
       this.startLocalSDPGenRemoteSDPRecvDelay = performance.now();
       this.endLocalSDPGenRemoteSDPRecvDelay = undefined;

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6242,6 +6242,6 @@ export default class Meeting extends StatelessWebexPlugin {
       return this.meetingRequest.sendReaction({reactionChannelUrl, reaction, participantId});
     }
 
-    return Promise.reject(new Error('Reaction Channel URL not found.'));
+    return Promise.reject(new Error('Error sending reaction, service url not found.'));
   }
 }

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -25,6 +25,7 @@ import {
   SEND_DTMF_ENDPOINT,
   _SLIDES_
 } from '../constants';
+import {Reaction} from '../reactions/reactions.type';
 
 /**
  * @class MeetingRequest
@@ -766,6 +767,28 @@ export default class MeetingRequest extends StatelessWebexPlugin {
     return this.request({
       method: HTTP_VERBS.GET,
       uri: keepAliveUrl
+    });
+  }
+
+  /**
+   * Make a network request to send a reaction.
+   * @param {Object} options
+   * @param {Url} options.reactionChannelUrl
+   * @param {Reaction} options.reaction
+   * @param {string} options.senderID
+   * @returns {Promise}
+   */
+  sendReaction({ reactionChannelUrl, reaction, participantId }: { reactionChannelUrl: string, reaction: Reaction, participantId: string }) {
+    const uri = `${reactionChannelUrl}`;
+
+    // @ts-ignore
+    return this.request({
+      method: HTTP_VERBS.POST,
+      uri,
+      body: {
+        sender: {participantId},
+        reaction,
+      }
     });
   }
 }

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -779,7 +779,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
    * @returns {Promise}
    */
   sendReaction({ reactionChannelUrl, reaction, participantId }: { reactionChannelUrl: string, reaction: Reaction, participantId: string }) {
-    const uri = `${reactionChannelUrl}`;
+    const uri = reactionChannelUrl;
 
     // @ts-ignore
     return this.request({

--- a/packages/@webex/plugin-meetings/src/reactions/reactions.ts
+++ b/packages/@webex/plugin-meetings/src/reactions/reactions.ts
@@ -1,0 +1,104 @@
+import {Reaction, ReactionType, SkinTone, SkinToneType} from './reactions.type';
+
+const Reactions: Record<ReactionType, Reaction> = {
+  smile: {
+    type: 'smile',
+    codepoints: '1F642',
+    shortcodes: ':slightly_smiling_face:'
+  },
+  sad: {
+    type: 'sad',
+    codepoints: '1F625',
+    shortcodes: ':sad_but_relieved_face:',
+  },
+  wow: {
+    type: 'wow',
+    codepoints: '1F62E',
+    shortcodes: ':open_mouth:',
+  },
+  haha: {
+    type: 'haha',
+    codepoints: '1F603',
+    shortcodes: ':smiley:'
+  },
+  celebrate: {
+    type: 'celebrate',
+    codepoints: '1F389',
+    shortcodes: ':party_popper:',
+  },
+  clap: {
+    type: 'clap',
+    codepoints: '1F44F',
+    shortcodes: ':clap:',
+  },
+  thumbs_up: {
+    type: 'thumb_up',
+    codepoints: '1F44D',
+    shortcodes: ':thumbsup:',
+  },
+  thumbs_down: {
+    type: 'thumb_down',
+    codepoints: '1F44E',
+    shortcodes: ':thumbsdown:',
+  },
+  heart: {
+    type: 'heart',
+    codepoints: '2764',
+    shortcodes: ':heart:',
+  },
+  fire: {
+    type: 'fire',
+    codepoints: '1F525',
+    shortcodes: ':fire:',
+  },
+  prayer: {
+    type: 'prayer',
+    codepoints: '1F64F',
+    shortcodes: ':pray:',
+  },
+  speed_up: {
+    type: 'speed_up',
+    codepoints: '1F407',
+    shortcodes: ':rabbit:',
+  },
+  slow_down: {
+    type: 'slow_down',
+    codepoints: '1F422',
+    shortcodes: ':turtle:',
+  }
+};
+
+const SkinTones: Record<SkinToneType, SkinTone> = {
+  normal: {
+    type: 'normal_skin_tone',
+    codepoints: '',
+    shortcodes: '',
+  },
+  light: {
+    type: 'light_skin_tone',
+    codepoints: '1F3FB',
+    shortcodes: ':skin-tone-2:',
+  },
+  medium_light: {
+    type: 'medium_light_skin_tone',
+    codepoints: '1F3FC',
+    shortcodes: ':skin-tone-3:',
+  },
+  medium: {
+    type: 'medium_skin_tone',
+    codepoints: '1F3FD',
+    shortcodes: ':skin-tone-4:',
+  },
+  medium_dark: {
+    type: 'medium_dark_skin_tone',
+    codepoints: '1F3FE',
+    shortcodes: ':skin-tone-5:',
+  },
+  dark: {
+    type: 'dark_skin_tone',
+    codepoints: '1F3FF',
+    shortcodes: ':skin-tone-6:',
+  }
+};
+
+export {Reactions, SkinTones};

--- a/packages/@webex/plugin-meetings/src/reactions/reactions.type.ts
+++ b/packages/@webex/plugin-meetings/src/reactions/reactions.type.ts
@@ -1,0 +1,36 @@
+
+export type EmoticonData = {
+  type: string;
+  codepoints?: string;
+  shortcodes?: string;
+}
+
+export type SkinTone = EmoticonData;
+export type Reaction = ReactionData & {
+  tone?: SkinTone;
+}
+
+export enum ReactionType {
+  smile = 'smile',
+  sad = 'sad',
+  wow = 'wow',
+  haha = 'haha',
+  celebrate = 'celebrate',
+  clap = 'clap',
+  thumbs_up = 'thumbs_up',
+  thumbs_down = 'thumbs_down',
+  heart = 'heart',
+  fire = 'fire',
+  prayer = 'prayer',
+  speed_up = 'speed_up',
+  slow_down = 'slow_down',
+}
+
+export enum SkinToneType {
+  normal = 'normal',
+  light = 'light',
+  medium_light = 'medium_light',
+  medium = 'medium',
+  medium_dark = 'medium_dark',
+  dark = 'dark',
+}

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -4630,7 +4630,7 @@ describe('plugin-meetings', () => {
         it('should fail sending a reaction if data channel is undefined', async () => {
           meeting.locusInfo.controls = {reactions: {reactionChannelUrl: undefined}};
 
-          await assert.isRejected(meeting.sendReaction('thumbs_down', 'light'), Error, 'Reaction Channel URL not found.');
+          await assert.isRejected(meeting.sendReaction('thumbs_down', 'light'), Error, 'Error sending reaction, service url not found.');
 
           assert.notCalled(meeting.meetingRequest.sendReaction);
         });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2469,7 +2469,7 @@ describe('plugin-meetings', () => {
           conversationUrl: 'some_convo_url',
           locusUrl: 'some_locus_url',
           sipUrl: 'some_sip_url', // or sipMeetingUri
-          meetingNumber: '123456', // this.config.experimental.enableUnifiedMeetings
+          meetingNumber: '123456', // `this.`config.experimental.enableUnifiedMeetings
           hostId: 'some_host_id' // this.owner;
         };
         const FAKE_SDK_CAPTCHA_INFO = {
@@ -4592,6 +4592,93 @@ describe('plugin-meetings', () => {
         it('stopKeepAlive handles missing keepAliveTimerId', async () => {
           assert.isNull(meeting.keepAliveTimerId);
           meeting.stopKeepAlive();
+        });
+      });
+
+      describe('#sendReaction', () => {
+        it('should have #sendReaction', () => {
+          assert.exists(meeting.sendReaction);
+        });
+
+        beforeEach(() => {
+          meeting.meetingRequest.sendReaction = sinon.stub().returns(Promise.resolve());
+        });
+
+        it('should send reaction with the right data and return a promise', async () => {
+          meeting.locusInfo.controls = {reactions: {reactionChannelUrl: 'Fake URL'}};
+
+          const reactionPromise = meeting.sendReaction('thumbs_down', 'light');
+
+          assert.exists(reactionPromise.then);
+          await reactionPromise;
+          assert.calledOnceWithExactly(meeting.meetingRequest.sendReaction, {
+            reactionChannelUrl: 'Fake URL',
+            reaction: {
+              type: 'thumb_down',
+              codepoints: '1F44E',
+              shortcodes: ':thumbsdown:',
+              tone: {
+                type: 'light_skin_tone',
+                codepoints: '1F3FB',
+                shortcodes: ':skin-tone-2:'
+              }
+            },
+            participantId: meeting.members.selfId,
+          });
+        });
+
+        it('should fail sending a reaction if data channel is undefined', async () => {
+          meeting.locusInfo.controls = {reactions: {reactionChannelUrl: undefined}};
+
+          await assert.isRejected(meeting.sendReaction('thumbs_down', 'light'), Error, 'Reaction Channel URL not found.');
+
+          assert.notCalled(meeting.meetingRequest.sendReaction);
+        });
+
+        it('should fail sending a reaction if reactionType is invalid ', async () => {
+          meeting.locusInfo.controls = {reactions: {reactionChannelUrl: 'Fake URL'}};
+
+          await assert.isRejected(meeting.sendReaction('invalid_reaction', 'light'), Error, 'invalid_reaction is not a valid reaction.');
+
+          assert.notCalled(meeting.meetingRequest.sendReaction);
+        });
+
+        it('should send a reaction with default skin tone if provided skinToneType is invalid ', async () => {
+          meeting.locusInfo.controls = {reactions: {reactionChannelUrl: 'Fake URL'}};
+
+          const reactionPromise = meeting.sendReaction('thumbs_down', 'invalid_skin_tone');
+
+          assert.exists(reactionPromise.then);
+          await reactionPromise;
+          assert.calledOnceWithExactly(meeting.meetingRequest.sendReaction, {
+            reactionChannelUrl: 'Fake URL',
+            reaction: {
+              type: 'thumb_down',
+              codepoints: '1F44E',
+              shortcodes: ':thumbsdown:',
+              tone: {type: 'normal_skin_tone', codepoints: '', shortcodes: ''}
+            },
+            participantId: meeting.members.selfId,
+          });
+        });
+
+        it('should send a reaction with default skin tone if none provided', async () => {
+          meeting.locusInfo.controls = {reactions: {reactionChannelUrl: 'Fake URL'}};
+
+          const reactionPromise = meeting.sendReaction('thumbs_down');
+
+          assert.exists(reactionPromise.then);
+          await reactionPromise;
+          assert.calledOnceWithExactly(meeting.meetingRequest.sendReaction, {
+            reactionChannelUrl: 'Fake URL',
+            reaction: {
+              type: 'thumb_down',
+              codepoints: '1F44E',
+              shortcodes: ':thumbsdown:',
+              tone: {type: 'normal_skin_tone', codepoints: '', shortcodes: ''}
+            },
+            participantId: meeting.members.selfId,
+          });
         });
       });
     });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2469,7 +2469,7 @@ describe('plugin-meetings', () => {
           conversationUrl: 'some_convo_url',
           locusUrl: 'some_locus_url',
           sipUrl: 'some_sip_url', // or sipMeetingUri
-          meetingNumber: '123456', // `this.`config.experimental.enableUnifiedMeetings
+          meetingNumber: '123456', // this.config.experimental.enableUnifiedMeetings
           hostId: 'some_host_id' // this.owner;
         };
         const FAKE_SDK_CAPTCHA_INFO = {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
@@ -1,7 +1,6 @@
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
-
 import Meetings from '@webex/plugin-meetings';
 import MeetingRequest from '@webex/plugin-meetings/src/meeting/request';
 
@@ -276,6 +275,31 @@ describe('plugin-meetings', () => {
 
         assert.equal(requestParams.method, 'GET');
         assert.equal(requestParams.uri, keepAliveUrl);
+      });
+    });
+
+    describe('#sendReaction', () => {
+      it('sends request to sendReaction', async () => {
+        const reactionChannelUrl = 'reactionChannelUrl';
+        const participantId = 'participantId';
+        const reaction = {
+          type: 'thumb_down',
+          codepoints: '1F44E',
+          shortcodes: ':thumbsdown:',
+          tone: {type: 'normal_skin_tone', codepoints: '', shortcodes: ''}
+        };
+
+        await meetingsRequest.sendReaction({
+          reactionChannelUrl,
+          reaction,
+          participantId
+        });
+        const requestParams = meetingsRequest.request.getCall(0).args[0];
+
+        assert.equal(requestParams.method, 'POST');
+        assert.equal(requestParams.uri, reactionChannelUrl);
+        assert.equal(requestParams.body.sender.participantId, participantId);
+        assert.equal(requestParams.body.reaction, reaction);
       });
     });
   });


### PR DESCRIPTION
# COMPLETES [#SPARK-393047](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-393047)

## This pull request addresses

Add new public method `sendReaction` on meetings plugin on the meeting object.

## by making the following changes

- add new request under plugin-meetings/meeting/request
- add new public method on the meeting object

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Unit tests, manual testing.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
