### PR TITLE
feat: allow for extra params to be provided when fetching meeting info

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
@@ -223,6 +223,7 @@ export default class MeetingInfoV2 {
    * @param {String} captchaInfo.id
    * @param {String} installedOrgID
    * @param {String} locusId
+   * @param {Object} extraParams
    * @returns {Promise} returns a meeting info object
    * @public
    * @memberof MeetingInfo
@@ -236,7 +237,8 @@ export default class MeetingInfoV2 {
       id: string;
     } = null,
     installedOrgID = null,
-    locusId = null
+    locusId = null,
+    extraParams = {}
   ) {
     const destinationType = await MeetingInfoUtil.getDestinationType({
       destination,
@@ -258,6 +260,7 @@ export default class MeetingInfoV2 {
       captchaInfo,
       installedOrgID,
       locusId,
+      extraParams,
     });
 
     // If the body only contains the default properties, we don't have enough to

--- a/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
@@ -1,3 +1,4 @@
+import {pickBy} from 'lodash';
 import url from 'url';
 
 import {
@@ -218,6 +219,15 @@ MeetingInfoUtil.getDestinationType = async (from) => {
 };
 
 /**
+ * Predicate function to be used when filtering request params.
+ * Currently this simply checks for truthy values but in future could restrict keys and values.
+ * @param {Any} value the request param value
+ * @param {String} key the request param key
+ * @returns {Boolean} if the key and value are valid as a request param
+ */
+MeetingInfoUtil.isValidRequestParam = (value: any, key: string): boolean => !!(key && value);
+
+/**
  * Helper function to build up a correct locus url depending on the value passed
  * @param {Object} options type and value to fetch meeting info
  * @param {String} options.type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
@@ -225,8 +235,11 @@ MeetingInfoUtil.getDestinationType = async (from) => {
  * @returns {Object} returns an object with {resource, method}
  */
 MeetingInfoUtil.getRequestBody = (options: {type: string; destination: object} | any) => {
-  const {type, destination, password, captchaInfo, installedOrgID, locusId} = options;
-  const body: any = {...DEFAULT_MEETING_INFO_REQUEST_BODY};
+  const {type, destination, password, captchaInfo, installedOrgID, locusId, extraParams} = options;
+  const body: any = {
+    ...DEFAULT_MEETING_INFO_REQUEST_BODY,
+    ...pickBy(extraParams, MeetingInfoUtil.isValidRequestParam),
+  };
 
   switch (type) {
     case _SIP_URI_:

--- a/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
@@ -1,4 +1,3 @@
-import {pickBy} from 'lodash';
 import url from 'url';
 
 import {
@@ -219,15 +218,6 @@ MeetingInfoUtil.getDestinationType = async (from) => {
 };
 
 /**
- * Predicate function to be used when filtering request params.
- * Currently this simply checks for truthy values but in future could restrict keys and values.
- * @param {Any} value the request param value
- * @param {String} key the request param key
- * @returns {Boolean} if the key and value are valid as a request param
- */
-MeetingInfoUtil.isValidRequestParam = (value: any, key: string): boolean => !!(key && value);
-
-/**
  * Helper function to build up a correct locus url depending on the value passed
  * @param {Object} options type and value to fetch meeting info
  * @param {String} options.type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
@@ -238,7 +228,7 @@ MeetingInfoUtil.getRequestBody = (options: {type: string; destination: object} |
   const {type, destination, password, captchaInfo, installedOrgID, locusId, extraParams} = options;
   const body: any = {
     ...DEFAULT_MEETING_INFO_REQUEST_BODY,
-    ...pickBy(extraParams, MeetingInfoUtil.isValidRequestParam),
+    ...extraParams,
   };
 
   switch (type) {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1203,9 +1203,11 @@ export default class Meeting extends StatelessWebexPlugin {
   public async fetchMeetingInfo({
     password = null,
     captchaCode = null,
+    extraParams = {},
   }: {
     password?: string;
     captchaCode?: string;
+    extraParams?: Record<string, any>;
   }) {
     // when fetch meeting info is called directly by the client, we want to clear out the random timer for sdk to do it
     if (this.fetchMeetingInfoTimeoutId) {
@@ -1239,7 +1241,8 @@ export default class Meeting extends StatelessWebexPlugin {
         captchaInfo,
         // @ts-ignore - config coming from registerPlugin
         this.config.installedOrgID,
-        this.locusId
+        this.locusId,
+        extraParams
       );
 
       this.parseMeetingInfo(info, this.destination);

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -972,11 +972,17 @@ export default class Meetings extends WebexPlugin {
    * @param {string} destination - sipURL, spaceId, phonenumber, or locus object}
    * @param {string} [type] - the optional specified type, such as locusId
    * @param {Boolean} useRandomDelayForInfo - whether a random delay should be added to fetching meeting info
+   * @param {Object} infoExtraParams extra parameters to be provided when fetching meeting info
    * @returns {Promise<Meeting>} A new Meeting.
    * @public
    * @memberof Meetings
    */
-  public create(destination: string, type: string = null, useRandomDelayForInfo = false) {
+  public create(
+    destination: string,
+    type: string = null,
+    useRandomDelayForInfo = false,
+    infoExtraParams = {}
+  ) {
     // TODO: type should be from a dictionary
 
     // Validate meeting information based on the provided destination and
@@ -1021,48 +1027,51 @@ export default class Meetings extends WebexPlugin {
           // Validate if a meeting was found.
           if (!meeting) {
             // Create a meeting based on the normalized destination and type.
-            return this.createMeeting(targetDest, type, useRandomDelayForInfo).then(
-              (createdMeeting: any) => {
-                // If the meeting was successfully created.
-                if (createdMeeting && createdMeeting.on) {
-                  // Create a destruction event for the meeting.
-                  createdMeeting.on(EVENTS.DESTROY_MEETING, (payload) => {
-                    // @ts-ignore
-                    if (this.config.autoUploadLogs) {
-                      this.uploadLogs({
-                        callStart: createdMeeting.locusInfo?.fullState?.lastActive,
-                        correlationId: createdMeeting.correlationId,
-                        feedbackId: createdMeeting.correlationId,
-                        locusId: createdMeeting.locusId,
-                        meetingId: createdMeeting.locusInfo?.info?.webExMeetingId,
-                      }).then(() => this.destroy(createdMeeting, payload.reason));
-                    } else {
-                      this.destroy(createdMeeting, payload.reason);
-                    }
-                  });
+            return this.createMeeting(
+              targetDest,
+              type,
+              useRandomDelayForInfo,
+              infoExtraParams
+            ).then((createdMeeting: any) => {
+              // If the meeting was successfully created.
+              if (createdMeeting && createdMeeting.on) {
+                // Create a destruction event for the meeting.
+                createdMeeting.on(EVENTS.DESTROY_MEETING, (payload) => {
+                  // @ts-ignore
+                  if (this.config.autoUploadLogs) {
+                    this.uploadLogs({
+                      callStart: createdMeeting.locusInfo?.fullState?.lastActive,
+                      correlationId: createdMeeting.correlationId,
+                      feedbackId: createdMeeting.correlationId,
+                      locusId: createdMeeting.locusId,
+                      meetingId: createdMeeting.locusInfo?.info?.webExMeetingId,
+                    }).then(() => this.destroy(createdMeeting, payload.reason));
+                  } else {
+                    this.destroy(createdMeeting, payload.reason);
+                  }
+                });
 
-                  createdMeeting.on(EVENTS.REQUEST_UPLOAD_LOGS, (meetingInstance) => {
-                    // @ts-ignore
-                    if (this.config.autoUploadLogs) {
-                      this.uploadLogs({
-                        callStart: meetingInstance?.locusInfo?.fullState?.lastActive,
-                        correlationId: meetingInstance.correlationId,
-                        feedbackId: meetingInstance.correlationId,
-                        locusId: meetingInstance.locusId,
-                        meetingId: meetingInstance.locusInfo?.info?.webExMeetingId,
-                      });
-                    }
-                  });
-                } else {
-                  LoggerProxy.logger.error(
-                    `Meetings:index#create --> ERROR, meeting does not have on method, will not be destroyed, meeting cleanup impossible for meeting: ${meeting}`
-                  );
-                }
-
-                // Return the newly created meeting.
-                return Promise.resolve(createdMeeting);
+                createdMeeting.on(EVENTS.REQUEST_UPLOAD_LOGS, (meetingInstance) => {
+                  // @ts-ignore
+                  if (this.config.autoUploadLogs) {
+                    this.uploadLogs({
+                      callStart: meetingInstance?.locusInfo?.fullState?.lastActive,
+                      correlationId: meetingInstance.correlationId,
+                      feedbackId: meetingInstance.correlationId,
+                      locusId: meetingInstance.locusId,
+                      meetingId: meetingInstance.locusInfo?.info?.webExMeetingId,
+                    });
+                  }
+                });
+              } else {
+                LoggerProxy.logger.error(
+                  `Meetings:index#create --> ERROR, meeting does not have on method, will not be destroyed, meeting cleanup impossible for meeting: ${meeting}`
+                );
               }
-            );
+
+              // Return the newly created meeting.
+              return Promise.resolve(createdMeeting);
+            });
           }
 
           // Return the existing meeting.
@@ -1075,6 +1084,7 @@ export default class Meetings extends WebexPlugin {
    * @param {String} destination see create()
    * @param {String} type see create()
    * @param {Boolean} useRandomDelayForInfo whether a random delay should be added to fetching meeting info
+   * @param {Object} infoExtraParams extra parameters to be provided when fetching meeting info
    * @returns {Promise} a new meeting instance complete with meeting info and destination
    * @private
    * @memberof Meetings
@@ -1082,7 +1092,8 @@ export default class Meetings extends WebexPlugin {
   private async createMeeting(
     destination: any,
     type: string = null,
-    useRandomDelayForInfo = false
+    useRandomDelayForInfo = false,
+    infoExtraParams = {}
   ) {
     const meeting = new Meeting(
       {
@@ -1130,12 +1141,12 @@ export default class Meetings extends WebexPlugin {
 
       if (enableUnifiedMeetings && !isMeetingActive && useRandomDelayForInfo && waitingTime > 0) {
         meeting.fetchMeetingInfoTimeoutId = setTimeout(
-          () => meeting.fetchMeetingInfo({}),
+          () => meeting.fetchMeetingInfo({extraParams: infoExtraParams}),
           waitingTime
         );
         meeting.parseMeetingInfo(undefined, destination);
       } else {
-        await meeting.fetchMeetingInfo({});
+        await meeting.fetchMeetingInfo({extraParams: infoExtraParams});
       }
     } catch (err) {
       if (

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -270,8 +270,7 @@ describe('plugin-meetings', () => {
 
       it('should fetch meeting info with provided extraParams', async () => {
         const requestResponse = {statusCode: 200, body: {meetingKey: '1234323'}};
-        const expectedExtraParams = {mtid: 'm9fe0afd8c435e892afcce9ea25b97046', joinTXId: 'TSmrX61wNF'}
-        const extraParams = {...expectedExtraParams, '': 'some-value', someKey: ''}; // Falsey keys and values should be removed
+        const extraParams = {mtid: 'm9fe0afd8c435e892afcce9ea25b97046', joinTXId: 'TSmrX61wNF'}
 
         webex.request.resolves(requestResponse);
 
@@ -285,7 +284,7 @@ describe('plugin-meetings', () => {
             supportHostKey: true,
             supportCountryList: true,
             meetingKey: '1234323',
-            ...expectedExtraParams,
+            ...extraParams,
           },
         });
         assert.deepEqual(result, requestResponse);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -268,6 +268,34 @@ describe('plugin-meetings', () => {
         );
       });
 
+      it('should fetch meeting info with provided extraParams', async () => {
+        const requestResponse = {statusCode: 200, body: {meetingKey: '1234323'}};
+        const expectedExtraParams = {mtid: 'm9fe0afd8c435e892afcce9ea25b97046', joinTXId: 'TSmrX61wNF'}
+        const extraParams = {...expectedExtraParams, '': 'some-value', someKey: ''}; // Falsey keys and values should be removed
+
+        webex.request.resolves(requestResponse);
+
+        const result = await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, null, null, null, null, extraParams);
+
+        assert.calledWith(webex.request, {
+          method: 'POST',
+          service: WBXAPPAPI_SERVICE,
+          resource: 'meetingInfo',
+          body: {
+            supportHostKey: true,
+            supportCountryList: true,
+            meetingKey: '1234323',
+            ...expectedExtraParams,
+          },
+        });
+        assert.deepEqual(result, requestResponse);
+        assert(Metrics.sendBehavioralMetric.calledOnce);
+        assert.calledWith(
+          Metrics.sendBehavioralMetric,
+          BEHAVIORAL_METRICS.FETCH_MEETING_INFO_V1_SUCCESS
+        );
+      });
+
       it('create adhoc meeting when conversationUrl passed with enableAdhocMeetings toggle', async () => {
         sinon.stub(meetingInfo, 'createAdhocSpaceMeeting').returns(Promise.resolve());
         await meetingInfo.fetchMeetingInfo('conversationUrl', _CONVERSATION_URL_);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
@@ -149,7 +149,35 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#isValidRequestParam', () => {
+      it('returns true when the key and value are truthy', () => {
+        assert.isTrue(MeetingInfoUtil.isValidRequestParam('value', 'key'));
+      });
+
+      it('returns false when the key is falsey', () => {
+        assert.isFalse(MeetingInfoUtil.isValidRequestParam('value', ''));
+      });
+
+      it('returns false when the value is falsey', () => {
+        assert.isFalse(MeetingInfoUtil.isValidRequestParam('', 'key'));
+      });
+
+      it('returns false when the kay and value are falsey', () => {
+        assert.isFalse(MeetingInfoUtil.isValidRequestParam('', ''));
+      });
+    });
+
     describe('#getRequestBody', () => {
+      let isValidRequestParamSpy;
+
+      beforeEach(() => {
+        isValidRequestParamSpy = sinon.spy(MeetingInfoUtil, 'isValidRequestParam');
+      });
+  
+      afterEach(() => {
+        isValidRequestParamSpy.restore();
+      });
+
       it('for _PERSONAL_ROOM_', () => {
         const res = MeetingInfoUtil.getRequestBody({
           type: _PERSONAL_ROOM_,
@@ -218,6 +246,33 @@ describe('plugin-meetings', () => {
           res.conversationUrl,
           'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49280'
         );
+      });
+
+      it('allows for extra params to be provided', () => {
+        const expectedExtraParams = {mtid: 'm9fe0afd8c435e892afcce9ea25b97046', joinTXId: 'TSmrX61wNF'}
+        const extraParams = {...expectedExtraParams, '': 'some-value', someKey: ''}; // Falsey keys and values should be removed
+
+        const res = MeetingInfoUtil.getRequestBody({
+          type: _CONVERSATION_URL_,
+          destination: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49281',
+          extraParams,
+        });
+
+        assert.deepEqual(
+          res,
+          {
+            conversationUrl: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49281',
+            supportHostKey: true,
+            supportCountryList: true,
+            ...expectedExtraParams,
+          }
+        );
+
+        // isValidRequestParam should be called once per extra param
+        assert.callCount(isValidRequestParamSpy, Object.keys(extraParams).length);
+        Object.entries(extraParams).forEach(([key, value]) => {
+          assert.calledWithExactly(isValidRequestParamSpy, value, key);
+        });
       });
     });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
@@ -149,34 +149,7 @@ describe('plugin-meetings', () => {
       });
     });
 
-    describe('#isValidRequestParam', () => {
-      it('returns true when the key and value are truthy', () => {
-        assert.isTrue(MeetingInfoUtil.isValidRequestParam('value', 'key'));
-      });
-
-      it('returns false when the key is falsey', () => {
-        assert.isFalse(MeetingInfoUtil.isValidRequestParam('value', ''));
-      });
-
-      it('returns false when the value is falsey', () => {
-        assert.isFalse(MeetingInfoUtil.isValidRequestParam('', 'key'));
-      });
-
-      it('returns false when the kay and value are falsey', () => {
-        assert.isFalse(MeetingInfoUtil.isValidRequestParam('', ''));
-      });
-    });
-
     describe('#getRequestBody', () => {
-      let isValidRequestParamSpy;
-
-      beforeEach(() => {
-        isValidRequestParamSpy = sinon.spy(MeetingInfoUtil, 'isValidRequestParam');
-      });
-  
-      afterEach(() => {
-        isValidRequestParamSpy.restore();
-      });
 
       it('for _PERSONAL_ROOM_', () => {
         const res = MeetingInfoUtil.getRequestBody({
@@ -249,8 +222,7 @@ describe('plugin-meetings', () => {
       });
 
       it('allows for extra params to be provided', () => {
-        const expectedExtraParams = {mtid: 'm9fe0afd8c435e892afcce9ea25b97046', joinTXId: 'TSmrX61wNF'}
-        const extraParams = {...expectedExtraParams, '': 'some-value', someKey: ''}; // Falsey keys and values should be removed
+        const extraParams = {mtid: 'm9fe0afd8c435e892afcce9ea25b97046', joinTXId: 'TSmrX61wNF'}
 
         const res = MeetingInfoUtil.getRequestBody({
           type: _CONVERSATION_URL_,
@@ -264,15 +236,9 @@ describe('plugin-meetings', () => {
             conversationUrl: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49281',
             supportHostKey: true,
             supportCountryList: true,
-            ...expectedExtraParams,
+            ...extraParams,
           }
         );
-
-        // isValidRequestParam should be called once per extra param
-        assert.callCount(isValidRequestParamSpy, Object.keys(extraParams).length);
-        Object.entries(extraParams).forEach(([key, value]) => {
-          assert.calledWithExactly(isValidRequestParamSpy, value, key);
-        });
       });
     });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2995,6 +2995,7 @@ describe('plugin-meetings', () => {
         const FAKE_CAPTCHA_AUDIO_URL = 'http://captchaaudio';
         const FAKE_CAPTCHA_REFRESH_URL = 'http://captcharefresh';
         const FAKE_INSTALLED_ORG_ID = '123456';
+        const FAKE_EXTRA_PARAMS = {mtid: 'm9fe0afd8c435e892afcce9ea25b97046', joinTXId: 'TSmrX61wNF'};
         const FAKE_MEETING_INFO = {
           conversationUrl: 'some_convo_url',
           locusUrl: 'some_locus_url',
@@ -3028,6 +3029,7 @@ describe('plugin-meetings', () => {
           await meeting.fetchMeetingInfo({
             password: FAKE_PASSWORD,
             captchaCode: FAKE_CAPTCHA_CODE,
+            extraParams: FAKE_EXTRA_PARAMS,
           });
 
           assert.calledWith(
@@ -3036,7 +3038,9 @@ describe('plugin-meetings', () => {
             FAKE_TYPE,
             FAKE_PASSWORD,
             {code: FAKE_CAPTCHA_CODE, id: FAKE_CAPTCHA_ID},
-            FAKE_INSTALLED_ORG_ID
+            FAKE_INSTALLED_ORG_ID,
+            meeting.locusId,
+            FAKE_EXTRA_PARAMS
           );
 
           assert.calledWith(meeting.parseMeetingInfo, {body: FAKE_MEETING_INFO}, FAKE_DESTINATION);
@@ -3078,7 +3082,10 @@ describe('plugin-meetings', () => {
             FAKE_DESTINATION,
             FAKE_TYPE,
             null,
-            null
+            null,
+            undefined,
+            meeting.locusId,
+            {}
           );
 
           // parseMeeting info


### PR DESCRIPTION
## This pull request addresses

In order to fix https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-421937 there is a need to be able to pass in extra parameters when fetching meeting info, specifically when creating a new meeting. 

## by making the following changes

This PR adds the ability to provide arbitrary additional params when creating and when fetching meeting info in general, filtered to ensure both key and value are truthy (this can be changed later of course).

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request
- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
