### PR TITLE
feat: schedule webrtc stats check with task queue

### DIFF
--- a/packages/@webex/plugin-meetings/src/common/taskQueue.ts
+++ b/packages/@webex/plugin-meetings/src/common/taskQueue.ts
@@ -9,9 +9,9 @@ type TaskQueueOptions = {
   scheduler?: TaskQueueScheduler;
 };
 
-const timout = (task) => setTimeout(task, 1000 / 16);
+const timout = (task) => setTimeout(task, 1000 / 60);
 const defaultSchedulerFactory = (): TaskQueueScheduler => {
-  const scheduler = window.requestIdleCallback || window.requestIdleCallback || timout;
+  const scheduler = window.requestIdleCallback || window.requestAnimationFrame || timout;
   const cancel = window.cancelIdleCallback || window.cancelAnimationFrame || clearTimeout;
 
   return (task) => {
@@ -25,7 +25,7 @@ const defaultSchedulerFactory = (): TaskQueueScheduler => {
  * Execute tasks asynchronously in fifo order.
  *
  * Task scheduler can be customised.
- * The default scheduler is the `requestIdleCallback` API which falls back to `requestIdleCallback` or `setTimeout`
+ * The default scheduler is the `requestIdleCallback` API which falls back to `requestAnimationFrame` or `setTimeout`
  *
  * Ideal for breaking up long running tasks.
  * @link https://web.dev/long-tasks-devtools/

--- a/packages/@webex/plugin-meetings/src/common/taskQueue.ts
+++ b/packages/@webex/plugin-meetings/src/common/taskQueue.ts
@@ -1,0 +1,86 @@
+import {Defer} from '@webex/common';
+import window from 'global/window';
+
+type Task<TResult> = () => TResult;
+type TaskItem<TResult> = {task: Task<TResult>; defer: Defer};
+type CancelScheduler = () => void;
+type TaskQueueScheduler = (fn: () => void) => CancelScheduler;
+type TaskQueueOptions = {
+  scheduler?: TaskQueueScheduler;
+};
+
+const timout = (task) => setTimeout(task, 1000 / 16);
+const defaultSchedulerFactory = (): TaskQueueScheduler => {
+  const scheduler = window.requestIdleCallback || window.requestIdleCallback || timout;
+  const cancel = window.cancelIdleCallback || window.cancelAnimationFrame || clearTimeout;
+
+  return (task) => {
+    const handler: any = scheduler(task);
+
+    return () => cancel(handler);
+  };
+};
+
+/**
+ * Execute tasks asynchronously in fifo order.
+ *
+ * Task scheduler can be customised.
+ * The default scheduler is the `requestIdleCallback` API which falls back to `requestIdleCallback` or `setTimeout`
+ *
+ * Ideal for breaking up long running tasks.
+ * @link https://web.dev/long-tasks-devtools/
+ * @returns {TaskQueue}
+ */
+export default class TaskQueue<TResult = void> {
+  private readonly scheduler;
+  private readonly queue: TaskItem<TResult>[] = [];
+  private cancelSchedule?: CancelScheduler;
+  private running = false;
+  private currentTask?: TaskItem<TResult>;
+
+  /**
+   * @constructs TaskQueue
+   */
+  constructor({scheduler}: TaskQueueOptions = {}) {
+    this.scheduler = scheduler || defaultSchedulerFactory();
+  }
+
+  private run = () => {
+    if (!this.running && this.queue.length > 0) {
+      this.running = true;
+      this.currentTask = this.queue.shift();
+      this.cancelSchedule = this.scheduler(() => {
+        const result = this.currentTask.task();
+        this.currentTask.defer.resolve(result);
+        this.running = false;
+        this.run();
+      });
+    }
+  };
+
+  /**
+   * Add a new task to the queue and start execution
+   * @param {Task} task
+   * @returns {Promise<TResult>}
+   */
+  public addTask(task: Task<TResult>): Promise<TResult> {
+    const defer = new Defer();
+    this.queue.push({task, defer});
+    this.run();
+
+    return defer.promise;
+  }
+
+  /**
+   * Stop the current task if any and clean the queue
+   * @returns {void}
+   */
+  public clear() {
+    if (this.running) {
+      this.cancelSchedule();
+      this.currentTask.defer.reject('Task was cancelled');
+      this.running = false;
+    }
+    this.queue.length = 0;
+  }
+}

--- a/packages/@webex/plugin-meetings/test/unit/spec/common/taskQueue.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/common/taskQueue.js
@@ -1,0 +1,94 @@
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import TaskQueue from '@webex/plugin-meetings/src/common/taskQueue';
+
+describe('common/taskQueue', () => {
+  let cancelScheduler;
+  let scheduler;
+  let queue;
+
+  beforeEach(() => {
+    cancelScheduler = sinon.stub().returns();
+    scheduler = sinon.fake((task) => {
+      task();
+      return cancelScheduler;
+    });
+    queue = new TaskQueue({scheduler});
+  });
+
+  afterEach(() => {
+    queue.clear();
+    queue = null;
+  });
+
+  it('should execute the scheduler', async () => {
+    const task = sinon.fake();
+
+    await queue.addTask(task);
+
+    assert.calledOnce(scheduler);
+  });
+
+  it("should wrap a task in a promise and resolve with the task's result", async () => {
+    const task = () => 42;
+
+    const taskResult = await queue.addTask(task);
+
+    assert.equal(taskResult, 42);
+  });
+
+  it('should execute tasks', async () => {
+    const task1 = sinon.fake();
+    const task2 = sinon.fake();
+
+    await queue.addTask(task1);
+    await queue.addTask(task2);
+
+    assert.calledOnce(task1);
+    assert.calledOnce(task2);
+  });
+
+  it('should execute tasks in order', async () => {
+    const task1 = () => 'a';
+    const task2 = () => 'b';
+    const task3 = () => 'c';
+
+    const results = await Promise.all([
+      queue.addTask(task1),
+      queue.addTask(task2),
+      queue.addTask(task3),
+    ]);
+
+    assert.deepEqual(results, ['a', 'b', 'c']);
+  });
+
+  it('cleans resources after cancelling and the currently running task fails', async () => {
+    scheduler = sinon.stub().returns(cancelScheduler);
+    queue = new TaskQueue({scheduler});
+
+    const task = sinon.fake();
+    const error = sinon.fake();
+
+    const promise = queue.addTask(task).catch(error);
+
+    queue.clear();
+
+    await promise;
+    assert.calledOnce(error);
+    assert.calledOnce(cancelScheduler);
+  });
+
+  it('should restart execution when a new task is added after clear', async () => {
+    const task1 = sinon.fake();
+    const task2 = sinon.fake();
+
+    await queue.addTask(task1);
+
+    queue.clear();
+
+    await queue.addTask(task2);
+
+    assert.calledOnce(task1);
+    assert.calledOnce(task2);
+  });
+});

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -13,7 +13,7 @@ const {assert} = chai;
 chai.use(chaiAsPromised);
 sinon.assert.expose(chai.assert, {prefix: ''});
 
-describe.only('plugin-meetings', () => {
+describe('plugin-meetings', () => {
   describe('StatsAnalyzer', () => {
     describe('compareSentAndReceived()', () => {
       let statsAnalyzer;

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -13,7 +13,7 @@ const {assert} = chai;
 chai.use(chaiAsPromised);
 sinon.assert.expose(chai.assert, {prefix: ''});
 
-describe('plugin-meetings', () => {
+describe.only('plugin-meetings', () => {
   describe('StatsAnalyzer', () => {
     describe('compareSentAndReceived()', () => {
       let statsAnalyzer;
@@ -212,8 +212,7 @@ describe('plugin-meetings', () => {
       };
 
       const progressTime = async () => {
-        // needed after analyzerInterval to execute the task in the queue
-        await clock.tickAsync(initialConfig.analyzerInterval * 1.5); // extra time
+        await clock.tickAsync(initialConfig.analyzerInterval);
         await testUtils.flushPromises();
       };
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -212,7 +212,8 @@ describe('plugin-meetings', () => {
       };
 
       const progressTime = async () => {
-        await clock.tickAsync(initialConfig.analyzerInterval);
+        // needed after analyzerInterval to execute the task in the queue
+        await clock.tickAsync(initialConfig.analyzerInterval * 1.5); // extra time
         await testUtils.flushPromises();
       };
 


### PR DESCRIPTION
# COMPLETES [SPARK-410242](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-410242)

## This pull request addresses

See the issue above

## by making the following changes

- add task queue
- use task queue to break up long tasks


### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
