### PR TITLE
fix(plugin-meetings): added error for transcription not working when guest joins first

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4102,6 +4102,12 @@ export default class Meeting extends StatelessWebexPlugin {
         opened LLM web socket connection successfully.`
       );
 
+      if (!this.inMeetingActions.isClosedCaptionActive) {
+        LoggerProxy.logger.error(
+          `Meeting:index#receiveTranscription --> Transcription cannot be started until a licensed user enables it`
+        );
+      }
+
       // retrieve and pass the payload
       this.transcription.subscribe((payload) => {
         Trigger.trigger(


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-432028 

## This pull request addresses
Raising this PR to merge the changes in beta branch for PR: https://github.com/webex/webex-js-sdk/pull/2993 

## by making the following changes
Added error message when a guest starts the transcription and it doesn't work until host enables it. Using isClosedCaptionsActive property inside meeting object. This is set to false until any licensed user enables transcription. Once they enable it, transcription starts working for guest user.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
