### PR TITLE
fix: throw error when sync meetings fails

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/request.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/request.ts
@@ -23,6 +23,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
         LoggerProxy.logger.error(
           `Meetings:request#getActiveMeetings --> failed to get locus details, ${error}`
         );
+        throw new Error('Failed to get locus details');
       });
   }
 
@@ -71,6 +72,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
               LoggerProxy.logger.error(
                 `Meetings:request#determineRedirections --> failed to get locus details from url: ${url}, reason: ${error}`
               );
+              throw new Error('Failed to get locus details');
             })
         )
       ).then(() => Promise.resolve(responseBody));

--- a/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
@@ -420,10 +420,10 @@ export default class ReconnectionManager {
     // So that on rejoin it known what parametrs it was using
     if (!this.meeting || !this.webex.meetings.getMeetingByType(_ID_, this.meeting.id)) {
       LoggerProxy.logger.info(
-        'ReconnectionManager:index#executeReconnection --> Meeting got deleted due to inactivity or ended remotely '
+        'ReconnectionManager:index#executeReconnection --> Meeting got deleted due to inactivity or ended remotely.'
       );
 
-      throw new Error('Unable to rejoin a meeting already ended or inactive .');
+      throw new Error('Unable to rejoin a meeting already ended or inactive.');
     }
 
     LoggerProxy.logger.info(


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-393171](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-393171)

## This pull request addresses

Incorrectly leaving the meeting when failing to sync meetings during client media failover.

## by making the following changes

Throwing an error when sync meetings fails so that, when caught, the reconnection is retried.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

1. Manually tested disconnecting from the network for 15 seconds, then reconnecting. During the reconnection process, disconnect from the network again while syncing meetings, and reconnect again.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
