### PR TITLE
fix(http-core): update qs version to fix vulnerability

### DIFF
--- a/packages/@webex/http-core/package.json
+++ b/packages/@webex/http-core/package.json
@@ -49,7 +49,7 @@
     "is-function": "^1.0.1",
     "lodash": "^4.17.21",
     "parse-headers": "^2.0.2",
-    "qs": "^6.7.0",
+    "qs": "^6.7.3",
     "request": "^2.88.0",
     "safe-buffer": "^5.2.0",
     "xtend": "^4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5020,7 +5020,7 @@ __metadata:
     lodash: ^4.17.21
     parse-headers: ^2.0.2
     prettier: ^2.7.1
-    qs: ^6.7.0
+    qs: ^6.7.3
     request: ^2.88.0
     safe-buffer: ^5.2.0
     sinon: ^9.2.4
@@ -21327,12 +21327,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.5.1, qs@npm:^6.7.0":
+"qs@npm:^6.5.1":
   version: 6.11.1
   resolution: "qs@npm:6.11.1"
   dependencies:
     side-channel: ^1.0.4
   checksum: 82ee78ef12a16f3372fae5b64f76f8aedecb000feea882bbff1af146c147f6eb66b08f9c3f34d7e076f28563586956318b9b2ca41141846cdd6d5ad6f241d52f
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.7.3":
+  version: 6.11.2
+  resolution: "qs@npm:6.11.2"
+  dependencies:
+    side-channel: ^1.0.4
+  checksum: e812f3c590b2262548647d62f1637b6989cc56656dc960b893fe2098d96e1bd633f36576f4cd7564dfbff9db42e17775884db96d846bebe4f37420d073ecdc0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES #[SPARK-398773](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-398773)

## This pull request addresses 

Fixes a vulnerability issue in the qs npm dependency. [CVE-2022-24999](https://nvd.nist.gov/vuln/detail/CVE-2022-24999)

## by making the following changes

Upgrading the qs value in http-core package to the latest value


### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [] I have updated the documentation accordingly

---

Ran test locally for http-core:
```
$ yarn test:unit --packages @webex/http-core
(node:50084) Warning: Accessing non-existent property 'VERSION' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)

==============================================
===== Testing with Jest @webex/http-core =====
==============================================

 PASS   @webex/http-core  packages/@webex/http-core/test/unit/spec/interceptors/http-status.js
  http-core
    Interceptors
      HttpStatusInterceptor
        #onResponse
          ✓ resolves on locus redirect error (1 ms)
          ✓ rejects when locus redirect is not intended (2 ms)

📦 report is created on: /Users/sreenara/Stuff/WebRTC/Client/webex-js-sdk-sknth/webex-js-sdk/coverage/html/jest-result.html
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        1.155 s, estimated 3 s
Ran all test suites matching /packages\/@webex\/http-core\/test\/unit\/spec\/interceptors\/http-status.js/i.
```