### PR TITLE
fix: handle out-of-order Locus delta DTOs

### DIFF
--- a/packages/@webex/plugin-meetings/src/common/queue.ts
+++ b/packages/@webex/plugin-meetings/src/common/queue.ts
@@ -1,13 +1,18 @@
 /**
- * Simple queue
+ * Simple queue in which the elements are always sorted
  */
-export default class SimpleQueue {
-  queue: any[];
+export default class SortedQueue<ItemType> {
+  queue: ItemType[];
+  // returns -1 if left < right, 0 if left === right, +1 if left > right
+  compareFunc: (left: ItemType, right: ItemType) => number;
+
   /**
-   * @constructs SimpleQueue
+   * @constructs SortedQueue
+   * @param {Function} compareFunc comparison function used for sorting the elements of the queue
    */
-  constructor() {
+  constructor(compareFunc: (left: ItemType, right: ItemType) => number) {
     this.queue = [];
+    this.compareFunc = compareFunc;
   }
 
   /**
@@ -23,8 +28,17 @@ export default class SimpleQueue {
    * @param {object} item
    * @returns {undefined}
    */
-  enqueue(item: object) {
-    this.queue.push(item);
+  enqueue(item: ItemType) {
+    // Find the index of the first item in the queue that's greater or equal to the new item.
+    // That's where we want to insert the new item.
+    const idx = this.queue.findIndex((existingItem) => {
+      return this.compareFunc(existingItem, item) >= 0;
+    });
+    if (idx >= 0) {
+      this.queue.splice(idx, 0, item);
+    } else {
+      this.queue.push(item);
+    }
   }
 
   /**
@@ -32,7 +46,7 @@ export default class SimpleQueue {
    * Returns null if the queue is empty.
    * @returns {(object|null)} Queue item or null.
    */
-  dequeue() {
+  dequeue(): ItemType {
     if (this.queue.length === 0) {
       return null;
     }

--- a/packages/@webex/plugin-meetings/test/unit/spec/common/queue.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/common/queue.js
@@ -11,7 +11,15 @@ describe('common/queue', () => {
   };
 
   beforeEach(() => {
-    fifo = new SimpleQueue();
+    fifo = new SimpleQueue((left, right) => {
+      if (left.text > right.text) {
+        return 1;
+      }
+      if (left.text < right.text) {
+        return -1;
+      }
+      return 0;
+    });
   });
 
   afterEach(() => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/common/queue.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/common/queue.js
@@ -1,5 +1,5 @@
 import {assert} from '@webex/test-helper-chai';
-import SimpleQueue from '@webex/plugin-meetings/src/common/queue';
+import SortedQueue from '@webex/plugin-meetings/src/common/queue';
 
 describe('common/queue', () => {
   let fifo = null;
@@ -11,7 +11,7 @@ describe('common/queue', () => {
   };
 
   beforeEach(() => {
-    fifo = new SimpleQueue((left, right) => {
+    fifo = new SortedQueue((left, right) => {
       if (left.text > right.text) {
         return 1;
       }
@@ -73,5 +73,26 @@ describe('common/queue', () => {
 
   it('Returns null if the queue is empty.', () => {
     assert.equal(fifo.dequeue(), null);
+  });
+
+  it('Implement lifo', () => {
+    const lifo = new SortedQueue((left, right) => {
+      if (left.text < right.text) {
+        return 1;
+      }
+      if (left.text > right.text) {
+        return -1;
+      }
+      return 0;
+    });
+
+    const item1 = {text: 'fake item1'};
+    const item2 = {text: 'fake item2'};
+
+    lifo.enqueue(item1);
+    lifo.enqueue(item2);
+
+    assert.equal(lifo.dequeue(), item2);
+    assert.equal(lifo.dequeue(), item1);
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/parser.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/parser.js
@@ -334,27 +334,5 @@ describe('locus-info/parser', () => {
 
       assert.isFalse(result);
     });
-
-    it('sets parser status to IDLE if workingCopy is invalid', () => {
-      const {IDLE, WORKING} = LocusDeltaParser.status;
-
-      parser.workingCopy = null;
-      parser.status = WORKING;
-
-      parser.isValidLocus(loci);
-
-      assert.equal(parser.status, IDLE);
-    });
-
-    it('sets parser status to IDLE if new loci is invalid', () => {
-      const {IDLE, WORKING} = LocusDeltaParser.status;
-
-      parser.workingCopy = loci;
-      parser.status = WORKING;
-
-      parser.isValidLocus(null);
-
-      assert.equal(parser.status, IDLE);
-    });
   });
 });


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-447996

## This pull request addresses

Existing design was to do a sync if client gets an out-of-order Locus delta event. However, it turns out that this is not a great solution, because in 1k meetings, delta events often come in the wrong order and if clients then start sending sync requests, Locus becomes overloaded and even more events may come out-of-order, triggering more syncs and it just gets worse and worse.

## by making the following changes

UCF team has done a change to cache out-of-order events and wait for some time to see if the missing events eventually come. If the missing events don't arrive within a certain random timeout between 10s and 15s, a sync is done. Also if the cache grows too much (more than 5 events), sync is also done immediately.

UCF design is described [here](https://confluence-eng-gpk2.cisco.com/conf/display/WBXT/Locus+DTO+Handling+optimization+for+1k+meeting) - see "Locus OOO(out-of-order) DTO sync" section.

This PR implements these changes in JS-SDK, by modifying the existing delta events queue to be sorted by baseSequence and introducing a new "BLOCKED" state if the event first in the queue has `baseSequence` higher than our current sequence. If the queue is longer than MAX_OOO_DELTA_COUNT (defined as 5) we do a sync immediately. Also when we go to the "BLOCKED" state, we start a random timer, when that timer expires before we get the missing event, we also do a sync.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

existing tests + new added tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
