### PR TITLE
fix(breakout): skip moved state main locus

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -1487,7 +1487,7 @@ export default class LocusInfo extends EventsScope {
    * @memberof LocusInfo
    */
   getTheLocusToUpdate(newLocus: any) {
-    const switchStatus = ControlsUtils.getSessionSwitchStatus(this.controls, newLocus.controls);
+    const switchStatus = ControlsUtils.getSessionSwitchStatus(this.controls, newLocus?.controls);
     if (switchStatus.isReturnToMain && this.mainSessionLocusCache) {
       return cloneDeep(this.mainSessionLocusCache);
     }

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -261,6 +261,9 @@ export default class Meetings extends WebexPlugin {
     const isSelfMoved = newLocus?.self?.state === _LEFT_ && newLocus?.self?.reason === _MOVED_;
     // @ts-ignore
     const deviceFromNewLocus = MeetingsUtil.getThisDevice(newLocus, this.webex.internal.device.url);
+    const isResourceMovedOnThisDevice =
+      deviceFromNewLocus?.state === _LEFT_ && deviceFromNewLocus?.reason === _MOVED_;
+
     const isNewLocusJoinThisDevice = MeetingsUtil.joinedOnThisDevice(
       meeting,
       newLocus,
@@ -300,9 +303,16 @@ export default class Meetings extends WebexPlugin {
 
       return false;
     }
-    if (isSelfMoved && newLocus?.self?.removed) {
+    if (isSelfMoved && (newLocus?.self?.removed || isResourceMovedOnThisDevice)) {
       LoggerProxy.logger.log(
-        'Meetings:index#isNeedHandleMainLocus --> self moved main locus with self removed status, not need to handle'
+        'Meetings:index#isNeedHandleMainLocus --> self moved main locus with self removed status or with device resource moved, not need to handle'
+      );
+
+      return false;
+    }
+    if (isSelfJoined && isResourceMovedOnThisDevice) {
+      LoggerProxy.logger.log(
+        'Meetings:index#isNeedHandleMainLocus --> self device left&moved in main locus with self joined status, not need to handle'
       );
 
       return false;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1083,7 +1083,7 @@ describe('plugin-meetings', () => {
               'meeting:meetingInfoAvailable'
             );
           };
-          
+
           it('creates the meeting from a successful meeting info fetch promise testing', async () => {
             const meeting = await webex.meetings.createMeeting('test destination', 'test type');
 
@@ -1104,7 +1104,7 @@ describe('plugin-meetings', () => {
                 permissionToken: 'PT',
                 meetingJoinUrl: 'meetingJoinUrl',
               };
-  
+
               assert.instanceOf(
                 meeting,
                 Meeting,
@@ -1112,7 +1112,7 @@ describe('plugin-meetings', () => {
               );
               checkCreateWithoutDelay(meeting, 'test destination', 'test type', infoExtraParamsProvided ? infoExtraParams : {}, expectedMeetingData);
             });
-  
+
             it(`creates the meeting from a successful meeting info fetch with random delay${infoExtraParamsProvided ? ' with infoExtraParams' : ''}`, async () => {
               const FAKE_LOCUS_MEETING = {
                 conversationUrl: 'locusConvURL',
@@ -1129,14 +1129,14 @@ describe('plugin-meetings', () => {
                   active: false,
                 },
               };
-  
+
               const meeting = await webex.meetings.createMeeting(
                 FAKE_LOCUS_MEETING,
                 'test type',
                 true,
                 infoExtraParams
               );
-  
+
               assert.instanceOf(
                 meeting,
                 Meeting,
@@ -1144,7 +1144,7 @@ describe('plugin-meetings', () => {
               );
               assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
               assert.calledOnce(setTimeoutSpy);
-  
+
               // Parse meeting info with locus object
               assert.equal(meeting.conversationUrl, 'locusConvURL');
               assert.equal(meeting.locusUrl, 'locusUrl');
@@ -1153,7 +1153,7 @@ describe('plugin-meetings', () => {
               assert.isUndefined(meeting.meetingJoinUrl);
               assert.equal(meeting.owner, 'locusOwner');
               assert.isUndefined(meeting.permissionToken);
-  
+
               // Add meeting and send trigger
               assert.calledWith(MeetingsUtil.getMeetingAddedType, 'test type');
               assert.calledTwice(TriggerProxy.trigger);
@@ -1170,7 +1170,7 @@ describe('plugin-meetings', () => {
                   type: 'test meeting added type',
                 }
               );
-  
+
               // When timer expires
               clock.tick(FAKE_TIME_TO_START);
               assert.calledWith(
@@ -1183,7 +1183,7 @@ describe('plugin-meetings', () => {
                 undefined,
                 infoExtraParamsProvided ? infoExtraParams : {}
               );
-  
+
               // Parse meeting info is called again with new meeting info
               await testUtils.flushPromises();
               assert.equal(meeting.conversationUrl, 'locusConvURL');
@@ -1193,7 +1193,7 @@ describe('plugin-meetings', () => {
               assert.equal(meeting.meetingJoinUrl, 'meetingJoinUrl');
               assert.equal(meeting.owner, 'locusOwner');
               assert.equal(meeting.permissionToken, 'PT');
-  
+
               assert.calledWith(
                 TriggerProxy.trigger,
                 meeting,
@@ -1744,7 +1744,41 @@ describe('plugin-meetings', () => {
         assert.equal(result, false);
         assert.calledWith(
           LoggerProxy.logger.log,
-          'Meetings:index#isNeedHandleMainLocus --> self moved main locus with self removed status, not need to handle'
+          'Meetings:index#isNeedHandleMainLocus --> self moved main locus with self removed status or with device resource moved, not need to handle'
+        );
+      });
+
+      it('check self is moved and device resource removed, return false', () => {
+        webex.meetings.meetingCollection.getActiveBreakoutLocus = sinon.stub().returns(null);
+        newLocus.self.state = 'LEFT';
+        newLocus.self.reason = 'MOVED';
+        sinon.stub(MeetingsUtil, 'getThisDevice').returns({
+          state: 'LEFT',
+          reason: 'MOVED',
+        });
+        LoggerProxy.logger.log = sinon.stub();
+        const result = webex.meetings.isNeedHandleMainLocus(meeting, newLocus);
+        assert.equal(result, false);
+        assert.calledWith(
+          LoggerProxy.logger.log,
+          'Meetings:index#isNeedHandleMainLocus --> self moved main locus with self removed status or with device resource moved, not need to handle'
+        );
+      });
+
+      it('check self is joined but device resource removed, return false', () => {
+        webex.meetings.meetingCollection.getActiveBreakoutLocus = sinon.stub().returns(null);
+        sinon.stub(MeetingsUtil, 'joinedOnThisDevice').returns(false);
+        newLocus.self.state = 'JOINED';
+        sinon.stub(MeetingsUtil, 'getThisDevice').returns({
+          state: 'LEFT',
+          reason: 'MOVED',
+        });
+        LoggerProxy.logger.log = sinon.stub();
+        const result = webex.meetings.isNeedHandleMainLocus(meeting, newLocus);
+        assert.equal(result, false);
+        assert.calledWith(
+          LoggerProxy.logger.log,
+          'Meetings:index#isNeedHandleMainLocus --> self device left&moved in main locus with self joined status, not need to handle'
         );
       });
     });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-442495

## This pull request addresses

to fix issue that sometimes can't get the right roster list when join into breakout session. The root cause is that sometimes will receive the moved main locus (the sequence is bigger one) first, then receive the breakout locus (the sequence is smaller) later, will drop the breakout locus by sequence comparing. Should skip the main locus that resource is moved on this device (follow native client's new logic on it)

## by making the following changes

add resource is moved on this device in `isNeedHandleMainLocus`, if resource is moved which mean already join into bo, drop this main locus 

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
