### PR TITLE
fix(plugin-meetings): changed sample app to use max-bundle

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -683,6 +683,7 @@ function getMediaSettings() {
   });
 
   settings.allowMediaInLobby = meetingsMediaInLobbySupportElm.checked;
+  settings.bundlePolicy = 'max-bundle';
 
   return settings;
 }


### PR DESCRIPTION
## This pull request addresses

Sample app is not using max-bundle for multistream meetings

## by making the following changes

Changed it to use max-bundle. I've hardcoded it, because we've GA-ed this some weeks ago so there is no need for another checkbox in an already crowded sample app UI.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

manually checked sample app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
