### PR TITLE
fix(plugin-meetings): add multistream logs to log buffer

### DIFF
--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:^",
-    "@webex/internal-media-core": "1.33.2",
+    "@webex/internal-media-core": "1.35.0",
     "@webex/internal-plugin-conversation": "workspace:^",
     "@webex/internal-plugin-device": "workspace:^",
     "@webex/internal-plugin-llm": "workspace:^",

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -164,38 +164,7 @@ Media.createMediaConnection = (
       {
         iceServers,
       },
-      debugId,
-      (messages, context) => {
-        // Convert argument `messages` object to an array.
-        const logMessages = Array.from(messages).map((message) =>
-          typeof message === 'object' ? JSON.stringify(message) : message
-        );
-
-        logMessages.unshift(`[${context.name}]`);
-
-        // Send log messages to appropriate logging function.
-        switch (context.level.name) {
-          case 'TRACE':
-            LoggerProxy.logger.trace(...logMessages);
-            break;
-          case 'DEBUG':
-            LoggerProxy.logger.debug(...logMessages);
-            break;
-          case 'INFO':
-            LoggerProxy.logger.info(...logMessages);
-            break;
-          case 'WARN':
-            LoggerProxy.logger.warn(...logMessages);
-            break;
-          case 'ERROR':
-            LoggerProxy.logger.error(...logMessages);
-            break;
-          case 'TIME':
-          case 'OFF':
-          default:
-            break;
-        }
-      }
+      debugId
     );
   }
 

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -164,7 +164,38 @@ Media.createMediaConnection = (
       {
         iceServers,
       },
-      debugId
+      debugId,
+      (messages, context) => {
+        // Convert argument `messages` object to an array.
+        const logMessages = Array.from(messages).map((message) =>
+          typeof message === 'object' ? JSON.stringify(message) : message
+        );
+
+        logMessages.unshift(`[${context.name}]`);
+
+        // Send log messages to appropriate logging function.
+        switch (context.level.name) {
+          case 'TRACE':
+            LoggerProxy.logger.trace(...logMessages);
+            break;
+          case 'DEBUG':
+            LoggerProxy.logger.debug(...logMessages);
+            break;
+          case 'INFO':
+            LoggerProxy.logger.info(...logMessages);
+            break;
+          case 'WARN':
+            LoggerProxy.logger.warn(...logMessages);
+            break;
+          case 'ERROR':
+            LoggerProxy.logger.error(...logMessages);
+            break;
+          case 'TIME':
+          case 'OFF':
+          default:
+            break;
+        }
+      }
     );
   }
 

--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -118,7 +118,7 @@ export default class RoapRequest extends StatelessWebexPlugin {
             res.body.mediaConnections.length > 0 &&
             res.body.mediaConnections[0];
 
-          LoggerProxy.logger.info(
+          LoggerProxy.logger.debug(
             `Roap:request#sendRoap --> response:${JSON.stringify(
               mediaConnections,
               null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,21 +4077,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:1.33.2":
-  version: 1.33.2
-  resolution: "@webex/internal-media-core@npm:1.33.2"
+"@webex/internal-media-core@npm:1.35.0":
+  version: 1.35.0
+  resolution: "@webex/internal-media-core@npm:1.35.0"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
-    "@webex/json-multistream": "npm:1.20.0"
+    "@webex/json-multistream": "npm:1.20.2"
     "@webex/ts-sdp": "npm:1.3.0"
-    "@webex/web-client-media-engine": "npm:1.37.4"
+    "@webex/web-client-media-engine": "npm:1.38.1"
     detectrtc: "npm:^1.4.1"
     events: "npm:^3.3.0"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
     webrtc-adapter: "npm:^8.1.2"
     xstate: "npm:^4.30.6"
-  checksum: a213d6cd5cd46f5278c64c4ad2d0541b21f9b296f0b7e767e42b757423e04e0dbfc7c134ebabac481512cb22d92f5ff892d63edacba7d583afabbba79925d706
+  checksum: c8466401eed1fb2ea3cddcc9fd537f891498b5ae0d1cc81963b5995e9521f6b7e364ae5009b99dc9023c67b4049e7ddba1bf240a35a66f5ab4ce90e1cf9cb5d5
   languageName: node
   linkType: hard
 
@@ -4529,17 +4529,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/json-multistream@npm:1.20.0":
-  version: 1.20.0
-  resolution: "@webex/json-multistream@npm:1.20.0"
-  checksum: 73d591f156ec83dfa9628e416552e0db6dfa5a50a29325df0b46d6ca2079680bdef030b4aac670de2045e6adb28a2d73907502eb52c7834affc1739e862dbaed
-  languageName: node
-  linkType: hard
-
-"@webex/json-multistream@npm:^1.20.1":
-  version: 1.20.1
-  resolution: "@webex/json-multistream@npm:1.20.1"
-  checksum: fd3e371993f1575f4e2a93b0b4252a76342829657c678338875cd87a6e859ec6fc0dd81d51fe6b13590e65ec9230ecc2b34c0607f146bc9df2f882b1700ce588
+"@webex/json-multistream@npm:1.20.2, @webex/json-multistream@npm:^1.20.2":
+  version: 1.20.2
+  resolution: "@webex/json-multistream@npm:1.20.2"
+  checksum: 73524594a289418ecda98bf35e66ce8281ffc9351b69fdb8e67d46afe911e6f2eea21f73c21455040b64abd38b3a0b3c16978784eca745f93e2ba61459ff12e8
   languageName: node
   linkType: hard
 
@@ -4671,7 +4664,7 @@ __metadata:
   resolution: "@webex/plugin-meetings@workspace:packages/@webex/plugin-meetings"
   dependencies:
     "@webex/common": "workspace:^"
-    "@webex/internal-media-core": "npm:1.33.2"
+    "@webex/internal-media-core": "npm:1.35.0"
     "@webex/internal-plugin-conversation": "workspace:^"
     "@webex/internal-plugin-device": "workspace:^"
     "@webex/internal-plugin-llm": "workspace:^"
@@ -5082,11 +5075,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:1.37.4":
-  version: 1.37.4
-  resolution: "@webex/web-client-media-engine@npm:1.37.4"
+"@webex/web-client-media-engine@npm:1.38.1":
+  version: 1.38.1
+  resolution: "@webex/web-client-media-engine@npm:1.38.1"
   dependencies:
-    "@webex/json-multistream": "npm:^1.20.1"
+    "@webex/json-multistream": "npm:^1.20.2"
     "@webex/rtcstats": "npm:^1.0.1"
     "@webex/ts-sdp": "npm:1.3.1"
     "@webex/webrtc-core": "npm:^1.2.0"
@@ -5094,7 +5087,7 @@ __metadata:
     js-logger: "npm:^1.6.1"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
-  checksum: f2290d8c5739c2ac5c7663fd0f09c70d56d71d536fc957bcb973a4dfc64fa9d30eac23e422e167e2ce1707d4f9f08a066bd5145f69851ee3e4a151ba5c416b98
+  checksum: deb6d20e9294577fdbb2a88640c02e4a45512503e9cf390397de2daede95406ca6a26cfa1ee2e5bf0b0cc9f9446c9159cd92f1f0023c7e0b8c57a5bb03968bc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES [SPARK-346121](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-346121)

This PR adds multistream logs to the log buffer to be sent after a call ends or fails.

## by making the following changes

The webrtc-media-core lib was altered to allow for a log handler for multistream logs.  This PR adds a log handler callback that maps the log types (`warn`, `info`, `debug`, etc) to the internal webex logger.

Note: relies on this PR: https://sqbu-github.cisco.com/WebExSquared/webrtc-media-core/pull/164

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
