### PR TITLE
fix: refactor code for sending /media requests to Locus

### DIFF
--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -51,29 +51,6 @@ export type BundlePolicy = ConstructorParameters<
 const Media: any = {};
 
 /**
- * format the media array for send
- * @param {String} mediaId
- * @param {Boolean} audioMuted
- * @param {Boolean} videoMuted
- * @returns {Array} medias
- */
-Media.generateLocalMedias = (mediaId: string, audioMuted: boolean, videoMuted: boolean) => {
-  if (mediaId) {
-    return [
-      {
-        localSdp: JSON.stringify({
-          audioMuted,
-          videoMuted,
-        }),
-        mediaId,
-      },
-    ];
-  }
-
-  return [];
-};
-
-/**
  * make a browser call to get the media
  * @param {SendOptions} options
  * @param {Object} config SDK Configuration for meetings plugin

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3659,6 +3659,8 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   public closePeerConnections() {
+    this.locusMediaRequest = undefined;
+
     if (this.mediaProperties.webrtcMediaConnection) {
       if (this.remoteMediaManager) {
         this.remoteMediaManager.stop();

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -124,6 +124,7 @@ import {REACTION_RELAY_TYPES} from '../reactions/constants';
 import RecordingController from '../recording-controller';
 import ControlsOptionsManager from '../controls-options-manager';
 import PermissionError from '../common/errors/permission';
+import {LocusMediaRequest} from './locusMediaRequest';
 
 const {isBrowser} = BrowserDetection();
 
@@ -467,6 +468,7 @@ export default class Meeting extends StatelessWebexPlugin {
   resource: string;
   roap: Roap;
   roapSeq: number;
+  selfUrl?: string; // comes from Locus, initialized by updateMeetingObject()
   sipUri: string;
   type: string;
   userId: string;
@@ -488,6 +490,7 @@ export default class Meeting extends StatelessWebexPlugin {
   keepAliveTimerId: NodeJS.Timeout;
   lastVideoLayoutInfo: any;
   locusInfo: any;
+  locusMediaRequest?: LocusMediaRequest;
   mediaProperties: MediaProperties;
   mediaRequestManagers: {
     audio: MediaRequestManager;
@@ -5489,6 +5492,23 @@ export default class Meeting extends StatelessWebexPlugin {
     });
 
     return MeetingUtil.validateOptions(options)
+      .then(() => {
+        this.locusMediaRequest = new LocusMediaRequest(
+          {
+            correlationId: this.correlationId,
+            device: {
+              url: this.deviceUrl,
+              // @ts-ignore
+              deviceType: this.config.deviceType,
+            },
+            preferTranscoding: !this.isMultistream,
+          },
+          {
+            // @ts-ignore
+            parent: this.webex,
+          }
+        );
+      })
       .then(() => this.roap.doTurnDiscovery(this, false))
       .then((turnDiscoveryObject) => {
         ({turnDiscoverySkippedReason} = turnDiscoveryObject);

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -1,7 +1,7 @@
 /* eslint-disable valid-jsdoc */
 import {defer} from 'lodash';
 import {Defer} from '@webex/common';
-import {StatelessWebexPlugin} from '@webex/webex-core';
+import {WebexPlugin} from '@webex/webex-core';
 import {MEDIA, HTTP_VERBS, ROAP} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
 
@@ -99,7 +99,7 @@ function isRequestAffectingConfluenceState(request: Request): boolean {
  * This class manages all /media API requests to Locus. Every call to that
  * Locus API has to go through this class.
  */
-export class LocusMediaRequest extends StatelessWebexPlugin {
+export class LocusMediaRequest extends WebexPlugin {
   private config: Config;
   private latestAudioMuted?: boolean;
   private latestVideoMuted?: boolean;

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -1,0 +1,261 @@
+/* eslint-disable valid-jsdoc */
+import {defer} from 'lodash';
+import {Defer} from '@webex/common';
+import {StatelessWebexPlugin} from '@webex/webex-core';
+import {MEDIA, HTTP_VERBS} from '../constants';
+import LoggerProxy from '../common/logs/logger-proxy';
+
+export type MediaRequestType = 'RoapMessage' | 'LocalMute';
+export type RequestResult = any;
+
+export type RoapRequest = {
+  type: 'RoapMessage';
+  selfUrl: string;
+  mediaId: string;
+  roapMessage: any;
+  reachability: any;
+  joinCookie: any; // any, because this is opaque to the client, we pass whatever object we got from one backend component (Orpheus) to the other (Locus)
+};
+
+export type LocalMuteRequest = {
+  type: 'LocalMute';
+  selfUrl: string;
+  mediaId: string;
+  muteOptions: {
+    audioMuted?: boolean;
+    videoMuted?: boolean;
+  };
+};
+
+export type Request = RoapRequest | LocalMuteRequest;
+
+/** Class representing a single /media request being sent to Locus */
+class InternalRequestInfo {
+  public readonly request: Request;
+  private pendingPromises: Defer[];
+  private sendRequestFn: (request: Request) => Promise<RequestResult>;
+
+  /** Constructor */
+  constructor(
+    request: Request,
+    pendingPromise: Defer,
+    sendRequestFn: (request: Request) => Promise<RequestResult>
+  ) {
+    this.request = request;
+    this.pendingPromises = [pendingPromise];
+    this.sendRequestFn = sendRequestFn;
+  }
+
+  /**
+   * Returns the list of pending promises associated with this request
+   */
+  public getPendingPromises() {
+    return this.pendingPromises;
+  }
+
+  /**
+   * Adds promises to the list of pending promises associated with this request
+   */
+  public addPendingPromises(pendingPromises: Defer[]) {
+    this.pendingPromises.push(...pendingPromises);
+  }
+
+  /**
+   * Executes the request. Returned promise is resolved once the request
+   * is completed (no matter if it succeeded or failed).
+   */
+  public execute(): Promise<void> {
+    return this.sendRequestFn(this.request)
+      .then((result) => {
+        // resolve all the pending promises associated with this request
+        this.pendingPromises.forEach((d) => d.resolve(result));
+      })
+      .catch((e) => {
+        // reject all the pending promises associated with this request
+        this.pendingPromises.forEach((d) => d.reject(e));
+      });
+  }
+}
+
+export type Config = {
+  device: {
+    url: string;
+    deviceType: string;
+  };
+  correlationId: string;
+  preferTranscoding: boolean;
+};
+
+/**
+ * This class manages all /media API requests to Locus. Every call to that
+ * Locus API has to go through this class.
+ */
+export class LocusMediaRequest extends StatelessWebexPlugin {
+  private config: Config;
+  private latestAudioMuted?: boolean;
+  private latestVideoMuted?: boolean;
+  private isRequestInProgress: boolean;
+  private queuedRequests: InternalRequestInfo[];
+
+  /**
+   * Constructor
+   */
+  constructor(config: Config, options: any) {
+    super({}, options);
+    this.isRequestInProgress = false;
+    this.queuedRequests = [];
+    this.config = config;
+  }
+
+  /**
+   * Add a request to the internal queue.
+   */
+  private addToQueue(info: InternalRequestInfo) {
+    if (info.request.type === 'LocalMute' && this.queuedRequests.length > 0) {
+      // We don't need additional local mute requests in the queue.
+      // We only need at most 1 local mute or 1 roap request, because
+      // roap requests also include mute state, so whatever request
+      // is sent out, it will send the latest local mute state.
+      // We only need to store the pendingPromises so that they get resolved
+      // when the roap request is sent out.
+      this.queuedRequests[0].addPendingPromises(info.getPendingPromises());
+
+      return;
+    }
+
+    if (info.request.type === 'RoapMessage' && this.queuedRequests.length > 0) {
+      // remove any LocalMute requests from the queue, because this Roap message
+      // will also update the mute status in Locus, so they are redundant
+      this.queuedRequests = this.queuedRequests.filter((r) => {
+        if (r.request.type === 'LocalMute') {
+          // we need to keep the pending promises from the local mute request
+          // that we're removing from the queue
+          info.addPendingPromises(r.getPendingPromises());
+
+          return false;
+        }
+
+        return true;
+      });
+    }
+
+    this.queuedRequests.push(info);
+  }
+
+  /**
+   * Takes the next request from the queue and executes it. Once that
+   * request is completed, the next one will be taken from the queue
+   * and executed and this is repeated until the queue is empty.
+   */
+  private executeNextQueuedRequest(): void {
+    if (this.isRequestInProgress) {
+      return;
+    }
+
+    const nextRequest = this.queuedRequests.shift();
+
+    if (nextRequest) {
+      this.isRequestInProgress = true;
+      nextRequest.execute().then(() => {
+        this.isRequestInProgress = false;
+        this.executeNextQueuedRequest();
+      });
+    }
+  }
+
+  /**
+   * Returns latest requested audio and video mute values. If they have never been
+   * requested, we assume audio/video to be muted.
+   */
+  private getLatestMuteState() {
+    const audioMuted = this.latestAudioMuted !== undefined ? this.latestAudioMuted : true;
+    const videoMuted = this.latestVideoMuted !== undefined ? this.latestVideoMuted : true;
+
+    return {audioMuted, videoMuted};
+  }
+
+  /**
+   * Prepares the uri and body for the media request to be sent to Locus
+   */
+  private sendHttpRequest(request: Request) {
+    const uri = `${request.selfUrl}/${MEDIA}`;
+
+    const {audioMuted, videoMuted} = this.getLatestMuteState();
+
+    // first setup things common to all requests
+    const body: any = {
+      device: this.config.device,
+      correlationId: this.config.correlationId,
+      clientMediaPreferences: {
+        preferTranscoding: this.config.preferTranscoding,
+      },
+    };
+
+    const localMedias: any = {
+      audioMuted,
+      videoMuted,
+    };
+
+    // now add things specific to request type
+    switch (request.type) {
+      case 'LocalMute':
+        body.respOnlySdp = true;
+        body.usingResource = null;
+        break;
+
+      case 'RoapMessage':
+        localMedias.roapMessage = request.roapMessage;
+        localMedias.reachability = request.reachability;
+        body.clientMediaPreferences.joinCookie = request.joinCookie;
+        break;
+    }
+
+    body.localMedias = [
+      {
+        localSdp: JSON.stringify(localMedias), // this part must be JSON stringified, Locus requires this
+        mediaId: request.mediaId,
+      },
+    ];
+
+    LoggerProxy.logger.info(
+      `Meeting:LocusMediaRequest#sendHttpRequest --> ${request.type} audioMuted=${audioMuted} videoMuted=${videoMuted}`
+    );
+
+    // @ts-ignore
+    return this.request({
+      method: HTTP_VERBS.PUT,
+      uri,
+      body,
+    });
+  }
+
+  /**
+   * Sends a media request to Locus
+   */
+  public send(request: Request): Promise<RequestResult> {
+    if (request.type === 'LocalMute') {
+      const {audioMuted, videoMuted} = request.muteOptions;
+
+      if (audioMuted !== undefined) {
+        this.latestAudioMuted = audioMuted;
+      }
+      if (videoMuted !== undefined) {
+        this.latestVideoMuted = videoMuted;
+      }
+    }
+
+    const pendingPromise = new Defer();
+
+    const newRequest = new InternalRequestInfo(
+      request,
+      pendingPromise,
+      this.sendHttpRequest.bind(this)
+    );
+
+    this.addToQueue(newRequest);
+
+    defer(() => this.executeNextQueuedRequest());
+
+    return pendingPromise.promise;
+  }
+}

--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -342,7 +342,9 @@ export class MuteState {
 
         this.state.server.localMute = this.type === AUDIO ? audioMuted : videoMuted;
 
-        meeting.locusInfo.onFullLocus(locus);
+        if (locus) {
+          meeting.locusInfo.onFullLocus(locus);
+        }
 
         return locus;
       })

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -594,52 +594,6 @@ export default class MeetingRequest extends StatelessWebexPlugin {
   }
 
   /**
-   * Toggle remote audio and/or video
-   * @param {Object} options options for toggling
-   * @param {String} options.selfId Locus self id??
-   * @param {String} options.locusUrl Locus url
-   * @param {String} options.deviceUrl Url of a device
-   * @param {String} options.resourceId Populated if you are paired to a device
-   * @param {String} options.localMedias local sdps
-   * @param {Boolean} options.preferTranscoding false for multistream (Homer), true for transcoded media (Edonus)
-   * @returns {Promise}
-   */
-  remoteAudioVideoToggle(
-    options:
-      | {
-          selfId: string;
-          locusUrl: string;
-          deviceUrl: string;
-          resourceId: string;
-          localMedias: string;
-        }
-      | any
-  ) {
-    const uri = `${options.locusUrl}/${PARTICIPANT}/${options.selfId}/${MEDIA}`;
-    const body = {
-      device: {
-        // @ts-ignore
-        deviceType: this.config.meetings.deviceType,
-        url: options.deviceUrl,
-      },
-      usingResource: options.resourceId || null,
-      correlationId: options.correlationId,
-      respOnlySdp: true,
-      localMedias: options.localMedias,
-      clientMediaPreferences: {
-        preferTranscoding: options.preferTranscoding ?? true,
-      },
-    };
-
-    // @ts-ignore
-    return this.request({
-      method: HTTP_VERBS.PUT,
-      uri,
-      body,
-    });
-  }
-
-  /**
    * change the content floor grant
    * @param {Object} options options for floor grant
    * @param {String} options.disposition floor action (granted/released)

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -72,7 +72,7 @@ MeetingUtil.remoteUpdateAudioVideo = (meeting, audioMuted?: boolean, videoMuted?
     .then((response) => {
       Metrics.postEvent({event: eventType.MEDIA_RESPONSE, meeting});
 
-      return response.body.locus;
+      return response?.body?.locus;
     });
 };
 

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -44,28 +44,30 @@ MeetingUtil.parseLocusJoin = (response) => {
   return parsed;
 };
 
-MeetingUtil.remoteUpdateAudioVideo = (audioMuted, videoMuted, meeting) => {
+MeetingUtil.remoteUpdateAudioVideo = (meeting, audioMuted?: boolean, videoMuted?: boolean) => {
   if (!meeting) {
     return Promise.reject(new ParameterError('You need a meeting object.'));
   }
-  const localMedias = Media.generateLocalMedias(meeting.mediaId, audioMuted, videoMuted);
 
-  if (isEmpty(localMedias)) {
+  if (!meeting.locusMediaRequest) {
     return Promise.reject(
-      new ParameterError('You need a media id on the meeting to change remote audio.')
+      new ParameterError(
+        'You need a meeting with a media connection, call Meeting.addMedia() first.'
+      )
     );
   }
 
   Metrics.postEvent({event: eventType.MEDIA_REQUEST, meeting});
 
-  return meeting.meetingRequest
-    .remoteAudioVideoToggle({
-      locusUrl: meeting.locusUrl,
-      selfId: meeting.selfId,
-      localMedias,
-      deviceUrl: meeting.deviceUrl,
-      correlationId: meeting.correlationId,
-      preferTranscoding: !meeting.isMultistream,
+  return meeting.locusMediaRequest
+    .send({
+      type: 'LocalMute',
+      selfUrl: meeting.selfUrl,
+      mediaId: meeting.mediaId,
+      muteOptions: {
+        audioMuted,
+        videoMuted,
+      },
     })
     .then((response) => {
       Metrics.postEvent({event: eventType.MEDIA_RESPONSE, meeting});

--- a/packages/@webex/plugin-meetings/src/roap/index.ts
+++ b/packages/@webex/plugin-meetings/src/roap/index.ts
@@ -98,11 +98,8 @@ export default class Roap extends StatelessWebexPlugin {
           roapMessage,
           locusSelfUrl: meeting.selfUrl,
           mediaId: options.mediaId,
-          correlationId: options.correlationId,
-          audioMuted: meeting.audio?.isLocallyMuted(),
-          videoMuted: meeting.video?.isLocallyMuted(),
           meetingId: meeting.id,
-          preferTranscoding: !meeting.isMultistream,
+          locusMediaRequest: meeting.locusMediaRequest,
         })
         .then(() => {
           LoggerProxy.logger.log(`Roap:index#sendRoapOK --> ROAP OK sent with seq ${options.seq}`);
@@ -135,11 +132,8 @@ export default class Roap extends StatelessWebexPlugin {
       roapMessage,
       locusSelfUrl: meeting.selfUrl,
       mediaId: options.mediaId,
-      correlationId: options.correlationId,
-      audioMuted: meeting.isAudioMuted(),
-      videoMuted: meeting.isVideoMuted(),
       meetingId: meeting.id,
-      preferTranscoding: !meeting.isMultistream,
+      locusMediaRequest: meeting.locusMediaRequest,
     });
   }
 
@@ -167,11 +161,8 @@ export default class Roap extends StatelessWebexPlugin {
         roapMessage,
         locusSelfUrl: meeting.selfUrl,
         mediaId: options.mediaId,
-        correlationId: options.correlationId,
-        audioMuted: meeting.audio?.isLocallyMuted(),
-        videoMuted: meeting.video?.isLocallyMuted(),
         meetingId: meeting.id,
-        preferTranscoding: !meeting.isMultistream,
+        locusMediaRequest: meeting.locusMediaRequest,
       })
       .then(() => {
         LoggerProxy.logger.log(
@@ -206,13 +197,10 @@ export default class Roap extends StatelessWebexPlugin {
 
         return this.roapRequest.sendRoap({
           roapMessage,
-          correlationId: meeting.correlationId,
           locusSelfUrl: meeting.selfUrl,
           mediaId: sendEmptyMediaId ? '' : meeting.mediaId,
-          audioMuted: meeting.audio?.isLocallyMuted(),
-          videoMuted: meeting.video?.isLocallyMuted(),
           meetingId: meeting.id,
-          preferTranscoding: !meeting.isMultistream,
+          locusMediaRequest: meeting.locusMediaRequest,
         });
       })
 

--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -3,7 +3,7 @@
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
 import LoggerProxy from '../common/logs/logger-proxy';
-import {MEDIA, HTTP_VERBS, REACHABILITY} from '../constants';
+import {REACHABILITY} from '../constants';
 import Metrics from '../metrics';
 import {eventType} from '../metrics/config';
 import {LocusMediaRequest} from '../meeting/locusMediaRequest';
@@ -73,7 +73,7 @@ export default class RoapRequest extends StatelessWebexPlugin {
     locusSelfUrl: string;
     mediaId: string;
     meetingId: string;
-    locusMediaRequest: LocusMediaRequest;
+    locusMediaRequest?: LocusMediaRequest;
   }) {
     const {roapMessage, locusSelfUrl, mediaId, meetingId, locusMediaRequest} = options;
 
@@ -81,6 +81,13 @@ export default class RoapRequest extends StatelessWebexPlugin {
       LoggerProxy.logger.info('Roap:request#sendRoap --> sending empty mediaID');
     }
 
+    if (!locusMediaRequest) {
+      LoggerProxy.logger.warn(
+        'Roap:request#sendRoap --> locusMediaRequest unavailable, not sending roap'
+      );
+
+      return Promise.reject(new Error('sendRoap called when locusMediaRequest is undefined'));
+    }
     const {localSdp: localSdpWithReachabilityData, joinCookie} = await this.attachReachabilityData({
       roapMessage,
     });

--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -176,15 +176,12 @@ export default class TurnDiscovery {
     return this.roapRequest
       .sendRoap({
         roapMessage,
-        correlationId: meeting.correlationId,
         // @ts-ignore - Fix missing type
         locusSelfUrl: meeting.selfUrl,
         // @ts-ignore - Fix missing type
         mediaId: isReconnecting ? '' : meeting.mediaId,
-        audioMuted: meeting.audio?.isLocallyMuted(),
-        videoMuted: meeting.video?.isLocallyMuted(),
         meetingId: meeting.id,
-        preferTranscoding: !meeting.isMultistream,
+        locusMediaRequest: meeting.locusMediaRequest,
       })
       .then(({mediaConnections}) => {
         if (mediaConnections) {
@@ -213,11 +210,8 @@ export default class TurnDiscovery {
       locusSelfUrl: meeting.selfUrl,
       // @ts-ignore - fix type
       mediaId: meeting.mediaId,
-      correlationId: meeting.correlationId,
-      audioMuted: meeting.audio?.isLocallyMuted(),
-      videoMuted: meeting.video?.isLocallyMuted(),
       meetingId: meeting.id,
-      preferTranscoding: !meeting.isMultistream,
+      locusMediaRequest: meeting.locusMediaRequest,
     });
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
@@ -1,0 +1,319 @@
+import sinon from 'sinon';
+import {assert} from '@webex/test-helper-chai';
+import { cloneDeep, defer } from 'lodash';
+
+import MockWebex from '@webex/test-helper-mock-webex';
+import Meetings from '@webex/plugin-meetings';
+import { LocalMuteRequest, LocusMediaRequest, RoapRequest } from "@webex/plugin-meetings/src/meeting/locusMediaRequest";
+import testUtils from '../../../utils/testUtils';
+import { Defer } from '@webex/common';
+
+describe('LocusMediaRequest.send()', () => {
+  let locusMediaRequest: LocusMediaRequest;
+  let webexRequestStub;
+  let mockWebex;
+
+  const fakeLocusResponse = {
+    locus: { something: 'whatever'}
+  };
+
+  const exampleRoapRequestBody:RoapRequest = {
+    type: 'RoapMessage',
+    mediaId: 'mediaId',
+    selfUrl: 'fakeMeetingSelfUrl',
+    roapMessage: {
+      messageType: 'OFFER',
+      sdps: ['sdp'],
+      version: '2',
+      seq: 1,
+      tieBreaker: 0xfffffffe,
+    },
+    reachability: {
+      'wjfkm.wjfkm.*': {udp:{reachable: true}, tcp:{reachable:false}},
+      '1eb65fdf-9643-417f-9974-ad72cae0e10f.59268c12-7a04-4b23-a1a1-4c74be03019a.*': {udp:{reachable: false}, tcp:{reachable:true}},
+    },
+    joinCookie: {
+      anycastEntryPoint: 'aws-eu-west-1',
+      clientIpAddress: 'some ip',
+      timeShot: '2023-05-23T08:03:49Z',
+    },
+  };
+
+  const createExpectedRoapBody = (expectedMessageType, expectedMute:{audioMuted: boolean, videoMuted: boolean}) => {
+    return {
+      device: { url: 'deviceUrl', deviceType: 'deviceType' },
+      correlationId: 'correlationId',
+      localMedias: [
+        {
+          localSdp: `{"audioMuted":${expectedMute.audioMuted},"videoMuted":${expectedMute.videoMuted},"roapMessage":{"messageType":"${expectedMessageType}","sdps":["sdp"],"version":"2","seq":1,"tieBreaker":4294967294},"reachability":{"wjfkm.wjfkm.*":{"udp":{"reachable":true},"tcp":{"reachable":false}},"1eb65fdf-9643-417f-9974-ad72cae0e10f.59268c12-7a04-4b23-a1a1-4c74be03019a.*":{"udp":{"reachable":false},"tcp":{"reachable":true}}}}`,
+          mediaId: 'mediaId'
+        }
+      ],
+      clientMediaPreferences: {
+        preferTranscoding: true,
+        joinCookie: {
+          anycastEntryPoint: 'aws-eu-west-1',
+          clientIpAddress: 'some ip',
+          timeShot: '2023-05-23T08:03:49Z'
+        }
+      }
+    };
+  };
+
+  const exampleLocalMuteRequestBody:LocalMuteRequest = {
+    type: 'LocalMute',
+    mediaId: 'mediaId',
+    selfUrl: 'fakeMeetingSelfUrl',
+    muteOptions: {},
+  };
+
+  const createExpectedLocalMuteBody = (expectedMute:{audioMuted: boolean, videoMuted: boolean}) => {
+    return {
+      device: {
+        url: 'deviceUrl',
+        deviceType: 'deviceType',
+      },
+      correlationId: 'correlationId',
+      usingResource: null,
+      respOnlySdp: true,
+      localMedias: [
+        {
+          mediaId: 'mediaId',
+          localSdp: `{"audioMuted":${expectedMute.audioMuted},"videoMuted":${expectedMute.videoMuted}}`,
+        },
+      ],
+      clientMediaPreferences: {
+        preferTranscoding: true,
+      },
+    }
+  };
+
+  beforeEach(() => {
+    mockWebex = new MockWebex({
+      children: {
+        meetings: Meetings,
+      },
+    });
+
+    locusMediaRequest = new LocusMediaRequest({
+      device: {
+        url: 'deviceUrl',
+        deviceType: 'deviceType',
+      },
+      correlationId: 'correlationId',
+      preferTranscoding: true,
+    }, {
+      parent: mockWebex,
+    });
+    webexRequestStub = sinon.stub(locusMediaRequest, 'request').resolves(fakeLocusResponse);
+  })
+
+  const sendLocalMute = (muteOptions) => locusMediaRequest.send({...exampleLocalMuteRequestBody, muteOptions});
+
+  const sendRoapMessage = (messageType) => {
+    const request = cloneDeep(exampleRoapRequestBody);
+
+    request.roapMessage.messageType = messageType;
+    return locusMediaRequest.send(request);
+  }
+
+  it('sends a roap message', async () => {
+    const result = await sendRoapMessage('OFFER');
+
+    assert.equal(result, fakeLocusResponse);
+
+    assert.calledOnceWithExactly(webexRequestStub, {
+      method: 'PUT',
+      uri: 'fakeMeetingSelfUrl/media',
+      body: createExpectedRoapBody('OFFER', {audioMuted: true, videoMuted: true}),
+    });
+  });
+
+  it('sends a local mute request', async () => {
+    const result = await sendLocalMute({audioMuted: false, videoMuted: false});
+
+    assert.equal(result, fakeLocusResponse);
+
+    assert.calledOnceWithExactly(webexRequestStub, {
+      method: 'PUT',
+      uri: 'fakeMeetingSelfUrl/media',
+      body: createExpectedLocalMuteBody({audioMuted: false, videoMuted: false}),
+    });
+  });
+
+  it('sends a local mute request with the last audio/video mute values when called multiple times in same processing cycle', async () => {
+    let result1;
+    let result2;
+
+    const promise1 = sendLocalMute({audioMuted: true, videoMuted: false})
+      .then((result) => {
+        result1 = result;
+      });
+
+    const promise2 = sendLocalMute({audioMuted: false, videoMuted: true})
+      .then((result) => {
+        result2 = result;
+      });
+
+    await testUtils.flushPromises();
+
+    await promise1;
+    await promise2;
+    assert.equal(result1, fakeLocusResponse);
+    assert.equal(result2, fakeLocusResponse);
+
+    assert.calledOnceWithExactly(webexRequestStub, {
+      method: 'PUT',
+      uri: 'fakeMeetingSelfUrl/media',
+      body: createExpectedLocalMuteBody({audioMuted: false, videoMuted: true}),
+    });
+
+  });
+
+  it('sends a local mute request with the last audio/video mute values', async () => {
+    await Promise.all([
+      sendLocalMute({audioMuted: undefined, videoMuted: false}),
+      sendLocalMute({audioMuted: true, videoMuted: undefined}),
+      sendLocalMute({audioMuted: false, videoMuted: true}),
+      sendLocalMute({audioMuted: true, videoMuted: false}),
+    ]);
+
+    assert.calledOnceWithExactly(webexRequestStub, {
+      method: 'PUT',
+      uri: 'fakeMeetingSelfUrl/media',
+      body: createExpectedLocalMuteBody({audioMuted: true, videoMuted: false}),
+    });
+
+  });
+
+  it('sends roap and local mute request', async () => {
+    await Promise.all([
+      sendLocalMute({audioMuted: false, videoMuted: undefined}),
+      sendRoapMessage('OFFER'),
+      sendLocalMute({audioMuted: true, videoMuted: false}),
+    ]);
+
+    /* check that only the roap message was sent and it had the last
+       values for audio and video mute
+    */
+    assert.calledOnceWithExactly(webexRequestStub, {
+      method: 'PUT',
+      uri: 'fakeMeetingSelfUrl/media',
+      body: createExpectedRoapBody('OFFER', {audioMuted: true, videoMuted: false}),
+    });
+  });
+
+  describe('queueing', () => {
+    let clock;
+    let requestsToLocus;
+    let results;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+      requestsToLocus = [];
+      results = [];
+
+      // setup the mock so that each new request that we send to Locus,
+      // returns a promise that we control from this test
+      webexRequestStub.callsFake(() => {
+        const defer = new Defer();
+        requestsToLocus.push(defer);
+        return defer.promise;
+      });
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('queues requests if there is one already in progress', async () => {
+      results.push(sendRoapMessage('OFFER'));
+
+      clock.tick(1);
+
+      // check that OFFER has been sent out
+      assert.calledWith(webexRequestStub, {
+        method: 'PUT',
+        uri: 'fakeMeetingSelfUrl/media',
+        body: createExpectedRoapBody('OFFER', {audioMuted: true, videoMuted: true}),
+      });
+
+      webexRequestStub.resetHistory();
+
+      // at this point the request should be sent out and "in progress",
+      // so any further calls should be queued
+      results.push(sendRoapMessage('OK'));
+
+      // OK should not be sent out yet, only queued
+      assert.notCalled(webexRequestStub);
+
+      // not simulate the first locus request (offer) to resolve,
+      // so that the next request from the queue (ok) can be sent out
+      requestsToLocus[0].resolve();
+      await testUtils.flushPromises();
+      clock.tick(1);
+
+      // verify OK was sent out
+      assert.calledWith(webexRequestStub, {
+        method: 'PUT',
+        uri: 'fakeMeetingSelfUrl/media',
+        body: createExpectedRoapBody('OK', {audioMuted: true, videoMuted: true}),
+      });
+
+      // promise returned by the first call to send OFFER should be resolved by now
+      await results[0];
+
+      // simulate Locus sending http response to OK
+      requestsToLocus[1].resolve();
+      await results[1];
+    });
+
+    it('combines local mute requests into a single /media request to Locus when queueing', async () => {
+      results.push(sendRoapMessage('OFFER'));
+      results.push(sendLocalMute({audioMuted: false, videoMuted: false}));
+
+      clock.tick(1);
+
+      // check that OFFER and local mute have been combined into
+      // a single OFFER request with the right mute values
+      assert.calledOnceWithExactly(webexRequestStub, {
+        method: 'PUT',
+        uri: 'fakeMeetingSelfUrl/media',
+        body: createExpectedRoapBody('OFFER', {audioMuted: false, videoMuted: false}),
+      });
+
+      webexRequestStub.resetHistory();
+
+      // at this point the request should be sent out and "in progress",
+      // so any further calls should be queued
+      results.push(sendLocalMute({audioMuted: true, videoMuted: false}));
+      results.push(sendRoapMessage('OK'));
+      results.push(sendLocalMute({audioMuted: false, videoMuted: true}));
+
+      // nothing should be sent out yet, only queued
+      assert.notCalled(webexRequestStub);
+
+      // now simulate the first locus request (offer) to resolve,
+      // so that the next request from the queue (ok) can be sent out
+      requestsToLocus[0].resolve();
+      await testUtils.flushPromises();
+      clock.tick(1);
+
+      // verify OK was sent out
+      assert.calledOnceWithExactly(webexRequestStub, {
+        method: 'PUT',
+        uri: 'fakeMeetingSelfUrl/media',
+        body: createExpectedRoapBody('OK', {audioMuted: false, videoMuted: true}),
+      });
+
+      // promise returned by the first call to send OFFER should be resolved by now
+      await results[0];
+
+      // simulate Locus sending http response to OK
+      requestsToLocus[1].resolve();
+      await results[1];
+    });
+  });
+
+
+})

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -134,50 +134,24 @@ describe('plugin-meetings', () => {
     });
 
     describe('remoteUpdateAudioVideo', () => {
-      it('#Should call meetingRequest.remoteAudioVideoToggle with correct parameters (multistream)', async () => {
+      it('#Should call meetingRequest.locusMediaRequest with correct parameters', async () => {
         const meeting = {
-          correlationId: 'correlation id',
-          isMultistream: true,
           mediaId: '12345',
-          meetingJoinUrl: 'meetingJoinUrl',
-          locusUrl: 'locusUrl',
-          deviceUrl: 'some device url',
-          selfId: 'self id',
-          meetingRequest: {
-            remoteAudioVideoToggle: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
+          selfUrl: 'self url',
+          locusMediaRequest: {
+            send: sinon.stub().resolves({body: {}, headers: {}}),
           },
         };
 
-        await MeetingUtil.remoteUpdateAudioVideo(true, false, meeting);
+        await MeetingUtil.remoteUpdateAudioVideo(meeting, true, false);
 
-        assert.calledOnce(meeting.meetingRequest.remoteAudioVideoToggle);
-        const parameter = meeting.meetingRequest.remoteAudioVideoToggle.getCall(0).args[0];
+        assert.calledOnce(meeting.locusMediaRequest.send);
+        const parameter = meeting.locusMediaRequest.send.getCall(0).args[0];
 
-        assert.equal(parameter.locusUrl, 'locusUrl');
-        assert.equal(parameter.selfId, 'self id');
-        assert.equal(parameter.correlationId, 'correlation id');
-        assert.equal(parameter.deviceUrl, 'some device url');
-        assert.deepEqual(parameter.localMedias, [
-          {localSdp: '{"audioMuted":true,"videoMuted":false}', mediaId: '12345'},
-        ]);
-        assert.equal(parameter.preferTranscoding, false);
-      });
-
-      it('#Should call meetingRequest.remoteAudioVideoToggle with preferTranscoding:true for non multistream connections', async () => {
-        const meeting = {
-          isMultistream: false,
-          mediaId: '12345',
-          meetingRequest: {
-            remoteAudioVideoToggle: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
-          },
-        };
-
-        await MeetingUtil.remoteUpdateAudioVideo(true, false, meeting);
-
-        assert.calledOnce(meeting.meetingRequest.remoteAudioVideoToggle);
-        const parameter = meeting.meetingRequest.remoteAudioVideoToggle.getCall(0).args[0];
-
-        assert.equal(parameter.preferTranscoding, true);
+        assert.equal(parameter.type, 'LocalMute');
+        assert.equal(parameter.selfUrl, 'self url');
+        assert.equal(parameter.mediaId, '12345');
+        assert.deepEqual(parameter.muteOptions, {audioMuted: true, videoMuted :false});
       });
     });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
@@ -54,6 +54,7 @@ describe('Roap', () => {
         },
         setRoapSeq: sinon.stub(),
         config: {experimental: {enableTurnDiscovery: false}},
+        locusMediaRequest: {fake: true},
         webex: { meetings: { reachability: { isAnyClusterReachable: () => true}}},
       };
 
@@ -99,48 +100,12 @@ describe('Roap', () => {
         assert.calledOnce(sendRoapStub);
         assert.calledWith(sendRoapStub, {
           roapMessage: expectedRoapMessage,
-          correlationId: meeting.correlationId,
           locusSelfUrl: meeting.selfUrl,
           mediaId: expectEmptyMediaId ? '' : meeting.mediaId,
-          audioMuted: meeting.audio?.isLocallyMuted(),
-          videoMuted: meeting.video?.isLocallyMuted(),
           meetingId: meeting.id,
-          preferTranscoding: true,
+          locusMediaRequest: meeting.locusMediaRequest,
         });
       })
     );
-    it('sends roap request with preferTranscoding=false for multistream meetings', async () => {
-      const roap = new Roap({}, {parent: 'fake'});
-
-      meeting.isMultistream = true;
-
-      await roap.sendRoapMediaRequest({
-        meeting,
-        sdp: 'sdp',
-        reconnect: false,
-        seq: 10,
-        tieBreaker: 1,
-      });
-
-      const expectedRoapMessage = {
-        messageType: 'OFFER',
-        sdps: ['sdp'],
-        version: '2',
-        seq: 10,
-        tieBreaker: 1,
-      };
-
-      assert.calledOnce(sendRoapStub);
-      assert.calledWith(sendRoapStub, {
-        roapMessage: expectedRoapMessage,
-        correlationId: meeting.correlationId,
-        locusSelfUrl: meeting.selfUrl,
-        mediaId: meeting.mediaId,
-        audioMuted: meeting.audio.isLocallyMuted(),
-        videoMuted: meeting.video.isLocallyMuted(),
-        meetingId: meeting.id,
-        preferTranscoding: false,
-      });
-    });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -51,7 +51,8 @@ describe('TurnDiscovery', () => {
       }),
       updateMediaConnections: sinon.stub(),
       webex: {meetings: {reachability: {isAnyClusterReachable: () => Promise.resolve(false)}}},
-      isMultistream: false
+      isMultistream: false,
+      locusMediaRequest: { fake: true },
     };
   });
 
@@ -74,13 +75,10 @@ describe('TurnDiscovery', () => {
         version: '2',
         seq: expectedSeq,
       },
-      correlationId: testMeeting.correlationId,
       locusSelfUrl: testMeeting.selfUrl,
       mediaId: expectedMediaId,
-      audioMuted: testMeeting.audio?.isLocallyMuted(),
-      videoMuted: testMeeting.video?.isLocallyMuted(),
       meetingId: testMeeting.id,
-      preferTranscoding: !testMeeting.isMultistream
+      locusMediaRequest: testMeeting.locusMediaRequest
     });
 
     if (messageType === 'TURN_DISCOVERY_REQUEST') {


### PR DESCRIPTION
# COMPLETES [SPARK-429638](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-429638), [SPARK-396696](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-396696)

## This pull request addresses

3 main issues:
1. When tracks are published, there are 2 separate state machines for audio and video and they trigger local mute updates in Locus independently. If these happen quickly one after another Locus may handle them out of order resulting in incorrect mute state.
2. Roap messages can happen at any time and they also end up calling /media API in Locus (same as local mute state updates), so they can happen while we are sending a local mute state update - this can cause problems and incorrect mute state in Locus.
3. If client mutes/unmutes very quickly at the beginning when joining a meeting and we try to send local mute update on /media API to Locus before we've sent an SDP offer, Locus fails, because there is no confluence in the server

## by making the following changes

Created a new class LocusMediaRequest that makes sure that we only ever have 1 /media request to Locus "in flight" and also avoids redundant calls to /media, for example, if we need to send a roap message and do a local mute update, these 2 requests can be combined into a single /media request or if there are multiple local mute state updates queued, they can all be combined into a single request with the latest required audioMuted and videoMuted values.
LocusMediaRequest also makes sure we don't call /media with just local mute updates before we've sent a Roap offer.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

Manual e2e testing with the web app + unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
