### PR TITLE
feat(ca-metrics): add behaviorual event for ca fails

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -30,6 +30,7 @@ import {
 import CallDiagnosticEventsBatcher from './call-diagnostic-metrics-batcher';
 import {
   CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD,
+  CALL_DIAGNOSTIC_EVENT_FAILED_TO_SEND,
   MEETING_INFO_LOOKUP_ERROR_CLIENT_CODE,
   NEW_LOCUS_ERROR_CLIENT_CODE,
   SERVICE_ERROR_CODES_TO_CLIENT_ERROR_CODES_MAP,
@@ -226,11 +227,17 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       const meeting = this.webex.meetings.meetingCollection.get(meetingId);
 
       if (!meeting) {
-        // TODO: add behavioral metrics to see if this actually happens in production.
         console.warn(
           'Attempt to send MQE but no meeting was found...',
           `event: ${name}, meetingId: ${meetingId}`
         );
+        // @ts-ignore
+        this.webex.internal.metrics.submitClientMetrics(CALL_DIAGNOSTIC_EVENT_FAILED_TO_SEND, {
+          fields: {
+            meetingId,
+            name,
+          },
+        });
 
         return;
       }
@@ -346,11 +353,17 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       const meeting = this.webex.meetings.meetingCollection.get(meetingId);
 
       if (!meeting) {
-        // TODO: add behavioral metrics to see if this actually happens in production.
         console.warn(
           'Attempt to send client event but no meeting was found...',
           `event: ${name}, meetingId: ${meetingId}`
         );
+        // @ts-ignore
+        this.webex.internal.metrics.submitClientMetrics(CALL_DIAGNOSTIC_EVENT_FAILED_TO_SEND, {
+          fields: {
+            meetingId,
+            name,
+          },
+        });
 
         return;
       }

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
@@ -451,3 +451,5 @@ export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEv
     fatal: false,
   },
 };
+
+export const CALL_DIAGNOSTIC_EVENT_FAILED_TO_SEND = 'js_sdk_call_diagnostic_event_failed_to_send';


### PR DESCRIPTION
# COMPLETES [SPARK-443315](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-443315)

## This pull request addresses

- add behavioural event to failing to send CA metric if meeting is not found
- have only seen this happening in SDK, this is to check how often it happens in production

## by making the following changes

- add event

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

-unit test, manual test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
