### PR TITLE
fix(plugin-meetings): dialout left reason

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1815,6 +1815,7 @@ export default class Meeting extends StatelessWebexPlugin {
             dialOut: {
               status: this.dialOutDeviceStatus,
               attendeeId: dialOutPstnDevice?.attendeeId,
+              reason: dialOutPstnDevice?.reason,
             },
           }
         );

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -572,6 +572,88 @@ describe('plugin-meetings', () => {
           assert.equal(meeting.isReactionsSupported(), true);
         });
       });
+
+      describe('#pstnUpdate', () => {
+
+        beforeEach(()=> {
+          meeting.locusInfo.self = {state: 'IDLE'};
+          meeting.dialOutUrl = "dialout:///8167d5ec-40c8-49b8-b49a-8717dbaa7d3a";
+        })
+
+        it('checks event MEETING_SELF_PHONE_AUDIO_UPDATE can return reason', () => {
+          const fakePayload = {
+            newSelf: {
+              pstnDevices: [{
+                attendeeId: 'test-id',
+                url: "dialout:///8167d5ec-40c8-49b8-b49a-8717dbaa7d3a",
+                deviceType: "PROVISIONAL",
+                state: 'LEFT',
+                reason: 'FAILURE'
+              }]
+            }
+          };
+
+          meeting.pstnUpdate(fakePayload);
+
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {
+              file: 'meeting/index',
+              function: 'setUpLocusSelfListener',
+            },
+            EVENT_TRIGGERS.MEETING_SELF_PHONE_AUDIO_UPDATE,
+            {
+              dialIn: {
+                status: '',
+                attendeeId: undefined,
+              },
+              dialOut: {
+                status: 'LEFT',
+                attendeeId: 'test-id',
+                reason: 'FAILURE',
+              },
+            }
+          );
+        });
+
+        it('checks event MEETING_SELF_PHONE_AUDIO_UPDATE can return undefined reason', () => {
+          const fakePayload = {
+            newSelf: {
+              pstnDevices: [{
+                attendeeId: 'test-id',
+                url: "dialout:///8167d5ec-40c8-49b8-b49a-8717dbaa7d3a",
+                deviceType: "PROVISIONAL",
+                state: 'LEFT',
+              }]
+            }
+          };
+
+          meeting.pstnUpdate(fakePayload);
+
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {
+              file: 'meeting/index',
+              function: 'setUpLocusSelfListener',
+            },
+            EVENT_TRIGGERS.MEETING_SELF_PHONE_AUDIO_UPDATE,
+            {
+              dialIn: {
+                status: '',
+                attendeeId: undefined,
+              },
+              dialOut: {
+                status: 'LEFT',
+                attendeeId: 'test-id',
+                reason: undefined,
+              },
+            }
+          );
+        });
+      });
+
       describe('#processRelayEvent', () => {
         it('should process a Reaction event type', () => {
           meeting.isReactionsSupported = sinon.stub().returns(true);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
This fix is required to complete following jira. Once this gets merged Cantina side fix will follow.
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-437454
## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >


## by making the following changes

< DESCRIBE YOUR CHANGES >
Event MEETING_SELF_PHONE_AUDIO_UPDATE is updated to return reason, this helps Cantina to distinguish between successful disconnect and disconnect due to failure.
Since there was no unit test related to pstnUpdate, I have added test related to my change.
<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
