### PR TITLE
feat: provided size hint chooses 1080 above 720px height

### DIFF
--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -118,8 +118,10 @@ export class RemoteMedia extends EventsScope {
       fs = 240;
     } else if (height < 540) {
       fs = 920;
-    } else {
+    } else if (height < 900) {
       fs = 3600;
+    } else {
+      fs = 8192;
     }
 
     this.receiveSlot?.setMaxFs(fs);

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -118,7 +118,7 @@ export class RemoteMedia extends EventsScope {
       fs = 240;
     } else if (height < 540) {
       fs = 920;
-    } else if (height < 900) {
+    } else if (height <= 720) {
       fs = 3600;
     } else {
       fs = 8192;

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -240,8 +240,8 @@ describe('RemoteMedia', () => {
         {height: 270, fs: 920},
         {height: 539, fs: 920},
         {height: 540, fs: 3600},
-        {height: 899, fs: 3600},
-        {height: 900, fs: 8192},
+        {height: 720, fs: 3600},
+        {height: 721, fs: 8192},
       ],
       ({height, fs}) => {
         it(`sets the max fs to ${fs} correctly when height is ${height}`, () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -240,6 +240,8 @@ describe('RemoteMedia', () => {
         {height: 270, fs: 920},
         {height: 539, fs: 920},
         {height: 540, fs: 3600},
+        {height: 899, fs: 3600},
+        {height: 900, fs: 8192},
       ],
       ({height, fs}) => {
         it(`sets the max fs to ${fs} correctly when height is ${height}`, () => {


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-414720

## This pull request addresses

Allows the set size hint functionality choose maxFs correlating to a 1080 video stream.

## by making the following changes

Added an extra threshold at 900px height, above which 1080 will be chosen

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
