### PR TITLE
fix: cannot join meetings if we have no microphone or camera permissions

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5117,10 +5117,13 @@ export default class Meeting extends StatelessWebexPlugin {
       .then(() => {
         this.setMercuryListener();
       })
-      .then(() =>
-        getDevices().then((devices) => {
-          MeetingUtil.handleDeviceLogging(devices);
-        })
+      .then(
+        () =>
+          getDevices()
+            .then((devices) => {
+              MeetingUtil.handleDeviceLogging(devices);
+            })
+            .catch(() => {}) // getDevices may fail if we don't have browser permissions, that's ok, we still can have a media connection
       )
       .then(() => {
         this.handleMediaLogging(this.mediaProperties);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1375,6 +1375,16 @@ describe('plugin-meetings', () => {
           );
           assert.calledOnce(fakeMediaConnection.initiateOffer);
         });
+
+        it('succeeds even if getDevices() throws', async () => {
+          meeting.meetingState = 'ACTIVE';
+
+          sinon
+            .stub(internalMediaModule, 'getDevices')
+            .rejects(new Error('fake error'));
+
+          await meeting.addMedia();
+        })
       });
 
       /* This set of tests are like semi-integration tests, they use real MuteState, Media, LocusMediaRequest and Roap classes.


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-442003

## This pull request addresses

When joining a meeting without microphone and camera permissions, addMedia() calls getDevices() from webrtc-core which throws a WcmeError of type `ErrorTypes.DEVICE_PERMISSION_DENIED`

## by making the following changes

Catching and ignoring the error thrown by getDevices() in addMedia(), because we don't need the device list for anything anyway, that call is only made for logging purposes.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

tested manually with the web app, also added unit test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
