### PR TITLE
 fix: add receive slot id and csi to log message

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5318,8 +5318,12 @@ export default class Meeting extends StatelessWebexPlugin {
         if (this.config.stats.enableStatsAnalyzer) {
           // @ts-ignore - config coming from registerPlugin
           this.networkQualityMonitor = new NetworkQualityMonitor(this.config.stats);
-          // @ts-ignore - config coming from registerPlugin
-          this.statsAnalyzer = new StatsAnalyzer(this.config.stats, this.networkQualityMonitor);
+          this.statsAnalyzer = new StatsAnalyzer(
+            // @ts-ignore - config coming from registerPlugin
+            this.config.stats,
+            (ssrc: number) => this.receiveSlotManager.findReceiveSlotBySsrc(ssrc),
+            this.networkQualityMonitor
+          );
           this.setupStatsAnalyzerEventHandlers();
           this.networkQualityMonitor.on(
             EVENT_TRIGGERS.NETWORK_QUALITY,

--- a/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/receiveSlotManager.ts
@@ -151,4 +151,16 @@ export class ReceiveSlotManager {
       });
     });
   }
+
+  /**
+   * Find a receive slot by a ssrc.
+   *
+   * @param ssrc - The ssrc of the receive slot to find.
+   * @returns - The receive slot with this ssrc, undefined if not found.
+   */
+  findReceiveSlotBySsrc(ssrc: number): ReceiveSlot | undefined {
+    return Object.values(this.allocatedSlots)
+      .flat()
+      .find((r) => ssrc && r.wcmeReceiveSlot?.id?.ssrc === ssrc);
+  }
 }

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlotManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/receiveSlotManager.ts
@@ -15,7 +15,7 @@ describe('ReceiveSlotManager', () => {
 
   beforeEach(() => {
     fakeWcmeSlot = {
-      id: 'fake wcme slot',
+      id: {ssrc: 1},
     };
     fakeReceiveSlots = [];
     mockReceiveSlotCtor = sinon.stub(ReceiveSlotModule, 'ReceiveSlot').callsFake((mediaType) => {
@@ -23,6 +23,7 @@ describe('ReceiveSlotManager', () => {
         id: `fake sdk receive slot ${fakeReceiveSlots.length + 1}`,
         mediaType,
         findMemberId: sinon.stub(),
+        wcmeReceiveSlot: fakeWcmeSlot,
       };
 
       fakeReceiveSlots.push(fakeReceiveSlot);
@@ -168,7 +169,6 @@ describe('ReceiveSlotManager', () => {
   });
 
   describe('updateMemberIds', () => {
-
     it('calls findMemberId() on all allocated receive slots', async () => {
       const audioSlots: ReceiveSlot[] = [];
       const videoSlots: ReceiveSlot[] = [];
@@ -187,9 +187,17 @@ describe('ReceiveSlotManager', () => {
 
       assert.strictEqual(fakeReceiveSlots.length, audioSlots.length + videoSlots.length);
 
-      fakeReceiveSlots.forEach(slot => {
+      fakeReceiveSlots.forEach((slot) => {
         assert.calledOnce(slot.findMemberId);
       });
+    });
+  });
+
+  describe('findReceiveSlotBySsrc', () => {
+    it('finds a receive slot with a specific id', async () => {
+      await receiveSlotManager.allocateSlot(MediaType.VideoMain);
+      assert.exists(receiveSlotManager.findReceiveSlotBySsrc(1));
+      assert.strictEqual(receiveSlotManager.findReceiveSlotBySsrc(2), undefined);
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -53,7 +53,12 @@ describe('plugin-meetings', () => {
       beforeEach(() => {
         const networkQualityMonitor = new NetworkQualityMonitor(initialConfig);
 
-        statsAnalyzer = new StatsAnalyzer(initialConfig, networkQualityMonitor, defaultStats);
+        statsAnalyzer = new StatsAnalyzer(
+          initialConfig,
+          () => ({}),
+          networkQualityMonitor,
+          defaultStats
+        );
 
         sandBoxSpy = sandbox.spy(
           statsAnalyzer.networkQualityMonitor,
@@ -188,7 +193,7 @@ describe('plugin-meetings', () => {
 
         networkQualityMonitor = new NetworkQualityMonitor(initialConfig);
 
-        statsAnalyzer = new StatsAnalyzer(initialConfig, networkQualityMonitor);
+        statsAnalyzer = new StatsAnalyzer(initialConfig, () => ({}), networkQualityMonitor);
 
         statsAnalyzer.on(EVENTS.LOCAL_MEDIA_STARTED, (data) => {
           receivedEventsData.local.started = data;


### PR DESCRIPTION
## This pull request addresses

A log message not having a receive slot or csi to which it corresponds.

## by making the following changes

Adding a receive slot lookup callback to the `StatsAnalyzer` to find a Receive Slot from an ssrc.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
