### PR TITLE
feat(conversation): do not encrypte meeting container policies

### DIFF
--- a/packages/@webex/internal-plugin-conversation/src/encryption-transforms.js
+++ b/packages/@webex/internal-plugin-conversation/src/encryption-transforms.js
@@ -82,6 +82,14 @@ export const transforms = toArray('outbound', {
   },
 
   encryptActivity(ctx, key, activity) {
+    // Meeting Container policy update requests do not need to be encrypted.
+    if (
+      activity?.target?.objectType === 'meetingContainer' &&
+      activity?.object?.objectType === 'policies'
+    ) {
+      return Promise.resolve();
+    }
+
     // Activity is already encrypted
     if (activity.encryptionKeyUrl || activity.object?.created === 'True') {
       return Promise.resolve();

--- a/packages/@webex/internal-plugin-conversation/test/unit/spec/encryption-transforms.js
+++ b/packages/@webex/internal-plugin-conversation/test/unit/spec/encryption-transforms.js
@@ -36,6 +36,29 @@ describe('plugin-conversation', () => {
           });
       });
 
+      it('does not transform when object type is "policies" for a "meetingContainer" activity', async () => {
+        const transform = transforms.find((t) => t.name === 'encryptActivity');
+        const transformStub = sinon.stub().resolves();
+
+        const ctx = {
+          transform: transformStub,
+        };
+        const key = null;
+        const activity = {
+          object: {
+            objectType: 'policies',
+          },
+          objectType: 'activity',
+          target: {
+            objectType: 'meetingContainer',
+          },
+          verb: 'update',
+        };
+
+        const results = await transform.fn(ctx, key, activity);
+        assert.equal(results, undefined);
+      });
+
       it('does transfom when created is not True', async () => {
         const transform = transforms.find((t) => t.name === 'encryptActivity');
         const transformStub = sinon.stub().resolves();


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to narrow the scope of the conversation encryption transforms to not include meeting container policy updates. This allows for these requests to be sent as intended by the service.

## Links

[SPARK-438073](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-438073)