### PR TITLE
feat(calendar): spark-413846 replace id with uri when call calendar api getPartipants and getNotes

### DIFF
--- a/packages/@webex/internal-plugin-calendar/src/calendar.js
+++ b/packages/@webex/internal-plugin-calendar/src/calendar.js
@@ -257,7 +257,7 @@ const Calendar = WebexPlugin.extend({
   },
 
   /**
-   * Retrieves a collection of meetings based on the request parameters
+   * get meeting notes using notesUrl from meeting object.
    * @param {String} notesUrl
    * @returns {Promise} Resolves with an object of meeting notes
    */

--- a/packages/@webex/internal-plugin-calendar/src/calendar.js
+++ b/packages/@webex/internal-plugin-calendar/src/calendar.js
@@ -261,7 +261,7 @@ const Calendar = WebexPlugin.extend({
    * @param {String} notesUrl
    * @returns {Promise} Resolves with an object of meeting notes
    */
-  getNotesByUri(notesUrl) {
+  getNotesByUrl(notesUrl) {
     return this.request({
       method: 'GET',
       uri: notesUrl,

--- a/packages/@webex/internal-plugin-calendar/src/calendar.js
+++ b/packages/@webex/internal-plugin-calendar/src/calendar.js
@@ -245,15 +245,26 @@ const Calendar = WebexPlugin.extend({
   },
 
   /**
-   * Retrieves an array of meeting participants for the meeting id
-   * @param {String} id
+   * Retrieves an array of meeting participants for the meeting participantsUrl
+   * @param {String} participantsUrl
    * @returns {Promise} Resolves with an object of meeting participants
    */
-  getParticipants(id) {
+  getParticipants(participantsUrl) {
     return this.request({
       method: 'GET',
-      service: 'calendar',
-      resource: `calendarEvents/${btoa(id)}/participants`,
+      uri: participantsUrl,
+    });
+  },
+
+  /**
+   * Retrieves a collection of meetings based on the request parameters
+   * @param {String} notesUrl
+   * @returns {Promise} Resolves with an object of meeting notes
+   */
+  getNotesByUri(notesUrl) {
+    return this.request({
+      method: 'GET',
+      uri: notesUrl,
     });
   },
 
@@ -294,7 +305,7 @@ const Calendar = WebexPlugin.extend({
         meetingObjects.forEach((meeting) => {
           if (!meeting.encryptedParticipants) {
             promises.push(
-              this.getParticipants(meeting.id).then((notesResponse) => {
+              this.getParticipants(meeting.participantsUrl).then((notesResponse) => {
                 meeting.encryptedParticipants = notesResponse.body.encryptedParticipants;
               })
             );

--- a/packages/@webex/internal-plugin-calendar/test/unit/spec/calendar.js
+++ b/packages/@webex/internal-plugin-calendar/test/unit/spec/calendar.js
@@ -291,7 +291,7 @@ describe('internal-plugin-calendar', () => {
       });
 
       describe('#getParticipants()', () => {
-        const id = 'meetingId123';
+        const uri = 'participantsUrl';
 
         it('should fetch the meeting participants', async () => {
           webex.request = sinon.stub().returns(
@@ -302,13 +302,34 @@ describe('internal-plugin-calendar', () => {
             })
           );
 
-          const res = await webex.internal.calendar.getParticipants(id);
+          const res = await webex.internal.calendar.getParticipants(uri);
 
           assert.equal(res.body.encryptedParticipants.length, 1);
           assert.calledWith(webex.request, {
             method: 'GET',
-            service: 'calendar',
-            resource: `calendarEvents/${btoa(id)}/participants`,
+            uri,
+          });
+        });
+      });
+
+      describe('#getNotesByUri()', () => {
+        const uri = 'notesUrl';
+
+        it('should fetch the meeting notes', async () => {
+          webex.request = sinon.stub().returns(
+            Promise.resolve({
+              body: {
+                encryptedParticipants: ['participant1'],
+              },
+            })
+          );
+
+          const res = await webex.internal.calendar.getNotesByUri(uri);
+
+          assert.equal(res.body.encryptedParticipants.length, 1);
+          assert.calledWith(webex.request, {
+            method: 'GET',
+            uri,
           });
         });
       });

--- a/packages/@webex/internal-plugin-calendar/test/unit/spec/calendar.js
+++ b/packages/@webex/internal-plugin-calendar/test/unit/spec/calendar.js
@@ -312,7 +312,7 @@ describe('internal-plugin-calendar', () => {
         });
       });
 
-      describe('#getNotesByUri()', () => {
+      describe('#getNotesByUrl()', () => {
         const uri = 'notesUrl';
 
         it('should fetch the meeting notes', async () => {
@@ -324,7 +324,7 @@ describe('internal-plugin-calendar', () => {
             })
           );
 
-          const res = await webex.internal.calendar.getNotesByUri(uri);
+          const res = await webex.internal.calendar.getNotesByUrl(uri);
 
           assert.equal(res.body.encryptedParticipants.length, 1);
           assert.calledWith(webex.request, {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-413846

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >
spark-413846 replace id with uri when call calendar api getPartipants and getNotesByUrl

< DESCRIBE YOUR CHANGES >
1. add new function: getNotesByUri
2. getParticipants replace id with uri  

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
