### PR TITLE
fix: enabled logs in integration tests, added logs for test start/end

### DIFF
--- a/karma-ng.conf.js
+++ b/karma-ng.conf.js
@@ -119,7 +119,7 @@ function makeConfig(packageName, argv) {
     logLevel: process.env.KARMA_LOG_LEVEL || 'INFO', // INFO is default value
 
     browserConsoleLogOptions: {
-      level: 'warn',
+      level: 'info',
     },
 
     client: {

--- a/packages/@webex/plugin-meetings/test/integration/spec/converged-space-meetings.js
+++ b/packages/@webex/plugin-meetings/test/integration/spec/converged-space-meetings.js
@@ -36,7 +36,7 @@ skipInNode(describe)('plugin-meetings', () => {
       integrationTestUtils.logTestsStartingAndEnding();
 
       let shouldSkip = false;
-      let users, alice, bob, chris;
+      let alice, bob, chris;
       let meeting = null;
       let space = null;
       let mediaReadyListener = null;
@@ -44,17 +44,12 @@ skipInNode(describe)('plugin-meetings', () => {
       before('setup users', async () => {
         const userSet = await webexTestUsers.generateTestUsers({
           count: 3,
+          names: ['alice', 'bob', 'chris'],
           whistler: process.env.WHISTLER || process.env.JENKINS,
           config
         });
 
-        users = userSet;
-        alice = users[0];
-        bob = users[1];
-        chris = users[2];
-        alice.name = 'alice';
-        bob.name = 'bob';
-        chris.name = 'chris';
+        ({alice, bob, chris} = userSet);
 
         const aliceSync = testUtils.syncAndEndMeeting(alice);
         const bobSync = testUtils.syncAndEndMeeting(bob);

--- a/packages/@webex/plugin-meetings/test/integration/spec/converged-space-meetings.js
+++ b/packages/@webex/plugin-meetings/test/integration/spec/converged-space-meetings.js
@@ -33,6 +33,8 @@ skipInNode(describe)('plugin-meetings', () => {
   // `addMedia()` fails on FF, this needs to be debuged and fixed in a later change
   if (!isBrowser('firefox')) {
     describe('converged-space-meeting', () => {
+      integrationTestUtils.logTestsStartingAndEnding();
+
       let shouldSkip = false;
       let users, alice, bob, chris;
       let meeting = null;

--- a/packages/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -57,6 +57,7 @@ const waitForPublished = (track, expectedPublished, description) => {
 
 skipInNode(describe)('plugin-meetings', () => {
   describe('journey', () => {
+    integrationTestUtils.logTestsStartingAndEnding();
     before(() =>
       webexTestUsers
         .generateTestUsers({

--- a/packages/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -17,7 +17,7 @@ const webexTestUsers = require('../../utils/webex-test-users');
 
 const {isBrowser} = BrowserDetection();
 
-let userSet, alice, bob, chris, enumerateSpy, channelUrlA, channelUrlB;
+let alice, bob, chris, enumerateSpy, channelUrlA, channelUrlB;
 
 const localTracks = {
   alice: {
@@ -62,16 +62,12 @@ skipInNode(describe)('plugin-meetings', () => {
       webexTestUsers
         .generateTestUsers({
           count: 3,
+          names: ['alice', 'bob', 'chris'],
           whistler: process.env.WHISTLER || process.env.JENKINS,
         })
         .then((users) => {
-          userSet = users;
-          alice = userSet[0];
-          bob = userSet[1];
-          chris = userSet[2];
-          alice.name = 'alice';
-          bob.name = 'bob';
-          chris.name = 'chris';
+          ({alice, bob, chris} = users);
+
           alice.webex.meetings.name = 'alice';
           bob.webex.meetings.name = 'bob';
           chris.webex.meetings.name = 'chris';

--- a/packages/@webex/plugin-meetings/test/integration/spec/space-meeting.js
+++ b/packages/@webex/plugin-meetings/test/integration/spec/space-meeting.js
@@ -32,6 +32,8 @@ const localTracks = {
 
 skipInNode(describe)('plugin-meetings', () => {
   describe('space-meeting', () => {
+    integrationTestUtils.logTestsStartingAndEnding();
+
     let space = null;
 
     before(() =>
@@ -65,7 +67,7 @@ skipInNode(describe)('plugin-meetings', () => {
         .then((conversation) => {
           assert.lengthOf(conversation.participants.items, 3);
           assert.lengthOf(conversation.activities.items, 1);
-          console.log('CONVERSATION', conversation);
+          console.log('CONVERSATION url:', conversation.url);
           space = conversation;
         })
         .then(async () => {
@@ -280,9 +282,13 @@ skipInNode(describe)('plugin-meetings', () => {
     });
 
     it('check for meeting cleanup', () => {
-      console.log('Alice ', alice.webex.meetings.getAllMeetings());
-      console.log('Bob ', bob.webex.meetings.getAllMeetings());
-      console.log('Chris ', chris.webex.meetings.getAllMeetings());
+      const dumpMeetings = (debugText, user) => {
+        console.log(`${debugText}: ${JSON.stringify(Object.keys(user.webex.meetings.getAllMeetings()))}`);
+      }
+
+      dumpMeetings('Alice', alice);
+      dumpMeetings('Bob', bob);
+      dumpMeetings('Chris', chris);
       assert.notExists(
         alice.webex.meetings.getMeetingByType('correlationId', alice.meeting.correlationId),
         'alice meeting exists'

--- a/packages/@webex/plugin-meetings/test/integration/spec/space-meeting.js
+++ b/packages/@webex/plugin-meetings/test/integration/spec/space-meeting.js
@@ -13,7 +13,7 @@ require('dotenv').config();
 
 const webexTestUsers = require('../../utils/webex-test-users');
 
-let userSet, alice, bob, chris, guest;
+let alice, bob, chris, guest;
 
 const localTracks = {
   alice: {
@@ -40,18 +40,11 @@ skipInNode(describe)('plugin-meetings', () => {
       webexTestUsers
         .generateTestUsers({
           count: 4,
+          names: ['alice', 'bob', 'chris', 'guest'],
           whistler: process.env.WHISTLER || process.env.JENKINS,
         })
         .then((users) => {
-          userSet = users;
-          alice = userSet[0];
-          bob = userSet[1];
-          chris = userSet[2];
-          guest = userSet[3];
-          alice.name = 'alice';
-          bob.name = 'bob';
-          chris.name = 'chris';
-          guest.name = 'guest';
+          ({alice, bob, chris, guest} = users);
         })
         .then(() =>
           Promise.all([testUtils.syncAndEndMeeting(alice), testUtils.syncAndEndMeeting(bob)])
@@ -312,10 +305,7 @@ skipInNode(describe)('plugin-meetings', () => {
           whistler: true,
         })
         .then((users) => {
-          userSet = users;
-          alice = userSet[0];
-          bob = userSet[1];
-          chris = userSet[2];
+          ({alice, bob, chris} = users);
         })
         .then(() => testUtils.syncAndEndMeeting(alice))
         .then(() => CMR.reserve(alice.webex, false))
@@ -387,12 +377,7 @@ skipInNode(describe)('plugin-meetings', () => {
           whistler: true,
         })
         .then((users) => {
-          userSet = users;
-          alice = userSet[0];
-          bob = userSet[1];
-          chris = userSet[2];
-          alice.name = 'alice';
-          bob.name = 'bob';
+          ({alice, bob, chris} = users);
         })
         .then(() => testUtils.syncAndEndMeeting(alice))
         .then(() => CMR.reserve(alice.webex, true))

--- a/packages/@webex/plugin-meetings/test/integration/spec/transcription.js
+++ b/packages/@webex/plugin-meetings/test/integration/spec/transcription.js
@@ -1,8 +1,11 @@
 import Transcription from '@webex/plugin-meetings/dist/transcription';
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
+import integrationTestUtils from '../../utils/integrationTestUtils';
 
 describe('transcription index', () => {
+  integrationTestUtils.logTestsStartingAndEnding();
+
   let webSocketUrl, members, sessionId, token, transcription;
 
   beforeEach(() => {

--- a/packages/@webex/plugin-meetings/test/utils/integrationTestUtils.js
+++ b/packages/@webex/plugin-meetings/test/utils/integrationTestUtils.js
@@ -1,6 +1,16 @@
 import {assert} from '@webex/test-helper-chai';
 import {Defer} from '@webex/common';
 
+const logTestsStartingAndEnding = () => {
+  beforeEach(function() {
+    console.log(`==== TEST STARTING: '${this.currentTest?.title}'`);
+  });
+
+  afterEach(function() {
+    console.log(`==== TEST FINISHED: '${this.currentTest?.title}' test result:${this.currentTest?.state}`);
+  });
+}
+
 const addMedia = async (user, options = {}) => {
 
   const {microphone, camera} = options;
@@ -42,5 +52,6 @@ const addMedia = async (user, options = {}) => {
 };
 
 export default {
-  addMedia
+  addMedia,
+  logTestsStartingAndEnding
 };


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-409797

## This pull request addresses

When integration tests fail in CircleCI it's very difficult to work out what happened, because of very limited logging.

## by making the following changes

Enabling more logs in integration tests. Also added logs to indicate when each test starts and ends.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

existing tests run in the pipeline

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
