### PR TITLE
fix(plugin-meetings): set breakoutStatus cache false avoid duplicate changes

### DIFF
--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -94,7 +94,7 @@ const Breakouts = WebexPlugin.extend({
       },
     },
     breakoutStatus: {
-      cache: false,
+      cache: true,
       deps: ['isInMainSession', 'status', 'groups'],
       /**
        * Returns the breakout status


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

The current problem is that the breakoutStatus does not change when the breakoutType changes from BREAKOUT to MAIN, but the breakoutStatus change event is still triggered.

The reason is that breakoutStatus is a derived state that uses the value of status in groups if it is currently in the main session, or the value of status if it is currently in the breakout session. but the cache property in derived's configuration is set to true.

## by making the following changes

set cache to false in derived's config.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
