### PR TITLE
fix: remove code for resetting of source state

### DIFF
--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:^",
-    "@webex/internal-media-core": "1.35.1",
+    "@webex/internal-media-core": "1.35.2",
     "@webex/internal-plugin-conversation": "workspace:^",
     "@webex/internal-plugin-device": "workspace:^",
     "@webex/internal-plugin-llm": "workspace:^",

--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
@@ -154,17 +154,4 @@ export class ReceiveSlot extends EventsScope {
   get wcmeReceiveSlot(): WcmeReceiveSlot {
     return this.mcReceiveSlot;
   }
-
-  /**
-   * Resets the source state to the default 'no source' value.
-   * This function should be called on receive slots that are
-   * no longer part of a media request. It's needed because WCME
-   * does not send any more events on such slots, so the sourceState
-   * value would not represent the truth anymore.
-   */
-  public resetSourceState() {
-    this.#sourceState = 'no source';
-    this.#csi = undefined;
-    this.#memberId = undefined;
-  }
 }

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
@@ -83,25 +83,6 @@ describe('ReceiveSlot', () => {
     assert.strictEqual(receiveSlot.sourceState, 'live');
   });
 
-  it('resets source related properties when resetSourceState() is called', () => {
-    const csi = 123456;
-    const fakeMemberId = '00000001-5555-6666-9012-345678901234';
-
-    findMemberIdCallbackStub.returns(fakeMemberId);
-
-    fakeWcmeSlot.emit(WcmeReceiveSlotEvents.SourceUpdate, 'live', csi);
-
-    assert.strictEqual(receiveSlot.memberId, fakeMemberId);
-    assert.strictEqual(receiveSlot.csi, csi);
-    assert.strictEqual(receiveSlot.sourceState, 'live');
-
-    receiveSlot.resetSourceState();
-
-    assert.strictEqual(receiveSlot.memberId, undefined);
-    assert.strictEqual(receiveSlot.csi, undefined);
-    assert.strictEqual(receiveSlot.sourceState, 'no source');
-  });
-
   describe('findMemberId()', () => {
     it('doesn\'t do anything if csi is not set', () => {
       // by default the receiveSlot does not have any csi or member id

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,21 +4077,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:1.35.1":
-  version: 1.35.1
-  resolution: "@webex/internal-media-core@npm:1.35.1"
+"@webex/internal-media-core@npm:1.35.2":
+  version: 1.35.2
+  resolution: "@webex/internal-media-core@npm:1.35.2"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@webex/json-multistream": "npm:1.20.2"
     "@webex/ts-sdp": "npm:1.3.0"
-    "@webex/web-client-media-engine": "npm:1.38.1"
+    "@webex/web-client-media-engine": "npm:1.38.4"
     detectrtc: "npm:^1.4.1"
     events: "npm:^3.3.0"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
     webrtc-adapter: "npm:^8.1.2"
     xstate: "npm:^4.30.6"
-  checksum: af4ca386d80daa3b51006db82cdf225a814fa3518bcb56d33684b76501a3fe8d8b20f45b9a8255ff547f0c7347cf50592b75f2235ec5bc9ec189fb8ac7ef2f80
+  checksum: 1fcb0df44a02d3ec81431b34a061e70948eac378f6b775c481a9a552cd737752fbb9b528a8354cf6f3041f5af621f78aa8e7748922eff2e8c4c8619731940643
   languageName: node
   linkType: hard
 
@@ -4664,7 +4664,7 @@ __metadata:
   resolution: "@webex/plugin-meetings@workspace:packages/@webex/plugin-meetings"
   dependencies:
     "@webex/common": "workspace:^"
-    "@webex/internal-media-core": "npm:1.35.1"
+    "@webex/internal-media-core": "npm:1.35.2"
     "@webex/internal-plugin-conversation": "workspace:^"
     "@webex/internal-plugin-device": "workspace:^"
     "@webex/internal-plugin-llm": "workspace:^"
@@ -5076,9 +5076,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:1.38.1":
-  version: 1.38.1
-  resolution: "@webex/web-client-media-engine@npm:1.38.1"
+"@webex/web-client-media-engine@npm:1.38.4":
+  version: 1.38.4
+  resolution: "@webex/web-client-media-engine@npm:1.38.4"
   dependencies:
     "@webex/json-multistream": "npm:^1.20.2"
     "@webex/rtcstats": "npm:^1.0.1"
@@ -5088,7 +5088,7 @@ __metadata:
     js-logger: "npm:^1.6.1"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
-  checksum: deb6d20e9294577fdbb2a88640c02e4a45512503e9cf390397de2daede95406ca6a26cfa1ee2e5bf0b0cc9f9446c9159cd92f1f0023c7e0b8c57a5bb03968bc9
+  checksum: 1e74b7302706de12a1c25720574a89b65520a7fad2f103682ddeb87f9c681ef582aea4da4a4f14c80968b04af0639020943ea95f7690ba641f30c73d839b1a49
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES # [SPARK-409890](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-409890)

## This pull request addresses

Videos sometimes not appear at all after switching layout.

## by making the following changes

Bringing in a new version of WCME that has the fix for https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-320266 and removing the SDK code that resets the sourceState for receive slots that are not used any more - this can be removed, because now this is taken care of by WCME.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
