### PR TITLE
feat(ca-metrics): refactor submitClient, support correlationId

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -78,7 +78,7 @@ export default class CallDiagnosticLatencies {
   public getShowInterstitialTime() {
     return this.getDiffBetweenTimestamps(
       'internal.client.interstitial-window.launched',
-      'internal.client.meeting.click.joinbutton'
+      'internal.client.interstitial-window.click.joinbutton'
     );
   }
 
@@ -243,9 +243,10 @@ export default class CallDiagnosticLatencies {
     const clickToInterstitial = this.getClickToInterstitial();
     const interstitialToJoinOk = this.getInterstitialToJoinOK();
     const joinConfJMT = this.getJoinConfJMT();
+    const stayLobbyTime = this.getStayLobbyTime() || 0;
 
     if (clickToInterstitial && interstitialToJoinOk && joinConfJMT) {
-      return clickToInterstitial + interstitialToJoinOk + joinConfJMT;
+      return clickToInterstitial + interstitialToJoinOk + joinConfJMT - stayLobbyTime;
     }
 
     return undefined;

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -77,8 +77,8 @@ export default class CallDiagnosticLatencies {
    */
   public getShowInterstitialTime() {
     return this.getDiffBetweenTimestamps(
-      'client.interstitial-window.launched',
-      'client.meeting.click.joinbutton'
+      'internal.client.interstitial-window.launched',
+      'internal.client.meeting.click.joinbutton'
     );
   }
 
@@ -88,7 +88,7 @@ export default class CallDiagnosticLatencies {
    */
   public getCallInitJoinReq() {
     return this.getDiffBetweenTimestamps(
-      'client.meeting.click.joinbutton',
+      'internal.client.meeting.click.joinbutton',
       'client.locus.join.request'
     );
   }
@@ -160,7 +160,7 @@ export default class CallDiagnosticLatencies {
   public getStayLobbyTime() {
     return this.getDiffBetweenTimestamps(
       'client.locus.join.response',
-      'host.meeting.participant.admitted'
+      'internal.host.meeting.participant.admitted'
     );
   }
 
@@ -178,8 +178,8 @@ export default class CallDiagnosticLatencies {
    */
   public getClickToInterstitial() {
     return this.getDiffBetweenTimestamps(
-      'client.meeting.click.joinbutton',
-      'client.meeting.interstitial-window.showed'
+      'internal.client.meeting.click.joinbutton',
+      'internal.client.meeting.interstitial-window.showed'
     );
   }
 
@@ -189,7 +189,7 @@ export default class CallDiagnosticLatencies {
    */
   public getInterstitialToJoinOK() {
     return this.getDiffBetweenTimestamps(
-      'client.meeting.click.joinbutton',
+      'internal.client.meeting.click.joinbutton',
       'client.locus.join.response'
     );
   }
@@ -200,7 +200,7 @@ export default class CallDiagnosticLatencies {
    */
   public getInterstitialToMediaOK() {
     return this.getDiffBetweenTimestamps(
-      'client.meeting.click.joinbutton',
+      'internal.client.meeting.click.joinbutton',
       'sdk.media-flow.started'
     );
   }

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -169,7 +169,7 @@ export default class CallDiagnosticLatencies {
    * @returns - latency
    */
   public getPageJMT() {
-    return this.latencyTimestamps.get('client.pageJMT.received') || undefined;
+    return this.latencyTimestamps.get('internal.client.pageJMT.received') || undefined;
   }
 
   /**

--- a/packages/@webex/internal-plugin-metrics/src/index.ts
+++ b/packages/@webex/internal-plugin-metrics/src/index.ts
@@ -9,7 +9,14 @@ import {registerInternalPlugin} from '@webex/webex-core';
 import Metrics from './metrics';
 import config from './config';
 import NewMetrics from './new-metrics';
-import {ClientEvent} from './metrics.types';
+import {
+  ClientEvent,
+  SubmitBehavioralEvent,
+  SubmitClientEvent,
+  SubmitInternalEvent,
+  SubmitOperationalEvent,
+  SubmitMQE,
+} from './metrics.types';
 import * as CALL_DIAGNOSTIC_CONFIG from './call-diagnostic/config';
 
 registerInternalPlugin('metrics', Metrics, {
@@ -22,4 +29,11 @@ registerInternalPlugin('newMetrics', NewMetrics, {
 
 export {default, getOSNameInternal} from './metrics';
 export {config, CALL_DIAGNOSTIC_CONFIG, NewMetrics};
-export type {ClientEvent};
+export type {
+  ClientEvent,
+  SubmitBehavioralEvent,
+  SubmitClientEvent,
+  SubmitInternalEvent,
+  SubmitMQE,
+  SubmitOperationalEvent,
+};

--- a/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
+++ b/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
@@ -11,6 +11,7 @@ export type SubmitClientEventOptions = {
   mediaConnections?: any[];
   rawError?: any;
   showToUser?: boolean;
+  correlationId?: string;
 };
 
 export type SubmitMQEOptions = {
@@ -86,3 +87,55 @@ export type MediaQualityEventVideoSetupDelayPayload =
 export type SubmitMQEPayload = RecursivePartial<MediaQualityEvent['payload']> & {
   intervals: MediaQualityEvent['payload']['intervals'];
 };
+
+export type SubmitInternalEvent = ({
+  name,
+  payload,
+  options,
+}: {
+  name: InternalEvent['name'];
+  payload?: RecursivePartial<InternalEvent['payload']>;
+  options: any;
+}) => void;
+
+export type SubmitBehavioralEvent = ({
+  name,
+  payload,
+  options,
+}: {
+  name: BehavioralEvent['name'];
+  payload?: RecursivePartial<BehavioralEvent['payload']>;
+  options: any;
+}) => void;
+
+export type SubmitClientEvent = ({
+  name,
+  payload,
+  options,
+}: {
+  name: ClientEvent['name'];
+  payload?: RecursivePartial<ClientEvent['payload']>;
+  options: SubmitClientEventOptions;
+}) => void;
+
+export type SubmitOperationalEvent = ({
+  name,
+  payload,
+  options,
+}: {
+  name: OperationalEvent['name'];
+  payload?: RecursivePartial<OperationalEvent['payload']>;
+  options: any;
+}) => void;
+
+export type SubmitMQE = ({
+  name,
+  payload,
+  options,
+}: {
+  name: MediaQualityEvent['name'];
+  payload: RecursivePartial<MediaQualityEvent['payload']> & {
+    intervals: MediaQualityEvent['payload']['intervals'];
+  };
+  options: any;
+}) => void;

--- a/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
+++ b/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
@@ -29,7 +29,8 @@ export type InternalEvent = {
     | 'internal.client.meeting.click.joinbutton'
     | 'internal.host.meeting.participant.admitted'
     | 'internal.client.meeting.interstitial-window.showed'
-    | 'internal.client.pageJMT.received';
+    | 'internal.client.pageJMT.received'
+    | 'internal.client.interstitial-window.click.joinbutton';
   payload?: never;
   options?: never;
 };
@@ -87,6 +88,8 @@ export type ClientType = NonNullable<RawEvent['origin']['clientInfo']>['clientTy
 export type SubClientType = NonNullable<RawEvent['origin']['clientInfo']>['subClientType'];
 export type NetworkType = RawEvent['origin']['networkType'];
 
+export type ClientEventPayload = RecursivePartial<ClientEvent['payload']>;
+
 export type MediaQualityEventAudioSetupDelayPayload =
   MediaQualityEvent['payload']['audioSetupDelay'];
 export type MediaQualityEventVideoSetupDelayPayload =
@@ -96,51 +99,31 @@ export type SubmitMQEPayload = RecursivePartial<MediaQualityEvent['payload']> & 
   intervals: MediaQualityEvent['payload']['intervals'];
 };
 
-export type SubmitInternalEvent = ({
-  name,
-  payload,
-  options,
-}: {
+export type SubmitInternalEvent = (args: {
   name: InternalEvent['name'];
   payload?: RecursivePartial<InternalEvent['payload']>;
   options: any;
 }) => void;
 
-export type SubmitBehavioralEvent = ({
-  name,
-  payload,
-  options,
-}: {
+export type SubmitBehavioralEvent = (args: {
   name: BehavioralEvent['name'];
   payload?: RecursivePartial<BehavioralEvent['payload']>;
   options: any;
 }) => void;
 
-export type SubmitClientEvent = ({
-  name,
-  payload,
-  options,
-}: {
+export type SubmitClientEvent = (args: {
   name: ClientEvent['name'];
   payload?: RecursivePartial<ClientEvent['payload']>;
   options: SubmitClientEventOptions;
 }) => void;
 
-export type SubmitOperationalEvent = ({
-  name,
-  payload,
-  options,
-}: {
+export type SubmitOperationalEvent = (args: {
   name: OperationalEvent['name'];
   payload?: RecursivePartial<OperationalEvent['payload']>;
   options: any;
 }) => void;
 
-export type SubmitMQE = ({
-  name,
-  payload,
-  options,
-}: {
+export type SubmitMQE = (args: {
   name: MediaQualityEvent['name'];
   payload: RecursivePartial<MediaQualityEvent['payload']> & {
     intervals: MediaQualityEvent['payload']['intervals'];

--- a/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
+++ b/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
@@ -21,7 +21,14 @@ export type SubmitMQEOptions = {
 };
 
 export type InternalEvent = {
-  name: 'internal.client.meetinginfo.request' | 'internal.client.meetinginfo.response';
+  name:
+    | 'internal.client.meetinginfo.request'
+    | 'internal.client.meetinginfo.response'
+    | 'internal.reset.join.latencies'
+    | 'internal.client.interstitial-window.launched'
+    | 'internal.client.meeting.click.joinbutton'
+    | 'internal.host.meeting.participant.admitted'
+    | 'internal.client.meeting.interstitial-window.showed';
   payload?: never;
   options?: never;
 };

--- a/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
+++ b/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
@@ -28,7 +28,8 @@ export type InternalEvent = {
     | 'internal.client.interstitial-window.launched'
     | 'internal.client.meeting.click.joinbutton'
     | 'internal.host.meeting.participant.admitted'
-    | 'internal.client.meeting.interstitial-window.showed';
+    | 'internal.client.meeting.interstitial-window.showed'
+    | 'internal.client.pageJMT.received';
   payload?: never;
   options?: never;
 };
@@ -41,7 +42,7 @@ export interface ClientEvent {
 
 export interface BehavioralEvent {
   // TODO: not implemented
-  name: 'host.meeting.participant.admitted' | 'client.pageJMT.received' | 'sdk.media-flow.started';
+  name: 'host.meeting.participant.admitted' | 'sdk.media-flow.started';
   payload?: never;
   options?: never;
 }

--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -70,7 +70,11 @@ class Metrics extends WebexPlugin {
     payload?: RecursivePartial<InternalEvent['payload']>;
     options: any;
   }) {
-    this.callDiagnosticLatencies.saveTimestamp(name);
+    if (name === 'internal.reset.join.latencies') {
+      this.callDiagnosticLatencies.clearTimestamps();
+    } else {
+      this.callDiagnosticLatencies.saveTimestamp(name);
+    }
   }
 
   /**

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -184,7 +184,7 @@ describe('plugin-metrics', () => {
           assert.deepEqual(webex.request.getCalls()[0].args[0].body.metrics[0].eventPayload.event, {
             name: 'client.media-engine.ready',
             joinTimes: {
-              totalMediaJMT: 40,
+              totalMediaJMT: 30,
             },
           });
           assert.lengthOf(webex.internal.newMetrics.callDiagnosticMetrics.callDiagnosticEventsBatcher.queue, 0);

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -65,13 +65,13 @@ describe("internal-plugin-metrics", () => {
     });
 
     it('calculates getShowInterstitialTime correctly', () => {
-      cdl.saveTimestamp('client.interstitial-window.launched', 10);
-      cdl.saveTimestamp('client.meeting.click.joinbutton', 20);
+      cdl.saveTimestamp('internal.client.interstitial-window.launched', 10);
+      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 20);
       assert.deepEqual(cdl.getShowInterstitialTime(), 10);
     });
 
     it('calculates getCallInitJoinReq correctly', () => {
-      cdl.saveTimestamp('client.meeting.click.joinbutton', 10);
+      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 10);
       cdl.saveTimestamp('client.locus.join.request', 20);
       assert.deepEqual(cdl.getCallInitJoinReq(), 10);
     });
@@ -114,36 +114,36 @@ describe("internal-plugin-metrics", () => {
 
     it('calculates getStayLobbyTime correctly', () => {
       cdl.saveTimestamp('client.locus.join.response', 10);
-      cdl.saveTimestamp('host.meeting.participant.admitted', 20);
+      cdl.saveTimestamp('internal.host.meeting.participant.admitted', 20);
       assert.deepEqual(cdl.getStayLobbyTime(), 10);
     });
 
     it('calculates getPageJMT correctly', () => {
-      cdl.saveTimestamp('client.pageJMT.received', 10);
+      cdl.saveTimestamp('internal.client.pageJMT.received', 10);
       assert.deepEqual(cdl.getPageJMT(), 10);
     });
 
     it('calculates getClickToInterstitial correctly', () => {
-      cdl.saveTimestamp('client.meeting.click.joinbutton', 10);
-      cdl.saveTimestamp('client.meeting.interstitial-window.showed', 20);
+      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 10);
+      cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 20);
       assert.deepEqual(cdl.getClickToInterstitial(), 10);
     });
 
     it('calculates getInterstitialToJoinOK correctly', () => {
-      cdl.saveTimestamp('client.meeting.click.joinbutton', 10);
+      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 10);
       cdl.saveTimestamp('client.locus.join.response', 20);
       assert.deepEqual(cdl.getInterstitialToJoinOK(), 10);
     });
 
     it('calculates getInterstitialToMediaOK correctly', () => {
-      cdl.saveTimestamp('client.meeting.click.joinbutton', 10);
+      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 10);
       cdl.saveTimestamp('sdk.media-flow.started', 20);
       assert.deepEqual(cdl.getInterstitialToMediaOK(), 10);
     });
 
     it('calculates getTotalJMT correctly', () => {
-      cdl.saveTimestamp('client.meeting.click.joinbutton', 10);
-      cdl.saveTimestamp('client.meeting.interstitial-window.showed', 20);
+      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 10);
+      cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 20);
       cdl.saveTimestamp('client.locus.join.response', 40);
       assert.deepEqual(cdl.getTotalJMT(), 40);
     });
@@ -157,8 +157,8 @@ describe("internal-plugin-metrics", () => {
     });
 
     it('calculates getClientJMT correctly', () => {
-      cdl.saveTimestamp('client.meeting.click.joinbutton', 5);
-      cdl.saveTimestamp('client.meeting.interstitial-window.showed', 7)
+      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 5);
+      cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 7)
       cdl.saveTimestamp('client.locus.join.request', 10);
       cdl.saveTimestamp('client.locus.join.response', 20);
       cdl.saveTimestamp('client.ice.start', 30);

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -66,7 +66,7 @@ describe("internal-plugin-metrics", () => {
 
     it('calculates getShowInterstitialTime correctly', () => {
       cdl.saveTimestamp('internal.client.interstitial-window.launched', 10);
-      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 20);
+      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 20);
       assert.deepEqual(cdl.getShowInterstitialTime(), 10);
     });
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -411,6 +411,8 @@ describe('internal-plugin-metrics', () => {
               fatal: true,
               name: 'other',
               shownToUser: false,
+              serviceErrorCode: 2409005,
+              errorCode: 4029
             }],
             loginType: 'login-ci',
             name: 'client.alert.displayed',
@@ -641,18 +643,20 @@ describe('internal-plugin-metrics', () => {
     });
     describe('#getErrorPayloadForClientErrorCode', () => {
       it('it should grab the payload for client error code correctly', () => {
-        const res = cd.getErrorPayloadForClientErrorCode(4008);
+        const res = cd.getErrorPayloadForClientErrorCode({clientErrorCode: 4008, serviceErrorCode: 10000});
         assert.deepEqual(res, {
           category: 'signaling',
           errorDescription: 'NewLocusError',
           fatal: true,
           name: 'other',
           shownToUser: false,
+          errorCode: 4008,
+          serviceErrorCode: 10000,
         });
       });
 
       it('it should return undefined if trying to get payload for client error code that doesnt exist', () => {
-        const res = cd.getErrorPayloadForClientErrorCode(123456);
+        const res = cd.getErrorPayloadForClientErrorCode({clientErrorCode: 123456, serviceErrorCode: 100000});
         assert.deepEqual(res, undefined);
       });
     });
@@ -666,6 +670,8 @@ describe('internal-plugin-metrics', () => {
           fatal: true,
           name: 'other',
           shownToUser: false,
+          errorCode: 4029,
+          serviceErrorCode: 2409005
         });
       });
 
@@ -677,6 +683,8 @@ describe('internal-plugin-metrics', () => {
           fatal: true,
           name: 'other',
           shownToUser: false,
+          serviceErrorCode: 2400000,
+          errorCode: 4008,
         });
       });
 
@@ -689,6 +697,8 @@ describe('internal-plugin-metrics', () => {
           fatal: true,
           name: 'other',
           shownToUser: false,
+          serviceErrorCode: 9400000,
+          errorCode: 4100,
         });
       });
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
@@ -23,6 +23,7 @@ describe("internal-plugin-metrics", () => {
       webex.emit('ready');
 
       webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp = sinon.stub();
+      webex.internal.newMetrics.callDiagnosticLatencies.clearTimestamps = sinon.stub();
       webex.internal.newMetrics.callDiagnosticMetrics.submitClientEvent = sinon.stub();
       webex.internal.newMetrics.callDiagnosticMetrics.submitMQE = sinon.stub();
     });
@@ -64,6 +65,24 @@ describe("internal-plugin-metrics", () => {
           networkType: 'wifi'
         }
       })
+    });
+
+    it('submits Internal Event successfully', () => {
+      webex.internal.newMetrics.submitInternalEvent({
+        name: 'client.mediaquality.event',
+      });
+
+      assert.calledWith(webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp, 'client.mediaquality.event')
+      assert.notCalled(webex.internal.newMetrics.callDiagnosticLatencies.clearTimestamps)
+    });
+
+    it('submits Internal Event successfully for clearing the join latencies', () => {
+      webex.internal.newMetrics.submitInternalEvent({
+        name: 'internal.reset.join.latencies',
+      });
+
+      assert.notCalled(webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp)
+      assert.calledOnce(webex.internal.newMetrics.callDiagnosticLatencies.clearTimestamps)
     });
   })
 })

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6329,20 +6329,6 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
-   *
-   * @returns {string} one of 'login-ci','unverified-guest', returns the login type of the current user
-   */
-  getCurLoginType() {
-    // @ts-ignore
-    if (this.webex.canAuthorize) {
-      // @ts-ignore
-      return this.webex.credentials.isUnverifiedGuest ? 'unverified-guest' : 'login-ci';
-    }
-
-    return null;
-  }
-
-  /**
    * End the current meeting for all
    * @returns {Promise}
    * @public

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5610,6 +5610,9 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   public leave(options: {resourceId?: string; reason?: any} = {} as any) {
     const leaveReason = options.reason || MEETING_REMOVED_REASON.CLIENT_LEAVE_REQUEST;
+    /// @ts-ignore
+    this.webex.internal.newMetrics.submitInternalEvent({name: 'internal.reset.join.latencies'});
+
     // @ts-ignore
     this.webex.internal.newMetrics.submitClientEvent({
       name: 'client.call.leave',

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5294,7 +5294,7 @@ export default class Meeting extends StatelessWebexPlugin {
         });
         // @ts-ignore
         this.webex.internal.newMetrics.submitClientEvent({
-          name: 'media-engine.ready',
+          name: 'client.media-engine.ready',
           options: {
             meetingId: this.id,
           },

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1243,8 +1243,8 @@ describe('plugin-meetings', () => {
 
           assert.called(webex.internal.newMetrics.submitClientEvent);
           assert.calledWithMatch(webex.internal.newMetrics.submitClientEvent, {
-            name: 'media-engine.ready',
-            options: {                   
+            name: 'client.media-engine.ready',
+            options: {
               meetingId: meeting.id,
             },
           });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2158,6 +2158,15 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.unsetRemoteTracks);
           assert.calledOnce(meeting.unsetPeerConnections);
         });
+
+        it('should reset call diagnostic latencies correctly', async () => {
+          const leave = meeting.leave();
+
+          assert.exists(leave.then);
+          await leave;
+          assert.calledWith(webex.internal.newMetrics.submitInternalEvent, {name: 'internal.reset.join.latencies'});
+        });
+
         describe('after audio/video is defined', () => {
           let handleClientRequest;
 


### PR DESCRIPTION
# COMPLETES [#SPARK-444959](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-444959)

## This pull request addresses

- add support to send client events without meetingId (for pre join)
- export public function types
- refactor latency formulas (instead of using client.meeting.* -- which we are not supposed to use, I created some internal events that have the same naming but prefixed with internal. (because they do match with what I need) instead and use those as internal events to save the latencies).

## by making the following changes

- refactor submitClientEvent
- split into 2 private functions to create client event

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

-unit test, manual test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
