### PR TITLE
fix(meetings): reaction controls service workaround

### DIFF
--- a/packages/@webex/plugin-meetings/src/controls-options-manager/util.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/util.ts
@@ -153,17 +153,22 @@ class Utils {
   ) {
     const requiredHints = [];
 
-    if (control.properties.enabled === true) {
-      requiredHints.push(DISPLAY_HINTS.ENABLE_REACTIONS);
-    }
-    if (control.properties.enabled === false) {
-      requiredHints.push(DISPLAY_HINTS.DISABLE_REACTIONS);
-    }
-    if (control.properties.showDisplayNameWithReactions === true) {
-      requiredHints.push(DISPLAY_HINTS.ENABLE_SHOW_DISPLAY_NAME);
-    }
-    if (control.properties.showDisplayNameWithReactions === false) {
-      requiredHints.push(DISPLAY_HINTS.DISABLE_SHOW_DISPLAY_NAME);
+    // This additional if statement avoids the display hint discrepency due to
+    // the service blocking partial requests with this property only.
+    if (control.properties.showDisplayNameWithReactions !== undefined) {
+      if (control.properties.showDisplayNameWithReactions === true) {
+        requiredHints.push(DISPLAY_HINTS.ENABLE_SHOW_DISPLAY_NAME);
+      }
+      if (control.properties.showDisplayNameWithReactions === false) {
+        requiredHints.push(DISPLAY_HINTS.DISABLE_SHOW_DISPLAY_NAME);
+      }
+    } else {
+      if (control.properties.enabled === true) {
+        requiredHints.push(DISPLAY_HINTS.ENABLE_REACTIONS);
+      }
+      if (control.properties.enabled === false) {
+        requiredHints.push(DISPLAY_HINTS.DISABLE_REACTIONS);
+      }
     }
 
     return Utils.hasHints({requiredHints, displayHints});

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/util.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/util.js
@@ -203,7 +203,22 @@ describe('plugin-meetings', () => {
                 });
               });
 
-              it('should call hasHints() with all properties after negotiating hints', () => {
+              it('should call hasHints() with only enabled hints when respective property is provided', () => {
+                const properties = {
+                  enabled: true,
+                };
+
+                ControlsOptionsUtil.canUpdateReactions({properties}, []);
+
+                assert.calledWith(ControlsOptionsUtil.hasHints, {
+                  requiredHints: [
+                    DISPLAY_HINTS.ENABLE_REACTIONS,
+                  ],
+                  displayHints: [],
+                });
+              });
+
+              it('should call hasHints() with only display name hints when respective property is provided', () => {
                 const properties = {
                   enabled: true,
                   showDisplayNameWithReactions: true,
@@ -213,7 +228,6 @@ describe('plugin-meetings', () => {
 
                 assert.calledWith(ControlsOptionsUtil.hasHints, {
                   requiredHints: [
-                    DISPLAY_HINTS.ENABLE_REACTIONS,
                     DISPLAY_HINTS.ENABLE_SHOW_DISPLAY_NAME,
                   ],
                   displayHints: [],


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to hot-fix the service issue not accepting partial controls payloads for reactions. This is explicitly for controls requests within meetings, and within the reactions scope only.

## Screenshots

![Screenshot 2023-06-13 at 10 31 16 AM](https://github.com/webex/webex-js-sdk/assets/14828820/ed6e237f-2de3-4086-ba18-a655cb6b9c14)
