### PR TITLE
feat(breakout): add unlockEdit parameter when update breakouts

### DIFF
--- a/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
@@ -731,6 +731,7 @@ describe('plugin-meetings', () => {
           id: 'groupId',
           sessions: [{name: 'Session 1'}],
         };
+        breakouts._clearEditLockInfo = sinon.stub();
         const result = await breakouts.update(params, true);
         assert.calledOnceWithExactly(webex.request, {
           method: 'PUT',
@@ -740,6 +741,7 @@ describe('plugin-meetings', () => {
             groups: [params],
           },
         });
+        assert.calledOnceWithExactly(breakouts._clearEditLockInfo);
       });
       it('throw error if missing id in params', async () => {
         const params = {

--- a/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
@@ -723,6 +723,24 @@ describe('plugin-meetings', () => {
           },
         });
       });
+      it('makes the request as expected when unlockEdit is true', async () => {
+        breakouts.editLock = {
+          token: 'token1',
+        };
+        const params = {
+          id: 'groupId',
+          sessions: [{name: 'Session 1'}],
+        };
+        const result = await breakouts.update(params, true);
+        assert.calledOnceWithExactly(webex.request, {
+          method: 'PUT',
+          uri: 'url',
+          body: {
+            editlock: {token: 'token1', refresh: false},
+            groups: [params],
+          },
+        });
+      });
       it('throw error if missing id in params', async () => {
         const params = {
           sessions: [{name: 'Session 1'}],


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >


< DESCRIBE THE CONTEXT OF THE ISSUE >

add unlockEdit parameter for update breakouts

< DESCRIBE YOUR CHANGES >

For case that host close manager dialog, need to update breakout and release edit lock at the same time

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
