### PR TITLE
fix(metrics): remove org_id, client_id and user_id tags from operational metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,13 @@ webex.rooms.create({ title: `My First Room` }).then(room => {
 
 #### _A note on browser usage_
 
-We provide a built, minified version of the SDK, that includes `window.Webex`. You can access it via [unpkg](https://unpkg.com/), [jsdelivr](https://jsdelivr.com/), or [gitcdn.xyz](https://gitcdn.xyz/).
+We provide a built, minified version of the SDK, that includes `window.Webex`. You can access it via [unpkg](https://unpkg.com/) or [jsdelivr](https://jsdelivr.com/).
 
 ```html
 <!-- unpkg -->
 <script crossorigin src="https://unpkg.com/webex/umd/webex.min.js"></script>
 <!-- jsdelivr -->
 <script crossorigin src="https://cdn.jsdelivr.net/npm/webex/umd/webex.min.js"></script>
-<!-- gitcdn -->
-<script
-  crossorigin
-  src="https://gitcdn.xyz/repo/webex/webex-js-sdk/master/docs/samples/webex.min.js"></script>
 ```
 
 If you're already using a bundler (like [Webpack](https://webpack.js.org/) or [Rollup](https://rollupjs.org/)) you can simply import/require the package and use the above snippet and assign the initialized `webex` variable to `window.webex`.

--- a/packages/@webex/internal-plugin-metrics/src/metrics.js
+++ b/packages/@webex/internal-plugin-metrics/src/metrics.js
@@ -69,14 +69,7 @@ const Metrics = WebexPlugin.extend({
       // eslint-disable-next-line no-undef
       domain:
         typeof window !== 'undefined' ? window.location.hostname || 'non-browser' : 'non-browser', // Check what else we could measure
-      client_id: this.webex.credentials.config.client_id,
     };
-
-    try {
-      payload.tags.org_id = this.webex.credentials.getOrgId();
-    } catch {
-      this.logger.info('metrics: unable to get orgId');
-    }
 
     payload.fields = {
       ...props.fields,
@@ -85,6 +78,7 @@ const Metrics = WebexPlugin.extend({
       sdk_version: this.webex.version,
       platform: 'Web',
       spark_user_agent: getSparkUserAgent(this.webex),
+      client_id: this.webex.credentials.config.client_id,
     };
 
     payload.type = props.type || this.webex.config.metrics.type;

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/metrics.js
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/metrics.js
@@ -199,16 +199,15 @@ describe('plugin-metrics', () => {
               assert.property(metric, 'eventPayload');
 
               assert.property(metric.tags, 'browser');
-              assert.property(metric.tags, 'org_id');
               assert.property(metric.tags, 'os');
               assert.property(metric.tags, 'domain');
-              assert.property(metric.tags, 'client_id');
 
               assert.property(metric.fields, 'browser_version');
               assert.property(metric.fields, 'os_version');
               assert.property(metric.fields, 'sdk_version');
               assert.property(metric.fields, 'platform');
               assert.property(metric.fields, 'spark_user_agent');
+              assert.property(metric.fields, 'client_id');
 
               assert.property(metric.context, 'app');
               assert.property(metric.context, 'locale');

--- a/packages/webex/README.md
+++ b/packages/webex/README.md
@@ -65,15 +65,13 @@ webex.rooms.create({ title: `My First Room` }).then(room => {
 
 #### _A note on browser usage_
 
-We provide a built, minified version of the SDK, that includes `window.Webex`. You can access it via [unpkg](https://unpkg.com/), [jsdelivr](https://jsdelivr.com/), or [gitcdn.xyz](https://gitcdn.xyz/).
+We provide a built, minified version of the SDK, that includes `window.Webex`. You can access it via [unpkg](https://unpkg.com/) or [jsdelivr](https://jsdelivr.com/).
 
 ```html
 <!-- unpkg -->
 <script src="https://unpkg.com/webex/umd/webex.min.js"></script>
 <!-- jsdelivr -->
 <script src="https://cdn.jsdelivr.net/npm/webex/umd/webex.min.js"></script>
-<!-- gitcdn -->
-<script src="https://gitcdn.xyz/repo/webex/webex-js-sdk/master/packages/node_modules/webex/umd/webex.min.js"></script>
 ```
 
 If you're already using a bundler (like [Webpack](https://webpack.js.org/)) you can simply import/require the package and use the above snippet and assign the initialized `webex` variable to `window.webex`.


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [#SPARK-403398](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-403398)

## This pull request addresses

removed org_id, client_id and user_id tags from operational metrics,
added client_id as part of fields instead of tags
added/updated unit test for the same

## by making the following changes

files - 
packages/@webex/internal-plugin-metrics/src/metrics.js
packages/@webex/internal-plugin-metrics/test/unit/spec/metrics.js
removed org_id, client_id and user_id tags from operational metrics,
added client_id as part of fields instead of tags
added/updated unit test for the same


<!-- You may include screenshots -->

`client_id` has been added to the field, PFA for the same as proof value has been passed in payload.

<img width="1479" alt="image" src="https://user-images.githubusercontent.com/3918217/225647413-62edbdbd-3237-4aac-a94c-50e24127f7df.png">


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
