### PR TITLE
fix(plugin-meetings): peerconnection detached only after sending last mqa

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -300,7 +300,6 @@ export class StatsAnalyzer extends EventsScope {
         this.mediaConnection = null;
       });
     }
-    this.mediaConnection = null;
 
     return Promise.resolve();
   }


### PR DESCRIPTION
# COMPLETES [SPARK-431624](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-431624)

## This pull request addresses

One of the customers reported an error thrown up at the time of leaving the meeting. The error is thrown because peerConnection is null at the time of getting and parsing stats one last time before cleaning up the peerConnection.

## by making the following changes

The change is simply to remove the peerConnection only after sending one last MQA data which already happens in [this line](https://github.com/webex/webex-js-sdk/pull/2867/files#diff-bfae05440410022d826a0f6d3ee83997e3471a619c6d7925db6da86a83597990R394). Just that we had to not remove peerConnection before the request for sending one last MQA data is complete.

## broader explanation is

The **MeetingUtil.cleanUp** method is being called thrice when meeting leave happens. 

- **First time -** From the **locusInfo.on(EVENTS.DESTROY_MEETING)** event where the **autoUploadLogs** isn't true. 
This is when cleanUp calls the **stopAnalyzer** and **stopAnalyzer** makes a **getStatsAndParse** request. Inside the **getStatsAndParse**, after getting stats from each transceiver, we set the directions in the **statsResults** as indicated in the below screenshot.
![Screenshot 2023-06-12 at 11 17 02 AM](https://github.com/webex/webex-js-sdk/assets/8044050/58953f49-e678-40cd-a581-edde07ac7523)


- **Second time -**  From the **MeetingUtil.leaveMeeting** 
When this **cleanUp** call happens, the promise for **getStatsAndParse** in the previous request hasn't been resolved yet. However, the **peerConnection** gets set to **null**. Now after this, when the **getStatsAndParse** request completes and we try to access the **peerConnection** to set the directions to stats results, it is already null and we are not able to access any of **audioTransceiver**, v**ideoTranciever** or **shareTranceiver**

- **Third time -** This is not impactful but this also happens
This call happens once the log upload is complete and the Meeting destroy is called

Therefore, the code solution for this is to not set peerConnection to null until the promise for getStatsAndParse is complete. 

CC - [Marcin Wojtczak](https://jira-eng-gpk2.cisco.com/jira/secure/ViewProfile.jspa?name=mawojtcz)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
