### PR TITLE
fix(CA): fix call analyzer event relative issues

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -353,6 +353,7 @@ export const MEETING_REMOVED_REASON = {
   FULLSTATE_REMOVED: 'FULLSTATE_REMOVED', // meeting got dropped ? not sure
   MEETING_INACTIVE_TERMINATING: 'MEETING_INACTIVE_TERMINATING', // Meeting got ended or everyone left the meeting
   CLIENT_LEAVE_REQUEST: 'CLIENT_LEAVE_REQUEST', // You triggered leave meeting
+  CLIENT_LEAVE_REQUEST_TAB_CLOSED: 'CLIENT_LEAVE_REQUEST_TAB_CLOSED', // You triggered leave meeting, such as closing the browser tab directly
   USER_ENDED_SHARE_STREAMS: 'USER_ENDED_SHARE_STREAMS', // user triggered stop share
   NO_MEETINGS_TO_SYNC: 'NO_MEETINGS_TO_SYNC', // After the syncMeeting no meeting exists
   MEETING_CONNECTION_FAILED: 'MEETING_CONNECTION_FAILED', // meeting failed to connect due to ice failures or firewall issue
@@ -733,6 +734,7 @@ export const DISPLAY_HINTS = {
 export const SELF_ROLES = {
   COHOST: 'COHOST',
   MODERATOR: 'MODERATOR',
+  ATTENDEE: 'ATTENDEE',
 };
 
 export const MEETING_STATE = {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -76,6 +76,7 @@ import {
   VIDEO,
   BNR_STATUS,
   HTTP_VERBS,
+  SELF_ROLES,
 } from '../constants';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import ParameterError from '../common/errors/parameter';
@@ -463,12 +464,12 @@ export default class Meeting extends StatelessWebexPlugin {
   statsAnalyzer: StatsAnalyzer;
   transcription: Transcription;
   updateMediaConnections: (mediaConnections: any[]) => void;
-  endCallInitiateJoinReq: any;
+  endCallInitJoinReq: any;
   endJoinReqResp: any;
   endLocalSDPGenRemoteSDPRecvDelay: any;
   joinedWith: any;
   locusId: any;
-  startCallInitiateJoinReq: any;
+  startCallInitJoinReq: any;
   startJoinReqResp: any;
   startLocalSDPGenRemoteSDPRecvDelay: any;
   wirelessShare: any;
@@ -481,7 +482,8 @@ export default class Meeting extends StatelessWebexPlugin {
   resourceUrl: string;
   selfId: string;
   state: any;
-
+  roles: any[];
+  environment: string;
   namespace = MEETINGS;
 
   /**
@@ -1447,12 +1449,12 @@ export default class Meeting extends StatelessWebexPlugin {
         };
       }
 
-      const callInitiateJoinReq = this.getCallInitiateJoinReq();
+      const callInitJoinReq = this.getCallInitJoinReq();
 
-      if (callInitiateJoinReq) {
+      if (callInitJoinReq) {
         options.joinTimes = {
           ...options.joinTimes,
-          callInitiateJoinReq,
+          callInitJoinReq,
         };
       }
 
@@ -1465,13 +1467,29 @@ export default class Meeting extends StatelessWebexPlugin {
         };
       }
 
-      const getTotalJmt = this.getTotalJmt();
+      const totalJmt = this.getTotalJmt();
 
-      if (getTotalJmt) {
+      if (totalJmt) {
         options.joinTimes = {
           ...options.joinTimes,
-          getTotalJmt,
+          totalJmt,
         };
+      }
+
+      const curUserType = this.getCurUserType();
+
+      if (curUserType) {
+        options.userType = curUserType;
+      }
+
+      const curLoginType = this.getCurLoginType();
+
+      if (curLoginType) {
+        options.loginType = curLoginType;
+      }
+
+      if (this.environment) {
+        options.environment = this.environment;
       }
 
       if (options.type === MQA_STATS.CA_TYPE) {
@@ -2656,6 +2674,8 @@ export default class Meeting extends StatelessWebexPlugin {
         webexMeetingInfo?.hostId ||
         this.owner;
       this.permissionToken = webexMeetingInfo?.permissionToken;
+      // Need to populate environment when sending CA event
+      this.environment = locusMeetingObject?.info.channel || webexMeetingInfo?.channel;
     }
   }
 
@@ -5285,7 +5305,14 @@ export default class Meeting extends StatelessWebexPlugin {
       data: {trigger: trigger.USER_INTERACTION, canProceed: false},
     });
     const leaveReason = options.reason || MEETING_REMOVED_REASON.CLIENT_LEAVE_REQUEST;
-
+    // add
+    if (leaveReason === MEETING_REMOVED_REASON.CLIENT_LEAVE_REQUEST_TAB_CLOSED) {
+      Metrics.postEvent({
+        event: eventType.LEAVE,
+        meeting: this,
+        data: {reason: leaveReason},
+      });
+    }
     LoggerProxy.logger.log('Meeting:index#leave --> Leaving a meeting');
 
     return MeetingUtil.leaveMeeting(this, options)
@@ -6184,29 +6211,31 @@ export default class Meeting extends StatelessWebexPlugin {
    *
    * @returns {undefined}
    */
-  setStartCallInitiateJoinReq() {
-    this.startCallInitiateJoinReq = performance.now();
-    this.endCallInitiateJoinReq = undefined;
+  setStartCallInitJoinReq() {
+    this.startCallInitJoinReq = performance.now();
+    this.endCallInitJoinReq = undefined;
   }
 
   /**
    *
    * @returns {undefined}
    */
-  setEndCallInitiateJoinReq() {
-    this.endCallInitiateJoinReq = performance.now();
+  setEndCallInitJoinReq() {
+    this.endCallInitJoinReq = performance.now();
   }
 
   /**
    *
    * @returns {string} duration between call initiate and sending join request to locus
    */
-  getCallInitiateJoinReq() {
-    const start = this.startCallInitiateJoinReq;
-    const end = this.endCallInitiateJoinReq;
+  getCallInitJoinReq() {
+    const start = this.startCallInitJoinReq;
+    const end = this.endCallInitJoinReq;
 
     if (start && end) {
-      const calculatedDelay = end - start;
+      let calculatedDelay = Math.round(end - start);
+
+      calculatedDelay = calculatedDelay < 0 ? 0 : calculatedDelay;
 
       return calculatedDelay > METRICS_JOIN_TIMES_MAX_DURATION ? undefined : calculatedDelay;
     }
@@ -6240,7 +6269,7 @@ export default class Meeting extends StatelessWebexPlugin {
     const end = this.endJoinReqResp;
 
     if (start && end) {
-      const calculatedDelay = end - start;
+      const calculatedDelay = Math.round(end - start);
 
       return calculatedDelay > METRICS_JOIN_TIMES_MAX_DURATION ? undefined : calculatedDelay;
     }
@@ -6253,10 +6282,44 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {string} duration between call initiate and successful locus join (even if it is in lobby)
    */
   getTotalJmt() {
-    const start = this.startCallInitiateJoinReq;
+    const start = this.startCallInitJoinReq;
     const end = this.endJoinReqResp;
 
-    return start && end ? end - start : undefined;
+    return start && end ? Math.round(end - start) : undefined;
+  }
+
+  /**
+   *
+   * @returns {string} one of 'attendee','host','cohost', returns the user type of the current user
+   */
+  getCurUserType() {
+    const {roles} = this;
+    if (roles) {
+      if (roles.includes(SELF_ROLES.MODERATOR)) {
+        return 'host';
+      }
+      if (roles.includes(SELF_ROLES.COHOST)) {
+        return 'cohost';
+      }
+      if (roles.includes(SELF_ROLES.ATTENDEE)) {
+        return 'attendee';
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   *
+   * @returns {string} one of 'login-ci','unverified-guest', returns the login type of the current user
+   */
+  getCurLoginType() {
+    const isGuest = this.guest;
+    if (isGuest !== null) {
+      return isGuest ? 'unverified-guest' : 'login-ci';
+    }
+
+    return null;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/metrics/index.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/index.ts
@@ -33,10 +33,10 @@ const anonymizeIPAddress = (localIp) => anonymize(localIp, 28, 96);
 const triggerTimers = ({event, meeting, data}) => {
   switch (event) {
     case eventType.CALL_INITIATED:
-      meeting.setStartCallInitiateJoinReq();
+      meeting.setStartCallInitJoinReq();
       break;
     case eventType.LOCUS_JOIN_REQUEST:
-      meeting.setEndCallInitiateJoinReq();
+      meeting.setEndCallInitJoinReq();
       meeting.setStartJoinReqResp();
       break;
     case eventType.LOCUS_JOIN_RESPONSE:
@@ -191,6 +191,9 @@ class Metrics {
         name: 'endpoint',
         networkType: 'unknown',
         userAgent: this.userAgentToString(),
+        userType: options.userType,
+        loginType: options.loginType,
+        channel: options.channel,
         clientInfo: {
           clientType: options.clientType,
           clientVersion: `${CLIENT_NAME}/${this.webex.version}`,
@@ -458,7 +461,7 @@ class Metrics {
       };
 
       if (err && err.body) {
-        errorPayload.errorData = err.body;
+        errorPayload.errorData = new Error(err.body);
       }
 
       if (err && err.statusCode) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -19,7 +19,7 @@ import {
   EVENT_TRIGGERS,
   _SIP_URI_,
   _MEETING_ID_,
-  LOCUSINFO,
+  LOCUSINFO, MEETING_REMOVED_REASON,
 } from '@webex/plugin-meetings/src/constants';
 import * as StatsAnalyzerModule from '@webex/plugin-meetings/src/statsAnalyzer';
 import EventsScope from '@webex/plugin-meetings/src/common/events/events-scope';
@@ -1476,7 +1476,21 @@ describe('plugin-meetings', () => {
             correlationId: meeting.correlationId,
             selfId: meeting.selfId,
             resourceId: meeting.resourceId,
+            deviceUrl: meeting.deviceUrl
+          });
+        });
+        it('should leave the meeting on the resource with reason', async () => {
+          const leave = meeting.leave({resourceId: meeting.resourceId, reason: MEETING_REMOVED_REASON.CLIENT_LEAVE_REQUEST});
+
+          assert.exists(leave.then);
+          await leave;
+          assert.calledWith(meeting.meetingRequest.leaveMeeting, {
+            locusUrl: meeting.locusUrl,
+            correlationId: meeting.correlationId,
+            selfId: meeting.selfId,
+            resourceId: meeting.resourceId,
             deviceUrl: meeting.deviceUrl,
+            reason: MEETING_REMOVED_REASON.CLIENT_LEAVE_REQUEST
           });
         });
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1472,51 +1472,5 @@ describe('plugin-meetings', () => {
       });
     });
 
-  //   it('userType & userLogin testing for CA data', async () => {
-  //     const FAKE_LOCUS_MEETING = {
-  //       conversationUrl: 'locusConvURL',
-  //       url: 'locusUrl',
-  //       info: {
-  //         webExMeetingId: 'locusMeetingId',
-  //         sipUri: 'locusSipUri',
-  //         owner: 'locusOwner',
-  //       },
-  //       meeting: {
-  //         startTime: "",
-  //       },
-  //       fullState: {
-  //         active: false,
-  //       },
-  //     };
-  //
-  //     const meeting = await webex.meetings.createMeeting(
-  //       FAKE_LOCUS_MEETING,
-  //       'test type',
-  //       true
-  //     );
-  //     meeting.roles = ['MODERATOR','COHOST','ATTENDEE'];
-  //     meeting.guest = true;
-  //     const options = {
-  //       event: 'event',
-  //       trackingId: 'trackingId',
-  //       locus: {},
-  //       mediaConnections: null,
-  //       errors: {}
-  //     };
-  //     webex.internal.services.get = sinon.stub();
-  //     meeting.getAnalyzerMetricsPrePayload(options);
-  //     assert.equal(options.userType, 'host');
-  //     assert.equal(options.loginType, 'unverified-guest');
-  //     meeting.roles = ['COHOST','ATTENDEE'];
-  //     meeting.guest = false;
-  //     meeting.getAnalyzerMetricsPrePayload(options);
-  //     assert.equal(options.userType, 'cohost');
-  //     assert.equal(options.loginType, 'login-ci');
-  //     meeting.roles = ['ATTENDEE'];
-  //     meeting.getAnalyzerMetricsPrePayload(options);
-  //     assert.equal(options.userType, 'attendee');
-  //   });
-  // });
-
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1371,5 +1371,152 @@ describe('plugin-meetings', () => {
         );
       });
     });
+
+    describe('#getAnalyzerMetricsPrePayload', () => {
+      it('userType & userLogin & environment testing for CA data', async () => {
+        const FAKE_LOCUS_MEETING = {
+          conversationUrl: 'locusConvURL',
+          url: 'locusUrl',
+          info: {
+            webExMeetingId: 'locusMeetingId',
+            sipUri: 'locusSipUri',
+            owner: 'locusOwner',
+          },
+          meeting: {
+            startTime: "",
+          },
+          fullState: {
+            active: false,
+          },
+        };
+
+        const meeting = await webex.meetings.createMeeting(
+          FAKE_LOCUS_MEETING,
+          'test type',
+          true
+        );
+        meeting.roles = ['MODERATOR','COHOST','ATTENDEE'];
+        meeting.guest = true;
+        const options = {
+          event: 'event',
+          trackingId: 'trackingId',
+          locus: {},
+          mediaConnections: null,
+          errors: {}
+        };
+        webex.internal.services.get = sinon.stub();
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.userType, 'host');
+        assert.equal(options.loginType, 'unverified-guest');
+        meeting.roles = ['COHOST','ATTENDEE'];
+        meeting.guest = false;
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.userType, 'cohost');
+        assert.equal(options.loginType, 'login-ci');
+        meeting.roles = ['ATTENDEE'];
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.userType, 'attendee');
+        meeting.environment = "prod";
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.environment, 'prod');
+      });
+    });
+
+    describe('#getAnalyzerMetricsPrePayload', () => {
+      it('userType & userLogin & environment testing for CA data', async () => {
+        const FAKE_LOCUS_MEETING = {
+          conversationUrl: 'locusConvURL',
+          url: 'locusUrl',
+          info: {
+            webExMeetingId: 'locusMeetingId',
+            sipUri: 'locusSipUri',
+            owner: 'locusOwner',
+          },
+          meeting: {
+            startTime: "",
+          },
+          fullState: {
+            active: false,
+          },
+        };
+
+        const meeting = await webex.meetings.createMeeting(
+          FAKE_LOCUS_MEETING,
+          'test type',
+          true
+        );
+        meeting.roles = ['MODERATOR','COHOST','ATTENDEE'];
+        meeting.guest = true;
+        const options = {
+          event: 'event',
+          trackingId: 'trackingId',
+          locus: {},
+          mediaConnections: null,
+          errors: {}
+        };
+        webex.internal.services.get = sinon.stub();
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.userType, 'host');
+        assert.equal(options.loginType, 'unverified-guest');
+        meeting.roles = ['COHOST','ATTENDEE'];
+        meeting.guest = false;
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.userType, 'cohost');
+        assert.equal(options.loginType, 'login-ci');
+        meeting.roles = ['ATTENDEE'];
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.userType, 'attendee');
+        meeting.environment = "prod";
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.environment, 'prod');
+      });
+    });
+
+  //   it('userType & userLogin testing for CA data', async () => {
+  //     const FAKE_LOCUS_MEETING = {
+  //       conversationUrl: 'locusConvURL',
+  //       url: 'locusUrl',
+  //       info: {
+  //         webExMeetingId: 'locusMeetingId',
+  //         sipUri: 'locusSipUri',
+  //         owner: 'locusOwner',
+  //       },
+  //       meeting: {
+  //         startTime: "",
+  //       },
+  //       fullState: {
+  //         active: false,
+  //       },
+  //     };
+  //
+  //     const meeting = await webex.meetings.createMeeting(
+  //       FAKE_LOCUS_MEETING,
+  //       'test type',
+  //       true
+  //     );
+  //     meeting.roles = ['MODERATOR','COHOST','ATTENDEE'];
+  //     meeting.guest = true;
+  //     const options = {
+  //       event: 'event',
+  //       trackingId: 'trackingId',
+  //       locus: {},
+  //       mediaConnections: null,
+  //       errors: {}
+  //     };
+  //     webex.internal.services.get = sinon.stub();
+  //     meeting.getAnalyzerMetricsPrePayload(options);
+  //     assert.equal(options.userType, 'host');
+  //     assert.equal(options.loginType, 'unverified-guest');
+  //     meeting.roles = ['COHOST','ATTENDEE'];
+  //     meeting.guest = false;
+  //     meeting.getAnalyzerMetricsPrePayload(options);
+  //     assert.equal(options.userType, 'cohost');
+  //     assert.equal(options.loginType, 'login-ci');
+  //     meeting.roles = ['ATTENDEE'];
+  //     meeting.getAnalyzerMetricsPrePayload(options);
+  //     assert.equal(options.userType, 'attendee');
+  //   });
+  // });
+
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1422,55 +1422,5 @@ describe('plugin-meetings', () => {
       });
     });
 
-    describe('#getAnalyzerMetricsPrePayload', () => {
-      it('userType & userLogin & environment testing for CA data', async () => {
-        const FAKE_LOCUS_MEETING = {
-          conversationUrl: 'locusConvURL',
-          url: 'locusUrl',
-          info: {
-            webExMeetingId: 'locusMeetingId',
-            sipUri: 'locusSipUri',
-            owner: 'locusOwner',
-          },
-          meeting: {
-            startTime: "",
-          },
-          fullState: {
-            active: false,
-          },
-        };
-
-        const meeting = await webex.meetings.createMeeting(
-          FAKE_LOCUS_MEETING,
-          'test type',
-          true
-        );
-        meeting.roles = ['MODERATOR','COHOST','ATTENDEE'];
-        meeting.guest = true;
-        const options = {
-          event: 'event',
-          trackingId: 'trackingId',
-          locus: {},
-          mediaConnections: null,
-          errors: {}
-        };
-        webex.internal.services.get = sinon.stub();
-        meeting.getAnalyzerMetricsPrePayload(options);
-        assert.equal(options.userType, 'host');
-        assert.equal(options.loginType, 'unverified-guest');
-        meeting.roles = ['COHOST','ATTENDEE'];
-        meeting.guest = false;
-        meeting.getAnalyzerMetricsPrePayload(options);
-        assert.equal(options.userType, 'cohost');
-        assert.equal(options.loginType, 'login-ci');
-        meeting.roles = ['ATTENDEE'];
-        meeting.getAnalyzerMetricsPrePayload(options);
-        assert.equal(options.userType, 'attendee');
-        meeting.environment = "prod";
-        meeting.getAnalyzerMetricsPrePayload(options);
-        assert.equal(options.environment, 'prod');
-      });
-    });
-
   });
 });


### PR DESCRIPTION
<ASSOCIATED ISSUE NUMBER/TRACKING LINK (REQUIRED)>

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-418661
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-401088
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-422176
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-418128

< DESCRIBE THE CONTEXT OF THE ISSUE >
SPARK-418661:  Need to populate environment when sending CA event, To use meeting info API returns environment parameter(channel: [ prod]) to populate client events. If hasn't it, not to set it. 
SPARK-401088: event.errors.errorData not in JSON format. Also values in joinTimes fields are invalid.
SPARK-422176: append CA event for the case of Many times users abandon meetings by just closing the browser tab.
SPARK-418128: WebApp need to populate CA event: userType and loginType.

< DESCRIBE YOUR CHANGES >

Those change are based on CA's data and business expansion, and are done according to the background business analysis logic.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
