### PR TITLE
fix(plugin-meetings): imports of MediaConnection from internal-media-core

### DIFF
--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:^",
-    "@webex/internal-media-core": "^0.0.17-beta",
+    "@webex/internal-media-core": "1.32.1",
     "@webex/internal-plugin-conversation": "workspace:^",
     "@webex/internal-plugin-device": "workspace:^",
     "@webex/internal-plugin-llm": "workspace:^",

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -3,14 +3,13 @@
  */
 /* globals navigator */
 
+import {RoapMediaConnection, MultistreamRoapMediaConnection} from '@webex/internal-media-core';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {AUDIO_INPUT, VIDEO_INPUT, MEDIA_TRACK_CONSTRAINT} from '../constants';
 import Config from '../config';
 import StaticConfig from '../common/config';
 import MediaError from '../common/errors/media';
 import BrowserDetection from '../common/browser-detection';
-
-import {RoapMediaConnection, MultistreamRoapMediaConnection} from './internal-media-core-wrapper';
 
 const {isBrowser} = BrowserDetection();
 

--- a/packages/@webex/plugin-meetings/src/media/internal-media-core-wrapper.ts
+++ b/packages/@webex/plugin-meetings/src/media/internal-media-core-wrapper.ts
@@ -1,9 +1,0 @@
-import {MediaConnection as MC} from '@webex/internal-media-core';
-
-/* We have this wrapper just because otherwise it's impossible to mock
- * RoapMediaConnection and MultistreamRoapMediaConnection constructors in unit tests,
- * because they are exported by @webex/internal-media-core as non-writable, non-configurable
- * properties of MediaConnection and sinon doesn't allow spying on them or stubbing them.
- */
-export const {RoapMediaConnection} = MC;
-export const {MultistreamRoapMediaConnection} = MC;

--- a/packages/@webex/plugin-meetings/src/media/properties.ts
+++ b/packages/@webex/plugin-meetings/src/media/properties.ts
@@ -1,4 +1,4 @@
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {ConnectionState, Event} from '@webex/internal-media-core';
 
 import {MEETINGS, PC_BAIL_TIMEOUT, QUALITY_LEVELS} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
@@ -214,7 +214,7 @@ export default class MediaProperties {
    */
   waitForMediaConnectionConnected() {
     const isConnected = () =>
-      this.webrtcMediaConnection.getConnectionState() === MC.ConnectionState.Connected;
+      this.webrtcMediaConnection.getConnectionState() === ConnectionState.Connected;
 
     if (isConnected()) {
       return Promise.resolve();
@@ -230,20 +230,17 @@ export default class MediaProperties {
 
         if (isConnected()) {
           clearTimeout(timer);
-          this.webrtcMediaConnection.off(
-            MC.Event.CONNECTION_STATE_CHANGED,
-            connectionStateListener
-          );
+          this.webrtcMediaConnection.off(Event.CONNECTION_STATE_CHANGED, connectionStateListener);
           resolve();
         }
       };
 
       timer = setTimeout(() => {
-        this.webrtcMediaConnection.off(MC.Event.CONNECTION_STATE_CHANGED, connectionStateListener);
+        this.webrtcMediaConnection.off(Event.CONNECTION_STATE_CHANGED, connectionStateListener);
         reject();
       }, PC_BAIL_TIMEOUT);
 
-      this.webrtcMediaConnection.on(MC.Event.CONNECTION_STATE_CHANGED, connectionStateListener);
+      this.webrtcMediaConnection.on(Event.CONNECTION_STATE_CHANGED, connectionStateListener);
     });
   }
 

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -4,7 +4,7 @@ import '@webex/internal-plugin-mercury';
 import '@webex/internal-plugin-conversation';
 // @ts-ignore
 import {WebexPlugin} from '@webex/webex-core';
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {setLogger} from '@webex/internal-media-core';
 
 import 'webrtc-adapter';
 
@@ -461,7 +461,7 @@ export default class Meetings extends WebexPlugin {
       LoggerProxy.set(this.webex.logger);
 
       mediaLogger = new MediaLogger();
-      MC.setLogger(mediaLogger);
+      setLogger(mediaLogger);
 
       /**
        * The MeetingInfo object to interact with server

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -1,5 +1,12 @@
 /* eslint-disable require-jsdoc */
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {
+  MediaRequest as WcmeMediaRequest,
+  Policy,
+  ActiveSpeakerInfo,
+  ReceiverSelectedInfo,
+  CodecInfo as WcmeCodecInfo,
+  H264Codec,
+} from '@webex/internal-media-core';
 
 import LoggerProxy from '../common/logs/logger-proxy';
 
@@ -47,8 +54,7 @@ const CODEC_DEFAULTS = {
   },
 };
 
-// @ts-ignore
-type SendMediaRequestsCallback = (mediaRequests: MC.MediaRequest[]) => void;
+type SendMediaRequestsCallback = (mediaRequests: WcmeMediaRequest[]) => void;
 
 export class MediaRequestManager {
   private sendMediaRequestsCallback: SendMediaRequestsCallback;
@@ -92,8 +98,7 @@ export class MediaRequestManager {
   }
 
   private sendRequests() {
-    // @ts-ignore
-    const wcmeMediaRequests: MC.MediaRequest[] = [];
+    const wcmeMediaRequests: WcmeMediaRequest[] = [];
 
     // todo: check how many streams we're asking for and what resolution and introduce some limits (spark-377701)
     const maxPayloadBitsPerSecond = 10 * 1000 * 1000;
@@ -101,24 +106,24 @@ export class MediaRequestManager {
     // map all the client media requests to wcme media requests
     Object.values(this.clientRequests).forEach((mr) => {
       wcmeMediaRequests.push(
-        new MC.MediaRequest(
+        new WcmeMediaRequest(
           mr.policyInfo.policy === 'active-speaker'
-            ? MC.Policy.ActiveSpeaker
-            : MC.Policy.ReceiverSelected,
+            ? Policy.ActiveSpeaker
+            : Policy.ReceiverSelected,
           mr.policyInfo.policy === 'active-speaker'
-            ? new MC.ActiveSpeakerInfo(
+            ? new ActiveSpeakerInfo(
                 mr.policyInfo.priority,
                 mr.policyInfo.crossPriorityDuplication,
                 mr.policyInfo.crossPolicyDuplication,
                 mr.policyInfo.preferLiveVideo
               )
-            : new MC.ReceiverSelectedInfo(mr.policyInfo.csi),
+            : new ReceiverSelectedInfo(mr.policyInfo.csi),
           mr.receiveSlots.map((receiveSlot) => receiveSlot.wcmeReceiveSlot),
           maxPayloadBitsPerSecond,
           mr.codecInfo && [
-            new MC.CodecInfo(
+            new WcmeCodecInfo(
               0x80,
-              new MC.H264Codec(
+              new H264Codec(
                 mr.codecInfo.maxFs || CODEC_DEFAULTS.h264.maxFs,
                 mr.codecInfo.maxFps || CODEC_DEFAULTS.h264.maxFps,
                 mr.codecInfo.maxMbps || CODEC_DEFAULTS.h264.maxMbps,

--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
@@ -1,5 +1,10 @@
 /* eslint-disable valid-jsdoc */
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {
+  MediaType,
+  ReceiveSlot as WcmeReceiveSlot,
+  ReceiveSlotEvents as WcmeReceiveSlotEvents,
+  SourceState,
+} from '@webex/internal-media-core';
 
 import LoggerProxy from '../common/logs/logger-proxy';
 import EventsScope from '../common/events/events-scope';
@@ -8,8 +13,7 @@ export const ReceiveSlotEvents = {
   SourceUpdate: 'sourceUpdate',
 };
 
-// @ts-ignore
-export type SourceState = MC.SourceState;
+export type {SourceState} from '@webex/internal-media-core';
 export type CSI = number;
 export type MemberId = string;
 export type ReceiveSlotId = string;
@@ -23,36 +27,31 @@ export type FindMemberIdCallback = (csi: CSI) => MemberId | undefined;
  * for example some participant's main video or audio
  */
 export class ReceiveSlot extends EventsScope {
-  // @ts-ignore
-  private readonly mcReceiveSlot: MC.ReceiveSlot;
+  private readonly mcReceiveSlot: WcmeReceiveSlot;
 
   private readonly findMemberIdCallback: FindMemberIdCallback;
 
   public readonly id: ReceiveSlotId;
 
-  // @ts-ignore
-  public readonly mediaType: MC.MediaType;
+  public readonly mediaType: MediaType;
 
   #memberId?: MemberId;
 
   #csi?: CSI;
 
-  // @ts-ignore
-  #sourceState: MC.SourceState;
+  #sourceState: SourceState;
 
   /**
    * constructor - don't use it directly, you should always use meeting.receiveSlotManager.allocateSlot()
    * to create any receive slots
    *
-   * @param {MC.MediaType} mediaType
-   * @param {MC.ReceiveSlot} mcReceiveSlot
+   * @param {MediaType} mediaType
+   * @param {ReceiveSlot} mcReceiveSlot
    * @param {FindMemberIdCallback} findMemberIdCallback callback for finding memberId for given CSI
    */
   constructor(
-    // @ts-ignore
-    mediaType: MC.MediaType,
-    // @ts-ignore
-    mcReceiveSlot: MC.ReceiveSlot,
+    mediaType: MediaType,
+    mcReceiveSlot: WcmeReceiveSlot,
     findMemberIdCallback: FindMemberIdCallback
   ) {
     super();
@@ -99,9 +98,8 @@ export class ReceiveSlot extends EventsScope {
     };
 
     this.mcReceiveSlot.on(
-      MC.ReceiveSlotEvents.SourceUpdate,
-      // @ts-ignore
-      (state: MC.SourceState, csi?: number) => {
+      WcmeReceiveSlotEvents.SourceUpdate,
+      (state: SourceState, csi?: number) => {
         LoggerProxy.logger.log(
           `ReceiveSlot#setupEventListeners --> got source update on receive slot ${this.id}, mediaType=${this.mediaType}, csi=${csi}, state=${state}`
         );
@@ -130,8 +128,7 @@ export class ReceiveSlot extends EventsScope {
   /**
    * The underlying WCME receive slot
    */
-  // @ts-ignore
-  get wcmeReceiveSlot(): MC.ReceiveSlot {
+  get wcmeReceiveSlot(): WcmeReceiveSlot {
     return this.mcReceiveSlot;
   }
 

--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
@@ -1,6 +1,6 @@
 /* eslint-disable valid-jsdoc */
 /* eslint-disable import/prefer-default-export */
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {MediaType} from '@webex/internal-media-core';
 
 import LoggerProxy from '../common/logs/logger-proxy';
 import Meeting from '../meeting';
@@ -12,11 +12,9 @@ import {CSI, ReceiveSlot} from './receiveSlot';
  * so this manager has a pool in order to re-use the slots that were released earlier.
  */
 export class ReceiveSlotManager {
-  // @ts-ignore
-  private allocatedSlots: {[key in MC.MediaType]: ReceiveSlot[]};
+  private allocatedSlots: {[key in MediaType]: ReceiveSlot[]};
 
-  // @ts-ignore
-  private freeSlots: {[key in MC.MediaType]: ReceiveSlot[]};
+  private freeSlots: {[key in MediaType]: ReceiveSlot[]};
 
   private meeting: Meeting;
 
@@ -26,16 +24,16 @@ export class ReceiveSlotManager {
    */
   constructor(meeting) {
     this.allocatedSlots = {
-      [MC.MediaType.AudioMain]: [],
-      [MC.MediaType.VideoMain]: [],
-      [MC.MediaType.AudioSlides]: [],
-      [MC.MediaType.VideoSlides]: [],
+      [MediaType.AudioMain]: [],
+      [MediaType.VideoMain]: [],
+      [MediaType.AudioSlides]: [],
+      [MediaType.VideoSlides]: [],
     };
     this.freeSlots = {
-      [MC.MediaType.AudioMain]: [],
-      [MC.MediaType.VideoMain]: [],
-      [MC.MediaType.AudioSlides]: [],
-      [MC.MediaType.VideoSlides]: [],
+      [MediaType.AudioMain]: [],
+      [MediaType.VideoMain]: [],
+      [MediaType.AudioSlides]: [],
+      [MediaType.VideoSlides]: [],
     };
     this.meeting = meeting;
   }
@@ -43,11 +41,10 @@ export class ReceiveSlotManager {
   /**
    * Creates a new receive slot or returns one from the existing pool of free slots
    *
-   * @param {MC.MediaType} mediaType
+   * @param {MediaType} mediaType
    * @returns {Promise<ReceiveSlot>}
    */
-  // @ts-ignore
-  async allocateSlot(mediaType: MC.MediaType): Promise<ReceiveSlot> {
+  async allocateSlot(mediaType: MediaType): Promise<ReceiveSlot> {
     if (!this.meeting?.mediaProperties?.webrtcMediaConnection) {
       return Promise.reject(new Error('Webrtc media connection is missing'));
     }
@@ -105,16 +102,16 @@ export class ReceiveSlotManager {
    */
   reset() {
     this.allocatedSlots = {
-      [MC.MediaType.AudioMain]: [],
-      [MC.MediaType.VideoMain]: [],
-      [MC.MediaType.AudioSlides]: [],
-      [MC.MediaType.VideoSlides]: [],
+      [MediaType.AudioMain]: [],
+      [MediaType.VideoMain]: [],
+      [MediaType.AudioSlides]: [],
+      [MediaType.VideoSlides]: [],
     };
     this.freeSlots = {
-      [MC.MediaType.AudioMain]: [],
-      [MC.MediaType.VideoMain]: [],
-      [MC.MediaType.AudioSlides]: [],
-      [MC.MediaType.VideoSlides]: [],
+      [MediaType.AudioMain]: [],
+      [MediaType.VideoMain]: [],
+      [MediaType.AudioSlides]: [],
+      [MediaType.VideoSlides]: [],
     };
   }
 

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -56,7 +56,7 @@ export function getMaxFs(paneSize: RemoteVideoResolution): number {
 }
 
 type Options = {
-  resolution?: RemoteVideoResolution; // applies only to groups of type MC.MediaType.VideoMain and MC.MediaType.VideoSlides
+  resolution?: RemoteVideoResolution; // applies only to groups of type MediaType.VideoMain and MediaType.VideoSlides
 };
 
 export type RemoteMediaId = string;

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
@@ -8,8 +8,8 @@ import {MediaRequestId, MediaRequestManager} from './mediaRequestManager';
 import {CSI, ReceiveSlot} from './receiveSlot';
 
 type Options = {
-  resolution?: RemoteVideoResolution; // applies only to groups of type MC.MediaType.VideoMain and MC.MediaType.VideoSlides
-  preferLiveVideo?: boolean; // applies only to groups of type MC.MediaType.VideoMain and MC.MediaType.VideoSlides
+  resolution?: RemoteVideoResolution; // applies only to groups of type MediaType.VideoMain and MediaType.VideoSlides
+  preferLiveVideo?: boolean; // applies only to groups of type MediaType.VideoMain and MediaType.VideoSlides
 };
 
 export class RemoteMediaGroup {

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
@@ -1,7 +1,7 @@
 /* eslint-disable valid-jsdoc */
 import {cloneDeep, remove} from 'lodash';
 import {EventMap} from 'typed-emitter';
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {MediaType} from '@webex/internal-media-core';
 
 import LoggerProxy from '../common/logs/logger-proxy';
 import EventsScope from '../common/events/events-scope';
@@ -434,7 +434,7 @@ export class RemoteMediaManager extends EventsScope {
       // eslint-disable-next-line no-await-in-loop
       this.slots.video.unused.push(
         // eslint-disable-next-line no-await-in-loop
-        await this.receiveSlotManager.allocateSlot(MC.MediaType.VideoMain)
+        await this.receiveSlotManager.allocateSlot(MediaType.VideoMain)
       );
     }
   }
@@ -478,7 +478,7 @@ export class RemoteMediaManager extends EventsScope {
     // create the audio receive slots
     for (let i = 0; i < this.config.audio.numOfActiveSpeakerStreams; i += 1) {
       // eslint-disable-next-line no-await-in-loop
-      const slot = await this.receiveSlotManager.allocateSlot(MC.MediaType.AudioMain);
+      const slot = await this.receiveSlotManager.allocateSlot(MediaType.AudioMain);
 
       this.slots.audio.push(slot);
     }
@@ -603,7 +603,7 @@ export class RemoteMediaManager extends EventsScope {
         // eslint-disable-next-line no-await-in-loop
         this.slots.video.unused.push(
           // eslint-disable-next-line no-await-in-loop
-          await this.receiveSlotManager.allocateSlot(MC.MediaType.VideoMain)
+          await this.receiveSlotManager.allocateSlot(MediaType.VideoMain)
         );
         numSlotsToCreate -= 1;
       }
@@ -781,7 +781,7 @@ export class RemoteMediaManager extends EventsScope {
 
     this.currentLayout.memberVideoPanes.push(newPane);
 
-    const receiveSlot = await this.receiveSlotManager.allocateSlot(MC.MediaType.VideoMain);
+    const receiveSlot = await this.receiveSlotManager.allocateSlot(MediaType.VideoMain);
 
     this.slots.video.receiverSelected.push(receiveSlot);
 

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-destructuring */
 
 import {cloneDeep} from 'lodash';
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {ConnectionState} from '@webex/internal-media-core';
 
 import EventsScope from '../common/events/events-scope';
 import {
@@ -335,7 +335,7 @@ export class StatsAnalyzer extends EventsScope {
    *
    * @private
    * @memberof StatsAnalyzer
-   * @param {MC.RoapMediaConnection} mediaConnection
+   * @param {RoapMediaConnection} mediaConnection
    * @returns {void}
    */
   updateMediaConnection(mediaConnection: any) {
@@ -347,7 +347,7 @@ export class StatsAnalyzer extends EventsScope {
    *
    * @public
    * @memberof StatsAnalyzer
-   * @param {MC.RoapMediaConnection} mediaConnection
+   * @param {RoapMediaConnection} mediaConnection
    * @returns {Promise}
    */
   public startAnalyzer(mediaConnection: any) {
@@ -820,7 +820,7 @@ export class StatsAnalyzer extends EventsScope {
 
     if (
       this.mediaConnection &&
-      this.mediaConnection.getConnectionState() === MC.ConnectionState.Failed
+      this.mediaConnection.getConnectionState() === ConnectionState.Failed
     ) {
       LoggerProxy.logger.trace(
         'StatsAnalyzer:index#getStatsAndParse --> media connection is in failed state'

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
@@ -1,4 +1,4 @@
-import * as internalMediaModule from '@webex/plugin-meetings/src/media/internal-media-core-wrapper';
+import * as internalMediaModule from '@webex/internal-media-core';
 import Media from '@webex/plugin-meetings/src/media/index';
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
@@ -1,6 +1,6 @@
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {ConnectionState, Event} from '@webex/internal-media-core';
 import MediaProperties from '@webex/plugin-meetings/src/media/properties';
 import MediaUtil from '@webex/plugin-meetings/src/media/util';
 import testUtils from '../../../utils/testUtils';
@@ -19,7 +19,7 @@ describe('MediaProperties', () => {
       getStats: sinon.stub().resolves([]),
       on: sinon.stub(),
       off: sinon.stub(),
-      getConnectionState: sinon.stub().returns(MC.ConnectionState.Connected),
+      getConnectionState: sinon.stub().returns(ConnectionState.Connected),
     };
 
     mediaProperties = new MediaProperties();
@@ -35,7 +35,7 @@ describe('MediaProperties', () => {
       await mediaProperties.waitForMediaConnectionConnected();
     });
     it('rejects after timeout if ice state does not reach connected/completed', async () => {
-      mockMC.getConnectionState.returns(MC.ConnectionState.Connecting);
+      mockMC.getConnectionState.returns(ConnectionState.Connecting);
 
       let promiseResolved = false;
       let promiseRejected = false;
@@ -60,15 +60,15 @@ describe('MediaProperties', () => {
 
       // check that listener was registered and removed
       assert.calledOnce(mockMC.on);
-      assert.equal(mockMC.on.getCall(0).args[0], MC.Event.CONNECTION_STATE_CHANGED);
+      assert.equal(mockMC.on.getCall(0).args[0], Event.CONNECTION_STATE_CHANGED);
       const listener = mockMC.on.getCall(0).args[1];
 
       assert.calledOnce(mockMC.off);
-      assert.calledWith(mockMC.off, MC.Event.CONNECTION_STATE_CHANGED, listener);
+      assert.calledWith(mockMC.off, Event.CONNECTION_STATE_CHANGED, listener);
     });
 
     it(`resolves when media connection reaches "connected" state`, async () => {
-      mockMC.getConnectionState.returns(MC.ConnectionState.Connecting);
+      mockMC.getConnectionState.returns(ConnectionState.Connecting);
 
       const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
 
@@ -89,11 +89,11 @@ describe('MediaProperties', () => {
 
       // check the right listener was registered
       assert.calledOnce(mockMC.on);
-      assert.equal(mockMC.on.getCall(0).args[0], MC.Event.CONNECTION_STATE_CHANGED);
+      assert.equal(mockMC.on.getCall(0).args[0], Event.CONNECTION_STATE_CHANGED);
       const listener = mockMC.on.getCall(0).args[1];
 
       // call the listener and pretend we are now connected
-      mockMC.getConnectionState.returns(MC.ConnectionState.Connected);
+      mockMC.getConnectionState.returns(ConnectionState.Connected);
       listener();
       await testUtils.flushPromises();
 
@@ -102,7 +102,7 @@ describe('MediaProperties', () => {
 
       // check that listener was removed
       assert.calledOnce(mockMC.off);
-      assert.calledWith(mockMC.off, MC.Event.CONNECTION_STATE_CHANGED, listener);
+      assert.calledWith(mockMC.off, Event.CONNECTION_STATE_CHANGED, listener);
 
       assert.calledOnce(clearTimeoutSpy);
     });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -22,7 +22,7 @@ import {
   LOCUSINFO,
   PC_BAIL_TIMEOUT,
 } from '@webex/plugin-meetings/src/constants';
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {ConnectionState, Event, Errors, ErrorType, RemoteTrackType} from '@webex/internal-media-core';
 import * as StatsAnalyzerModule from '@webex/plugin-meetings/src/statsAnalyzer';
 import EventsScope from '@webex/plugin-meetings/src/common/events/events-scope';
 import Meetings, {CONSTANTS} from '@webex/plugin-meetings';
@@ -959,7 +959,7 @@ describe('plugin-meetings', () => {
         beforeEach(() => {
           fakeMediaConnection = {
             close: sinon.stub(),
-            getConnectionState: sinon.stub().returns(MC.ConnectionState.Connected),
+            getConnectionState: sinon.stub().returns(ConnectionState.Connected),
             initiateOffer: sinon.stub().resolves({}),
             on: sinon.stub(),
           };
@@ -1207,7 +1207,7 @@ describe('plugin-meetings', () => {
           meeting.meetingState = 'ACTIVE';
           fakeMediaConnection.getConnectionState = sinon
             .stub()
-            .returns(MC.ConnectionState.Connecting);
+            .returns(ConnectionState.Connecting);
           const clock = sinon.useFakeTimers();
           const media = meeting.addMedia({
             mediaSettings: {},
@@ -3538,19 +3538,19 @@ describe('plugin-meetings', () => {
 
         it('should register for all the correct RoapMediaConnection events', () => {
           meeting.setupMediaConnectionListeners();
-          assert.isFunction(eventListeners[MC.Event.ROAP_STARTED]);
-          assert.isFunction(eventListeners[MC.Event.ROAP_DONE]);
-          assert.isFunction(eventListeners[MC.Event.ROAP_FAILURE]);
-          assert.isFunction(eventListeners[MC.Event.ROAP_MESSAGE_TO_SEND]);
-          assert.isFunction(eventListeners[MC.Event.REMOTE_TRACK_ADDED]);
-          assert.isFunction(eventListeners[MC.Event.CONNECTION_STATE_CHANGED]);
+          assert.isFunction(eventListeners[Event.ROAP_STARTED]);
+          assert.isFunction(eventListeners[Event.ROAP_DONE]);
+          assert.isFunction(eventListeners[Event.ROAP_FAILURE]);
+          assert.isFunction(eventListeners[Event.ROAP_MESSAGE_TO_SEND]);
+          assert.isFunction(eventListeners[Event.REMOTE_TRACK_ADDED]);
+          assert.isFunction(eventListeners[Event.CONNECTION_STATE_CHANGED]);
         });
 
         it('should trigger a media:ready event when REMOTE_TRACK_ADDED is fired', () => {
           meeting.setupMediaConnectionListeners();
-          eventListeners[MC.Event.REMOTE_TRACK_ADDED]({
+          eventListeners[Event.REMOTE_TRACK_ADDED]({
             track: 'track',
-            type: MC.RemoteTrackType.AUDIO,
+            type: RemoteTrackType.AUDIO,
           });
           assert.equal(TriggerProxy.trigger.getCall(1).args[2], 'media:ready');
           assert.deepEqual(TriggerProxy.trigger.getCall(1).args[3], {
@@ -3558,9 +3558,9 @@ describe('plugin-meetings', () => {
             stream: true,
           });
 
-          eventListeners[MC.Event.REMOTE_TRACK_ADDED]({
+          eventListeners[Event.REMOTE_TRACK_ADDED]({
             track: 'track',
-            type: MC.RemoteTrackType.VIDEO,
+            type: RemoteTrackType.VIDEO,
           });
           assert.equal(TriggerProxy.trigger.getCall(2).args[2], 'media:ready');
           assert.deepEqual(TriggerProxy.trigger.getCall(2).args[3], {
@@ -3568,9 +3568,9 @@ describe('plugin-meetings', () => {
             stream: true,
           });
 
-          eventListeners[MC.Event.REMOTE_TRACK_ADDED]({
+          eventListeners[Event.REMOTE_TRACK_ADDED]({
             track: 'track',
-            type: MC.RemoteTrackType.SCREENSHARE_VIDEO,
+            type: RemoteTrackType.SCREENSHARE_VIDEO,
           });
           assert.equal(TriggerProxy.trigger.getCall(3).args[2], 'media:ready');
           assert.deepEqual(TriggerProxy.trigger.getCall(3).args[3], {
@@ -3620,51 +3620,51 @@ describe('plugin-meetings', () => {
           };
 
           it('should send metrics for SdpOfferCreationError error', () => {
-            const fakeError = new MC.Errors.SdpOfferCreationError(fakeErrorMessage, {
+            const fakeError = new Errors.SdpOfferCreationError(fakeErrorMessage, {
               name: fakeErrorName,
               cause: {name: fakeRootCauseName},
             });
 
-            eventListeners[MC.Event.ROAP_FAILURE](fakeError);
+            eventListeners[Event.ROAP_FAILURE](fakeError);
 
             checkMetricSent(eventType.LOCAL_SDP_GENERATED);
             checkBehavioralMetricSent(
               BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE,
-              MC.Errors.ErrorCode.SdpOfferCreationError,
+              Errors.ErrorCode.SdpOfferCreationError,
               fakeErrorMessage,
               fakeRootCauseName
             );
           });
 
           it('should send metrics for SdpOfferHandlingError error', () => {
-            const fakeError = new MC.Errors.SdpOfferHandlingError(fakeErrorMessage, {
+            const fakeError = new Errors.SdpOfferHandlingError(fakeErrorMessage, {
               name: fakeErrorName,
               cause: {name: fakeRootCauseName},
             });
 
-            eventListeners[MC.Event.ROAP_FAILURE](fakeError);
+            eventListeners[Event.ROAP_FAILURE](fakeError);
 
             checkMetricSent(eventType.REMOTE_SDP_RECEIVED);
             checkBehavioralMetricSent(
               BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE,
-              MC.Errors.ErrorCode.SdpOfferHandlingError,
+              Errors.ErrorCode.SdpOfferHandlingError,
               fakeErrorMessage,
               fakeRootCauseName
             );
           });
 
           it('should send metrics for SdpAnswerHandlingError error', () => {
-            const fakeError = new MC.Errors.SdpAnswerHandlingError(fakeErrorMessage, {
+            const fakeError = new Errors.SdpAnswerHandlingError(fakeErrorMessage, {
               name: fakeErrorName,
               cause: {name: fakeRootCauseName},
             });
 
-            eventListeners[MC.Event.ROAP_FAILURE](fakeError);
+            eventListeners[Event.ROAP_FAILURE](fakeError);
 
             checkMetricSent(eventType.REMOTE_SDP_RECEIVED);
             checkBehavioralMetricSent(
               BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE,
-              MC.Errors.ErrorCode.SdpAnswerHandlingError,
+              Errors.ErrorCode.SdpAnswerHandlingError,
               fakeErrorMessage,
               fakeRootCauseName
             );
@@ -3672,15 +3672,15 @@ describe('plugin-meetings', () => {
 
           it('should send metrics for SdpError error', () => {
             // SdpError is usually without a cause
-            const fakeError = new MC.Errors.SdpError(fakeErrorMessage, {name: fakeErrorName});
+            const fakeError = new Errors.SdpError(fakeErrorMessage, {name: fakeErrorName});
 
-            eventListeners[MC.Event.ROAP_FAILURE](fakeError);
+            eventListeners[Event.ROAP_FAILURE](fakeError);
 
             checkMetricSent(eventType.LOCAL_SDP_GENERATED);
             // expectedMetadataType is the error name in this case
             checkBehavioralMetricSent(
               BEHAVIORAL_METRICS.INVALID_ICE_CANDIDATE,
-              MC.Errors.ErrorCode.SdpError,
+              Errors.ErrorCode.SdpError,
               fakeErrorMessage,
               fakeErrorName
             );
@@ -3688,24 +3688,24 @@ describe('plugin-meetings', () => {
 
           it('should send metrics for IceGatheringError error', () => {
             // IceGatheringError is usually without a cause
-            const fakeError = new MC.Errors.IceGatheringError(fakeErrorMessage, {
+            const fakeError = new Errors.IceGatheringError(fakeErrorMessage, {
               name: fakeErrorName,
             });
 
-            eventListeners[MC.Event.ROAP_FAILURE](fakeError);
+            eventListeners[Event.ROAP_FAILURE](fakeError);
 
             checkMetricSent(eventType.LOCAL_SDP_GENERATED);
             // expectedMetadataType is the error name in this case
             checkBehavioralMetricSent(
               BEHAVIORAL_METRICS.INVALID_ICE_CANDIDATE,
-              MC.Errors.ErrorCode.IceGatheringError,
+              Errors.ErrorCode.IceGatheringError,
               fakeErrorMessage,
               fakeErrorName
             );
           });
         });
 
-        describe('handles MC.Event.ROAP_MESSAGE_TO_SEND correctly', () => {
+        describe('handles Event.ROAP_MESSAGE_TO_SEND correctly', () => {
           let sendRoapOKStub;
           let sendRoapMediaRequestStub;
           let sendRoapAnswerStub;
@@ -3723,7 +3723,7 @@ describe('plugin-meetings', () => {
           });
 
           it('handles OK message correctly', () => {
-            eventListeners[MC.Event.ROAP_MESSAGE_TO_SEND]({
+            eventListeners[Event.ROAP_MESSAGE_TO_SEND]({
               roapMessage: {messageType: 'OK', seq: 1},
             });
 
@@ -3742,7 +3742,7 @@ describe('plugin-meetings', () => {
           });
 
           it('handles OFFER message correctly', () => {
-            eventListeners[MC.Event.ROAP_MESSAGE_TO_SEND]({
+            eventListeners[Event.ROAP_MESSAGE_TO_SEND]({
               roapMessage: {
                 messageType: 'OFFER',
                 seq: 1,
@@ -3768,7 +3768,7 @@ describe('plugin-meetings', () => {
           });
 
           it('handles ANSWER message correctly', () => {
-            eventListeners[MC.Event.ROAP_MESSAGE_TO_SEND]({
+            eventListeners[Event.ROAP_MESSAGE_TO_SEND]({
               roapMessage: {
                 messageType: 'ANSWER',
                 seq: 10,
@@ -3795,7 +3795,7 @@ describe('plugin-meetings', () => {
           it('sends metrics if fails to send roap ANSWER message', async () => {
             sendRoapAnswerStub.rejects(new Error('sending answer failed'));
 
-            await eventListeners[MC.Event.ROAP_MESSAGE_TO_SEND]({
+            await eventListeners[Event.ROAP_MESSAGE_TO_SEND]({
               roapMessage: {
                 messageType: 'ANSWER',
                 seq: 10,
@@ -3817,9 +3817,9 @@ describe('plugin-meetings', () => {
             );
           });
 
-          [MC.ErrorType.CONFLICT, MC.ErrorType.DOUBLECONFLICT].forEach((errorType) =>
+          [ErrorType.CONFLICT, ErrorType.DOUBLECONFLICT].forEach((errorType) =>
             it(`handles ERROR message indicating glare condition correctly (errorType=${errorType})`, () => {
-              eventListeners[MC.Event.ROAP_MESSAGE_TO_SEND]({
+              eventListeners[Event.ROAP_MESSAGE_TO_SEND]({
                 roapMessage: {
                   messageType: 'ERROR',
                   seq: 10,
@@ -3850,11 +3850,11 @@ describe('plugin-meetings', () => {
           );
 
           it('handles ERROR message indicating other errors correctly', () => {
-            eventListeners[MC.Event.ROAP_MESSAGE_TO_SEND]({
+            eventListeners[Event.ROAP_MESSAGE_TO_SEND]({
               roapMessage: {
                 messageType: 'ERROR',
                 seq: 10,
-                errorType: MC.ErrorType.FAILED,
+                errorType: ErrorType.FAILED,
                 tieBreaker: 12345,
               },
             });
@@ -3864,7 +3864,7 @@ describe('plugin-meetings', () => {
             assert.calledOnce(sendRoapErrorStub);
             assert.calledWith(sendRoapErrorStub, {
               seq: 10,
-              errorType: MC.ErrorType.FAILED,
+              errorType: ErrorType.FAILED,
               mediaId: meeting.mediaId,
               correlationId: meeting.correlationId,
             });

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
@@ -1,7 +1,7 @@
 /* eslint-disable require-jsdoc */
 import EventEmitter from 'events';
 
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {MediaType, ReceiveSlotEvents as WcmeReceiveSlotEvents} from '@webex/internal-media-core';
 import {ReceiveSlot, ReceiveSlotEvents} from '@webex/plugin-meetings/src/multistream/receiveSlot';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
@@ -25,7 +25,7 @@ describe('ReceiveSlot', () => {
     fakeStream = {id: 'fake stream'};
     fakeWcmeSlot = new FakeWcmeSlot(fakeStream);
     findMemberIdCallbackStub = sinon.stub();
-    receiveSlot = new ReceiveSlot(MC.MediaType.VideoMain, fakeWcmeSlot, findMemberIdCallbackStub);
+    receiveSlot = new ReceiveSlot(MediaType.VideoMain, fakeWcmeSlot, findMemberIdCallbackStub);
   });
 
   describe('forwards events from underlying wcme receive slot', () => {
@@ -43,7 +43,7 @@ describe('ReceiveSlot', () => {
         eventData = data;
       });
 
-      fakeWcmeSlot.emit(MC.ReceiveSlotEvents.SourceUpdate, 'live', csi);
+      fakeWcmeSlot.emit(WcmeReceiveSlotEvents.SourceUpdate, 'live', csi);
 
       assert.strictEqual(eventEmitted, true);
       assert.deepEqual(eventData, {
@@ -58,7 +58,7 @@ describe('ReceiveSlot', () => {
 
   it('has public properties', () => {
     assert.strictEqual(receiveSlot.id, 'r1');
-    assert.strictEqual(receiveSlot.mediaType, MC.MediaType.VideoMain);
+    assert.strictEqual(receiveSlot.mediaType, MediaType.VideoMain);
   });
 
   it("exposes underlying wcme receive slot's properties", () => {
@@ -76,7 +76,7 @@ describe('ReceiveSlot', () => {
 
     findMemberIdCallbackStub.returns(fakeMemberId);
 
-    fakeWcmeSlot.emit(MC.ReceiveSlotEvents.SourceUpdate, 'live', csi);
+    fakeWcmeSlot.emit(WcmeReceiveSlotEvents.SourceUpdate, 'live', csi);
 
     assert.strictEqual(receiveSlot.memberId, fakeMemberId);
     assert.strictEqual(receiveSlot.csi, csi);
@@ -89,7 +89,7 @@ describe('ReceiveSlot', () => {
 
     findMemberIdCallbackStub.returns(fakeMemberId);
 
-    fakeWcmeSlot.emit(MC.ReceiveSlotEvents.SourceUpdate, 'live', csi);
+    fakeWcmeSlot.emit(WcmeReceiveSlotEvents.SourceUpdate, 'live', csi);
 
     assert.strictEqual(receiveSlot.memberId, fakeMemberId);
     assert.strictEqual(receiveSlot.csi, csi);

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlotManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlotManager.ts
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {MediaType} from '@webex/internal-media-core';
 import {ReceiveSlotManager} from '@webex/plugin-meetings/src/multistream/receiveSlotManager';
 import * as ReceiveSlotModule from '@webex/plugin-meetings/src/multistream/receiveSlot';
 
@@ -48,7 +48,7 @@ describe('ReceiveSlotManager', () => {
     fakeMeeting.mediaProperties.webrtcMediaConnection = null;
 
     assert.isRejected(
-      receiveSlotManager.allocateSlot(MC.MediaType.VideoMain),
+      receiveSlotManager.allocateSlot(MediaType.VideoMain),
       'Webrtc media connection is missing'
     );
   });
@@ -56,16 +56,16 @@ describe('ReceiveSlotManager', () => {
   it('allocates a slot when allocateSlot() is called and there are no free slots', async () => {
     assert.deepEqual(receiveSlotManager.getStats(), {numAllocatedSlots: {}, numFreeSlots: {}});
 
-    const slot = await receiveSlotManager.allocateSlot(MC.MediaType.VideoMain);
+    const slot = await receiveSlotManager.allocateSlot(MediaType.VideoMain);
 
     assert.calledOnce(fakeMeeting.mediaProperties.webrtcMediaConnection.createReceiveSlot);
     assert.calledWith(
       fakeMeeting.mediaProperties.webrtcMediaConnection.createReceiveSlot,
-      MC.MediaType.VideoMain
+      MediaType.VideoMain
     );
 
     assert.calledOnce(mockReceiveSlotCtor);
-    assert.calledWith(mockReceiveSlotCtor, MC.MediaType.VideoMain, fakeWcmeSlot, sinon.match.func);
+    assert.calledWith(mockReceiveSlotCtor, MediaType.VideoMain, fakeWcmeSlot, sinon.match.func);
     assert.strictEqual(slot, fakeReceiveSlots[0]);
 
     assert.deepEqual(receiveSlotManager.getStats(), {
@@ -75,7 +75,7 @@ describe('ReceiveSlotManager', () => {
   });
 
   it('reuses previously freed slot when allocateSlot() is called and a free slot is available', async () => {
-    const slot1 = await receiveSlotManager.allocateSlot(MC.MediaType.VideoMain);
+    const slot1 = await receiveSlotManager.allocateSlot(MediaType.VideoMain);
 
     assert.calledOnce(fakeMeeting.mediaProperties.webrtcMediaConnection.createReceiveSlot);
     assert.calledOnce(mockReceiveSlotCtor);
@@ -93,7 +93,7 @@ describe('ReceiveSlotManager', () => {
     mockReceiveSlotCtor.resetHistory();
 
     // allocate another slot, this time the previous one should be returned instead of allocating any new ones
-    const slot2 = await receiveSlotManager.allocateSlot(MC.MediaType.VideoMain);
+    const slot2 = await receiveSlotManager.allocateSlot(MediaType.VideoMain);
 
     assert.notCalled(fakeMeeting.mediaProperties.webrtcMediaConnection.createReceiveSlot);
     assert.notCalled(mockReceiveSlotCtor);
@@ -108,7 +108,7 @@ describe('ReceiveSlotManager', () => {
   });
 
   it('does not reuse any slots after reset() is called', async () => {
-    const slot1 = await receiveSlotManager.allocateSlot(MC.MediaType.VideoMain);
+    const slot1 = await receiveSlotManager.allocateSlot(MediaType.VideoMain);
 
     assert.calledOnce(fakeMeeting.mediaProperties.webrtcMediaConnection.createReceiveSlot);
     assert.calledOnce(mockReceiveSlotCtor);
@@ -125,7 +125,7 @@ describe('ReceiveSlotManager', () => {
     assert.deepEqual(receiveSlotManager.getStats(), {numAllocatedSlots: {}, numFreeSlots: {}});
 
     // allocate another slot, because we called reset(), the old free slot should not be reused
-    const slot2 = await receiveSlotManager.allocateSlot(MC.MediaType.VideoMain);
+    const slot2 = await receiveSlotManager.allocateSlot(MediaType.VideoMain);
 
     assert.calledOnce(fakeMeeting.mediaProperties.webrtcMediaConnection.createReceiveSlot);
     assert.calledOnce(mockReceiveSlotCtor);
@@ -140,7 +140,7 @@ describe('ReceiveSlotManager', () => {
   });
 
   it('does not reuse slots if they have different media type', async () => {
-    const slot1 = await receiveSlotManager.allocateSlot(MC.MediaType.VideoMain);
+    const slot1 = await receiveSlotManager.allocateSlot(MediaType.VideoMain);
 
     assert.calledOnce(fakeMeeting.mediaProperties.webrtcMediaConnection.createReceiveSlot);
     assert.calledOnce(mockReceiveSlotCtor);
@@ -151,16 +151,16 @@ describe('ReceiveSlotManager', () => {
     mockReceiveSlotCtor.resetHistory();
 
     // allocate another slot, this time for main audio, so it should be a completely new slot
-    const slot2 = await receiveSlotManager.allocateSlot(MC.MediaType.AudioMain);
+    const slot2 = await receiveSlotManager.allocateSlot(MediaType.AudioMain);
 
     assert.calledOnce(fakeMeeting.mediaProperties.webrtcMediaConnection.createReceiveSlot);
     assert.calledWith(
       fakeMeeting.mediaProperties.webrtcMediaConnection.createReceiveSlot,
-      MC.MediaType.AudioMain
+      MediaType.AudioMain
     );
 
     assert.calledOnce(mockReceiveSlotCtor);
-    assert.calledWith(mockReceiveSlotCtor, MC.MediaType.AudioMain, fakeWcmeSlot, sinon.match.func);
+    assert.calledWith(mockReceiveSlotCtor, MediaType.AudioMain, fakeWcmeSlot, sinon.match.func);
 
     // verify that in fact we got a brand new slot
     assert.strictEqual(slot2, fakeReceiveSlots[1]);

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -1,7 +1,7 @@
 /* eslint-disable require-jsdoc */
 import EventEmitter from 'events';
 
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {MediaType} from '@webex/internal-media-core';
 import {RemoteMedia, RemoteMediaEvents} from '@webex/plugin-meetings/src/multistream/remoteMedia';
 import {ReceiveSlotEvents} from '@webex/plugin-meetings/src/multistream/receiveSlot';
 import sinon from 'sinon';
@@ -16,7 +16,7 @@ describe('RemoteMedia', () => {
   beforeEach(() => {
     fakeStream = {id: 'fake stream'};
     fakeReceiveSlot = new EventEmitter();
-    fakeReceiveSlot.mediaType = MC.MediaType.AudioMain;
+    fakeReceiveSlot.mediaType = MediaType.AudioMain;
     fakeReceiveSlot.memberId = '12345678';
     fakeReceiveSlot.csi = 999;
     fakeReceiveSlot.sourceState = 'avatar';

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaGroup.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {MediaType} from '@webex/internal-media-core';
 import {RemoteMediaGroup} from '@webex/plugin-meetings/src/multistream/remoteMediaGroup';
 import {RemoteMedia} from '@webex/plugin-meetings/src/multistream/remoteMedia';
 import {ReceiveSlot} from '@webex/plugin-meetings/src/multistream/receiveSlot';
@@ -8,13 +8,11 @@ import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
 
 class FakeSlot extends EventEmitter {
-  // @ts-ignore
-  public mediaType: MC.MediaType;
+  public mediaType: MediaType;
 
   public id: string;
 
-  // @ts-ignore
-  constructor(mediaType: MC.MediaType, id: string) {
+  constructor(mediaType: MediaType, id: string) {
     super();
     this.mediaType = mediaType;
     this.id = id;
@@ -51,7 +49,7 @@ describe('RemoteMediaGroup', () => {
 
     fakeReceiveSlots = Array(NUM_SLOTS)
       .fill(null)
-      .map((_, index) => new FakeSlot(MC.MediaType.VideoMain, `fake receive slot ${index}`));
+      .map((_, index) => new FakeSlot(MediaType.VideoMain, `fake receive slot ${index}`));
   });
 
   const getLastActiveSpeakerRequestId = () =>
@@ -370,7 +368,7 @@ describe('RemoteMediaGroup', () => {
 
       const unpinnedRemoteMediaFromGroup = group.getRemoteMedia('all')[0];
       const otherRemoteMedia = new RemoteMedia(
-        new FakeSlot(MC.MediaType.VideoMain, 'other slot') as unknown as ReceiveSlot,
+        new FakeSlot(MediaType.VideoMain, 'other slot') as unknown as ReceiveSlot,
         fakeMediaRequestManager
       );
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaManager.ts
@@ -1,7 +1,7 @@
 /* eslint-disable require-jsdoc */
 import EventEmitter from 'events';
 
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {MediaType} from '@webex/internal-media-core';
 import {
   Configuration,
   Event,
@@ -17,15 +17,13 @@ import {CSI, ReceiveSlotId} from '@webex/plugin-meetings/src/multistream/receive
 import testUtils from '../../../utils/testUtils';
 
 class FakeSlot extends EventEmitter {
-  // @ts-ignore
-  public mediaType: MC.MediaType;
+  public mediaType: MediaType;
 
   public id: string;
 
   public csi?: number;
 
-  // @ts-ignore
-  constructor(mediaType: MC.MediaType, id: string) {
+  constructor(mediaType: MediaType, id: string) {
     super();
     this.mediaType = mediaType;
     this.id = id;
@@ -117,12 +115,12 @@ describe('RemoteMediaManager', () => {
   let fakeVideoSlot;
 
   beforeEach(() => {
-    fakeAudioSlot = new FakeSlot(MC.MediaType.AudioMain, 'fake audio slot');
-    fakeVideoSlot = new FakeSlot(MC.MediaType.VideoMain, 'fake video slot');
+    fakeAudioSlot = new FakeSlot(MediaType.AudioMain, 'fake audio slot');
+    fakeVideoSlot = new FakeSlot(MediaType.VideoMain, 'fake video slot');
 
     fakeReceiveSlotManager = {
       allocateSlot: sinon.stub().callsFake((mediaType) => {
-        if (mediaType === MC.MediaType.AudioMain) {
+        if (mediaType === MediaType.AudioMain) {
           return Promise.resolve(fakeAudioSlot);
         }
 
@@ -178,8 +176,8 @@ describe('RemoteMediaManager', () => {
       await remoteMediaManager.start();
 
       // check that the 2nd start() creates slots and media requests and is not a no-op
-      assert.calledWith(fakeReceiveSlotManager.allocateSlot, MC.MediaType.AudioMain);
-      assert.calledWith(fakeReceiveSlotManager.allocateSlot, MC.MediaType.VideoMain);
+      assert.calledWith(fakeReceiveSlotManager.allocateSlot, MediaType.AudioMain);
+      assert.calledWith(fakeReceiveSlotManager.allocateSlot, MediaType.VideoMain);
 
       assert.called(fakeMediaRequestManagers.audio.addRequest);
       assert.called(fakeMediaRequestManagers.video.addRequest);
@@ -225,7 +223,7 @@ describe('RemoteMediaManager', () => {
       await testUtils.flushPromises();
 
       assert.callCount(fakeReceiveSlotManager.allocateSlot, 5);
-      assert.alwaysCalledWith(fakeReceiveSlotManager.allocateSlot, MC.MediaType.AudioMain);
+      assert.alwaysCalledWith(fakeReceiveSlotManager.allocateSlot, MediaType.AudioMain);
 
       assert.isNotNull(createdAudioGroup);
       if (createdAudioGroup) {
@@ -233,7 +231,7 @@ describe('RemoteMediaManager', () => {
         assert.isTrue(
           createdAudioGroup
             .getRemoteMedia()
-            .every((remoteMedia) => remoteMedia.mediaType === MC.MediaType.AudioMain)
+            .every((remoteMedia) => remoteMedia.mediaType === MediaType.AudioMain)
         );
         assert.strictEqual(createdAudioGroup.getRemoteMedia('pinned').length, 0);
       }
@@ -281,7 +279,7 @@ describe('RemoteMediaManager', () => {
       // even though our "big one" layout is not the default one, the remote media manager should still
       // preallocate enough video receive slots for it up front
       assert.callCount(fakeReceiveSlotManager.allocateSlot, 99);
-      assert.alwaysCalledWith(fakeReceiveSlotManager.allocateSlot, MC.MediaType.VideoMain);
+      assert.alwaysCalledWith(fakeReceiveSlotManager.allocateSlot, MediaType.VideoMain);
     });
 
     it('starts with the initial layout', async () => {
@@ -513,7 +511,7 @@ describe('RemoteMediaManager', () => {
       await remoteMediaManager.setLayout('Stage');
 
       assert.callCount(fakeReceiveSlotManager.allocateSlot, 9);
-      assert.alwaysCalledWith(fakeReceiveSlotManager.allocateSlot, MC.MediaType.VideoMain);
+      assert.alwaysCalledWith(fakeReceiveSlotManager.allocateSlot, MediaType.VideoMain);
     });
 
     it('releases slots when switching to layout that requires less active speaker slots', async () => {
@@ -540,7 +538,7 @@ describe('RemoteMediaManager', () => {
       fakeReceiveSlotManager.releaseSlot.getCalls().forEach((call) => {
         const slot = call.args[0];
 
-        assert.strictEqual(slot.mediaType, MC.MediaType.VideoMain);
+        assert.strictEqual(slot.mediaType, MediaType.VideoMain);
       });
     });
 
@@ -622,7 +620,7 @@ describe('RemoteMediaManager', () => {
           slotCounter += 1;
           const newSlotId = `fake video slot ${slotCounter}`;
 
-          fakeSlots[newSlotId] = new FakeSlot(MC.MediaType.VideoMain, newSlotId);
+          fakeSlots[newSlotId] = new FakeSlot(MediaType.VideoMain, newSlotId);
           return fakeSlots[newSlotId];
         });
 
@@ -1125,7 +1123,7 @@ describe('RemoteMediaManager', () => {
 
       // new slot should be allocated
       assert.calledOnce(fakeReceiveSlotManager.allocateSlot);
-      assert.calledWith(fakeReceiveSlotManager.allocateSlot, MC.MediaType.VideoMain);
+      assert.calledWith(fakeReceiveSlotManager.allocateSlot, MediaType.VideoMain);
 
       // and a media request sent out
       assert.calledOnce(fakeMediaRequestManagers.video.addRequest);
@@ -1154,7 +1152,7 @@ describe('RemoteMediaManager', () => {
 
       // new slot should be allocated
       assert.calledOnce(fakeReceiveSlotManager.allocateSlot);
-      assert.calledWith(fakeReceiveSlotManager.allocateSlot, MC.MediaType.VideoMain);
+      assert.calledWith(fakeReceiveSlotManager.allocateSlot, MediaType.VideoMain);
 
       // but no media requests sent out
       assert.notCalled(fakeMediaRequestManagers.video.addRequest);
@@ -1183,7 +1181,7 @@ describe('RemoteMediaManager', () => {
       await remoteMediaManager.start();
       await remoteMediaManager.setLayout('Stage');
 
-      const fakeNewSlot = new FakeSlot(MC.MediaType.VideoMain, 'fake video slot');
+      const fakeNewSlot = new FakeSlot(MediaType.VideoMain, 'fake video slot');
       const fakeRequestId = 'fake request id';
 
       fakeReceiveSlotManager.allocateSlot.resolves(fakeNewSlot);

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -2,7 +2,7 @@ import 'jsdom-global/register';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
-import {MediaConnection as MC} from '@webex/internal-media-core';
+import {ConnectionState} from '@webex/internal-media-core';
 
 import {StatsAnalyzer, EVENTS} from '../../../../src/statsAnalyzer';
 import NetworkQualityMonitor from '../../../../src/networkQualityMonitor';
@@ -136,7 +136,7 @@ describe('plugin-meetings', () => {
         };
 
         pc = {
-          getConnectionState: sinon.stub().returns(MC.ConnectionState.Connected),
+          getConnectionState: sinon.stub().returns(ConnectionState.Connected),
           getTransceiverStats: sinon.stub().resolves({
             audio: {
               sender: [fakeStats.audio.sender],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,12 +1402,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4":
   version: 7.20.7
   resolution: "@babel/runtime@npm:7.20.7"
   dependencies:
     regenerator-runtime: "npm:^0.13.11"
   checksum: b22b904439569fa3b28627fc398d9bb9619f14bc9165cdf63ab5fa248660a10104ae81514607cbe55e4e26fe0d4048a89263f47f1f3da1e37f8e670b95acf244
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.18.9":
+  version: 7.20.13
+  resolution: "@babel/runtime@npm:7.20.13"
+  dependencies:
+    regenerator-runtime: "npm:^0.13.11"
+  checksum: 0e09b4915318248aeeccdf6dc6a8ccdeedbe4b7187fa4159eaa569c4a407c36f3b8689296296b25246671987efe2253dd6e3bab63a40deedcdbd49b8845204e6
   languageName: node
   linkType: hard
 
@@ -4061,9 +4070,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:^0.0.17-beta":
-  version: 0.0.17-beta
-  resolution: "@webex/internal-media-core@npm:0.0.17-beta"
+"@webex/internal-media-core@npm:1.32.1":
+  version: 1.32.1
+  resolution: "@webex/internal-media-core@npm:1.32.1"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@webex/json-multistream": "npm:1.20.0"
@@ -4075,7 +4084,7 @@ __metadata:
     uuid: "npm:^8.3.2"
     webrtc-adapter: "npm:^8.1.1"
     xstate: "npm:^4.30.6"
-  checksum: 4f823b20536d27c7b4e687ef075db597811ef6e815e0a6cd843f99808e2dc5b918a75a232672adf93ba5bf6b1cc1fb4f92286f70274082834a899217ad4e97ae
+  checksum: 215b924e4c2291ba5a2bb471f16a2469c5080f2b09e892131d4005a9ef0d98d7701686cd3b3b07040a2968e06312307b59e85fbda7625ece90ccaf8668c536fa
   languageName: node
   linkType: hard
 
@@ -4655,7 +4664,7 @@ __metadata:
   resolution: "@webex/plugin-meetings@workspace:packages/@webex/plugin-meetings"
   dependencies:
     "@webex/common": "workspace:^"
-    "@webex/internal-media-core": "npm:^0.0.17-beta"
+    "@webex/internal-media-core": "npm:1.32.1"
     "@webex/internal-plugin-conversation": "workspace:^"
     "@webex/internal-plugin-device": "workspace:^"
     "@webex/internal-plugin-llm": "workspace:^"


### PR DESCRIPTION
## This pull request addresses

TS errors related to MediaConnection types.

## by making the following changes

Fix is done in @webex/internal-media-core lib in this [PR](https://sqbu-github.cisco.com/WebExSquared/webrtc-media-core/pull/157) and this SDK PR is just updating the SDK accordingly so that it builds: basically we now import all the MediaConnection types directly from @webex/internal-media-core, they are not wrapped with `MediaConnection` anymore.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
