### PR TITLE
fix(meeting): added noFramesSent noVideoEncoded events

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -308,6 +308,8 @@ export const EVENT_TRIGGERS = {
   MEETING_SELF_IS_SHARING_BLOCKED: 'meeting:self:isSharingBlocked',
   MEETING_CONTROLS_LAYOUT_UPDATE: 'meeting:layout:update',
   MEETING_ENTRY_EXIT_TONE_UPDATE: 'meeting:entryExitTone:update',
+  MEETING_NO_FRAMES_SENT: 'meeting:noFramesSent',
+  MEETING_NO_VIDEO_ENCODED: 'meeting:noVideoEncoded',
   MEMBERS_UPDATE: 'members:update',
   MEMBERS_CONTENT_UPDATE: 'members:content:update',
   MEMBERS_HOST_UPDATE: 'members:host:update',

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4520,6 +4520,35 @@ export default class Meeting extends StatelessWebexPlugin {
         },
       });
     });
+    this.statsAnalyzer.on(StatsAnalyzerEvents.NO_VIDEO_ENCODED, (data) => {
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.NO_VIDEO_ENCODED);
+      Trigger.trigger(
+        this,
+        {
+          file: 'meeting/index',
+          function: 'compareLastStatsResult',
+        },
+        EVENT_TRIGGERS.MEETING_NO_VIDEO_ENCODED,
+        data
+      );
+    });
+    this.statsAnalyzer.on(StatsAnalyzerEvents.NO_FRAMES_SENT, (data) => {
+      if (
+        (this.mediaProperties.mediaDirection?.sendVideo && data.mediaType === 'video') ||
+        (this.mediaProperties.mediaDirection?.sendShare && data.mediaType === 'share')
+      ) {
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.NO_FRAMES_SENT);
+        Trigger.trigger(
+          this,
+          {
+            file: 'meeting/index',
+            function: 'compareLastStatsResult',
+          },
+          EVENT_TRIGGERS.MEETING_NO_FRAMES_SENT,
+          data
+        );
+      }
+    });
   };
 
   /**

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -1,6 +1,8 @@
 // Metrics constants ----------------------------------------------------------
 
 const BEHAVIORAL_METRICS = {
+  NO_FRAMES_SENT: 'js_sdk_meetings_no_frames_sent',
+  NO_VIDEO_ENCODED: 'js_sdk_meetings_no_video_encoded',
   MEETINGS_REGISTRATION_FAILED: 'js_sdk_meetings_registration_failed',
   MEETINGS_REGISTRATION_SUCCESS: 'js_sdk_meetings_registration_success',
   MERCURY_CONNECTION_FAILURE: 'js_sdk_mercury_connection_failure',

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/global.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/global.ts
@@ -80,6 +80,7 @@ const STATS_DEFAULT = {
       send: {
         width: 0,
         height: 0,
+        framesSent: 0,
       },
       recv: {
         width: 0,
@@ -90,6 +91,7 @@ const STATS_DEFAULT = {
       send: {
         width: 0,
         height: 0,
+        framesSent: 0,
       },
       recv: {
         width: 0,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1329,6 +1329,71 @@ describe('plugin-meetings', () => {
               data: {intervalData: fakeData, networkType: 'wifi'},
             });
           });
+          it('NO_FRAMES_SENT triggers "meeting:noFramesSent" event and sends metrics', async () => {
+            meeting.mediaProperties.mediaDirection = {sendVideo: true};
+            statsAnalyzerStub.emit(
+              {file: 'test', function: 'test'},
+              StatsAnalyzerModule.EVENTS.NO_FRAMES_SENT,
+              {mediaType: 'video'}
+            );
+
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meeting),
+              {
+                file: 'meeting/index',
+                function: 'compareLastStatsResult',
+              },
+              EVENT_TRIGGERS.MEETING_NO_FRAMES_SENT,
+              {
+                mediaType: 'video',
+              }
+            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.NO_FRAMES_SENT);
+          });
+          it('NO_FRAMES_SENT triggers "meeting:noFramesSent" event and sends metrics for share', async () => {
+            meeting.mediaProperties.mediaDirection = {sendShare: true};
+            statsAnalyzerStub.emit(
+              {file: 'test', function: 'test'},
+              StatsAnalyzerModule.EVENTS.NO_FRAMES_SENT,
+              {mediaType: 'share'}
+            );
+
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meeting),
+              {
+                file: 'meeting/index',
+                function: 'compareLastStatsResult',
+              },
+              EVENT_TRIGGERS.MEETING_NO_FRAMES_SENT,
+              {
+                mediaType: 'share',
+              }
+            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.NO_FRAMES_SENT);
+          });
+          it('NO_VIDEO_ENCODED triggers "meeting:noVideoEncoded" event and sends metrics', async () => {
+            statsAnalyzerStub.emit(
+              {file: 'test', function: 'test'},
+              StatsAnalyzerModule.EVENTS.NO_VIDEO_ENCODED,
+              {mediaType: 'video'}
+            );
+
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meeting),
+              {
+                file: 'meeting/index',
+                function: 'compareLastStatsResult',
+              },
+              EVENT_TRIGGERS.MEETING_NO_VIDEO_ENCODED,
+              {
+                mediaType: 'video',
+              }
+            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.NO_VIDEO_ENCODED);
+          });
         });
       });
       describe('#acknowledge', () => {
@@ -3605,14 +3670,17 @@ describe('plugin-meetings', () => {
       describe('#setUpLocusServicesListener', () => {
         it('listens to the locus services update event', (done) => {
           const newLocusServices = {
-              services: {
-                record: {
-                  url: 'url',
-                }
+            services: {
+              record: {
+                url: 'url',
               },
+            },
           };
 
-          meeting.recordingController = {setServiceUrl: sinon.stub().returns(undefined), setSessionId: sinon.stub().returns(undefined)};
+          meeting.recordingController = {
+            setServiceUrl: sinon.stub().returns(undefined),
+            setSessionId: sinon.stub().returns(undefined),
+          };
 
           meeting.locusInfo.emit(
             {function: 'test', file: 'test'},
@@ -3620,7 +3688,10 @@ describe('plugin-meetings', () => {
             newLocusServices
           );
 
-          assert.calledWith(meeting.recordingController.setServiceUrl, newLocusServices.services.record.url);
+          assert.calledWith(
+            meeting.recordingController.setServiceUrl,
+            newLocusServices.services.record.url
+          );
           assert.calledOnce(meeting.recordingController.setSessionId);
           done();
         });


### PR DESCRIPTION
# COMPLETES #[SPARK-452740](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-452740)

## This pull request addresses

Currently, we don't send any metric when frames are not being sent for various reasons on mobile devices. If device is not sending videoFrames or video is not encoded, we are not triggering any event for that.

## by making the following changes

As part of this PR:
1) added an EVENT when video is encoded but frames are not sent in statsAnalyzer
2) added an EVENT when video is not being encoded in statsAnalyzer
3) Emitted two new EVENTS for the above scenarios
4) sending behavioral metric to Amplitude for above scenarios


### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
Test the following scenarios:
- when frames sent is 0
- when frames sent value is not changing
- when frames sent is 0 but video is encoded
- when video is not being encoded 

## Screenshot of samples page for the new events
![Screenshot 2023-09-06 at 5 04 32 PM](https://github.com/webex/webex-js-sdk/assets/72344404/4cb21ec7-a869-4c9f-b748-c3a0bc0c4bd4)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
