### PR TITLE
fix(plugin-meetings): add optional chaining around stats lookup

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -492,23 +492,23 @@ export class StatsAnalyzer extends EventsScope {
       const getCurrentStatsTotals = (keyPrefix: string, value: string): number =>
         Object.keys(this.statsResults)
           .filter((key) => key.startsWith(keyPrefix))
-          .reduce((prev, cur) => prev + (this.statsResults[cur].recv[value] || 0), 0);
+          .reduce((prev, cur) => prev + (this.statsResults[cur]?.recv[value] || 0), 0);
 
       const getPreviousStatsTotals = (keyPrefix: string, value: string): number =>
         Object.keys(this.statsResults)
           .filter((key) => key.startsWith(keyPrefix))
-          .reduce((prev, cur) => prev + (this.lastStatsResults[cur].recv[value] || 0), 0);
+          .reduce((prev, cur) => prev + (this.lastStatsResults[cur]?.recv[value] || 0), 0);
 
       const getCurrentResolutionsStatsTotals = (keyPrefix: string, value: string): number =>
         Object.keys(this.statsResults)
           .filter((key) => key.startsWith(keyPrefix))
-          .reduce((prev, cur) => prev + (this.statsResults.resolutions[cur].recv[value] || 0), 0);
+          .reduce((prev, cur) => prev + (this.statsResults.resolutions[cur]?.recv[value] || 0), 0);
 
       const getPreviousResolutionsStatsTotals = (keyPrefix: string, value: string): number =>
         Object.keys(this.statsResults)
           .filter((key) => key.startsWith(keyPrefix))
           .reduce(
-            (prev, cur) => prev + (this.lastStatsResults.resolutions[cur].recv[value] || 0),
+            (prev, cur) => prev + (this.lastStatsResults.resolutions[cur]?.recv[value] || 0),
             0
           );
 


### PR DESCRIPTION
# COMPLETES [SPARK-408995](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-408995)

## This pull request addresses

An error where stats for a previous transceiver are missing causing a TypeError.

## by making the following changes

Adding optional chaining around the lookup of the stats results.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
