### PR TITLE
feat(package-tools): improve version control

### DIFF
--- a/packages/tools/package/src/commands/increment/increment.ts
+++ b/packages/tools/package/src/commands/increment/increment.ts
@@ -58,6 +58,7 @@ const increment: CommandsCommand<Options> = {
         ? options.packages.includes(pack.name)
         : true)))
       .then((packs) => Promise.all(packs.map((pack) => pack.inspect())))
+      .then((packs) => Promise.all(packs.map((pack) => pack.syncVersion())))
       .then((packs) => {
         const incrementBy: Partial<PackageVersion> = {
           major: options.major ? parseInt(options.major, 10) : undefined,

--- a/packages/tools/package/src/models/package/package.constants.ts
+++ b/packages/tools/package/src/models/package/package.constants.ts
@@ -1,9 +1,9 @@
 /**
- * Path, relative to the package root, to the package definition file.
+ * Default version to set version information to if no data is available.
  *
  * @internal
  */
-const PACKAGE_DEFINITION_FILE = './package.json';
+const DEFAULT_VERSION = '0.0.0';
 
 /**
  * Default, production tag for NPM.
@@ -12,7 +12,15 @@ const PACKAGE_DEFINITION_FILE = './package.json';
  */
 const STABLE_TAG = 'latest';
 
+/**
+ * Path, relative to the package root, to the package definition file.
+ *
+ * @internal
+ */
+const PACKAGE_DEFINITION_FILE = './package.json';
+
 const CONSTANTS = {
+  DEFAULT_VERSION,
   PACKAGE_DEFINITION_FILE,
   STABLE_TAG,
 };

--- a/packages/tools/package/src/models/package/package.ts
+++ b/packages/tools/package/src/models/package/package.ts
@@ -8,6 +8,8 @@ import type {
   Config,
   Data,
   Definition,
+  InspectOptions,
+  PackageInfo,
   Version,
 } from './package.types';
 
@@ -42,6 +44,12 @@ class Package {
     this.data = {
       location: config.location,
       name: config.name,
+      packageInfo: {
+        version: Package.CONSTANTS.DEFAULT_VERSION,
+        'dist-tags': {
+          [Package.CONSTANTS.STABLE_TAG]: Package.CONSTANTS.DEFAULT_VERSION,
+        },
+      },
       version: {
         major: 0,
         minor: 0,
@@ -143,7 +151,7 @@ class Package {
   }
 
   /**
-   * Inspect the remote data for this Package instance.
+   * Inspect the registry data for this Package instance.
    *
    * @remarks
    * This uses the Yarn class to communicate with the target NPM registry for
@@ -152,12 +160,21 @@ class Package {
    * @returns - Promise resolving with this Package instance.
    */
   public inspect(): Promise<this> {
-    return Yarn.view({ package: this.data.name, distTags: true })
-      .then((tags) => {
-        const version = tags[this.data.version.tag]
-          || `${tags[CONSTANTS.STABLE_TAG] || '0.0.0'}-${this.data.version.tag}.0`;
+    const { tag } = this.data.version;
 
-        this.data.version = Package.parseVersionStringToObject(version);
+    return Package.inspect({ package: this.data.name })
+      .then((packageInfo) => {
+        this.data.packageInfo = packageInfo;
+
+        const tagVersion = packageInfo['dist-tags'][tag];
+
+        if (tagVersion) {
+          this.data.version = Package.parseVersionStringToObject(tagVersion);
+
+          return this;
+        }
+
+        this.data.version = Package.parseVersionStringToObject(`${packageInfo.version}-${tag}.0`);
 
         return this;
       });
@@ -182,10 +199,68 @@ class Package {
   }
 
   /**
+   * Synchronize this package tag with the current stable package tag version.
+   *
+   * @remarks
+   * This method will skip any modifications if the current version tag is
+   * stable.
+   *
+   * @returns - This Package instance.
+   */
+  public syncVersion(): this {
+    const { version } = this.data;
+
+    if (version.tag === Package.CONSTANTS.STABLE_TAG) {
+      return this;
+    }
+
+    const stable = Package.parseVersionStringToObject(this.data.packageInfo['dist-tags'].latest);
+
+    let hasVersionChanged = false;
+
+    if (version.major !== stable.major) {
+      version.major = stable.major;
+      hasVersionChanged = true;
+    }
+
+    if (version.minor !== stable.minor) {
+      version.minor = stable.minor;
+      hasVersionChanged = true;
+    }
+
+    if (version.patch !== stable.patch) {
+      version.patch = stable.patch;
+      hasVersionChanged = true;
+    }
+
+    if (hasVersionChanged) {
+      version.release = 0;
+    }
+
+    return this;
+  }
+
+  /**
    * Constants associated with the Package class.
    */
   public static get CONSTANTS() {
     return CONSTANTS;
+  }
+
+  /**
+   * Inspect the registry data for the provided package name.
+   *
+   * @param options - Inspect Options.
+   * @returns - Package Info for the provided package.
+   */
+  public static inspect(options: InspectOptions): Promise<PackageInfo> {
+    return Yarn.view({ distTags: true, package: options.package, version: true })
+      .catch(() => ({
+        version: Package.CONSTANTS.DEFAULT_VERSION,
+        'dist-tags': {
+          [Package.CONSTANTS.STABLE_TAG]: Package.CONSTANTS.DEFAULT_VERSION,
+        },
+      }));
   }
 
   /**

--- a/packages/tools/package/src/models/package/package.types.ts
+++ b/packages/tools/package/src/models/package/package.types.ts
@@ -1,4 +1,22 @@
 /**
+ * Package and version information from the registry.
+ *
+ * @public
+ */
+export interface PackageInfo {
+  /**
+   * Primary version for this Package on the registry.
+   */
+  version: string;
+
+  /**
+   * Record of all distribution tags and their versions availble for this
+   * package on the registry.
+   */
+  'dist-tags': Record<string, string>;
+}
+
+/**
  * Version Object for defining a Package instance version.
  *
  * @public
@@ -89,7 +107,24 @@ export interface Data {
   name: string;
 
   /**
+   * Inspected package and version info from the registry.
+   */
+  packageInfo: PackageInfo;
+
+  /**
    * Version of the associated Package instance.
    */
   version: Version;
+}
+
+/**
+ * Options to be provided to Package.Inspect().
+ *
+ * @public
+ */
+export interface InspectOptions {
+  /**
+   * Package to inspect on the registry.
+   */
+  package: string;
 }

--- a/packages/tools/package/src/utils/yarn/yarn.ts
+++ b/packages/tools/package/src/utils/yarn/yarn.ts
@@ -64,8 +64,7 @@ class Yarn {
       .join(' ');
 
     return Executor.execute(`${CONSTANTS.COMMANDS.VIEW} ${params}`)
-      .then((results) => JSON.parse(results))
-      .catch(() => ({}));
+      .then((results) => JSON.parse(results));
   }
 
   /**

--- a/packages/tools/package/test/integration/increment/increment.test.js
+++ b/packages/tools/package/test/integration/increment/increment.test.js
@@ -94,6 +94,7 @@ describe('increment', () => {
 
       spies.package = {
         inspect: spyOn(Package.prototype, 'inspect').and.callFake(function func() { return Promise.resolve(this); }),
+        syncVersion: spyOn(Package.prototype, 'syncVersion').and.callFake(function func() { return Promise.resolve(this); }),
         incrementVersion: spyOn(Package.prototype, 'incrementVersion').and.callFake(function func() { return this; }),
         apply: spyOn(Package.prototype, 'apply').and.callFake(function func() { return Promise.resolve(this); }),
       };
@@ -125,6 +126,16 @@ describe('increment', () => {
           });
         });
     });
+
+    it('should call "package.inspect()" for each located package', () => increment.handler(options)
+      .then(() => {
+        expect(spies.package.inspect).toHaveBeenCalledTimes(listResolve.length);
+      }));
+
+    it('should call "package.syncVersion()" for each located package', () => increment.handler(options)
+      .then(() => {
+        expect(spies.package.syncVersion).toHaveBeenCalledTimes(listResolve.length);
+      }));
 
     it('should not increment any packages when the version details provided are undefined', () => increment.handler({})
       .then((results) => {

--- a/packages/tools/package/test/integration/yarn/yarn.test.js
+++ b/packages/tools/package/test/integration/yarn/yarn.test.js
@@ -262,15 +262,6 @@ describe('Yarn', () => {
           expect(calledWith.includes('--json')).toBeTrue();
         }));
 
-      it('should not catch', () => {
-        spies.Executor.execute.and.rejectWith(new Error());
-
-        return Yarn.view()
-          .then(() => {
-            expect(true).toBeTrue();
-          });
-      });
-
       it('should attempt to parse the results of the "Executor.execute()" method', () => Yarn.view({})
         .then(() => {
           expect(spies.JSON.parse).toHaveBeenCalledOnceWith(executorExecuteResolve);


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to update the package increment workflow to allow for synchronizing the branched package versions with the latest package version on publish.

## Example

* `latest` branch is coupled to `{package}` NPMJS tag with version `3.2.1`
* `next` branch is coupled to `{package}@next` NPMJS tag with version `3.2.1-next.25`

**Pull Request is made against `latest` branch, and merged**

* `latest` NPMJS version is now `3.2.2`
* `next` NPMJS version remains at `3.2.1-next.25`

**Pull Request is made against `next` branch, and merged**

* `latest` NPMJS version remains `3.2.2`
* `next` NPMJS version is now `3.2.2-next.1`

