### PR TITLE
fix(plugin-meetings): check if joinedWith exists in changedSelf

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
@@ -294,6 +294,7 @@ SelfUtils.getStatus = (status) => ({
 SelfUtils.wasMediaInactiveOrReleased = (oldSelf: any = {}, changedSelf: any) =>
   oldSelf.joinedWith &&
   oldSelf.joinedWith.state === _JOINED_ &&
+  changedSelf.joinedWith &&
   changedSelf.joinedWith.state === _LEFT_ &&
   (changedSelf.joinedWith.reason === MEETING_END_REASON.INACTIVE ||
     changedSelf.joinedWith.reason === MEETING_END_REASON.MEDIA_RELEASED);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-412189](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-412189)

## This pull request addresses

The ExtCare customer is trying to join the meeting without having a gap for the media to be attached to the locus and that caused both of the users to be stuck in the waiting room.

## by making the following changes

This PR fixes the above issue by waiting for the locus event to be complete and then proceed with syncMeetings. 

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
