### PR TITLE
fix: default bundle policy from WCME not applied

### DIFF
--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -19,6 +19,8 @@ import BrowserDetection from '../common/browser-detection';
 
 const {isBrowser} = BrowserDetection();
 
+type MultistreamConnectionConfig = ConstructorParameters<typeof MultistreamRoapMediaConnection>[0];
+
 export type BundlePolicy = ConstructorParameters<
   typeof MultistreamRoapMediaConnection
 >[0]['bundlePolicy'];
@@ -166,17 +168,19 @@ Media.createMediaConnection = (
   }
 
   if (isMultistream) {
-    return new MultistreamRoapMediaConnection(
-      {
-        iceServers,
-        enableMainAudio:
-          mediaProperties.mediaDirection?.sendAudio || mediaProperties.mediaDirection?.receiveAudio,
-        enableMainVideo:
-          mediaProperties.mediaDirection?.sendVideo || mediaProperties.mediaDirection?.receiveVideo,
-        bundlePolicy,
-      },
-      debugId
-    );
+    const config: MultistreamConnectionConfig = {
+      iceServers,
+      enableMainAudio:
+        mediaProperties.mediaDirection?.sendAudio || mediaProperties.mediaDirection?.receiveAudio,
+      enableMainVideo:
+        mediaProperties.mediaDirection?.sendVideo || mediaProperties.mediaDirection?.receiveVideo,
+    };
+
+    if (bundlePolicy) {
+      config.bundlePolicy = bundlePolicy;
+    }
+
+    return new MultistreamRoapMediaConnection(config, debugId);
   }
 
   if (!mediaProperties) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
@@ -170,7 +170,6 @@ describe('createMediaConnection', () => {
           iceServers: [],
           enableMainAudio,
           enableMainVideo,
-          bundlePolicy: undefined,
         },
         'some debug id'
       );
@@ -201,10 +200,39 @@ describe('createMediaConnection', () => {
         iceServers: [],
         enableMainAudio: true,
         enableMainVideo: true,
-        bundlePolicy: undefined,
       },
       'debug string'
     );
+
+    it('does not pass bundlePolicy to MultistreamRoapMediaConnection if bundlePolicy is undefined', () => {
+      const multistreamRoapMediaConnectionConstructorStub = sinon
+        .stub(internalMediaModule, 'MultistreamRoapMediaConnection')
+        .returns(fakeRoapMediaConnection);
+  
+      Media.createMediaConnection(true, 'debug string', {
+        mediaProperties: {
+          mediaDirection: {
+            sendAudio: true,
+            sendVideo: true,
+            sendShare: false,
+            receiveAudio: true,
+            receiveVideo: true,
+            receiveShare: true,
+          },
+        },
+        bundlePolicy: undefined
+      });
+      assert.calledOnce(multistreamRoapMediaConnectionConstructorStub);
+      assert.calledWith(
+        multistreamRoapMediaConnectionConstructorStub,
+        {
+          iceServers: [],
+          enableMainAudio: true,
+          enableMainVideo: true,
+        },
+        'debug string'
+      );
+    });
   });
 
   it('passes empty ICE servers array to RoapMediaConnection if turnServerInfo is undefined (multistream disabled)', () => {


### PR DESCRIPTION
## This pull request addresses

WCME has a default value for bundle policy, but that value is not being used, because SDK is explicitly setting it to undefined

## by making the following changes

Avoid passing bundle policy as undefined

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
