### PR TITLE
feat(plugin-rooms): get meeting details for a room

### DIFF
--- a/packages/@webex/plugin-rooms/src/rooms.js
+++ b/packages/@webex/plugin-rooms/src/rooms.js
@@ -334,7 +334,7 @@ const Rooms = WebexPlugin.extend({
     })
       .then((res) => res.body)
       .catch((res) => {
-        if (res.statusCode === 403 && res.body.message.endsWith('announcement only space.')) {
+        if (res.statusCode === 403 && res.body?.message?.endsWith('announcement only space.')) {
           return Promise.resolve(undefined);
         }
 

--- a/packages/@webex/plugin-rooms/src/rooms.js
+++ b/packages/@webex/plugin-rooms/src/rooms.js
@@ -306,8 +306,8 @@ const Rooms = WebexPlugin.extend({
         .then((convo) => buildRoomInfo(this.webex, convo))
     );
   },
-  
-    /**
+
+  /**
    * Returns a room's meeting details.
    * @instance
    * @memberof Rooms
@@ -334,12 +334,12 @@ const Rooms = WebexPlugin.extend({
     })
       .then((res) => res.body)
       .catch((res) => {
-          if (res.statusCode === 403 && res.body.message.endsWith('announcement only space.')) {
-            return Promise.resolve(undefined);
-          }
+        if (res.statusCode === 403 && res.body.message.endsWith('announcement only space.')) {
+          return Promise.resolve(undefined);
+        }
 
-          return Promise.reject(res);
-        });
+        return Promise.reject(res);
+      });
   },
 
   /**

--- a/packages/@webex/plugin-rooms/src/rooms.js
+++ b/packages/@webex/plugin-rooms/src/rooms.js
@@ -312,7 +312,7 @@ const Rooms = WebexPlugin.extend({
    * @instance
    * @memberof Rooms
    * @param {RoomObject|string} room
-   * @returns {Promise<RoomMeetingDetailsObject>}
+   * @returns {Promise<RoomMeetingDetailsObject>|Promise<undefined>}
    * @example
    * webex.rooms.create({title: 'Get Room Meeting Details Example'})
    *   .then(function(room) {

--- a/packages/@webex/plugin-rooms/test/integration/spec/rooms.js
+++ b/packages/@webex/plugin-rooms/test/integration/spec/rooms.js
@@ -422,6 +422,44 @@ describe('plugin-rooms', function () {
             assert.instanceOf(reason, WebexHttpError.NotFound);
           }));
     });
+
+    describe('#getMeetingDetails()', () => {
+      let room0, room1, room;
+
+      beforeEach(() =>
+        Promise.all([
+          webex.rooms.create({title: 'Webex Test Room'})
+            .then((r) => webex.rooms.getMeetingDetails(r))
+            .then((roomMeetingDetails) => {
+              room0 = roomMeetingDetails
+            }),
+          webex.rooms.create({title: 'Webex Test Announcement Room', isAnnouncementOnly: true})
+            .then((r) => {
+              room = r
+              return webex.rooms.getMeetingDetails(r)
+            })
+            .then((roomMeetingDetails) => {
+              room1 = roomMeetingDetails;
+          }),
+        ])
+      );
+
+      it("retrieves a specific room's meeting details", () =>
+        webex.rooms.get(room0.id)
+          .then((r) => webex.rooms.getMeetingDetails(r))
+          .then((r) => {
+            assert.equal(r.id, room0.id);
+            assert.equal(r.meetingLink, room0.meetingLink);
+          }));
+
+      it("returns undefined for announcement only rooms", () =>
+        webex.rooms.getMeetingDetails(room)
+          .then((r) => {
+            assert.equal(r, undefined);
+            assert.equal(room1, undefined);
+            assert.equal(room.isAnnouncementOnly, true);
+          }));
+    });
   });
 });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES N/A

## This pull request addresses

Adds the ability to get a room's meeting information.

## by making the following changes

Uses the public API (hydra) [`rooms/{roomId}/meetingInfo`](https://developer.webex.com/docs/api/v1/rooms/get-room-meeting-details) endpoint to get the details.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
