### PR TITLE
feat(editdisplayname): updated locus event emitter handlers

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -336,6 +336,7 @@ export const EVENT_TRIGGERS = {
   MEETING_SELF_LEFT: 'meeting:self:left',
   NETWORK_QUALITY: 'network:quality',
   MEDIA_NEGOTIATED: 'media:negotiated',
+  MEETING_SELF_PERSON_NAME_UPDATED: 'meeting:selfPersonNameUpdated',
   // the following events apply only to multistream media connections
   ACTIVE_SPEAKER_CHANGED: 'media:activeSpeakerChanged',
   REMOTE_VIDEO_SOURCE_COUNT_CHANGED: 'media:remoteVideoSourceCountChanged',
@@ -605,6 +606,7 @@ export const LOCUSINFO = {
     MEDIA_INACTIVITY: 'MEDIA_INACTIVITY',
     LINKS_SERVICES: 'LINKS_SERVICES',
     SELF_MODERATOR_OR_COHOST_UPGRADE: 'SELF_MODERATOR_OR_COHOST_UPGRADE',
+    SELF_PERSON_NAME_UPDATED: 'SELF_PERSON_NAME_UPDATED',
   },
 };
 

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -1268,6 +1268,17 @@ export default class LocusInfo extends EventsScope {
           }
         );
       }
+      // When the display name of participant's are changed
+      if (parsedSelves.updates.personNameChanged) {
+        this.emitScoped(
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.SELF_PERSON_NAME_UPDATED,
+          {personName: parsedSelves.current.personName, moderator: parsedSelves.current.moderator}
+        );
+      }
 
       if (parsedSelves.updates.isUserObserving) {
         this.emitScoped(

--- a/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
@@ -65,6 +65,7 @@ SelfUtils.parse = (self: any, deviceId: string) => {
       isSharingBlocked: SelfUtils.isSharingBlocked(self),
       breakoutSessions: SelfUtils.getBreakoutSessions(self),
       breakout: SelfUtils.getBreakout(self),
+      personName: SelfUtils.getPersonName(self),
     };
   }
 
@@ -125,6 +126,7 @@ SelfUtils.getSelves = (oldSelf, newSelf, deviceId) => {
     previous?.canNotViewTheParticipantList !== current.canNotViewTheParticipantList;
   updates.isSharingBlockedChanged = previous?.isSharingBlocked !== current.isSharingBlocked;
   updates.breakoutsChanged = SelfUtils.breakoutsChanged(previous, current);
+  updates.personNameChanged = previous?.personName !== current?.personName;
 
   return {
     previous,
@@ -132,6 +134,13 @@ SelfUtils.getSelves = (oldSelf, newSelf, deviceId) => {
     updates,
   };
 };
+
+/**
+ * To get the updated participant display name in the meeting
+ * @param {Object} self
+ * @returns {string} participant's name
+ */
+SelfUtils.getPersonName = (self: any) => self?.person?.name;
 
 /**
  * Checks if user has joined the meeting

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -2655,6 +2655,20 @@ export default class Meeting extends StatelessWebexPlugin {
         }
       );
     });
+
+    this.locusInfo.on(LOCUSINFO.EVENTS.SELF_PERSON_NAME_UPDATED, (payload) => {
+      Trigger.trigger(
+        this,
+        {
+          file: 'meeting/index',
+          function: 'setUpLocusInfoSelfListener',
+        },
+        EVENT_TRIGGERS.MEETING_SELF_PERSON_NAME_UPDATED,
+        {
+          payload,
+        }
+      );
+    });
   }
 
   /**


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-423148

## This pull request addresses
Whenever participants display name is changed, it emits display hints which is listened in Cantina.

## by making the following changes

< DESCRIBE YOUR CHANGES >

![Screenshot 2023-04-21 at 2 36 16 PM](https://user-images.githubusercontent.com/11624479/233738375-cb1d572f-d6c8-44cf-bb37-1f95d53f5237.png)

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
