### PR TITLE
Spark 391543 use bounded adapter

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -850,6 +850,7 @@ export const RESOURCE = {
 
 export const REACHABILITY = {
   localStorage: 'reachability.result',
+  namespace: 'Reachability',
 };
 
 export const ROAP = {

--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -13,12 +13,14 @@ import {eventType} from '../metrics/config';
 export default class RoapRequest extends StatelessWebexPlugin {
   /**
    * Joins a meeting via ROAP
-   * @param {Object} options
+   * @param {Object} localSdp
    * @returns {Promise} returns a promise that resolves/rejects whatever the request does
    */
-
-  attachRechabilityData(localSdp) {
-    const reachabilityData = window.localStorage.getItem(REACHABILITY.localStorage);
+  async attachRechabilityData(localSdp) {
+    // @ts-ignore
+    const reachabilityData = await this.webex.boundedStorage
+      .get(REACHABILITY.namespace, REACHABILITY.localStorage)
+      .catch(() => {});
 
     if (reachabilityData) {
       try {
@@ -77,77 +79,79 @@ export default class RoapRequest extends StatelessWebexPlugin {
 
     Metrics.postEvent({event: eventType.MEDIA_REQUEST, meetingId});
 
-    // @ts-ignore
-    return this.webex
-      .request({
-        uri: mediaUrl,
-        method: HTTP_VERBS.PUT,
-        body: {
-          device: {
-            url: deviceUrl,
-            // @ts-ignore
-            deviceType: this.config.meetings.deviceType,
-          },
-          correlationId,
-          localMedias: [
-            {
-              localSdp: JSON.stringify(
-                this.attachRechabilityData({
-                  roapMessage,
-                  // eslint-disable-next-line no-warning-comments
-                  // TODO: check whats the need for video and audiomute
-                  audioMuted: !!options.audioMuted,
-                  videoMuted: !!options.videoMuted,
-                })
-              ),
-              mediaId: options.mediaId,
+    return this.attachRechabilityData({
+      roapMessage,
+      // eslint-disable-next-line no-warning-comments
+      // TODO: check whats the need for video and audiomute
+      audioMuted: !!options.audioMuted,
+      videoMuted: !!options.videoMuted,
+    }).then((sdpWithReachability) => {
+      // @ts-ignore
+      return this.webex
+        .request({
+          uri: mediaUrl,
+          method: HTTP_VERBS.PUT,
+          body: {
+            device: {
+              url: deviceUrl,
+              // @ts-ignore
+              deviceType: this.config.meetings.deviceType,
             },
-          ],
-          clientMediaPreferences: {
-            preferTranscoding: options.preferTranscoding ?? true,
+            correlationId,
+            localMedias: [
+              {
+                localSdp: JSON.stringify(sdpWithReachability),
+                mediaId: options.mediaId,
+              },
+            ],
+            clientMediaPreferences: {
+              preferTranscoding: options.preferTranscoding ?? true,
+            },
           },
-        },
-      })
-      .then((res) => {
-        Metrics.postEvent({event: eventType.MEDIA_RESPONSE, meetingId});
+        })
+        .then((res) => {
+          Metrics.postEvent({event: eventType.MEDIA_RESPONSE, meetingId});
 
-        // always it will be the first mediaConnection Object
-        const mediaConnections =
-          res.body.mediaConnections &&
-          res.body.mediaConnections.length > 0 &&
-          res.body.mediaConnections[0];
+          // always it will be the first mediaConnection Object
+          const mediaConnections =
+            res.body.mediaConnections &&
+            res.body.mediaConnections.length > 0 &&
+            res.body.mediaConnections[0];
 
-        LoggerProxy.logger.info(
-          `Roap:request#sendRoap --> response:${JSON.stringify(
-            mediaConnections,
-            null,
-            2
-          )}'\n StatusCode:'${res.statusCode}`
-        );
-        const {locus} = res.body;
+          LoggerProxy.logger.info(
+            `Roap:request#sendRoap --> response:${JSON.stringify(
+              mediaConnections,
+              null,
+              2
+            )}'\n StatusCode:'${res.statusCode}`
+          );
+          const {locus} = res.body;
 
-        locus.roapSeq = options.roapMessage.seq;
+          locus.roapSeq = options.roapMessage.seq;
 
-        return {
-          locus,
-          ...(mediaConnections && {mediaConnections: res.body.mediaConnections}),
-        };
-      })
-      .catch((err) => {
-        Metrics.postEvent({
-          event: eventType.MEDIA_RESPONSE,
-          meetingId,
-          data: {error: Metrics.parseLocusError(err, true)},
+          return {
+            locus,
+            ...(mediaConnections && {mediaConnections: res.body.mediaConnections}),
+          };
+        })
+        .catch((err) => {
+          Metrics.postEvent({
+            event: eventType.MEDIA_RESPONSE,
+            meetingId,
+            data: {error: Metrics.parseLocusError(err, true)},
+          });
+          LoggerProxy.logger.error(
+            `Roap:request#sendRoap --> Error:${JSON.stringify(err, null, 2)}`
+          );
+          LoggerProxy.logger.error(
+            `Roap:request#sendRoapRequest --> errorBody:${JSON.stringify(
+              roapMessage,
+              null,
+              2
+            )} + '\\n mediaId:'${options.mediaId}`
+          );
+          throw err;
         });
-        LoggerProxy.logger.error(`Roap:request#sendRoap --> Error:${JSON.stringify(err, null, 2)}`);
-        LoggerProxy.logger.error(
-          `Roap:request#sendRoapRequest --> errorBody:${JSON.stringify(
-            roapMessage,
-            null,
-            2
-          )} + '\\n mediaId:'${options.mediaId}`
-        );
-        throw err;
-      });
+    });
   }
 }

--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -238,19 +238,19 @@ export default class TurnDiscovery {
    *                                 media connection just after a reconnection
    * @returns {Promise}
    */
-  doTurnDiscovery(meeting: Meeting, isReconnecting?: boolean) {
+  async doTurnDiscovery(meeting: Meeting, isReconnecting?: boolean) {
     // @ts-ignore - fix type
-    const isAnyClusterReachable = meeting.webex.meetings.reachability.isAnyClusterReachable();
+    const isAnyClusterReachable = await meeting.webex.meetings.reachability.isAnyClusterReachable();
 
     if (isAnyClusterReachable) {
       LoggerProxy.logger.info(
         'Roap:turnDiscovery#doTurnDiscovery --> reachability has not failed, skipping TURN discovery'
       );
 
-      return Promise.resolve({
+      return {
         turnServerInfo: undefined,
         turnDiscoverySkippedReason: 'reachability',
-      });
+      };
     }
 
     // @ts-ignore - fix type
@@ -259,7 +259,7 @@ export default class TurnDiscovery {
         'Roap:turnDiscovery#doTurnDiscovery --> TURN discovery disabled in config, skipping it'
       );
 
-      return Promise.resolve({turnServerInfo: undefined, turnDiscoverySkippedReason: 'config'});
+      return {turnServerInfo: undefined, turnDiscoverySkippedReason: 'config'};
     }
 
     return this.sendRoapTurnDiscoveryRequest(meeting, isReconnecting)
@@ -285,7 +285,7 @@ export default class TurnDiscovery {
           stack: e.stack,
         });
 
-        return Promise.resolve({turnServerInfo: undefined, turnDiscoverySkippedReason: undefined});
+        return {turnServerInfo: undefined, turnDiscoverySkippedReason: undefined};
       });
   }
 }

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -1,50 +1,84 @@
 import {assert} from '@webex/test-helper-chai';
+import MockWebex from '@webex/test-helper-mock-webex';
+import sinon from 'sinon';
 import Reachability from '@webex/plugin-meetings/src/reachability/';
 
 describe('isAnyClusterReachable', () => {
-  before(function () {
-    this.jsdom = require('jsdom-global')('', {url: 'http://localhost'});
-  });
-  after(function () {
-    this.jsdom();
+  let webex;
+
+  beforeEach(() => {
+    webex = new MockWebex();
   });
 
-  afterEach(() => {
-    window.localStorage.clear();
-  });
-
-  const checkIsClusterReachable = (mockStorage: any, expectedValue: boolean) => {
+  const checkIsClusterReachable = async (mockStorage: any, expectedValue: boolean) => {
     if (mockStorage) {
-      window.localStorage.setItem('reachability.result', JSON.stringify(mockStorage));
+      await webex.boundedStorage.put(
+        'Reachability',
+        'reachability.result',
+        JSON.stringify(mockStorage)
+      );
     }
-    const reachability = new Reachability({});
+    const reachability = new Reachability(webex);
 
-    const result = reachability.isAnyClusterReachable();
+    const result = await reachability.isAnyClusterReachable();
 
     assert.equal(result, expectedValue);
   };
 
-  it('returns true when udp is reachable', () => {
-    checkIsClusterReachable({x: {udp: {reachable: 'true'}, tcp: {reachable: 'false'}}}, true);
+  it('returns true when udp is reachable', async () => {
+    await checkIsClusterReachable({x: {udp: {reachable: 'true'}, tcp: {reachable: 'false'}}}, true);
   });
 
-  it('returns true when tcp is reachable', () => {
-    checkIsClusterReachable({x: {udp: {reachable: 'false'}, tcp: {reachable: 'true'}}}, true);
+  it('returns true when tcp is reachable', async () => {
+    await checkIsClusterReachable({x: {udp: {reachable: 'false'}, tcp: {reachable: 'true'}}}, true);
   });
 
-  it('returns true when both tcp and udp are reachable', () => {
-    checkIsClusterReachable({x: {udp: {reachable: 'true'}, tcp: {reachable: 'true'}}}, true);
+  it('returns true when both tcp and udp are reachable', async () => {
+    await checkIsClusterReachable({x: {udp: {reachable: 'true'}, tcp: {reachable: 'true'}}}, true);
   });
 
-  it('returns false when both tcp and udp are unreachable', () => {
-    checkIsClusterReachable({x: {udp: {reachable: 'false'}, tcp: {reachable: 'false'}}}, false);
+  it('returns false when both tcp and udp are unreachable', async () => {
+    await checkIsClusterReachable({x: {udp: {reachable: 'false'}, tcp: {reachable: 'false'}}}, false);
   });
 
-  it('returns false when reachability result is empty', () => {
-    checkIsClusterReachable({x: {}}, false);
+  it('returns false when reachability result is empty', async () => {
+    await checkIsClusterReachable({x: {}}, false);
   });
 
-  it('returns false when reachability.result item is not there', () => {
-    checkIsClusterReachable(undefined, false);
+  it('returns false when reachability.result item is not there', async () => {
+    await checkIsClusterReachable(undefined, false);
   });
+});
+
+describe('gatherReachability', () => {
+  let webex;
+
+  beforeEach(async () => {
+    webex = new MockWebex();
+
+    await webex.boundedStorage.put(
+      'Reachability',
+      'reachability.result',
+      JSON.stringify({old: 'results'})
+    );
+  });
+
+  it('stores the reachability', async () => {
+    const reachability = new Reachability(webex);
+
+    const clusters = {some: 'clusters'};
+    const reachabilityResults = {some: 'results'};
+
+    reachability.reachabilityRequest.getClusters = sinon.stub().returns(clusters);
+    (reachability as any).performReachabilityCheck = sinon.stub().returns(reachabilityResults)
+
+    const result = await reachability.gatherReachability();
+
+    assert.equal(result, reachabilityResults);
+
+    const storedResult = await webex.boundedStorage.get('Reachability', 'reachability.result');
+
+    assert.equal(JSON.stringify(result), storedResult);
+  });
+
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
@@ -1,0 +1,114 @@
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import MockWebex from '@webex/test-helper-mock-webex';
+import Metrics from '@webex/plugin-meetings/src/metrics';
+
+import RoapRequest from '@webex/plugin-meetings/src/roap/request';
+
+
+describe('RoapRequest', () => {
+  describe('attachRechabilityData', () => {
+    let webex;
+
+    beforeEach(() => {
+      webex = new MockWebex();
+    });
+    
+    it('attaches the reachability data when it exists', async () => {
+      // @ts-ignore
+      const roapRequest = new RoapRequest({}, {parent: webex});
+
+      const sdp = {some: 'attribute'};
+
+      const reachabilitData = {reachability: 'data'};
+
+      await webex.boundedStorage.put(
+        'Reachability',
+        'reachability.result',
+        JSON.stringify(reachabilitData)
+      );
+
+      const newSdp = await roapRequest.attachRechabilityData(sdp);
+
+      assert.deepEqual(newSdp, {
+        some: 'attribute',
+        reachability: reachabilitData
+      })
+    });
+  
+    it('handles the case when realiability data does not exist', async () => {
+      // @ts-ignore
+      const roapRequest = new RoapRequest({}, {parent: webex});
+
+      const sdp = {some: 'attribute'};
+
+      const newSdp = await roapRequest.attachRechabilityData(sdp);
+
+      assert.deepEqual(newSdp, sdp);
+    });
+  });
+
+  describe('sendRoap', () => {
+    let webex;
+
+    beforeEach(() => {
+      webex = new MockWebex();
+    });
+
+    it('calls attachReliabilityData', async () => {
+      Metrics.postEvent = sinon.stub();
+
+      // @ts-ignore
+      const roapRequest = new RoapRequest({}, {parent: webex});
+
+      const newSdp = {new: 'sdp'}
+
+      roapRequest.attachRechabilityData = sinon.stub().returns(Promise.resolve(newSdp));
+      webex.request.returns(Promise.resolve({
+        body: {
+          locus: {}
+        }
+      }))
+
+      const result = await roapRequest.sendRoap({
+        roapMessage: {seq: 1},
+        locusSelfUrl: 'locusSelfUrl',
+        mediaId: 'mediaId',
+        correlationId: 'correlationId',
+        audioMuted: true,
+        videoMuted: true,
+        meetingId: 'meetingId',
+        preferTranscoding: true
+      });
+
+      assert.calledOnceWithExactly(webex.request, {
+        uri: 'locusSelfUrl/media',
+        method: 'PUT',
+        body: {
+          device: {
+            url: undefined,
+            deviceType: undefined,
+          },
+          correlationId: 'correlationId',
+          localMedias: [{
+            localSdp: JSON.stringify(newSdp),
+            mediaId: 'mediaId'
+          }],
+          clientMediaPreferences: {preferTranscoding: true}
+        },
+      });
+
+      assert.calledOnceWithExactly(roapRequest.attachRechabilityData, {
+        roapMessage: {seq: 1},
+        audioMuted: true,
+        videoMuted: true
+      })
+
+      assert.deepEqual(result, {
+        locus: {
+          roapSeq: 1
+        }
+      });
+    });
+  })
+});

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -46,7 +46,7 @@ describe('TurnDiscovery', () => {
         testMeeting.roapSeq = newSeq;
       }),
       updateMediaConnections: sinon.stub(),
-      webex: {meetings: {reachability: {isAnyClusterReachable: () => false}}},
+      webex: {meetings: {reachability: {isAnyClusterReachable: () => Promise.resolve(false)}}},
       isMultistream: false
     };
   });
@@ -244,7 +244,7 @@ describe('TurnDiscovery', () => {
 
     it('resolves with undefined when cluster is reachable', async () => {
       const prev = testMeeting.webex.meetings.reachability.isAnyClusterReachable;
-      testMeeting.webex.meetings.reachability.isAnyClusterReachable = () => true;
+      testMeeting.webex.meetings.reachability.isAnyClusterReachable = () => Promise.resolve(true);
       const result = await new TurnDiscovery(mockRoapRequest).doTurnDiscovery(testMeeting);
 
       const {turnServerInfo, turnDiscoverySkippedReason} = result;
@@ -275,6 +275,8 @@ describe('TurnDiscovery', () => {
       const td = new TurnDiscovery(mockRoapRequest);
       const turnDiscoveryPromise = td.doTurnDiscovery(testMeeting, false);
 
+      await testUtils.flushPromises();
+
       // simulate the response without the password
       td.handleTurnDiscoveryResponse({
         headers: [
@@ -294,6 +296,8 @@ describe('TurnDiscovery', () => {
       const td = new TurnDiscovery(mockRoapRequest);
       const turnDiscoveryPromise = td.doTurnDiscovery(testMeeting, false);
 
+      await testUtils.flushPromises();
+
       // simulate the response without the headers
       td.handleTurnDiscoveryResponse({});
 
@@ -308,6 +312,8 @@ describe('TurnDiscovery', () => {
     it('resolves with undefined if the response has empty headers array', async () => {
       const td = new TurnDiscovery(mockRoapRequest);
       const turnDiscoveryPromise = td.doTurnDiscovery(testMeeting, false);
+
+      await testUtils.flushPromises();
 
       // simulate the response without the headers
       td.handleTurnDiscoveryResponse({headers: []});
@@ -324,6 +330,8 @@ describe('TurnDiscovery', () => {
       const td = new TurnDiscovery(mockRoapRequest);
 
       const turnDiscoveryPromise = td.doTurnDiscovery(testMeeting, false);
+
+      await testUtils.flushPromises();
 
       // check that TURN_DISCOVERY_REQUEST was sent
       await checkRoapMessageSent('TURN_DISCOVERY_REQUEST', 0);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # 

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-391543

## This pull request addresses

This is the only place in the SDK where localStorage is used instead of using the boundedStorage interface. localStorage should
 not be used directly as it ignores the preferences of the SDK user to use their chosen storage adapater.
## by making the following changes

< DESCRIBE YOUR CHANGES >

Roap and RoapRequest were using localStorage directly. I've updated them to use boundedStorage instead. This necessitated some slight refactoring to allow these classes to use the async boundedStorage interface.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
