### PR TITLE
fix: ignore old full Locus DTOs

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -267,12 +267,19 @@ export default class LocusInfo extends EventsScope {
    * @returns {object} null
    * @memberof LocusInfo
    */
-  // eslint-disable-next-line @typescript-eslint/no-shadow
   onFullLocus(locus: any, eventType?: string) {
     if (!locus) {
       LoggerProxy.logger.error(
         'Locus-info:index#onFullLocus --> object passed as argument was invalid, continuing.'
       );
+    }
+
+    if (!this.locusParser.isNewFullLocus(locus)) {
+      LoggerProxy.logger.info(
+        `Locus-info:index#onFullLocus --> ignoring old full locus DTO, eventType=${eventType}`
+      );
+
+      return;
     }
     this.updateParticipantDeltas(locus.participants);
     this.scheduledMeeting = locus.meeting || null;

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -1648,10 +1648,37 @@ describe('plugin-meetings', () => {
         sandbox.stub(locusInfo, 'updateParticipants');
         sandbox.stub(locusInfo, 'isMeetingActive');
         sandbox.stub(locusInfo, 'handleOneOnOneEvent');
+        sandbox.stub(locusParser, 'isNewFullLocus').returns(true);
 
         locusInfo.onFullLocus(fakeLocus, eventType);
 
         assert.equal(fakeLocus, locusParser.workingCopy);
+      });
+
+      it('onFullLocus() does not do anything if the incoming full locus DTO is old', () => {
+        const eventType = 'fakeEvent';
+
+        locusParser.workingCopy = {};
+
+        const oldWorkingCopy = locusParser.workingCopy;
+
+        const spies = [
+          sandbox.stub(locusInfo, 'updateParticipantDeltas'),
+          sandbox.stub(locusInfo, 'updateLocusInfo'),
+          sandbox.stub(locusInfo, 'updateParticipants'),
+          sandbox.stub(locusInfo, 'isMeetingActive'),
+          sandbox.stub(locusInfo, 'handleOneOnOneEvent'),
+        ];
+
+        sandbox.stub(locusParser, 'isNewFullLocus').returns(false);
+
+        locusInfo.onFullLocus(fakeLocus, eventType);
+
+        spies.forEach((spy) => {
+          assert.notCalled(spy);
+        })
+
+        assert.equal(oldWorkingCopy, locusParser.workingCopy);
       });
 
       it('onDeltaAction applies locus delta data to meeting', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/parser.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/parser.js
@@ -238,6 +238,68 @@ describe('locus-info/parser', () => {
     });
   });
 
+  describe('Full Locus handling', () => {
+    describe('isNewFullLocus', () => {
+      let parser;
+
+      beforeEach(() => {
+        parser = new LocusDeltaParser();
+      })
+      it('returns false if incoming Locus is not valid', () => {
+        const fakeInvalidIncomingLocus = {};
+
+        parser.workingCopy = { sequence: {rangeStart: 0, rangeEnd: 0, entries: [1]}};
+
+        assert.isFalse(parser.isNewFullLocus(fakeInvalidIncomingLocus));
+      });
+
+      const runCheck = (incomingSequence, currentSequence, expectedResult) => {
+        parser.workingCopy = { sequence: {rangeStart: 0, rangeEnd: 0, entries: [1, 2, currentSequence]}};
+
+        const fakeIncomingLocus = { sequence: {rangeStart: 0, rangeEnd: 0, entries: [1, 10, incomingSequence]}};
+
+        assert.strictEqual(parser.isNewFullLocus(fakeIncomingLocus), expectedResult);
+      }
+      it('returns true if there is no working copy', () => {
+        const fakeIncomingLocus = { sequence: {rangeStart: 0, rangeEnd: 0, entries: [10]}};
+
+        // sanity check that we initially have no working copy 
+        assert.isNull(parser.workingCopy);
+
+        assert.isTrue(parser.isNewFullLocus(fakeIncomingLocus));
+      });
+
+      it('returns true if new sequence is higher than existing one', () => {
+        runCheck(101, 100, true);
+      });
+
+      it('returns false if new sequence is same than existing one', () => {
+        runCheck(100, 100, false);
+      });
+
+      it('returns false if new sequence is older than existing one', () => {
+        runCheck(99, 100, false);
+      });
+
+      it('returns true if incoming Locus has empty sequence', () => {
+        parser.workingCopy = { sequence: {rangeStart: 0, rangeEnd: 0, entries: [1, 2, 3]}};
+
+        const fakeIncomingLocus = { sequence: {rangeStart: 0, rangeEnd: 0, entries: []}};
+
+        assert.isTrue(parser.isNewFullLocus(fakeIncomingLocus));
+      });
+
+      it('returns true if working copy has empty sequence', () => {
+        parser.workingCopy = { sequence: {rangeStart: 0, rangeEnd: 0, entries: []}};
+
+        const fakeIncomingLocus = { sequence: {rangeStart: 0, rangeEnd: 0, entries: [1,2,3]}};
+
+        assert.isTrue(parser.isNewFullLocus(fakeIncomingLocus));
+      });
+
+    })
+  });
+
   describe('Invalid Locus objects', () => {
     let sandbox = null;
     let parser;


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-447189

## This pull request addresses

Integration test "users "bob" and "chris" join the meeting" from the converged-space-meeting.js sometimes fails, because we receive Locus DTO events out of order over the websocket.

## by making the following changes

Fixed JS-SDK to ignore full locus DTOs that are older than current working copy. I've confirmed with Locus team that this is what we should do.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Added new unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
