### PR TITLE
fix(plugin-meetings): clear previous requests after reconnection

### DIFF
--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -175,6 +175,15 @@ export class MediaRequestManager {
     );
   }
 
+  /**
+   * Clears the previous media requests.
+   *
+   * @returns {void}
+   */
+  public clearPreviousRequests(): void {
+    this.previousWCMEMediaRequests = [];
+  }
+
   private sendRequests() {
     const wcmeMediaRequests: WcmeMediaRequest[] = [];
 
@@ -214,7 +223,7 @@ export class MediaRequestManager {
       );
     });
 
-    //! IMPORTANT: this is only a temporary fix. This will soon be done in the jmp layer (@webex/jmp-multistream)
+    //! IMPORTANT: this is only a temporary fix. This will soon be done in the jmp layer (@webex/json-multistream)
     // https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-326713
     if (!this.checkIsNewRequestsEqualToPrev(wcmeMediaRequests)) {
       this.sendMediaRequestsCallback(wcmeMediaRequests);

--- a/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
@@ -22,6 +22,7 @@ import {eventType, reconnection, errorObjects} from '../metrics/config';
 import Media from '../media';
 import Metrics from '../metrics';
 import Meeting from '../meeting';
+import {MediaRequestManager} from '../multistream/mediaRequestManager';
 
 /**
  * Used to indicate that the reconnect logic needs to be retried.
@@ -570,9 +571,11 @@ export default class ReconnectionManager {
 
     // resend media requests
     if (this.meeting.isMultistream) {
-      Object.values(this.meeting.mediaRequestManagers).forEach((mediaRequestManager) =>
-        // @ts-ignore - Fix type
-        mediaRequestManager.commit()
+      Object.values(this.meeting.mediaRequestManagers).forEach(
+        (mediaRequestManager: MediaRequestManager) => {
+          mediaRequestManager.clearPreviousRequests();
+          mediaRequestManager.commit();
+        }
       );
     }
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -572,7 +572,6 @@ describe('MediaRequestManager', () => {
     // nothing should be sent out as we didn't commit the requests
     assert.notCalled(sendMediaRequestsCallback);
 
-
     mediaRequestManager.commit();
     checkMediaRequestsSent([
       {
@@ -601,7 +600,6 @@ describe('MediaRequestManager', () => {
       },
     ]);
 
-
     // check that when calling commit()
     // all requests are not re-sent again (avoid duplicate requests)
     mediaRequestManager.commit();
@@ -621,7 +619,6 @@ describe('MediaRequestManager', () => {
 
     assert.notCalled(sendMediaRequestsCallback);
 
-
     mediaRequestManager.commit();
     checkMediaRequestsSent([
       {
@@ -635,11 +632,11 @@ describe('MediaRequestManager', () => {
     // now reset everything
     mediaRequestManager.reset();
 
-     // calling commit now should not cause any requests to be sent out
-     mediaRequestManager.commit();
-     checkMediaRequestsSent([]);
+    // calling commit now should not cause any requests to be sent out
+    mediaRequestManager.commit();
+    checkMediaRequestsSent([]);
 
-     //add new request
+    //add new request
     addReceiverSelectedRequest(1501, fakeReceiveSlots[1], RECEIVER_SELECTED_MAX_FS, false);
 
     // commit
@@ -653,8 +650,38 @@ describe('MediaRequestManager', () => {
         receiveSlot: fakeWcmeSlots[1],
         maxFs: RECEIVER_SELECTED_MAX_FS,
       },
-    ])
-  })
+    ]);
+  });
+
+  it('can send same media request after previous requests have been cleared', () => {
+    // add a request and commit
+    addReceiverSelectedRequest(1500, fakeReceiveSlots[0], RECEIVER_SELECTED_MAX_FS, false);
+    mediaRequestManager.commit();
+    checkMediaRequestsSent([
+      {
+        policy: 'receiver-selected',
+        csi: 1500,
+        receiveSlot: fakeWcmeSlots[0],
+        maxFs: RECEIVER_SELECTED_MAX_FS,
+      },
+    ]);
+
+    // clear previous requests
+    mediaRequestManager.clearPreviousRequests();
+
+    // commit same request
+    mediaRequestManager.commit();
+
+    // check the request was sent
+    checkMediaRequestsSent([
+      {
+        policy: 'receiver-selected',
+        csi: 1500,
+        receiveSlot: fakeWcmeSlots[0],
+        maxFs: RECEIVER_SELECTED_MAX_FS,
+      },
+    ]);
+  });
 
   it('re-sends media requests after degradation preferences are set', () => {
     // set max macroblocks limit
@@ -785,7 +812,6 @@ describe('MediaRequestManager', () => {
 
     sendMediaRequestsCallback.resetHistory();
 
-
     const maxFsHandlerCall = fakeReceiveSlots[0].on.getCall(1);
 
     const maxFsHandler = maxFsHandlerCall.args[1];
@@ -812,5 +838,4 @@ describe('MediaRequestManager', () => {
       },
     ]);
   });
-
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
@@ -43,8 +43,8 @@ describe('plugin-meetings', () => {
           webrtcMediaConnection: fakeMediaConnection,
         },
         mediaRequestManagers: {
-          audio: {commit: sinon.stub()},
-          video: {commit: sinon.stub()},
+          audio: {commit: sinon.stub(), clearPreviousRequests: sinon.stub()},
+          video: {commit: sinon.stub(), clearPreviousRequests: sinon.stub()},
         },
         roap: {
           doTurnDiscovery: sinon.stub().resolves({

--- a/packages/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
@@ -84,22 +84,26 @@ describe('plugin-meetings', () => {
       ]);
     });
 
-    it('does not re-request media for non-multistream meetings', async () => {
+    it('does not clear previous requests and re-request media for non-multistream meetings', async () => {
       fakeMeeting.isMultistream = false;
       const rm = new ReconnectionManager(fakeMeeting);
 
       await rm.reconnect();
 
+      assert.notCalled(fakeMeeting.mediaRequestManagers.audio.clearPreviousRequests);
+      assert.notCalled(fakeMeeting.mediaRequestManagers.video.clearPreviousRequests);
       assert.notCalled(fakeMeeting.mediaRequestManagers.audio.commit);
       assert.notCalled(fakeMeeting.mediaRequestManagers.video.commit);
     });
 
-    it('does re-request media for multistream meetings', async () => {
+    it('does clear previous requests and re-request media for multistream meetings', async () => {
       fakeMeeting.isMultistream = true;
       const rm = new ReconnectionManager(fakeMeeting);
 
       await rm.reconnect();
 
+      assert.calledOnce(fakeMeeting.mediaRequestManagers.audio.clearPreviousRequests);
+      assert.calledOnce(fakeMeeting.mediaRequestManagers.video.clearPreviousRequests);
       assert.calledOnce(fakeMeeting.mediaRequestManagers.audio.commit);
       assert.calledOnce(fakeMeeting.mediaRequestManagers.video.commit);
     });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [WEBEX-327337](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-327337)

## This pull request addresses

Media requests are not resent after reconnecting to the meeting. This issue is caused by the SDK workaround for removing duplicate requests.

## by making the following changes

Clear the previous requests array after reconnecting to the meeting but prior to resending the media requests.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

1. Manually tested disconnecting from the network for 15 seconds and reconnecting, then checking the logs to see if the media request has been sent, and checking to see if media can be seen and heard.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
