### PR TITLE
fix: effects contraints update

### DIFF
--- a/packages/@webex/media-helpers/README.md
+++ b/packages/@webex/media-helpers/README.md
@@ -83,8 +83,6 @@ const microphoneTrack = new LocalMicrophoneTrack(new MediaStream([audioTrackFrom
 // Create the effect.
 const effect = new NoiseReductionEffect({
   authToken: '<encoded-string>',
-  workletProcessorUrl: 'https://my-worklet-processor-url', // For 'WORKLET' mode
-  legacyProcessorUrl: 'https://my-legacy-processor-url', // For 'LEGACY' mode
   mode: 'WORKLET', // or 'LEGACY'
 });
 

--- a/packages/@webex/plugin-meetings/src/meetings/meetings.types.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/meetings.types.ts
@@ -3,7 +3,10 @@ import type {
   VirtualBackgroundEffectOptions,
 } from '@webex/media-helpers';
 
-type INoiseReductionEffect = Omit<NoiseReductionEffectOptions, 'authToken'>;
+type INoiseReductionEffect = Omit<
+  NoiseReductionEffectOptions,
+  'authToken' | 'workletProcessorUrl' | 'legacyProcessorUrl'
+>;
 type IVirtualBackgroundEffect = Omit<VirtualBackgroundEffectOptions, 'authToken'>;
 
 export type {INoiseReductionEffect, IVirtualBackgroundEffect};

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -431,10 +431,8 @@ describe('plugin-meetings', () => {
         it('creates noise reduction effect with custom options passed', async () => {
           const effectOptions = {
             audioContext: {},
-            workletProcessorUrl: "test.url.com",
             mode: "WORKLET",
-            env: "prod",
-            avoidSimd: false
+            env: "prod"
           };
 
           const result = await webex.meetings.createNoiseReductionEffect(effectOptions);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

## This pull request addresses

For noise reduction effect in meetings, we don't want to expose `workletProcessorUrl` and `legacyProcessorUrl` to users while creating noise reduction effect.

## by making the following changes

Omitted `workletProcessorUrl` and `legacyProcessorUrl` from `INoiseReductionEffect` in meetings.types.ts file.
Also updated readme.md file and test case file.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
