### PR TITLE
fix: SDK requesting too many streams from Homer

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -14,7 +14,7 @@
     "node": ">=16"
   },
   "dependencies": {
-    "@webex/internal-media-core": "1.38.3",
+    "@webex/internal-media-core": "1.38.5",
     "@webex/web-media-effects": "^2.8.0"
   },
   "browserify": {

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:^",
-    "@webex/internal-media-core": "1.38.3",
+    "@webex/internal-media-core": "1.38.5",
     "@webex/internal-plugin-conversation": "workspace:^",
     "@webex/internal-plugin-device": "workspace:^",
     "@webex/internal-plugin-llm": "workspace:^",

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4804,6 +4804,10 @@ export default class Meeting extends StatelessWebexPlugin {
             mediaContent,
           }
         );
+
+        if (mediaContent === 'MAIN') {
+          this.mediaRequestManagers.video.setNumCurrentSources(numTotalSources, numLiveSources);
+        }
       }
     );
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -7,6 +7,7 @@ import {
   Errors,
   ErrorType,
   Event,
+  MediaContent,
   MediaType,
   RemoteTrackType,
 } from '@webex/internal-media-core';
@@ -4809,7 +4810,9 @@ export default class Meeting extends StatelessWebexPlugin {
           }
         );
 
-        this.mediaRequestManagers.video.setNumCurrentSources(numTotalSources, numLiveSources);
+        if (mediaContent === MediaContent.Main) {
+          this.mediaRequestManagers.video.setNumCurrentSources(numTotalSources, numLiveSources);
+        }
       }
     );
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -8,7 +8,6 @@ import {
   ErrorType,
   Event,
   MediaType,
-  MediaContent,
   RemoteTrackType,
 } from '@webex/internal-media-core';
 
@@ -670,6 +669,7 @@ export default class Meeting extends StatelessWebexPlugin {
           // @ts-ignore - config coming from registerPlugin
           degradationPreferences: this.config.degradationPreferences,
           kind: 'audio',
+          trimRequestsToNumOfSources: false,
         }
       ),
       video: new MediaRequestManager(
@@ -690,6 +690,7 @@ export default class Meeting extends StatelessWebexPlugin {
           // @ts-ignore - config coming from registerPlugin
           degradationPreferences: this.config.degradationPreferences,
           kind: 'video',
+          trimRequestsToNumOfSources: true,
         }
       ),
       screenShareAudio: new MediaRequestManager(
@@ -710,6 +711,7 @@ export default class Meeting extends StatelessWebexPlugin {
           // @ts-ignore - config coming from registerPlugin
           degradationPreferences: this.config.degradationPreferences,
           kind: 'audio',
+          trimRequestsToNumOfSources: false,
         }
       ),
       screenShareVideo: new MediaRequestManager(
@@ -730,6 +732,7 @@ export default class Meeting extends StatelessWebexPlugin {
           // @ts-ignore - config coming from registerPlugin
           degradationPreferences: this.config.degradationPreferences,
           kind: 'video',
+          trimRequestsToNumOfSources: false,
         }
       ),
     };
@@ -4806,9 +4809,7 @@ export default class Meeting extends StatelessWebexPlugin {
           }
         );
 
-        if (mediaContent === MediaContent.Main) {
-          this.mediaRequestManagers.video.setNumCurrentSources(numTotalSources, numLiveSources);
-        }
+        this.mediaRequestManagers.video.setNumCurrentSources(numTotalSources, numLiveSources);
       }
     );
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -8,6 +8,7 @@ import {
   ErrorType,
   Event,
   MediaType,
+  MediaContent,
   RemoteTrackType,
 } from '@webex/internal-media-core';
 
@@ -4805,7 +4806,7 @@ export default class Meeting extends StatelessWebexPlugin {
           }
         );
 
-        if (mediaContent === 'MAIN') {
+        if (mediaContent === MediaContent.Main) {
           this.mediaRequestManagers.video.setNumCurrentSources(numTotalSources, numLiveSources);
         }
       }

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -427,6 +427,8 @@ export class MediaRequestManager {
 
   public reset() {
     this.clientRequests = {};
+    this.numTotalSources = 0;
+    this.numLiveSources = 0;
   }
 
   public setNumCurrentSources(numTotalSources: number, numLiveSources: number) {

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -9,7 +9,7 @@ import {
   getRecommendedMaxBitrateForFrameSize,
   RecommendedOpusBitrates,
 } from '@webex/internal-media-core';
-import {cloneDeep, debounce, isEmpty} from 'lodash';
+import {cloneDeepWith, debounce, isEmpty} from 'lodash';
 
 import LoggerProxy from '../common/logs/logger-proxy';
 
@@ -73,6 +73,9 @@ type Options = {
   degradationPreferences: DegradationPreferences;
   kind: Kind;
 };
+
+type ClientRequestsMap = {[key: MediaRequestId]: MediaRequest};
+
 export class MediaRequestManager {
   private sendMediaRequestsCallback: SendMediaRequestsCallback;
 
@@ -80,7 +83,7 @@ export class MediaRequestManager {
 
   private counter: number;
 
-  private clientRequests: {[key: MediaRequestId]: MediaRequest};
+  private clientRequests: ClientRequestsMap;
 
   private degradationPreferences: DegradationPreferences;
 
@@ -90,9 +93,14 @@ export class MediaRequestManager {
 
   private previousStreamRequests: Array<StreamRequest> = [];
 
+  private numTotalSources?: number;
+  private numLiveSources?: number;
+
   constructor(sendMediaRequestsCallback: SendMediaRequestsCallback, options: Options) {
     this.sendMediaRequestsCallback = sendMediaRequestsCallback;
     this.counter = 0;
+    this.numLiveSources = undefined;
+    this.numTotalSources = undefined;
     this.clientRequests = {};
     this.degradationPreferences = options.degradationPreferences;
     this.kind = options.kind;
@@ -108,8 +116,7 @@ export class MediaRequestManager {
     this.sendRequests(); // re-send requests after preferences are set
   }
 
-  private getDegradedClientRequests() {
-    const clientRequests = cloneDeep(this.clientRequests);
+  private getDegradedClientRequests(clientRequests: ClientRequestsMap) {
     const maxFsLimits = [
       getMaxFs('best'),
       getMaxFs('large'),
@@ -122,7 +129,7 @@ export class MediaRequestManager {
     // reduce max-fs until total macroblocks is below limit
     for (let i = 0; i < maxFsLimits.length; i += 1) {
       let totalMacroblocksRequested = 0;
-      Object.entries(clientRequests).forEach(([id, mr]) => {
+      Object.values(clientRequests).forEach((mr) => {
         if (mr.codecInfo) {
           mr.codecInfo.maxFs = Math.min(
             mr.preferredMaxFs || CODEC_DEFAULTS.h264.maxFs,
@@ -130,9 +137,7 @@ export class MediaRequestManager {
             maxFsLimits[i]
           );
           // we only consider sources with "live" state
-          const slotsWithLiveSource = this.clientRequests[id].receiveSlots.filter(
-            (rs) => rs.sourceState === 'live'
-          );
+          const slotsWithLiveSource = mr.receiveSlots.filter((rs) => rs.sourceState === 'live');
           totalMacroblocksRequested += mr.codecInfo.maxFs * slotsWithLiveSource.length;
         }
       });
@@ -149,8 +154,6 @@ export class MediaRequestManager {
         );
       }
     }
-
-    return clientRequests;
   }
 
   /**
@@ -231,42 +234,137 @@ export class MediaRequestManager {
     this.previousStreamRequests = [];
   }
 
+  /** Modifies the passed in clientRequests and makes sure that in total they don't ask
+   *  for more streams than there are available.
+   *
+   * @param {Object} clientRequests
+   * @returns {void}
+   */
+  private trimRequests(clientRequests: ClientRequestsMap) {
+    const preferLiveVideo = this.getPreferLiveVideo();
+
+    if (this.numLiveSources === undefined || this.numTotalSources === undefined) {
+      // for audio and screen share we don't keep track of number of sources and we don't do trimming
+      return;
+    }
+
+    // preferLiveVideo being undefined means that there are no active-speaker requests so we don't need to do any trimming
+    if (preferLiveVideo === undefined) {
+      return;
+    }
+
+    let numStreamsAvailable = preferLiveVideo ? this.numLiveSources : this.numTotalSources;
+
+    Object.values(clientRequests)
+      .sort((a, b) => {
+        // we have to count how many streams we're asking for
+        // and should not ask for more than numStreamsAvailable in total,
+        // so we might need to trim active-speaker requests and first ones to trim should be
+        // the ones with lowest priority
+
+        // receiver-selected requests have priority over active-speakers
+        if (a.policyInfo.policy === 'receiver-selected') {
+          return -1;
+        }
+        if (b.policyInfo.policy === 'receiver-selected') {
+          return 1;
+        }
+
+        // and active-speakers are sorted by descending priority
+        return b.policyInfo.priority - a.policyInfo.priority;
+      })
+      .forEach((request) => {
+        // we only trim active-speaker requests
+        if (request.policyInfo.policy === 'active-speaker') {
+          const trimmedCount = Math.min(numStreamsAvailable, request.receiveSlots.length);
+
+          request.receiveSlots.length = trimmedCount;
+
+          numStreamsAvailable -= trimmedCount;
+        } else {
+          numStreamsAvailable -= request.receiveSlots.length;
+        }
+
+        if (numStreamsAvailable < 0) {
+          numStreamsAvailable = 0;
+        }
+      });
+  }
+
+  private getPreferLiveVideo(): boolean | undefined {
+    let preferLiveVideo;
+
+    Object.values(this.clientRequests).forEach((mr) => {
+      if (mr.policyInfo.policy === 'active-speaker') {
+        // take the value from first encountered active speaker request
+        if (preferLiveVideo === undefined) {
+          preferLiveVideo = mr.policyInfo.preferLiveVideo;
+        }
+
+        if (mr.policyInfo.preferLiveVideo !== preferLiveVideo) {
+          throw new Error(
+            'a mix of active-speaker groups with different values for preferLiveVideo is not supported'
+          );
+        }
+      }
+    });
+
+    return preferLiveVideo;
+  }
+
+  private cloneClientRequests(): ClientRequestsMap {
+    // we clone the client requests but without cloning the ReceiveSlots that they reference
+    return cloneDeepWith(this.clientRequests, (value, key) => {
+      if (key === 'receiveSlots') {
+        return [...value];
+      }
+
+      return undefined;
+    });
+  }
+
   private sendRequests() {
     const streamRequests: StreamRequest[] = [];
 
-    const clientRequests = this.getDegradedClientRequests();
+    // clone the requests so that any modifications we do to them don't affect the original ones
+    const clientRequests = this.cloneClientRequests();
+
+    this.trimRequests(clientRequests);
+    this.getDegradedClientRequests(clientRequests);
 
     // map all the client media requests to wcme stream requests
     Object.values(clientRequests).forEach((mr) => {
-      streamRequests.push(
-        new StreamRequest(
-          mr.policyInfo.policy === 'active-speaker'
-            ? Policy.ActiveSpeaker
-            : Policy.ReceiverSelected,
-          mr.policyInfo.policy === 'active-speaker'
-            ? new ActiveSpeakerInfo(
-                mr.policyInfo.priority,
-                mr.policyInfo.crossPriorityDuplication,
-                mr.policyInfo.crossPolicyDuplication,
-                mr.policyInfo.preferLiveVideo
-              )
-            : new ReceiverSelectedInfo(mr.policyInfo.csi),
-          mr.receiveSlots.map((receiveSlot) => receiveSlot.wcmeReceiveSlot),
-          this.getMaxPayloadBitsPerSecond(mr),
-          mr.codecInfo && [
-            new WcmeCodecInfo(
-              0x80,
-              new H264Codec(
-                mr.codecInfo.maxFs,
-                mr.codecInfo.maxFps || CODEC_DEFAULTS.h264.maxFps,
-                this.getH264MaxMbps(mr),
-                mr.codecInfo.maxWidth,
-                mr.codecInfo.maxHeight
-              )
-            ),
-          ]
-        )
-      );
+      if (mr.receiveSlots.length > 0) {
+        streamRequests.push(
+          new StreamRequest(
+            mr.policyInfo.policy === 'active-speaker'
+              ? Policy.ActiveSpeaker
+              : Policy.ReceiverSelected,
+            mr.policyInfo.policy === 'active-speaker'
+              ? new ActiveSpeakerInfo(
+                  mr.policyInfo.priority,
+                  mr.policyInfo.crossPriorityDuplication,
+                  mr.policyInfo.crossPolicyDuplication,
+                  mr.policyInfo.preferLiveVideo
+                )
+              : new ReceiverSelectedInfo(mr.policyInfo.csi),
+            mr.receiveSlots.map((receiveSlot) => receiveSlot.wcmeReceiveSlot),
+            this.getMaxPayloadBitsPerSecond(mr),
+            mr.codecInfo && [
+              new WcmeCodecInfo(
+                0x80,
+                new H264Codec(
+                  mr.codecInfo.maxFs,
+                  mr.codecInfo.maxFps || CODEC_DEFAULTS.h264.maxFps,
+                  this.getH264MaxMbps(mr),
+                  mr.codecInfo.maxWidth,
+                  mr.codecInfo.maxHeight
+                )
+              ),
+            ]
+          )
+        );
+      }
     });
 
     //! IMPORTANT: this is only a temporary fix. This will soon be done in the jmp layer (@webex/json-multistream)
@@ -327,5 +425,12 @@ export class MediaRequestManager {
 
   public reset() {
     this.clientRequests = {};
+  }
+
+  public setNumCurrentSources(numTotalSources: number, numLiveSources: number) {
+    this.numTotalSources = numTotalSources;
+    this.numLiveSources = numLiveSources;
+
+    this.sendRequests();
   }
 }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -4265,6 +4265,80 @@ describe('plugin-meetings', () => {
             });
           });
         });
+
+        describe('audio and video source count change events', () => {
+          beforeEach(() => {
+            TriggerProxy.trigger.resetHistory();
+            meeting.setupMediaConnectionListeners();
+          });
+
+          it('registers for audio and video source count changed', () => {
+            assert.isFunction(eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED]);
+            assert.isFunction(eventListeners[Event.AUDIO_SOURCES_COUNT_CHANGED]);
+          })
+
+          it('forwards the VIDEO_SOURCES_COUNT_CHANGED event as "media:remoteVideoSourceCountChanged"', () => {
+            const numTotalSources = 10;
+            const numLiveSources = 6;
+            const mediaContent = 'SLIDES';
+
+            eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, mediaContent);
+
+            assert.calledOnceWithExactly(TriggerProxy.trigger,
+              meeting,
+              sinon.match.object,
+              'media:remoteVideoSourceCountChanged',
+              {
+                numTotalSources,
+                numLiveSources,
+                mediaContent,
+              }
+            );
+          });
+
+          it('forwards the AUDIO_SOURCES_COUNT_CHANGED event as "media:remoteAudioSourceCountChanged"', () => {
+            const numTotalSources = 5;
+            const numLiveSources = 2;
+            const mediaContent = 'MAIN';
+
+            eventListeners[Event.AUDIO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, mediaContent);
+
+            assert.calledOnceWithExactly(TriggerProxy.trigger,
+              meeting,
+              sinon.match.object,
+              'media:remoteAudioSourceCountChanged',
+              {
+                numTotalSources,
+                numLiveSources,
+                mediaContent,
+              }
+            );
+          });
+
+          it('calls setNumCurrentSources() when receives VIDEO_SOURCES_COUNT_CHANGED event for MAIN', () => {
+            const numTotalSources = 20;
+            const numLiveSources = 10;
+            const mediaContent = 'MAIN';
+
+            const setNumCurrentSourcesSpy = sinon.stub(meeting.mediaRequestManagers.video, 'setNumCurrentSources');
+
+            eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, mediaContent);
+
+            assert.calledOnceWithExactly(setNumCurrentSourcesSpy, numTotalSources, numLiveSources);
+          });
+
+          it('does not call setNumCurrentSources() when receives VIDEO_SOURCES_COUNT_CHANGED event for SLIDES', () => {
+            const numTotalSources = 20;
+            const numLiveSources = 10;
+            const mediaContent = 'SLIDES';
+
+            const setNumCurrentSourcesSpy = sinon.stub(meeting.mediaRequestManagers.video, 'setNumCurrentSources');
+
+            eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, mediaContent);
+
+            assert.notCalled(setNumCurrentSourcesSpy);
+          });
+        })
       });
       describe('#setUpLocusInfoSelfListener', () => {
         it('listens to the self unadmitted guest event', (done) => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -4317,16 +4317,28 @@ describe('plugin-meetings', () => {
             );
           });
 
-          it('calls setNumCurrentSources() when receives VIDEO_SOURCES_COUNT_CHANGED event', () => {
+          it('calls setNumCurrentSources() when receives VIDEO_SOURCES_COUNT_CHANGED event for MAIN', () => {
             const numTotalSources = 20;
             const numLiveSources = 10;
 
             const setNumCurrentSourcesSpy = sinon.stub(meeting.mediaRequestManagers.video, 'setNumCurrentSources');
 
-            eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, 'whatever');
+            eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, 'MAIN');
 
             assert.calledOnceWithExactly(setNumCurrentSourcesSpy, numTotalSources, numLiveSources);
           });
+
+          it('does not call setNumCurrentSources() when receives VIDEO_SOURCES_COUNT_CHANGED event for SLIDES', () => {
+            const numTotalSources = 20;
+            const numLiveSources = 10;
+
+            const setNumCurrentSourcesSpy = sinon.stub(meeting.mediaRequestManagers.video, 'setNumCurrentSources');
+
+            eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, 'SLIDES');
+
+            assert.notCalled(setNumCurrentSourcesSpy);
+          });
+
         })
       });
       describe('#setUpLocusInfoSelfListener', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -4282,6 +4282,8 @@ describe('plugin-meetings', () => {
             const numLiveSources = 6;
             const mediaContent = 'SLIDES';
 
+            sinon.stub(meeting.mediaRequestManagers.video, 'setNumCurrentSources');
+
             eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, mediaContent);
 
             assert.calledOnceWithExactly(TriggerProxy.trigger,
@@ -4315,28 +4317,15 @@ describe('plugin-meetings', () => {
             );
           });
 
-          it('calls setNumCurrentSources() when receives VIDEO_SOURCES_COUNT_CHANGED event for MAIN', () => {
+          it('calls setNumCurrentSources() when receives VIDEO_SOURCES_COUNT_CHANGED event', () => {
             const numTotalSources = 20;
             const numLiveSources = 10;
-            const mediaContent = 'MAIN';
 
             const setNumCurrentSourcesSpy = sinon.stub(meeting.mediaRequestManagers.video, 'setNumCurrentSources');
 
-            eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, mediaContent);
+            eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, 'whatever');
 
             assert.calledOnceWithExactly(setNumCurrentSourcesSpy, numTotalSources, numLiveSources);
-          });
-
-          it('does not call setNumCurrentSources() when receives VIDEO_SOURCES_COUNT_CHANGED event for SLIDES', () => {
-            const numTotalSources = 20;
-            const numLiveSources = 10;
-            const mediaContent = 'SLIDES';
-
-            const setNumCurrentSourcesSpy = sinon.stub(meeting.mediaRequestManagers.video, 'setNumCurrentSources');
-
-            eventListeners[Event.VIDEO_SOURCES_COUNT_CHANGED](numTotalSources, numLiveSources, mediaContent);
-
-            assert.notCalled(setNumCurrentSourcesSpy);
           });
         })
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -1354,8 +1354,42 @@ describe('MediaRequestManager', () => {
             },
           ], {preferLiveVideo});
         });
+
+        it('resets num of sources to 0 when reset() is called', async () => {
+          // set available streams to non-zero value
+          limitNumAvailableStreams(preferLiveVideo, 4);
+          sendMediaRequestsCallback.resetHistory();
+
+          // do the reset
+          mediaRequestManager.reset();
+
+          // add some receiver-selected and active-speaker requests
+          addReceiverSelectedRequest(200, fakeReceiveSlots[0], MAX_FS_360p, false);
+          addActiveSpeakerRequest(
+            255,
+            [fakeReceiveSlots[1], fakeReceiveSlots[2], fakeReceiveSlots[3]],
+            MAX_FS_360p,
+            false,
+            preferLiveVideo
+          );
+
+          mediaRequestManager.commit();
+
+          // verify that AS request was trimmed to 0, because we've reset mediaRequestManager so available streams count is 0 now
+          checkMediaRequestsSent([
+            {
+              policy: 'receiver-selected',
+              csi: 200,
+              receiveSlot: fakeWcmeSlots[0],
+              maxPayloadBitsPerSecond: MAX_PAYLOADBITSPS_360p,
+              maxFs: MAX_FS_360p,
+              maxMbps: MAX_MBPS_360p,
+            },
+          ], {preferLiveVideo});
+        });
       })
     );
+
 
     it('throws if there are 2 active-speaker requests with different preferLiveVideo values', () => {
       addActiveSpeakerRequest(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4164,13 +4164,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:1.38.3":
-  version: 1.38.3
-  resolution: "@webex/internal-media-core@npm:1.38.3"
+"@webex/internal-media-core@npm:1.38.5":
+  version: 1.38.5
+  resolution: "@webex/internal-media-core@npm:1.38.5"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@webex/json-multistream": "npm:2.0.1"
-    "@webex/ts-sdp": "npm:1.3.2"
+    "@webex/ts-sdp": "npm:1.4.1"
     "@webex/web-client-media-engine": "npm:2.1.3"
     detectrtc: "npm:^1.4.1"
     events: "npm:^3.3.0"
@@ -4178,7 +4178,7 @@ __metadata:
     uuid: "npm:^8.3.2"
     webrtc-adapter: "npm:^8.1.2"
     xstate: "npm:^4.30.6"
-  checksum: 1aad4e8b205b8057c325643e8341cca41202493107acd871bb3e726490a0e0fce3a11e75c7d4df88667a64f9d7be177f4d7bb05b7c75973d3bc9b064615a49e8
+  checksum: ee9d23e90465182d7f4dce40ebfb9c04418deb00873c8222ada9d59cd8d8928e2d772361d3284c6dedd651d694bf3c45b475d6ce918d149039641c5b0e1bd497
   languageName: node
   linkType: hard
 
@@ -4645,7 +4645,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webex/media-helpers@workspace:packages/@webex/media-helpers"
   dependencies:
-    "@webex/internal-media-core": "npm:1.38.3"
+    "@webex/internal-media-core": "npm:1.38.5"
     "@webex/test-helper-chai": "workspace:^"
     "@webex/test-helper-mock-webex": "workspace:^"
     "@webex/web-media-effects": "npm:^2.8.0"
@@ -4781,7 +4781,7 @@ __metadata:
   resolution: "@webex/plugin-meetings@workspace:packages/@webex/plugin-meetings"
   dependencies:
     "@webex/common": "workspace:^"
-    "@webex/internal-media-core": "npm:1.38.3"
+    "@webex/internal-media-core": "npm:1.38.5"
     "@webex/internal-plugin-conversation": "workspace:^"
     "@webex/internal-plugin-device": "workspace:^"
     "@webex/internal-plugin-llm": "workspace:^"
@@ -5197,10 +5197,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/ts-sdp@npm:1.3.2":
-  version: 1.3.2
-  resolution: "@webex/ts-sdp@npm:1.3.2"
-  checksum: 6c96fcd880dc068315be85c9edea2b00deeb1ff1fa351f85ce3aeda335ced839b799883113925ee78ef9d77e4f59a8433dc73320aa4fcb03fe1fbc376ad59d2f
+"@webex/ts-sdp@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@webex/ts-sdp@npm:1.4.1"
+  checksum: 1249d16ab5c8c6b150f292f5da8734badb65451a5c9a59683fcc0278274dcda7a52ff4914135c9b058cf960a50ff470d3820bb890cb910964fa9c73378654309
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES #
[SPARK-430526](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-430526)

## This pull request addresses

SDK is sometimes requesting more streams that are actually available and this messes up Homer's calculations for bandwidth estimation and as a result we sometimes get "bandwidth limited" source state for some receive slots instead of the video.

## by making the following changes

Changed MediaRequestManager so that it trims the active-speaker media requests to not ask in total across all requests for more than the num of total or live sources (depending on the preferLiveVideo option). This is done only for main video, no need for it for slides or audio.


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

manual testing with sample app and web app, unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
