### PR TITLE
fix(plugin-meetings): remove listeners

### DIFF
--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -5,6 +5,8 @@ import {assert} from '@webex/test-helper-chai';
 import {getMaxFs} from '@webex/plugin-meetings/src/multistream/remoteMedia';
 import FakeTimers from '@sinonjs/fake-timers';
 import * as mediaCore from '@webex/internal-media-core';
+import { assertFunction } from '@babel/types';
+import { expect } from 'chai';
 
 type ExpectedActiveSpeaker = {
   policy: 'active-speaker';
@@ -79,7 +81,7 @@ describe('MediaRequestManager', () => {
   });
 
   // helper function for adding an active speaker request
-  const addActiveSpeakerRequest = (priority, receiveSlots, maxFs, commit = false) =>
+  const addActiveSpeakerRequest = (priority, receiveSlots, maxFs, commit = false) => 
     mediaRequestManager.addRequest(
       {
         policyInfo: {
@@ -381,7 +383,7 @@ describe('MediaRequestManager', () => {
     ]);
   });
 
-  it('removes the events maxFsUpdate and sourceUpdate when cancelRequest() is called', () => {
+  it('removes the events maxFsUpdate and sourceUpdate when cancelRequest() is called', async () => {
 
     const requestId = addActiveSpeakerRequest(255, [fakeReceiveSlots[2], fakeReceiveSlots[3]], MAX_FS_720p);
 
@@ -393,6 +395,9 @@ describe('MediaRequestManager', () => {
 
     const maxFsEventName = maxFsHandlerCall.args[0];
     const sourceUpdateEventName = sourceUpdateHandler.args[0];
+
+    expect(sourceUpdateHandler.args[1]).to.be.a('function');
+    expect(maxFsHandlerCall.args[1]).to.be.a('function');
 
     assert.equal(maxFsEventName, 'maxFsUpdate')
     assert.equal(sourceUpdateEventName, 'sourceUpdate')
@@ -1075,3 +1080,7 @@ describe('MediaRequestManager', () => {
     });
   });
 });
+function assertEqual(arg0: any, arg1: string) {
+  throw new Error('Function not implemented.');
+}
+

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -381,6 +381,23 @@ describe('MediaRequestManager', () => {
     ]);
   });
 
+  it('removes the events maxFsUpdate and sourceUpdate when cancelRequest() is called', () => {
+
+    const requestId = addActiveSpeakerRequest(255, [fakeReceiveSlots[2], fakeReceiveSlots[3]], MAX_FS_720p);
+
+    mediaRequestManager.cancelRequest(requestId, true);
+
+    const sourceUpdateHandler = fakeReceiveSlots[2].off.getCall(0);
+
+    const maxFsHandlerCall = fakeReceiveSlots[2].off.getCall(1);
+
+    const maxFsEventName = maxFsHandlerCall.args[0];
+    const sourceUpdateEventName = sourceUpdateHandler.args[0];
+
+    assert.equal(maxFsEventName, 'maxFsUpdate')
+    assert.equal(sourceUpdateEventName, 'sourceUpdate')
+  });
+
   it('cancels the requests correctly when cancelRequest() is called with commit=true', () => {
     const requestIds = [
       addActiveSpeakerRequest(255, [fakeReceiveSlots[0], fakeReceiveSlots[1]], MAX_FS_720p),


### PR DESCRIPTION
Listener for maxFsUpdate was not removed on cancelRequest which was causing warning for memory leak detected in canitna on pagination

 This PR fixes that issue by removing the listeners

# COMPLETES #< INSERT LINK TO ISSUE >

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-436891

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >
Listener for maxFsUpdate was not removed on cancelRequest which was causing warning for memory leak detected in canitna on pagination

 This PR fixes that issue by removing the listeners

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
