### PR TITLE
fix(plugin-meetings): trigger ask return to main event after meeting joined

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1214,6 +1214,16 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
+   * returns meeting is joined
+   * @private
+   * @memberof Meeting
+   * @returns {Boolean}
+   */
+  private isJoined() {
+    return this.joinedWith?.state === 'JOINED';
+  }
+
+  /**
    * Fetches meeting information.
    * @param {Object} options
    * @param {String} [options.password] optional
@@ -1502,14 +1512,16 @@ export default class Meeting extends StatelessWebexPlugin {
     });
 
     this.breakouts.on(BREAKOUTS.EVENTS.ASK_RETURN_TO_MAIN, () => {
-      Trigger.trigger(
-        this,
-        {
-          file: 'meeting/index',
-          function: 'setUpBreakoutsListener',
-        },
-        EVENT_TRIGGERS.MEETING_BREAKOUTS_ASK_RETURN_TO_MAIN
-      );
+      if (this.isJoined()) {
+        Trigger.trigger(
+          this,
+          {
+            file: 'meeting/index',
+            function: 'setUpBreakoutsListener',
+          },
+          EVENT_TRIGGERS.MEETING_BREAKOUTS_ASK_RETURN_TO_MAIN
+        );
+      }
     });
 
     this.breakouts.on(BREAKOUTS.EVENTS.LEAVE_BREAKOUT, () => {
@@ -4178,7 +4190,7 @@ export default class Meeting extends StatelessWebexPlugin {
     // @ts-ignore - Fix type
     const {url, info: {datachannelUrl} = {}} = this.locusInfo;
 
-    const isJoined = this.joinedWith && this.joinedWith.state === 'JOINED';
+    const isJoined = this.isJoined();
 
     // @ts-ignore - Fix type
     if (this.webex.internal.llm.isConnected()) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2710,6 +2710,19 @@ describe('plugin-meetings', () => {
         });
       });
 
+      describe("#isJoined", () => {
+        it("should returns isJoined correctly", () => {
+          meeting.joinedWith = undefined;
+          assert.equal(meeting.isJoined(), false);
+
+          meeting.joinedWith = {state: "NOT_JOINED"};
+          assert.equal(meeting.isJoined(), false);
+          
+          meeting.joinedWith = {state: "JOINED"};
+          assert.equal(meeting.isJoined(), true);
+        });
+      });
+
       describe('#fetchMeetingInfo', () => {
         const FAKE_DESTINATION = 'something@somecompany.com';
         const FAKE_TYPE = _SIP_URI_;
@@ -4463,8 +4476,16 @@ describe('plugin-meetings', () => {
           );
         });
 
+        it('should not trigger ASK_RETURN_TO_MAIN before joined', () => {
+          TriggerProxy.trigger.reset();
+          meeting.joinedWith = {state: "NOT_JOINED"};
+          meeting.breakouts.trigger('ASK_RETURN_TO_MAIN');
+          assert.notCalled(TriggerProxy.trigger);
+        });
+
         it('listens to the ask return to main event from breakouts and triggers the ask return to main event from meeting', () => {
           TriggerProxy.trigger.reset();
+          meeting.joinedWith = {state: "JOINED"};
           meeting.breakouts.trigger('ASK_RETURN_TO_MAIN');
           assert.calledWith(
             TriggerProxy.trigger,


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [SPARK-442867](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-442867)

## This pull request addresses

should trigger ASK_RETURN_TO_MAIN event after meeting joined.

## by making the following changes

check if meeting isJoined before trigger ASK_RETURN_TO_MAIN event.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
