### PR TITLE
fix: add receive slot id and csi to log message

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5261,8 +5261,18 @@ export default class Meeting extends StatelessWebexPlugin {
         if (this.config.stats.enableStatsAnalyzer) {
           // @ts-ignore - config coming from registerPlugin
           this.networkQualityMonitor = new NetworkQualityMonitor(this.config.stats);
-          // @ts-ignore - config coming from registerPlugin
-          this.statsAnalyzer = new StatsAnalyzer(this.config.stats, this.networkQualityMonitor);
+          this.statsAnalyzer = new StatsAnalyzer(
+            // @ts-ignore - config coming from registerPlugin
+            this.config.stats,
+            (ssrc: number) => {
+              const receiveSlots = Object.keys(this.receiveSlotManager.allocatedSlots)
+                .map((key) => this.receiveSlotManager.allocatedSlots[key])
+                .flat();
+
+              return receiveSlots.find((r) => ssrc && r.wcmeReceiveSlot.id.ssrc === ssrc);
+            },
+            this.networkQualityMonitor
+          );
           this.setupStatsAnalyzerEventHandlers();
           this.networkQualityMonitor.on(
             EVENT_TRIGGERS.NETWORK_QUALITY,

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5264,13 +5264,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this.statsAnalyzer = new StatsAnalyzer(
             // @ts-ignore - config coming from registerPlugin
             this.config.stats,
-            (ssrc: number) => {
-              const receiveSlots = Object.keys(this.receiveSlotManager.allocatedSlots)
-                .map((key) => this.receiveSlotManager.allocatedSlots[key])
-                .flat();
-
-              return receiveSlots.find((r) => ssrc && r.wcmeReceiveSlot.id.ssrc === ssrc);
-            },
+            (ssrc: number) => this.receiveSlotManager.findReceiveSlotBySsrc(ssrc),
             this.networkQualityMonitor
           );
           this.setupStatsAnalyzerEventHandlers();

--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
@@ -163,6 +163,6 @@ export class ReceiveSlotManager {
   findReceiveSlotBySsrc(ssrc: number): ReceiveSlot | undefined {
     return Object.values(this.allocatedSlots)
       .flat()
-      .find((r) => ssrc && r.wcmeReceiveSlot.id.ssrc === ssrc);
+      .find((r) => ssrc && r.wcmeReceiveSlot?.id?.ssrc === ssrc);
   }
 }

--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
@@ -12,7 +12,7 @@ import {CSI, ReceiveSlot} from './receiveSlot';
  * so this manager has a pool in order to re-use the slots that were released earlier.
  */
 export class ReceiveSlotManager {
-  private allocatedSlots: {[key in MediaType]: ReceiveSlot[]};
+  allocatedSlots: {[key in MediaType]: ReceiveSlot[]};
 
   private freeSlots: {[key in MediaType]: ReceiveSlot[]};
 

--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
@@ -12,7 +12,7 @@ import {CSI, ReceiveSlot} from './receiveSlot';
  * so this manager has a pool in order to re-use the slots that were released earlier.
  */
 export class ReceiveSlotManager {
-  allocatedSlots: {[key in MediaType]: ReceiveSlot[]};
+  private allocatedSlots: {[key in MediaType]: ReceiveSlot[]};
 
   private freeSlots: {[key in MediaType]: ReceiveSlot[]};
 
@@ -152,5 +152,17 @@ export class ReceiveSlotManager {
         slot.findMemberId();
       });
     });
+  }
+
+  /**
+   * Find a receive slot by a ssrc.
+   *
+   * @param ssrc - The ssrc of the receive slot to find.
+   * @returns - The receive slot with this ssrc, undefined if not found.
+   */
+  findReceiveSlotBySsrc(ssrc: number): ReceiveSlot | undefined {
+    return Object.values(this.allocatedSlots)
+      .flat()
+      .find((r) => ssrc && r.wcmeReceiveSlot.id.ssrc === ssrc);
   }
 }

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -949,9 +949,9 @@ export class StatsAnalyzer extends EventsScope {
     if (result.bytesReceived) {
       let kilobytes = 0;
       const receiveSlot = this.receiveSlotCallback(result.ssrc);
-      const idAndCsi = `id: "${receiveSlot.id || ''}"${
-        receiveSlot.csi ? ` and csi: ${receiveSlot.csi}` : ''
-      }`;
+      const idAndCsi = receiveSlot
+        ? `id: "${receiveSlot.id || ''}"${receiveSlot.csi ? ` and csi: ${receiveSlot.csi}` : ''}`
+        : '';
 
       if (!this.statsResults.internal[mediaType][sendrecvType].prevBytesReceived) {
         this.statsResults.internal[mediaType][sendrecvType].prevBytesReceived =

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -528,7 +528,8 @@ export class StatsAnalyzer extends EventsScope {
           currentStats.totalPacketsSent === 0
         ) {
           LoggerProxy.logger.info(
-            `StatsAnalyzer:index#compareLastStatsResult --> No audio RTP packets sent`
+            `StatsAnalyzer:index#compareLastStatsResult --> No audio RTP packets sent`,
+            currentStats.totalPacketsSent
           );
         } else {
           if (
@@ -536,7 +537,8 @@ export class StatsAnalyzer extends EventsScope {
             currentStats.totalAudioEnergy === 0
           ) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> No audio Energy present`
+              `StatsAnalyzer:index#compareLastStatsResult --> No audio Energy present`,
+              currentStats.totalAudioEnergy
             );
           }
 
@@ -570,14 +572,16 @@ export class StatsAnalyzer extends EventsScope {
 
         if (currentPacketsReceived === previousPacketsReceived || currentPacketsReceived === 0) {
           LoggerProxy.logger.info(
-            `StatsAnalyzer:index#compareLastStatsResult --> No audio RTP packets received`
+            `StatsAnalyzer:index#compareLastStatsResult --> No audio RTP packets received`,
+            currentPacketsReceived
           );
         } else if (
           currentSamplesReceived === previousSamplesReceived ||
           currentSamplesReceived === 0
         ) {
           LoggerProxy.logger.info(
-            `StatsAnalyzer:index#compareLastStatsResult --> No audio samples received`
+            `StatsAnalyzer:index#compareLastStatsResult --> No audio samples received`,
+            currentSamplesReceived
           );
         }
 
@@ -594,7 +598,8 @@ export class StatsAnalyzer extends EventsScope {
           currentStats.totalPacketsSent === 0
         ) {
           LoggerProxy.logger.info(
-            `StatsAnalyzer:index#compareLastStatsResult --> No video RTP packets sent`
+            `StatsAnalyzer:index#compareLastStatsResult --> No video RTP packets sent`,
+            currentStats.totalPacketsSent
           );
         } else {
           if (
@@ -602,7 +607,8 @@ export class StatsAnalyzer extends EventsScope {
             currentStats.framesEncoded === 0
           ) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> No video Frames Encoded`
+              `StatsAnalyzer:index#compareLastStatsResult --> No video Frames Encoded`,
+              currentStats.framesEncoded
             );
           }
 
@@ -612,7 +618,8 @@ export class StatsAnalyzer extends EventsScope {
             this.statsResults.resolutions['video-send'].send.framesSent === 0
           ) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> No video Frames sent`
+              `StatsAnalyzer:index#compareLastStatsResult --> No video Frames sent`,
+              this.statsResults.resolutions['video-send'].send.framesSent
             );
           }
         }
@@ -648,24 +655,28 @@ export class StatsAnalyzer extends EventsScope {
 
         if (currentPacketsReceived === previousPacketsReceived || currentPacketsReceived === 0) {
           LoggerProxy.logger.info(
-            `StatsAnalyzer:index#compareLastStatsResult --> No video RTP packets received`
+            `StatsAnalyzer:index#compareLastStatsResult --> No video RTP packets received`,
+            currentPacketsReceived
           );
         } else {
           if (currentFramesReceived === previousFramesReceived || currentFramesReceived === 0) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> No video frames received`
+              `StatsAnalyzer:index#compareLastStatsResult --> No video frames received`,
+              currentFramesReceived
             );
           }
 
           if (currentFramesDecoded === previousFramesDecoded || currentFramesDecoded === 0) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> No video frames decoded`
+              `StatsAnalyzer:index#compareLastStatsResult --> No video frames decoded`,
+              currentFramesDecoded
             );
           }
 
           if (currentFramesDropped - previousFramesDropped > 10) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> video frames are getting dropped`
+              `StatsAnalyzer:index#compareLastStatsResult --> video frames are getting dropped`,
+              currentFramesDropped - previousFramesDropped
             );
           }
         }
@@ -684,7 +695,8 @@ export class StatsAnalyzer extends EventsScope {
           currentStats.totalPacketsSent === 0
         ) {
           LoggerProxy.logger.info(
-            `StatsAnalyzer:index#compareLastStatsResult --> No share RTP packets sent`
+            `StatsAnalyzer:index#compareLastStatsResult --> No share RTP packets sent`,
+            currentStats.totalPacketsSent
           );
         } else {
           if (
@@ -692,7 +704,8 @@ export class StatsAnalyzer extends EventsScope {
             currentStats.framesEncoded === 0
           ) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> No share frames getting encoded`
+              `StatsAnalyzer:index#compareLastStatsResult --> No share frames getting encoded`,
+              currentStats.framesEncoded
             );
           }
 
@@ -702,7 +715,8 @@ export class StatsAnalyzer extends EventsScope {
             this.statsResults.resolutions['video-share-send'].send.framesSent === 0
           ) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> No share frames sent`
+              `StatsAnalyzer:index#compareLastStatsResult --> No share frames sent`,
+              this.statsResults.resolutions['video-share-send'].send.framesSent
             );
           }
         }
@@ -740,24 +754,28 @@ export class StatsAnalyzer extends EventsScope {
 
         if (currentPacketsReceived === previousPacketsReceived || currentPacketsReceived === 0) {
           LoggerProxy.logger.info(
-            `StatsAnalyzer:index#compareLastStatsResult --> No share RTP packets received`
+            `StatsAnalyzer:index#compareLastStatsResult --> No share RTP packets received`,
+            currentPacketsReceived
           );
         } else {
           if (currentFramesReceived === previousFramesReceived || currentFramesReceived === 0) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> No share frames received`
+              `StatsAnalyzer:index#compareLastStatsResult --> No share frames received`,
+              currentFramesReceived
             );
           }
 
           if (currentFramesDecoded === previousFramesDecoded || currentFramesDecoded === 0) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> No share frames decoded`
+              `StatsAnalyzer:index#compareLastStatsResult --> No share frames decoded`,
+              currentFramesDecoded
             );
           }
 
           if (currentFramesDropped - previousFramesDropped > 10) {
             LoggerProxy.logger.info(
-              `StatsAnalyzer:index#compareLastStatsResult --> share frames are getting dropped`
+              `StatsAnalyzer:index#compareLastStatsResult --> share frames are getting dropped`,
+              currentFramesDropped - previousFramesDropped
             );
           }
         }
@@ -930,6 +948,10 @@ export class StatsAnalyzer extends EventsScope {
 
     if (result.bytesReceived) {
       let kilobytes = 0;
+      const receiveSlot = this.receiveSlotCallback(result.ssrc);
+      const idAndCsi = `id: "${receiveSlot.id || ''}"${
+        receiveSlot.csi ? ` and csi: ${receiveSlot.csi}` : ''
+      }`;
 
       if (!this.statsResults.internal[mediaType][sendrecvType].prevBytesReceived) {
         this.statsResults.internal[mediaType][sendrecvType].prevBytesReceived =
@@ -979,12 +1001,9 @@ export class StatsAnalyzer extends EventsScope {
         result.packetsReceived;
 
       if (this.statsResults[mediaType][sendrecvType].packetsReceived === 0) {
-        const receiveSlot = this.receiveSlotCallback(result.ssrc);
         if (receiveSlot) {
           LoggerProxy.logger.info(
-            `StatsAnalyzer:index#processInboundRTPResult --> No packets received for receive slot id: "${
-              receiveSlot.id || ''
-            }"${receiveSlot.csi ? ` and csi: ${receiveSlot.csi}` : ''}`,
+            `StatsAnalyzer:index#processInboundRTPResult --> No packets received for receive slot ${idAndCsi}`,
             this.statsResults[mediaType][sendrecvType].packetsReceived
           );
         }
@@ -999,7 +1018,7 @@ export class StatsAnalyzer extends EventsScope {
           : 0;
       if (this.statsResults[mediaType][sendrecvType].currentPacketLossRatio > 3) {
         LoggerProxy.logger.info(
-          'StatsAnalyzer:index#processInboundRTPResult --> Packets getting lost from the receiver ',
+          `StatsAnalyzer:index#processInboundRTPResult --> Packets getting lost from the receiver with slot ${idAndCsi}`,
           this.statsResults[mediaType][sendrecvType].currentPacketLossRatio
         );
       }

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -75,7 +75,7 @@ export class StatsAnalyzer extends EventsScope {
   statsInterval: NodeJS.Timeout;
   statsResults: any;
   statsStarted: any;
-  receiveSlotCallback: (csi: number) => ReceiveSlot;
+  receiveSlotCallback: (csi: number) => ReceiveSlot | undefined;
 
   /**
    * Creates a new instance of StatsAnalyzer

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlotManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlotManager.ts
@@ -14,7 +14,7 @@ describe('ReceiveSlotManager', () => {
 
   beforeEach(() => {
     fakeWcmeSlot = {
-      id: 'fake wcme slot',
+      id: {ssrc: 1},
     };
     fakeMeeting = {
       mediaProperties: {
@@ -32,6 +32,7 @@ describe('ReceiveSlotManager', () => {
         id: `fake sdk receive slot ${fakeReceiveSlots.length + 1}`,
         mediaType,
         findMemberId: sinon.stub(),
+        wcmeReceiveSlot: fakeWcmeSlot,
       };
 
       fakeReceiveSlots.push(fakeReceiveSlot);
@@ -174,7 +175,6 @@ describe('ReceiveSlotManager', () => {
   });
 
   describe('updateMemberIds', () => {
-
     it('calls findMemberId() on all allocated receive slots', async () => {
       const audioSlots: ReceiveSlot[] = [];
       const videoSlots: ReceiveSlot[] = [];
@@ -193,9 +193,17 @@ describe('ReceiveSlotManager', () => {
 
       assert.strictEqual(fakeReceiveSlots.length, audioSlots.length + videoSlots.length);
 
-      fakeReceiveSlots.forEach(slot => {
+      fakeReceiveSlots.forEach((slot) => {
         assert.calledOnce(slot.findMemberId);
       });
+    });
+  });
+
+  describe('findReceiveSlotBySsrc', () => {
+    it('finds a receive slot with a specific id', async () => {
+      await receiveSlotManager.allocateSlot(MediaType.VideoMain);
+      assert.exists(receiveSlotManager.findReceiveSlotBySsrc(1));
+      assert.strictEqual(receiveSlotManager.findReceiveSlotBySsrc(2), undefined);
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -55,7 +55,7 @@ describe('plugin-meetings', () => {
 
         statsAnalyzer = new StatsAnalyzer(
           initialConfig,
-          () => undefined,
+          () => ({}),
           networkQualityMonitor,
           defaultStats
         );
@@ -189,7 +189,7 @@ describe('plugin-meetings', () => {
 
         networkQualityMonitor = new NetworkQualityMonitor(initialConfig);
 
-        statsAnalyzer = new StatsAnalyzer(initialConfig, () => undefined, networkQualityMonitor);
+        statsAnalyzer = new StatsAnalyzer(initialConfig, () => ({}), networkQualityMonitor);
 
         statsAnalyzer.on(EVENTS.LOCAL_MEDIA_STARTED, (data) => {
           receivedEventsData.local.started = data;

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -53,7 +53,12 @@ describe('plugin-meetings', () => {
       beforeEach(() => {
         const networkQualityMonitor = new NetworkQualityMonitor(initialConfig);
 
-        statsAnalyzer = new StatsAnalyzer(initialConfig, networkQualityMonitor, defaultStats);
+        statsAnalyzer = new StatsAnalyzer(
+          initialConfig,
+          () => undefined,
+          networkQualityMonitor,
+          defaultStats
+        );
 
         sandBoxSpy = sandbox.spy(
           statsAnalyzer.networkQualityMonitor,
@@ -184,7 +189,7 @@ describe('plugin-meetings', () => {
 
         networkQualityMonitor = new NetworkQualityMonitor(initialConfig);
 
-        statsAnalyzer = new StatsAnalyzer(initialConfig, networkQualityMonitor);
+        statsAnalyzer = new StatsAnalyzer(initialConfig, () => undefined, networkQualityMonitor);
 
         statsAnalyzer.on(EVENTS.LOCAL_MEDIA_STARTED, (data) => {
           receivedEventsData.local.started = data;


### PR DESCRIPTION
## This pull request addresses

A log message not having a receive slot or csi to which it corresponds.

## by making the following changes

Adding a receive slot lookup callback to the `StatsAnalyzer` to find a Receive Slot from an ssrc.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
