### PR TITLE
chore(logger): handle runtime config.historyLength changes

### DIFF
--- a/packages/@webex/plugin-logger/src/config.js
+++ b/packages/@webex/plugin-logger/src/config.js
@@ -18,6 +18,6 @@
 export default {
   logger: {
     level: process.env.WEBEX_LOG_LEVEL,
-    historyLength: 1000,
+    historyLength: 10000,
   },
 };

--- a/packages/@webex/plugin-logger/src/logger.js
+++ b/packages/@webex/plugin-logger/src/logger.js
@@ -377,7 +377,7 @@ function makeLoggerMethod(level, impl, type, neverPrint = false, alwaysBuffer = 
         stringified.unshift('|  '.repeat(this.groupLevel));
         buffer.push(stringified);
         if (buffer.length > historyLength) {
-          buffer.shift();
+          buffer.splice(0, buffer.length - historyLength);
         }
         if (level === 'group') this.groupLevel += 1;
         if (level === 'groupEnd' && this.groupLevel > 0) this.groupLevel -= 1;


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #SPARK-431897

## This pull request addresses

- reduce log truncations

## by making the following changes

- increasing the config.historyLength default value to 10000
- handle runtime config.historyLength changes

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
