### PR TITLE
fix: update publish command and add notice to raise PR against next branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+> ## Note: The master branch is being locked, and there won't be any more releases from that branch. Kindly initiate new pull requests against the next branch instead.
+
 We'd love for you to contribute to our source code and to make **Webex Javascript SDK** even better than it is today!
 If you would like to contribute to this repository by adding features, enhancements or bug fixes, you must follow our process:
 

--- a/packages/@webex/common-evented/package.json
+++ b/packages/@webex/common-evented/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/common-timers/package.json
+++ b/packages/@webex/common-timers/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/common/package.json
+++ b/packages/@webex/common/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/helper-html/package.json
+++ b/packages/@webex/helper-html/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/helper-image/package.json
+++ b/packages/@webex/helper-image/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/http-core/package.json
+++ b/packages/@webex/http-core/package.json
@@ -56,7 +56,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-avatar/package.json
+++ b/packages/@webex/internal-plugin-avatar/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-board/package.json
+++ b/packages/@webex/internal-plugin-board/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-calendar/package.json
+++ b/packages/@webex/internal-plugin-calendar/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-conversation/package.json
+++ b/packages/@webex/internal-plugin-conversation/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-device/package.json
+++ b/packages/@webex/internal-plugin-device/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-dss/package.json
+++ b/packages/@webex/internal-plugin-dss/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-ediscovery/package.json
+++ b/packages/@webex/internal-plugin-ediscovery/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-encryption/package.json
+++ b/packages/@webex/internal-plugin-encryption/package.json
@@ -60,7 +60,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-feature/package.json
+++ b/packages/@webex/internal-plugin-feature/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-flag/package.json
+++ b/packages/@webex/internal-plugin-flag/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-llm/package.json
+++ b/packages/@webex/internal-plugin-llm/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-locus/package.json
+++ b/packages/@webex/internal-plugin-locus/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-lyra/package.json
+++ b/packages/@webex/internal-plugin-lyra/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-mercury/package.json
+++ b/packages/@webex/internal-plugin-mercury/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-metrics/package.json
+++ b/packages/@webex/internal-plugin-metrics/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-presence/package.json
+++ b/packages/@webex/internal-plugin-presence/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-scheduler/package.json
+++ b/packages/@webex/internal-plugin-scheduler/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-search/package.json
+++ b/packages/@webex/internal-plugin-search/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-support/package.json
+++ b/packages/@webex/internal-plugin-support/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integratio:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-team/package.json
+++ b/packages/@webex/internal-plugin-team/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-user/package.json
+++ b/packages/@webex/internal-plugin-user/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-voicea/package.json
+++ b/packages/@webex/internal-plugin-voicea/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/internal-plugin-wdm/package.json
+++ b/packages/@webex/internal-plugin-wdm/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/jsdoctrinetest/package.json
+++ b/packages/@webex/jsdoctrinetest/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-attachment-actions/package.json
+++ b/packages/@webex/plugin-attachment-actions/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-authorization-browser-first-party/package.json
+++ b/packages/@webex/plugin-authorization-browser-first-party/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-authorization-browser/package.json
+++ b/packages/@webex/plugin-authorization-browser/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-authorization-node/package.json
+++ b/packages/@webex/plugin-authorization-node/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-authorization/package.json
+++ b/packages/@webex/plugin-authorization/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-device-manager/package.json
+++ b/packages/@webex/plugin-device-manager/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-logger/package.json
+++ b/packages/@webex/plugin-logger/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "yarn run -T tsc --declaration true --declarationDir ./dist",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test:broken": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-memberships/package.json
+++ b/packages/@webex/plugin-memberships/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-messages/package.json
+++ b/packages/@webex/plugin-messages/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-people/package.json
+++ b/packages/@webex/plugin-people/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-rooms/package.json
+++ b/packages/@webex/plugin-rooms/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-team-memberships/package.json
+++ b/packages/@webex/plugin-team-memberships/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-teams/package.json
+++ b/packages/@webex/plugin-teams/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/plugin-webhooks/package.json
+++ b/packages/@webex/plugin-webhooks/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/recipe-private-web-client/package.json
+++ b/packages/@webex/recipe-private-web-client/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/storage-adapter-local-forage/package.json
+++ b/packages/@webex/storage-adapter-local-forage/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/storage-adapter-local-storage/package.json
+++ b/packages/@webex/storage-adapter-local-storage/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/storage-adapter-session-storage/package.json
+++ b/packages/@webex/storage-adapter-session-storage/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/storage-adapter-spec/package.json
+++ b/packages/@webex/storage-adapter-spec/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-appid/package.json
+++ b/packages/@webex/test-helper-appid/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-automation/package.json
+++ b/packages/@webex/test-helper-automation/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-chai/package.json
+++ b/packages/@webex/test-helper-chai/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-file/package.json
+++ b/packages/@webex/test-helper-file/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-make-local-url/package.json
+++ b/packages/@webex/test-helper-make-local-url/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-mocha/package.json
+++ b/packages/@webex/test-helper-mocha/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-mock-web-socket/package.json
+++ b/packages/@webex/test-helper-mock-web-socket/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-mock-webex/package.json
+++ b/packages/@webex/test-helper-mock-webex/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-refresh-callback/package.json
+++ b/packages/@webex/test-helper-refresh-callback/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-retry/package.json
+++ b/packages/@webex/test-helper-retry/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-server/package.json
+++ b/packages/@webex/test-helper-server/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-helper-test-users/package.json
+++ b/packages/@webex/test-helper-test-users/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/test-users/package.json
+++ b/packages/@webex/test-users/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/webex-core/package.json
+++ b/packages/@webex/webex-core/package.json
@@ -66,7 +66,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/webex-server/package.json
+++ b/packages/@webex/webex-server/package.json
@@ -80,7 +80,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration:broken": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/webrtc/package.json
+++ b/packages/@webex/webrtc/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",

--- a/packages/@webex/xunit-with-logs/package.json
+++ b/packages/@webex/xunit-with-logs/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "deploy:npm": "echo yarn npm publish",
+    "deploy:npm": "yarn npm publish",
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #<[SPARK-449056](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-449056)>

## This pull request addresses

- Updates the publish command in each `package.json` file under packages
- Add notice to announce `master` branch will be frozen and to raise all the PRs against `next` branch

## by making the following changes

<img width="961" alt="Screenshot 2023-08-23 at 8 32 06 PM" src="https://github.com/webex/webex-js-sdk/assets/131742425/0ed49705-d4c3-406f-b5ec-724305f7d47f">


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
