### PR TITLE
fix(conversation): use file.url instead of file.scr.loc for download

### DIFF
--- a/packages/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/@webex/internal-plugin-conversation/src/conversation.js
@@ -425,9 +425,7 @@ const Conversation = WebexPlugin.extend({
     let promise;
 
     if (isEncrypted) {
-      promise = this.webex.internal.encryption.download(item.scr, item.options);
-    } else if (item.scr && item.scr.loc) {
-      promise = this._downloadUnencryptedFile(item.scr.loc, options);
+      promise = this.webex.internal.encryption.download(item.url, item.scr, item.options);
     } else {
       promise = this._downloadUnencryptedFile(item.url, options);
     }

--- a/packages/@webex/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/@webex/internal-plugin-conversation/test/integration/spec/get.js
@@ -154,6 +154,7 @@ describe('plugin-conversation', function () {
             scr: {
               loc: makeLocalUrl('/sample-image-small-one.png'),
             },
+            url: makeLocalUrl('/sample-image-small-one.png')
           })
           .then((f) =>
             fh.isMatchingFile(f, sampleImageSmallOnePng).then((result) => assert.isTrue(result))

--- a/packages/@webex/internal-plugin-encryption/test/unit/spec/encryption.js
+++ b/packages/@webex/internal-plugin-encryption/test/unit/spec/encryption.js
@@ -22,18 +22,18 @@ describe('internal-plugin-encryption', () => {
     });
 
     describe('check _fetchDownloadUrl()', () => {
-      const scrArray = [
+      const fileArray = [
         {
-          loc: 'https://files-api-intb1.ciscospark.com/v1/spaces/a0cba376-fc05-4b88-af4b-cfffa7465f9a/contents/1d3931e7-9e31-46bc-8084-d766a8f72c99/versions/5fa9caf87a98410aae49e0173856a974/bytes',
+          url: 'https://files-api-intb1.ciscospark.com/v1/spaces/a0cba376-fc05-4b88-af4b-cfffa7465f9a/contents/1d3931e7-9e31-46bc-8084-d766a8f72c99/versions/5fa9caf87a98410aae49e0173856a974/bytes',
         },
         {
-          loc: 'https://files-api-intb2.ciscospark.com/v1/spaces/a0cba376-fc05-4b88-af4b-cfffa7465f9a/contents/1d3931e7-9e31-46bc-8084-d766a8f72c99/versions/5fa9caf87a98410aae49e0173856a974/bytes',
+          url: 'https://files-api-intb2.ciscospark.com/v1/spaces/a0cba376-fc05-4b88-af4b-cfffa7465f9a/contents/1d3931e7-9e31-46bc-8084-d766a8f72c99/versions/5fa9caf87a98410aae49e0173856a974/bytes',
         },
         {
-          loc: 'https://www.test-api.com/v1/spaces/test-path-name-space/contents/test-path-name-contents/versions/test-version/bytes',
+          url: 'https://www.test-api.com/v1/spaces/test-path-name-space/contents/test-path-name-contents/versions/test-version/bytes',
         },
         {
-          loc: 'http://www.test-api.com/v1/spaces/test-path-name-space/contents/test-path-name-contents/versions/test-version/bytes',
+          url: 'http://www.test-api.com/v1/spaces/test-path-name-space/contents/test-path-name-contents/versions/test-version/bytes',
         },
       ];
       const options = undefined;
@@ -44,7 +44,7 @@ describe('internal-plugin-encryption', () => {
 
         spyStub = sinon.stub(webex.internal.encryption, 'request').callsFake(returnStub);
 
-        scrArray.forEach((scr) => webex.internal.encryption._fetchDownloadUrl(scr, options));
+        fileArray.forEach((file) => webex.internal.encryption._fetchDownloadUrl(file.url, options));
       });
 
       it('verifying file service uris', () => {
@@ -68,10 +68,10 @@ describe('internal-plugin-encryption', () => {
       });
 
       it('verifying endpoints', () => {
-        assert.equal(spyStub.args[0][0].body.endpoints[0], scrArray[0].loc);
-        assert.equal(spyStub.args[1][0].body.endpoints[0], scrArray[1].loc);
-        assert.equal(spyStub.args[2][0].body.endpoints[0], scrArray[2].loc);
-        assert.equal(spyStub.args[3][0].body.endpoints[0], scrArray[3].loc);
+        assert.equal(spyStub.args[0][0].body.endpoints[0], fileArray[0].url);
+        assert.equal(spyStub.args[1][0].body.endpoints[0], fileArray[1].url);
+        assert.equal(spyStub.args[2][0].body.endpoints[0], fileArray[2].url);
+        assert.equal(spyStub.args[3][0].body.endpoints[0], fileArray[3].url);
       });
 
       afterEach(() => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-443057

## This pull request addresses

clients should not use file.scr.loc for downloading files. instead should use file.url. this change *needs* to happen with Federation Phase 4 incoming. as files are migrated across clusters, the url will change (from source to target cluster url). services *can not* and *will not* change the `file.scr.loc` (they would have to decrypt the scr and re-encrypt with new values)

## by making the following changes

for downloading files simply replace all uses of `file.scr.loc` with `file.url`

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
