### PR TITLE
fix(board): fix integration board tests for download files

### DIFF
--- a/packages/@webex/internal-plugin-board/test/integration/spec/board.js
+++ b/packages/@webex/internal-plugin-board/test/integration/spec/board.js
@@ -109,7 +109,9 @@ describe('plugin-board', () => {
       it('uploads image to webex files', () =>
         participants[0].webex.internal.board
           ._uploadImage(board, fixture)
-          .then((scr) => participants[1].webex.internal.encryption.download(scr))
+          .then((scr) => {
+            participants[0].webex.logger.debug('@@@@', scr)
+            return participants[1].webex.internal.encryption.download(scr.loc, scr)})
           .then((downloadedFile) =>
             fh
               .isMatchingFile(downloadedFile, fixture)
@@ -142,7 +144,7 @@ describe('plugin-board', () => {
               res.image.scr
             );
           })
-          .then((decryptedScr) => participants[2].webex.internal.encryption.download(decryptedScr))
+          .then((decryptedScr) => participants[2].webex.internal.encryption.download(decryptedScr.loc, decryptedScr))
           .then((file) =>
             fh.isMatchingFile(file, fixture).then((result) => assert.deepEqual(result, true))
           );
@@ -190,7 +192,7 @@ describe('plugin-board', () => {
 
       it('matches file file downloaded', () =>
         participants[0].webex.internal.encryption
-          .download(testScr)
+          .download(testScr.loc, testScr)
           .then((downloadedFile) =>
             fh
               .isMatchingFile(downloadedFile, fixture)
@@ -199,7 +201,7 @@ describe('plugin-board', () => {
 
       it('allows others to download image', () =>
         participants[2].webex.internal.encryption
-          .download(testScr)
+          .download(testScr.loc, testScr)
           .then((downloadedFile) =>
             fh
               .isMatchingFile(downloadedFile, fixture)
@@ -245,7 +247,7 @@ describe('plugin-board', () => {
             })
             .then(() =>
               participants[0].webex.internal.encryption
-                .download(testScr)
+                .download(testScr.loc, testScr)
                 .then((downloadedFile) => fh.isMatchingFile(downloadedFile, fixture))
                 .then((res) => assert.isTrue(res))
             );


### PR DESCRIPTION
## This pull request addresses
recently merged https://github.com/webex/webex-js-sdk/pull/2925/files which changes how files are downloaded. the board integration tests download files and were not updated (somehow the previous PR got green build, anyways...)

## by making the following changes
updated the packages/@webex/internal-plugin-board/test/integration/spec/board.js tests

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
