### PR TITLE
fix(plugin-meetings): facing mode in get media streams

### DIFF
--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -490,12 +490,16 @@ Media.getMedia = (audio: any | boolean, video: any | boolean, config: any) => {
         {
           deviceId: video.deviceId ? video.deviceId : undefined,
           width: 320,
-          height: 180
+          height: 180,
+          frameRate: video.frameRate ? video.frameRate : undefined,
+          facingMode: video.facingMode ? video.facingMode : undefined,
         } :
         {
           deviceId: video.deviceId ? video.deviceId : undefined,
           width: video.width ? video.width : defaultWidth,
-          height: video.height ? video.height : defaultHeight
+          height: video.height ? video.height : defaultHeight,
+          frameRate: video.frameRate ? video.frameRate : undefined,
+          facingMode: video.facingMode ? video.facingMode : undefined,
         } :
       false,
     fake: process.env.NODE_ENV === 'test' // Special case to get fake media for Firefox browser for testing

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -715,6 +715,13 @@ describe('plugin-meetings', () => {
               height: {
                 max: 200,
                 ideal: 200
+              },
+              frameRate: {
+                ideal: 15,
+                max: 30
+              },
+              facingMode: {
+                ideal: 'user'
               }
             }
           };


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #<[SPARK-391910](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-391910) >

## This pull request addresses

Added support to pass `facingMode` and `frameRate` while setting custom video resolution in `getMediaStreams` method of meetings.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
