### PR TITLE
fix(CA): fix call analyzer event relative issues

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -368,6 +368,7 @@ export const MEETING_REMOVED_REASON = {
   FULLSTATE_REMOVED: 'FULLSTATE_REMOVED', // meeting got dropped ? not sure
   MEETING_INACTIVE_TERMINATING: 'MEETING_INACTIVE_TERMINATING', // Meeting got ended or everyone left the meeting
   CLIENT_LEAVE_REQUEST: 'CLIENT_LEAVE_REQUEST', // You triggered leave meeting
+  CLIENT_LEAVE_REQUEST_TAB_CLOSED: 'CLIENT_LEAVE_REQUEST_TAB_CLOSED', // You triggered leave meeting, such as closing the browser tab directly
   USER_ENDED_SHARE_STREAMS: 'USER_ENDED_SHARE_STREAMS', // user triggered stop share
   NO_MEETINGS_TO_SYNC: 'NO_MEETINGS_TO_SYNC', // After the syncMeeting no meeting exists
   MEETING_CONNECTION_FAILED: 'MEETING_CONNECTION_FAILED', // meeting failed to connect due to ice failures or firewall issue

--- a/packages/@webex/plugin-meetings/src/metrics/index.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/index.ts
@@ -31,10 +31,10 @@ const anonymizeIPAddress = (localIp) => anonymize(localIp, 28, 96);
 const triggerTimers = ({event, meeting, data}) => {
   switch (event) {
     case eventType.CALL_INITIATED:
-      meeting.setStartCallInitiateJoinReq();
+      meeting.setStartCallInitJoinReq();
       break;
     case eventType.LOCUS_JOIN_REQUEST:
-      meeting.setEndCallInitiateJoinReq();
+      meeting.setEndCallInitJoinReq();
       meeting.setStartJoinReqResp();
       break;
     case eventType.LOCUS_JOIN_RESPONSE:
@@ -189,6 +189,9 @@ class Metrics {
         name: 'endpoint',
         networkType: 'unknown',
         userAgent: this.userAgentToString(),
+        userType: options.userType,
+        loginType: options.loginType,
+        channel: options.channel,
         clientInfo: {
           clientType: options.clientType,
           clientVersion: `${CLIENT_NAME}/${this.webex.version}`,
@@ -461,7 +464,7 @@ class Metrics {
       };
 
       if (err && err.body) {
-        errorPayload.errorData = {error: err.body};
+        errorPayload.errorData = new Error(err.body);
       }
 
       if (err && err.statusCode) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -19,8 +19,7 @@ import {
   EVENT_TRIGGERS,
   _SIP_URI_,
   _MEETING_ID_,
-  LOCUSINFO,
-  PC_BAIL_TIMEOUT,
+  LOCUSINFO, MEETING_REMOVED_REASON,
 } from '@webex/plugin-meetings/src/constants';
 import * as InternalMediaCoreModule from '@webex/internal-media-core';
 import {
@@ -1675,7 +1674,21 @@ describe('plugin-meetings', () => {
             correlationId: meeting.correlationId,
             selfId: meeting.selfId,
             resourceId: meeting.resourceId,
+            deviceUrl: meeting.deviceUrl
+          });
+        });
+        it('should leave the meeting on the resource with reason', async () => {
+          const leave = meeting.leave({resourceId: meeting.resourceId, reason: MEETING_REMOVED_REASON.CLIENT_LEAVE_REQUEST});
+
+          assert.exists(leave.then);
+          await leave;
+          assert.calledWith(meeting.meetingRequest.leaveMeeting, {
+            locusUrl: meeting.locusUrl,
+            correlationId: meeting.correlationId,
+            selfId: meeting.selfId,
+            resourceId: meeting.resourceId,
             deviceUrl: meeting.deviceUrl,
+            reason: MEETING_REMOVED_REASON.CLIENT_LEAVE_REQUEST
           });
         });
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1614,5 +1614,56 @@ describe('plugin-meetings', () => {
         assert.equal(result, false);
       });
     });
+
+    describe('#getAnalyzerMetricsPrePayload', () => {
+      it('userType & userLogin & environment testing for CA data', async () => {
+        const FAKE_LOCUS_MEETING = {
+          conversationUrl: 'locusConvURL',
+          url: 'locusUrl',
+          info: {
+            webExMeetingId: 'locusMeetingId',
+            sipUri: 'locusSipUri',
+            owner: 'locusOwner',
+          },
+          meeting: {
+            startTime: "",
+          },
+          fullState: {
+            active: false,
+          },
+        };
+
+        const meeting = await webex.meetings.createMeeting(
+          FAKE_LOCUS_MEETING,
+          'test type',
+          true
+        );
+        meeting.roles = ['MODERATOR','COHOST','ATTENDEE'];
+        meeting.guest = true;
+        const options = {
+          event: 'event',
+          trackingId: 'trackingId',
+          locus: {},
+          mediaConnections: null,
+          errors: {}
+        };
+        webex.internal.services.get = sinon.stub();
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.userType, 'host');
+        assert.equal(options.loginType, 'unverified-guest');
+        meeting.roles = ['COHOST','ATTENDEE'];
+        meeting.guest = false;
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.userType, 'cohost');
+        assert.equal(options.loginType, 'login-ci');
+        meeting.roles = ['ATTENDEE'];
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.userType, 'attendee');
+        meeting.environment = "prod";
+        meeting.getAnalyzerMetricsPrePayload(options);
+        assert.equal(options.environment, 'prod');
+      });
+    });
+
   });
 });


### PR DESCRIPTION
<ASSOCIATED ISSUE NUMBER/TRACKING LINK (REQUIRED)>

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-418661
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-401088
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-422176
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-418128

< DESCRIBE THE CONTEXT OF THE ISSUE >
SPARK-418661: Need to populate environment when sending CA event, To use meeting info API returns environment parameter(channel: [ prod]) to populate client events. If hasn't it, not to set it.
SPARK-401088: event.errors.errorData not in JSON format. Also values in joinTimes fields are invalid.
SPARK-422176: append CA event for the case of Many times users abandon meetings by just closing the browser tab.
SPARK-418128: WebApp need to populate CA event: userType and loginType.

< DESCRIBE YOUR CHANGES >

Those change are based on CA's data and business expansion, and are done according to the background business analysis logic.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
