### PR TITLE
feat(ca): fix error for meeting info

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
@@ -347,11 +347,12 @@ export default class MeetingInfoV2 {
       })
       .catch((err) => {
         if (meetingId) {
+          const parsedError = Metrics.parseWebexApiError(err, true);
           Metrics.postEvent({
             event: eventType.MEETING_INFO_RESPONSE,
             meetingId,
             data: {
-              errors: [Metrics.parseWebexApiError(err, true)],
+              errors: parsedError ? [parsedError] : undefined,
               meetingLookupUrl: err?.url,
             },
           });

--- a/packages/@webex/plugin-meetings/src/metrics/index.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/index.ts
@@ -468,7 +468,7 @@ class Metrics {
       return this.generateErrorPayload(clientCodeError, showToUser, error.name.OTHER, err);
     }
 
-    return null;
+    return this.generateErrorPayload(4100, showToUser, error.name.OTHER, err);
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -483,7 +483,7 @@ describe('plugin-meetings', () => {
 
       it('should not have errors if parsing error returns null', async () => {
         Metrics.postEvent = sinon.stub();
-        Metrics.parseWebexApiError = sinon.stub().returns(null);
+        sinon.stub(Metrics, 'parseWebexApiError').returns(null);
         const message = 'a message';
         const meetingInfoData = 'meeting info';
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -483,6 +483,7 @@ describe('plugin-meetings', () => {
 
       it('should not have errors if parsing error returns null', async () => {
         Metrics.postEvent = sinon.stub();
+        Metrics.parseWebexApiError = sinon.stub().returns(null);
         const message = 'a message';
         const meetingInfoData = 'meeting info';
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -481,6 +481,43 @@ describe('plugin-meetings', () => {
         }
       });
 
+      it('should not have errors if parsing error returns null', async () => {
+        Metrics.postEvent = sinon.stub();
+        const message = 'a message';
+        const meetingInfoData = 'meeting info';
+
+        webex.request = sinon.stub().rejects({
+          statusCode: 403,
+          body: {message, code: 1000000, data: {meetingInfo: meetingInfoData}},
+          url: 'http://api-url.com',
+        });
+        try {
+          await meetingInfo.fetchMeetingInfo(
+            '1234323',
+            _MEETING_ID_,
+            'abc',
+            {
+              id: '999',
+              code: 'aabbcc11',
+            },
+            null,
+            null,
+            {},
+            {meetingId: 'meeting-id'}
+          );
+          assert.fail('fetchMeetingInfo should have thrown, but has not done that');
+        } catch (err) {
+          assert.calledWith(Metrics.postEvent, {
+            event: 'client.meetinginfo.response',
+            meetingId: 'meeting-id',
+            data: {
+              errors: undefined,
+              meetingLookupUrl: 'http://api-url.com',
+            }
+          });
+        }
+      });
+
       it('should throw MeetingInfoV2PasswordError for 403 response', async () => {
         const FAKE_MEETING_INFO = {blablabla: 'some_fake_meeting_info'};
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/metrics/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/metrics/index.js
@@ -154,7 +154,7 @@ browserOnly(describe)('Meeting metrics', () => {
       });
     });
 
-    it('returns  null for unknown error', () => {
+    it('returns default 4100 mapping for unknown error', () => {
       const err = {
         body: {
           code: 123456,
@@ -162,7 +162,16 @@ browserOnly(describe)('Meeting metrics', () => {
       };
       const res = metrics.parseWebexApiError(err, false);
 
-      assert.deepEqual(res, null);
+      assert.deepEqual(res, {
+        shownToUser: false,
+        category: 'signaling',
+        errorDescription: 'MeetingInfoLookupError',
+        errorCode: 4100,
+        fatal: true,
+        name: 'other',
+        serviceErrorCode: 123456,
+        errorData:  { error: { code: 123456 } },
+      });
     });
   });
 


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

- fix critical issue in CA, errors cannot contain empty array or [null] if the error mapping fails
- add default error mapping for meeting info response err

## by making the following changes

- refactor

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

manual, unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
