### PR TITLE
fix(plugin-meetings): no-frames-received-sent-stats-error

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/global.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/global.ts
@@ -76,16 +76,6 @@ const STATS_DEFAULT = {
     },
   },
   resolutions: {
-    audio: {
-      send: {
-        width: 0,
-        height: 0,
-      },
-      recv: {
-        width: 0,
-        height: 0,
-      },
-    },
     video: {
       send: {
         width: 0,

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -420,9 +420,6 @@ export class StatsAnalyzer extends EventsScope {
       case 'inbound-rtp':
         this.processInboundRTPResult(getStatsResult, type);
         break;
-      case 'track':
-        this.processTrackResult(getStatsResult, type);
-        break;
       case 'remote-inbound-rtp':
       case 'remote-outbound-rtp':
         // @ts-ignore
@@ -881,6 +878,7 @@ export class StatsAnalyzer extends EventsScope {
     const mediaType = type || STATS.AUDIO_CORRELATE;
     const sendrecvType = STATS.SEND_DIRECTION;
 
+    this.processTrackResult(result, type, sendrecvType);
     if (result.bytesSent) {
       let kilobytes = 0;
 
@@ -955,6 +953,7 @@ export class StatsAnalyzer extends EventsScope {
     const mediaType = type || STATS.AUDIO_CORRELATE;
     const sendrecvType = STATS.RECEIVE_DIRECTION;
 
+    this.processTrackResult(result, type, sendrecvType);
     if (result.bytesReceived) {
       let kilobytes = 0;
 
@@ -1158,29 +1157,29 @@ export class StatsAnalyzer extends EventsScope {
    * @private
    * @param {*} result
    * @param {*} mediaType
+   * @param {*} sendrecvType
    * @returns {void}
    * @memberof StatsAnalyzer
    */
-  private processTrackResult(result: any, mediaType: any) {
-    if (!result || result.type !== 'track') {
+  private processTrackResult(result: any, mediaType: any, sendrecvType: any) {
+    if (!result || mediaType === STATS.AUDIO_CORRELATE) {
       return;
     }
-    if (result.type !== 'track') return;
-
-    const sendrecvType =
-      result.remoteSource === true ? STATS.RECEIVE_DIRECTION : STATS.SEND_DIRECTION;
-
+    if (result.type !== 'inbound-rtp' && result.type !== 'outbound-rtp') {
+      return;
+    }
     if (result.frameWidth && result.frameHeight) {
       this.statsResults.resolutions[mediaType][sendrecvType].width = result.frameWidth;
       this.statsResults.resolutions[mediaType][sendrecvType].height = result.frameHeight;
-      this.statsResults.resolutions[mediaType][sendrecvType].framesSent = result.framesSent;
-      this.statsResults.resolutions[mediaType][sendrecvType].hugeFramesSent = result.hugeFramesSent;
     }
 
     if (sendrecvType === STATS.RECEIVE_DIRECTION) {
       this.statsResults.resolutions[mediaType][sendrecvType].framesReceived = result.framesReceived;
       this.statsResults.resolutions[mediaType][sendrecvType].framesDecoded = result.framesDecoded;
       this.statsResults.resolutions[mediaType][sendrecvType].framesDropped = result.framesDropped;
+    } else if (sendrecvType === STATS.SEND_DIRECTION) {
+      this.statsResults.resolutions[mediaType][sendrecvType].framesSent = result.framesSent;
+      this.statsResults.resolutions[mediaType][sendrecvType].hugeFramesSent = result.hugeFramesSent;
     }
 
     if (result.trackIdentifier && mediaType !== STATS.AUDIO_CORRELATE) {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-251243

## This pull request addresses
The logs were filled with 'No video frames sent/received/decoded' and 'No audio samples sent/received/decoded' logs. 

Root cause:
RTCStatsReport used to send statistics for type = 'track' which had the details about the track like frames sent, frames height etc. Now this information is being sent in the type inbound-rtp and outbound-rtp statistics

Fixed the StatsAnalyzer to correctly populate the track results.

## by making the following changes
Calling the processTrackResult function from the  processInboundRTPResult and processOutboundRTPResult functions.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
