### PR TITLE
fix: version of internal-media-core used by media-helpers doesn't match plugin-meetings

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -14,7 +14,7 @@
     "node": ">=16"
   },
   "dependencies": {
-    "@webex/internal-media-core": "1.36.1"
+    "@webex/internal-media-core": "1.38.0"
   },
   "browserify": {
     "transform": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,24 +4077,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:1.36.1":
-  version: 1.36.1
-  resolution: "@webex/internal-media-core@npm:1.36.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.18.9"
-    "@webex/json-multistream": "npm:1.22.0"
-    "@webex/ts-sdp": "npm:1.3.2"
-    "@webex/web-client-media-engine": "npm:1.42.1-hf-428816.1"
-    detectrtc: "npm:^1.4.1"
-    events: "npm:^3.3.0"
-    typed-emitter: "npm:^2.1.0"
-    uuid: "npm:^8.3.2"
-    webrtc-adapter: "npm:^8.1.2"
-    xstate: "npm:^4.30.6"
-  checksum: 519b6e02a0457f54358eb267d84231559ed0c75093426e80a1bb68852a673234aab83f47ac42466e1f18e2736043474ba4066ecb3e120cd0ade0ed67a67ffad5
-  languageName: node
-  linkType: hard
-
 "@webex/internal-media-core@npm:1.38.0":
   version: 1.38.0
   resolution: "@webex/internal-media-core@npm:1.38.0"
@@ -4547,13 +4529,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/json-multistream@npm:1.22.0, @webex/json-multistream@npm:^1.22.0":
-  version: 1.22.0
-  resolution: "@webex/json-multistream@npm:1.22.0"
-  checksum: 6441cd766547cb51ab76808d400d662400a821731f67b2419951090cbf0c793e6a823d134d43c9660fa876d21821b4ffc2f9dda5a1e704041d5394a3d85f7e2b
-  languageName: node
-  linkType: hard
-
 "@webex/json-multistream@npm:2.0.1":
   version: 2.0.1
   resolution: "@webex/json-multistream@npm:2.0.1"
@@ -4572,7 +4547,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webex/media-helpers@workspace:packages/@webex/media-helpers"
   dependencies:
-    "@webex/internal-media-core": "npm:1.36.1"
+    "@webex/internal-media-core": "npm:1.38.0"
     "@webex/test-helper-chai": "workspace:^"
     "@webex/test-helper-mock-webex": "workspace:^"
     sinon: "npm:^9.2.4"
@@ -5130,23 +5105,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:1.42.1-hf-428816.1":
-  version: 1.42.1-hf-428816.1
-  resolution: "@webex/web-client-media-engine@npm:1.42.1-hf-428816.1"
-  dependencies:
-    "@webex/json-multistream": "npm:^1.22.0"
-    "@webex/rtcstats": "npm:^1.0.1"
-    "@webex/ts-sdp": "npm:1.3.1"
-    "@webex/webrtc-core": "npm:1.6.3"
-    async: "npm:^3.2.4"
-    bowser: "npm:^2.11.0"
-    js-logger: "npm:^1.6.1"
-    typed-emitter: "npm:^2.1.0"
-    uuid: "npm:^8.3.2"
-  checksum: d915cd1960cdb0ccf9fdd01e3168ed68bbdaf7f6a9504df1b4055a2a79346636a39633aa8f7dbbd5e773fd5ca50f8a7c8ccb8bd48170d5c591460b1db56f4c30
-  languageName: node
-  linkType: hard
-
 "@webex/web-client-media-engine@npm:2.0.7":
   version: 2.0.7
   resolution: "@webex/web-client-media-engine@npm:2.0.7"
@@ -5242,7 +5200,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/webrtc-core@npm:1.6.3, @webex/webrtc-core@npm:^1.6.3":
+"@webex/webrtc-core@npm:^1.6.3":
   version: 1.6.3
   resolution: "@webex/webrtc-core@npm:1.6.3"
   dependencies:


### PR DESCRIPTION
## This pull request addresses

Version of internal-media-core used in media-helpers doesn't match the one used by plugin-meetings. This can potentially cause problems, for example screen sharing to not work. Thankfully the 2 different versions of internal-media-core are using 2 versions of WCME that both use same version of webrtc-core so it's not an issue this time and screen sharing should still work without this fix.

## by making the following changes

updated package.json

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
