### PR TITLE
fix(Live-Annotation): processStrokeMessage format bug

### DIFF
--- a/packages/@webex/plugin-meetings/src/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/index.ts
@@ -44,20 +44,22 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
    * @returns {void}
    */
   private processStrokeMessage(request) {
-    this.decryptContent(request.encryptionKeyUrl, request.content).then((decryptedContent) => {
-      request.content = decryptedContent;
-      TriggerProxy.trigger(
-        this,
-        {
-          file: 'annotation',
-          function: 'processStrokeMessage',
-        },
-        EVENT_TRIGGERS.ANNOTATION_STROKE_DATA,
-        {
-          data: request,
-        }
-      );
-    });
+    this.decryptContent(request.value.encryptionKeyUrl, request.value.content).then(
+      (decryptedContent) => {
+        request.value.content = decryptedContent;
+        TriggerProxy.trigger(
+          this,
+          {
+            file: 'annotation',
+            function: 'processStrokeMessage',
+          },
+          EVENT_TRIGGERS.ANNOTATION_STROKE_DATA,
+          {
+            payload: request.value,
+          }
+        );
+      }
+    );
   }
 
   /** bind all events from mercury

--- a/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
@@ -142,9 +142,9 @@ describe('live-annotation', () => {
 
         const spy = sinon.spy(annotationService, "processStrokeMessage");
 
-        annotationService.eventDataProcessor({data: {relayType: 'annotation.client', request: 'request'}});
+        annotationService.eventDataProcessor({data: {relayType: 'annotation.client', request:{value:{encryptionKeyUrl:"encryptionKeyUrl"}}}});
 
-        assert.calledOnceWithExactly(spy, 'request');
+        assert.calledOnceWithExactly(spy, {value:{encryptionKeyUrl:"encryptionKeyUrl"}});
 
       });
 
@@ -153,7 +153,7 @@ describe('live-annotation', () => {
         const spy = sinon.spy();
         annotationService.on(EVENT_TRIGGERS.ANNOTATION_STROKE_DATA, spy);
 
-        await annotationService.processStrokeMessage({encryptionKeyUrl: 'encryptionKeyUrl', content: 'content'});
+        await annotationService.processStrokeMessage({value:{encryptionKeyUrl: 'encryptionKeyUrl', content: 'content'}});
 
         assert.calledOnceWithExactly(spy, {
           payload: {encryptionKeyUrl: 'encryptionKeyUrl', content: 'decryptedContent'},

--- a/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
@@ -156,7 +156,7 @@ describe('live-annotation', () => {
         await annotationService.processStrokeMessage({encryptionKeyUrl: 'encryptionKeyUrl', content: 'content'});
 
         assert.calledOnceWithExactly(spy, {
-          data: {encryptionKeyUrl: 'encryptionKeyUrl', content: 'decryptedContent'},
+          payload: {encryptionKeyUrl: 'encryptionKeyUrl', content: 'decryptedContent'},
         });
 
       });


### PR DESCRIPTION
 fix processStrokeMessage format bug. The format needs to follow the protocol

https://confluence-eng-gpk2.cisco.com/conf/display/WMT/Annotation+Protocol+Detail+Definition

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
