### PR TITLE
fix(call-analyzer): fix client.call.leave reason

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/index.ts
+++ b/packages/@webex/internal-plugin-metrics/src/index.ts
@@ -11,6 +11,7 @@ import config from './config';
 import NewMetrics from './new-metrics';
 import {
   ClientEvent,
+  ClientEventLeaveReason,
   SubmitBehavioralEvent,
   SubmitClientEvent,
   SubmitInternalEvent,
@@ -31,6 +32,7 @@ export {default, getOSNameInternal} from './metrics';
 export {config, CALL_DIAGNOSTIC_CONFIG, NewMetrics};
 export type {
   ClientEvent,
+  ClientEventLeaveReason,
   SubmitBehavioralEvent,
   SubmitClientEvent,
   SubmitInternalEvent,

--- a/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
+++ b/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
@@ -89,6 +89,7 @@ export type SubClientType = NonNullable<RawEvent['origin']['clientInfo']>['subCl
 export type NetworkType = NonNullable<RawEvent['origin']>['networkType'];
 
 export type ClientEventPayload = RecursivePartial<ClientEvent['payload']>;
+export type ClientEventLeaveReason = ClientEvent['payload']['leaveReason'];
 
 export type MediaQualityEventAudioSetupDelayPayload = NonNullable<
   MediaQualityEvent['payload']

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2489,7 +2489,7 @@ describe('plugin-meetings', () => {
         });
 
         it('should send client.call.leave after meetingRequest.leaveMeeting', async () => {
-          const leave = meeting.leave();
+          const leave = meeting.leave({clientEventLeaveReason: 'ended-by-locus'});
 
           await leave;
 
@@ -2498,7 +2498,7 @@ describe('plugin-meetings', () => {
             payload: {
               trigger: 'user-interaction',
               canProceed: false,
-              leaveReason: 'CLIENT_LEAVE_REQUEST',
+              leaveReason: 'ended-by-locus',
             },
             options: {meetingId: meeting.id},
           });
@@ -2522,7 +2522,7 @@ describe('plugin-meetings', () => {
             payload: {
               trigger: 'user-interaction',
               canProceed: false,
-              leaveReason: 'CLIENT_LEAVE_REQUEST',
+              leaveReason: undefined,
               errors: [
                 {
                   fatal: false,


### PR DESCRIPTION
## COMPLETES

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-458903

## This pull request addresses

Currently we are using one of `MEETING_REMOVED_REASON` as the CA event leaveReason.  These are not valid values for the CA event, which needs to be one of 'paired-leave' | 'one-to-one' | 'ended-by-locus'.

We should not conflate locus leave reason with CA event leave reason.

## by making the following changes

I added a new prop/arg to meeting.leave() (`clientEventLeaveReason`) that can be used to pass in one of the valid CA reasons. By default this property will be undefined (it is optional).

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Updated unit tests and tested manually.

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly
