### PR TITLE
feat(plugin-meetings): fallback to getting preferred site from user

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -953,6 +953,8 @@ export default class Meetings extends WebexPlugin {
               user?.userPreferences?.userPreferencesItems?.preferredWebExSite;
             if (preferredWebexSite) {
               this.preferredWebexSite = preferredWebexSite;
+            } else {
+              throw new Error('site not found');
             }
           })
           .catch(() => {

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -942,6 +942,27 @@ export default class Meetings extends WebexPlugin {
       if (res) {
         this.preferredWebexSite = MeetingsUtil.parseDefaultSiteFromMeetingPreferences(res);
       }
+
+      // fall back to getting the preferred site from the user information
+      if (!this.preferredWebexSite) {
+        // @ts-ignore
+        return this.webex.internal.user
+          .get()
+          .then((user) => {
+            const preferredWebexSite =
+              user?.userPreferences?.userPreferencesItems?.preferredWebExSite;
+            if (preferredWebexSite) {
+              this.preferredWebexSite = preferredWebexSite;
+            }
+          })
+          .catch(() => {
+            LoggerProxy.logger.error(
+              'Failed to fetch preferred site from user - no site will be set'
+            );
+          });
+      }
+
+      return Promise.resolve();
     });
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1382,6 +1382,9 @@ describe('plugin-meetings', () => {
       });
 
       describe('#fetchUserPreferredWebexSite', () => {
+
+        let loggerProxySpy;
+
         it('should call request.getMeetingPreferences to get the preferred webex site ', async () => {
           assert.isDefined(webex.meetings.preferredWebexSite);
           await webex.meetings.fetchUserPreferredWebexSite();
@@ -1390,6 +1393,8 @@ describe('plugin-meetings', () => {
         });
 
         const setup = ({user} = {}) => {
+          loggerProxySpy = sinon.spy(LoggerProxy.logger, 'error');
+
           Object.assign(webex.internal, {
             services: {
               getMeetingPreferences: sinon.stub().returns(Promise.resolve({})),
@@ -1414,6 +1419,10 @@ describe('plugin-meetings', () => {
           await webex.meetings.fetchUserPreferredWebexSite().then(() => {
             assert.equal(webex.meetings.preferredWebexSite, '');
           });
+          assert.calledOnceWithExactly(
+            loggerProxySpy,
+            'Failed to fetch preferred site from user - no site will be set'
+          );
         });
 
         it('should fall back to fetching the site from the user', async () => {
@@ -1430,6 +1439,7 @@ describe('plugin-meetings', () => {
           await webex.meetings.fetchUserPreferredWebexSite();
 
           assert.equal(webex.meetings.preferredWebexSite, 'site.webex.com');
+          assert.notCalled(loggerProxySpy);
         });
 
         forEach([
@@ -1444,6 +1454,10 @@ describe('plugin-meetings', () => {
             await webex.meetings.fetchUserPreferredWebexSite();
 
             assert.equal(webex.meetings.preferredWebexSite, '');
+            assert.calledOnceWithExactly(
+              loggerProxySpy,
+              'Failed to fetch preferred site from user - no site will be set'
+            );
           });
         });
 
@@ -1455,6 +1469,10 @@ describe('plugin-meetings', () => {
           await webex.meetings.fetchUserPreferredWebexSite();
 
           assert.equal(webex.meetings.preferredWebexSite, '');
+          assert.calledOnceWithExactly(
+            loggerProxySpy,
+            'Failed to fetch preferred site from user - no site will be set'
+          );
         });
 
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1381,7 +1381,7 @@ describe('plugin-meetings', () => {
         });
       });
 
-      describe.only('#fetchUserPreferredWebexSite', () => {
+      describe('#fetchUserPreferredWebexSite', () => {
         it('should call request.getMeetingPreferences to get the preferred webex site ', async () => {
           assert.isDefined(webex.meetings.preferredWebexSite);
           await webex.meetings.fetchUserPreferredWebexSite();


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

Sometimes the request to fetch the preferred site information from hydra fails. In that case fall back to getting it from the user info.

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
