### PR TITLE
fix: emitting SourceUpdate event when memberId is found for ReceiveSlot

### DIFF
--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
@@ -120,6 +120,22 @@ export class ReceiveSlot extends EventsScope {
   public findMemberId() {
     if (this.#memberId === undefined && this.#csi) {
       this.#memberId = this.findMemberIdCallback(this.#csi);
+
+      if (this.#memberId) {
+        // if we found the memberId, simulate source update so that the client app knows that something's changed
+        this.emit(
+          {
+            file: 'meeting/receiveSlot',
+            function: 'findMemberId',
+          },
+          ReceiveSlotEvents.SourceUpdate,
+          {
+            state: this.#sourceState,
+            csi: this.#csi,
+            memberId: this.#memberId,
+          }
+        );
+      }
     }
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
@@ -111,15 +111,30 @@ describe('ReceiveSlot', () => {
     });
 
     it('finds a member id if member id is undefined and CSI is known', () => {
+      let emittedSourceUpdateEvent = null;
+
       // setup receiveSlot to have a csi without a member id
       const csi = 12345;
+      const fakeMemberId = 'aaa-bbb-ccc-ddd';
       fakeWcmeSlot.emit(WcmeReceiveSlotEvents.SourceUpdate, 'live', csi);
       findMemberIdCallbackStub.reset();
+      findMemberIdCallbackStub.returns(fakeMemberId);
+
+      receiveSlot.on(ReceiveSlotEvents.SourceUpdate, (data) => {
+        emittedSourceUpdateEvent = data;
+      });
 
       receiveSlot.findMemberId();
 
       assert.calledOnce(findMemberIdCallbackStub);
       assert.calledWith(findMemberIdCallbackStub, csi);
+
+      assert.deepEqual(emittedSourceUpdateEvent, {
+        state: 'live',
+        csi,
+        memberId: fakeMemberId,
+      });
+
     });
 
     it('doesn\'t do anything if member id already set', () => {


### PR DESCRIPTION
# COMPLETES #SPARK-405017
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-405017

## This pull request addresses

When we find memberId after a Locus update, the app doesn't know about the change.

## by making the following changes

We now emit SourceUpdate event so that the existing app code for that event handles the memberId update too.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
