### PR TITLE
feat(internal-plugin-support): allow productAreaTag and issueTypeTag to be in log metadata

### DIFF
--- a/packages/@webex/internal-plugin-support/src/support.js
+++ b/packages/@webex/internal-plugin-support/src/support.js
@@ -128,6 +128,8 @@ const Support = WebexPlugin.extend({
       'correlationId',
       'meetingId',
       'surveySessionId',
+      'productAreaTag',
+      'issueTypeTag',
     ]
       .map((key) => {
         if (metadata[key]) {

--- a/packages/@webex/internal-plugin-support/test/unit/spec/support.js
+++ b/packages/@webex/internal-plugin-support/test/unit/spec/support.js
@@ -76,6 +76,22 @@ describe('plugin-support', function () {
 
       assert.equal(found?.value, surveySessionId);
     });
+
+    it('sends productAreaTag if specified in metadata', () => {
+      const productAreaTag = 'product-area-tag';
+      const result = webex.internal.support._constructFileMetadata({productAreaTag});
+      const found = result.find((attr) => attr.key === 'productAreaTag');
+
+      assert.equal(found?.value, productAreaTag);
+    });
+
+    it('sends issueTypeTag if specified in metadata', () => {
+      const issueTypeTag = 'issueTypeTag';
+      const result = webex.internal.support._constructFileMetadata({issueTypeTag});
+      const found = result.find((attr) => attr.key === 'issueTypeTag');
+
+      assert.equal(found?.value, issueTypeTag);
+    });
   });
 
   describe('#submitLogs()', () => {


### PR DESCRIPTION
# COMPLETES # [SPARK-409305](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-409305)

## This pull request addresses

Sending of product area and issue in the log metadata.

## by making the following changes

adding the keys: `productAreaTag` and `issueTypeTag` in  method : `_constructFileMetadata`

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Tested the sdk code locally with the client code.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
