### PR TITLE
fix: reconnection fails when TURN discovery is skipped because of rea…

### DIFF
--- a/packages/@webex/plugin-meetings/src/roap/index.ts
+++ b/packages/@webex/plugin-meetings/src/roap/index.ts
@@ -199,19 +199,23 @@ export default class Roap extends StatelessWebexPlugin {
     // When reconnecting, it's important that the first roap message being sent out has empty media id.
     // Normally this is the roap offer, but when TURN discovery is enabled,
     // then this is the TURN discovery request message
-    const sendEmptyMediaId = reconnect && !meeting.config.experimental.enableTurnDiscovery;
+    return this.turnDiscovery
+      .isSkipped(meeting)
+      .then((isTurnDiscoverySkipped) => {
+        const sendEmptyMediaId = reconnect && isTurnDiscoverySkipped;
 
-    return this.roapRequest
-      .sendRoap({
-        roapMessage,
-        correlationId: meeting.correlationId,
-        locusSelfUrl: meeting.selfUrl,
-        mediaId: sendEmptyMediaId ? '' : meeting.mediaId,
-        audioMuted: meeting.audio?.isLocallyMuted(),
-        videoMuted: meeting.video?.isLocallyMuted(),
-        meetingId: meeting.id,
-        preferTranscoding: !meeting.isMultistream,
+        return this.roapRequest.sendRoap({
+          roapMessage,
+          correlationId: meeting.correlationId,
+          locusSelfUrl: meeting.selfUrl,
+          mediaId: sendEmptyMediaId ? '' : meeting.mediaId,
+          audioMuted: meeting.audio?.isLocallyMuted(),
+          videoMuted: meeting.video?.isLocallyMuted(),
+          meetingId: meeting.id,
+          preferTranscoding: !meeting.isMultistream,
+        });
       })
+
       .then(({locus, mediaConnections}) => {
         if (mediaConnections) {
           meeting.updateMediaConnections(mediaConnections);

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
@@ -54,6 +54,7 @@ describe('Roap', () => {
         },
         setRoapSeq: sinon.stub(),
         config: {experimental: {enableTurnDiscovery: false}},
+        webex: { meetings: { reachability: { isAnyClusterReachable: () => true}}},
       };
 
       sendRoapStub = sinon.stub(RoapRequest.prototype, 'sendRoap').resolves({});
@@ -65,19 +66,19 @@ describe('Roap', () => {
     });
 
     [
-      {reconnect: true, enableTurnDiscovery: true, expectEmptyMediaId: false},
-      {reconnect: true, enableTurnDiscovery: false, expectEmptyMediaId: true},
-      {reconnect: false, enableTurnDiscovery: true, expectEmptyMediaId: false},
-      {reconnect: false, enableTurnDiscovery: false, expectEmptyMediaId: false},
-    ].forEach(({reconnect, enableTurnDiscovery, expectEmptyMediaId}) =>
+      {reconnect: true, turnDiscoverySkipped: false, expectEmptyMediaId: false},
+      {reconnect: true, turnDiscoverySkipped: true, expectEmptyMediaId: true},
+      {reconnect: false, turnDiscoverySkipped: false, expectEmptyMediaId: false},
+      {reconnect: false, turnDiscoverySkipped: true, expectEmptyMediaId: false},
+    ].forEach(({reconnect, turnDiscoverySkipped, expectEmptyMediaId}) =>
       it(`sends roap OFFER with ${expectEmptyMediaId ? 'empty ' : ''}mediaId when ${
         reconnect ? '' : 'not '
       }reconnecting and TURN discovery is ${
-        enableTurnDiscovery ? 'enabled' : 'disabled'
+        turnDiscoverySkipped ? 'skipped' : 'not skipped'
       }`, async () => {
-        meeting.config.experimental.enableTurnDiscovery = enableTurnDiscovery;
-
         const roap = new Roap({}, {parent: 'fake'});
+
+        sinon.stub(roap.turnDiscovery, 'isSkipped').resolves(turnDiscoverySkipped);
 
         await roap.sendRoapMediaRequest({
           meeting,

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -367,6 +367,27 @@ describe('TurnDiscovery', () => {
     });
   });
 
+  describe('isSkipped', () => {
+    [
+      {enabledInConfig: true, isAnyClusterReachable: true, expectedIsSkipped: true},
+      {enabledInConfig: true, isAnyClusterReachable: false, expectedIsSkipped: false},
+      {enabledInConfig: false, isAnyClusterReachable: true, expectedIsSkipped: true},
+      {enabledInConfig: false, isAnyClusterReachable: false, expectedIsSkipped: true},
+    ].forEach(({enabledInConfig, isAnyClusterReachable, expectedIsSkipped}) => {
+      it(`returns ${expectedIsSkipped} when TURN discovery is ${enabledInConfig ? '' : 'not '} enabled in config and isAnyClusterReachable() returns ${isAnyClusterReachable ? 'true' : 'false'}`, async () => {
+        testMeeting.config.experimental.enableTurnDiscovery = enabledInConfig;
+
+        sinon.stub(testMeeting.webex.meetings.reachability, 'isAnyClusterReachable').resolves(isAnyClusterReachable);
+
+        const td = new TurnDiscovery(mockRoapRequest);
+
+        const isSkipped = await td.isSkipped(testMeeting);
+
+        assert.equal(isSkipped, expectedIsSkipped);
+      })
+    })
+  })
+
   describe('handleTurnDiscoveryResponse', () => {
     it("doesn't do anything if turn discovery was not started", () => {
       const td = new TurnDiscovery(mockRoapRequest);


### PR DESCRIPTION
# COMPLETES #[SPARK-424966](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-424966)

## This pull request addresses

When TURN discovery was enabled in config and reachability returned some successful connections SDK was not sending the Roap message with empty mediaId on reconnection. This resulted in Locus not recreating a confluence and as a result Homer would not accept a new DTLS connection, so the reconnection was stuck in "connecting" forever.

## by making the following changes

Made sure that when Roap checks if TURN discovery is being done or not it checks all the conditions and not just the config.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

manually tested end2end with sample app + unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
