### PR TITLE
feat(gitignore): remove types folder from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ _site
 doc
 docker-env
 dist
-types
 html-report
 js-bin
 local/


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

- remove types folder from `.gitignore` so that they get published to npm

## by making the following changes

- change gitignore

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
