### PR TITLE
Spark 456521 adjust built metric fetch options

### DIFF
--- a/packages/@webex/http-core/src/index.js
+++ b/packages/@webex/http-core/src/index.js
@@ -59,10 +59,6 @@ export const protoprepareFetchOptions = curry(function protoprepareFetchOptions(
 
   lodashDefaults(options, defaultOptions);
 
-  if (!options.json && options.json !== false) {
-    Reflect.deleteProperty(options, 'json');
-  }
-
   options.logger = options.logger || this.logger || console;
 
   return _prepareFetchOptions(options);
@@ -95,7 +91,9 @@ const setRequestTimings = (options) => {
  */
 export const setTimingsAndFetch = (options) => {
   // call the fetch API
-  return fetch(setRequestTimings(options));
+  const opts = setRequestTimings(options);
+
+  return fetch(opts.uri, opts);
 };
 
 const defaultOptions = {

--- a/packages/@webex/http-core/src/request/utils.ts
+++ b/packages/@webex/http-core/src/request/utils.ts
@@ -56,7 +56,7 @@ export async function prepareFetchOptions(options: any): Promise<any> {
 
   options.headers = options.headers || {};
 
-  if (options.json === true) {
+  if (options.json) {
     // don't override existing accept header declared by user
     options.headers.accept = options.headers.accept || options.headers.Accept || 'application/json';
 
@@ -64,7 +64,7 @@ export async function prepareFetchOptions(options: any): Promise<any> {
     if (options.method !== 'GET' && options.method !== 'HEAD') {
       options.headers['content-type'] =
         options.headers['content-type'] || options.headers['Content-Type'] || 'application/json';
-      options.body = JSON.stringify(options.body);
+      options.body = JSON.stringify(options.json === true ? options.body : options.json);
     }
   } else if (options.json !== undefined) {
     Reflect.deleteProperty(options, 'json');

--- a/packages/@webex/http-core/src/request/utils.ts
+++ b/packages/@webex/http-core/src/request/utils.ts
@@ -56,6 +56,20 @@ export async function prepareFetchOptions(options: any): Promise<any> {
 
   options.headers = options.headers || {};
 
+  if (options.json === true) {
+    // don't override existing accept header declared by user
+    options.headers.accept = options.headers.accept || options.headers.Accept || 'application/json';
+
+    // don't override existing content-type header declared by user
+    if (options.method !== 'GET' && options.method !== 'HEAD') {
+      options.headers['content-type'] =
+        options.headers['content-type'] || options.headers['Content-Type'] || 'application/json';
+      options.body = JSON.stringify(options.body);
+    }
+  } else if (options.json !== undefined) {
+    Reflect.deleteProperty(options, 'json');
+  }
+
   options.download = new EventEmitter();
   options.upload = new EventEmitter();
 

--- a/packages/@webex/http-core/src/request/utils.ts
+++ b/packages/@webex/http-core/src/request/utils.ts
@@ -72,6 +72,7 @@ export async function prepareFetchOptions(options: any): Promise<any> {
 
   options.download = new EventEmitter();
   options.upload = new EventEmitter();
+  options.keepalive = true;
 
   return intercept(options, options.interceptors, 'Request').then(() => options);
 }

--- a/packages/@webex/http-core/test/unit/spec/index.js
+++ b/packages/@webex/http-core/test/unit/spec/index.js
@@ -42,12 +42,13 @@ describe('http-core index tests', () => {
 
     it('calls fetch with expected options', async () => {
       sinon.useFakeTimers(now);
-      const options = {};
+      const options = {uri: 'foo'};
 
       const newOptions = setTimingsAndFetch(options);
 
       sinon.assert.calledOnce(global.fetch);
-      sinon.assert.calledWith(global.fetch, {
+      sinon.assert.calledWith(global.fetch, 'foo', {
+        uri: 'foo',
         $timings: {requestStart: now, networkStart: now},
       });
       sinon.restore();

--- a/packages/@webex/http-core/test/unit/spec/index.js
+++ b/packages/@webex/http-core/test/unit/spec/index.js
@@ -23,6 +23,7 @@ describe('http-core index tests', () => {
           trackingid: 'undefined_1',
           'spark-user-agent': 'webex-js-sdk/development (node)',
         },
+        keepalive: true,
       });
 
       assert.equal(typeof options.logger, 'object');

--- a/packages/@webex/http-core/test/unit/spec/request/utils.js
+++ b/packages/@webex/http-core/test/unit/spec/request/utils.js
@@ -61,5 +61,17 @@ describe('Request utils', () => {
         });
       });
     });
+
+    it('updates body as expected when json = some object', async () => {
+      const options = {
+        json: {bar: 'baz'},
+        headers: {accept: 'foo', 'content-type': 'bar'},
+        interceptors: [WebexTrackingIdInterceptor.create(), UserAgentInterceptor.create()],
+      };
+
+      return utils.prepareFetchOptions(options).then(() => {
+        assert.equal(options.body, '{"bar":"baz"}');
+      });
+    });
   });
 });

--- a/packages/@webex/http-core/test/unit/spec/request/utils.js
+++ b/packages/@webex/http-core/test/unit/spec/request/utils.js
@@ -40,6 +40,7 @@ describe('Request utils', () => {
 
         assert.equal(options.download != undefined, true);
         assert.equal(options.upload != undefined, true);
+        assert.equal(options.keepalive, true);
       });
     });
 

--- a/packages/@webex/http-core/test/unit/spec/request/utils.js
+++ b/packages/@webex/http-core/test/unit/spec/request/utils.js
@@ -22,14 +22,42 @@ describe('Request utils', () => {
   describe('#prepareFetchOptions()', () => {
     it('updates options as expected', async () => {
       const options = {
+        json: true,
+        body: {foo: 'bar'},
+        headers: {},
         interceptors: [WebexTrackingIdInterceptor.create(), UserAgentInterceptor.create()],
       };
 
       return utils.prepareFetchOptions(options).then(() => {
-        assert.equal(Object.keys(options.headers).length, 2);
+        assert.deepEqual(options.headers, {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          trackingid: 'undefined_1',
+          'spark-user-agent': 'webex-js-sdk/development (node)',
+        });
+
+        assert.equal(options.body, '{"foo":"bar"}');
 
         assert.equal(options.download != undefined, true);
         assert.equal(options.upload != undefined, true);
+      });
+    });
+
+    it('updates options as expected when accept and content-type exist', async () => {
+      const options = {
+        json: true,
+        body: {foo: 'bar'},
+        headers: {accept: 'foo', 'content-type': 'bar'},
+        interceptors: [WebexTrackingIdInterceptor.create(), UserAgentInterceptor.create()],
+      };
+
+      return utils.prepareFetchOptions(options).then(() => {
+        assert.deepEqual(options.headers, {
+          accept: 'foo',
+          'content-type': 'bar',
+          trackingid: 'undefined_1',
+          'spark-user-agent': 'webex-js-sdk/development (node)',
+        });
       });
     });
   });


### PR DESCRIPTION
## COMPLETES

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-456521

## This pull request addresses

After more testing via a modified Cantina, the options returned from 
sdk.buildClientEventFetchRequestOptions() needed a few tweaks.

## by making the following changes

- added 'keepalive: true' instead of expecting it to be added in cantina
- convert body to JSON string when json=true
- default header content-type to 'application/json'
- default header accepts to 'application/json'

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Updated unit tests and manually tested.

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly
