### PR TITLE
feat(plugin-meetings): fix si trigger

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -601,7 +601,7 @@ const MeetingUtil = {
       }
     }
     Trigger.trigger(
-      this,
+      meeting,
       {
         file: 'meeting/util',
         function: 'parseInterpretationInfo',

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -226,7 +226,7 @@ describe('plugin-meetings', () => {
     membersSpy = sinon.spy(MembersImport, 'default');
     meetingRequestSpy = sinon.spy(MeetingRequestImport, 'default');
 
-    TriggerProxy.trigger = sinon.stub().returns(true);
+    sinon.stub(TriggerProxy, 'trigger').returns(true);
     Metrics.initialSetup(webex);
     MediaUtil.createMediaStream = sinon.stub().callsFake((tracks) => {
       return {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -21,6 +21,7 @@ describe('plugin-meetings', () => {
         log: sandbox.stub(),
         error: sandbox.stub(),
         warn: sandbox.stub(),
+        debug: sandbox.stub(),
       };
 
       LoggerConfig.set({
@@ -42,6 +43,7 @@ describe('plugin-meetings', () => {
       meeting.annotaion = {cleanUp: sinon.stub()};
       meeting.getWebexObject = sinon.stub().returns(webex);
       meeting.simultaneousInterpretation = {cleanUp: sinon.stub()};
+      meeting.trigger = sinon.stub();
     });
 
     afterEach(() => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -57,7 +57,7 @@ describe('plugin-meetings', () => {
       verboseEvents: true,
       enable: false,
     });
-    TriggerProxy.trigger = sinon.stub().returns(true);
+    sinon.stub(TriggerProxy, 'trigger').returns(true);
   });
 
   let webex;

--- a/packages/@webex/plugin-meetings/test/unit/spec/members/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/index.js
@@ -232,7 +232,7 @@ describe('plugin-meetings', () => {
       it('should send clear event if clear members', () => {
         const members = createMembers({url: url1});
         members.membersCollection.setAll(fakeMembersCollection);
-        Trigger.trigger = sinon.stub();
+        sinon.stub(Trigger, 'trigger');
         members.clearMembers();
         assert.deepEqual(members.membersCollection.members, {});
         assert.calledWith(
@@ -250,7 +250,6 @@ describe('plugin-meetings', () => {
     describe('#locusParticipantsUpdate', () => {
       it('should send member update event with session info', () => {
         const members = createMembers({url: url1});
-        Trigger.trigger = sinon.stub();
         const fakePayload = {
           participants: {
             forEach: sinon.stub(),


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

The parseInterpretationInfo was throwing an error when the when attempting to trigger an event. The first argument for the `Trigger.trigger` must be an object with a trigger method. This is usually a webex plugin or similar. In this case it needed to be the meeting, as the util has no trigger method.

This was masked by the unit tests because other tests would assign Trigger.trigger to be a sinon stub, thus stubbing for all subsequent tests.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
