### PR TITLE
fix(plugin-meetings): listen to relay event from llm when update llm

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4601,13 +4601,17 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     // @ts-ignore - Fix type
-    return this.webex.internal.llm.registerAndConnect(url, datachannelUrl).then(() => {
-      // @ts-ignore - Fix type
-      this.webex.internal.llm.on('event:relay.event', this.processRelayEvent);
-      LoggerProxy.logger.info(
-        'Meeting:index#updateLLMConnection --> enabled to receive relay events!'
-      );
-    });
+    return this.webex.internal.llm
+      .registerAndConnect(url, datachannelUrl)
+      .then((registerAndConnectResult) => {
+        // @ts-ignore - Fix type
+        this.webex.internal.llm.on('event:relay.event', this.processRelayEvent);
+        LoggerProxy.logger.info(
+          'Meeting:index#updateLLMConnection --> enabled to receive relay events!'
+        );
+
+        return Promise.resolve(registerAndConnectResult);
+      });
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4513,9 +4513,6 @@ export default class Meeting extends StatelessWebexPlugin {
         // @ts-ignore - config coming from registerPlugin
         if (this.config.enableAutomaticLLM) {
           await this.updateLLMConnection();
-          // @ts-ignore - Fix type
-          this.webex.internal.llm.on('event:relay.event', this.processRelayEvent);
-          LoggerProxy.logger.info('Meeting:index#join --> enabled to receive relay events!');
         }
 
         return join;
@@ -4604,7 +4601,13 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     // @ts-ignore - Fix type
-    return this.webex.internal.llm.registerAndConnect(url, datachannelUrl);
+    return this.webex.internal.llm.registerAndConnect(url, datachannelUrl).then(() => {
+      // @ts-ignore - Fix type
+      this.webex.internal.llm.on('event:relay.event', this.processRelayEvent);
+      LoggerProxy.logger.info(
+        'Meeting:index#updateLLMConnection --> enabled to receive relay events!'
+      );
+    });
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -981,24 +981,15 @@ describe('plugin-meetings', () => {
 
           it('should call updateLLMConnection upon joining if config value is set', async () => {
             meeting.config.enableAutomaticLLM = true;
-            meeting.webex.internal.llm.on = sinon.stub();
-            meeting.processRelayEvent = sinon.stub();
             await meeting.join();
 
             assert.calledOnce(meeting.updateLLMConnection);
-            assert.calledOnceWithExactly(
-              meeting.webex.internal.llm.on,
-              'event:relay.event',
-              meeting.processRelayEvent
-            );
           });
 
           it('should not call updateLLMConnection upon joining if config value is not set', async () => {
-            meeting.webex.internal.llm.on = sinon.stub();
             await meeting.join();
 
             assert.notCalled(meeting.updateLLMConnection);
-            assert.notCalled(meeting.webex.internal.llm.on);
           });
 
           it('should invoke `receiveTranscription()` if receiveTranscription is set to true', async () => {
@@ -5684,6 +5675,8 @@ describe('plugin-meetings', () => {
             .stub()
             .returns(Promise.resolve('something'));
           webex.internal.llm.disconnectLLM = sinon.stub().returns(Promise.resolve());
+          meeting.webex.internal.llm.on = sinon.stub();
+          meeting.processRelayEvent = sinon.stub();
         });
 
         it('does not connect if the call is not joined yet', async () => {
@@ -5697,6 +5690,7 @@ describe('plugin-meetings', () => {
           assert.notCalled(webex.internal.llm.registerAndConnect);
           assert.notCalled(webex.internal.llm.disconnectLLM);
           assert.equal(result, undefined);
+          assert.notCalled(meeting.webex.internal.llm.on);
         });
 
         it('returns undefined if llm is already connected and the locus url is unchanged', async () => {
@@ -5711,17 +5705,24 @@ describe('plugin-meetings', () => {
           assert.notCalled(webex.internal.llm.registerAndConnect);
           assert.notCalled(webex.internal.llm.disconnectLLM);
           assert.equal(result, undefined);
+          assert.notCalled(meeting.webex.internal.llm.on);
         });
 
         it('connects if not already connected', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.locusInfo = {url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
+          
 
           const result = await meeting.updateLLMConnection();
 
           assert.notCalled(webex.internal.llm.disconnectLLM);
           assert.calledWith(webex.internal.llm.registerAndConnect, 'a url', 'a datachannel url');
           assert.equal(result, 'something');
+          assert.calledOnceWithExactly(
+            meeting.webex.internal.llm.on,
+            'event:relay.event',
+            meeting.processRelayEvent
+          );
         });
 
         it('disconnects if first if the locus url has changed', async () => {
@@ -5740,12 +5741,19 @@ describe('plugin-meetings', () => {
             'a datachannel url'
           );
           assert.equal(result, 'something');
+          assert.calledOnceWithExactly(
+            meeting.webex.internal.llm.on,
+            'event:relay.event',
+            meeting.processRelayEvent
+          );
         });
 
         it('disconnects when the state is not JOINED', async () => {
           meeting.joinedWith = {state: 'any other state'};
           webex.internal.llm.isConnected.returns(true);
           webex.internal.llm.getLocusUrl.returns('a url');
+          meeting.webex.internal.llm.off = sinon.stub();
+          meeting.processRelayEvent = sinon.stub();
 
           meeting.locusInfo = {url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
 
@@ -5754,7 +5762,13 @@ describe('plugin-meetings', () => {
           assert.calledWith(webex.internal.llm.disconnectLLM);
           assert.notCalled(webex.internal.llm.registerAndConnect);
           assert.equal(result, undefined);
+          assert.calledOnceWithExactly(
+            meeting.webex.internal.llm.off,
+            'event:relay.event',
+            meeting.processRelayEvent
+          );
         });
+
       });
 
       describe('#setLocus', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-429053](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-429053)

## This pull request addresses

current issue: the locus url changes when user join or leave a breakout session, and the connection to the LLM is reconnected, and it will stop listening to the `event:relay.event` event and will not listen to it again.

## by making the following changes

listen to `event:relay.event` of LLM when connection updates

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
