### PR TITLE
fix: add missing frame sizes for mqe

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -853,6 +853,14 @@ export class StatsAnalyzer extends EventsScope {
     if (result.bytesSent) {
       let kilobytes = 0;
 
+      if (result.frameWidth && result.frameHeight) {
+        this.statsResults.resolutions[mediaType][sendrecvType].width = result.frameWidth;
+        this.statsResults.resolutions[mediaType][sendrecvType].height = result.frameHeight;
+        this.statsResults.resolutions[mediaType][sendrecvType].framesSent = result.framesSent;
+        this.statsResults.resolutions[mediaType][sendrecvType].hugeFramesSent =
+          result.hugeFramesSent;
+      }
+
       if (!this.statsResults.internal[mediaType][sendrecvType].prevBytesSent) {
         this.statsResults.internal[mediaType][sendrecvType].prevBytesSent = result.bytesSent;
       }
@@ -925,6 +933,13 @@ export class StatsAnalyzer extends EventsScope {
 
     if (result.bytesReceived) {
       let kilobytes = 0;
+
+      if (result.frameWidth && result.frameHeight) {
+        this.statsResults.resolutions[mediaType][sendrecvType].width = result.frameWidth;
+        this.statsResults.resolutions[mediaType][sendrecvType].height = result.frameHeight;
+        this.statsResults.resolutions[mediaType][sendrecvType].framesReceived =
+          result.framesReceived;
+      }
 
       if (!this.statsResults.internal[mediaType][sendrecvType].prevBytesReceived) {
         this.statsResults.internal[mediaType][sendrecvType].prevBytesReceived =
@@ -1136,13 +1151,6 @@ export class StatsAnalyzer extends EventsScope {
 
     const sendrecvType =
       result.remoteSource === true ? STATS.RECEIVE_DIRECTION : STATS.SEND_DIRECTION;
-
-    if (result.frameWidth && result.frameHeight) {
-      this.statsResults.resolutions[mediaType][sendrecvType].width = result.frameWidth;
-      this.statsResults.resolutions[mediaType][sendrecvType].height = result.frameHeight;
-      this.statsResults.resolutions[mediaType][sendrecvType].framesSent = result.framesSent;
-      this.statsResults.resolutions[mediaType][sendrecvType].hugeFramesSent = result.hugeFramesSent;
-    }
 
     if (sendrecvType === STATS.RECEIVE_DIRECTION) {
       this.statsResults.resolutions[mediaType][sendrecvType].framesReceived = result.framesReceived;

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -199,12 +199,11 @@ export const getVideoReceiverMqa = ({videoReceiver, statsResults, lastMqaDataSen
   videoReceiver.streams[0].common.framesDropped =
     statsResults.resolutions[mediaType][sendrecvType].framesDropped - lastFramesDropped;
   videoReceiver.streams[0].receivedHeight =
-    statsResults.resolutions[mediaType][sendrecvType].height;
-  videoReceiver.streams[0].receivedWidth = statsResults.resolutions[mediaType][sendrecvType].width;
+    statsResults.resolutions[mediaType][sendrecvType].height || 0;
+  videoReceiver.streams[0].receivedWidth =
+    statsResults.resolutions[mediaType][sendrecvType].width || 0;
   videoReceiver.streams[0].receivedFrameSize =
-    (statsResults.resolutions[mediaType][sendrecvType].height *
-      statsResults.resolutions[mediaType][sendrecvType].height) /
-    256;
+    (videoReceiver.streams[0].receivedHeight * videoReceiver.streams[0].receivedWidth) / 256;
 
   videoReceiver.streams[0].receivedKeyFrames =
     statsResults[mediaType][sendrecvType].keyFramesDecoded - lastKeyFramesDecoded || 0;
@@ -284,10 +283,9 @@ export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, m
     ? (totalFrameSentInaMin * 100) / 60
     : 0;
   videoSender.streams[0].transmittedHeight =
-    statsResults.resolutions[mediaType][sendrecvType].height;
-  videoSender.streams[0].transmittedWidth = statsResults.resolutions[mediaType][sendrecvType].width;
+    statsResults.resolutions[mediaType][sendrecvType].height || 0;
+  videoSender.streams[0].transmittedWidth =
+    statsResults.resolutions[mediaType][sendrecvType].width || 0;
   videoSender.streams[0].transmittedFrameSize =
-    (statsResults.resolutions[mediaType][sendrecvType].height *
-      statsResults.resolutions[mediaType][sendrecvType].width) /
-    254;
+    (videoSender.streams[0].transmittedHeight * videoSender.streams[0].transmittedWidth) / 256;
 };


### PR DESCRIPTION
# COMPLETES [WEBEX-322073](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-322073)

## This pull request addresses

Missing values from MQE intervals.

## by making the following changes

Making sure the values exist when the related values are undefined, as well as fixing the calculations.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly
