### PR TITLE
feat(ca-metrics): do not subtract stay in lobby for mediaJMT

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -311,10 +311,9 @@ export default class CallDiagnosticLatencies {
     const clickToInterstitial = this.getClickToInterstitial();
     const interstitialToJoinOk = this.getInterstitialToJoinOK();
     const joinConfJMT = this.getJoinConfJMT();
-    const stayLobbyTime = this.getStayLobbyTime() || 0;
 
     if (clickToInterstitial && interstitialToJoinOk && joinConfJMT) {
-      return clickToInterstitial + interstitialToJoinOk + joinConfJMT - stayLobbyTime;
+      return clickToInterstitial + interstitialToJoinOk + joinConfJMT;
     }
 
     return undefined;

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable valid-jsdoc */
-import {StatelessWebexPlugin} from '@webex/webex-core';
+import {WebexPlugin} from '@webex/webex-core';
 
 import {MetricEventNames} from '../metrics.types';
 
@@ -11,11 +11,11 @@ import {MetricEventNames} from '../metrics.types';
  * @exports
  * @class CallDiagnosticLatencies
  */
-export default class CallDiagnosticLatencies extends StatelessWebexPlugin {
+export default class CallDiagnosticLatencies extends WebexPlugin {
   latencyTimestamps: Map<MetricEventNames, number>;
   precomputedLatencies: Map<string, number>;
   // meetingId that the current latencies are for
-  meetingId?: string;
+  private meetingId?: string;
 
   /**
    * @constructor

--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -41,8 +41,6 @@ class Metrics extends WebexPlugin {
   constructor(...args) {
     super(...args);
 
-    this.callDiagnosticLatencies = new CallDiagnosticLatencies();
-
     this.onReady();
   }
 
@@ -54,6 +52,8 @@ class Metrics extends WebexPlugin {
     this.webex.once('ready', () => {
       // @ts-ignore
       this.callDiagnosticMetrics = new CallDiagnosticMetrics({}, {parent: this.webex});
+      // @ts-ignore
+      this.callDiagnosticLatencies = new CallDiagnosticLatencies({webex: this.webex});
     });
   }
 
@@ -160,6 +160,10 @@ class Metrics extends WebexPlugin {
     options: SubmitClientEventOptions;
   }) {
     this.callDiagnosticLatencies.saveTimestamp(name);
+    // save the meetingId so we can use the meeting object in latency calculations if needed
+    if (options?.meetingId && !this.callDiagnosticLatencies.meetingId) {
+      this.callDiagnosticLatencies.setMeetingId(options.meetingId);
+    }
     this.callDiagnosticMetrics.submitClientEvent({name, payload, options});
   }
 }

--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -53,7 +53,7 @@ class Metrics extends WebexPlugin {
       // @ts-ignore
       this.callDiagnosticMetrics = new CallDiagnosticMetrics({}, {parent: this.webex});
       // @ts-ignore
-      this.callDiagnosticLatencies = new CallDiagnosticLatencies({webex: this.webex});
+      this.callDiagnosticLatencies = new CallDiagnosticLatencies({}, {parent: this.webex});
     });
   }
 
@@ -73,7 +73,7 @@ class Metrics extends WebexPlugin {
     if (name === 'internal.reset.join.latencies') {
       this.callDiagnosticLatencies.clearTimestamps();
     } else {
-      this.callDiagnosticLatencies.saveTimestamp(name);
+      this.callDiagnosticLatencies.saveTimestamp({key: name});
     }
   }
 
@@ -90,7 +90,7 @@ class Metrics extends WebexPlugin {
     payload?: RecursivePartial<BehavioralEvent['payload']>;
     options?: any;
   }) {
-    this.callDiagnosticLatencies.saveTimestamp(name);
+    this.callDiagnosticLatencies.saveTimestamp({key: name});
     throw new Error('Not implemented.');
   }
 
@@ -125,7 +125,7 @@ class Metrics extends WebexPlugin {
     };
     options: any;
   }) {
-    this.callDiagnosticLatencies.saveTimestamp(name);
+    this.callDiagnosticLatencies.saveTimestamp({key: name});
     this.callDiagnosticMetrics.submitMQE({name, payload, options});
   }
 
@@ -159,11 +159,10 @@ class Metrics extends WebexPlugin {
     payload?: RecursivePartial<ClientEvent['payload']>;
     options: SubmitClientEventOptions;
   }) {
-    this.callDiagnosticLatencies.saveTimestamp(name);
-    // save the meetingId so we can use the meeting object in latency calculations if needed
-    if (options?.meetingId && !this.callDiagnosticLatencies.meetingId) {
-      this.callDiagnosticLatencies.setMeetingId(options.meetingId);
-    }
+    this.callDiagnosticLatencies.saveTimestamp({
+      key: name,
+      options: {meetingId: options?.meetingId},
+    });
     this.callDiagnosticMetrics.submitClientEvent({name, payload, options});
   }
 }

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -191,7 +191,7 @@ describe('plugin-metrics', () => {
           assert.deepEqual(webex.request.getCalls()[0].args[0].body.metrics[0].eventPayload.event, {
             name: 'client.media-engine.ready',
             joinTimes: {
-              totalMediaJMT: 30,
+              totalMediaJMT: 40,
               interstitialToMediaOKJMT: 10,
               callInitMediaEngineReady: 10,
               stayLobbyTime: 10,

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -191,7 +191,7 @@ describe('plugin-metrics', () => {
           assert.deepEqual(webex.request.getCalls()[0].args[0].body.metrics[0].eventPayload.event, {
             name: 'client.media-engine.ready',
             joinTimes: {
-              totalMediaJMT: 40,
+              totalMediaJMT: 30,
               interstitialToMediaOKJMT: 10,
               callInitMediaEngineReady: 10,
               stayLobbyTime: 10,

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -11,7 +11,17 @@ describe("internal-plugin-metrics", () => {
     beforeEach(() => {
       sinon.createSandbox();
       sinon.useFakeTimers(now.getTime());
-      cdl = new CallDiagnosticLatencies();
+      cdl = new CallDiagnosticLatencies({webex: {
+        meetings:{
+          meetingCollection: {
+            get: (id: string) => {
+              if(id === 'meeting-id') {
+                return {id:'meeting-id', allowMediaInLobby: true};
+              }
+            }
+          }
+        }
+      }});
     });
 
     afterEach(() => {
@@ -185,6 +195,19 @@ describe("internal-plugin-metrics", () => {
     });
 
     it('calculates getTotalMediaJMT correctly', () => {
+      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 5);
+      cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 8);
+      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 10);
+      cdl.saveTimestamp('client.locus.join.request', 12);
+      cdl.saveTimestamp('client.locus.join.response', 20);
+      cdl.saveTimestamp('internal.host.meeting.participant.admitted', 24)
+      cdl.saveTimestamp('client.ice.start', 30);
+      cdl.saveTimestamp('client.ice.end', 40);
+      assert.deepEqual(cdl.getTotalMediaJMT(), 27);
+    })
+
+    it('calculates getTotalMediaJMT correctly with allowMediaInLobby true', () => {
+      cdl.setMeetingId('meeting-id');
       cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 5);
       cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 8);
       cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 10);

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -184,6 +184,17 @@ describe("internal-plugin-metrics", () => {
       assert.deepEqual(cdl.getTotalJMT(), 45);
     });
 
+    it('calculates getTotalMediaJMT correctly', () => {
+      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 5);
+      cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 8);
+      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 10);
+      cdl.saveTimestamp('client.locus.join.request', 12);
+      cdl.saveTimestamp('client.locus.join.response', 20);
+      cdl.saveTimestamp('client.ice.start', 30);
+      cdl.saveTimestamp('client.ice.end', 40);
+      assert.deepEqual(cdl.getTotalMediaJMT(), 31);
+    })
+
     it('calculates getJoinConfJMT correctly', () => {
       cdl.saveTimestamp('client.locus.join.request', 10);
       cdl.saveTimestamp('client.locus.join.response', 20);

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -1,45 +1,51 @@
 import {assert} from '@webex/test-helper-chai';
-import CallDiagnosticLatencies from '../../../../src/call-diagnostic/call-diagnostic-metrics-latencies'
+import CallDiagnosticLatencies from '../../../../src/call-diagnostic/call-diagnostic-metrics-latencies';
 import sinon from 'sinon';
 
-describe("internal-plugin-metrics", () => {
-  describe("CallDiagnosticLatencies", () => {
+describe('internal-plugin-metrics', () => {
+  describe('CallDiagnosticLatencies', () => {
     let cdl: CallDiagnosticLatencies;
     var now = new Date();
-
 
     beforeEach(() => {
       sinon.createSandbox();
       sinon.useFakeTimers(now.getTime());
-      cdl = new CallDiagnosticLatencies({webex: {
-        meetings:{
+      const webex = {
+        meetings: {
           meetingCollection: {
             get: (id: string) => {
-              if(id === 'meeting-id') {
-                return {id:'meeting-id', allowMediaInLobby: true};
+              if (id === 'meeting-id') {
+                return {id: 'meeting-id', allowMediaInLobby: true};
               }
-            }
-          }
+            },
+          },
+        },
+      };
+
+      cdl = new CallDiagnosticLatencies(
+        {},
+        {
+          parent: webex,
         }
-      }});
+      );
     });
 
     afterEach(() => {
       sinon.restore();
-    })
+    });
 
     it('should save timestamp correctly', () => {
       assert.deepEqual(cdl.latencyTimestamps.size, 0);
-      cdl.saveTimestamp('client.alert.displayed');
+      cdl.saveTimestamp({key: 'client.alert.displayed'});
       assert.deepEqual(cdl.latencyTimestamps.size, 1);
-      assert.deepEqual(cdl.latencyTimestamps.get('client.alert.displayed'), now.getTime())
+      assert.deepEqual(cdl.latencyTimestamps.get('client.alert.displayed'), now.getTime());
     });
 
     it('should save latency correctly', () => {
       assert.deepEqual(cdl.precomputedLatencies.size, 0);
       cdl.saveLatency('client.alert.displayed', 10);
       assert.deepEqual(cdl.precomputedLatencies.size, 1);
-      assert.deepEqual(cdl.precomputedLatencies.get('client.alert.displayed'), 10)
+      assert.deepEqual(cdl.precomputedLatencies.get('client.alert.displayed'), 10);
     });
 
     it('should save only first timestamp correctly', () => {
@@ -61,30 +67,30 @@ describe("internal-plugin-metrics", () => {
 
     it('should update existing property and now add new keys', () => {
       assert.deepEqual(cdl.latencyTimestamps.size, 0);
-      cdl.saveTimestamp('client.alert.displayed');
+      cdl.saveTimestamp({key: 'client.alert.displayed'});
       assert.deepEqual(cdl.latencyTimestamps.get('client.alert.displayed'), now.getTime());
-      cdl.saveTimestamp('client.alert.displayed', 1234);
+      cdl.saveTimestamp({key: 'client.alert.displayed', value: 1234});
       assert.deepEqual(cdl.latencyTimestamps.get('client.alert.displayed'), 1234);
       assert.deepEqual(cdl.latencyTimestamps.size, 1);
-    })
+    });
 
     it('should clear all timestamps correctly', () => {
-      cdl.saveTimestamp('client.alert.displayed');
-      cdl.saveTimestamp('client.alert.removed');
+      cdl.saveTimestamp({key: 'client.alert.displayed'});
+      cdl.saveTimestamp({key: 'client.alert.removed'});
       assert.deepEqual(cdl.latencyTimestamps.size, 2);
       cdl.clearTimestamps();
       assert.deepEqual(cdl.latencyTimestamps.size, 0);
     });
 
     it('should calculate diff between timestamps correctly', () => {
-      cdl.saveTimestamp('client.alert.displayed', 10);
-      cdl.saveTimestamp('client.alert.removed', 20);
+      cdl.saveTimestamp({key: 'client.alert.displayed', value: 10});
+      cdl.saveTimestamp({key: 'client.alert.removed', value: 20});
       const res = cdl.getDiffBetweenTimestamps('client.alert.displayed', 'client.alert.removed');
       assert.deepEqual(res, 10);
     });
 
     it('it returns undefined if either one is doesnt exist', () => {
-      cdl.saveTimestamp('client.alert.displayed', 10);
+      cdl.saveTimestamp({key: 'client.alert.displayed', value: 10});
       const res1 = cdl.getDiffBetweenTimestamps('client.alert.displayed', 'client.alert.removed');
       assert.deepEqual(res1, undefined);
       const res2 = cdl.getDiffBetweenTimestamps('client.alert.removed', 'client.alert.displayed');
@@ -92,68 +98,113 @@ describe("internal-plugin-metrics", () => {
     });
 
     it('calculates getMeetingInfoReqResp correctly', () => {
-      cdl.saveTimestamp('internal.client.meetinginfo.request', 10);
-      cdl.saveTimestamp('internal.client.meetinginfo.response', 20);
+      cdl.saveTimestamp({key: 'internal.client.meetinginfo.request', value: 10});
+      cdl.saveTimestamp({key: 'internal.client.meetinginfo.response', value: 20});
       assert.deepEqual(cdl.getMeetingInfoReqResp(), 10);
     });
 
     it('calculates getShowInterstitialTime correctly', () => {
-      cdl.saveTimestamp('internal.client.interstitial-window.launched', 10);
-      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 20);
+      cdl.saveTimestamp({key: 'internal.client.interstitial-window.launched', value: 10});
+      cdl.saveTimestamp({key: 'internal.client.interstitial-window.click.joinbutton', value: 20});
       assert.deepEqual(cdl.getShowInterstitialTime(), 10);
     });
 
     it('calculates getCallInitJoinReq correctly', () => {
-      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 10);
-      cdl.saveTimestamp('client.locus.join.request', 20);
+      cdl.saveTimestamp({key: 'internal.client.meeting.click.joinbutton', value: 10});
+      cdl.saveTimestamp({key: 'client.locus.join.request', value: 20});
       assert.deepEqual(cdl.getCallInitJoinReq(), 10);
     });
 
     it('calculates getCallInitJoinReq correctly without click join button event', () => {
       cdl.saveLatency('internal.call.init.join.req', 12);
-      cdl.saveTimestamp('client.locus.join.request', 20);
+      cdl.saveTimestamp({
+        key: 'client.locus.join.request',
+        value: 20,
+      });
       assert.deepEqual(cdl.getCallInitJoinReq(), 12);
     });
 
     it('calculates getJoinReqResp correctly', () => {
-      cdl.saveTimestamp('client.locus.join.request', 10);
-      cdl.saveTimestamp('client.locus.join.response', 20);
+      cdl.saveTimestamp({
+        key: 'client.locus.join.request',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 20,
+      });
       assert.deepEqual(cdl.getJoinReqResp(), 10);
     });
 
     it('calculates getLocalSDPGenRemoteSDPRecv correctly', () => {
-      cdl.saveTimestamp('client.media-engine.local-sdp-generated', 10);
-      cdl.saveTimestamp('client.media-engine.remote-sdp-received', 20);
+      cdl.saveTimestamp({
+        key: 'client.media-engine.local-sdp-generated',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.media-engine.remote-sdp-received',
+        value: 20,
+      });
       assert.deepEqual(cdl.getLocalSDPGenRemoteSDPRecv(), 10);
     });
 
     it('calculates getICESetupTime correctly', () => {
-      cdl.saveTimestamp('client.ice.start', 10);
-      cdl.saveTimestamp('client.ice.end', 20);
+      cdl.saveTimestamp({
+        key: 'client.ice.start',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.end',
+        value: 20,
+      });
       assert.deepEqual(cdl.getICESetupTime(), 10);
     });
 
     it('calculates getAudioICESetupTime correctly', () => {
-      cdl.saveTimestamp('client.ice.start', 10);
-      cdl.saveTimestamp('client.ice.end', 20);
+      cdl.saveTimestamp({
+        key: 'client.ice.start',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.end',
+        value: 20,
+      });
       assert.deepEqual(cdl.getAudioICESetupTime(), 10);
     });
 
     it('calculates getVideoICESetupTime correctly', () => {
-      cdl.saveTimestamp('client.ice.start', 10);
-      cdl.saveTimestamp('client.ice.end', 20);
+      cdl.saveTimestamp({
+        key: 'client.ice.start',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.end',
+        value: 20,
+      });
       assert.deepEqual(cdl.getVideoICESetupTime(), 10);
     });
 
     it('calculates getShareICESetupTime correctly', () => {
-      cdl.saveTimestamp('client.ice.start', 10);
-      cdl.saveTimestamp('client.ice.end', 20);
+      cdl.saveTimestamp({
+        key: 'client.ice.start',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.end',
+        value: 20,
+      });
       assert.deepEqual(cdl.getShareICESetupTime(), 10);
     });
 
     it('calculates getStayLobbyTime correctly', () => {
-      cdl.saveTimestamp('client.locus.join.response', 10);
-      cdl.saveTimestamp('internal.host.meeting.participant.admitted', 20);
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'internal.host.meeting.participant.admitted',
+        value: 20,
+      });
       assert.deepEqual(cdl.getStayLobbyTime(), 10);
     });
 
@@ -163,110 +214,261 @@ describe("internal-plugin-metrics", () => {
     });
 
     it('calculates getClickToInterstitial correctly', () => {
-      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 10);
-      cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 20);
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.click.joinbutton',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 20,
+      });
       assert.deepEqual(cdl.getClickToInterstitial(), 10);
     });
 
     it('calculates getClickToInterstitial without join button timestamp', () => {
       cdl.saveLatency('internal.click.to.interstitial', 5);
-      cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 20);
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 20,
+      });
       assert.deepEqual(cdl.getClickToInterstitial(), 5);
     });
 
     it('calculates getInterstitialToJoinOK correctly', () => {
-      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 10);
-      cdl.saveTimestamp('client.locus.join.response', 20);
+      cdl.saveTimestamp({
+        key: 'internal.client.interstitial-window.click.joinbutton',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 20,
+      });
       assert.deepEqual(cdl.getInterstitialToJoinOK(), 10);
     });
 
     it('calculates getCallInitMediaEngineReady correctly', () => {
-      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 10);
-      cdl.saveTimestamp('client.media-engine.ready', 20);
+      cdl.saveTimestamp({
+        key: 'internal.client.interstitial-window.click.joinbutton',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.media-engine.ready',
+        value: 20,
+      });
       assert.deepEqual(cdl.getCallInitMediaEngineReady(), 10);
     });
 
     it('calculates getTotalJMT correctly', () => {
-      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 5);
-      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 10);
-      cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 20);
-      cdl.saveTimestamp('client.locus.join.response', 40);
+      cdl.saveTimestamp({
+        key: 'internal.client.interstitial-window.click.joinbutton',
+        value: 5,
+      });
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.click.joinbutton',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 20,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 40,
+      });
       assert.deepEqual(cdl.getTotalJMT(), 45);
     });
 
     it('calculates getTotalMediaJMT correctly', () => {
-      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 5);
-      cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 8);
-      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 10);
-      cdl.saveTimestamp('client.locus.join.request', 12);
-      cdl.saveTimestamp('client.locus.join.response', 20);
-      cdl.saveTimestamp('internal.host.meeting.participant.admitted', 24)
-      cdl.saveTimestamp('client.ice.start', 30);
-      cdl.saveTimestamp('client.ice.end', 40);
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.click.joinbutton',
+        value: 5,
+      });
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 8,
+      });
+      cdl.saveTimestamp({
+        key: 'internal.client.interstitial-window.click.joinbutton',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.request',
+        value: 12,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 20,
+      });
+      cdl.saveTimestamp({
+        key: 'internal.host.meeting.participant.admitted',
+        value: 24,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.start',
+        value: 30,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.end',
+        value: 40,
+      });
       assert.deepEqual(cdl.getTotalMediaJMT(), 27);
-    })
+    });
 
     it('calculates getTotalMediaJMT correctly with allowMediaInLobby true', () => {
-      cdl.setMeetingId('meeting-id');
-      cdl.saveTimestamp('internal.client.meeting.click.joinbutton', 5);
-      cdl.saveTimestamp('internal.client.meeting.interstitial-window.showed', 8);
-      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 10);
-      cdl.saveTimestamp('client.locus.join.request', 12);
-      cdl.saveTimestamp('client.locus.join.response', 20);
-      cdl.saveTimestamp('client.ice.start', 30);
-      cdl.saveTimestamp('client.ice.end', 40);
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.click.joinbutton',
+        value: 5,
+        options: {meetingId: 'meeting-id'},
+      });
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 8,
+      });
+      cdl.saveTimestamp({
+        key: 'internal.client.interstitial-window.click.joinbutton',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.request',
+        value: 12,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 20,
+      });
+      cdl.saveTimestamp({
+        key: 'internal.host.meeting.participant.admitted',
+        value: 24,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.start',
+        value: 30,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.end',
+        value: 40,
+      });
       assert.deepEqual(cdl.getTotalMediaJMT(), 31);
-    })
+    });
 
     it('calculates getJoinConfJMT correctly', () => {
-      cdl.saveTimestamp('client.locus.join.request', 10);
-      cdl.saveTimestamp('client.locus.join.response', 20);
-      cdl.saveTimestamp('client.ice.start', 30);
-      cdl.saveTimestamp('client.ice.end', 40);
+      cdl.saveTimestamp({
+        key: 'client.locus.join.request',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 20,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.start',
+        value: 30,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.end',
+        value: 40,
+      });
       assert.deepEqual(cdl.getJoinConfJMT(), 20);
     });
 
     it('calculates getClientJMT correctly', () => {
-      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 2);
-      cdl.saveTimestamp('client.locus.join.request', 6);
-      cdl.saveTimestamp('client.locus.join.response', 8);
-      cdl.saveTimestamp('client.ice.start', 10);
-      cdl.saveTimestamp('client.ice.end', 11);
+      cdl.saveTimestamp({
+        key: 'internal.client.interstitial-window.click.joinbutton',
+        value: 2,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.request',
+        value: 6,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 8,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.start',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.end',
+        value: 11,
+      });
       assert.deepEqual(cdl.getClientJMT(), 3);
     });
 
     it('calculates getAudioJoinRespRxStart correctly', () => {
-      cdl.saveTimestamp('client.locus.join.response', 5);
-      cdl.saveTimestamp('client.media.rx.start', 7);
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 5,
+      });
+      cdl.saveTimestamp({
+        key: 'client.media.rx.start',
+        value: 7,
+      });
       assert.deepEqual(cdl.getAudioJoinRespRxStart(), 2);
     });
 
     it('calculates getVideoJoinRespRxStart correctly', () => {
-      cdl.saveTimestamp('client.locus.join.response', 5);
-      cdl.saveTimestamp('client.media.rx.start', 7);
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 5,
+      });
+      cdl.saveTimestamp({
+        key: 'client.media.rx.start',
+        value: 7,
+      });
       assert.deepEqual(cdl.getVideoJoinRespRxStart(), 2);
     });
 
     it('calculates getAudioJoinRespTxStart correctly', () => {
-      cdl.saveTimestamp('client.locus.join.response', 5);
-      cdl.saveTimestamp('client.media.tx.start', 7);
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 5,
+      });
+      cdl.saveTimestamp({
+        key: 'client.media.tx.start',
+        value: 7,
+      });
       assert.deepEqual(cdl.getAudioJoinRespTxStart(), 2);
     });
 
     it('calculates getVideoJoinRespTxStart correctly', () => {
-      cdl.saveTimestamp('client.locus.join.response', 5);
-      cdl.saveTimestamp('client.media.tx.start', 7);
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 5,
+      });
+      cdl.saveTimestamp({
+        key: 'client.media.tx.start',
+        value: 7,
+      });
       assert.deepEqual(cdl.getVideoJoinRespTxStart(), 2);
     });
 
     it('calculates getInterstitialToMediaOKJMT correctly', () => {
-      cdl.saveTimestamp('internal.client.interstitial-window.click.joinbutton', 4);
-      cdl.saveTimestamp('client.locus.join.response', 10);
-      cdl.saveTimestamp('internal.host.meeting.participant.admitted', 12);
-      cdl.saveTimestamp('client.media.rx.start', 14);
-      cdl.saveTimestamp('client.media.tx.start', 15);
-      cdl.saveTimestamp('client.media.rx.start', 16);
+      cdl.saveTimestamp({
+        key: 'internal.client.interstitial-window.click.joinbutton',
+        value: 4,
+      });
+      cdl.saveTimestamp({
+        key: 'client.locus.join.response',
+        value: 10,
+      });
+      cdl.saveTimestamp({
+        key: 'internal.host.meeting.participant.admitted',
+        value: 12,
+      });
+      cdl.saveTimestamp({
+        key: 'client.media.rx.start',
+        value: 14,
+      });
+      cdl.saveTimestamp({
+        key: 'client.media.tx.start',
+        value: 15,
+      });
+      cdl.saveTimestamp({
+        key: 'client.media.rx.start',
+        value: 16,
+      });
       assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 8);
     });
-  })
-})
+  });
+});

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
@@ -24,25 +24,55 @@ describe("internal-plugin-metrics", () => {
 
       webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp = sinon.stub();
       webex.internal.newMetrics.callDiagnosticLatencies.clearTimestamps = sinon.stub();
+      webex.internal.newMetrics.callDiagnosticLatencies.setMeetingId = sinon.stub();
       webex.internal.newMetrics.callDiagnosticMetrics.submitClientEvent = sinon.stub();
       webex.internal.newMetrics.callDiagnosticMetrics.submitMQE = sinon.stub();
     });
 
-    it('submits Client Event successfully', () => {
-      webex.internal.newMetrics.submitClientEvent({
-        name: 'client.alert.displayed',
-        options: {
-          meetingId: '123',
-        }
+    describe('submitClientEvent', () => {
+      it('submits Client Event successfully', () => {
+        webex.internal.newMetrics.submitClientEvent({
+          name: 'client.alert.displayed',
+          options: {
+            meetingId: '123',
+          },
+        });
+
+        assert.calledWith(
+          webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp,
+          'client.alert.displayed'
+        );
+        assert.calledWith(webex.internal.newMetrics.callDiagnosticMetrics.submitClientEvent, {
+          name: 'client.alert.displayed',
+          payload: undefined,
+          options: {meetingId: '123'},
+        });
       });
 
-      assert.calledWith(webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp, "client.alert.displayed")
-      assert.calledWith(webex.internal.newMetrics.callDiagnosticMetrics.submitClientEvent, {
-        name: 'client.alert.displayed',
-        payload: undefined,
-        options: { meetingId: '123' }
-      })
+      it('saves current meetingId successfully on submitClientEvent if meetingId is provided', () => {
+        webex.internal.newMetrics.submitClientEvent({
+          name: 'client.alert.displayed',
+          options: {
+            meetingId: '123',
+          },
+        });
+
+        assert.calledWith(webex.internal.newMetrics.callDiagnosticLatencies.setMeetingId, '123');
+      });
+
+      it('doesnt save meetingId on submitClientEvent if meetingId is provided', () => {
+        webex.internal.newMetrics.callDiagnosticLatencies.meetingId = '123';
+        webex.internal.newMetrics.submitClientEvent({
+          name: 'client.alert.displayed',
+          options: {
+            meetingId: '123',
+          },
+        });
+
+        assert.notCalled(webex.internal.newMetrics.callDiagnosticLatencies.setMeetingId);
+      });
     });
+
 
     it('submits MQE successfully', () => {
       webex.internal.newMetrics.submitMQE({

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
@@ -24,55 +24,28 @@ describe("internal-plugin-metrics", () => {
 
       webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp = sinon.stub();
       webex.internal.newMetrics.callDiagnosticLatencies.clearTimestamps = sinon.stub();
-      webex.internal.newMetrics.callDiagnosticLatencies.setMeetingId = sinon.stub();
       webex.internal.newMetrics.callDiagnosticMetrics.submitClientEvent = sinon.stub();
       webex.internal.newMetrics.callDiagnosticMetrics.submitMQE = sinon.stub();
     });
 
-    describe('submitClientEvent', () => {
-      it('submits Client Event successfully', () => {
-        webex.internal.newMetrics.submitClientEvent({
-          name: 'client.alert.displayed',
-          options: {
-            meetingId: '123',
-          },
-        });
-
-        assert.calledWith(
-          webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp,
-          'client.alert.displayed'
-        );
-        assert.calledWith(webex.internal.newMetrics.callDiagnosticMetrics.submitClientEvent, {
-          name: 'client.alert.displayed',
-          payload: undefined,
-          options: {meetingId: '123'},
-        });
+    it('submits Client Event successfully', () => {
+      webex.internal.newMetrics.submitClientEvent({
+        name: 'client.alert.displayed',
+        options: {
+          meetingId: '123',
+        },
       });
 
-      it('saves current meetingId successfully on submitClientEvent if meetingId is provided', () => {
-        webex.internal.newMetrics.submitClientEvent({
-          name: 'client.alert.displayed',
-          options: {
-            meetingId: '123',
-          },
-        });
-
-        assert.calledWith(webex.internal.newMetrics.callDiagnosticLatencies.setMeetingId, '123');
-      });
-
-      it('doesnt save meetingId on submitClientEvent if meetingId is provided', () => {
-        webex.internal.newMetrics.callDiagnosticLatencies.meetingId = '123';
-        webex.internal.newMetrics.submitClientEvent({
-          name: 'client.alert.displayed',
-          options: {
-            meetingId: '123',
-          },
-        });
-
-        assert.notCalled(webex.internal.newMetrics.callDiagnosticLatencies.setMeetingId);
+      assert.calledWith(
+        webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp,
+        {key: 'client.alert.displayed', options: {meetingId: '123'}}
+      );
+      assert.calledWith(webex.internal.newMetrics.callDiagnosticMetrics.submitClientEvent, {
+        name: 'client.alert.displayed',
+        payload: undefined,
+        options: {meetingId: '123'},
       });
     });
-
 
     it('submits MQE successfully', () => {
       webex.internal.newMetrics.submitMQE({
@@ -85,7 +58,7 @@ describe("internal-plugin-metrics", () => {
         }
       });
 
-      assert.calledWith(webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp, 'client.mediaquality.event')
+      assert.calledWith(webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp, {key: 'client.mediaquality.event'})
       assert.calledWith(webex.internal.newMetrics.callDiagnosticMetrics.submitMQE, {
         name: 'client.mediaquality.event',
         //@ts-ignore
@@ -102,7 +75,7 @@ describe("internal-plugin-metrics", () => {
         name: 'client.mediaquality.event',
       });
 
-      assert.calledWith(webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp, 'client.mediaquality.event')
+      assert.calledWith(webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp, {key: 'client.mediaquality.event'})
       assert.notCalled(webex.internal.newMetrics.callDiagnosticLatencies.clearTimestamps)
     });
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -550,6 +550,7 @@ export default class Meeting extends StatelessWebexPlugin {
   environment: string;
   namespace = MEETINGS;
   annotationInfo: AnnotationInfo;
+  allowMediaInLobby: boolean;
 
   /**
    * @param {Object} attrs
@@ -5258,6 +5259,8 @@ export default class Meeting extends StatelessWebexPlugin {
       bundlePolicy,
       allowMediaInLobby,
     } = options;
+
+    this.allowMediaInLobby = options?.allowMediaInLobby;
 
     // If the user is unjoined or guest waiting in lobby dont allow the user to addMedia
     // @ts-ignore - isUserUnadmitted coming from SelfUtil

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1200,7 +1200,7 @@ describe('plugin-meetings', () => {
           });
         });
 
-        const checkWorking = () => {
+        const checkWorking = ({allowMediaInLobby} = {}) => {
           assert.calledOnce(meeting.roap.doTurnDiscovery);
           assert.calledWith(meeting.roap.doTurnDiscovery, meeting, false);
           assert.calledOnce(meeting.mediaProperties.setMediaDirection);
@@ -1213,6 +1213,7 @@ describe('plugin-meetings', () => {
           );
           assert.calledOnce(meeting.setMercuryListener);
           assert.calledOnce(fakeMediaConnection.initiateOffer);
+          assert.equal(meeting.allowMediaInLobby, allowMediaInLobby);
         }
 
         it('should attach the media and return promise', async () => {
@@ -1246,7 +1247,7 @@ describe('plugin-meetings', () => {
           assert.exists(media);
           await media;
 
-          checkWorking();
+          checkWorking({allowMediaInLobby: true});
         });
 
         it('should pass the turn server info to the peer connection', async () => {


### PR DESCRIPTION
# COMPLETES [SPARK-422888](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-422888)
[SPARK-449067](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-449067)

- since we're creating the media connection in lobby now, it doesn't make sense to subtract it from totalMediaJMT

## by making the following changes

- refactor

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

-unit test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
