### PR TITLE
feat(plugin-meetings): add method to enable music mode

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -7566,6 +7566,32 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
+   * Method to enable or disable the 'Music mode' effect on audio track
+   *
+   * @param {boolean} shouldEnableMusicMode
+   * @returns {Promise}
+   */
+  async enableMusicMode(shouldEnableMusicMode: boolean) {
+    this.checkMediaConnection();
+
+    if (!this.isMultistream) {
+      throw new Error('enableMusicMode() only supported with multistream');
+    }
+
+    if (shouldEnableMusicMode) {
+      await this.mediaProperties.webrtcMediaConnection.setCodecParameters(MediaType.AudioMain, {
+        maxaveragebitrate: '64000',
+        maxplaybackrate: '48000',
+      });
+    } else {
+      await this.mediaProperties.webrtcMediaConnection.deleteCodecParameters(MediaType.AudioMain, [
+        'maxaveragebitrate',
+        'maxplaybackrate',
+      ]);
+    }
+  }
+
+  /**
    * Publishes specified local tracks in the meeting
    *
    * @param {Object} tracks

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -4126,6 +4126,43 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#enableMusicMode', () => {
+      beforeEach(() => {
+        meeting.isMultistream = true;
+          meeting.mediaProperties.webrtcMediaConnection = {
+            setCodecParameters: sinon.stub().resolves({}),
+            deleteCodecParameters: sinon.stub().resolves({}),
+          };
+      });
+      [
+        {shouldEnableMusicMode: true},
+        {shouldEnableMusicMode: false},
+      ].forEach(({shouldEnableMusicMode}) => {
+        it(`fails if there is no media connection for shouldEnableMusicMode: ${shouldEnableMusicMode}`, async () => {
+          meeting.mediaProperties.webrtcMediaConnection = undefined;
+          await assert.isRejected(meeting.enableMusicMode(shouldEnableMusicMode));
+        });
+      });
+
+      it('should set the codec parameters when shouldEnableMusicMode is true', async () => {
+        await meeting.enableMusicMode(true);
+        assert.calledOnceWithExactly(meeting.mediaProperties.webrtcMediaConnection.setCodecParameters, MediaType.AudioMain, {
+          maxaveragebitrate: '64000',
+          maxplaybackrate: '48000',
+        });
+        assert.notCalled(meeting.mediaProperties.webrtcMediaConnection.deleteCodecParameters);
+      });
+
+      it('should set the codec parameters when shouldEnableMusicMode is false', async () => {
+        await meeting.enableMusicMode(false);
+        assert.calledOnceWithExactly(meeting.mediaProperties.webrtcMediaConnection.deleteCodecParameters, MediaType.AudioMain, [
+          'maxaveragebitrate',
+          'maxplaybackrate',
+        ]);
+        assert.notCalled(meeting.mediaProperties.webrtcMediaConnection.setCodecParameters);
+      });
+    });
+
     describe('Public Event Triggers', () => {
       let sandbox;
       const {ENDED} = CONSTANTS;


### PR DESCRIPTION
# COMPLETES # [SPARK-434477](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-434477)

## This pull request addresses
For multistream, we need to set/delete sdp parameters for music mode on audio lines that is performed by the `setCodecParameters` and `deleteCodecParameters` of WCME. We are writing a method to interface the same with the client.

## by making the following changes
We are writing a method `enableMusicMode` to interface the with the web-client to apply/remove the codecParameters on the audio lines for music mode.

### Change Type
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
