### PR TITLE
fix: workaround for edonus bug when handling Roap glare

### DIFF
--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2209,6 +2209,190 @@ describe('plugin-meetings', () => {
           );
           assert.isTrue(myPromiseResolved);
         });
+
+        it('should request floor only after roap transaction is completed', async () => {
+          const eventListeners = {};
+
+          meeting.webex.meetings.reachability = {
+            isAnyClusterReachable: sandbox.stub().resolves(true)
+          };
+
+          const fakeMediaConnection = {
+            close: sinon.stub(),
+            getConnectionState: sinon.stub().returns(ConnectionState.Connected),
+            initiateOffer: sinon.stub().resolves({}),
+
+            // mock the on() method and store all the listeners
+            on: sinon.stub().callsFake((event, listener) => {
+              eventListeners[event] = listener;
+            }),
+
+            updateSendReceiveOptions: sinon.stub().callsFake(() => {
+              // trigger ROAP_STARTED before updateSendReceiveOptions() resolves
+              if (eventListeners[Event.ROAP_STARTED]) {
+                eventListeners[Event.ROAP_STARTED]();
+              } else {
+                throw new Error('ROAP_STARTED listener not registered')
+              }
+              return Promise.resolve();
+            }),
+          };
+
+          meeting.mediaProperties.waitForMediaConnectionConnected = sinon.stub().resolves();
+          meeting.mediaProperties.getCurrentConnectionType = sinon.stub().resolves('udp');
+          Media.createMediaConnection = sinon.stub().returns(fakeMediaConnection);
+
+          const requestScreenShareFloorStub = sandbox.stub(meeting, 'requestScreenShareFloor').resolves({});
+
+          let myPromiseResolved = false;
+
+          meeting.meetingState = 'ACTIVE';
+          await meeting.addMedia({
+            mediaSettings: {},
+          });
+
+          meeting
+            .updateMedia({
+              localShare: mockLocalShare,
+              mediaSettings: {
+                sendShare: true,
+              },
+            })
+            .then(() => {
+              myPromiseResolved = true;
+            });
+
+          await testUtils.flushPromises();
+
+          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions);
+          assert.isFalse(myPromiseResolved);
+
+          // verify that requestScreenShareFloorStub was not called yet
+          assert.notCalled(requestScreenShareFloorStub);
+
+          eventListeners[Event.ROAP_DONE]();
+          await testUtils.flushPromises();
+
+          // now it should have been called
+          assert.calledOnce(requestScreenShareFloorStub);
+        });
+      });
+
+      describe('#updateShare', () => {
+        const mockLocalShare = {id: 'mock local share stream'};
+        let eventListeners;
+        let fakeMediaConnection;
+        let requestScreenShareFloorStub;
+
+        const FAKE_TRACKS = {
+          screenshareVideo: {
+            id: 'fake share track',
+            getSettings: sinon.stub().returns({}),
+          },
+        };
+
+        beforeEach(async () => {
+          eventListeners = {};
+
+          sinon.stub(MeetingUtil, 'getTrack').callsFake((stream) => {
+            if (stream === mockLocalShare) {
+              return {audioTrack: null, videoTrack: FAKE_TRACKS.screenshareVideo};
+            }
+
+            return {audioTrack: null, videoTrack: null};
+          });
+
+          meeting.webex.meetings.reachability = {
+            isAnyClusterReachable: sinon.stub().resolves(true)
+          };
+
+          fakeMediaConnection = {
+            close: sinon.stub(),
+            getConnectionState: sinon.stub().returns(ConnectionState.Connected),
+            initiateOffer: sinon.stub().resolves({}),
+
+            // mock the on() method and store all the listeners
+            on: sinon.stub().callsFake((event, listener) => {
+              eventListeners[event] = listener;
+            }),
+
+            updateSendReceiveOptions: sinon.stub().callsFake(() => {
+              // trigger ROAP_STARTED before updateSendReceiveOptions() resolves
+              if (eventListeners[Event.ROAP_STARTED]) {
+                eventListeners[Event.ROAP_STARTED]();
+              } else {
+                throw new Error('ROAP_STARTED listener not registered')
+              }
+              return Promise.resolve();
+            }),
+          };
+
+          meeting.mediaProperties.waitForMediaConnectionConnected = sinon.stub().resolves();
+          meeting.mediaProperties.getCurrentConnectionType = sinon.stub().resolves('udp');
+          Media.createMediaConnection = sinon.stub().returns(fakeMediaConnection);
+
+          requestScreenShareFloorStub = sinon.stub(meeting, 'requestScreenShareFloor').resolves({});
+
+          meeting.meetingState = 'ACTIVE';
+          await meeting.addMedia({
+            mediaSettings: {},
+          });
+        });
+
+        afterEach(() => {
+          sinon.restore();
+        });
+
+        it('when starting share, it should request floor only after roap transaction is completed', async () => {
+          let myPromiseResolved = false;
+
+          meeting
+            .updateShare({
+              sendShare: true,
+              receiveShare: true,
+              stream: mockLocalShare,
+            })
+            .then(() => {
+              myPromiseResolved = true;
+            });
+
+          await testUtils.flushPromises();
+
+          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions);
+          assert.isFalse(myPromiseResolved);
+
+          // verify that requestScreenShareFloorStub was not called yet
+          assert.notCalled(requestScreenShareFloorStub);
+
+          eventListeners[Event.ROAP_DONE]();
+          await testUtils.flushPromises();
+
+          // now it should have been called
+          assert.calledOnce(requestScreenShareFloorStub);
+        });
+
+        it('when changing screen share stream and no roap transaction happening, it requests floor immediately', async () => {
+          let myPromiseResolved = false;
+
+          // simulate a case when no roap transaction is triggered by updateSendReceiveOptions
+          meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions = sinon.stub().resolves({});
+
+          meeting
+            .updateShare({
+              sendShare: true,
+              receiveShare: true,
+              stream: mockLocalShare,
+            })
+            .then(() => {
+              myPromiseResolved = true;
+            });
+
+          await testUtils.flushPromises();
+
+          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions);
+          assert.calledOnce(requestScreenShareFloorStub);
+          assert.isTrue(myPromiseResolved);
+        });
       });
 
       describe('#changeVideoLayout', () => {


### PR DESCRIPTION
# COMPLETES #
This is a workaround for https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-308749

## This pull request addresses

Edonus sometimes doesn't handle Roap glare correctly. This happens especially when we are stealing screen share from someone. In that case we send an SDP offer to Edonus and also request floor from Locus. Locus giving us floor triggers an offer from Edonus. Edonus should not send us that offer if it already has an outstanding offer from us, but it does it and it sends it with an increased seq, which is a breach of the Roap protocol and as a result Linus doesn't correctly detect the glare condition and even though we reply with Error-Conflict to Edonus' offer, Linus keeps resending us that offer until eventually Edonus times out and call is destroyed.

## by making the following changes

Changing the code so that we only send the floor request to Locus after Roap offer-answer-ok sequence started by us is fully completed. This alignes our behaviour on beta more closely with how this has been done on master. On master floor request was sent after we received http response from Locus for our Roap offer (so it wasn't waiting for the answer and OK to be completed) and that was causing this issue to happen only roughly 1 in 10 times when stealing screen share. Without this fix, we are hitting the Edonus bug about 90% of the time when stealing screen share.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Manual e2e with samples app, also running integration tests in circle ci multiple times

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
