### PR TITLE
fix: don't send fake TCP reachability results

### DIFF
--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -412,6 +412,7 @@ export default class Reachability {
       reachabilityMap[clusterId] = {
         udp: latencyResult,
         tcp: {untested: 'true'},
+        xtls: {untested: 'true'},
       };
     });
 

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -140,7 +140,7 @@ export default class Reachability {
    * @memberof Reachability
    */
   private buildPeerConnectionConfig(cluster: any) {
-    const iceServers = _.uniq([...cluster.udp, ...cluster.tcp]).map((url) => ({
+    const iceServers = _.uniq(cluster.udp).map((url) => ({
       username: '',
       credential: '',
       urls: [url],
@@ -411,7 +411,7 @@ export default class Reachability {
 
       reachabilityMap[clusterId] = {
         udp: latencyResult,
-        tcp: latencyResult,
+        tcp: {untested: 'true'},
       };
     });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -186,6 +186,9 @@ describe('gatherReachability', () => {
           tcp: {
             untested: 'true',
           },
+          xtls: {
+            untested: 'true',
+          },
           udp: {
             clientMediaIPs: ['1.1.1.1'],
             latencyInMilliseconds: '12312',
@@ -193,6 +196,9 @@ describe('gatherReachability', () => {
           },
         },
         id2: {
+          xtls: {
+            untested: 'true',
+          },
           tcp: {
             untested: 'true',
           },


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-382443

## This pull request addresses

JS-SDK has always been sending UDP and TCP reachability results, but in fact the checks are done only over udp. TCP results were set to the same what was for UDP. With the current way how we do reachability, it's impossible to do it over TCP (it would require changes to Linus).

## by making the following changes

Indicating to the backend that we don't do reachability over TCP and xTLS by setting `untested:"true"` field

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests + manually joined a meeting with the web app to check that nothing is broken end-2-end and confirmed with Orpheus team that it's all fine on their side

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
