### PR TITLE
fix(plugin-calendar): enhance getFreeBusy function

### DIFF
--- a/packages/@webex/internal-plugin-calendar/src/calendar.encrypt.helper.js
+++ b/packages/@webex/internal-plugin-calendar/src/calendar.encrypt.helper.js
@@ -72,12 +72,16 @@ const EncryptHelper = {
     });
   },
   /**
-   * Encrypt free-busy request payload
+   * Encrypt free-busy request payload, if request payload only includes the sensitive data, like email, need to encrypt these reqeust parameters, and playload includes encrypt url.
+   * Otherwise, don't encrypt playload and without encrypt url,Due to calendar serivce will vaild both encrypt url and sensitive that are both present. if not, will return 400 bad reqeust to caller.
    * @param {object} [ctx] context
    * @param {object} [data] free busy payload data
    * @returns {Promise} Resolves with encrypted request payload
    * */
   encryptFreeBusyRequest: (ctx, data) => {
+    if (!data.emails || !Array.isArray(data.emails)) {
+      return Promise.resolve();
+    }
     if (ctx.encryptionKeyUrl) {
       return _encryptFreeBusyPayload(data, ctx);
     }

--- a/packages/@webex/internal-plugin-calendar/test/unit/spec/calendar.encrypt.helper.js
+++ b/packages/@webex/internal-plugin-calendar/test/unit/spec/calendar.encrypt.helper.js
@@ -1,12 +1,12 @@
 import sinon from 'sinon';
 import {expect} from '@webex/test-helper-chai';
-import EncryptHelper from "@webex/internal-plugin-calendar/src/calendar.encrypt.helper"
+import EncryptHelper from '@webex/internal-plugin-calendar/src/calendar.encrypt.helper';
 describe('internal-plugin-calendar', () => {
   describe('encryptHelper', () => {
     let ctx;
     beforeEach(() => {
       ctx = {
-        encryptionKeyUrl: "http://example.com/encryption-key",
+        encryptionKeyUrl: 'http://example.com/encryption-key',
         webex: {
           internal: {
             encryption: {
@@ -23,30 +23,28 @@ describe('internal-plugin-calendar', () => {
 
     it('#encryptFreebusyRequestData with emails should ', async () => {
       const freeBusyRequest = {
-        start:"20230712T10:20:00Z",
-        end:"20230712T20:20:00Z",
-        emails: [
-          "test@webex.com"
-        ]
+        start: '20230712T10:20:00Z',
+        end: '20230712T20:20:00Z',
+        emails: ['test@webex.com'],
       };
-        const expectedCiphertext = 'some encrpty data';
-        ctx.webex.internal.encryption.encryptText.callsFake((key, ciphertext) =>
-          Promise.resolve(expectedCiphertext)
-        );
+      const expectedCiphertext = 'some encrpty data';
+      ctx.webex.internal.encryption.encryptText.callsFake((key, ciphertext) =>
+        Promise.resolve(expectedCiphertext)
+      );
       await EncryptHelper.encryptFreeBusyRequest(ctx, freeBusyRequest);
       expect(freeBusyRequest.emails[0]).to.be.equal(expectedCiphertext);
     });
 
     it('#encryptFreebusyRequestData not include emails, but include ids- should b', async () => {
       const freeBusyRequest = {
-        start: "20230712T10:20:00Z",
-        end: "20230712T20:20:00Z",
-        userIds: ["91aee1231"],
+        start: '20230712T10:20:00Z',
+        end: '20230712T20:20:00Z',
+        userIds: ['91aee1231'],
       };
-       const expectedCiphertext = "91aee1231";
-       ctx.webex.internal.encryption.encryptText.callsFake((key, ciphertext) =>
-         Promise.resolve(expectedCiphertext)
-       );
+      const expectedCiphertext = '91aee1231';
+      ctx.webex.internal.encryption.encryptText.callsFake((key, ciphertext) =>
+        Promise.resolve(expectedCiphertext)
+      );
       await EncryptHelper.encryptFreeBusyRequest(ctx, freeBusyRequest);
       expect(freeBusyRequest.userIds[0]).to.equal(expectedCiphertext);
     });

--- a/packages/@webex/internal-plugin-calendar/test/unit/spec/calendar.encrypt.helper.js
+++ b/packages/@webex/internal-plugin-calendar/test/unit/spec/calendar.encrypt.helper.js
@@ -1,0 +1,54 @@
+import sinon from 'sinon';
+import {expect} from '@webex/test-helper-chai';
+import EncryptHelper from "@webex/internal-plugin-calendar/src/calendar.encrypt.helper"
+describe('internal-plugin-calendar', () => {
+  describe('encryptHelper', () => {
+    let ctx;
+    beforeEach(() => {
+      ctx = {
+        encryptionKeyUrl: "http://example.com/encryption-key",
+        webex: {
+          internal: {
+            encryption: {
+              encryptText: sinon.stub(),
+            },
+          },
+        },
+      };
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('#encryptFreebusyRequestData with emails should ', async () => {
+      const freeBusyRequest = {
+        start:"20230712T10:20:00Z",
+        end:"20230712T20:20:00Z",
+        emails: [
+          "test@webex.com"
+        ]
+      };
+        const expectedCiphertext = 'some encrpty data';
+        ctx.webex.internal.encryption.encryptText.callsFake((key, ciphertext) =>
+          Promise.resolve(expectedCiphertext)
+        );
+      await EncryptHelper.encryptFreeBusyRequest(ctx, freeBusyRequest);
+      expect(freeBusyRequest.emails[0]).to.be.equal(expectedCiphertext);
+    });
+
+    it('#encryptFreebusyRequestData not include emails, but include ids- should b', async () => {
+      const freeBusyRequest = {
+        start: "20230712T10:20:00Z",
+        end: "20230712T20:20:00Z",
+        userIds: ["91aee1231"],
+      };
+       const expectedCiphertext = "91aee1231";
+       ctx.webex.internal.encryption.encryptText.callsFake((key, ciphertext) =>
+         Promise.resolve(expectedCiphertext)
+       );
+      await EncryptHelper.encryptFreeBusyRequest(ctx, freeBusyRequest);
+      expect(freeBusyRequest.userIds[0]).to.equal(expectedCiphertext);
+    });
+  });
+});


### PR DESCRIPTION
  <!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [WEBEX-343541](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-343541)>

## This pull request addresses
[WEBEX-343541](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-343541)
< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >
  I have a use case that invokes invokes 'getFreeBusy' by room id list to get room free busy. In this case, don't need to encrypt the id list of the request parameter, and also need to send a request without encrypt url. Only when free busy request payload only includes the sensitive data, like email, need to encrypt these request parameters, and payload includes encrypt url.
    Otherwise, don't encrypt the payload and encrypt url, Due to the calendar service will valid both encrypt url and the sensitivity that are both present. if not, will return 400 bad request to the caller.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
