### PR TITLE
fix: update memberId on ReceiveSlots when members are updated

### DIFF
--- a/packages/@webex/plugin-meetings/src/members/index.ts
+++ b/packages/@webex/plugin-meetings/src/members/index.ts
@@ -296,6 +296,8 @@ export default class Members extends StatelessWebexPlugin {
       const delta = this.handleLocusInfoUpdatedParticipants(payload);
       const full = this.handleMembersUpdate(delta); // SDK should propagate the full list for both delta and non delta updates
 
+      this.receiveSlotManager.updateMemberIds();
+
       Trigger.trigger(
         this,
         {

--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
@@ -91,7 +91,7 @@ export class ReceiveSlot extends EventsScope {
   /**
    * registers event handlers with the underlying ReceiveSlot
    */
-  setupEventListeners() {
+  private setupEventListeners() {
     const scope = {
       file: 'meeting/receiveSlot',
       function: 'setupEventListeners',
@@ -114,6 +114,13 @@ export class ReceiveSlot extends EventsScope {
         });
       }
     );
+  }
+
+  /** Tries to find the member id for this receive slot if it hasn't got one */
+  public findMemberId() {
+    if (this.#memberId === undefined && this.#csi) {
+      this.#memberId = this.findMemberIdCallback(this.#csi);
+    }
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
@@ -141,4 +141,16 @@ export class ReceiveSlotManager {
       numFreeSlots,
     };
   }
+
+  /**
+   * Tries to find the member id on all allocated receive slots
+   * This function should be called when new members are added to the meeting.
+   */
+  updateMemberIds() {
+    Object.keys(this.allocatedSlots).forEach((key) => {
+      this.allocatedSlots[key].forEach((slot: ReceiveSlot) => {
+        slot.findMemberId();
+      });
+    });
+  }
 }

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
@@ -101,4 +101,40 @@ describe('ReceiveSlot', () => {
     assert.strictEqual(receiveSlot.csi, undefined);
     assert.strictEqual(receiveSlot.sourceState, 'no source');
   });
+
+  describe('findMemberId()', () => {
+    it('doesn\'t do anything if csi is not set', () => {
+      // by default the receiveSlot does not have any csi or member id
+      receiveSlot.findMemberId();
+
+      assert.notCalled(findMemberIdCallbackStub);
+    });
+
+    it('finds a member id if member id is undefined and CSI is known', () => {
+      // setup receiveSlot to have a csi without a member id
+      const csi = 12345;
+      fakeWcmeSlot.emit(WcmeReceiveSlotEvents.SourceUpdate, 'live', csi);
+      findMemberIdCallbackStub.reset();
+
+      receiveSlot.findMemberId();
+
+      assert.calledOnce(findMemberIdCallbackStub);
+      assert.calledWith(findMemberIdCallbackStub, csi);
+    });
+
+    it('doesn\'t do anything if member id already set', () => {
+      // setup receiveSlot to have a csi and a member id
+      const csi = 12345;
+      const memberId = '12345678-1234-5678-9012-345678901234';
+
+      findMemberIdCallbackStub.returns(memberId);
+
+      fakeWcmeSlot.emit(WcmeReceiveSlotEvents.SourceUpdate, 'live', csi);
+      findMemberIdCallbackStub.reset();
+
+      receiveSlot.findMemberId();
+
+      assert.notCalled(findMemberIdCallbackStub);
+    });
+  });
 });


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-405017

## This pull request addresses

When a remote participant joins a meeting, we get a source update event on a receive slot and a Locus update on the member (with the new csi value for the video stream for that member). If the receive slot event comes before the Locus update, the SDK ReceiveSlot (and consequently also the RemoteMedia object) will have memberId set to undefined.

## by making the following changes

Updating memberId on all receive slots that have it undefined whenever any Locus update to members happens

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
