### PR TITLE
feat(plugin-meetings): use the first site if none are default

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/util.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/util.ts
@@ -112,11 +112,13 @@ MeetingsUtil.checkForCorrelationId = (deviceUrl, locus) => {
 MeetingsUtil.parseDefaultSiteFromMeetingPreferences = (userPreferences) => {
   let result = '';
 
-  if (userPreferences && userPreferences.sites) {
+  if (userPreferences?.sites?.length) {
     const defaultSite = userPreferences.sites.find((site) => site.default);
 
     if (defaultSite) {
       result = defaultSite.siteUrl;
+    } else {
+      result = userPreferences.sites[0].siteUrl;
     }
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
@@ -33,7 +33,7 @@ describe('plugin-meetings', () => {
         );
       });
 
-      it('should work fine if no default true site', () => {
+      it('should take the first site if none are default', () => {
         const userPreferences = {
           sites: [
             {
@@ -51,7 +51,10 @@ describe('plugin-meetings', () => {
           ],
         };
 
-        assert.equal(MeetingsUtil.parseDefaultSiteFromMeetingPreferences(userPreferences), '');
+        assert.equal(
+          MeetingsUtil.parseDefaultSiteFromMeetingPreferences(userPreferences),
+          'site1-example.webex.com'
+        );
       });
 
       it('should work fine if sites an empty array', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

This is affecting test users. They are being created with no site set to default. Since the user has at least one site available to use, it makes sense in this case to return that from parseDefaultSiteFromMeetingPreferences 

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
