### PR TITLE
fix(plugin-meetings): set correct local audio state in localsdp 

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -330,6 +330,17 @@ class MuteState {
   }
 
   /**
+   * Returns true if the user is locally muted
+   *
+   * @public
+   * @memberof MuteState
+   * @returns {Boolean}
+   */
+  public isLocallyMuted() {
+    return this.state.client.localMute || this.state.server.localMute;
+  }
+
+  /**
    * Returns true if the user is muted as a result of the client request (and not remotely muted)
    *
    * @public

--- a/packages/@webex/plugin-meetings/src/roap/index.ts
+++ b/packages/@webex/plugin-meetings/src/roap/index.ts
@@ -170,8 +170,8 @@ export default class Roap extends StatelessWebexPlugin {
           locusSelfUrl: meeting.selfUrl,
           mediaId: options.mediaId,
           correlationId: options.correlationId,
-          audioMuted: meeting.isAudioMuted(),
-          videoMuted: meeting.isVideoMuted(),
+          audioMuted: meeting.audio?.isLocallyMuted(),
+          videoMuted: meeting.video?.isLocallyMuted(),
           meetingId: meeting.id,
         })
         .then(() => {
@@ -222,8 +222,8 @@ export default class Roap extends StatelessWebexPlugin {
         locusSelfUrl: meeting.selfUrl,
         mediaId: options.mediaId,
         correlationId: options.correlationId,
-        audioMuted: options.audioMuted,
-        videoMuted: options.videoMuted,
+        audioMuted: meeting.audio?.isLocallyMuted(),
+        videoMuted: meeting.video?.isLocallyMuted(),
         meetingId: meeting.id,
       })
       .then(() => {
@@ -295,8 +295,8 @@ export default class Roap extends StatelessWebexPlugin {
         correlationId: meeting.correlationId,
         locusSelfUrl: meeting.selfUrl,
         mediaId: sendEmptyMediaId ? '' : meeting.mediaId,
-        audioMuted: meeting.isAudioMuted(),
-        videoMuted: meeting.isVideoMuted(),
+        audioMuted: meeting.audio?.isLocallyMuted(),
+        videoMuted: meeting.video?.isLocallyMuted(),
         meetingId: meeting.id,
       })
       .then(({locus, mediaConnections}) => {
@@ -353,8 +353,8 @@ export default class Roap extends StatelessWebexPlugin {
               roapMessage,
               // eslint-disable-next-line no-warning-comments
               // TODO: check whats the need for video and audiomute
-              audioMuted: !!meeting.isAudioMuted(),
-              videoMuted: !!meeting.isVideoMuted(),
+              audioMuted: meeting.audio?.isLocallyMuted(),
+              videoMuted: meeting.video?.isLocallyMuted(),
             })
           ),
           // mediaId: meeting.mediaId

--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -177,8 +177,8 @@ export default class TurnDiscovery {
         locusSelfUrl: meeting.selfUrl,
         // @ts-ignore - Fix missing type
         mediaId: isReconnecting ? '' : meeting.mediaId,
-        audioMuted: meeting.isAudioMuted(),
-        videoMuted: meeting.isVideoMuted(),
+        audioMuted: meeting.audio?.isLocallyMuted(),
+        videoMuted: meeting.video?.isLocallyMuted(),
         meetingId: meeting.id,
       })
       .then(({mediaConnections}) => {
@@ -211,8 +211,8 @@ export default class TurnDiscovery {
       // @ts-ignore - fix type
       mediaId: meeting.mediaId,
       correlationId: meeting.correlationId,
-      audioMuted: meeting.isAudioMuted(),
-      videoMuted: meeting.isVideoMuted(),
+      audioMuted: meeting.audio?.isLocallyMuted(),
+      videoMuted: meeting.video?.isLocallyMuted(),
       meetingId: meeting.id,
     });
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
@@ -161,6 +161,17 @@ describe('plugin-meetings', () => {
       assert.isFalse(audio.isSelf());
     });
 
+    describe('#isLocallyMuted()', () => {
+      it('does not consider remote mute status for audio', async () => {
+        // simulate being already remote muted
+        meeting.remoteMuted = true;
+        // create a new MuteState intance
+        audio = createMuteState(AUDIO, meeting, {sendAudio: true});
+
+        assert.isFalse(audio.isLocallyMuted());
+      });
+    });
+
     describe('#handleClientRequest', () => {
       it('disables/enables the local audio track when audio is muted/unmuted', async () => {
         // mute

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
@@ -47,8 +47,12 @@ describe('Roap', () => {
       correlationId: 'correlation id',
       selfUrl: 'self url',
       mediaId: 'media id',
-      isAudioMuted: () => true,
-      isVideoMuted: () => false,
+      audio:{
+        isLocallyMuted: () => true,
+      },
+      video:{
+        isLocallyMuted: () => false,
+      },
       setRoapSeq: sinon.stub(),
       config: {experimental: {enableTurnDiscovery: false}},
     };
@@ -99,8 +103,8 @@ describe('Roap', () => {
           correlationId: meeting.correlationId,
           locusSelfUrl: meeting.selfUrl,
           mediaId: expectEmptyMediaId ? '' : meeting.mediaId,
-          audioMuted: meeting.isAudioMuted(),
-          videoMuted: meeting.isVideoMuted(),
+          audioMuted: meeting.audio?.isLocallyMuted(),
+          videoMuted: meeting.video?.isLocallyMuted(),
           meetingId: meeting.id,
         });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -40,8 +40,12 @@ describe('TurnDiscovery', () => {
       mediaId: 'fake media id',
       locusUrl: `https://locus-a.wbx2.com/locus/api/v1/loci/${FAKE_LOCUS_ID}`,
       roapSeq: -1,
-      isAudioMuted: () => true,
-      isVideoMuted: () => false,
+      audio:{
+        isLocallyMuted: () => true,
+      },
+      video:{
+        isLocallyMuted: () => false,
+      },
       setRoapSeq: sinon.fake((newSeq) => {
         testMeeting.roapSeq = newSeq;
       }),
@@ -72,8 +76,8 @@ describe('TurnDiscovery', () => {
       correlationId: testMeeting.correlationId,
       locusSelfUrl: testMeeting.selfUrl,
       mediaId: expectedMediaId,
-      audioMuted: testMeeting.isAudioMuted(),
-      videoMuted: testMeeting.isVideoMuted(),
+      audioMuted: testMeeting.audio?.isLocallyMuted(),
+      videoMuted: testMeeting.video?.isLocallyMuted(),
       meetingId: testMeeting.id,
     });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-390306](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-390306)

## This pull request addresses

When the user joins remotely muted (meeting demands users to join muted), then the user unmutes themselves, the locus wasn't unmuting the user. This is because, on join locus thinks we are locally muted as well as remotely muted as we send localSdp based on both local mute state and remote mute state.

## by making the following changes

We have introduced a new audio method to know if we are locally muted which is sent on the /media request on join. This way, locus is aware we are remotely muted but locally un mute. This way the ROAP OFFER / ANSWER / OK cycle is corrected.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
