### PR TITLE
fix: add enum constants for video and display track

### DIFF
--- a/packages/@webex/media-helpers/src/constants.ts
+++ b/packages/@webex/media-helpers/src/constants.ts
@@ -1,0 +1,29 @@
+import {VideoDeviceConstraints} from '@webex/internal-media-core';
+
+export enum FacingMode {
+  user = 'user',
+  environment = 'environment',
+}
+
+// can be used later on when we add constraints in create display track
+export enum DisplaySurface {
+  browser = 'browser',
+  monitor = 'monitor',
+  window = 'window',
+}
+
+export const PresetCameraConstraints: {[key: string]: VideoDeviceConstraints} = {
+  '1080p': {frameRate: 30, width: 1920, height: 1080},
+
+  '720p': {frameRate: 30, width: 1280, height: 720},
+
+  '480p': {frameRate: 30, width: 640, height: 480},
+
+  '360p': {frameRate: 30, width: 640, height: 360},
+
+  '240p': {frameRate: 30, width: 320, height: 240},
+
+  '180p': {frameRate: 30, width: 320, height: 180},
+
+  '120p': {frameRate: 30, width: 160, height: 120},
+};

--- a/packages/@webex/media-helpers/src/index.ts
+++ b/packages/@webex/media-helpers/src/index.ts
@@ -19,3 +19,5 @@ export type {
   NoiseReductionEffectOptions,
   VirtualBackgroundEffectOptions,
 } from '@webex/web-media-effects';
+
+export {FacingMode, DisplaySurface, PresetCameraConstraints} from './constants';

--- a/packages/@webex/plugin-meetings/src/index.ts
+++ b/packages/@webex/plugin-meetings/src/index.ts
@@ -22,6 +22,9 @@ export {
   createMicrophoneTrack,
   createCameraTrack,
   createDisplayTrack,
+  FacingMode,
+  DisplaySurface,
+  PresetCameraConstraints,
 } from '@webex/media-helpers';
 
 export default Meetings;


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-445825](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-445825) >

## This pull request addresses

We need pre-defined constant values for camera and screen share track which can be used by users to create these tracks.

## by making the following changes

Added 3 constant enum values from webrtc-core repo which are: `FacingMode`, `DisplaySurface`, `PresetCameraConstraints`

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
