### PR TITLE
fix(encryption): node-jose version

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ const packages = [
   '@webex/internal-plugin-encryption',
   '@webex/internal-plugin-feature',
   '@webex/internal-plugin-flag',
+  '@webex/internal-plugin-scheduler',
   '@webex/internal-plugin-llm',
   '@webex/internal-plugin-locus',
   '@webex/internal-plugin-lyra',

--- a/packages/@webex/internal-plugin-conversation/src/share-activity.js
+++ b/packages/@webex/internal-plugin-conversation/src/share-activity.js
@@ -156,7 +156,7 @@ const ShareActivity = WebexPlugin.extend({
    */
   add(file, options) {
     options = options || {};
-    options.claimedFileType = file.displayName.substring(file.displayName.lastIndexOf('.'));
+    options.claimedFileType = file.name.substring(file.name.lastIndexOf('.'));
     let upload = this.uploads.get(file);
 
     if (upload) {

--- a/packages/@webex/internal-plugin-device/src/device.js
+++ b/packages/@webex/internal-plugin-device/src/device.js
@@ -645,9 +645,9 @@ const Device = WebexPlugin.extend({
     delete body.services;
     delete body.serviceHostMap;
 
-    const {etag} = response.headers;
+    const {etag} = response.headers || {};
 
-    if (this.etag && this.etag === etag) {
+    if (this.etag && etag && this.etag === etag) {
       // If current etag matches the previous one and we have sent
       // If-None-Match header the developer and entitlement feature
       // toggles will not be returned

--- a/packages/@webex/internal-plugin-encryption/package.json
+++ b/packages/@webex/internal-plugin-encryption/package.json
@@ -44,7 +44,7 @@
     "debug": "^4.3.4",
     "isomorphic-webcrypto": "^2.3.8",
     "lodash": "^4.17.21",
-    "node-jose": "^2.0.0",
+    "node-jose": "^2.2.0",
     "node-kms": "^0.4.0",
     "node-scr": "^0.3.0",
     "pkijs": "^2.1.84",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4883,7 +4883,7 @@ __metadata:
     debug: ^4.3.4
     isomorphic-webcrypto: ^2.3.8
     lodash: ^4.17.21
-    node-jose: ^2.0.0
+    node-jose: ^2.2.0
     node-kms: ^0.4.0
     node-scr: ^0.3.0
     pkijs: ^2.1.84
@@ -18578,7 +18578,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-jose@npm:^2.0.0":
+"node-jose@npm:^2.0.0, node-jose@npm:^2.2.0":
   version: 2.2.0
   resolution: "node-jose@npm:2.2.0"
   dependencies:


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to update the version of the dependency `node-jose` within the `encryption` plugin to prevent a potential bug introduced with platform iterations [infinite looping].

## NOTES

This also includes fixes for failing integration tests in:

* internal-plugin-device
* internal-plugin-conversation

## Links

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-407814
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-411322