### PR TITLE
fix(Live-Annotation): not show annotation share Camera

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -2375,6 +2375,7 @@ export default class Meeting extends StatelessWebexPlugin {
                   memberId: contentShare.beneficiaryId,
                   url: contentShare.url,
                   shareInstanceId: contentShare.shareInstanceId,
+                  annotationInfo: contentShare.annotation,
                 }
               );
             };
@@ -2444,6 +2445,7 @@ export default class Meeting extends StatelessWebexPlugin {
             memberId: contentShare.beneficiaryId,
             url: contentShare.url,
             shareInstanceId: contentShare.shareInstanceId,
+            annotationInfo: contentShare.annotation,
           }
         );
         this.members.locusMediaSharesUpdate(payload);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2717,7 +2717,6 @@ describe('plugin-meetings', () => {
 
           meeting.joinedWith = {state: "NOT_JOINED"};
           assert.equal(meeting.isJoined(), false);
-
           meeting.joinedWith = {state: "JOINED"};
           assert.equal(meeting.isJoined(), true);
         });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2717,6 +2717,7 @@ describe('plugin-meetings', () => {
 
           meeting.joinedWith = {state: "NOT_JOINED"};
           assert.equal(meeting.isJoined(), false);
+
           meeting.joinedWith = {state: "JOINED"};
           assert.equal(meeting.isJoined(), true);
         });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -5677,7 +5677,7 @@ describe('plugin-meetings', () => {
             resourceUrl,
             isAccepting,
             otherBeneficiaryId,
-            annotation,
+            annotationInfo,
             url,
             shareInstanceId
           ) => {
@@ -5705,7 +5705,7 @@ describe('plugin-meetings', () => {
             if (isGranting) {
               if (isContent) {
                 activeSharingId.content = beneficiaryId;
-                newPayload.current.content = generateContent(beneficiaryId, FLOOR_ACTION.GRANTED,annotation);
+                newPayload.current.content = generateContent(beneficiaryId, FLOOR_ACTION.GRANTED);
 
                 if (isEqual(newPayload.current, newPayload.previous)) {
                   eventTrigger.member = null;
@@ -5759,7 +5759,7 @@ describe('plugin-meetings', () => {
                     eventTrigger.share.push({
                       eventName: EVENT_TRIGGERS.MEETING_STARTED_SHARING_REMOTE,
                       functionName: 'remoteShare',
-                      eventPayload: {memberId: beneficiaryId, url, shareInstanceId},
+                      eventPayload: {memberId: beneficiaryId, url, shareInstanceId, annotationInfo},
                     });
                   }
                 }


### PR DESCRIPTION
Should not show out annotate button when native client share Camer
Add annotation for start share message
# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-444849?filter=-1
## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
