### PR TITLE
fix: enabled screen share for multistream

### DIFF
--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:^",
-    "@webex/internal-media-core": "1.33.1",
+    "@webex/internal-media-core": "1.33.2",
     "@webex/internal-plugin-conversation": "workspace:^",
     "@webex/internal-plugin-device": "workspace:^",
     "@webex/internal-plugin-llm": "workspace:^",

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
@@ -115,7 +115,7 @@ const TwoMainPlusSixSmallLayout: VideoLayout = {
 
 // A strip of 8 small video panes (thumbnails) displayed at the top of a remote screenshare:
 const RemoteScreenShareWithSmallThumbnailsLayout: VideoLayout = {
-  // screenShareVideo: {size: 'best'}, // todo: SPARK-393485: uncomment this once backend supports screen sharing
+  screenShareVideo: {size: 'best'},
   activeSpeakerVideoPaneGroups: [
     {
       id: 'thumbnails',
@@ -153,7 +153,7 @@ const Stage2x2With6ThumbnailsLayout: VideoLayout = {
 export const DefaultConfiguration: Configuration = {
   audio: {
     numOfActiveSpeakerStreams: 3,
-    numOfScreenShareStreams: 0, // todo: SPARK-393485: change to 1 once backend supports screen sharing
+    numOfScreenShareStreams: 1,
   },
   video: {
     preferLiveVideo: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,21 +4077,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:1.33.1":
-  version: 1.33.1
-  resolution: "@webex/internal-media-core@npm:1.33.1"
+"@webex/internal-media-core@npm:1.33.2":
+  version: 1.33.2
+  resolution: "@webex/internal-media-core@npm:1.33.2"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@webex/json-multistream": "npm:1.20.0"
     "@webex/ts-sdp": "npm:1.3.0"
-    "@webex/web-client-media-engine": "npm:^1.36.3"
+    "@webex/web-client-media-engine": "npm:1.37.4"
     detectrtc: "npm:^1.4.1"
     events: "npm:^3.3.0"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
-    webrtc-adapter: "npm:^8.1.1"
+    webrtc-adapter: "npm:^8.1.2"
     xstate: "npm:^4.30.6"
-  checksum: 97584be0899d0864b0d2947820455db66959ec5778a18c561c6f91f66456b3f1406234f311be02856a897194575fbe4d709dc6931aecaa3a9ee068b02f96d631
+  checksum: a213d6cd5cd46f5278c64c4ad2d0541b21f9b296f0b7e767e42b757423e04e0dbfc7c134ebabac481512cb22d92f5ff892d63edacba7d583afabbba79925d706
   languageName: node
   linkType: hard
 
@@ -4671,7 +4671,7 @@ __metadata:
   resolution: "@webex/plugin-meetings@workspace:packages/@webex/plugin-meetings"
   dependencies:
     "@webex/common": "workspace:^"
-    "@webex/internal-media-core": "npm:1.33.1"
+    "@webex/internal-media-core": "npm:1.33.2"
     "@webex/internal-plugin-conversation": "workspace:^"
     "@webex/internal-plugin-device": "workspace:^"
     "@webex/internal-plugin-llm": "workspace:^"
@@ -5082,9 +5082,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:^1.36.3":
-  version: 1.37.3
-  resolution: "@webex/web-client-media-engine@npm:1.37.3"
+"@webex/web-client-media-engine@npm:1.37.4":
+  version: 1.37.4
+  resolution: "@webex/web-client-media-engine@npm:1.37.4"
   dependencies:
     "@webex/json-multistream": "npm:^1.20.1"
     "@webex/rtcstats": "npm:^1.0.1"
@@ -5094,7 +5094,7 @@ __metadata:
     js-logger: "npm:^1.6.1"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
-  checksum: 36dcdd90200cfe8128de7317ee034ac74383d6dc32017bec48a516c25428e408346998880cb4849d2a0db19f9a61b4ca5f341c4e11df9d252b3f6dfccc174493
+  checksum: f2290d8c5739c2ac5c7663fd0f09c70d56d71d536fc957bcb973a4dfc64fa9d30eac23e422e167e2ce1707d4f9f08a066bd5145f69851ee3e4a151ba5c416b98
   languageName: node
   linkType: hard
 
@@ -23038,7 +23038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webrtc-adapter@npm:^8.1.1, webrtc-adapter@npm:^8.1.2":
+"webrtc-adapter@npm:^8.1.2":
   version: 8.2.0
   resolution: "webrtc-adapter@npm:8.2.0"
   dependencies:


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-393485

## This pull request addresses

Enables receiving and sending of screen share in multistream meetings

## by making the following changes

using latest internal-media-core version that:
 - contains WCME version that has a workaround for missing bundling support in the backend (required for screen share to work)
 - enables floorControlledPresentation in WCME config 

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
