### PR TITLE
feat (plugin-meetings): refactor for the call api add edit lock info  

### DIFF
--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -361,13 +361,16 @@ const Breakouts = WebexPlugin.extend({
    * @returns {Promise}
    */
   doToggleBreakout(enable) {
+    const body = {
+      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock?.token}} : {}),
+      ...{enableBreakoutSession: enable},
+    };
+
     // @ts-ignore
     return this.webex.request({
       method: HTTP_VERBS.PUT,
       uri: this.url,
-      body: {
-        enableBreakoutSession: enable,
-      },
+      body,
     });
   },
 
@@ -377,31 +380,16 @@ const Breakouts = WebexPlugin.extend({
    * @returns {Promise}
    */
   async create(sessions) {
+    const body = {
+      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock?.token}} : {}),
+      ...{groups: [{sessions}]},
+    };
     // @ts-ignore
-    const bodyInfo =
-      this.editLock && !!this.editLock.token
-        ? {
-            groups: [
-              {
-                sessions,
-              },
-            ],
-            editlock: {
-              token: this.editLock.token,
-            },
-          }
-        : {
-            groups: [
-              {
-                sessions,
-              },
-            ],
-          };
     const breakInfo = await this.webex
       .request({
         method: HTTP_VERBS.PUT,
         uri: this.url,
-        body: bodyInfo,
+        body,
       })
       .catch((error) => {
         return Promise.reject(
@@ -424,31 +412,16 @@ const Breakouts = WebexPlugin.extend({
    * @returns {Promise}
    */
   async clearSessions() {
+    const body = {
+      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock?.token}} : {}),
+      ...{groups: [{action: BREAKOUTS.ACTION.DELETE}]},
+    };
     // @ts-ignore
-    const bodyInfo =
-      this.editLock && !!this.editLock.token
-        ? {
-            groups: [
-              {
-                action: BREAKOUTS.ACTION.DELETE,
-              },
-            ],
-            editlock: {
-              token: this.editLock.token,
-            },
-          }
-        : {
-            groups: [
-              {
-                action: BREAKOUTS.ACTION.DELETE,
-              },
-            ],
-          };
     const breakInfo = await this.webex
       .request({
         method: HTTP_VERBS.PUT,
         uri: this.url,
-        body: bodyInfo,
+        body,
       })
       .catch((error) => {
         return Promise.reject(
@@ -479,12 +452,17 @@ const Breakouts = WebexPlugin.extend({
       ...params,
     };
 
+    const body = {
+      ...(this.editLock && !!this.editLock.token
+        ? {editlock: {token: this.editLock?.token, refresh: true}}
+        : {}),
+      ...{groups: [payload]},
+    };
+
     return this.request({
       method: HTTP_VERBS.PUT,
       uri: this.url,
-      body: {
-        groups: [payload],
-      },
+      body,
     }).catch((error) => {
       return Promise.reject(
         boServiceErrorHandler(error, 'Breakouts#start --> Edit lock token mismatch')
@@ -507,12 +485,15 @@ const Breakouts = WebexPlugin.extend({
       ...params,
     };
 
+    const body = {
+      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock?.token}} : {}),
+      ...{groups: [payload]},
+    };
+
     return this.request({
       method: HTTP_VERBS.PUT,
       uri: this.url,
-      body: {
-        groups: [payload],
-      },
+      body,
     }).catch((error) => {
       return Promise.reject(
         boServiceErrorHandler(error, 'Breakouts#end --> Edit lock token mismatch')
@@ -536,6 +517,7 @@ const Breakouts = WebexPlugin.extend({
     }
     if (breakout.body?.editlock && editlock) {
       this.set('editLock', breakout.body.editlock);
+      this.keepEditLockAlive();
     }
 
     return breakout;

--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -486,7 +486,9 @@ const Breakouts = WebexPlugin.extend({
     };
 
     const body = {
-      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock.token}} : {}),
+      ...(this.editLock && !!this.editLock.token
+        ? {editlock: {token: this.editLock.token, refresh: true}}
+        : {}),
       ...{groups: [payload]},
     };
 

--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -362,7 +362,7 @@ const Breakouts = WebexPlugin.extend({
    */
   doToggleBreakout(enable) {
     const body = {
-      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock?.token}} : {}),
+      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock.token}} : {}),
       ...{enableBreakoutSession: enable},
     };
 
@@ -381,7 +381,7 @@ const Breakouts = WebexPlugin.extend({
    */
   async create(sessions) {
     const body = {
-      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock?.token}} : {}),
+      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock.token}} : {}),
       ...{groups: [{sessions}]},
     };
     // @ts-ignore
@@ -413,7 +413,7 @@ const Breakouts = WebexPlugin.extend({
    */
   async clearSessions() {
     const body = {
-      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock?.token}} : {}),
+      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock.token}} : {}),
       ...{groups: [{action: BREAKOUTS.ACTION.DELETE}]},
     };
     // @ts-ignore
@@ -454,7 +454,7 @@ const Breakouts = WebexPlugin.extend({
 
     const body = {
       ...(this.editLock && !!this.editLock.token
-        ? {editlock: {token: this.editLock?.token, refresh: true}}
+        ? {editlock: {token: this.editLock.token, refresh: true}}
         : {}),
       ...{groups: [payload]},
     };
@@ -486,7 +486,7 @@ const Breakouts = WebexPlugin.extend({
     };
 
     const body = {
-      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock?.token}} : {}),
+      ...(this.editLock && !!this.editLock.token ? {editlock: {token: this.editLock.token}} : {}),
       ...{groups: [payload]},
     };
 

--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -584,16 +584,18 @@ const Breakouts = WebexPlugin.extend({
    * @returns {void}
    */
   unLockEditBreakout() {
-    this.request({
-      method: HTTP_VERBS.DELETE,
-      uri: `${this.url}/editlock/${this.editLock.token}`,
-    })
-      .then(() => {
-        this._clearEditLockInfo();
+    if (this.editLock && !!this.editLock.token) {
+      this.request({
+        method: HTTP_VERBS.DELETE,
+        uri: `${this.url}/editlock/${this.editLock.token}`,
       })
-      .catch((error) => {
-        return Promise.reject(boServiceErrorHandler(error, 'Breakouts#unLockEditBreakout'));
-      });
+        .then(() => {
+          this._clearEditLockInfo();
+        })
+        .catch((error) => {
+          return Promise.reject(boServiceErrorHandler(error, 'Breakouts#unLockEditBreakout'));
+        });
+    }
   },
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
@@ -857,6 +857,12 @@ describe('plugin-meetings', () => {
           uri: 'url/editlock/2ad57140-01b5-4bd0-a5a7-4dccdc06904c',
         });
       });
+
+      it('do not call unLock if edit lock info not exist ', async () => {
+        
+        breakouts.unLockEditBreakout();
+        assert.notCalled(webex.request);
+      });
     });
 
     describe('keepEditLockAlive', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-400286

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >
add edit lock info for the dotoggle/create/end api

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
