### PR TITLE
feat: extract media status on members from nested participant

### DIFF
--- a/packages/@webex/plugin-meetings/src/member/index.ts
+++ b/packages/@webex/plugin-meetings/src/member/index.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
  */
 import {MEETINGS, _IN_LOBBY_, _NOT_IN_MEETING_, _IN_MEETING_} from '../constants';
-import {IExternalRoles, ParticipantWithRoles} from './types';
+import {IExternalRoles, IMediaStatus, ParticipantWithRoles} from './types';
 
 import MemberUtil from './util';
 
@@ -30,6 +30,7 @@ export default class Member {
   isUser: any;
   isVideoMuted: any;
   roles: IExternalRoles;
+  mediaStatus: IMediaStatus;
   name: any;
   participant: any;
   status: any;
@@ -247,6 +248,19 @@ export default class Member {
      * @memberof Member
      */
     this.roles = null;
+
+    /**
+     * @instance
+     * @type {IMediaStatus}
+     * @public
+     * @memberof Member
+     * @example {audio: MediaStatus.RECVONLY, video: MediaStatus.SENDRECV}
+     */
+    this.mediaStatus = {
+      audio: null,
+      video: null,
+    };
+
     // TODO: more participant types
     // such as native client, web client, is a device, what type of phone, etc
     this.processParticipant(participant);
@@ -325,6 +339,8 @@ export default class Member {
       this.isAudioMuted,
       this.type
     );
+
+    this.mediaStatus = MemberUtil.extractMediaStatus(this.participant);
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/member/types.ts
+++ b/packages/@webex/plugin-meetings/src/member/types.ts
@@ -22,3 +22,17 @@ export type ParticipantWithRoles = {
     };
   };
 };
+
+// values are inherited from locus so don't update these
+export enum MediaStatus {
+  RECVONLY = 'RECVONLY', // participant only receiving and not sending
+  SENDONLY = 'SENDONLY', // participant only sending and not receiving
+  SENDRECV = 'SENDRECV', // participant both sending and receiving
+  INACTIVE = 'INACTIVE', // participant is not connected to media source
+  UNKNOWN = 'UNKNOWN', // participant has not added media in the meeting
+}
+
+export interface IMediaStatus {
+  audio: MediaStatus;
+  video: MediaStatus;
+}

--- a/packages/@webex/plugin-meetings/src/member/util.ts
+++ b/packages/@webex/plugin-meetings/src/member/util.ts
@@ -1,4 +1,10 @@
-import {IExternalRoles, ParticipantWithRoles, ServerRoles, ServerRoleShape} from './types';
+import {
+  IExternalRoles,
+  ParticipantWithRoles,
+  ServerRoles,
+  ServerRoleShape,
+  IMediaStatus,
+} from './types';
 import {
   _USER_,
   _RESOURCE_ROOM_,
@@ -345,6 +351,22 @@ MemberUtil.extractId = (participant: any) => {
   }
 
   return null;
+};
+
+/**
+ * extracts the media status from nested participant object
+ * @param {Object} participant the locus participant
+ * @returns {Object}
+ */
+MemberUtil.extractMediaStatus = (participant: any): IMediaStatus => {
+  if (!participant) {
+    throw new ParameterError('Media status could not be extracted, participant is undefined.');
+  }
+
+  return {
+    audio: participant.status.audioStatus,
+    video: participant.status.videoStatus,
+  };
 };
 
 /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/member/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/member/index.js
@@ -5,22 +5,21 @@ import MemberUtil from '@webex/plugin-meetings/src/member/util';
 import Member from '@webex/plugin-meetings/src/member';
 
 describe('member', () => {
+  const participant = {controls: {}, status: {}};
+
+  const member = new Member(participant);
+
   afterEach(() => {
     sinon.restore();
   });
 
   it('checks member properties', () => {
-    const member = new Member({});
     assert.exists(member.supportsInterpretation);
     assert.exists(member.supportsBreakouts);
     assert.exists(member.supportLiveAnnotation);
   });
 
   it('checks that processParticipant calls isHandRaised', () => {
-    const participant = {controls: {}};
-
-    const member = new Member({});
-
     sinon.spy(MemberUtil, 'isHandRaised');
     member.processParticipant(participant);
 
@@ -29,10 +28,6 @@ describe('member', () => {
 
   describe('roles', () => {
     it('checks that processParticipant calls processRoles', () => {
-      const participant = {};
-
-      const member = new Member({});
-
       sinon.spy(member, 'processRoles');
       member.processParticipant(participant);
 
@@ -40,14 +35,42 @@ describe('member', () => {
     });
 
     it('checks that processRoles calls extractControlRoles', () => {
-      const participant = {};
-
-      const member = new Member({});
-
       sinon.spy(MemberUtil, 'extractControlRoles');
       member.processParticipant(participant);
 
       assert.calledOnceWithExactly(MemberUtil.extractControlRoles, participant);
+    });
+  });
+
+  describe('#processParticipant', () => {
+    it('checks that processParticipant calls isHandRaised', () => {
+      sinon.spy(MemberUtil, 'isHandRaised');
+      member.processParticipant(participant);
+
+      assert.calledOnceWithExactly(MemberUtil.isHandRaised, participant);
+    });
+  })
+
+  describe('#processMember', () => {
+    it('checks that processMember calls isRemovable', () => {
+      sinon.spy(MemberUtil, 'isRemovable');
+      member.processMember();
+
+      assert.calledOnce(MemberUtil.isRemovable);
+    });
+
+    it('checks that processMember calls isMutable', () => {
+      sinon.spy(MemberUtil, 'isMutable');
+      member.processMember();
+
+      assert.calledOnce(MemberUtil.isMutable);
+    });
+
+    it('checks that processMember calls extractMediaStatus', () => {
+      sinon.spy(MemberUtil, 'extractMediaStatus');
+      member.processMember();
+
+      assert.calledOnceWithExactly(MemberUtil.extractMediaStatus, participant);
     });
   })
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/member/util.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/member/util.js
@@ -423,3 +423,34 @@ describe('plugin-meetings', () => {
     });
   });
 });
+
+describe('extractMediaStatus', () => {
+  it('throws error when there is no participant', () => {
+    assert.throws(() => {
+      MemberUtil.extractMediaStatus()
+    }, 'Media status could not be extracted, participant is undefined.');
+  });
+
+  it('returns undefined media status when participant audio/video status is not present', () => {
+    const participant = {
+      status: {}
+    };
+    
+    const mediaStatus = MemberUtil.extractMediaStatus(participant)
+
+    assert.deepEqual(mediaStatus, {audio: undefined, video: undefined});
+  });
+
+  it('returns correct media status when participant audio/video status is present', () => {
+    const participant = {
+      status: {
+        audioStatus: 'RECVONLY',
+        videoStatus: 'SENDRECV'
+      }
+    };
+    
+    const mediaStatus = MemberUtil.extractMediaStatus(participant)
+
+    assert.deepEqual(mediaStatus, {audio: 'RECVONLY', video: 'SENDRECV'});
+  });
+});


### PR DESCRIPTION
NOTE: This is beta branch PR for a merged [PR](https://github.com/webex/webex-js-sdk/pull/2953) in master.

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-445419](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-445419) >

## This pull request addresses

A user wanted to know the status of remote participant's audio/video status mean whether it's being sent or not. Currently we have status object on nested participant object which can be accessed like,
`meeting.members.membersCollection.members['memberId'].participant.status`

To have an easy access, we extracted it on members object and user can access it like,
`meeting.members.membersCollection.members['memberId'].mediaStatus`

## by making the following changes

Extracted media status in member class.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
