### PR TITLE
Meeting Roster Control - Edit Display Name Feature

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -7,6 +7,7 @@ export const AUDIO = 'audio';
 export const AUDIO_INPUT = 'audioinput';
 export const AUDIO_STATUS = 'audioStatus';
 export const ALERT = 'alert';
+export const ALIAS = 'alias';
 export const ANSWER = 'answer';
 
 export const CALL = 'call';
@@ -803,6 +804,8 @@ export const DISPLAY_HINTS = {
   MUTE_ALL: 'MUTE_ALL',
   UNMUTE_ALL: 'UNMUTE_ALL',
   PRESENTER_CONTROL: 'PRESENTER_CONTROL',
+  CAN_RENAME_SELF_AND_OBSERVED: 'CAN_RENAME_SELF_AND_OBSERVED',
+  CAN_RENAME_OTHERS: 'CAN_RENAME_OTHERS',
 
   // breakout session
   BREAKOUT_MANAGEMENT: 'BREAKOUT_MANAGEMENT',

--- a/packages/@webex/plugin-meetings/src/meeting/in-meeting-actions.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/in-meeting-actions.ts
@@ -46,6 +46,8 @@ interface IInMeetingActions {
   canAdmitLobbyToBreakout?: boolean;
   isBreakoutPreassignmentsEnabled?: boolean;
   canUserAskForHelp?: boolean;
+  canUserRenameSelfAndObserved?: boolean;
+  canUserRenameOthers?: boolean;
 }
 
 /**
@@ -128,6 +130,10 @@ export default class InMeetingActions implements IInMeetingActions {
 
   canUserAskForHelp = null;
 
+  canUserRenameSelfAndObserved = null;
+
+  canUserRenameOthers = null;
+
   /**
    * Returns all meeting action options
    * @returns {Object}
@@ -170,6 +176,8 @@ export default class InMeetingActions implements IInMeetingActions {
     canAdmitLobbyToBreakout: this.canAdmitLobbyToBreakout,
     isBreakoutPreassignmentsEnabled: this.isBreakoutPreassignmentsEnabled,
     canUserAskForHelp: this.canUserAskForHelp,
+    canUserRenameSelfAndObserved: this.canUserRenameSelfAndObserved,
+    canUserRenameOthers: this.canUserRenameOthers,
   });
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -2336,6 +2336,10 @@ export default class Meeting extends StatelessWebexPlugin {
             payload.info.userDisplayHints
           ),
           canUserAskForHelp: MeetingUtil.canUserAskForHelp(payload.info.userDisplayHints),
+          canUserRenameSelfAndObserved: MeetingUtil.canUserRenameSelfAndObserved(
+            payload.info.userDisplayHints
+          ),
+          canUserRenameOthers: MeetingUtil.canUserRenameOthers(payload.info.userDisplayHints),
         });
 
         this.recordingController.setDisplayHints(payload.info.userDisplayHints);

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -518,5 +518,10 @@ MeetingUtil.canSendReactions = (originalValue, displayHints) => {
 
   return originalValue;
 };
+MeetingUtil.canUserRenameSelfAndObserved = (displayHints) =>
+  displayHints.includes(DISPLAY_HINTS.CAN_RENAME_SELF_AND_OBSERVED);
+
+MeetingUtil.canUserRenameOthers = (displayHints) =>
+  displayHints.includes(DISPLAY_HINTS.CAN_RENAME_OTHERS);
 
 export default MeetingUtil;

--- a/packages/@webex/plugin-meetings/src/members/index.ts
+++ b/packages/@webex/plugin-meetings/src/members/index.ts
@@ -1018,4 +1018,39 @@ export default class Members extends StatelessWebexPlugin {
 
     return csis;
   }
+
+  /**
+   * Edit display name of participants in a meeting
+   * @param {string} memberId - id of the participant who is receiving request
+   * @param {string} requestingParticipantId - id of the participant who is sending request (optional)
+   * @param {string} [alias] - alias name
+   * @returns {Promise}
+   * @public
+   * @memberof Members
+   */
+  public editDisplayName(memberId: string, requestingParticipantId: string, alias: string) {
+    if (!this.locusUrl) {
+      return Promise.reject(
+        new ParameterError(
+          'The associated locus url for this meetings members object must be defined.'
+        )
+      );
+    }
+    if (!memberId) {
+      return Promise.reject(
+        new ParameterError('The member id must be defined to edit display name of the member.')
+      );
+    }
+
+    const {locusUrl} = this;
+
+    const options = MembersUtil.generateEditDisplayNameMemberOptions(
+      memberId,
+      requestingParticipantId,
+      alias,
+      locusUrl
+    );
+
+    return this.membersRequest.editDisplayNameMember(options);
+  }
 }

--- a/packages/@webex/plugin-meetings/src/members/request.ts
+++ b/packages/@webex/plugin-meetings/src/members/request.ts
@@ -1,3 +1,4 @@
+/* eslint-disable require-jsdoc */
 // @ts-ignore
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
@@ -126,6 +127,19 @@ export default class MembersRequest extends StatelessWebexPlugin {
     }
 
     const requestParams = MembersUtil.getLowerAllHandsMemberRequestParams(options);
+
+    // @ts-ignore
+    return this.request(requestParams);
+  }
+
+  editDisplayNameMember(options) {
+    if (!options || !options.locusUrl || !options.requestingParticipantId) {
+      throw new ParameterError(
+        'requestingParticipantId must be defined, and the associated locus url for this meeting object must be defined.'
+      );
+    }
+
+    const requestParams = MembersUtil.editDisplayNameMemberRequestParams(options);
 
     // @ts-ignore
     return this.request(requestParams);

--- a/packages/@webex/plugin-meetings/src/members/request.ts
+++ b/packages/@webex/plugin-meetings/src/members/request.ts
@@ -1,4 +1,3 @@
-/* eslint-disable require-jsdoc */
 // @ts-ignore
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
@@ -132,7 +131,14 @@ export default class MembersRequest extends StatelessWebexPlugin {
     return this.request(requestParams);
   }
 
-  editDisplayNameMember(options) {
+  /**
+   *
+   * @param {Object} options with format of {locusUrl: string, requestingParticipantId: string}
+   * @returns {Promise}
+   * @throws {Error} if the options are not valid and complete, must have requestingParticipantId AND locusUrl
+   * @memberof MembersRequest
+   */
+  editDisplayNameMember(options: {locusUrl: string; requestingParticipantId: string}) {
     if (!options || !options.locusUrl || !options.requestingParticipantId) {
       throw new ParameterError(
         'requestingParticipantId must be defined, and the associated locus url for this meeting object must be defined.'

--- a/packages/@webex/plugin-meetings/src/members/util.ts
+++ b/packages/@webex/plugin-meetings/src/members/util.ts
@@ -176,11 +176,11 @@ MembersUtil.generateLowerAllHandsMemberOptions = (requestingParticipantId, locus
 });
 
 /**
- * @param {String} memberId
- * @param {String} requestingParticipantId
- * @param {String} alias
- * @param {String} locusUrl
- * @returns {Object}
+ * @param {String} memberId id of the participant who is receiving request
+ * @param {String} requestingParticipantId id of the participant who is sending request (optional)
+ * @param {String} alias alias name
+ * @param {String} locusUrl url
+ * @returns {Object} consists of {memberID: string, requestingParticipantId: string, alias: string, locusUrl: string}
  */
 MembersUtil.generateEditDisplayNameMemberOptions = (
   memberId,

--- a/packages/@webex/plugin-meetings/src/members/util.ts
+++ b/packages/@webex/plugin-meetings/src/members/util.ts
@@ -175,6 +175,13 @@ MembersUtil.generateLowerAllHandsMemberOptions = (requestingParticipantId, locus
   locusUrl,
 });
 
+/**
+ * @param {String} memberId
+ * @param {String} requestingParticipantId
+ * @param {String} alias
+ * @param {String} locusUrl
+ * @returns {Object}
+ */
 MembersUtil.generateEditDisplayNameMemberOptions = (
   memberId,
   requestingParticipantId,
@@ -255,6 +262,10 @@ MembersUtil.getLowerAllHandsMemberRequestParams = (options) => {
   };
 };
 
+/**
+ * @param {Object} options with format of {locusUrl: string, requestingParticipantId: string}
+ * @returns {Object} request parameters (method, uri, body) needed to make a editDisplayName request
+ */
 MembersUtil.editDisplayNameMemberRequestParams = (options) => {
   const body = {
     aliasValue: options.alias,

--- a/packages/@webex/plugin-meetings/src/members/util.ts
+++ b/packages/@webex/plugin-meetings/src/members/util.ts
@@ -9,6 +9,7 @@ import {
   DIALER_REGEX,
   SEND_DTMF_ENDPOINT,
   _REMOVE_,
+  ALIAS,
 } from '../constants';
 
 import {RoleAssignmentOptions, RoleAssignmentRequest, ServerRoleShape} from './types';
@@ -174,6 +175,18 @@ MembersUtil.generateLowerAllHandsMemberOptions = (requestingParticipantId, locus
   locusUrl,
 });
 
+MembersUtil.generateEditDisplayNameMemberOptions = (
+  memberId,
+  requestingParticipantId,
+  alias,
+  locusUrl
+) => ({
+  memberId,
+  requestingParticipantId,
+  alias,
+  locusUrl,
+});
+
 MembersUtil.getMuteMemberRequestParams = (options) => {
   const property = options.isAudio === false ? 'video' : 'audio';
   const body = {
@@ -237,6 +250,20 @@ MembersUtil.getLowerAllHandsMemberRequestParams = (options) => {
 
   return {
     method: HTTP_VERBS.PATCH,
+    uri,
+    body,
+  };
+};
+
+MembersUtil.editDisplayNameMemberRequestParams = (options) => {
+  const body = {
+    aliasValue: options.alias,
+    requestingParticipantId: options.requestingParticipantId,
+  };
+  const uri = `${options.locusUrl}/${PARTICIPANT}/${options.memberId}/${ALIAS}`;
+
+  return {
+    method: HTTP_VERBS.POST,
     uri,
     body,
   };

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/in-meeting-actions.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/in-meeting-actions.ts
@@ -41,8 +41,10 @@ describe('plugin-meetings', () => {
         canManageBreakout: null,
         canAdmitLobbyToBreakout: null,
         canUserAskForHelp: null,
+        canUserRenameSelfAndObserved: null,
+        canUserRenameOthers: null,
         isBreakoutPreassignmentsEnabled: null,
-        ...expected
+        ...expected,
       };
 
       // Check get retuns all the correct values at once
@@ -88,7 +90,9 @@ describe('plugin-meetings', () => {
       'canManageBreakout',
       'canAdmitLobbyToBreakout',
       'canUserAskForHelp',
-      'isBreakoutPreassignmentsEnabled'
+      'canUserRenameSelfAndObserved',
+      'canUserRenameOthers',
+      'isBreakoutPreassignmentsEnabled',
     ].forEach((key) => {
       it(`get and set for ${key} work as expected`, () => {
         const inMeetingActions = new InMeetingActions();

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -416,7 +416,10 @@ describe('plugin-meetings', () => {
           assert.calledWith(meeting.members.admitMembers, [uuid1]);
         });
         it('should call from a breakout session if caller is in a breakout session', async () => {
-          const locusUrls = {authorizingLocusUrl: 'authorizingLocusUrl', mainLocusUrl: 'mainLocusUrl'};
+          const locusUrls = {
+            authorizingLocusUrl: 'authorizingLocusUrl',
+            mainLocusUrl: 'mainLocusUrl',
+          };
           await meeting.admit([uuid1], locusUrls);
           assert.calledOnce(meeting.members.admitMembers);
           assert.calledWith(meeting.members.admitMembers, [uuid1], locusUrls);
@@ -2220,7 +2223,7 @@ describe('plugin-meetings', () => {
               meeting.isMultistream = true;
 
               const result = await meeting.updateMedia({
-                  mediaSettings,
+                mediaSettings,
               });
 
               assert.calledOnceWithExactly(
@@ -5075,6 +5078,8 @@ describe('plugin-meetings', () => {
         let handleDataChannelUrlChangeSpy;
         let canEnableReactionsSpy;
         let canSendReactionsSpy;
+        let canUserRenameSelfAndObservedSpy;
+        let canUserRenameOthersSpy;
 
         beforeEach(() => {
           locusInfoOnSpy = sinon.spy(meeting.locusInfo, 'on');
@@ -5100,6 +5105,8 @@ describe('plugin-meetings', () => {
           handleDataChannelUrlChangeSpy = sinon.spy(meeting, 'handleDataChannelUrlChange');
           canEnableReactionsSpy = sinon.spy(MeetingUtil, 'canEnableReactions');
           canSendReactionsSpy = sinon.spy(MeetingUtil, 'canSendReactions');
+          canUserRenameSelfAndObservedSpy = sinon.spy(MeetingUtil, 'canUserRenameSelfAndObserved');
+          canUserRenameOthersSpy = sinon.spy(MeetingUtil, 'canUserRenameOthers');
         });
 
         afterEach(() => {
@@ -5145,6 +5152,8 @@ describe('plugin-meetings', () => {
           assert.calledWith(handleDataChannelUrlChangeSpy, payload.info.datachannelUrl);
           assert.calledWith(canEnableReactionsSpy, null, payload.info.userDisplayHints);
           assert.calledWith(canSendReactionsSpy, null, payload.info.userDisplayHints);
+          assert.calledWith(canUserRenameSelfAndObservedSpy, payload.info.userDisplayHints);
+          assert.calledWith(canUserRenameOthersSpy, payload.info.userDisplayHints);
 
           assert.calledWith(
             TriggerProxy.trigger,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -73,7 +73,7 @@ describe('plugin-meetings', () => {
       const mockTrack = {
         underlyingTrack: {
           getSettings: fakeDevice,
-        }
+        },
       };
 
       it('#log - should log [info, warn, error, log] to console', () => {
@@ -202,12 +202,14 @@ describe('plugin-meetings', () => {
 
       it('#Should call meetingRequest.joinMeeting with breakoutsSupported=true when passed in as true', async () => {
         const meeting = {
-          meetingRequest: {joinMeeting: sinon.stub().returns(Promise.resolve({body: {}, headers: {}}))}
+          meetingRequest: {
+            joinMeeting: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
+          },
         };
 
         MeetingUtil.parseLocusJoin = sinon.stub();
         await MeetingUtil.joinMeeting(meeting, {
-          breakoutsSupported: true
+          breakoutsSupported: true,
         });
 
         assert.calledOnce(meeting.meetingRequest.joinMeeting);
@@ -215,7 +217,6 @@ describe('plugin-meetings', () => {
 
         assert.equal(parameter.breakoutsSupported, true);
       });
-
 
       it('#Should call meetingRequest.joinMeeting with preferTranscoding=false when multistream is enabled', async () => {
         const meeting = {
@@ -346,6 +347,23 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('canUserRenameSelfAndObserved', () => {
+      it('works as expected', () => {
+        assert.deepEqual(
+          MeetingUtil.canUserRenameSelfAndObserved(['CAN_RENAME_SELF_AND_OBSERVED']),
+          true
+        );
+        assert.deepEqual(MeetingUtil.canUserRenameSelfAndObserved([]), false);
+      });
+    });
+
+    describe('canUserRenameOthers', () => {
+      it('works as expected', () => {
+        assert.deepEqual(MeetingUtil.canUserRenameOthers(['CAN_RENAME_OTHERS']), true);
+        assert.deepEqual(MeetingUtil.canUserRenameOthers([]), false);
+      });
+    });
+
     describe('bothLeaveAndEndMeetingAvailable', () => {
       it('works as expected', () => {
         assert.deepEqual(
@@ -410,12 +428,20 @@ describe('plugin-meetings', () => {
 
     describe('reactions', () => {
       describe('canEnableReactions', () => {
-        [[null, DISPLAY_HINTS.ENABLE_REACTIONS, true], [null, DISPLAY_HINTS.DISABLE_REACTIONS, false], [null, undefined, null]].forEach(() => ([originalValue, displayHint, expected]) => {
+        [
+          [null, DISPLAY_HINTS.ENABLE_REACTIONS, true],
+          [null, DISPLAY_HINTS.DISABLE_REACTIONS, false],
+          [null, undefined, null],
+        ].forEach(() => ([originalValue, displayHint, expected]) => {
           assert.deepEqual(MeetingUtil.canEnableReactions(originalValue, [displayHint]), expected);
         });
       });
       describe('canEnableReactions', () => {
-        [[null, DISPLAY_HINTS.REACTIONS_ACTIVE, true], [null, DISPLAY_HINTS.REACTIONS_INACTIVE, false], [null, undefined, null]].forEach(([originalValue, displayHint, expected]) => {
+        [
+          [null, DISPLAY_HINTS.REACTIONS_ACTIVE, true],
+          [null, DISPLAY_HINTS.REACTIONS_INACTIVE, false],
+          [null, undefined, null],
+        ].forEach(([originalValue, displayHint, expected]) => {
           assert.deepEqual(MeetingUtil.canSendReactions(originalValue, [displayHint]), expected);
         });
       });
@@ -430,7 +456,10 @@ describe('plugin-meetings', () => {
 
     describe('isSuppressBreakoutSupport', () => {
       it('works as expected', () => {
-        assert.deepEqual(MeetingUtil.isSuppressBreakoutSupport(['UCF_SUPPRESS_BREAKOUTS_SUPPORT']), true);
+        assert.deepEqual(
+          MeetingUtil.isSuppressBreakoutSupport(['UCF_SUPPRESS_BREAKOUTS_SUPPORT']),
+          true
+        );
         assert.deepEqual(MeetingUtil.isSuppressBreakoutSupport([]), false);
       });
     });
@@ -451,9 +480,12 @@ describe('plugin-meetings', () => {
 
     describe('isBreakoutPreassignmentsEnabled', () => {
       it('works as expected', () => {
-        assert.deepEqual(MeetingUtil.isBreakoutPreassignmentsEnabled(['DISABLE_BREAKOUT_PREASSIGNMENTS']), false);
+        assert.deepEqual(
+          MeetingUtil.isBreakoutPreassignmentsEnabled(['DISABLE_BREAKOUT_PREASSIGNMENTS']),
+          false
+        );
         assert.deepEqual(MeetingUtil.isBreakoutPreassignmentsEnabled([]), true);
       });
     });
-  })
+  });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/members/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/request.js
@@ -107,7 +107,11 @@ describe('plugin-meetings', () => {
       it('sends a PATCH to the locus endpoint', async () => {
         const locusUrl = url1;
         const memberId = 'test1';
-        const roles = [{type: 'PRESENTER', hasRole: true}, {type: 'MODERATOR', hasRole: false}, {type: 'COHOST', hasRole: true}];
+        const roles = [
+          {type: 'PRESENTER', hasRole: true},
+          {type: 'MODERATOR', hasRole: false},
+          {type: 'COHOST', hasRole: true},
+        ];
 
         const options = {
           memberId,
@@ -215,6 +219,28 @@ describe('plugin-meetings', () => {
             requestingParticipantId: memberId,
           },
         });
+      });
+    });
+
+    describe('#editDisplayName', () => {
+      it('sends a POST request to the locus endpoint', async () => {
+        const locusUrl = url1;
+        const memberId = 'test1';
+        const requestingParticipantId = 'test2';
+        const aliasValue = 'alias';
+
+        const options = {
+          memberId,
+          requestingParticipantId,
+          aliasValue,
+          locusUrl,
+        };
+
+        await membersRequest.editDisplayNameMember(options);
+        const requestParams = membersRequest.request.getCall(0).args[0];
+
+        assert.equal(requestParams.method, 'POST');
+        assert.equal(requestParams.uri, `${locusUrl}/participant/${memberId}/alias`);
       });
     });
   });

--- a/packages/@webex/plugin-meetings/test/unit/spec/members/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/utils.js
@@ -15,27 +15,48 @@ describe('plugin-meetings', () => {
     describe('#generateRoleAssignmentMemberOptions', () => {
       it('returns the correct options', () => {
         const memberId = 'test';
-        const roles = [{type: 'PRESENTER', hasRole: true}, {type: 'MODERATOR', hasRole: true}, {type: 'COHOST', hasRole: true}]
+        const roles = [
+          {type: 'PRESENTER', hasRole: true},
+          {type: 'MODERATOR', hasRole: true},
+          {type: 'COHOST', hasRole: true},
+        ];
         const locusUrl = 'urlTest1';
 
-        assert.deepEqual(MembersUtil.generateRoleAssignmentMemberOptions(memberId, roles, locusUrl), {
-          memberId,
-          roles,
-          locusUrl,
-        });
+        assert.deepEqual(
+          MembersUtil.generateRoleAssignmentMemberOptions(memberId, roles, locusUrl),
+          {
+            memberId,
+            roles,
+            locusUrl,
+          }
+        );
       });
     });
 
     describe('#getRoleAssignmentMemberRequestParams', () => {
       it('returns the correct request params', () => {
-        const format = {locusUrl: 'locusUrl', memberId: 'test', roles: [{type: 'PRESENTER', hasRole: true}, {type: 'MODERATOR', hasRole: false}, {type: 'COHOST', hasRole: true}]};
+        const format = {
+          locusUrl: 'locusUrl',
+          memberId: 'test',
+          roles: [
+            {type: 'PRESENTER', hasRole: true},
+            {type: 'MODERATOR', hasRole: false},
+            {type: 'COHOST', hasRole: true},
+          ],
+        };
 
         assert.deepEqual(MembersUtil.getRoleAssignmentMemberRequestParams(format), {
           method: 'PATCH',
           uri: `locusUrl/${PARTICIPANT}/test/${CONTROLS}`,
-          body: {role: {
-            roles: [{type: 'PRESENTER', hasRole: true}, {type: 'MODERATOR', hasRole: false}, {type: 'COHOST', hasRole: true}]
-          }},
+          body: {
+            role: {
+              roles: [
+                {type: 'PRESENTER', hasRole: true},
+                {type: 'MODERATOR', hasRole: false},
+                {type: 'COHOST', hasRole: true},
+              ],
+            },
+          },
         });
       });
     });
@@ -62,6 +83,29 @@ describe('plugin-meetings', () => {
           MembersUtil.generateLowerAllHandsMemberOptions(requestingParticipantId, locusUrl),
           {
             requestingParticipantId,
+            locusUrl,
+          }
+        );
+      });
+    });
+    describe('#generateEditDisplayNameMemberOptions', () => {
+      it('returns the correct options', () => {
+        const locusUrl = 'urlTest1';
+        const memberId = 'test1';
+        const requestingParticipantId = 'test2';
+        const alias = 'alias';
+
+        assert.deepEqual(
+          MembersUtil.generateEditDisplayNameMemberOptions(
+            memberId,
+            requestingParticipantId,
+            alias,
+            locusUrl
+          ),
+          {
+            memberId,
+            requestingParticipantId,
+            alias,
             locusUrl,
           }
         );


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-411666

## This pull request addresses

Added new feature edit display name for the participants in a meeting

## by making the following changes

* If a Host/Cohost/Attendee renames self, Clients can use [locus.info](http://locus.info/).displayHints.joined[].CAN_RENAME_SELF_AND_OBSERVED to render the UI.
* If a Host/Cohost renames another participant, Clients can use 
locus.info.displayHints.moderator[].CAN_RENAME_OTHERS or locus.info.displayHints.coHost[].CAN_RENAME_OTHERS to render the UI.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
