### PR TITLE
perf(internal-plugin-calendar): remove meaningless remote calls to improve performance

### DIFF
--- a/packages/@webex/internal-plugin-calendar/src/calendar.js
+++ b/packages/@webex/internal-plugin-calendar/src/calendar.js
@@ -362,14 +362,6 @@ const Calendar = WebexPlugin.extend({
         const promises = [];
 
         meetingObjects.forEach((meeting) => {
-          if (!meeting.encryptedNotes) {
-            promises.push(
-              this.getNotes(meeting.id).then((notesResponse) => {
-                meeting.encryptedNotes = notesResponse.body && notesResponse.body.encryptedNotes;
-              })
-            );
-          }
-
           if (!meeting.encryptedParticipants) {
             promises.push(
               this.getParticipants(meeting.id).then((notesResponse) => {

--- a/packages/@webex/internal-plugin-calendar/test/unit/spec/calendar.js
+++ b/packages/@webex/internal-plugin-calendar/test/unit/spec/calendar.js
@@ -211,18 +211,6 @@ describe('internal-plugin-calendar', () => {
                 },
               })
             );
-          // getNotes stub
-          webexRequestStub
-            .withArgs({
-              method: 'GET',
-              service: 'calendar',
-              resource: `calendarEvents/${base64.encode('calendar1')}/notes`,
-            })
-            .returns(
-              Promise.resolve({
-                body: null,
-              })
-            );
 
           // Assign webexRequestStub to webex.request
           webex.request = webexRequestStub;
@@ -231,7 +219,7 @@ describe('internal-plugin-calendar', () => {
 
           assert.equal(res.length, 2);
           assert.deepEqual(res, [
-            {id: 'calendar1', encryptedNotes: null, encryptedParticipants: ['participant1']},
+            {id: 'calendar1', encryptedParticipants: ['participant1']},
             {id: 'calendar2', encryptedNotes: 'notes2', encryptedParticipants: ['participant2']},
           ]);
           assert.calledWith(webex.request, {
@@ -239,11 +227,6 @@ describe('internal-plugin-calendar', () => {
             service: 'calendar',
             resource: 'calendarEvents',
             qs: {fromDate: 'xx-xx', toDate: 'xx-nn'},
-          });
-          assert.calledWith(webex.request, {
-            method: 'GET',
-            service: 'calendar',
-            resource: `calendarEvents/${base64.encode('calendar1')}/notes`,
           });
         });
 
@@ -262,27 +245,13 @@ describe('internal-plugin-calendar', () => {
               Promise.resolve({
                 body: {
                   items: [
-                    {id: 'calendar1', encryptedParticipants: ['participant1']},
+                    {id: 'calendar1', encryptedNotes: 'notes1', encryptedParticipants: ['participant1']},
                     {
                       id: 'calendar2',
                       encryptedNotes: 'notes2',
                       encryptedParticipants: ['participant2'],
                     },
                   ],
-                },
-              })
-            );
-          // getNotes stub
-          webexRequestStub
-            .withArgs({
-              method: 'GET',
-              service: 'calendar',
-              resource: `calendarEvents/${base64.encode('calendar1')}/notes`,
-            })
-            .returns(
-              Promise.resolve({
-                body: {
-                  encryptedNotes: 'notes1',
                 },
               })
             );
@@ -302,11 +271,6 @@ describe('internal-plugin-calendar', () => {
             service: 'calendar',
             resource: 'calendarEvents',
             qs: {fromDate: 'xx-xx', toDate: 'xx-nn'},
-          });
-          assert.calledWith(webex.request, {
-            method: 'GET',
-            service: 'calendar',
-            resource: `calendarEvents/${base64.encode('calendar1')}/notes`,
           });
         });
       });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-425801

## This pull request addresses

Originally, the list(...) API will return a list of calendar events, for each calendar event, if it does not return notes data, it will send out a new API call to get notes for that calendar event.

The api call to get notes separately in above list(...) API is meaningless because if a calendar event has notes, the notes will be returned in list API. This implementation will cause performance issue.

## by making the following changes

Remove meaningless API calls of fetching notes separately.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Test it manually on web page, and run unit test to cover it automatically.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
