### PR TITLE
feat(meetings): move COM to public

### DIFF
--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -140,7 +140,7 @@ export default class ControlsOptionsManager {
    * @param {Array<ControlConfig>} controls - Spread Array of ControlConfigs
    * @returns {Promise<Array<any>>}- Promise resolving if the request was successful.
    */
-  protected update(...controls: Array<ControlConfig>) {
+  public update(...controls: Array<ControlConfig>) {
     const payload = controls.reduce((output, control) => {
       if (!Object.keys(Control).includes(control.scope)) {
         throw new Error(


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to migrate the private method of the `controls-option-manager`: `update()` to public for usage within the webex web client.