### PR TITLE
fix: geohint info missing in Locus join requests

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5427,6 +5427,10 @@ export default class Meeting extends StatelessWebexPlugin {
           url: this.deviceUrl,
           // @ts-ignore
           deviceType: this.config.deviceType,
+          // @ts-ignore
+          countryCode: this.webex.meetings.geoHintInfo?.countryCode,
+          // @ts-ignore
+          regionCode: this.webex.meetings.geoHintInfo?.regionCode,
         },
         preferTranscoding: !this.isMultistream,
       },

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -83,6 +83,8 @@ export type Config = {
   device: {
     url: string;
     deviceType: string;
+    countryCode?: string;
+    regionCode?: string;
   };
   correlationId: string;
   preferTranscoding: boolean;

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -185,11 +185,11 @@ export default class MeetingRequest extends StatelessWebexPlugin {
       body.deviceCapabilities = deviceCapabilities;
     }
     // @ts-ignore
-    if (this.webex.meetings.clientRegion) {
+    if (this.webex.meetings.geoHintInfo) {
       // @ts-ignore
-      body.device.countryCode = this.webex.meetings.clientRegion.countryCode;
+      body.device.countryCode = this.webex.meetings.geoHintInfo.countryCode;
       // @ts-ignore
-      body.device.regionCode = this.webex.meetings.clientRegion.regionCode;
+      body.device.regionCode = this.webex.meetings.geoHintInfo.regionCode;
     }
 
     if (moderator !== undefined) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1653,6 +1653,7 @@ describe('plugin-meetings', () => {
             meeting.mediaProperties.getCurrentConnectionType = sinon.stub().resolves('udp');
             meeting.setMercuryListener = sinon.stub();
             meeting.locusInfo.onFullLocus = sinon.stub();
+            meeting.webex.meetings.geoHintInfo = {regionCode: 'EU', countryCode: 'UK'};
             meeting.webex.meetings.reachability = {
               isAnyClusterReachable: sinon.stub().resolves(true),
             };
@@ -1778,7 +1779,7 @@ describe('plugin-meetings', () => {
               method: 'PUT',
               uri: `${meeting.selfUrl}/media`,
               body: {
-                device: {url: meeting.deviceUrl, deviceType: meeting.config.deviceType},
+                device: {url: meeting.deviceUrl, deviceType: meeting.config.deviceType, regionCode: 'EU', countryCode: 'UK'},
                 correlationId: meeting.correlationId,
                 localMedias: [
                   {
@@ -1799,7 +1800,7 @@ describe('plugin-meetings', () => {
               method: 'PUT',
               uri: `${meeting.selfUrl}/media`,
               body: {
-                device: {url: meeting.deviceUrl, deviceType: meeting.config.deviceType},
+                device: {url: meeting.deviceUrl, deviceType: meeting.config.deviceType, regionCode: 'EU', countryCode: 'UK'},
                 correlationId: meeting.correlationId,
                 localMedias: [
                   {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
@@ -41,7 +41,7 @@ describe('LocusMediaRequest.send()', () => {
 
   const createExpectedRoapBody = (expectedMessageType, expectedMute:{audioMuted: boolean, videoMuted: boolean}) => {
     return {
-      device: { url: 'deviceUrl', deviceType: 'deviceType' },
+      device: { url: 'deviceUrl', deviceType: 'deviceType', regionCode: 'regionCode' },
       correlationId: 'correlationId',
       localMedias: [
         {
@@ -72,6 +72,7 @@ describe('LocusMediaRequest.send()', () => {
       device: {
         url: 'deviceUrl',
         deviceType: 'deviceType',
+        regionCode: 'regionCode',
       },
       correlationId: 'correlationId',
       usingResource: null,
@@ -105,6 +106,7 @@ describe('LocusMediaRequest.send()', () => {
       device: {
         url: 'deviceUrl',
         deviceType: 'deviceType',
+        regionCode: 'regionCode',
       },
       correlationId: 'correlationId',
       preferTranscoding: true,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
@@ -18,7 +18,7 @@ describe('plugin-meetings', () => {
       },
     });
 
-    webex.meetings.clientRegion = {
+    webex.meetings.geoHintInfo = {
       countryCode: 'US',
       regionCode: 'WEST-COAST',
     };


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-458352

## This pull request addresses
SDK is not sending geohint information to Locus when joining meetings, because the code in joinMeeting() is reading a field `this.webex.meetings.clientRegion`, but that information is stored inside `this.webex.meetings.geoHintInfo`.

The code has been incorrect like this since the beginning when geohint request was added 3 years ago - it never worked.

## by making the following changes

Using correct field to read geohint info.

Also added geohint to /media requests.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Existing tests + manual e2e run with web app (confirmed with Orpheus that they received the geohint)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
