### PR TITLE
fix(plugin-meetings): no-frames-received-sent-stats-error

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -308,6 +308,8 @@ export const EVENT_TRIGGERS = {
   MEETING_SELF_IS_SHARING_BLOCKED: 'meeting:self:isSharingBlocked',
   MEETING_CONTROLS_LAYOUT_UPDATE: 'meeting:layout:update',
   MEETING_ENTRY_EXIT_TONE_UPDATE: 'meeting:entryExitTone:update',
+  MEETING_NO_FRAMES_SENT: 'meeting:noFramesSent',
+  MEETING_NO_VIDEO_ENCODED: 'meeting:noVideoEncoded',
   MEMBERS_UPDATE: 'members:update',
   MEMBERS_CONTENT_UPDATE: 'members:content:update',
   MEMBERS_HOST_UPDATE: 'members:host:update',

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4514,6 +4514,35 @@ export default class Meeting extends StatelessWebexPlugin {
         },
       });
     });
+    this.statsAnalyzer.on(StatsAnalyzerEvents.NO_VIDEO_ENCODED, (data) => {
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.NO_VIDEO_ENCODED);
+      Trigger.trigger(
+        this,
+        {
+          file: 'meeting/index',
+          function: 'compareLastStatsResult',
+        },
+        EVENT_TRIGGERS.MEETING_NO_VIDEO_ENCODED,
+        data
+      );
+    });
+    this.statsAnalyzer.on(StatsAnalyzerEvents.NO_FRAMES_SENT, (data) => {
+      if (
+        (this.mediaProperties.mediaDirection?.sendVideo && data.mediaType === 'video') ||
+        (this.mediaProperties.mediaDirection?.sendShare && data.mediaType === 'share')
+      ) {
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.NO_FRAMES_SENT);
+        Trigger.trigger(
+          this,
+          {
+            file: 'meeting/index',
+            function: 'compareLastStatsResult',
+          },
+          EVENT_TRIGGERS.MEETING_NO_FRAMES_SENT,
+          data
+        );
+      }
+    });
   };
 
   /**

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -1,6 +1,8 @@
 // Metrics constants ----------------------------------------------------------
 
 const BEHAVIORAL_METRICS = {
+  NO_FRAMES_SENT: 'js_sdk_meetings_no_frames_sent',
+  NO_VIDEO_ENCODED: 'js_sdk_meetings_no_video_encoded',
   MEETINGS_REGISTRATION_FAILED: 'js_sdk_meetings_registration_failed',
   MEETINGS_REGISTRATION_SUCCESS: 'js_sdk_meetings_registration_success',
   MERCURY_CONNECTION_FAILURE: 'js_sdk_mercury_connection_failure',

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/global.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/global.ts
@@ -76,16 +76,6 @@ const STATS_DEFAULT = {
     },
   },
   resolutions: {
-    audio: {
-      send: {
-        width: 0,
-        height: 0,
-      },
-      recv: {
-        width: 0,
-        height: 0,
-      },
-    },
     video: {
       send: {
         width: 0,

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/global.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/global.ts
@@ -80,6 +80,7 @@ const STATS_DEFAULT = {
       send: {
         width: 0,
         height: 0,
+        framesSent: 0,
       },
       recv: {
         width: 0,
@@ -90,6 +91,7 @@ const STATS_DEFAULT = {
       send: {
         width: 0,
         height: 0,
+        framesSent: 0,
       },
       recv: {
         width: 0,

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -420,9 +420,6 @@ export class StatsAnalyzer extends EventsScope {
       case 'inbound-rtp':
         this.processInboundRTPResult(getStatsResult, type);
         break;
-      case 'track':
-        this.processTrackResult(getStatsResult, type);
-        break;
       case 'remote-inbound-rtp':
       case 'remote-outbound-rtp':
         // @ts-ignore
@@ -881,6 +878,7 @@ export class StatsAnalyzer extends EventsScope {
     const mediaType = type || STATS.AUDIO_CORRELATE;
     const sendrecvType = STATS.SEND_DIRECTION;
 
+    this.processTrackResult(result, type, sendrecvType);
     if (result.bytesSent) {
       let kilobytes = 0;
 
@@ -955,6 +953,7 @@ export class StatsAnalyzer extends EventsScope {
     const mediaType = type || STATS.AUDIO_CORRELATE;
     const sendrecvType = STATS.RECEIVE_DIRECTION;
 
+    this.processTrackResult(result, type, sendrecvType);
     if (result.bytesReceived) {
       let kilobytes = 0;
 
@@ -1158,29 +1157,29 @@ export class StatsAnalyzer extends EventsScope {
    * @private
    * @param {*} result
    * @param {*} mediaType
+   * @param {*} sendrecvType
    * @returns {void}
    * @memberof StatsAnalyzer
    */
-  private processTrackResult(result: any, mediaType: any) {
-    if (!result || result.type !== 'track') {
+  private processTrackResult(result: any, mediaType: any, sendrecvType: any) {
+    if (!result || mediaType === STATS.AUDIO_CORRELATE) {
       return;
     }
-    if (result.type !== 'track') return;
-
-    const sendrecvType =
-      result.remoteSource === true ? STATS.RECEIVE_DIRECTION : STATS.SEND_DIRECTION;
-
+    if (result.type !== 'inbound-rtp' && result.type !== 'outbound-rtp') {
+      return;
+    }
     if (result.frameWidth && result.frameHeight) {
       this.statsResults.resolutions[mediaType][sendrecvType].width = result.frameWidth;
       this.statsResults.resolutions[mediaType][sendrecvType].height = result.frameHeight;
-      this.statsResults.resolutions[mediaType][sendrecvType].framesSent = result.framesSent;
-      this.statsResults.resolutions[mediaType][sendrecvType].hugeFramesSent = result.hugeFramesSent;
     }
 
     if (sendrecvType === STATS.RECEIVE_DIRECTION) {
       this.statsResults.resolutions[mediaType][sendrecvType].framesReceived = result.framesReceived;
       this.statsResults.resolutions[mediaType][sendrecvType].framesDecoded = result.framesDecoded;
       this.statsResults.resolutions[mediaType][sendrecvType].framesDropped = result.framesDropped;
+    } else if (sendrecvType === STATS.SEND_DIRECTION) {
+      this.statsResults.resolutions[mediaType][sendrecvType].framesSent = result.framesSent;
+      this.statsResults.resolutions[mediaType][sendrecvType].hugeFramesSent = result.hugeFramesSent;
     }
 
     if (result.trackIdentifier && mediaType !== STATS.AUDIO_CORRELATE) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1329,6 +1329,71 @@ describe('plugin-meetings', () => {
               data: {intervalData: fakeData, networkType: 'wifi'},
             });
           });
+          it('NO_FRAMES_SENT triggers "meeting:noFramesSent" event and sends metrics', async () => {
+            meeting.mediaProperties.mediaDirection = {sendVideo: true};
+            statsAnalyzerStub.emit(
+              {file: 'test', function: 'test'},
+              StatsAnalyzerModule.EVENTS.NO_FRAMES_SENT,
+              {mediaType: 'video'}
+            );
+
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meeting),
+              {
+                file: 'meeting/index',
+                function: 'compareLastStatsResult',
+              },
+              EVENT_TRIGGERS.MEETING_NO_FRAMES_SENT,
+              {
+                mediaType: 'video',
+              }
+            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.NO_FRAMES_SENT);
+          });
+          it('NO_FRAMES_SENT triggers "meeting:noFramesSent" event and sends metrics for share', async () => {
+            meeting.mediaProperties.mediaDirection = {sendShare: true};
+            statsAnalyzerStub.emit(
+              {file: 'test', function: 'test'},
+              StatsAnalyzerModule.EVENTS.NO_FRAMES_SENT,
+              {mediaType: 'share'}
+            );
+
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meeting),
+              {
+                file: 'meeting/index',
+                function: 'compareLastStatsResult',
+              },
+              EVENT_TRIGGERS.MEETING_NO_FRAMES_SENT,
+              {
+                mediaType: 'share',
+              }
+            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.NO_FRAMES_SENT);
+          });
+          it('NO_VIDEO_ENCODED triggers "meeting:noVideoEncoded" event and sends metrics', async () => {
+            statsAnalyzerStub.emit(
+              {file: 'test', function: 'test'},
+              StatsAnalyzerModule.EVENTS.NO_VIDEO_ENCODED,
+              {mediaType: 'video'}
+            );
+
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meeting),
+              {
+                file: 'meeting/index',
+                function: 'compareLastStatsResult',
+              },
+              EVENT_TRIGGERS.MEETING_NO_VIDEO_ENCODED,
+              {
+                mediaType: 'video',
+              }
+            );
+            assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.NO_VIDEO_ENCODED);
+          });
         });
       });
       describe('#acknowledge', () => {
@@ -3605,14 +3670,17 @@ describe('plugin-meetings', () => {
       describe('#setUpLocusServicesListener', () => {
         it('listens to the locus services update event', (done) => {
           const newLocusServices = {
-              services: {
-                record: {
-                  url: 'url',
-                }
+            services: {
+              record: {
+                url: 'url',
               },
+            },
           };
 
-          meeting.recordingController = {setServiceUrl: sinon.stub().returns(undefined), setSessionId: sinon.stub().returns(undefined)};
+          meeting.recordingController = {
+            setServiceUrl: sinon.stub().returns(undefined),
+            setSessionId: sinon.stub().returns(undefined),
+          };
 
           meeting.locusInfo.emit(
             {function: 'test', file: 'test'},
@@ -3620,7 +3688,10 @@ describe('plugin-meetings', () => {
             newLocusServices
           );
 
-          assert.calledWith(meeting.recordingController.setServiceUrl, newLocusServices.services.record.url);
+          assert.calledWith(
+            meeting.recordingController.setServiceUrl,
+            newLocusServices.services.record.url
+          );
           assert.calledOnce(meeting.recordingController.setSessionId);
           done();
         });


### PR DESCRIPTION
# COMPLETES #[SPARK-452740](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-452740) and [SPARK-251243](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-251243)

## This pull request addresses

Currently, we don't send any metric when frames are not being sent for various reasons on mobile devices. If device is not sending videoFrames or video is not encoded, we are not triggering any event for that.

To trigger the event we need information about the framesSent and framesEncoded. The logs were filled with 'No video frames sent/received/decoded' and 'No audio samples sent/received/decoded' logs.

Root cause:
RTCStatsReport used to send statistics for type = 'track' which had the details about the track like frames sent, frames height etc. Now this information is being sent in the type inbound-rtp and outbound-rtp statistics

Fixed the StatsAnalyzer to correctly populate the track results.

## by making the following changes

As part of this PR:
1) added an EVENT when video is encoded but frames are not sent in statsAnalyzer
2) added an EVENT when video is not being encoded in statsAnalyzer
3) Emitted two new EVENTS for the above scenarios
4) sending behavioral metric to Amplitude for above scenarios

##Reference PR in master
[fix(plugin-meetings): no-frames-received-sent-stats-error](https://github.com/webex/webex-js-sdk/pull/3017) 
[ fix(meeting): added noFramesSent noVideoEncoded events](https://github.com/webex/webex-js-sdk/pull/3041)
### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
