### PR TITLE
Feat(Live-Annotation): start share with annotation info

### DIFF
--- a/packages/@webex/plugin-meetings/src/annotation/annotation.types.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/annotation.types.ts
@@ -25,6 +25,9 @@ type CommandRequestBody = {
   shareInstanceId: string;
   receivers?: any[];
 };
+/**
+ * Type for an annotation Object include annotation version and privilege
+ */
 type AnnotationInfo = {
   version: string;
   policy: ANNOTATION_POLICY;

--- a/packages/@webex/plugin-meetings/src/annotation/annotation.types.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/annotation.types.ts
@@ -29,6 +29,7 @@ interface IAnnotationChannel {
   acceptRequest: (approval) => undefined | Promise<void>;
   declineRequest: (approval) => undefined | Promise<void>;
   closeAnnotation: (requestData: RequestData) => undefined | Promise<void>;
+  // change annotation privilege
   changeAnnotationOptions: (remoteShareUrl, annotationInfo) => undefined | Promise<void>;
   // === below is for attendee
   approveAnnotation: (requestData: RequestData) => undefined | Promise<void>;

--- a/packages/@webex/plugin-meetings/src/annotation/annotation.types.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/annotation.types.ts
@@ -29,7 +29,7 @@ interface IAnnotationChannel {
   acceptRequest: (approval) => undefined | Promise<void>;
   declineRequest: (approval) => undefined | Promise<void>;
   closeAnnotation: (requestData: RequestData) => undefined | Promise<void>;
-  changeAnnotationOptions: (options, meeting) => undefined | Promise<void>;
+  changeAnnotationOptions: (remoteShareUrl, annotationInfo) => undefined | Promise<void>;
   // === below is for attendee
   approveAnnotation: (requestData: RequestData) => undefined | Promise<void>;
   cancelApproveAnnotation: (requestData: RequestData, approval) => undefined | Promise<void>;

--- a/packages/@webex/plugin-meetings/src/annotation/annotation.types.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/annotation.types.ts
@@ -1,3 +1,5 @@
+import {ANNOTATION_POLICY} from './constants';
+
 /**
  * Type for an StrokeData Object
  */
@@ -23,6 +25,10 @@ type CommandRequestBody = {
   shareInstanceId: string;
   receivers?: any[];
 };
+type AnnotationInfo = {
+  version: string;
+  policy: ANNOTATION_POLICY;
+};
 
 interface IAnnotationChannel {
   // === below is for presenter
@@ -40,4 +46,4 @@ interface IAnnotationChannel {
   locusUrlUpdate: (locusUrl: string) => void;
 }
 
-export type {StrokeData, RequestData, CommandRequestBody, IAnnotationChannel};
+export type {StrokeData, RequestData, CommandRequestBody, IAnnotationChannel, AnnotationInfo};

--- a/packages/@webex/plugin-meetings/src/annotation/constants.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/constants.ts
@@ -12,11 +12,11 @@ export const ANNOTATION_STATUS = {
   RUNNING_ANNOTATION: 'RUNNING_ANNOTATION',
 };
 
-export const ANNOTATION_POLICY = {
-  ANYONE_CAN_ANNOTATE: 'AnyoneCanAnnotate',
-  APPROVAL: 'Approval',
-  ANNOTATION_NOT_ALLOWED: 'AnnotationNotAllowed',
-};
+export enum ANNOTATION_POLICY {
+  ANYONE_CAN_ANNOTATE = 'AnyoneCanAnnotate',
+  APPROVAL = 'Approval',
+  ANNOTATION_NOT_ALLOWED = 'AnnotationNotAllowed',
+}
 
 export const ANNOTATION_REQUEST_TYPE = {
   ANNOTATION_MESSAGE: 'annotation_message',

--- a/packages/@webex/plugin-meetings/src/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/index.ts
@@ -40,10 +40,11 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
 
   /**
    * Process Stroke Data
-   * @param {request} request stroke data
+   * @param {object}  data
    * @returns {void}
    */
-  private processStrokeMessage(request) {
+  private processStrokeMessage(data) {
+    const {request} = data;
     this.decryptContent(request.value.encryptionKeyUrl, request.value.content).then(
       (decryptedContent) => {
         request.value.content = decryptedContent;
@@ -55,7 +56,7 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
           },
           EVENT_TRIGGERS.ANNOTATION_STROKE_DATA,
           {
-            payload: request.value,
+            payload: data,
           }
         );
       }
@@ -96,7 +97,7 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
     switch (e?.data?.relayType) {
       case ANNOTATION_RELAY_TYPES.ANNOTATION_CLIENT:
         this.seqNum = (e?.sequenceNumber || 0) + 1;
-        this.processStrokeMessage(e.data.request);
+        this.processStrokeMessage(e.data);
         break;
       default:
         break;
@@ -283,12 +284,17 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
 
   /**
    * Change annotation options
-   * @param {object} options
-   * @param {object} meeting
+   * @param {remoteShareUrl} remoteShareUrl
+   * @param {annotationInfo} annotationInfo
    * @returns {Promise}
    */
-  public changeAnnotationOptions(options, meeting) {
-    return meeting?.meetingRequest.changeMeetingFloor(options);
+  public changeAnnotationOptions(remoteShareUrl, annotationInfo) {
+    // @ts-ignore
+    return this.request({
+      method: HTTP_VERBS.PATCH,
+      url: remoteShareUrl,
+      body: annotationInfo,
+    });
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -124,6 +124,7 @@ import RecordingController from '../recording-controller';
 import ControlsOptionsManager from '../controls-options-manager';
 import PermissionError from '../common/errors/permission';
 import {LocusMediaRequest} from './locusMediaRequest';
+import {AnnotationInfo} from '../annotation/annotation.types';
 
 const {isBrowser} = BrowserDetection();
 
@@ -537,6 +538,7 @@ export default class Meeting extends StatelessWebexPlugin {
   roles: any[];
   environment: string;
   namespace = MEETINGS;
+  annotationInfo: AnnotationInfo;
 
   /**
    * @param {Object} attrs
@@ -6555,6 +6557,7 @@ export default class Meeting extends StatelessWebexPlugin {
           deviceUrl: this.deviceUrl,
           uri: content.url,
           resourceUrl: this.resourceUrl,
+          annotationInfo: this.annotationInfo,
         })
         .then(() => {
           this.isSharing = true;
@@ -7672,13 +7675,14 @@ export default class Meeting extends StatelessWebexPlugin {
       audio?: LocalTrack; // todo: for now screen share audio is not supported (will be done in SPARK-399690)
       video?: LocalDisplayTrack;
     };
+    annotationInfo?: AnnotationInfo;
   }): Promise<void> {
     this.checkMediaConnection();
 
     if (!this.isMultistream) {
       throw new Error('publishTracks() only supported with multistream');
     }
-
+    this.annotationInfo = tracks.annotationInfo;
     if (tracks.screenShare?.video) {
       const oldTrack = this.mediaProperties.shareTrack;
       const localDisplayTrack = tracks.screenShare?.video;

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -29,6 +29,7 @@ import {
 } from '../constants';
 import {SendReactionOptions, ToggleReactionsOptions} from './request.type';
 import MeetingUtil from './util';
+import {AnnotationInfo} from '../annotation/annotation.types';
 
 /**
  * @class MeetingRequest
@@ -630,7 +631,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
           deviceUrl: string;
           resourceId: string;
           uri: string;
-          annotation: any;
+          annotationInfo: AnnotationInfo;
         }
       | any
   ) {
@@ -664,8 +665,8 @@ export default class MeetingRequest extends StatelessWebexPlugin {
     if (options?.resourceToken) {
       body.resourceToken = options?.resourceToken;
     }
-    if (options?.annotation) {
-      body.annotation = options?.annotation;
+    if (options?.annotationInfo) {
+      body.annotation = options?.annotationInfo;
     }
 
     // @ts-ignore

--- a/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
@@ -354,8 +354,7 @@ describe('live-annotation', () => {
               url: 'remoteShareUrl',
               body: {annotationInfo: { version: '1', policy: 'AnnotationNotAllowed' }}
           });
-
-        //  assert.calledOnceWithExactly(meeting.meetingRequest.changeMeetingFloor, options);
+          assert.equal(result, 'REQUEST_RETURN_VALUE')
         });
       });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
@@ -144,7 +144,10 @@ describe('live-annotation', () => {
 
         annotationService.eventDataProcessor({data: {relayType: 'annotation.client', request:{value:{encryptionKeyUrl:"encryptionKeyUrl"}}}});
 
-        assert.calledOnceWithExactly(spy, {value:{encryptionKeyUrl:"encryptionKeyUrl"}});
+        assert.calledOnceWithExactly(spy, {
+          relayType: 'annotation.client',
+          request: { value: { encryptionKeyUrl: 'encryptionKeyUrl' } }
+        } );
 
       });
 
@@ -153,7 +156,7 @@ describe('live-annotation', () => {
         const spy = sinon.spy();
         annotationService.on(EVENT_TRIGGERS.ANNOTATION_STROKE_DATA, spy);
 
-        await annotationService.processStrokeMessage({value:{encryptionKeyUrl: 'encryptionKeyUrl', content: 'content'}});
+        await annotationService.processStrokeMessage({request:{value:{encryptionKeyUrl: 'encryptionKeyUrl', content: 'content'}}});
 
         assert.calledOnceWithExactly(spy, {
           payload: {encryptionKeyUrl: 'encryptionKeyUrl', content: 'decryptedContent'},

--- a/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
@@ -159,7 +159,7 @@ describe('live-annotation', () => {
         await annotationService.processStrokeMessage({request:{value:{encryptionKeyUrl: 'encryptionKeyUrl', content: 'content'}}});
 
         assert.calledOnceWithExactly(spy, {
-          payload: {encryptionKeyUrl: 'encryptionKeyUrl', content: 'decryptedContent'},
+          payload:{request:{value:{encryptionKeyUrl: 'encryptionKeyUrl', content: 'decryptedContent'}}} ,
         });
 
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
@@ -341,20 +341,21 @@ describe('live-annotation', () => {
       });
 
       describe('change annotation options', () => {
-        it('makes change annotation options as expected', () => {
-          const options =  {
+        it('makes change annotation options as expected', async() => {
+          const options =  { annotationInfo:{
               version: '1',
               policy: 'AnnotationNotAllowed',
-          };
-          const meeting = {
-            meetingRequest : {
-              changeMeetingFloor: () => {
-              }
-            }
-          }
-          sinon.spy(meeting.meetingRequest, 'changeMeetingFloor');
-          annotationService.changeAnnotationOptions(options,meeting);
-          assert.calledOnceWithExactly(meeting.meetingRequest.changeMeetingFloor, options);
+          }};
+
+          const remoteShareUrl = 'remoteShareUrl';
+          const result = await annotationService.changeAnnotationOptions(remoteShareUrl,options);
+          assert.calledOnceWithExactly(webex.request, {
+              method: 'PATCH',
+              url: 'remoteShareUrl',
+              body: {annotationInfo: { version: '1', policy: 'AnnotationNotAllowed' }}
+          });
+
+        //  assert.calledOnceWithExactly(meeting.meetingRequest.changeMeetingFloor, options);
         });
       });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -86,6 +86,7 @@ import {
   MeetingInfoV2PasswordError,
   MeetingInfoV2PolicyError,
 } from '../../../../src/meeting-info/meeting-info-v2';
+import {ANNOTATION_POLICY} from "../../../../src/annotation/constants";
 
 const {getBrowserName, getOSVersion} = BrowserDetection();
 
@@ -4129,6 +4130,14 @@ describe('plugin-meetings', () => {
             checkVideoPublished(videoTrack);
             checkScreenShareVideoPublished(videoShareTrack);
           });
+        });
+        it('creates instance and publishes with annotation info', async () => {
+          const annotationInfo = {
+            version: '1',
+            policy: ANNOTATION_POLICY.APPROVAL,
+          };
+          await meeting.publishTracks({annotationInfo});
+          assert.equal(meeting.annotationInfo, annotationInfo);
         });
 
         describe('unpublishTracks', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
@@ -560,13 +560,13 @@ describe('plugin-meetings', () => {
       const deviceUrl = 'deviceUrl';
       const locusUrl = 'locusUrl';
       meetingsRequest.config.meetings.deviceType = 'deviceType';
-  
+
       await meetingsRequest.declineMeeting({
         locusUrl,
         deviceUrl,
         reason
       });
-  
+
       const expectedBody = {
         device: {
           deviceType: 'deviceType',
@@ -574,7 +574,7 @@ describe('plugin-meetings', () => {
         },
         reason,
       };
-  
+
       checkRequest({
         method: 'PUT',
         uri: `${locusUrl}/participant/decline`,
@@ -606,7 +606,7 @@ describe('plugin-meetings', () => {
         resourceId: 'resourceId',
         resourceUrl: 'resourceUrl',
         uri: 'optionsUrl',
-        annotation:{
+        annotationInfo:{
           version: '1',
           policy: 'Approval',
         },


### PR DESCRIPTION
Feat(Live-Annotation): start share with annotation info
The presenter with live-annotation info can change annotation privilege

## by making the following changes
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-438213?filter=-1
< DESCRIBE YOUR CHANGES >
<img width="537" alt="image" src="https://github.com/webex/webex-js-sdk/assets/141471/42cf0610-3ae1-41d1-823a-a4477beda82e">

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
