### PR TITLE
Feat/ca metrics/ add call init media engine ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "node ./tooling/index.js build && yarn run build:tsc",
     "build:tsc": "yarn run tsc -p ./config/tsconfig.typecheck.json --noEmit && yarn workspace @webex/internal-plugin-metrics run build && yarn workspace @webex/plugin-meetings run build",
     "build:script": "node ./tooling/index.js build --umd",
-    "build:skip-samples": "node ./tooling/index.js build --skip-samples && yarn workspace @webex/plugin-meetings run build",
+    "build:skip-samples": "node ./tooling/index.js build --skip-samples && yarn workspace @webex/internal-plugin-metrics run build && yarn workspace @webex/plugin-meetings run build",
     "build:dev": "NODE_ENV=development node ./tooling/index.js build",
     "prebuild:docs": "rimraf ./docs/api",
     "build:docs": "documentation build --config documentation/config.yml --format html --output ./docs/api --github ./packages/webex/src/index.js ./packages/@webex/plugin-*/src/index.[tj]s --babel=./babel.config.json",

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -81,9 +81,10 @@ const CallDiagnosticEventsBatcher = Batcher.extend({
         joinTimes.localSDPGenRemoteSDPRecv = cdl.getLocalSDPGenRemoteSDPRecv();
         break;
 
-      // TODO: Figure out equivalent for WEBRTC
       case 'client.media-engine.ready':
         joinTimes.totalMediaJMT = cdl.getTotalMediaJMT();
+        joinTimes.interstitialToMediaOKJMT = cdl.getInterstitialToMediaOKJMT();
+        joinTimes.callInitMediaEngineReady = cdl.getInterstitialToMediaOKJMT(); // same as interstitialToMediaOKJMT
         break;
 
       case 'client.mediaquality.event':

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -268,6 +268,17 @@ export default class CallDiagnosticLatencies {
   }
 
   /**
+   * Interstitial To Media OK JMT
+   * @returns - latency
+   */
+  public getInterstitialToMediaOKJMT() {
+    return this.getDiffBetweenTimestamps(
+      'internal.client.interstitial-window.click.joinbutton',
+      'client.media-engine.ready'
+    );
+  }
+
+  /**
    * Audio setup delay receive
    */
   public getAudioJoinRespRxStart() {

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -185,6 +185,8 @@ describe('plugin-metrics', () => {
             name: 'client.media-engine.ready',
             joinTimes: {
               totalMediaJMT: 30,
+              interstitialToMediaOKJMT: 10,
+              callInitMediaEngineReady: 10,
             },
           });
           assert.lengthOf(webex.internal.newMetrics.callDiagnosticMetrics.callDiagnosticEventsBatcher.queue, 0);

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -189,5 +189,11 @@ describe("internal-plugin-metrics", () => {
       cdl.saveTimestamp('client.media.tx.start', 7);
       assert.deepEqual(cdl.getVideoJoinRespTxStart(), 2);
     });
+
+    it('calculates getInterstitialToMediaOKJMT correctly', () => {
+      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 5);
+      cdl.saveTimestamp('client.media-engine.ready', 7);
+      assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 2);
+    });
   })
 })


### PR DESCRIPTION
# COMPLETES [SPARK-440536](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-440536)

## This pull request addresses

- add callInitMediaEngineReady latency
 
## by making the following changes

- add callInitMediaEngineReady

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

-unit test, manual test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
