### PR TITLE
feat(): byok revoked error handling

### DIFF
--- a/packages/@webex/internal-plugin-encryption/src/constants.js
+++ b/packages/@webex/internal-plugin-encryption/src/constants.js
@@ -1,0 +1,3 @@
+export const KMS_KEY_REVOKE_FAILURE = 'event:kms:key:revoke:encryption:failure';
+export const KMS_KEY_REVOKE_ERROR_STATUS = 405;
+export const KMS_KEY_REVOKE_ERROR_CODES = [405005, 405006];

--- a/packages/@webex/internal-plugin-encryption/src/kms-batcher.js
+++ b/packages/@webex/internal-plugin-encryption/src/kms-batcher.js
@@ -5,7 +5,7 @@
 import {safeSetTimeout} from '@webex/common-timers';
 import {Batcher} from '@webex/webex-core';
 
-import {KmsError, KmsTimeoutError} from './kms-errors';
+import {KmsError, KmsTimeoutError, handleKmsKeyRevokedEncryptionFailure} from './kms-errors';
 
 export const TIMEOUT_SYMBOL = Symbol('TIMEOUT_SYMBOL');
 
@@ -133,6 +133,8 @@ const KmsBatcher = Batcher.extend({
    * @returns {Promise}
    */
   handleItemFailure(item, reason) {
+    handleKmsKeyRevokedEncryptionFailure(item, this.webex);
+
     return this.getDeferredForResponse(item).then((defer) => {
       defer.reject(reason || new KmsError(item.body));
     });

--- a/packages/@webex/internal-plugin-encryption/src/kms-errors.js
+++ b/packages/@webex/internal-plugin-encryption/src/kms-errors.js
@@ -5,6 +5,12 @@
 import {Exception} from '@webex/common';
 import {WebexHttpError} from '@webex/webex-core';
 
+import {
+  KMS_KEY_REVOKE_ERROR_CODES,
+  KMS_KEY_REVOKE_FAILURE,
+  KMS_KEY_REVOKE_ERROR_STATUS,
+} from './constants';
+
 /**
  * Error class for KMS errors
  */
@@ -145,3 +151,17 @@ export class DryError extends WebexHttpError {
     return message;
   }
 }
+
+/**
+ * Function triggers an event when specific encryption failures are received.
+ */
+
+// eslint-disable-next-line consistent-return
+export const handleKmsKeyRevokedEncryptionFailure = (item, webex) => {
+  if (
+    item.status === KMS_KEY_REVOKE_ERROR_STATUS &&
+    KMS_KEY_REVOKE_ERROR_CODES.includes(item.body.errorCode)
+  ) {
+    webex.internal.encryption.trigger(KMS_KEY_REVOKE_FAILURE);
+  }
+};

--- a/packages/@webex/internal-plugin-encryption/test/unit/spec/kms-errors.js
+++ b/packages/@webex/internal-plugin-encryption/test/unit/spec/kms-errors.js
@@ -1,0 +1,70 @@
+import {assert} from '@webex/test-helper-chai';
+import {handleKmsKeyRevokedEncryptionFailure} from '../../../src/kms-errors'
+import sinon from 'sinon';
+
+describe('handleKmsKeyRevokedEncryptionFailure', () => {
+
+    it('triggers `event:kms:key:revoke:encryption:failure` event when correct error code is detected', () => {
+        const webex = {
+            internal: {
+                encryption: {
+                trigger: sinon.spy()
+              },
+            },
+          }
+
+        const item = {
+            status: 405,
+            body: {
+                errorCode: 405005,
+            }
+        }
+
+        handleKmsKeyRevokedEncryptionFailure(item, webex);
+        
+        assert.calledOnce(webex.internal.encryption.trigger);
+        assert.calledWithExactly(webex.internal.encryption.trigger, `event:kms:key:revoke:encryption:failure`);
+    });
+
+    it('does not trigger `event:kms:key:revoke:encryption:failure` event when correct status but wrong error code is detected', () => {
+        const webex = {
+            internal: {
+                encryption: {
+                trigger: sinon.spy()
+              },
+            },
+          }
+
+        const item = {
+            status: 405,
+            body: {
+                errorCode: 405009,
+            }
+        }
+
+        handleKmsKeyRevokedEncryptionFailure(item, webex);
+         
+        assert.notCalled(webex.internal.encryption.trigger);
+       });
+
+       it('does not trigger `event:kms:key:revoke:encryption:failure` event when wrong status but correct error code is detected', () => {
+        const webex = {
+            internal: {
+                encryption: {
+                trigger: sinon.spy()
+              },
+            },
+          }
+
+        const item = {
+            status: 403,
+            body: {
+                errorCode: 405005,
+            }
+        }
+
+        handleKmsKeyRevokedEncryptionFailure(item, webex);
+         
+        assert.notCalled(webex.internal.encryption.trigger);
+       });
+});


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-459735

## This pull request addresses

Error handling when an encryption key is revoked and kms throws 405 error codes


## by making the following changes

Added an event listener that gets triggered as soon as the specific error codes start coming in from revoking the key.


<!-- You may include screenshots -->
<img width="1430" alt="Screenshot 2023-09-07 at 10 04 04 AM" src="https://github.com/webex/webex-js-sdk/assets/24454065/511b9344-5d6b-4681-b726-72e490ec2558">


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
