### PR TITLE
fix: ask for delta instead of full locus DTO when handling DESYNC

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -99,7 +99,6 @@ export default class LocusInfo extends EventsScope {
         break;
       case USE_CURRENT:
         meeting.locusDesync = false;
-        meeting.needToGetFullLocus = false;
         break;
       case DESYNC:
         meeting.meetingRequest

--- a/packages/@webex/plugin-meetings/src/locus-info/parser.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/parser.ts
@@ -27,7 +27,7 @@ export default class Parser {
     ERROR: 'ERROR',
   };
 
-  queue: any;
+  queue: SimpleQueue;
   workingCopy: any;
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -278,7 +278,7 @@ export class MuteState {
         this.state.server.localMute = this.type === AUDIO ? audioMuted : videoMuted;
 
         if (locus) {
-          meeting.locusInfo.onDeltaLocus(locus);
+          meeting.locusInfo.handleLocusDelta(locus, meeting);
         }
 
         return locus;

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -383,40 +383,6 @@ export default class MeetingRequest extends StatelessWebexPlugin {
   }
 
   /**
-   * Syns the missed delta event
-   * @param {Object} options
-   * @param {boolean} options.desync flag to get partial or whole locus object
-   * @param {String} options.syncUrl sync url to get ht elatest locus delta
-   * @returns {Promise}
-   */
-  syncMeeting(options: {desync: boolean; syncUrl: string}) {
-    /* eslint-disable no-else-return */
-    const {desync} = options;
-    let {syncUrl} = options;
-
-    /* istanbul ignore else */
-    if (desync) {
-      // check for existing URL parameters
-      syncUrl = syncUrl
-        .concat(syncUrl.split('?')[1] ? '&' : '?')
-        .concat(`${LOCUS.SYNCDEBUG}=${desync}`);
-    }
-
-    // @ts-ignore
-    return this.request({
-      method: HTTP_VERBS.GET,
-      uri: syncUrl,
-    }) // TODO: Handle if delta sync failed . Get the full locus object
-      .catch((err) => {
-        LoggerProxy.logger.error(
-          `Meeting:request#syncMeeting --> Error syncing meeting, error ${err}`
-        );
-
-        return err;
-      });
-  }
-
-  /**
    * Request to get the complete locus object
    * @param {Object} options
    * @param {boolean} options.desync flag to get partial or whole locus object

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -18,7 +18,6 @@ import {
   HTTP_VERBS,
   LEAVE,
   LOCI,
-  LOCUS,
   PARTICIPANT,
   PROVISIONAL_TYPE_DIAL_IN,
   PROVISIONAL_TYPE_DIAL_OUT,
@@ -383,28 +382,22 @@ export default class MeetingRequest extends StatelessWebexPlugin {
   }
 
   /**
-   * Request to get the complete locus object
+   * Sends a requests to get the latest locus DTO, it might be a full Locus or a delta, depending on the url provided
    * @param {Object} options
-   * @param {boolean} options.desync flag to get partial or whole locus object
    * @param {String} options.locusUrl sync url to get ht elatest locus delta
    * @returns {Promise}
    */
-  getFullLocus(options: {desync: boolean; locusUrl: string}) {
-    let {locusUrl} = options;
-    const {desync} = options;
+  getLocusDTO(options: {url: string}) {
+    const {url} = options;
 
-    if (locusUrl) {
-      if (desync) {
-        locusUrl += `?${LOCUS.SYNCDEBUG}=${desync}`;
-      }
-
+    if (url) {
       // @ts-ignore
       return this.request({
         method: HTTP_VERBS.GET,
-        uri: locusUrl,
+        uri: url,
       }).catch((err) => {
         LoggerProxy.logger.error(
-          `Meeting:request#getFullLocus --> Error getting full locus, error ${err}`
+          `Meeting:request#getLocusDTO --> Error getting latest locus, error ${err}`
         );
 
         return err;

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -529,7 +529,7 @@ const MeetingUtil = {
     const locus = response?.body?.locus;
 
     if (locus) {
-      meeting.locusInfo.onDeltaLocus(locus);
+      meeting.locusInfo.handleLocusDelta(locus, meeting);
     }
 
     return response;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
@@ -37,7 +37,7 @@ describe('plugin-meetings', () => {
       unmuteVideoAllowed: true,
 
       locusInfo: {
-        onDeltaLocus: sinon.stub(),
+        handleLocusDelta: sinon.stub(),
       },
       members: {
         selfId: 'fake self id',

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -179,10 +179,10 @@ describe('plugin-meetings', () => {
     });
 
     describe('updateLocusWithDelta', () => {
-      it('should call onDeltaLocus with the new delta locus', () => {
+      it('should call handleLocusDelta with the new delta locus', () => {
         const meeting = {
           locusInfo: {
-            onDeltaLocus: sinon.stub()
+            handleLocusDelta: sinon.stub()
           },
         };
 
@@ -195,13 +195,13 @@ describe('plugin-meetings', () => {
         const response = MeetingUtil.updateLocusWithDelta(meeting, originalResponse);
 
         assert.deepEqual(response, originalResponse);
-        assert.calledOnceWithExactly(meeting.locusInfo.onDeltaLocus, 'locus');
+        assert.calledOnceWithExactly(meeting.locusInfo.handleLocusDelta, 'locus', meeting);
       });
 
       it('should handle locus being missing from the response', () => {
         const meeting = {
           locusInfo: {
-            onDeltaLocus: sinon.stub(),
+            handleLocusDelta: sinon.stub(),
           },
         };
 
@@ -212,7 +212,7 @@ describe('plugin-meetings', () => {
         const response = MeetingUtil.updateLocusWithDelta(meeting, originalResponse);
 
         assert.deepEqual(response, originalResponse);
-        assert.notCalled(meeting.locusInfo.onDeltaLocus);
+        assert.notCalled(meeting.locusInfo.handleLocusDelta);
       });
 
       it('should work with an undefined meeting', () => {


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-450417

## This pull request addresses

According to https://sqbu-github.cisco.com/WebExSquared/locus/wiki/Locus-Delta-Events, in the DESYNC case the client should use syncUrl from the workingCopy to obtain the most up-to-date delta from Locus. However, existing SDK implementation is always fetching full Locus instead of the delta. This can have bad consequences for 1k meetings where the Locus DTO is very large.

## by making the following changes

Changed the code to ask for delta if we have syncUrl and fallback to full DTO otherwise.

Also fixed the code that handles delta response from http requests triggered from sendLocalMuteRequestToServer() and updateLocusWithDelta() - the existing code was calling onDeltaLocus() which means it was bypassing the queue for delta processing and it could cause problems if there was for example a sync in progress. Fixed it by calling handleLocusDelta() instead.

Also removed some unused code.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Unit tests and manually tested e2e by hacking SDK to force it to fall into a DESYNC case (normally it doesn't happen often)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
