### PR TITLE
feat(multistream): improve logging for setLayout

### DIFF
--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlot.ts
@@ -160,6 +160,13 @@ export class ReceiveSlot extends EventsScope {
   }
 
   /**
+   * @returns {string} a log message used to identify the receive slot
+   */
+  public get logString() {
+    return `ReceiveSlot - ${this.id}: ${JSON.stringify(this.mcReceiveSlot.id)}`;
+  }
+
+  /**
    * The MediaStream object associated with this slot.
    *
    * @returns {MediaStream} The MediaStreamTrack.

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable valid-jsdoc */
-import {cloneDeep, remove} from 'lodash';
+import {cloneDeep, forEach, remove} from 'lodash';
 import {EventMap} from 'typed-emitter';
 import {MediaType} from '@webex/internal-media-core';
 
@@ -690,6 +690,25 @@ export class RemoteMediaManager extends EventsScope {
   }
 
   /**
+   * Logs the state of the receive slots
+   */
+  private logReceieveSlots() {
+    let logMessage = '';
+    forEach(this.receiveSlotAllocations.activeSpeaker, (group, groupName) => {
+      logMessage += `group: ${groupName}\n${group.slots.map((slot) => slot.logString).join(' ')}`;
+    });
+
+    logMessage += '\nreceiverSelected:\n';
+    forEach(this.receiveSlotAllocations.receiverSelected, (slot, key) => {
+      logMessage += ` ${key}: ${slot.logString}\n`;
+    });
+
+    LoggerProxy.logger.log(
+      `RemoteMediaManager#updateVideoReceiveSlots --> receive slots updated: unused=${this.slots.video.unused.length}, activeSpeaker=${this.slots.video.activeSpeaker.length}, receiverSelected=${this.slots.video.receiverSelected.length}\n${logMessage}`
+    );
+  }
+
+  /**
    * Makes sure we have the right number of receive slots created for the current layout
    * and allocates them to the right video panes / pane groups
    *
@@ -713,9 +732,7 @@ export class RemoteMediaManager extends EventsScope {
     // allocate receiver selected
     this.allocateSlotsToReceiverSelectedVideoPaneGroups();
 
-    LoggerProxy.logger.log(
-      `RemoteMediaManager#updateVideoReceiveSlots --> receive slots updated: unused=${this.slots.video.unused.length}, activeSpeaker=${this.slots.video.activeSpeaker.length}, receiverSelected=${this.slots.video.receiverSelected.length}`
-    );
+    this.logReceieveSlots();
 
     // If this is the initial layout, there may be some "unused" slots left because of the preallocation
     // done in this.preallocateVideoReceiveSlots(), so release them now

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlot.ts
@@ -9,6 +9,8 @@ import {assert} from '@webex/test-helper-chai';
 class FakeWcmeSlot extends EventEmitter {
   public stream;
 
+  public id = 'fake id';
+
   constructor(stream) {
     super();
     this.stream = stream;
@@ -27,6 +29,12 @@ describe('ReceiveSlot', () => {
     findMemberIdCallbackStub = sinon.stub();
     receiveSlot = new ReceiveSlot(MediaType.VideoMain, fakeWcmeSlot, findMemberIdCallbackStub);
   });
+
+  describe('logString', () => {
+    it('has a log string', () => {
+      assert.equal(receiveSlot.logString, `ReceiveSlot - ${receiveSlot.id}: "fake id"`);
+    });
+  })
 
   describe('forwards events from underlying wcme receive slot', () => {
     it('forwards SourceUpdate', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES

SPARK-417486

## This pull request addresses

Lack of logging when changing layout

## by making the following changes

Logs the slots in remoteMediaManager

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
