### PR TITLE
feat(plugin-meetings): added setActiveSpeakerCsis() API

### DIFF
--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
@@ -72,7 +72,7 @@ export class RemoteMediaGroup {
    *
    */
   public fixCsis(
-    remoteMediaCsis: {remoteMedia: RemoteMedia; csi: number | undefined}[],
+    remoteMediaCsis: {remoteMedia: RemoteMedia; csi?: number | undefined}[],
     commit = true
   ): void {
     forEach(remoteMediaCsis, ({csi, remoteMedia}) => {

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
@@ -70,6 +70,7 @@ export class RemoteMediaGroup {
   /**
    * setActiveSpeakerCsis - sets csis for remoteMedia
    * pins when csis is there and unpins when csi is undefined
+   * @internal
    */
   public setActiveSpeakerCsis(
     remoteMediaCsis: {remoteMedia: RemoteMedia; csi?: number}[],
@@ -196,6 +197,10 @@ export class RemoteMediaGroup {
     throw new Error(`remote media object ${remoteMedia.id} not found in the group`);
   }
 
+  /**
+   * setPreferLiveVideo - sets preferLiveVideo to true/false
+   * @internal
+   */
   public setPreferLiveVideo(preferLiveVideo: boolean, commit: boolean) {
     if (this.options.preferLiveVideo !== preferLiveVideo) {
       this.options.preferLiveVideo = preferLiveVideo;

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
@@ -68,8 +68,10 @@ export class RemoteMediaGroup {
   }
 
   /**
-   * setActiveSpeakerCsis - sets csis for remoteMedia
-   * pins when csis is there and unpins when csi is undefined
+   * Sets CSIs for multiple RemoteMedia instances belonging to this RemoteMediaGroup.
+   * For each entry in the remoteMediaCsis array:
+   * - if csi is specified, the RemoteMedia instance is pinned to that CSI
+   * - if csi is undefined, the RemoteMedia instance is unpinned
    * @internal
    */
   public setActiveSpeakerCsis(

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
@@ -68,26 +68,35 @@ export class RemoteMediaGroup {
   }
 
   /**
-   * fixCsis
+   * setCsis - sets csis for remoteMedia
    *
    */
-  public fixCsis(
-    remoteMediaCsis: {remoteMedia: RemoteMedia; csi?: number | undefined}[],
-    commit = true
-  ): void {
+  public setCsis(remoteMediaCsis: {remoteMedia: RemoteMedia; csi?: number}[], commit = true): void {
     forEach(remoteMediaCsis, ({csi, remoteMedia}) => {
       if (csi) {
         if (!(this.pinnedRemoteMedia.indexOf(remoteMedia) >= 0)) {
           const unpinId = this.unpinnedRemoteMedia.indexOf(remoteMedia);
-          this.unpinnedRemoteMedia.splice(unpinId, 1);
-          this.pinnedRemoteMedia.push(remoteMedia);
+          if (unpinId >= 0) {
+            this.unpinnedRemoteMedia.splice(unpinId, 1);
+            this.pinnedRemoteMedia.push(remoteMedia);
+          } else {
+            throw new Error(
+              `failed to pin a remote media object ${remoteMedia.id}, because it is not found in this remote media group`
+            );
+          }
         }
         remoteMedia.sendMediaRequest(csi, false);
       } else {
         if (!(this.unpinnedRemoteMedia.indexOf(remoteMedia) >= 0)) {
           const pinId = this.pinnedRemoteMedia.indexOf(remoteMedia);
-          this.pinnedRemoteMedia.splice(pinId, 1);
-          this.unpinnedRemoteMedia.push(remoteMedia);
+          if (pinId >= 0) {
+            this.pinnedRemoteMedia.splice(pinId, 1);
+            this.unpinnedRemoteMedia.push(remoteMedia);
+          } else {
+            throw new Error(
+              `failed to unpin a remote media object ${remoteMedia.id}, because it is not found in this remote media group`
+            );
+          }
         }
         remoteMedia.cancelMediaRequest(false);
       }

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
@@ -68,10 +68,13 @@ export class RemoteMediaGroup {
   }
 
   /**
-   * setCsis - sets csis for remoteMedia
-   *
+   * setActiveSpeakerCsis - sets csis for remoteMedia
+   * pins when csis is there and unpins when csi is undefined
    */
-  public setCsis(remoteMediaCsis: {remoteMedia: RemoteMedia; csi?: number}[], commit = true): void {
+  public setActiveSpeakerCsis(
+    remoteMediaCsis: {remoteMedia: RemoteMedia; csi?: number}[],
+    commit = true
+  ): void {
     forEach(remoteMediaCsis, ({csi, remoteMedia}) => {
       if (csi) {
         if (!(this.pinnedRemoteMedia.indexOf(remoteMedia) >= 0)) {

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
@@ -506,12 +506,12 @@ export class RemoteMediaManager extends EventsScope {
   }
 
   /**
-   * setActiveSpeakerCsis - sets the csis
-   * pins when csi is present and unpins when csi is undefined
+   * Sets CSIs for multiple RemoteMedia instances belonging to RemoteMediaGroup.
+   * For each entry in the remoteMediaCsis array:
+   * - if csi is specified, the RemoteMedia instance is pinned to that CSI
+   * - if csi is undefined, the RemoteMedia instance is unpinned
    */
-  public setActiveSpeakerCsis(
-    remoteMediaCsis: {remoteMedia: RemoteMedia; csi: number | undefined}[]
-  ) {
+  public setActiveSpeakerCsis(remoteMediaCsis: {remoteMedia: RemoteMedia; csi?: number}[]) {
     Object.values(this.media.video.activeSpeakerGroups).forEach((remoteMediaGroup) => {
       const groupRemoteMediaCsis = remoteMediaCsis.filter(({remoteMedia}) =>
         remoteMediaGroup.includes(remoteMedia)

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
@@ -506,15 +506,18 @@ export class RemoteMediaManager extends EventsScope {
   }
 
   /**
-   * setCsis - sets the csis
+   * setActiveSpeakerCsis - sets the csis
+   * pins when csi is present and unpins when csi is undefined
    */
-  public setCsis(remoteMediaCsis: {remoteMedia: RemoteMedia; csi: number | undefined}[]) {
+  public setActiveSpeakerCsis(
+    remoteMediaCsis: {remoteMedia: RemoteMedia; csi: number | undefined}[]
+  ) {
     Object.values(this.media.video.activeSpeakerGroups).forEach((remoteMediaGroup) => {
       const groupRemoteMediaCsis = remoteMediaCsis.filter(({remoteMedia}) =>
         remoteMediaGroup.includes(remoteMedia)
       );
       if (groupRemoteMediaCsis.length > 0) {
-        remoteMediaGroup.setCsis(groupRemoteMediaCsis, false);
+        remoteMediaGroup.setActiveSpeakerCsis(groupRemoteMediaCsis, false);
       }
     });
     this.mediaRequestManagers.video.commit();

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
@@ -506,15 +506,15 @@ export class RemoteMediaManager extends EventsScope {
   }
 
   /**
-   * fixCsis
+   * setCsis - sets the csis
    */
-  public fixCsis(remoteMediaCsis: {remoteMedia: RemoteMedia; csi: number | undefined}[]) {
+  public setCsis(remoteMediaCsis: {remoteMedia: RemoteMedia; csi: number | undefined}[]) {
     Object.values(this.media.video.activeSpeakerGroups).forEach((remoteMediaGroup) => {
       const groupRemoteMediaCsis = remoteMediaCsis.filter(({remoteMedia}) =>
         remoteMediaGroup.includes(remoteMedia)
       );
       if (groupRemoteMediaCsis.length > 0) {
-        remoteMediaGroup.fixCsis(groupRemoteMediaCsis, false);
+        remoteMediaGroup.setCsis(groupRemoteMediaCsis, false);
       }
     });
     this.mediaRequestManagers.video.commit();

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
@@ -506,6 +506,21 @@ export class RemoteMediaManager extends EventsScope {
   }
 
   /**
+   * fixCsis
+   */
+  public fixCsis(remoteMediaCsis: {remoteMedia: RemoteMedia; csi: number | undefined}[]) {
+    Object.values(this.media.video.activeSpeakerGroups).forEach((remoteMediaGroup) => {
+      const groupRemoteMediaCsis = remoteMediaCsis.filter(({remoteMedia}) =>
+        remoteMediaGroup.includes(remoteMedia)
+      );
+      if (groupRemoteMediaCsis.length > 0) {
+        remoteMediaGroup.fixCsis(groupRemoteMediaCsis, false);
+      }
+    });
+    this.mediaRequestManagers.video.commit();
+  }
+
+  /**
    * Creates the audio slots
    */
   private async createAudioMedia() {

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaGroup.ts
@@ -144,6 +144,200 @@ describe('RemoteMediaGroup', () => {
 
   });
 
+  describe('fixCsis', () => {
+    it('checks when there is a csi and remote media is not in pinned array', () => {
+      const PINNED_INDEX = 2;
+      const CSI = 11111;
+
+      const group = new RemoteMediaGroup(fakeMediaRequestManager, fakeReceiveSlots, 255, true, {
+        resolution: 'medium',
+        preferLiveVideo: true,
+      });
+
+      // initially nothing should be pinned
+      assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS); // by default should return 'all'
+      assert.strictEqual(group.getRemoteMedia('all').length, NUM_SLOTS);
+      assert.strictEqual(group.getRemoteMedia('unpinned').length, NUM_SLOTS);
+      assert.strictEqual(group.getRemoteMedia('pinned').length, 0);
+
+      const remoteMedia = group.getRemoteMedia('all')[PINNED_INDEX];
+
+      resetHistory();
+
+      group.fixCsis([{remoteMedia, csi: CSI}], false);
+
+      assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS); // by default should return 'all'
+      assert.strictEqual(group.getRemoteMedia('all').length, NUM_SLOTS);
+      assert.strictEqual(group.getRemoteMedia('unpinned').length, NUM_SLOTS - 1);
+      assert.strictEqual(group.getRemoteMedia('pinned').length, 1);
+
+      assert.strictEqual(group.isPinned(remoteMedia), true);
+      // now check that correct media requests were sent...
+
+      const expectedReceiverSelectedSlots = [fakeReceiveSlots[PINNED_INDEX]];
+      const expectedActiveSpeakerReceiveSlots = fakeReceiveSlots.filter(
+        (_, idx) => idx !== PINNED_INDEX
+      );
+
+      // the previous active speaker media request for the group should have been cancelled
+      assert.calledOnce(fakeMediaRequestManager.cancelRequest);
+      assert.calledWith(fakeMediaRequestManager.cancelRequest, 'fake active speaker request 1');
+      // a new one should be sent for active speaker and for receiver selected
+      assert.calledTwice(fakeMediaRequestManager.addRequest);
+      assert.calledWith(
+        fakeMediaRequestManager.addRequest,
+        sinon.match({
+          policyInfo: sinon.match({
+            policy: 'active-speaker',
+            priority: 255,
+          }),
+          receiveSlots: expectedActiveSpeakerReceiveSlots,
+          codecInfo: sinon.match({
+            codec: 'h264',
+            maxFs: 3600,
+          }),
+        })
+      );
+      assert.calledWith(
+        fakeMediaRequestManager.addRequest,
+        sinon.match({
+          policyInfo: sinon.match({
+            policy: 'receiver-selected',
+            csi: CSI,
+          }),
+          receiveSlots: expectedReceiverSelectedSlots,
+          codecInfo: sinon.match({
+            codec: 'h264',
+            maxFs: 3600,
+          }),
+        })
+      );
+      assert.notCalled(fakeMediaRequestManager.commit);
+    });
+
+    it('checks when there is csi and remoteMedia is in pinned array', () => {
+      const PINNED_INDEX = 4;
+
+      const group = new RemoteMediaGroup(fakeMediaRequestManager, fakeReceiveSlots, 255, true, {
+        resolution: 'medium',
+        preferLiveVideo: true,
+      });
+
+      // take one instance of remote media from the group
+      const remoteMedia = group.getRemoteMedia('all')[PINNED_INDEX];
+
+      resetHistory();
+
+      // pin it so that it is in pinned array
+      group.fixCsis([{remoteMedia, csi: 1234}], false);
+
+      assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS); // by default should return 'all'
+      assert.strictEqual(group.getRemoteMedia('all').length, NUM_SLOTS);
+      assert.strictEqual(group.getRemoteMedia('unpinned').length, NUM_SLOTS - 1);
+      assert.strictEqual(group.getRemoteMedia('pinned').length, 1);
+
+      resetHistory();
+      // normally this would result in the underlying receive slot csi to be updated, because we're using fake
+      // receive slots, we have to do that manually:
+      fakeReceiveSlots[PINNED_INDEX].csi = 1234;
+      const expectedReceiverSelectedSlots = [fakeReceiveSlots[PINNED_INDEX]];
+
+      // pin again to same CSI
+      group.fixCsis([{remoteMedia, csi: 1234}], false);
+
+      assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS); // by default should return 'all'
+      assert.strictEqual(group.getRemoteMedia('all').length, NUM_SLOTS);
+      assert.strictEqual(group.getRemoteMedia('unpinned').length, NUM_SLOTS - 1);
+      assert.strictEqual(group.getRemoteMedia('pinned').length, 1);
+
+      assert.strictEqual(group.isPinned(remoteMedia), true);
+      
+      assert.calledTwice(fakeMediaRequestManager.cancelRequest);
+      assert.calledWith(fakeMediaRequestManager.cancelRequest, 'fake receiver selected request 1');
+
+      assert.calledWith(
+        fakeMediaRequestManager.addRequest,
+        sinon.match({
+          policyInfo: sinon.match({
+            policy: 'receiver-selected',
+            csi: 1234,
+          }),
+          receiveSlots: expectedReceiverSelectedSlots,
+          codecInfo: sinon.match({
+            codec: 'h264',
+            maxFs: 3600,
+          }),
+        })
+      );
+      assert.notCalled(fakeMediaRequestManager.commit);
+    });
+
+    it('checks fixCsis with array of remoteMedia to pin and unpin', () => {
+      const PINNED_INDEX = 2;
+      const PINNED_INDEX2 = 0;
+      const CSI = 11111;
+      const CSI2 = 12345;
+
+      const group = new RemoteMediaGroup(fakeMediaRequestManager, fakeReceiveSlots, 255, true, {
+        resolution: 'medium',
+        preferLiveVideo: true,
+      });
+
+      // initially nothing should be pinned
+      assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS); // by default should return 'all'
+      assert.strictEqual(group.getRemoteMedia('all').length, NUM_SLOTS);
+      assert.strictEqual(group.getRemoteMedia('unpinned').length, NUM_SLOTS);
+      assert.strictEqual(group.getRemoteMedia('pinned').length, 0);
+
+      const remoteMedia = group.getRemoteMedia('all')[PINNED_INDEX];
+
+      resetHistory();
+
+      const remoteMedia2 = group.getRemoteMedia('all')[PINNED_INDEX2];
+
+      const remoteMedisCsis = [{remoteMedia, csi: CSI}, {remoteMedia: remoteMedia2, csi: CSI2}, {remoteMedia}];
+
+      group.fixCsis(remoteMedisCsis, false);
+
+     // one pane should still remain pinned
+     assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS);
+     assert.strictEqual(group.getRemoteMedia('all').length, NUM_SLOTS);
+     assert.strictEqual(group.getRemoteMedia('unpinned').length, NUM_SLOTS - 1);
+     assert.strictEqual(group.getRemoteMedia('pinned').length, 1);
+
+     assert.strictEqual(group.isPinned(remoteMedia), false);
+     assert.strictEqual(group.isPinned(remoteMedia2), true);
+
+     assert.calledTwice(fakeMediaRequestManager.cancelRequest);
+     assert.calledWith(fakeMediaRequestManager.cancelRequest, 'fake receiver selected request 1');
+     assert.notCalled(fakeMediaRequestManager.commit);
+    });
+
+    it('check commit is only called once', () => {
+      const PINNED_INDEX = 2;
+      const PINNED_INDEX2 = 0;
+      const CSI = 11111;
+      const CSI2 = 12345;
+
+      const group = new RemoteMediaGroup(fakeMediaRequestManager, fakeReceiveSlots, 255, true, {
+        resolution: 'medium',
+        preferLiveVideo: true,
+      });
+
+      const remoteMedia = group.getRemoteMedia('all')[PINNED_INDEX];
+
+      resetHistory();
+
+      const remoteMedia2 = group.getRemoteMedia('all')[PINNED_INDEX2];
+
+      const remoteMedisCsis = [{remoteMedia, csi: CSI}, {remoteMedia: remoteMedia2, csi: CSI2}, {remoteMedia}];
+
+      group.fixCsis(remoteMedisCsis, true);
+
+      assert.calledOnce(fakeMediaRequestManager.commit);
+    });
+  });
+
   describe('pinning', () => {
     it('works as expected', () => {
       const PINNED_INDEX = 2;

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaGroup.ts
@@ -144,7 +144,7 @@ describe('RemoteMediaGroup', () => {
 
   });
 
-  describe('setCsis', () => {
+  describe('setActiveSpeakerCsis', () => {
     it('checks when there is a csi and remote media is not in pinned array', () => {
       const PINNED_INDEX = 2;
       const CSI = 11111;
@@ -164,7 +164,7 @@ describe('RemoteMediaGroup', () => {
 
       resetHistory();
 
-      group.setCsis([{remoteMedia, csi: CSI}], false);
+      group.setActiveSpeakerCsis([{remoteMedia, csi: CSI}], false);
 
       assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS); // by default should return 'all'
       assert.strictEqual(group.getRemoteMedia('all').length, NUM_SLOTS);
@@ -229,7 +229,7 @@ describe('RemoteMediaGroup', () => {
       resetHistory();
 
       // pin it so that it is in pinned array
-      group.setCsis([{remoteMedia, csi: 1234}], false);
+      group.setActiveSpeakerCsis([{remoteMedia, csi: 1234}], false);
 
       assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS); // by default should return 'all'
       assert.strictEqual(group.getRemoteMedia('all').length, NUM_SLOTS);
@@ -243,7 +243,7 @@ describe('RemoteMediaGroup', () => {
       const expectedReceiverSelectedSlots = [fakeReceiveSlots[PINNED_INDEX]];
 
       // pin again to same CSI
-      group.setCsis([{remoteMedia, csi: 1234}], false);
+      group.setActiveSpeakerCsis([{remoteMedia, csi: 1234}], false);
 
       assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS); // by default should return 'all'
       assert.strictEqual(group.getRemoteMedia('all').length, NUM_SLOTS);
@@ -272,7 +272,7 @@ describe('RemoteMediaGroup', () => {
       assert.notCalled(fakeMediaRequestManager.commit);
     });
 
-    it('checks setCsis with array of remoteMedia to pin and unpin', () => {
+    it('checks setActiveSpeakerCsis with array of remoteMedia to pin and unpin', () => {
       const PINNED_INDEX = 2;
       const PINNED_INDEX2 = 0;
       const CSI = 11111;
@@ -295,7 +295,7 @@ describe('RemoteMediaGroup', () => {
 
       const remoteMedisCsis = [{remoteMedia, csi: CSI}, {remoteMedia: remoteMedia2, csi: CSI2}];
 
-      group.setCsis(remoteMedisCsis, false);
+      group.setActiveSpeakerCsis(remoteMedisCsis, false);
 
      assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS);
      assert.strictEqual(group.getRemoteMedia('all').length, NUM_SLOTS);
@@ -307,7 +307,7 @@ describe('RemoteMediaGroup', () => {
 
      resetHistory();
 
-     group.setCsis([{remoteMedia}], false);
+     group.setActiveSpeakerCsis([{remoteMedia}], false);
 
      // one pane should still remain pinned
      assert.strictEqual(group.getRemoteMedia().length, NUM_SLOTS);
@@ -341,7 +341,7 @@ describe('RemoteMediaGroup', () => {
 
       const remoteMedisCsis = [{remoteMedia, csi: CSI}, {remoteMedia: remoteMedia2, csi: CSI2}, {remoteMedia}];
 
-      group.setCsis(remoteMedisCsis, true);
+      group.setActiveSpeakerCsis(remoteMedisCsis, true);
 
       assert.calledOnce(fakeMediaRequestManager.commit);
     });
@@ -351,7 +351,7 @@ describe('RemoteMediaGroup', () => {
         resolution: 'medium',
         preferLiveVideo: true,
       });
-      assert.throws(() => group.setCsis([{remoteMedia: {id: 'r1'} as any, csi: 123}], false), 'failed to pin a remote media object r1, because it is not found in this remote media group');
+      assert.throws(() => group.setActiveSpeakerCsis([{remoteMedia: {id: 'r1'} as any, csi: 123}], false), 'failed to pin a remote media object r1, because it is not found in this remote media group');
     });
 
     it('throws when remoteMedia id is not in unpinned and pinned array - csi is not there', () => {
@@ -359,7 +359,7 @@ describe('RemoteMediaGroup', () => {
         resolution: 'medium',
         preferLiveVideo: true,
       });
-      assert.throws(() => group.setCsis([{remoteMedia: {id: 'r1'} as any}], false), 'failed to unpin a remote media object r1, because it is not found in this remote media group');
+      assert.throws(() => group.setActiveSpeakerCsis([{remoteMedia: {id: 'r1'} as any}], false), 'failed to unpin a remote media object r1, because it is not found in this remote media group');
     });
   });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaGroup.ts
@@ -346,7 +346,7 @@ describe('RemoteMediaGroup', () => {
       assert.calledOnce(fakeMediaRequestManager.commit);
     });
 
-    it.only('throws when remoteMedia id is not in unpinned and pinned array - csi is there', () => {
+    it('throws when remoteMedia id is not in unpinned and pinned array - csi is there', () => {
       const group = new RemoteMediaGroup(fakeMediaRequestManager, fakeReceiveSlots, 255, true, {
         resolution: 'medium',
         preferLiveVideo: true,
@@ -354,7 +354,7 @@ describe('RemoteMediaGroup', () => {
       assert.throws(() => group.setCsis([{remoteMedia: {id: 'r1'} as any, csi: 123}], false), 'failed to pin a remote media object r1, because it is not found in this remote media group');
     });
 
-    it.only('throws when remoteMedia id is not in unpinned and pinned array - csi is not there', () => {
+    it('throws when remoteMedia id is not in unpinned and pinned array - csi is not there', () => {
       const group = new RemoteMediaGroup(fakeMediaRequestManager, fakeReceiveSlots, 255, true, {
         resolution: 'medium',
         preferLiveVideo: true,

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaManager.ts
@@ -1724,14 +1724,14 @@ describe('RemoteMediaManager', () => {
     });
   });
 
-  describe('setCsis', () => {
-    it('calls setCsis on the correct remote media group', async () => {
+  describe('setActiveSpeakerCsis', () => {
+    it('calls setActiveSpeakerCsis on the correct remote media group', async () => {
       let currentLayoutInfo: VideoLayoutChangedEventData | null = null;
       let setCsisStub;
 
       remoteMediaManager.on(Event.VideoLayoutChanged, (layoutInfo: VideoLayoutChangedEventData) => {
         currentLayoutInfo = layoutInfo;
-        setCsisStub = sinon.stub(layoutInfo.activeSpeakerVideoPanes.main, 'setCsis');
+        setCsisStub = sinon.stub(layoutInfo.activeSpeakerVideoPanes.main, 'setActiveSpeakerCsis');
       });
 
       await remoteMediaManager.start();
@@ -1742,7 +1742,7 @@ describe('RemoteMediaManager', () => {
       if (currentLayoutInfo) {
         const remoteVideo = currentLayoutInfo.activeSpeakerVideoPanes.main.getRemoteMedia()[0];
 
-        remoteMediaManager.setCsis([{remoteMedia: remoteVideo}]);
+        remoteMediaManager.setActiveSpeakerCsis([{remoteMedia: remoteVideo}]);
 
         assert.calledOnce(setCsisStub);
         assert.calledWith(setCsisStub, [{remoteMedia: remoteVideo}], false);
@@ -1750,13 +1750,13 @@ describe('RemoteMediaManager', () => {
       }
     });
 
-    it('does not call setCsis on the incorrect media group', async () => {
+    it('does not call setActiveSpeakerCsis on the incorrect media group', async () => {
       let currentLayoutInfo: VideoLayoutChangedEventData | null = null;
       let setCsisStub;
 
       remoteMediaManager.on(Event.VideoLayoutChanged, (layoutInfo: VideoLayoutChangedEventData) => {
         currentLayoutInfo = layoutInfo;
-        setCsisStub = sinon.stub(layoutInfo.activeSpeakerVideoPanes.main, 'setCsis');
+        setCsisStub = sinon.stub(layoutInfo.activeSpeakerVideoPanes.main, 'setActiveSpeakerCsis');
       });
 
       await remoteMediaManager.start();
@@ -1765,7 +1765,7 @@ describe('RemoteMediaManager', () => {
       assert.isNotNull(currentLayoutInfo);
 
       if (currentLayoutInfo) {
-        remoteMediaManager.setCsis([{remoteMedia: {}}]);
+        remoteMediaManager.setActiveSpeakerCsis([{remoteMedia: {}}]);
 
         assert.notCalled(setCsisStub);
         assert.calledOnce(fakeMediaRequestManagers.video.commit);
@@ -1787,7 +1787,7 @@ describe('RemoteMediaManager', () => {
 
       remoteMediaManager.on(Event.VideoLayoutChanged, (layoutInfo: VideoLayoutChangedEventData) => {
         currentLayoutInfo = layoutInfo;
-        Object.values(layoutInfo.activeSpeakerVideoPanes).forEach((group) => stubs.push(sinon.stub(group, 'setCsis')));
+        Object.values(layoutInfo.activeSpeakerVideoPanes).forEach((group) => stubs.push(sinon.stub(group, 'setActiveSpeakerCsis')));
       });
 
       await remoteMediaManager.start();
@@ -1802,7 +1802,7 @@ describe('RemoteMediaManager', () => {
 
         const remoteMediaCsis = [{remoteMedia: remoteMedia1}, {remoteMedia: remoteMedia2}];
 
-        remoteMediaManager.setCsis([{remoteMedia: remoteMedia1}, {remoteMedia: remoteMedia2}]);
+        remoteMediaManager.setActiveSpeakerCsis([{remoteMedia: remoteMedia1}, {remoteMedia: remoteMedia2}]);
 
         stubs.forEach((stub, index) => {
           assert.calledWith(stub, [remoteMediaCsis[index]], false)

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaManager.ts
@@ -1724,14 +1724,14 @@ describe('RemoteMediaManager', () => {
     });
   });
 
-  describe('fixCsis', () => {
-    it('calls fixCsis on the correct remote media group', async () => {
+  describe('setCsis', () => {
+    it('calls setCsis on the correct remote media group', async () => {
       let currentLayoutInfo: VideoLayoutChangedEventData | null = null;
-      let fixCsisStub;
+      let setCsisStub;
 
       remoteMediaManager.on(Event.VideoLayoutChanged, (layoutInfo: VideoLayoutChangedEventData) => {
         currentLayoutInfo = layoutInfo;
-        fixCsisStub = sinon.stub(layoutInfo.activeSpeakerVideoPanes.main, 'fixCsis');
+        setCsisStub = sinon.stub(layoutInfo.activeSpeakerVideoPanes.main, 'setCsis');
       });
 
       await remoteMediaManager.start();
@@ -1742,21 +1742,21 @@ describe('RemoteMediaManager', () => {
       if (currentLayoutInfo) {
         const remoteVideo = currentLayoutInfo.activeSpeakerVideoPanes.main.getRemoteMedia()[0];
 
-        remoteMediaManager.fixCsis([{remoteMedia: remoteVideo}]);
+        remoteMediaManager.setCsis([{remoteMedia: remoteVideo}]);
 
-        assert.calledOnce(fixCsisStub);
-        assert.calledWith(fixCsisStub, [{remoteMedia: remoteVideo}], false);
+        assert.calledOnce(setCsisStub);
+        assert.calledWith(setCsisStub, [{remoteMedia: remoteVideo}], false);
         assert.calledOnce(fakeMediaRequestManagers.video.commit);
       }
     });
 
-    it('does not call fixCsis on the incorrect media group', async () => {
+    it('does not call setCsis on the incorrect media group', async () => {
       let currentLayoutInfo: VideoLayoutChangedEventData | null = null;
-      let fixCsisStub;
+      let setCsisStub;
 
       remoteMediaManager.on(Event.VideoLayoutChanged, (layoutInfo: VideoLayoutChangedEventData) => {
         currentLayoutInfo = layoutInfo;
-        fixCsisStub = sinon.stub(layoutInfo.activeSpeakerVideoPanes.main, 'fixCsis');
+        setCsisStub = sinon.stub(layoutInfo.activeSpeakerVideoPanes.main, 'setCsis');
       });
 
       await remoteMediaManager.start();
@@ -1765,9 +1765,9 @@ describe('RemoteMediaManager', () => {
       assert.isNotNull(currentLayoutInfo);
 
       if (currentLayoutInfo) {
-        remoteMediaManager.fixCsis([{remoteMedia: {}}]);
+        remoteMediaManager.setCsis([{remoteMedia: {}}]);
 
-        assert.notCalled(fixCsisStub);
+        assert.notCalled(setCsisStub);
         assert.calledOnce(fakeMediaRequestManagers.video.commit);
       }
     });
@@ -1787,7 +1787,7 @@ describe('RemoteMediaManager', () => {
 
       remoteMediaManager.on(Event.VideoLayoutChanged, (layoutInfo: VideoLayoutChangedEventData) => {
         currentLayoutInfo = layoutInfo;
-        Object.values(layoutInfo.activeSpeakerVideoPanes).forEach((group) => stubs.push(sinon.stub(group, 'fixCsis')));
+        Object.values(layoutInfo.activeSpeakerVideoPanes).forEach((group) => stubs.push(sinon.stub(group, 'setCsis')));
       });
 
       await remoteMediaManager.start();
@@ -1802,7 +1802,7 @@ describe('RemoteMediaManager', () => {
 
         const remoteMediaCsis = [{remoteMedia: remoteMedia1}, {remoteMedia: remoteMedia2}];
 
-        remoteMediaManager.fixCsis([{remoteMedia: remoteMedia1}, {remoteMedia: remoteMedia2}]);
+        remoteMediaManager.setCsis([{remoteMedia: remoteMedia1}, {remoteMedia: remoteMedia2}]);
 
         stubs.forEach((stub, index) => {
           assert.calledWith(stub, [remoteMediaCsis[index]], false)


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-436886

## This pull request addresses
Added fixCsis to be called with an array so that we avoid sending too many requests to pin/unpin

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
