### PR TITLE
Revert "feat(plugin-meetings): video restrictions"

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -2587,18 +2587,10 @@ export default class Meeting extends StatelessWebexPlugin {
             requiredHints: [DISPLAY_HINTS.DISABLE_RAISE_HAND],
             displayHints: payload.info.userDisplayHints,
           }),
-          canEnableVideo:
-            (ControlsOptionsUtil.hasHints({
-              requiredHints: [DISPLAY_HINTS.ENABLE_VIDEO],
-              displayHints: payload.info.userDisplayHints,
-            }) &&
-              ControlsOptionsUtil.hasPolicies({
-                requiredPolicies: [SELF_POLICY.SUPPORT_VIDEO],
-                policies: this.selfUserPolicies,
-              })) ||
-            // @ts-ignore
-            !this.config.experimental.enableUnifiedMeetings ||
-            this.isLocusCall(),
+          canEnableVideo: ControlsOptionsUtil.hasHints({
+            requiredHints: [DISPLAY_HINTS.ENABLE_VIDEO],
+            displayHints: payload.info.userDisplayHints,
+          }),
           canDisableVideo: ControlsOptionsUtil.hasHints({
             requiredHints: [DISPLAY_HINTS.DISABLE_VIDEO],
             displayHints: payload.info.userDisplayHints,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -5707,16 +5707,6 @@ describe('plugin-meetings', () => {
               expectedEnabled: false,
             },
             {
-              actionName: 'canEnableVideo',
-              callType: 'CALL',
-              expectedEnabled: true,
-            },
-            {
-              actionName: 'canEnableVideo',
-              callType: 'MEETING',
-              expectedEnabled: false,
-            },
-            {
               actionName: 'canShareDesktop',
               callType: 'CALL',
               expectedEnabled: true,
@@ -5775,11 +5765,6 @@ describe('plugin-meetings', () => {
               requiredPolicies: [SELF_POLICY.SUPPORT_CAMERA_SHARE],
             },
             {
-              actionName: 'canEnableVideo',
-              requiredDisplayHints: [DISPLAY_HINTS.ENABLE_VIDEO],
-              requiredPolicies: [SELF_POLICY.SUPPORT_VIDEO],
-            },
-            {
               actionName: 'canBroadcastMessageToBreakout',
               requiredDisplayHints: [DISPLAY_HINTS.BROADCAST_MESSAGE_TO_BREAKOUT],
               requiredPolicies: [SELF_POLICY.SUPPORT_BROADCAST_MESSAGE],
@@ -5797,12 +5782,6 @@ describe('plugin-meetings', () => {
             {
               actionName: 'canShareDesktop',
               requiredDisplayHints: [DISPLAY_HINTS.SHARE_DESKTOP],
-              requiredPolicies: [],
-              enableUnifiedMeetings: false,
-            },
-            {
-              actionName: 'canEnableVideo',
-              requiredDisplayHints: [],
               requiredPolicies: [],
               enableUnifiedMeetings: false,
             },


### PR DESCRIPTION
Reverts webex/webex-js-sdk#3004
Write now we are not sure if canEnableVideo, which affects Start Video in in meeting actions, should also check for policy.
For SUPPORT_VIDEO policy we should stop user to have video on interstitial page as well and not just in meeting. We have to look for a solution for that.

This requires reverting as it's breaking video call for users who have the policy available