### PR TITLE
feat(plugin-meetings): installed org ID

### DIFF
--- a/packages/@webex/plugin-meetings/src/config.ts
+++ b/packages/@webex/plugin-meetings/src/config.ts
@@ -89,6 +89,7 @@ export default {
     receiveTranscription: false,
     enableExtmap: false,
     enableAutomaticLLM: false,
+    installedOrgID: undefined,
     experimental: {
       enableMediaNegotiatedEvent: false,
       enableUnifiedMeetings: false,

--- a/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
@@ -190,6 +190,7 @@ export default class MeetingInfoV2 {
    * @param {Object} captchaInfo
    * @param {String} captchaInfo.code
    * @param {String} captchaInfo.id
+   * @param {String} installedOrgID
    * @returns {Promise} returns a meeting info object
    * @public
    * @memberof MeetingInfo
@@ -201,7 +202,8 @@ export default class MeetingInfoV2 {
     captchaInfo: {
       code: string;
       id: string;
-    } = null
+    } = null,
+    installedOrgID = null
   ) {
     const destinationType = await MeetingInfoUtil.getDestinationType({
       destination,
@@ -217,7 +219,12 @@ export default class MeetingInfoV2 {
       return this.createAdhocSpaceMeeting(destinationType.destination);
     }
 
-    const body = await MeetingInfoUtil.getRequestBody({...destinationType, password, captchaInfo});
+    const body = await MeetingInfoUtil.getRequestBody({
+      ...destinationType,
+      password,
+      captchaInfo,
+      installedOrgID,
+    });
 
     const options: any = {
       method: HTTP_VERBS.POST,

--- a/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
@@ -224,7 +224,7 @@ MeetingInfoUtil.getDestinationType = async (from) => {
  * @returns {Object} returns an object with {resource, method}
  */
 MeetingInfoUtil.getRequestBody = (options: {type: string; destination: object} | any) => {
-  const {type, destination, password, captchaInfo} = options;
+  const {type, destination, password, captchaInfo, installedOrgID} = options;
   const body: any = {
     supportHostKey: true,
     supportCountryList: true,
@@ -269,6 +269,10 @@ MeetingInfoUtil.getRequestBody = (options: {type: string; destination: object} |
   if (captchaInfo) {
     body.captchaID = captchaInfo.id;
     body.captchaVerifyCode = captchaInfo.code;
+  }
+
+  if (installedOrgID) {
+    body.installedOrgID = installedOrgID;
   }
 
   return body;

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1174,7 +1174,9 @@ export default class Meeting extends StatelessWebexPlugin {
         this.destination,
         this.destinationType,
         password,
-        captchaInfo
+        captchaInfo,
+        // @ts-ignore - config coming from registerPlugin
+        this.config.installedOrgID
       );
 
       this.parseMeetingInfo(info, this.destination);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -211,6 +211,33 @@ describe('plugin-meetings', () => {
         );
       });
 
+      it('should fetch meeting info with provided installedOrgID', async () => {
+        const requestResponse = {statusCode: 200, body: {meetingKey: '1234323'}};
+        const installedOrgID = '123456';
+
+        webex.request.resolves(requestResponse);
+
+        const result = await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, null, null, installedOrgID);
+
+        assert.calledWith(webex.request, {
+          method: 'POST',
+          service: WBXAPPAPI_SERVICE,
+          resource: 'meetingInfo',
+          body: {
+            supportHostKey: true,
+            supportCountryList: true,
+            meetingKey: '1234323',
+            installedOrgID,
+          },
+        });
+        assert.deepEqual(result, requestResponse);
+        assert(Metrics.sendBehavioralMetric.calledOnce);
+        assert.calledWith(
+          Metrics.sendBehavioralMetric,
+          BEHAVIORAL_METRICS.FETCH_MEETING_INFO_V1_SUCCESS
+        );
+      });
+
       it('create adhoc meeting when conversationUrl passed with enableAdhocMeetings toggle', async () => {
         sinon.stub(meetingInfo, 'createAdhocSpaceMeeting').returns(Promise.resolve());
         await meetingInfo.fetchMeetingInfo('conversationUrl', _CONVERSATION_URL_);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2942,6 +2942,7 @@ describe('plugin-meetings', () => {
         const FAKE_CAPTCHA_IMAGE_URL = 'http://captchaimage';
         const FAKE_CAPTCHA_AUDIO_URL = 'http://captchaaudio';
         const FAKE_CAPTCHA_REFRESH_URL = 'http://captcharefresh';
+        const FAKE_INSTALLED_ORG_ID = '123456';
         const FAKE_MEETING_INFO = {
           conversationUrl: 'some_convo_url',
           locusUrl: 'some_locus_url',
@@ -2969,6 +2970,7 @@ describe('plugin-meetings', () => {
           meeting.requiredCaptcha = FAKE_SDK_CAPTCHA_INFO;
           meeting.destination = FAKE_DESTINATION;
           meeting.destinationType = FAKE_TYPE;
+          meeting.config.installedOrgID = FAKE_INSTALLED_ORG_ID;
           meeting.parseMeetingInfo = sinon.stub().returns(undefined);
 
           await meeting.fetchMeetingInfo({
@@ -2981,7 +2983,8 @@ describe('plugin-meetings', () => {
             FAKE_DESTINATION,
             FAKE_TYPE,
             FAKE_PASSWORD,
-            {code: FAKE_CAPTCHA_CODE, id: FAKE_CAPTCHA_ID}
+            {code: FAKE_CAPTCHA_CODE, id: FAKE_CAPTCHA_ID},
+            FAKE_INSTALLED_ORG_ID
           );
 
           assert.calledWith(meeting.parseMeetingInfo, {body: FAKE_MEETING_INFO}, FAKE_DESTINATION);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Add the installedOrgID parameter when fetching meeting info. This represents the org ID of the machine, rather than the user which is why I've made it a config parameter i.e. it is not expected to change over the lifetime of the sdk instance

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
