### PR TITLE
feat(SendSlotsManager): initial setup and related meeting changes (#1)

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -12,7 +12,6 @@ import {
   MediaContent,
   MediaType,
   RemoteTrackType,
-  SendSlot,
 } from '@webex/internal-media-core';
 
 import {
@@ -102,6 +101,7 @@ import {
 } from '../meeting-info/meeting-info-v2';
 import BrowserDetection from '../common/browser-detection';
 import {CSI, ReceiveSlotManager} from '../multistream/receiveSlotManager';
+import SendSlotManager from '../multistream/sendSlotManager';
 import {MediaRequestManager} from '../multistream/mediaRequestManager';
 import {
   Configuration as RemoteMediaManagerConfiguration,
@@ -553,7 +553,7 @@ export default class Meeting extends StatelessWebexPlugin {
   namespace = MEETINGS;
   annotationInfo: AnnotationInfo;
   allowMediaInLobby: boolean;
-  sendSlots = new Map<MediaType, SendSlot>();
+  sendSlotManager: SendSlotManager = new SendSlotManager(LoggerProxy);
 
   /**
    * @param {Object} attrs
@@ -5212,13 +5212,11 @@ export default class Meeting extends StatelessWebexPlugin {
     this.mediaProperties.setMediaPeerConnection(mc);
     this.setupMediaConnectionListeners();
 
-    // create a send slot for each media type
-    // TODO: in some cases we may not want to create send slots for all media types
     if (this.isMultistream) {
-      this.sendSlots.set(MediaType.VideoMain, mc.createSendSlot(MediaType.VideoMain));
-      this.sendSlots.set(MediaType.AudioMain, mc.createSendSlot(MediaType.AudioMain));
-      this.sendSlots.set(MediaType.VideoSlides, mc.createSendSlot(MediaType.VideoSlides));
-      this.sendSlots.set(MediaType.AudioSlides, mc.createSendSlot(MediaType.AudioSlides));
+      this.sendSlotManager.createSlot(mc, MediaType.VideoMain, false);
+      this.sendSlotManager.createSlot(mc, MediaType.AudioMain, false);
+      this.sendSlotManager.createSlot(mc, MediaType.VideoSlides, false);
+      this.sendSlotManager.createSlot(mc, MediaType.AudioSlides, false);
     }
 
     // publish the streams
@@ -5693,7 +5691,6 @@ export default class Meeting extends StatelessWebexPlugin {
   };
 
   /**
-   * TODO: Make changes here to activate and deactivate streams when sendslots manager is ready
    * Updates the media connection - it allows to enable/disable all audio/video/share in the meeting.
    * This does not affect the published tracks, so for example if a microphone track is published and
    * updateMedia({audioEnabled: false}) is called, the audio will not be sent or received anymore,
@@ -5725,41 +5722,35 @@ export default class Meeting extends StatelessWebexPlugin {
       return this.enqueueMediaUpdate(MEDIA_UPDATE_TYPE.UPDATE_MEDIA, options);
     }
 
-    if (this.isMultistream) {
-      if (videoEnabled !== undefined) {
-        throw new Error(
-          'enabling/disabling video in a meeting is not supported for multistream, it can only be done upfront when calling addMedia()'
-        );
-      }
-
-      if (receiveShare !== undefined) {
-        throw new Error(
-          'toggling receiveShare in a multistream meeting is not supported, to control receiving screen share call meeting.remoteMediaManager.setLayout() with appropriate layout'
-        );
-      }
+    if (this.isMultistream && receiveShare !== undefined) {
+      throw new Error(
+        'toggling receiveShare in a multistream meeting is not supported, to control receiving screen share call meeting.remoteMediaManager.setLayout() with appropriate layout'
+      );
     }
 
     if (audioEnabled !== undefined) {
       this.mediaProperties.mediaDirection.sendAudio = audioEnabled;
       this.mediaProperties.mediaDirection.receiveAudio = audioEnabled;
       this.audio.enable(this, audioEnabled);
+      if (this.isMultistream) {
+        this.sendSlotManager.setActive(MediaType.AudioMain, audioEnabled);
+      }
     }
 
     if (videoEnabled !== undefined) {
       this.mediaProperties.mediaDirection.sendVideo = videoEnabled;
       this.mediaProperties.mediaDirection.receiveVideo = videoEnabled;
       this.video.enable(this, videoEnabled);
+      if (this.isMultistream) {
+        this.sendSlotManager.setActive(MediaType.VideoMain, videoEnabled);
+      }
     }
 
     if (receiveShare !== undefined) {
       this.mediaProperties.mediaDirection.receiveShare = receiveShare;
     }
 
-    if (this.isMultistream) {
-      if (audioEnabled !== undefined) {
-        await this.mediaProperties.webrtcMediaConnection.enableMultistreamAudio(audioEnabled);
-      }
-    } else {
+    if (!this.isMultistream) {
       await this.updateTranscodedMediaConnection();
     }
 
@@ -6829,12 +6820,12 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     if (shouldEnableMusicMode) {
-      await this.mediaProperties.webrtcMediaConnection.setCodecParameters(MediaType.AudioMain, {
+      await this.sendSlotManager.setCodecParameters(MediaType.AudioMain, {
         maxaveragebitrate: '64000',
         maxplaybackrate: '48000',
       });
     } else {
-      await this.mediaProperties.webrtcMediaConnection.deleteCodecParameters(MediaType.AudioMain, [
+      await this.sendSlotManager.deleteCodecParameters(MediaType.AudioMain, [
         'maxaveragebitrate',
         'maxplaybackrate',
       ]);
@@ -6910,7 +6901,7 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   private async publishStream(stream: LocalStream, mediaType: MediaType) {
     if (this.isMultistream && this.mediaProperties.webrtcMediaConnection) {
-      await this.sendSlots.get(mediaType).publishStream(stream);
+      await this.sendSlotManager.publishStream(mediaType, stream);
     }
   }
 
@@ -6922,7 +6913,7 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   private async unpublishStream(mediaType: MediaType) {
     if (this.isMultistream && this.mediaProperties.webrtcMediaConnection) {
-      await this.sendSlots.get(mediaType).unpublishStream();
+      await this.sendSlotManager.unpublishStream(mediaType);
     }
   }
 

--- a/packages/@webex/plugin-meetings/src/multistream/sendSlotManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/sendSlotManager.ts
@@ -1,0 +1,162 @@
+import {
+  SendSlot,
+  MediaType,
+  LocalStream,
+  MultistreamRoapMediaConnection,
+} from '@webex/internal-media-core';
+
+export default class SendSlotManager {
+  private readonly slots: Map<MediaType, SendSlot> = new Map();
+  private readonly LoggerProxy: any;
+
+  constructor(LoggerProxy: any) {
+    this.LoggerProxy = LoggerProxy;
+  }
+
+  /**
+   * This method is used to create a sendSlot for the given mediaType and returns the created sendSlot
+   * @param {MultistreamRoapMediaConnection} mediaConnection MultistreamRoapMediaConnection for which a sendSlot needs to be created
+   * @param {MediaType} mediaType MediaType for which a sendSlot needs to be created (AUDIO_MAIN/VIDEO_MAIN/AUDIO_SLIDES/VIDEO_SLIDES)
+   * @param {boolean} active This is optional boolean to set the active state of the sendSlot. Default is true
+   * @returns {SendSlot} slot The created sendSlot
+   */
+  public createSlot(
+    mediaConnection: MultistreamRoapMediaConnection,
+    mediaType: MediaType,
+    active = true
+  ): SendSlot {
+    if (this.slots.has(mediaType)) {
+      throw new Error(`Slot for ${mediaType} already exists`);
+    }
+
+    const slot: SendSlot = mediaConnection.createSendSlot(mediaType, active);
+
+    this.slots.set(mediaType, slot);
+
+    this.LoggerProxy.logger.info(
+      `SendSlotsManager->createSlot#Created slot for ${mediaType} with active ${active}`
+    );
+
+    return slot;
+  }
+
+  /**
+   * This method is used to retrieve the sendSlot for the given mediaType
+   * @param {MediaType} mediaType of which the slot needs to be retrieved
+   * @returns {SendSlot}
+   */
+  public getSlot(mediaType: MediaType): SendSlot {
+    const slot = this.slots.get(mediaType);
+
+    if (!slot) {
+      throw new Error(`Slot for ${mediaType} does not exist`);
+    }
+
+    return slot;
+  }
+
+  /**
+   * This method publishes the given stream to the sendSlot for the given mediaType
+   * @param {MediaType} mediaType MediaType of the sendSlot to which a stream needs to be published (AUDIO_MAIN/VIDEO_MAIN/AUDIO_SLIDES/VIDEO_SLIDES)
+   * @param {LocalStream} stream LocalStream to be published
+   * @returns {Promise<void>}
+   */
+  public async publishStream(mediaType: MediaType, stream: LocalStream): Promise<void> {
+    const slot = this.slots.get(mediaType);
+
+    if (!slot) {
+      throw new Error(`Slot for ${mediaType} does not exist`);
+    }
+
+    await slot.publishStream(stream);
+
+    this.LoggerProxy.logger.info(
+      `SendSlotsManager->publishStream#Published stream for ${mediaType} and stream ${stream}`
+    );
+  }
+
+  /**
+   * This method unpublishes the stream from the sendSlot of the given mediaType
+   * @param {MediaType} mediaType MediaType of the sendSlot from which a stream needs to be unpublished (AUDIO_MAIN/VIDEO_MAIN/AUDIO_SLIDES/VIDEO_SLIDES)
+   * @returns {Promise<void>}
+   */
+  public async unpublishStream(mediaType: MediaType): Promise<void> {
+    const slot = this.slots.get(mediaType);
+
+    if (!slot) {
+      throw new Error(`Slot for ${mediaType} does not exist`);
+    }
+
+    await slot.unpublishStream();
+
+    this.LoggerProxy.logger.info(
+      `SendSlotsManager->unpublishStream#Unpublished stream for ${mediaType}`
+    );
+  }
+
+  /**
+   * This method is used to set the active state of the sendSlot for the given mediaType
+   * @param {MediaType} mediaType The MediaType of the sendSlot for which the active state needs to be set (AUDIO_MAIN/VIDEO_MAIN/AUDIO_SLIDES/VIDEO_SLIDES)
+   * @param {boolean} active The boolean to set the active state of the sendSlot. Default is true
+   * @returns {void}
+   */
+  public setActive(mediaType: MediaType, active = true): void {
+    const slot = this.slots.get(mediaType);
+
+    if (!slot) {
+      throw new Error(`Slot for ${mediaType} does not exist`);
+    }
+
+    slot.active = active;
+
+    this.LoggerProxy.logger.info(
+      `SendSlotsManager->setActive#Set active for ${mediaType} to ${active}`
+    );
+  }
+
+  /**
+   * This method is used to set the codec parameters for the sendSlot of the given mediaType
+   * @param {MediaType} mediaType MediaType of the sendSlot for which the codec parameters needs to be set (AUDIO_MAIN/VIDEO_MAIN/AUDIO_SLIDES/VIDEO_SLIDES)
+   * @param {Object} codecParameters
+   * @returns {Promise<void>}
+   */
+  public async setCodecParameters(
+    mediaType: MediaType,
+    codecParameters: {
+      [key: string]: string | undefined; // As per ts-sdp undefined is considered as a valid value to be used for codec parameters
+    }
+  ): Promise<void> {
+    // These codec parameter changes underneath are SDP value changes that are taken care by WCME automatically. So no need for any change in streams from the web sdk side
+    const slot = this.slots.get(mediaType);
+
+    if (!slot) {
+      throw new Error(`Slot for ${mediaType} does not exist`);
+    }
+
+    await slot.setCodecParameters(codecParameters);
+
+    this.LoggerProxy.logger.info(
+      `SendSlotsManager->setCodecParameters#Set codec parameters for ${mediaType} to ${codecParameters}`
+    );
+  }
+
+  /**
+   * This method is used to delete the codec parameters for the sendSlot of the given mediaType
+   * @param {MediaType} mediaType MediaType of the sendSlot for which the codec parameters needs to be deleted (AUDIO_MAIN/VIDEO_MAIN/AUDIO_SLIDES/VIDEO_SLIDES)
+   * @param {Array<String>} parameters Array of keys of the codec parameters to be deleted
+   * @returns {Promise<void>}
+   */
+  public async deleteCodecParameters(mediaType: MediaType, parameters: string[]): Promise<void> {
+    const slot = this.slots.get(mediaType);
+
+    if (!slot) {
+      throw new Error(`Slot for ${mediaType} does not exist`);
+    }
+
+    await slot.deleteCodecParameters(parameters);
+
+    this.LoggerProxy.logger.info(
+      `SendSlotsManager->deleteCodecParameters#Deleted the following codec parameters -> ${parameters} for ${mediaType}`
+    );
+  }
+}

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -66,6 +66,7 @@ import Metrics from '@webex/plugin-meetings/src/metrics';
 import BEHAVIORAL_METRICS from '@webex/plugin-meetings/src/metrics/constants';
 import {MediaRequestManager} from '@webex/plugin-meetings/src/multistream/mediaRequestManager';
 import * as ReceiveSlotManagerModule from '@webex/plugin-meetings/src/multistream/receiveSlotManager';
+import * as SendSlotManagerModule from '@webex/plugin-meetings/src/multistream/sendSlotManager';
 
 import LLM from '@webex/internal-plugin-llm';
 import Mercury from '@webex/internal-plugin-mercury';
@@ -408,6 +409,36 @@ describe('plugin-meetings', () => {
             assert.calledOnce(meeting.members.findMemberByCsi);
             assert.calledWith(meeting.members.findMemberByCsi, 123);
             assert.equal(memberId, undefined);
+          });
+        });
+
+        describe('creates SendSlot manager instance', () => {
+          let mockSendSlotManagerCtor;
+
+          beforeEach(() => {
+            mockSendSlotManagerCtor = sinon
+              .stub(SendSlotManagerModule,'default');
+              console.log(mockSendSlotManagerCtor);
+
+            meeting = new Meeting(
+              {
+                userId: uuid1,
+                resource: uuid2,
+                deviceUrl: uuid3,
+                locus: {url: url1},
+                destination: testDestination,
+                destinationType: _MEETING_ID_,
+              },
+              {
+                parent: webex,
+              }
+            );
+
+            meeting.mediaProperties.webrtcMediaConnection = {createSendSlot: sinon.stub()};
+          });
+
+          it('calls SendSlotManager constructor', () => {
+            assert.calledOnce(mockSendSlotManagerCtor);
           });
         });
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/sendSlotManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/sendSlotManager.ts
@@ -1,0 +1,216 @@
+import SendSlotManager from '@webex/plugin-meetings/src/multistream/sendSlotManager';
+import { LocalStream, MediaType, MultistreamRoapMediaConnection } from "@webex/internal-media-core";
+import {expect} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+
+describe('SendSlotsManager', () => {
+    let sendSlotsManager: SendSlotManager;
+    const LoggerProxy = {
+        logger: {
+            info: sinon.stub(),
+        },
+    };
+    
+    beforeEach(() => {
+        sendSlotsManager = new SendSlotManager(LoggerProxy);
+    });
+    
+    describe('createSlot', () => {
+        let mediaConnection;
+        const mediaType = MediaType.AudioMain;
+
+        beforeEach(() => {
+            mediaConnection = {
+                createSendSlot: sinon.stub(),
+            } as MultistreamRoapMediaConnection;
+        });
+
+        it('should create a slot for the given mediaType', () => {
+            sendSlotsManager.createSlot(mediaConnection, mediaType);
+        
+            expect(mediaConnection.createSendSlot.calledWith(mediaType, true));
+        });
+
+        it('should create a slot for the given mediaType & active state', () => {
+            sendSlotsManager.createSlot(mediaConnection, mediaType, false);
+        
+            expect(mediaConnection.createSendSlot.calledWith(mediaType, false));
+        });
+    
+        it('should throw an error if a slot for the given mediaType already exists', () => {
+            sendSlotsManager.createSlot(mediaConnection, mediaType);
+        
+            expect(() => sendSlotsManager.createSlot(mediaConnection, mediaType)).to.throw(`Slot for ${mediaType} already exists`);
+        });
+    });
+
+    describe('getSlot', () => {
+        const mediaType = MediaType.AudioMain;
+        let mediaConnection;
+
+        beforeEach(() => {
+            mediaConnection = {
+                createSendSlot: sinon.stub().returns({}),
+            } as MultistreamRoapMediaConnection;
+        });
+
+        it('should return the slot for the given mediaType', () => {
+            const slot = sendSlotsManager.createSlot(mediaConnection,mediaType);
+        
+            expect(sendSlotsManager.getSlot(mediaType)).to.equal(slot);
+        });
+
+        it('should throw an error if a slot for the given mediaType does not exist', () => {
+            expect(() => sendSlotsManager.getSlot(mediaType)).to.throw(`Slot for ${mediaType} does not exist`);
+        });
+    });
+    
+    describe('publishStream', () => {
+        let mediaConnection;
+        const mediaType = MediaType.AudioMain;
+        const stream = {} as LocalStream;
+
+        beforeEach(() => {
+            mediaConnection = {
+                createSendSlot: sinon.stub(),
+            } as MultistreamRoapMediaConnection;
+        });
+
+        it('should publish the given stream to the sendSlot for the given mediaType', async () => {
+            const slot = {
+                publishStream: sinon.stub().resolves(),
+            };
+            mediaConnection.createSendSlot.returns(slot);
+            sendSlotsManager.createSlot(mediaConnection, mediaType);
+        
+            await sendSlotsManager.publishStream(mediaType, stream);
+        
+            expect(slot.publishStream.calledWith(stream));
+        });
+
+        it('should throw an error if a slot for the given mediaType does not exist', (done) => {
+            sendSlotsManager.publishStream(mediaType, stream).catch((error) => {
+                expect(error.message).to.equal(`Slot for ${mediaType} does not exist`);
+                done();
+            });
+        });
+    });
+
+    describe('unpublishStream', () => {
+        let mediaConnection;
+        const mediaType = MediaType.AudioMain;
+
+        beforeEach(() => {
+            mediaConnection = {
+                createSendSlot: sinon.stub(),
+            } as MultistreamRoapMediaConnection;
+        });
+
+        it('should unpublish the stream from the sendSlot of the given mediaType', async () => {
+            const slot = {
+                unpublishStream: sinon.stub().resolves(),
+            };
+            mediaConnection.createSendSlot.returns(slot);
+            sendSlotsManager.createSlot(mediaConnection, mediaType);
+        
+            await sendSlotsManager.unpublishStream(mediaType);
+        
+            expect(slot.unpublishStream.called);
+        });
+
+        it('should throw an error if a slot for the given mediaType does not exist',(done) => {
+            sendSlotsManager.unpublishStream(mediaType).catch((error) => {
+                expect(error.message).to.equal(`Slot for ${mediaType} does not exist`);
+                done();
+            });
+        });
+    });
+
+    describe('setActive', () => {
+        let mediaConnection;
+        const mediaType = MediaType.AudioMain;
+
+        beforeEach(() => {
+            mediaConnection = {
+                createSendSlot: sinon.stub(),
+            } as MultistreamRoapMediaConnection;
+        });
+
+        it('should set the active state of the sendSlot for the given mediaType', async () => {
+            const slot = {
+                setActive: sinon.stub().resolves(),
+            };
+            mediaConnection.createSendSlot.returns(slot);
+            sendSlotsManager.createSlot(mediaConnection, mediaType);
+        
+            await sendSlotsManager.setActive(mediaType,true);
+        
+            expect(slot.setActive.called);
+        });
+
+        it('should throw an error if a slot for the given mediaType does not exist', () => {
+            expect(() => sendSlotsManager.setActive(mediaType)).to.throw(`Slot for ${mediaType} does not exist`)
+        });
+    });
+
+    describe('setCodecParameters', () => {
+        let mediaConnection;
+        const mediaType = MediaType.AudioMain;
+        const codecParameters = {};
+
+        beforeEach(() => {
+            mediaConnection = {
+                createSendSlot: sinon.stub(),
+            } as MultistreamRoapMediaConnection;
+        });
+
+        it('should set the codec parameters of the sendSlot for the given mediaType', async () => {
+            const slot = {
+                setCodecParameters: sinon.stub().resolves(),
+            };
+            mediaConnection.createSendSlot.returns(slot);
+            sendSlotsManager.createSlot(mediaConnection, mediaType);
+        
+            await sendSlotsManager.setCodecParameters(mediaType, codecParameters);
+        
+            expect(slot.setCodecParameters.calledWith(codecParameters));
+        });
+
+        it('should throw an error if a slot for the given mediaType does not exist', (done) => {
+            sendSlotsManager.setCodecParameters(mediaType, codecParameters).catch((error) => {
+                expect(error.message).to.equal(`Slot for ${mediaType} does not exist`);
+                done();
+            });
+        });
+    });
+
+    describe('deleteCodecParameters', () => {
+        let mediaConnection;
+        const mediaType = MediaType.AudioMain;
+
+        beforeEach(() => {
+            mediaConnection = {
+                createSendSlot: sinon.stub(),
+            } as MultistreamRoapMediaConnection;
+        });
+
+        it('should delete the codec parameters of the sendSlot for the given mediaType', async () => {
+            const slot = {
+                deleteCodecParameters: sinon.stub().resolves(),
+            };
+            mediaConnection.createSendSlot.returns(slot);
+            sendSlotsManager.createSlot(mediaConnection, mediaType);
+        
+            await sendSlotsManager.deleteCodecParameters(mediaType,[]);
+        
+            expect(slot.deleteCodecParameters.called);
+        });
+
+        it('should throw an error if a slot for the given mediaType does not exist', (done) => {
+            sendSlotsManager.deleteCodecParameters(mediaType,[]).catch((error) => {
+                expect(error.message).to.equal(`Slot for ${mediaType} does not exist`);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
# COMPLETES [SPARK-448467](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-448467) & [SPARK-449102](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-449102)

## This pull request addresses

- Setting up of SendSlotManager and it's relevant UT
- Updating the usage of codecParameter APIs for music mode to SendSlots
