### PR TITLE
feat(ca-metrics): add bind to passed in func

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
 
 # orbs
 orbs:
-  browser-tools: circleci/browser-tools@1.3.0
+  browser-tools: circleci/browser-tools@1.4.2
 
 # Reusable commands for jobs
 commands:

--- a/packages/@webex/plugin-meetings/src/breakouts/breakout.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/breakout.ts
@@ -68,7 +68,7 @@ const Breakout = WebexPlugin.extend({
     breakoutEvent.onBreakoutMoveRequest(
       {currentSession: this, meeting, breakoutMoveId},
       // @ts-ignore
-      this.webex.internal.newMetrics.submitClientEvent
+      this.webex.internal.newMetrics.submitClientEvent.bind(this.webex.internal.newMetrics)
     );
     const result = await this.request({
       method: HTTP_VERBS.POST,
@@ -83,7 +83,7 @@ const Breakout = WebexPlugin.extend({
     breakoutEvent.onBreakoutMoveResponse(
       {currentSession: this, meeting, breakoutMoveId},
       // @ts-ignore
-      this.webex.internal.newMetrics.submitClientEvent
+      this.webex.internal.newMetrics.submitClientEvent.bind(this.webex.internal.newMetrics)
     );
 
     return result;

--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -356,7 +356,7 @@ const Breakouts = WebexPlugin.extend({
           breakoutMoveId: params.breakoutMoveId,
         },
         // @ts-ignore
-        this.webex.internal.newMetrics.submitClientEvent
+        this.webex.internal.newMetrics.submitClientEvent.bind(this.webex.internal.newMetrics)
       );
     }
   },

--- a/packages/@webex/plugin-meetings/test/unit/spec/breakouts/breakout.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/breakouts/breakout.ts
@@ -89,6 +89,8 @@ describe('plugin-meetings', () => {
         })
         };
 
+        sinon.stub(webex.internal.newMetrics.submitClientEvent, 'bind').returns(webex.internal.newMetrics.submitClientEvent);
+
         let onBreakoutMoveRequestStub = sinon.stub(breakoutEvent, 'onBreakoutMoveRequest');
         let onBreakoutMoveResponseStub = sinon.stub(breakoutEvent, 'onBreakoutMoveResponse');
         await breakout.join();

--- a/packages/@webex/plugin-meetings/test/unit/spec/breakouts/events.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/breakouts/events.ts
@@ -49,6 +49,8 @@ describe('plugin-meetings', () => {
       it('send metric as expected', () => {
         const submitClientEvent = sinon.stub();
 
+        sinon.stub(submitClientEvent, 'bind').returns(webex.internal.newMetrics.submitClientEvent);
+
         breakoutEvent.postMoveCallAnalyzer = sinon.stub();
         const eventInfo = {newSession, mockMeeting, breakoutMoveId};
         breakoutEvent.onBreakoutMoveRequest(eventInfo, submitClientEvent);
@@ -61,6 +63,8 @@ describe('plugin-meetings', () => {
       it('send metric as expected', () => {
         const submitClientEvent = sinon.stub();
 
+        sinon.stub(submitClientEvent, 'bind').returns(webex.internal.newMetrics.submitClientEvent);
+
         breakoutEvent.postMoveCallAnalyzer = sinon.stub();
         const eventInfo = {newSession, mockMeeting, breakoutMoveId};
         breakoutEvent.onBreakoutMoveResponse(eventInfo, submitClientEvent);
@@ -71,6 +75,8 @@ describe('plugin-meetings', () => {
     describe('onBreakoutJoinResponse', () => {
       it('send metric as expected', () => {
         const submitClientEvent = sinon.stub();
+
+        sinon.stub(submitClientEvent, 'bind').returns(webex.internal.newMetrics.submitClientEvent);
 
         breakoutEvent.postMoveCallAnalyzer = sinon.stub();
         const eventInfo = {newSession, mockMeeting, breakoutMoveId};


### PR DESCRIPTION
# COMPLETES [SPARK-440536](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-440536)

## This pull request addresses

- fix issue with breakouts CA events, forgot to bind `this`
## by making the following changes

< DESCRIBE YOUR CHANGES >

-add .bind(this)

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- manual test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
