### PR TITLE
fix(meetings): set controls to switch

### DIFF
--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -140,32 +140,48 @@ export default class ControlsOptionsManager {
    * @returns {Promise}
    */
   private setControls(setting: {[key in Setting]?: boolean}): Promise<any> {
-    const muteUnmuteAll = Object.keys(setting).includes(Setting.muted);
+    LoggerProxy.logger.log(
+      `ControlsOptionsManager:index#setControls --> ${JSON.stringify(setting)}`
+    );
 
-    const body = muteUnmuteAll ? {audio: {}} : {};
-    for (const [key, value] of Object.entries(setting)) {
-      LoggerProxy.logger.log(`ControlsOptionsManager:index#setControls --> ${key} [${value}]`);
-      // mute unmute all has different body structure than toggling disable hard mute
-      // or mute on entry by themselves
-      if (muteUnmuteAll) {
-        if (Util?.[`${value ? CAN_SET : CAN_UNSET}${Setting.muted}`](this.displayHints)) {
-          body.audio[camelCase(key)] = value;
-        } else {
-          return Promise.reject(
-            new PermissionError(
-              `${Setting.muted} [${value}] not allowed, due to moderator property.`
-            )
-          );
-        }
-      } else if (Util?.[`${value ? CAN_SET : CAN_UNSET}${key}`](this.displayHints)) {
-        body[camelCase(key)] = {
-          [ENABLED]: value,
-        };
-      } else {
-        return Promise.reject(
-          new PermissionError(`${key} [${value}] not allowed, due to moderator property.`)
-        );
+    const body: Record<string, any> = {};
+    let error: PermissionError;
+
+    Object.entries(setting).forEach(([key, value]) => {
+      if (!Util?.[`${value ? CAN_SET : CAN_UNSET}${key}`](this.displayHints)) {
+        error = new PermissionError(`${key} [${value}] not allowed, due to moderator property.`);
       }
+
+      if (error) {
+        return;
+      }
+
+      switch (key) {
+        case Setting.muted:
+          body.audio = body.audio
+            ? {...body.audio, [camelCase(key)]: value}
+            : {[camelCase(key)]: value};
+          break;
+
+        case Setting.disallowUnmute:
+        case Setting.muteOnEntry:
+          if (Object.keys(setting).includes(Setting.muted)) {
+            body.audio = body.audio
+              ? {...body.audio, [camelCase(key)]: value}
+              : {[camelCase(key)]: value};
+            body.audio[camelCase(key)] = value;
+          } else {
+            body[camelCase(key)] = {[ENABLED]: value};
+          }
+          break;
+
+        default:
+          error = new PermissionError(`${key} [${value}] not allowed, due to moderator property.`);
+      }
+    });
+
+    if (error) {
+      return Promise.reject(error);
     }
 
     // @ts-ignore


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to update the getControls() method to be scalable using a switch statement.

This unblocks work with in meeting options.