### PR TITLE
feat(conversation): add recipients to reactions

### DIFF
--- a/packages/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/@webex/internal-plugin-conversation/src/conversation.js
@@ -309,10 +309,11 @@ const Conversation = WebexPlugin.extend({
   /**
    * delete a reaction
    * @param {Object} conversation
-   * @param {Object} reactionId
+   * @param {Object} reactionId,
+   * @param {String} recipientId,
    * @returns {Promise<Activity>}
    */
-  deleteReaction(conversation, reactionId) {
+  deleteReaction(conversation, reactionId, recipientId) {
     const deleteReactionPayload = {
       actor: {objectType: 'person', id: this.webex.internal.device.userId},
       object: {
@@ -327,6 +328,11 @@ const Conversation = WebexPlugin.extend({
       verb: 'delete',
     };
 
+    // Is not required for the request to be accepted, but follows specification.
+    if (recipientId) {
+      deleteReactionPayload.recipients = {items: [{id: recipientId, objectType: 'person'}]};
+    }
+
     return this.sendReaction(conversation, deleteReactionPayload);
   },
 
@@ -335,9 +341,10 @@ const Conversation = WebexPlugin.extend({
    * @param {Object} conversation
    * @param {Object} displayName must be 'celebrate', 'heart', 'thumbsup', 'smiley', 'haha', 'confused', 'sad'
    * @param {Object} activity activity object from convo we are reacting to
+   * @param {String} recipientId,
    * @returns {Promise<Activity>}
    */
-  addReaction(conversation, displayName, activity) {
+  addReaction(conversation, displayName, activity, recipientId) {
     return this.createReactionHmac(displayName, activity).then((hmac) => {
       const addReactionPayload = {
         actor: {objectType: 'person', id: this.webex.internal.device.userId},
@@ -357,6 +364,10 @@ const Conversation = WebexPlugin.extend({
           hmac,
         },
       };
+
+      if (recipientId) {
+        addReactionPayload.recipients = {items: [{id: recipientId, objectType: 'person'}]};
+      }
 
       return this.sendReaction(conversation, addReactionPayload);
     });
@@ -1051,6 +1062,10 @@ const Conversation = WebexPlugin.extend({
           id: activity.parentActivityId || activity.parent.id,
           type: activity.activityType || activity.parent.type,
         };
+      }
+
+      if (activity.recipients) {
+        act.recipients = activity.recipients;
       }
 
       if (isString(act.actor)) {

--- a/packages/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -41,8 +41,9 @@ describe('plugin-conversation', () => {
         const recipientId = 'example-recipient-id';
         const expected = {items: [{id: recipientId, objectType: 'person'}]}
         conversation.sendReaction = sinon.stub().returns(Promise.resolve())
+        conversation.createReactionHmac = sinon.stub().returns(Promise.resolve('hmac'))
         
-        return conversation.deleteReaction({}, 'example-display-name', {}, recipientId)
+        return conversation.addReaction({}, 'example-display-name', {}, recipientId)
           .then(() => {
             assert.deepEqual(conversation.sendReaction.args[0][1].recipients, expected);
           });

--- a/packages/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -35,6 +35,46 @@ describe('plugin-conversation', () => {
       webex.internal.services.getServiceFromClusterId = sinon.stub().returns({url: convoUrl});
     });
 
+    describe('addReaction()', () => {
+      it('should add recipients to the payload if provided', () => {
+        const {conversation} = webex.internal;
+        const recipientId = 'example-recipient-id';
+        const expected = {items: [{id: recipientId, objectType: 'person'}]}
+        conversation.sendReaction = sinon.stub().returns(Promise.resolve())
+        
+        return conversation.deleteReaction({}, 'example-display-name', {}, recipientId)
+          .then(() => {
+            assert.deepEqual(conversation.sendReaction.args[0][1].recipients, expected);
+          });
+      });
+    });
+
+    describe('deleteReaction()', () => {
+      it('should add recipients to the payload if provided', () => {
+        const {conversation} = webex.internal;
+        const recipientId = 'example-recipient-id';
+        const expected = {items: [{id: recipientId, objectType: 'person'}]}
+        conversation.sendReaction = sinon.stub().returns(Promise.resolve())
+        
+        return conversation.deleteReaction({}, 'example-reaction-id', recipientId)
+          .then(() => {
+            assert.deepEqual(conversation.sendReaction.args[0][1].recipients, expected);
+          });
+      });
+    });
+
+    describe('prepare()', () => {
+      it('should ammend activity recipients to the returned object', () => {
+        const {conversation} = webex.internal;
+        const activity = { recipients: 'example-recipients' };
+
+        return conversation.prepare(activity)
+          .then((results) => {
+            assert.deepEqual(results.recipients, activity.recipients);
+        });
+      });
+    });
+
     describe('processInmeetingchatEvent()', () => {
       beforeEach(() => {
         webex.transform = sinon.stub().callsFake((obj) => Promise.resolve(obj));


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to add recipients to reactions within conversations for Direct IMC.

## Links

[SPARK-419331](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-419331)