### PR TITLE
feat(legacy): generate test config

### DIFF
--- a/packages/@webex/internal-plugin-flag/jest.config.js
+++ b/packages/@webex/internal-plugin-flag/jest.config.js
@@ -1,0 +1,3 @@
+const config = require('@webex/jest-config-legacy');
+
+module.exports = config;

--- a/packages/@webex/internal-plugin-flag/package.json
+++ b/packages/@webex/internal-plugin-flag/package.json
@@ -17,8 +17,9 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "test": "yarn test:style",
-    "test:style": "eslint ./src/**/*.*"
+    "test": "yarn test:style && yarn test:unit",
+    "test:style": "eslint ./src/**/*.*",
+    "test:unit": "jest"
   },
   "browserify": {
     "transform": [
@@ -40,8 +41,10 @@
     "@babel/core": "^7.17.10",
     "@webex/babel-config-legacy": "workspace:^",
     "@webex/eslint-config-legacy": "workspace:^",
+    "@webex/jest-config-legacy": "workspace:^",
     "@webex/legacy-tools": "workspace:^",
     "eslint": "^8.24.0",
+    "jest": "^29.5.0",
     "prettier": "^2.7.1"
   }
 }

--- a/packages/legacy/eslint/static/ignore-patterns.js
+++ b/packages/legacy/eslint/static/ignore-patterns.js
@@ -16,6 +16,7 @@ const ignorePatterns = [
   '*.json',
   '**/*.json',
   '*.lock',
+  '*.config.*',
   // end decorator
 ];
 

--- a/packages/legacy/jest/README.md
+++ b/packages/legacy/jest/README.md
@@ -1,0 +1,60 @@
+# @webex/jest-config-legacy
+
+[![icense: mit](https://img.shields.io/badge/License-MIT-blueviolet?style=flat-square)](https://github.com/webex/webex-js-sdk/blob/master/LICENSE)
+![state: beta](https://img.shields.io/badge/State\-Beta-blue?style=flat-square)
+![scope: internal](https://img.shields.io/badge/Scope-Internal-red?style=flat-square)
+
+This package is an internal and private plugin used as a shared module when applying a standard [Jest](https://jestjs.io/) ruleset to legacy modules within this project.
+
+* [Installation](#installation)
+* [Usage](#usage)
+* [Contribute](#contribute)
+* [Maintainers](#maintainers)
+
+## Installation
+
+Since this package is marked `private` as a part of its definition, it can only be consumed locally within this project.
+
+This package is meant to be consumed as a **dev-dependency**, and requires the following peer-dependencies:
+
+* `@babel/core`
+* `jest`
+* `@webex/babel-config-legacy`
+
+Installation, local to this project, can be performed by using the following commands:
+
+```bash
+# Project root installation.
+yarn add --dev @webex/jest-config-legacy @webex/babel-config-legacy @babel/core jest
+
+# Package installation.
+yarn workspace @{scope}/{package} add --dev @webex/jest-config-legacy @webex/babel-config-legacy @babel/core jest
+```
+
+## Usage
+
+This package is expected to be used with [Jest](https://jestjs.io/).
+
+A Jest configuration file must be consumed within the target package using the following configuration definition example:
+
+```js
+// ./jest.config.js
+const config = require('@webex/jest-config-legacy');
+
+const modified = {
+  ...config,
+  ...{ /* override configuration */ },
+};
+
+module.exports = modified;
+```
+
+This package is also dependent on our locally referencable `@webex/babel-config-legacy` package to provide the jest runner with the babel tooling needed to interpret source code when applicable.
+
+## Contribute
+
+Pull requests welcome. Please see [CONTRIBUTING.md](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md) for more details.
+
+## Maintainers
+
+This package is maintained by [Cisco Webex for Developers](https://developer.webex.com/).

--- a/packages/legacy/jest/package.json
+++ b/packages/legacy/jest/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@webex/jest-config-legacy",
+  "private": true,
+  "packageManager": "yarn@3.4.1",
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0",
+    "yarn": ">=3.0.0"
+  },
+  "type": "commonjs",
+  "main": "./static/index.js",
+  "files": [
+    "./static"
+  ],
+  "dependencies": {
+    "jest": "^29.3.1",
+    "jest-environment-jsdom": "^29.1.2",
+    "ts-jest": "^29.0.3"
+  }
+}

--- a/packages/legacy/jest/static/index.js
+++ b/packages/legacy/jest/static/index.js
@@ -1,0 +1,14 @@
+module.exports = {
+  clearMocks: true,
+  rootDir: './',
+  testEnvironment: 'jsdom',
+  collectCoverage: false,
+  coverageReporters: ['text'],
+  coverageProvider: 'v8',
+  transform: {
+    '\\.[jt]sx?$': ['babel-jest', {rootMode: 'upward'}],
+  },
+  reporters: ['default'],
+  testMatch: ['<rootDir>/test/unit/**/!(lib|fixture)/*.[jt]s'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5089,12 +5089,14 @@ __metadata:
     "@webex/internal-plugin-conversation": "workspace:^"
     "@webex/internal-plugin-device": "workspace:^"
     "@webex/internal-plugin-flag": "workspace:^"
+    "@webex/jest-config-legacy": "workspace:^"
     "@webex/legacy-tools": "workspace:^"
     "@webex/test-helper-chai": "workspace:^"
     "@webex/test-helper-mock-webex": "workspace:^"
     "@webex/test-helper-test-users": "workspace:^"
     "@webex/webex-core": "workspace:^"
     eslint: ^8.24.0
+    jest: ^29.5.0
     lodash: ^4.17.21
     prettier: ^2.7.1
   languageName: unknown
@@ -5341,6 +5343,16 @@ __metadata:
     jasmine-spec-reporter: ^7.0.0
   peerDependencies:
     jasmine: ^4.5.0
+  languageName: unknown
+  linkType: soft
+
+"@webex/jest-config-legacy@workspace:^, @webex/jest-config-legacy@workspace:packages/legacy/jest":
+  version: 0.0.0-use.local
+  resolution: "@webex/jest-config-legacy@workspace:packages/legacy/jest"
+  dependencies:
+    jest: ^29.3.1
+    jest-environment-jsdom: ^29.1.2
+    ts-jest: ^29.0.3
   languageName: unknown
   linkType: soft
 
@@ -15876,7 +15888,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^29.3.1":
+"jest@npm:^29.3.1, jest@npm:^29.5.0":
   version: 29.5.0
   resolution: "jest@npm:29.5.0"
   dependencies:


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to generate the core jest config as an elevated package. This package is being consumed in the *test* package: `internal-plugin-flag`.