### PR TITLE
fix(locus-info): adding lastModified field when handling requestedToU…

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
@@ -37,6 +37,7 @@ SelfUtils.parse = (self: any, deviceId: string) => {
       remoteMuted: SelfUtils.getRemoteMuted(self),
       unmuteAllowed: SelfUtils.getUnmuteAllowed(self),
       localAudioUnmuteRequested: SelfUtils.getLocalAudioUnmuteRequested(self),
+      localAudioUnmuteRequestedTimeStamp: SelfUtils.getLocalAudioUnmuteRequestedTimeStamp(self),
       localAudioUnmuteRequired: SelfUtils.getLocalAudioUnmuteRequired(self),
       lastModified: SelfUtils.getLastModified(self),
       modifiedBy: SelfUtils.getModifiedBy(self),
@@ -270,6 +271,10 @@ SelfUtils.getRemoteMuted = (self: any) => {
 
 SelfUtils.getLocalAudioUnmuteRequested = (self) => !!self?.controls?.audio?.requestedToUnmute;
 
+// requestedToUnmute timestamp
+SelfUtils.getLocalAudioUnmuteRequestedTimeStamp = (self) =>
+  Date.parse(self?.controls?.audio?.lastModifiedRequestedToUnmute) || 0;
+
 SelfUtils.getUnmuteAllowed = (self) => {
   if (!self || !self.controls || !self.controls.audio) {
     return null;
@@ -443,7 +448,10 @@ SelfUtils.localAudioUnmuteRequestedByServer = (oldSelf: any = {}, changedSelf: a
     );
   }
 
-  return changedSelf.localAudioUnmuteRequested && !oldSelf.localAudioUnmuteRequested;
+  return (
+    changedSelf.localAudioUnmuteRequested &&
+    changedSelf.localAudioUnmuteRequestedTimeStamp > oldSelf.localAudioUnmuteRequestedTimeStamp
+  );
 };
 
 SelfUtils.localAudioUnmuteRequiredByServer = (oldSelf: any = {}, changedSelf: any) => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -1063,6 +1063,7 @@ describe('plugin-meetings', () => {
         const selfWithRequestedToUnmute = cloneDeep(self);
 
         selfWithRequestedToUnmute.controls.audio.requestedToUnmute = true;
+        selfWithRequestedToUnmute.controls.audio.lastModifiedRequestedToUnmute = '2023-06-16T19:25:04.369Z';
 
         locusInfo.webex.internal.device.url = self.deviceUrl;
         locusInfo.emitScoped = sinon.stub();

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
@@ -251,6 +251,55 @@ describe('plugin-meetings', () => {
           assert.equal(updates.canNotViewTheParticipantListChanged, false);
         });
       });
+
+      describe('localAudioUnmuteRequestedByServer', () => {
+        it('should return localAudioUnmuteRequestedByServer = false when requestedToUnmute = false', () => {
+          const clonedSelf = cloneDeep(self);
+
+          const {updates} = SelfUtils.getSelves(self, clonedSelf);
+
+          assert.equal(updates.localAudioUnmuteRequestedByServer, false);
+        });
+
+        it('should return localAudioUnmuteRequestedByServer = true when first request is made with requestedToUnmute = true', () => {
+          const clonedSelf = cloneDeep(self);
+
+          //request to unmute with timestamp
+          clonedSelf.controls.audio.requestedToUnmute = true;
+          clonedSelf.controls.audio.lastModifiedRequestedToUnmute = '2023-06-16T18:25:04.369Z';
+
+          const {updates} = SelfUtils.getSelves(self, clonedSelf);
+
+          assert.equal(updates.localAudioUnmuteRequestedByServer, true);
+        });
+
+        it('should return localAudioUnmuteRequestedByServer = true when requestedToUnmute = true and new requests lastModifiedRequestedToUnmute timestamp is greater than old one', () => {
+          self.controls.audio.requestedToUnmute = true;
+          self.controls.audio.lastModifiedRequestedToUnmute = '2023-06-16T18:25:04.369Z';
+          const clonedSelf = cloneDeep(self);
+
+          //request to unmute with timestamp
+          clonedSelf.controls.audio.requestedToUnmute = true;
+          clonedSelf.controls.audio.lastModifiedRequestedToUnmute = '2023-06-16T19:25:04.369Z';
+
+          const {updates} = SelfUtils.getSelves(self, clonedSelf);
+
+          assert.equal(updates.localAudioUnmuteRequestedByServer, true);
+        });
+
+        it('should return localAudioUnmuteRequestedByServer = false when requestedToUnmute but lastModifiedRequestedToUnmute timestamps are same', () => {
+          self.controls.audio.requestedToUnmute = true;
+          self.controls.audio.lastModifiedRequestedToUnmute = '2023-06-16T18:25:04.369Z';
+          const clonedSelf = cloneDeep(self);
+
+          clonedSelf.controls.audio.requestedToUnmute = true;
+          clonedSelf.controls.audio.lastModifiedRequestedToUnmute = '2023-06-16T18:25:04.369Z'
+
+          const {updates} = SelfUtils.getSelves(self, clonedSelf);
+
+          assert.equal(updates.localAudioUnmuteRequestedByServer, false);
+        });
+      });
     });
 
     describe('isSharingBlocked', () => {


### PR DESCRIPTION

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #SPARK-316107

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-316107

## This pull request addresses

the issue that event `meeting:self:requestedToUnmute` is generated only once even if locus sends multiple requests with requestedToUnmute=true. This results in UI showing the 'requested to unmute' banner only once even when multiple requests to unmute were made in the same meeting. 

## by making the following changes

- reading the timeStamp that locus sends with `requestedToUnmute` call: `lastModifiedRequestToUnmuteTime` 
- storing `lastModifiedRequestToUnmuteTime` and comparing it with older request's timeStamp to correctly generate and fire the event `meeting:self:requestedToUnmute` as many time as requestedToUnmute=true.
- All the above changes result in UI correctly displaying the requested to unmute banner as many times as the request was made. 


<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

wrote unit tests in @webex/plugin-meetings/test/unit/locus-info

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
