### PR TITLE
fix(plugin-conversation): Send kms on join

### DIFF
--- a/packages/@webex/internal-plugin-conversation/src/encryption-transforms.js
+++ b/packages/@webex/internal-plugin-conversation/src/encryption-transforms.js
@@ -100,11 +100,7 @@ export const transforms = toArray('outbound', {
       .then(() => {
         key = key || activity[KEY];
       })
-      .then(() => ctx.transform('encryptObject', key, activity.object)).then(() => {
-        console.log('@@@: encryption activity.origin', key);
-
-        return ctx.transform('encryptObject', key, activity.origin);
-      });
+      .then(() => ctx.transform('encryptObject', key, activity.object));
   },
 
   maybeEncryptTarget(ctx, key, activity) {

--- a/packages/@webex/internal-plugin-conversation/src/encryption-transforms.js
+++ b/packages/@webex/internal-plugin-conversation/src/encryption-transforms.js
@@ -100,7 +100,11 @@ export const transforms = toArray('outbound', {
       .then(() => {
         key = key || activity[KEY];
       })
-      .then(() => ctx.transform('encryptObject', key, activity.object));
+      .then(() => ctx.transform('encryptObject', key, activity.object)).then(() => {
+        console.log('@@@: encryption activity.origin', key);
+
+        return ctx.transform('encryptObject', key, activity.origin);
+      });
   },
 
   maybeEncryptTarget(ctx, key, activity) {

--- a/packages/@webex/internal-plugin-team/src/team.js
+++ b/packages/@webex/internal-plugin-team/src/team.js
@@ -192,6 +192,10 @@ const Team = WebexPlugin.extend({
    * @returns {Promise} Resolves with the conversation
    */
   joinConversation(team, conversation, userId) {
+    if (!userId) {
+      return Promise.reject(new Error('`userId` is required'));
+    }
+
     const body = {
       kmsMessage: {
         client: {
@@ -209,11 +213,12 @@ const Team = WebexPlugin.extend({
       },
     };
 
-    return this.webex.request({
-      method: 'POST',
-      uri: `${team.url}/conversations/${conversation.id}/participants`,
-      body
-    })
+    return this.webex
+      .request({
+        method: 'POST',
+        uri: `${team.url}/conversations/${conversation.id}/participants`,
+        body,
+      })
       .then((res) => res.body);
   },
 

--- a/packages/@webex/internal-plugin-team/src/team.js
+++ b/packages/@webex/internal-plugin-team/src/team.js
@@ -4,6 +4,7 @@
 
 import querystring from 'querystring';
 
+import uuid from 'uuid';
 import {find, pick, uniq} from 'lodash';
 import {WebexPlugin} from '@webex/webex-core';
 
@@ -187,14 +188,32 @@ const Team = WebexPlugin.extend({
    * Join a team conversation
    * @param {TeamObject} team
    * @param {ConversationObject} conversation
+   * @param {userId} userId
    * @returns {Promise} Resolves with the conversation
    */
-  joinConversation(team, conversation) {
-    return this.webex
-      .request({
-        method: 'POST',
-        uri: `${team.url}/conversations/${conversation.id}/participants`,
-      })
+  joinConversation(team, conversation, userId) {
+    const body = {
+      kmsMessage: {
+        client: {
+          clientId: this.webex.internal.device.url,
+          credential: {
+            bearer: this.webex.credentials.supertoken.access_token,
+            userId,
+          },
+        },
+        method: 'create',
+        requestId: uuid.v4(),
+        resourceUri: conversation.kmsResourceObjectUrl,
+        uri: '/authorizations',
+        userIds: [userId],
+      },
+    };
+
+    return this.webex.request({
+      method: 'POST',
+      uri: `${team.url}/conversations/${conversation.id}/participants`,
+      body
+    })
       .then((res) => res.body);
   },
 

--- a/packages/@webex/internal-plugin-team/test/integration/spec/actions.js
+++ b/packages/@webex/internal-plugin-team/test/integration/spec/actions.js
@@ -314,7 +314,7 @@ describe('plugin-team', () => {
 
       it('adds the user to an open team conversation', () =>
         spock.webex.internal.team
-          .joinConversation(team, conversation)
+          .joinConversation(team, conversation, spock.id)
           .then((c) => assert.notInclude(c.tags, 'NOT_JOINED')));
     });
 

--- a/packages/@webex/internal-plugin-team/test/unit/spec/team.js
+++ b/packages/@webex/internal-plugin-team/test/unit/spec/team.js
@@ -108,5 +108,46 @@ describe('plugin-team', () => {
           .then(() => assert.equal(webex.internal.user.recordUUID.callCount, 0));
       });
     });
+
+    describe('#joinConversation', () => {
+      const conversation = {kmsResourceObjectUrl: 'convoKroUrl', id: 'convoId'};
+      const team = {url: 'teamUrl'};
+      const userId = 'userId';
+
+      beforeEach(() => {
+        webex.credentials.supertoken = {access_token: 'fake_token'};
+      });
+
+      it('requires userId to joinConversation', () =>
+        assert.isRejected(webex.internal.team.joinConversation(team, conversation), /`userId` is required/));
+
+      it('makes POST to convo service with correct body kmsMessage', () => {
+        webex.credentials.supertoken = {access_token: 'fake_token'}
+        return webex.internal.team.joinConversation(team, conversation, userId).then(() => {
+          assert.calledWith(
+            webex.request,
+            sinon.match({
+              method: 'POST',
+              uri: `${team.url}/conversations/${conversation.id}/participants`,
+              body: {
+                kmsMessage: {
+                  client: {
+                    clientId: webex.internal.device.url,
+                    credential: {
+                      bearer: webex.credentials.supertoken.access_token,
+                      userId,
+                    },
+                  },
+                  method: 'create',
+                  resourceUri: conversation.kmsResourceObjectUrl,
+                  uri: '/authorizations',
+                  userIds: [userId],
+                }
+              },
+            })
+          );
+        })
+      })
+    })
   });
 });


### PR DESCRIPTION
# COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-371632

## This pull request addresses

when users join a space we need to send a new kmsMessage

## by making the following changes

`packages/@webex/internal-plugin-team/src/team.js` `.joinConversation` now takes an additional argument `userId`. this argument *must* be provided. this function also creates a new body with a kmsMessage sent with the POST to convo to join the space

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
