### PR TITLE
fix(http-core): update qs version to fix vulnerability

### DIFF
--- a/packages/@webex/http-core/package.json
+++ b/packages/@webex/http-core/package.json
@@ -49,7 +49,7 @@
     "is-function": "^1.0.1",
     "lodash": "^4.17.21",
     "parse-headers": "^2.0.2",
-    "qs": "^6.7.0",
+    "qs": "^6.7.3",
     "request": "^2.88.0",
     "safe-buffer": "^5.2.0",
     "xtend": "^4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5002,7 +5002,7 @@ __metadata:
     lodash: ^4.17.21
     parse-headers: ^2.0.2
     prettier: ^2.7.1
-    qs: ^6.7.0
+    qs: ^6.7.3
     request: ^2.88.0
     safe-buffer: ^5.2.0
     sinon: ^9.2.4
@@ -21266,7 +21266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.11.0, qs@npm:^6.5.1, qs@npm:^6.7.0":
+"qs@npm:6.11.0, qs@npm:^6.5.1":
   version: 6.11.0
   resolution: "qs@npm:6.11.0"
   dependencies:
@@ -21279,6 +21279,15 @@ __metadata:
   version: 6.9.7
   resolution: "qs@npm:6.9.7"
   checksum: 5bbd263332ccf320a1f36d04a2019a5834dc20bcb736431eaccde2a39dcba03fb26d2fd00174f5d7bc26aaad1cad86124b18440883ac042ea2a0fca6170c1bf1
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.7.3":
+  version: 6.11.1
+  resolution: "qs@npm:6.11.1"
+  dependencies:
+    side-channel: ^1.0.4
+  checksum: 82ee78ef12a16f3372fae5b64f76f8aedecb000feea882bbff1af146c147f6eb66b08f9c3f34d7e076f28563586956318b9b2ca41141846cdd6d5ad6f241d52f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES #[SPARK-398773](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-398773)

## This pull request addresses 

Fixes a vulnerability issue in the qs npm dependency. [CVE-2022-24999](https://nvd.nist.gov/vuln/detail/CVE-2022-24999)

## by making the following changes

Upgrading the qs value in http-core package to the latest value


### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [] I have updated the documentation accordingly

---