### PR TITLE
feat: provide size hint remote media

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -1934,7 +1934,7 @@ async function getStatsForVideoPane(meeting, videoPane) {
   return result;
 }
 
-const remoteMediaIds = {};
+let remoteMediaIds = {};
 
 function setSizeHint() {
   const sizeHintValue =  document.getElementById('size-hint-input').value;
@@ -1954,6 +1954,10 @@ function addRemoteMediaOption(remoteMedia) {
   option.text = remoteMedia.id;
 
   select.add(option);
+}
+
+function clearRemoteMedia() {
+  remoteMediaIds = {};
 }
 
 function processNewVideoPane(meeting, paneGroupId, paneId, remoteMedia) {
@@ -2053,6 +2057,7 @@ function setupMultistreamEventListeners(meeting) {
     console.log('memberVideoPanes:', memberVideoPanes);
     console.log('screenShareVideo:', screenShareVideo);
 
+    clearRemoteMedia();
     currentVideoPaneList.length = 0;
     clearAllMultistreamVideoElements();
     createVideoElementsForLayout(layoutId);

--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -1934,8 +1934,32 @@ async function getStatsForVideoPane(meeting, videoPane) {
   return result;
 }
 
+const remoteMediaIds = {};
+
+function setSizeHint() {
+  const sizeHintValue =  document.getElementById('size-hint-input').value;
+  const remoteMediaId = document.getElementById('remote-media-selector').value;
+
+  let [width, height] = sizeHintValue.split(',');
+
+  remoteMediaIds[remoteMediaId].setSizeHint(parseInt(width), parseInt(height))
+}
+
+function addRemoteMediaOption(remoteMedia) {
+  remoteMediaIds[remoteMedia.id] = remoteMedia;
+  const select = document.getElementById('remote-media-selector');
+
+  const option = document.createElement('option');
+  option.value = remoteMedia.id;
+  option.text = remoteMedia.id;
+
+  select.add(option);
+}
+
 function processNewVideoPane(meeting, paneGroupId, paneId, remoteMedia) {
   const videoPane = allVideoPanes[paneGroupId][paneId];
+
+  addRemoteMediaOption(remoteMedia);
 
   videoPane.remoteMedia = remoteMedia;
   videoPane.videoEl.srcObject = remoteMedia.stream;

--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -39,6 +39,11 @@
             </div>
           </div>
           <div><button id="get-stats" onclick="getStats()">Get stats</button> or CTRL+click on a video pane to see its stats.</div>
+          <div style="display: flex">
+            <select name="remote-media-selector" id="remote-media-selector"></select>
+            <input id="size-hint-input" />
+            <button id="size-hint" onclick="setSizeHint()">Set size hint</button>
+          </div>
         </fieldset>
       </div>
     </section>

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -57,6 +57,8 @@ const CODEC_DEFAULTS = {
   },
 };
 
+const DEBOUNCED_SOURCE_UPDATE_TIME = 10;
+
 type DegradationPreferences = {
   maxMacroblocksLimit: number;
 };
@@ -88,7 +90,10 @@ export class MediaRequestManager {
     this.slotsActiveInLastMediaRequest = {};
     this.degradationPreferences = degradationPreferences;
     this.sourceUpdateListener = this.commit.bind(this);
-    this.debouncedSourceUpdateListener = debounce(this.sourceUpdateListener, 10);
+    this.debouncedSourceUpdateListener = debounce(
+      this.sourceUpdateListener,
+      DEBOUNCED_SOURCE_UPDATE_TIME
+    );
   }
 
   private resetInactiveReceiveSlots() {

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -57,7 +57,7 @@ const CODEC_DEFAULTS = {
   },
 };
 
-const DEBOUNCED_SOURCE_UPDATE_TIME = 10;
+const DEBOUNCED_SOURCE_UPDATE_TIME = 1000;
 
 type DegradationPreferences = {
   maxMacroblocksLimit: number;

--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
@@ -11,6 +11,7 @@ import EventsScope from '../common/events/events-scope';
 
 export const ReceiveSlotEvents = {
   SourceUpdate: 'sourceUpdate',
+  MaxFsUpdate: 'maxFsUpdate',
 };
 
 export type {SourceState} from '@webex/internal-media-core';
@@ -79,6 +80,25 @@ export class ReceiveSlot extends EventsScope {
    */
   public get csi() {
     return this.#csi;
+  }
+
+  /**
+   * Set the max frame size for this slot
+   * @param newFs frame size
+   */
+  public setMaxFs(newFs) {
+    // emit event for media request manager to listen to
+
+    this.emit(
+      {
+        file: 'meeting/receiveSlot',
+        function: 'findMemberId',
+      },
+      ReceiveSlotEvents.MaxFsUpdate,
+      {
+        maxFs: newFs,
+      }
+    );
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -103,6 +103,31 @@ export class RemoteMedia extends EventsScope {
   }
 
   /**
+   * Supply the width and height of the video element
+   * to restrict the requested resolution to this size
+   * @param width width of the video element
+   * @param height height of the video element
+   */
+  public setSizeHint(width, height) {
+    // only base on height for now
+    let fs: number;
+
+    if (height < 135) {
+      // 90p translated to a FS
+      fs = 60;
+    } else if (height < 270) {
+      // 180p translated to a FS
+      fs = 225;
+    } else if (height < 540) {
+      fs = 920;
+    } else {
+      fs = 3600;
+    }
+
+    this.receiveSlot.setMaxFs(fs);
+  }
+
+  /**
    * Invalidates the remote media by clearing the reference to a receive slot and
    * cancelling the media request.
    * After this call the remote media is unusable.

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -113,10 +113,8 @@ export class RemoteMedia extends EventsScope {
     let fs: number;
 
     if (height < 135) {
-      // 90p translated to a FS
       fs = 60;
     } else if (height < 270) {
-      // 180p translated to a FS
       fs = 225;
     } else if (height < 540) {
       fs = 920;

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -115,14 +115,14 @@ export class RemoteMedia extends EventsScope {
     if (height < 135) {
       fs = 60;
     } else if (height < 270) {
-      fs = 225;
+      fs = 240;
     } else if (height < 540) {
       fs = 920;
     } else {
       fs = 3600;
     }
 
-    this.receiveSlot.setMaxFs(fs);
+    this.receiveSlot?.setMaxFs(fs);
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -3,6 +3,7 @@ import {ReceiveSlot} from '@webex/plugin-meetings/src/multistream/receiveSlot';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
 import {getMaxFs} from '@webex/plugin-meetings/src/multistream/remoteMedia';
+import FakeTimers from '@sinonjs/fake-timers';
 
 type ExpectedActiveSpeaker = {
   policy: 'active-speaker';
@@ -801,4 +802,41 @@ describe('MediaRequestManager', () => {
       },
     ]);
   });
+
+  it('respects the preferredMaxFs if set', () => {
+    sendMediaRequestsCallback.resetHistory();
+    const clock = FakeTimers.install({now: Date.now()});
+
+    addActiveSpeakerRequest(255, fakeReceiveSlots.slice(0, 10), getMaxFs('large'), true);
+
+    sendMediaRequestsCallback.resetHistory();
+
+
+    const maxFsHandlerCall = fakeReceiveSlots[0].on.getCall(1);
+
+    const maxFsHandler = maxFsHandlerCall.args[1];
+    const eventName = maxFsHandlerCall.args[0];
+
+    assert.equal(eventName, 'maxFsUpdate');
+
+    const preferredFrameSize = 100;
+
+    maxFsHandler({maxFs: preferredFrameSize});
+
+    clock.tick(9);
+
+    assert.notCalled(sendMediaRequestsCallback);
+
+    clock.tick(1);
+
+    checkMediaRequestsSent([
+      {
+        policy: 'active-speaker',
+        priority: 255,
+        receiveSlots: fakeWcmeSlots.slice(0, 10),
+        maxFs: preferredFrameSize,
+      },
+    ]);
+  });
+
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -823,7 +823,7 @@ describe('MediaRequestManager', () => {
 
     maxFsHandler({maxFs: preferredFrameSize});
 
-    clock.tick(9);
+    clock.tick(999);
 
     assert.notCalled(sendMediaRequestsCallback);
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
@@ -152,4 +152,23 @@ describe('ReceiveSlot', () => {
       assert.notCalled(findMemberIdCallbackStub);
     });
   });
+
+  describe('setMaxFs()', () => {
+    it('emits the correct event', () => {
+      sinon.stub(receiveSlot, 'emit');
+      receiveSlot.setMaxFs(100);
+
+      assert.calledOnceWithExactly(
+        receiveSlot.emit,
+        {
+          file: 'meeting/receiveSlot',
+          function: 'findMemberId',
+        },
+        ReceiveSlotEvents.MaxFsUpdate,
+        {
+          maxFs: 100,
+        }
+      );
+    })
+  });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -229,8 +229,8 @@ describe('RemoteMedia', () => {
     forEach(
       [
         {height: 134, fs: 60},
-        {height: 135, fs: 225},
-        {height: 269, fs: 225},
+        {height: 135, fs: 240},
+        {height: 269, fs: 240},
         {height: 270, fs: 920},
         {height: 539, fs: 920},
         {height: 540, fs: 3600},

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -226,6 +226,12 @@ describe('RemoteMedia', () => {
   });
 
   describe('setSizeHint()', () => {
+
+    it('works if the receive slot is undefined', () => {
+      remoteMedia.receiveSlot = undefined;
+      remoteMedia.setSizeHint(100, 100);
+    });
+
     forEach(
       [
         {height: 134, fs: 60},

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -6,6 +6,7 @@ import {RemoteMedia, RemoteMediaEvents} from '@webex/plugin-meetings/src/multist
 import {ReceiveSlotEvents} from '@webex/plugin-meetings/src/multistream/receiveSlot';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
+import { forEach } from 'lodash';
 
 describe('RemoteMedia', () => {
   let remoteMedia;
@@ -21,6 +22,7 @@ describe('RemoteMedia', () => {
     fakeReceiveSlot.csi = 999;
     fakeReceiveSlot.sourceState = 'avatar';
     fakeReceiveSlot.stream = fakeStream;
+    fakeReceiveSlot.setMaxFs = sinon.stub();
 
     fakeMediaRequestManager = {
       addRequest: sinon.stub(),
@@ -221,5 +223,25 @@ describe('RemoteMedia', () => {
         assert.strictEqual(eventEmitted, false);
       });
     });
+  });
+
+  describe('setSizeHint()', () => {
+    forEach(
+      [
+        {height: 134, fs: 60},
+        {height: 135, fs: 225},
+        {height: 269, fs: 225},
+        {height: 270, fs: 920},
+        {height: 539, fs: 920},
+        {height: 540, fs: 3600},
+      ],
+      ({height, fs}) => {
+        it(`sets the max fs to ${fs} correctly when height is ${height}`, () => {
+          remoteMedia.setSizeHint(100, height);
+
+          assert.calledOnceWithExactly(fakeReceiveSlot.setMaxFs, fs);
+        });
+      }
+    );
   });
 });


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-385727

## This pull request addresses

Adds size hint API to multistream

## by making the following changes

The width and height of a video element can be given to the remote media object which causes a request to be sent respecting the frame size calculated from the width and height.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
