### PR TITLE
fix: changes required to work with new internal media core api

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -14,7 +14,7 @@
     "node": ">=16"
   },
   "dependencies": {
-    "@webex/internal-media-core": "1.38.2",
+    "@webex/internal-media-core": "1.38.3",
     "@webex/web-media-effects": "^2.8.0"
   },
   "browserify": {

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:^",
-    "@webex/internal-media-core": "1.38.2",
+    "@webex/internal-media-core": "1.38.3",
     "@webex/internal-plugin-conversation": "workspace:^",
     "@webex/internal-plugin-device": "workspace:^",
     "@webex/internal-plugin-llm": "workspace:^",

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -77,6 +77,22 @@ Media.getLocalMedia = (options: any, config: object) => {
   return Promise.resolve(undefined);
 };
 
+Media.getDirection = (receive: boolean, send: boolean) => {
+  if (!receive && !send) {
+    return 'inactive';
+  }
+
+  if (receive && send) {
+    return 'sendrecv';
+  }
+
+  if (receive) {
+    return 'recvonly';
+  }
+
+  return 'sendonly';
+};
+
 /**
  * creates a webrtc media connection with provided tracks and mediaDirection configuration
  *
@@ -186,9 +202,9 @@ Media.createMediaConnection = (
         screenShareVideo: shareTrack?.underlyingTrack,
       },
       receive: {
-        audio: mediaDirection.receiveAudio,
-        video: mediaDirection.receiveVideo,
-        screenShareVideo: mediaDirection.receiveShare,
+        audio: Media.getDirection(mediaDirection.receiveAudio, mediaDirection.sendAudio),
+        video: Media.getDirection(mediaDirection.receiveVideo, mediaDirection.sendVideo),
+        screenShareVideo: Media.getDirection(mediaDirection.receiveShare, mediaDirection.sendShare),
         remoteQualityLevel,
       },
     },

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -196,17 +196,17 @@ Media.createMediaConnection = (
       },
     },
     {
-      send: {
+      localTracks: {
         audio: audioTrack?.underlyingTrack,
         video: videoTrack?.underlyingTrack,
         screenShareVideo: shareTrack?.underlyingTrack,
       },
-      receive: {
+      direction: {
         audio: Media.getDirection(mediaDirection.receiveAudio, mediaDirection.sendAudio),
         video: Media.getDirection(mediaDirection.receiveVideo, mediaDirection.sendVideo),
         screenShareVideo: Media.getDirection(mediaDirection.receiveShare, mediaDirection.sendShare),
-        remoteQualityLevel,
       },
+      remoteQualityLevel,
     },
     debugId
   );

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5994,8 +5994,8 @@ export default class Meeting extends StatelessWebexPlugin {
       .then(() => this.preMedia(localStream, localShare, mediaSettings))
       .then(() =>
         this.mediaProperties.webrtcMediaConnection
-          .updateSendReceiveOptions({
-            send: {
+          .update({
+            localTracks: {
               audio: this.mediaProperties.mediaDirection.sendAudio
                 ? this.mediaProperties.audioTrack.underlyingTrack
                 : null,
@@ -6006,7 +6006,7 @@ export default class Meeting extends StatelessWebexPlugin {
                 ? this.mediaProperties.shareTrack.underlyingTrack
                 : null,
             },
-            receive: {
+            direction: {
               audio: Media.getDirection(
                 this.mediaProperties.mediaDirection.receiveAudio,
                 this.mediaProperties.mediaDirection.sendAudio
@@ -6019,13 +6019,11 @@ export default class Meeting extends StatelessWebexPlugin {
                 this.mediaProperties.mediaDirection.receiveShare,
                 this.mediaProperties.mediaDirection.sendShare
               ),
-              remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
             },
+            remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
           })
           .then(() => {
-            LoggerProxy.logger.info(
-              `${LOG_HEADER} webrtcMediaConnection.updateSendReceiveOptions done`
-            );
+            LoggerProxy.logger.info(`${LOG_HEADER} webrtcMediaConnection.update done`);
           })
           .catch((error) => {
             LoggerProxy.logger.error(`${LOG_HEADER} Error updatedMedia, `, error);
@@ -6105,9 +6103,9 @@ export default class Meeting extends StatelessWebexPlugin {
 
     return MeetingUtil.validateOptions({sendAudio, localStream: stream})
       .then(() =>
-        this.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions({
-          send: {audio: track},
-          receive: {
+        this.mediaProperties.webrtcMediaConnection.update({
+          localTracks: {audio: track},
+          direction: {
             audio: Media.getDirection(receiveAudio, sendAudio),
             video: Media.getDirection(
               this.mediaProperties.mediaDirection.receiveVideo,
@@ -6117,8 +6115,8 @@ export default class Meeting extends StatelessWebexPlugin {
               this.mediaProperties.mediaDirection.receiveShare,
               this.mediaProperties.mediaDirection.sendShare
             ),
-            remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
           },
+          remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
         })
       )
       .then(() => {
@@ -6168,9 +6166,9 @@ export default class Meeting extends StatelessWebexPlugin {
 
     return MeetingUtil.validateOptions({sendVideo, localStream: stream})
       .then(() =>
-        this.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions({
-          send: {video: track},
-          receive: {
+        this.mediaProperties.webrtcMediaConnection.update({
+          localTracks: {video: track},
+          direction: {
             audio: Media.getDirection(
               this.mediaProperties.mediaDirection.receiveAudio,
               this.mediaProperties.mediaDirection.sendAudio
@@ -6180,8 +6178,8 @@ export default class Meeting extends StatelessWebexPlugin {
               this.mediaProperties.mediaDirection.receiveShare,
               this.mediaProperties.mediaDirection.sendShare
             ),
-            remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
           },
+          remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
         })
       )
       .then(() => {
@@ -6262,9 +6260,9 @@ export default class Meeting extends StatelessWebexPlugin {
       .then(() => this.checkForStopShare(sendShare, previousSendShareStatus))
       .then((startShare) =>
         this.mediaProperties.webrtcMediaConnection
-          .updateSendReceiveOptions({
-            send: {screenShareVideo: track},
-            receive: {
+          .update({
+            localTracks: {screenShareVideo: track},
+            direction: {
               audio: Media.getDirection(
                 this.mediaProperties.mediaDirection.receiveAudio,
                 this.mediaProperties.mediaDirection.sendAudio
@@ -6274,8 +6272,8 @@ export default class Meeting extends StatelessWebexPlugin {
                 this.mediaProperties.mediaDirection.sendVideo
               ),
               screenShareVideo: Media.getDirection(receiveShare, sendShare),
-              remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
             },
+            remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
           })
           .then(() =>
             this.enqueueMediaUpdate(MEDIA_UPDATE_TYPE.LAMBDA, {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6007,9 +6007,18 @@ export default class Meeting extends StatelessWebexPlugin {
                 : null,
             },
             receive: {
-              audio: this.mediaProperties.mediaDirection.receiveAudio,
-              video: this.mediaProperties.mediaDirection.receiveVideo,
-              screenShareVideo: this.mediaProperties.mediaDirection.receiveShare,
+              audio: Media.getDirection(
+                this.mediaProperties.mediaDirection.receiveAudio,
+                this.mediaProperties.mediaDirection.sendAudio
+              ),
+              video: Media.getDirection(
+                this.mediaProperties.mediaDirection.receiveVideo,
+                this.mediaProperties.mediaDirection.sendVideo
+              ),
+              screenShareVideo: Media.getDirection(
+                this.mediaProperties.mediaDirection.receiveShare,
+                this.mediaProperties.mediaDirection.sendShare
+              ),
               remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
             },
           })
@@ -6099,9 +6108,15 @@ export default class Meeting extends StatelessWebexPlugin {
         this.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions({
           send: {audio: track},
           receive: {
-            audio: options.receiveAudio,
-            video: this.mediaProperties.mediaDirection.receiveVideo,
-            screenShareVideo: this.mediaProperties.mediaDirection.receiveShare,
+            audio: Media.getDirection(receiveAudio, sendAudio),
+            video: Media.getDirection(
+              this.mediaProperties.mediaDirection.receiveVideo,
+              this.mediaProperties.mediaDirection.sendVideo
+            ),
+            screenShareVideo: Media.getDirection(
+              this.mediaProperties.mediaDirection.receiveShare,
+              this.mediaProperties.mediaDirection.sendShare
+            ),
             remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
           },
         })
@@ -6156,9 +6171,15 @@ export default class Meeting extends StatelessWebexPlugin {
         this.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions({
           send: {video: track},
           receive: {
-            audio: this.mediaProperties.mediaDirection.receiveAudio,
-            video: options.receiveVideo,
-            screenShareVideo: this.mediaProperties.mediaDirection.receiveShare,
+            audio: Media.getDirection(
+              this.mediaProperties.mediaDirection.receiveAudio,
+              this.mediaProperties.mediaDirection.sendAudio
+            ),
+            video: Media.getDirection(receiveVideo, sendVideo),
+            screenShareVideo: Media.getDirection(
+              this.mediaProperties.mediaDirection.receiveShare,
+              this.mediaProperties.mediaDirection.sendShare
+            ),
             remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
           },
         })
@@ -6244,9 +6265,15 @@ export default class Meeting extends StatelessWebexPlugin {
           .updateSendReceiveOptions({
             send: {screenShareVideo: track},
             receive: {
-              audio: this.mediaProperties.mediaDirection.receiveAudio,
-              video: this.mediaProperties.mediaDirection.receiveVideo,
-              screenShareVideo: options.receiveShare,
+              audio: Media.getDirection(
+                this.mediaProperties.mediaDirection.receiveAudio,
+                this.mediaProperties.mediaDirection.sendAudio
+              ),
+              video: Media.getDirection(
+                this.mediaProperties.mediaDirection.receiveVideo,
+                this.mediaProperties.mediaDirection.sendVideo
+              ),
+              screenShareVideo: Media.getDirection(receiveShare, sendShare),
               remoteQualityLevel: this.mediaProperties.remoteQualityLevel,
             },
           })

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
@@ -82,17 +82,17 @@ describe('createMediaConnection', () => {
         },
       },
       {
-        send: {
+        localTracks: {
           audio: fakeAudioTrack.underlyingTrack,
           video: fakeVideoTrack.underlyingTrack,
           screenShareVideo: undefined,
         },
-        receive: {
+        direction: {
           audio: 'inactive',
           video: 'sendrecv',
           screenShareVideo: 'recvonly',
-          remoteQualityLevel: 'HIGH',
         },
+        remoteQualityLevel: 'HIGH',
       },
       'some debug id'
     );
@@ -208,7 +208,7 @@ describe('createMediaConnection', () => {
       const multistreamRoapMediaConnectionConstructorStub = sinon
         .stub(internalMediaModule, 'MultistreamRoapMediaConnection')
         .returns(fakeRoapMediaConnection);
-  
+
       Media.createMediaConnection(true, 'debug string', {
         mediaProperties: {
           mediaDirection: {
@@ -285,17 +285,17 @@ describe('createMediaConnection', () => {
         },
       },
       {
-        send: {
+        localTracks: {
           audio: fakeAudioTrack.underlyingTrack,
           video: undefined,
           screenShareVideo: fakeVideoTrack.underlyingTrack,
         },
-        receive: {
+        direction: {
           audio: 'sendrecv',
           video: 'sendrecv',
           screenShareVideo: 'sendrecv',
-          remoteQualityLevel: 'HIGH',
         },
+        remoteQualityLevel: 'HIGH',
       },
       'some debug id'
     );

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
@@ -35,10 +35,10 @@ describe('createMediaConnection', () => {
     Media.createMediaConnection(false, 'some debug id', {
       mediaProperties: {
         mediaDirection: {
-          sendAudio: true,
+          sendAudio: false,
           sendVideo: true,
           sendShare: false,
-          receiveAudio: true,
+          receiveAudio: false,
           receiveVideo: true,
           receiveShare: true,
         },
@@ -88,9 +88,9 @@ describe('createMediaConnection', () => {
           screenShareVideo: undefined,
         },
         receive: {
-          audio: true,
-          video: true,
-          screenShareVideo: true,
+          audio: 'inactive',
+          video: 'sendrecv',
+          screenShareVideo: 'recvonly',
           remoteQualityLevel: 'HIGH',
         },
       },
@@ -291,9 +291,9 @@ describe('createMediaConnection', () => {
           screenShareVideo: fakeVideoTrack.underlyingTrack,
         },
         receive: {
-          audio: true,
-          video: true,
-          screenShareVideo: true,
+          audio: 'sendrecv',
+          video: 'sendrecv',
+          screenShareVideo: 'sendrecv',
           remoteQualityLevel: 'HIGH',
         },
       },

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2313,11 +2313,11 @@ describe('plugin-meetings', () => {
                 receiveShare: true,
               };
               meeting.mediaProperties.webrtcMediaConnection = {
-                updateSendReceiveOptions: sinon.stub(),
+                update: sinon.stub(),
               };
               sinon.stub(MeetingUtil, 'getTrack').returns({audioTrack: FAKE_AUDIO_TRACK});
             });
-            it('calls this.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions', () =>
+            it('calls this.mediaProperties.webrtcMediaConnection.update', () =>
               meeting
                 .updateAudio({
                   sendAudio: true,
@@ -2326,18 +2326,18 @@ describe('plugin-meetings', () => {
                 })
                 .then(() => {
                   assert.calledOnce(
-                    meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions
+                    meeting.mediaProperties.webrtcMediaConnection.update
                   );
                   assert.calledWith(
-                    meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions,
+                    meeting.mediaProperties.webrtcMediaConnection.update,
                     {
-                      send: {audio: FAKE_AUDIO_TRACK},
-                      receive: {
+                      localTracks: {audio: FAKE_AUDIO_TRACK},
+                      direction: {
                         audio: 'sendrecv',
                         video: 'sendrecv',
                         screenShareVideo: 'recvonly',
-                        remoteQualityLevel: 'HIGH',
                       },
+                      remoteQualityLevel: 'HIGH',
                     }
                   );
                 }));
@@ -2481,7 +2481,7 @@ describe('plugin-meetings', () => {
 
           sandbox.stub(meeting, 'canUpdateMedia').returns(false);
           meeting.mediaProperties.webrtcMediaConnection = {
-            updateSendReceiveOptions: sinon.stub().resolves({}),
+            update: sinon.stub().resolves({}),
           };
 
           let myPromiseResolved = false;
@@ -2497,7 +2497,7 @@ describe('plugin-meetings', () => {
             });
 
           // verify that nothing was done
-          assert.notCalled(meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions);
+          assert.notCalled(meeting.mediaProperties.webrtcMediaConnection.update);
 
           // now trigger processing of the queue
           meeting.canUpdateMedia.restore();
@@ -2506,22 +2506,22 @@ describe('plugin-meetings', () => {
           meeting.processNextQueuedMediaUpdate();
           await testUtils.flushPromises();
 
-          // and check that updateSendReceiveOptions is called with the original args
-          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions);
+          // and check that update is called with the original args
+          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.update);
           assert.calledWith(
-            meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions,
+            meeting.mediaProperties.webrtcMediaConnection.update,
             {
-              send: {
+              localTracks: {
                 audio: FAKE_TRACKS.audio,
                 video: FAKE_TRACKS.video,
                 screenShareVideo: FAKE_TRACKS.screenshareVideo,
               },
-              receive: {
+              direction: {
                 audio: 'sendrecv',
                 video: 'sendrecv',
                 screenShareVideo: 'sendrecv',
-                remoteQualityLevel: 'HIGH',
               },
+              remoteQualityLevel: 'HIGH',
             }
           );
           assert.isTrue(myPromiseResolved);
@@ -2544,8 +2544,8 @@ describe('plugin-meetings', () => {
               eventListeners[event] = listener;
             }),
 
-            updateSendReceiveOptions: sinon.stub().callsFake(() => {
-              // trigger ROAP_STARTED before updateSendReceiveOptions() resolves
+            update: sinon.stub().callsFake(() => {
+              // trigger ROAP_STARTED before update() resolves
               if (eventListeners[Event.ROAP_STARTED]) {
                 eventListeners[Event.ROAP_STARTED]();
               } else {
@@ -2583,7 +2583,7 @@ describe('plugin-meetings', () => {
 
           await testUtils.flushPromises();
 
-          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions);
+          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.update);
           assert.isFalse(myPromiseResolved);
 
           // verify that requestScreenShareFloorStub was not called yet
@@ -2636,8 +2636,8 @@ describe('plugin-meetings', () => {
               eventListeners[event] = listener;
             }),
 
-            updateSendReceiveOptions: sinon.stub().callsFake(() => {
-              // trigger ROAP_STARTED before updateSendReceiveOptions() resolves
+            update: sinon.stub().callsFake(() => {
+              // trigger ROAP_STARTED before update() resolves
               if (eventListeners[Event.ROAP_STARTED]) {
                 eventListeners[Event.ROAP_STARTED]();
               } else {
@@ -2678,7 +2678,7 @@ describe('plugin-meetings', () => {
 
           await testUtils.flushPromises();
 
-          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions);
+          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.update);
           assert.isFalse(myPromiseResolved);
 
           // verify that requestScreenShareFloorStub was not called yet
@@ -2694,8 +2694,8 @@ describe('plugin-meetings', () => {
         it('when changing screen share stream and no roap transaction happening, it requests floor immediately', async () => {
           let myPromiseResolved = false;
 
-          // simulate a case when no roap transaction is triggered by updateSendReceiveOptions
-          meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions = sinon
+          // simulate a case when no roap transaction is triggered by update
+          meeting.mediaProperties.webrtcMediaConnection.update = sinon
             .stub()
             .resolves({});
 
@@ -2711,7 +2711,7 @@ describe('plugin-meetings', () => {
 
           await testUtils.flushPromises();
 
-          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.updateSendReceiveOptions);
+          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.update);
           assert.calledOnce(requestScreenShareFloorStub);
           assert.isTrue(myPromiseResolved);
         });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2333,9 +2333,9 @@ describe('plugin-meetings', () => {
                     {
                       send: {audio: FAKE_AUDIO_TRACK},
                       receive: {
-                        audio: true,
-                        video: true,
-                        screenShareVideo: true,
+                        audio: 'sendrecv',
+                        video: 'sendrecv',
+                        screenShareVideo: 'recvonly',
                         remoteQualityLevel: 'HIGH',
                       },
                     }
@@ -2517,9 +2517,9 @@ describe('plugin-meetings', () => {
                 screenShareVideo: FAKE_TRACKS.screenshareVideo,
               },
               receive: {
-                audio: true,
-                video: true,
-                screenShareVideo: true,
+                audio: 'sendrecv',
+                video: 'sendrecv',
+                screenShareVideo: 'sendrecv',
                 remoteQualityLevel: 'HIGH',
               },
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4164,9 +4164,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:1.38.2":
-  version: 1.38.2
-  resolution: "@webex/internal-media-core@npm:1.38.2"
+"@webex/internal-media-core@npm:1.38.3":
+  version: 1.38.3
+  resolution: "@webex/internal-media-core@npm:1.38.3"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@webex/json-multistream": "npm:2.0.1"
@@ -4178,7 +4178,7 @@ __metadata:
     uuid: "npm:^8.3.2"
     webrtc-adapter: "npm:^8.1.2"
     xstate: "npm:^4.30.6"
-  checksum: 2f125e9a2f5f15bf9b769befcb198d2f731e747ecc8d26b533b04e8e12f127bfc1c384fe69057f670efa81cdfcbcb06f6009756aea53ae88cf633fd0c0ae69d6
+  checksum: 1aad4e8b205b8057c325643e8341cca41202493107acd871bb3e726490a0e0fce3a11e75c7d4df88667a64f9d7be177f4d7bb05b7c75973d3bc9b064615a49e8
   languageName: node
   linkType: hard
 
@@ -4645,7 +4645,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webex/media-helpers@workspace:packages/@webex/media-helpers"
   dependencies:
-    "@webex/internal-media-core": "npm:1.38.2"
+    "@webex/internal-media-core": "npm:1.38.3"
     "@webex/test-helper-chai": "workspace:^"
     "@webex/test-helper-mock-webex": "workspace:^"
     "@webex/web-media-effects": "npm:^2.8.0"
@@ -4781,7 +4781,7 @@ __metadata:
   resolution: "@webex/plugin-meetings@workspace:packages/@webex/plugin-meetings"
   dependencies:
     "@webex/common": "workspace:^"
-    "@webex/internal-media-core": "npm:1.38.2"
+    "@webex/internal-media-core": "npm:1.38.3"
     "@webex/internal-plugin-conversation": "workspace:^"
     "@webex/internal-plugin-device": "workspace:^"
     "@webex/internal-plugin-llm": "workspace:^"


### PR DESCRIPTION
internal-media-core PR with the API changes: https://sqbu-github.cisco.com/WebExSquared/webrtc-media-core/pull/183

This PR has a minimum set of changes in JS-SDK for it to work with internal-media-core from above PR. There should be no change in behavior here. 

It's a step towards having webrtc-core local tracks in transcoded meetings APIs