### PR TITLE
fix: call disconnecting after calling updateMedia

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4905,32 +4905,6 @@ export default class Meeting extends StatelessWebexPlugin {
             // we actually get a OFFER from the server and a GLAR condition happens
             if (startShare) {
               // We are assuming that the clients are connected when doing an update
-              // @ts-ignore
-              return this.share();
-            }
-
-            return Promise.resolve();
-          })
-          .then(() =>
-            logRequest(
-              this.roap.sendRoapMediaRequest({
-                sdp: this.mediaProperties.peerConnection.sdp,
-                roapSeq: this.roapSeq,
-                meeting: this, // or can pass meeting ID
-              }),
-              {
-                header: `${LOG_HEADER} sendRoapMediaRequest being sent`,
-                success: `${LOG_HEADER} sendRoadMediaRequest successful`,
-                failure: `${LOG_HEADER} Error updateMedia on send roap media request, `,
-              }
-            )
-          )
-          .then(() => this.checkForStopShare(mediaSettings.sendShare, previousSendShareStatus))
-          .then((startShare) => {
-            // This is a special case if we do an /floor grant followed by /media
-            // we actually get a OFFER from the server and a GLAR condition happens
-            if (startShare) {
-              // We are assuming that the clients are connected when doing an update
               return this.requestScreenShareFloor();
             }
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses
@marcin-bazyl 

the roap bug from the "Participants being kicked out of real world converged meeting" space is a regression on SDK master that was introduced in the [prettier PR](https://github.com/webex/webex-js-sdk/pull/2548) - every time anyone calls Meeting.updateMedia() SDK sends the new Offer twice (increasing the seq each time), so as a result you will be dropped from the call.
This is because updateMedia() calls sendRoapMediaRequest() twice: the block between lines 4888 and 4913 should be removed - it's a duplication of the block in the next lines - looks like some merge that has gone wrong

## by making the following changes
removed the merged code

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
