### PR TITLE
fix: echo problem solve when usePhoneAudio is used

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4019,11 +4019,30 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   public usePhoneAudio(phoneNumber: string) {
-    if (!phoneNumber) {
-      return this.dialInPstn();
-    }
+    const promise = phoneNumber ? this.dialOutPstn(phoneNumber) : this.dialInPstn();
 
-    return this.dialOutPstn(phoneNumber);
+    return promise
+      .then(() => {
+        LoggerProxy.logger.info(
+          `Meeting:index#usePhoneAudio --> ${
+            phoneNumber ? 'dialOutPstn' : 'dialInPstn'
+          } request completed`
+        );
+        LoggerProxy.logger.info(
+          `Meeting:index#usePhoneAudio --> removing audio track from desktop`
+        );
+
+        // removing audio from desktop to avoid echo as phone audio is being used
+        Media.stopTracks(this.mediaProperties.audioTrack);
+      })
+      .catch((error) => {
+        LoggerProxy.logger.error(
+          'Meeting:index#usePhoneAudio --> Failed to move audio to phone',
+          error
+        );
+
+        return Promise.reject(error);
+      });
   }
 
   /**


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-405437](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-405437) >

## This pull request addresses

When using the usePhoneAudio() function to do a dial-out/dial-in the audio stays active in the SDK even though audio is also connected via PSTN and this causes echo. Muting audio in the SDK is an option and that stops the echo but that doesn't seem right. Issue is not present in Webex Meeting desktop and web clients.

## by making the following changes

Stopped the audio in sdk on desktop when dial-out or dial-in is successful.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
