### PR TITLE
feat(pre-join): add new correlationId logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,8 @@ jobs:
       COVERAGE: true
     steps:
       - checkout_and_fetch_tags
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          chrome-version: 116.0.5845.96 # TODO: remove when chromedriver downloads are fixed
       - install_graphicsmagick_and_libgcrypt
       - restore_node_modules
       - restore_built_packages

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -594,7 +594,7 @@ export default class Meeting extends StatelessWebexPlugin {
      */
     if (attrs.correlationId) {
       LoggerProxy.logger.log(
-        `Meetings:index#constructor --> Initializing the meetin object with correlation id from app ${this.correlationId}`
+        `Meetings:index#constructor --> Initializing the meeting object with correlation id from app ${this.correlationId}`
       );
       this.correlationId = attrs.correlationId;
     } else {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -204,7 +204,6 @@ export enum ScreenShareFloorStatus {
  * @property {String} [meetingQuality.remote]
  * @property {Boolean} [rejoin]
  * @property {Boolean} [enableMultistream]
- * @property {String} [correlationId]
  */
 
 /**
@@ -593,7 +592,14 @@ export default class Meeting extends StatelessWebexPlugin {
      * @public
      * @memberof Meeting
      */
-    this.correlationId = this.id;
+    if (attrs.correlationId) {
+      LoggerProxy.logger.log(
+        `Meetings:index#constructor --> Initializing the meetin object with correlation id from app ${this.correlationId}`
+      );
+      this.correlationId = attrs.correlationId;
+    } else {
+      this.correlationId = this.id;
+    }
     /**
      * @instance
      * @type {String}
@@ -4251,16 +4257,9 @@ export default class Meeting extends StatelessWebexPlugin {
       joinSuccess = resolve;
     });
 
-    if (options.correlationId) {
-      this.setCorrelationId(options.correlationId);
-      LoggerProxy.logger.log(
-        `Meeting:index#join --> Using a new correlation id from app ${this.correlationId}`
-      );
-    }
-
     if (!this.hasJoinedOnce) {
       this.hasJoinedOnce = true;
-    } else if (!options.correlationId) {
+    } else {
       LoggerProxy.logger.log(
         `Meeting:index#join --> Generating a new correlation id for meeting ${this.id}`
       );
@@ -4768,7 +4767,7 @@ export default class Meeting extends StatelessWebexPlugin {
     };
 
     if (error instanceof Errors.SdpOfferCreationError) {
-      sendBehavioralMetric(BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE, error, this.id);
+      sendBehavioralMetric(BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE, error, this.correlationId);
 
       // @ts-ignore
       this.webex.internal.newMetrics.submitClientEvent({
@@ -4782,7 +4781,7 @@ export default class Meeting extends StatelessWebexPlugin {
       error instanceof Errors.SdpOfferHandlingError ||
       error instanceof Errors.SdpAnswerHandlingError
     ) {
-      sendBehavioralMetric(BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE, error, this.id);
+      sendBehavioralMetric(BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE, error, this.correlationId);
 
       // @ts-ignore
       this.webex.internal.newMetrics.submitClientEvent({
@@ -4794,7 +4793,7 @@ export default class Meeting extends StatelessWebexPlugin {
       });
     } else if (error instanceof Errors.SdpError) {
       // this covers also the case of Errors.IceGatheringError which extends Errors.SdpError
-      sendBehavioralMetric(BEHAVIORAL_METRICS.INVALID_ICE_CANDIDATE, error, this.id);
+      sendBehavioralMetric(BEHAVIORAL_METRICS.INVALID_ICE_CANDIDATE, error, this.correlationId);
 
       // @ts-ignore
       this.webex.internal.newMetrics.submitClientEvent({

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1054,6 +1054,7 @@ export default class Meetings extends WebexPlugin {
    * @param {string} [type] - the optional specified type, such as locusId
    * @param {Boolean} useRandomDelayForInfo - whether a random delay should be added to fetching meeting info
    * @param {Object} infoExtraParams extra parameters to be provided when fetching meeting info
+   * @param {string} correlationId - the optional specified correlationId
    * @returns {Promise<Meeting>} A new Meeting.
    * @public
    * @memberof Meetings
@@ -1062,7 +1063,8 @@ export default class Meetings extends WebexPlugin {
     destination: string,
     type: string = null,
     useRandomDelayForInfo = false,
-    infoExtraParams = {}
+    infoExtraParams = {},
+    correlationId: string = undefined
   ) {
     // TODO: type should be from a dictionary
 
@@ -1112,7 +1114,8 @@ export default class Meetings extends WebexPlugin {
               targetDest,
               type,
               useRandomDelayForInfo,
-              infoExtraParams
+              infoExtraParams,
+              correlationId
             ).then((createdMeeting: any) => {
               // If the meeting was successfully created.
               if (createdMeeting && createdMeeting.on) {
@@ -1166,6 +1169,7 @@ export default class Meetings extends WebexPlugin {
    * @param {String} type see create()
    * @param {Boolean} useRandomDelayForInfo whether a random delay should be added to fetching meeting info
    * @param {Object} infoExtraParams extra parameters to be provided when fetching meeting info
+   * @param {String} correlationId the optional specified correlationId
    * @returns {Promise} a new meeting instance complete with meeting info and destination
    * @private
    * @memberof Meetings
@@ -1174,7 +1178,8 @@ export default class Meetings extends WebexPlugin {
     destination: any,
     type: string = null,
     useRandomDelayForInfo = false,
-    infoExtraParams = {}
+    infoExtraParams = {},
+    correlationId: string = undefined
   ) {
     const meeting = new Meeting(
       {
@@ -1188,6 +1193,7 @@ export default class Meetings extends WebexPlugin {
         meetingInfoProvider: this.meetingInfo,
         destination,
         destinationType: type,
+        correlationId,
       },
       {
         // @ts-ignore

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -187,6 +187,7 @@ describe('plugin-meetings', () => {
   let testDestination;
   let membersSpy;
   let meetingRequestSpy;
+  let correlationId;
 
   beforeEach(() => {
     webex = new MockWebex({
@@ -245,6 +246,7 @@ describe('plugin-meetings', () => {
     test3 = `test3-${uuid.v4()}`;
     test4 = `test4-${uuid.v4()}`;
     testDestination = `testDestination-${uuid.v4()}`;
+    correlationId = uuid.v4();
 
     meeting = new Meeting(
       {
@@ -254,6 +256,7 @@ describe('plugin-meetings', () => {
         locus: {url: url1},
         destination: testDestination,
         destinationType: _MEETING_ID_,
+        correlationId,
       },
       {
         parent: webex,
@@ -272,9 +275,11 @@ describe('plugin-meetings', () => {
           assert.exists(meeting.options);
           assert.exists(meeting.attrs);
           assert.exists(meeting.id);
+          assert.exists(meeting.correlationId);
           assert.equal(meeting.userId, uuid1);
           assert.equal(meeting.resource, uuid2);
           assert.equal(meeting.deviceUrl, uuid3);
+          assert.equal(meeting.correlationId, correlationId);
           assert.deepEqual(meeting.meetingInfo, {});
           assert.instanceOf(meeting.members, Members);
           assert.calledOnceWithExactly(
@@ -325,6 +330,21 @@ describe('plugin-meetings', () => {
           assert.instanceOf(meeting.mediaRequestManagers.screenShareAudio, MediaRequestManager);
           assert.instanceOf(meeting.mediaRequestManagers.screenShareVideo, MediaRequestManager);
         });
+
+        it('uses meeting id as correlation id if not provided in constructor', () => {
+          const newMeeting = new Meeting({
+            userId: uuid1,
+            resource: uuid2,
+            deviceUrl: uuid3,
+            locus: {url: url1},
+            destination: testDestination,
+            destinationType: _MEETING_ID_,
+          },
+          {
+            parent: webex,
+          });
+          assert.equal(newMeeting.correlationId, newMeeting.id);
+        })
 
         describe('creates ReceiveSlot manager instance', () => {
           let mockReceiveSlotManagerCtor;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -679,23 +679,26 @@ describe('plugin-meetings', () => {
 
         it('calls createMeeting and returns its promise', async () => {
           const FAKE_USE_RANDOM_DELAY = true;
-          const create = webex.meetings.create(test1, test2, FAKE_USE_RANDOM_DELAY);
+          const correlationId = 'my-correlationId';
+          const create = webex.meetings.create(test1, test2, FAKE_USE_RANDOM_DELAY, {}, correlationId);
 
           assert.exists(create.then);
           await create;
           assert.calledOnce(webex.meetings.createMeeting);
-          assert.calledWith(webex.meetings.createMeeting, test1, test2, FAKE_USE_RANDOM_DELAY, {});
+          assert.calledWith(webex.meetings.createMeeting, test1, test2, FAKE_USE_RANDOM_DELAY, {}, correlationId);
         });
 
         it('calls createMeeting with extra info params and returns its promise', async () => {
           const FAKE_USE_RANDOM_DELAY = false;
+          const correlationId = 'my-correlationId';
+
           const FAKE_INFO_EXTRA_PARAMS = {mtid: 'm9fe0afd8c435e892afcce9ea25b97046', joinTXId: 'TSmrX61wNF'};
-          const create = webex.meetings.create(test1, test2, FAKE_USE_RANDOM_DELAY, FAKE_INFO_EXTRA_PARAMS);
+          const create = webex.meetings.create(test1, test2, FAKE_USE_RANDOM_DELAY, FAKE_INFO_EXTRA_PARAMS, correlationId);
 
           assert.exists(create.then);
           await create;
           assert.calledOnce(webex.meetings.createMeeting);
-          assert.calledWith(webex.meetings.createMeeting, test1, test2, FAKE_USE_RANDOM_DELAY, FAKE_INFO_EXTRA_PARAMS);
+          assert.calledWith(webex.meetings.createMeeting, test1, test2, FAKE_USE_RANDOM_DELAY, FAKE_INFO_EXTRA_PARAMS, correlationId);
         });
 
         it('creates a new meeting when a scheduled meeting exists in the conversation', async () => {
@@ -1095,6 +1098,9 @@ describe('plugin-meetings', () => {
             if (expectedMeetingData.meetingJoinUrl) {
               assert.equal(meeting.meetingJoinUrl, expectedMeetingData.meetingJoinUrl);
             }
+            if(expectedMeetingData.correlationId) {
+              assert.equal(meeting.correlationId, expectedMeetingData.correlationId);
+            }
             assert.equal(meeting.destination, destination);
             assert.equal(meeting.destinationType, type);
             assert.calledWith(
@@ -1124,6 +1130,7 @@ describe('plugin-meetings', () => {
             const expectedMeetingData = {
               permissionToken: 'PT',
               meetingJoinUrl: 'meetingJoinUrl',
+              correlationId: meeting.id,
             };
 
             checkCreateWithoutDelay(meeting, 'test destination', 'test type', {}, expectedMeetingData);
@@ -1334,6 +1341,16 @@ describe('plugin-meetings', () => {
             );
             checkCreateWithoutDelay(meeting, FAKE_LOCUS_MEETING, 'test type');
           });
+
+          it('creates meeting with the correlationId provided', async () => {
+            const meeting = await webex.meetings.createMeeting('test destination', 'test type', false, {}, 'my-correlationId');
+
+            const expectedMeetingData = {
+              correlationId: 'my-correlationId',
+            };
+
+            checkCreateWithoutDelay(meeting, 'test destination', 'test type', {}, expectedMeetingData);
+          })
         });
 
         describe('rejected MeetingInfo.#fetchMeetingInfo', () => {


### PR DESCRIPTION
# COMPLETES [SPARK-454228](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-454228)

## This pull request addresses
- at the moment, correlationId is passed to the join method on the meeting object in SDK. This is too late in the flow. Updating correlationID in SDK should be done as part of the createMeeting method.
- needed for pre-join CA metrics 

## by making the following changes
- remove correlationId options from public join method to public create method.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
-unit test, manual test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
