### PR TITLE
feat: sending ipver parameter to Locus and Orpheus

### DIFF
--- a/packages/@webex/plugin-meetings/README.md
+++ b/packages/@webex/plugin-meetings/README.md
@@ -117,7 +117,7 @@ webex.meetings.getMeetingByType('SIP_URI', sipUri);
 
 ```js
 webex.meetings.personalMeetingRoom; // the personal meeting room instance
-webex.meetings.reachability; // the reachability instance, not initialized until after setReachability is called
+webex.meetings.reachability; // the reachability instance
 webex.meetings.meetingCollection; // the collection of meetings instance
 webex.meetings.meetingInfo; // the meeting info instance
 ```

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1236,3 +1236,13 @@ export const DEFAULT_MEETING_INFO_REQUEST_BODY = {
   supportHostKey: true,
   supportCountryList: true,
 };
+
+/** the values for IP_VERSION are fixed and defined in Orpheus API */
+export const IP_VERSION = {
+  unknown: 0,
+  only_ipv4: 4,
+  only_ipv6: 6,
+  ipv4_and_ipv6: 1,
+} as const;
+
+export type IP_VERSION = (typeof IP_VERSION)[keyof typeof IP_VERSION];

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -2,7 +2,7 @@
 import {defer} from 'lodash';
 import {Defer} from '@webex/common';
 import {WebexPlugin} from '@webex/webex-core';
-import {MEDIA, HTTP_VERBS, ROAP} from '../constants';
+import {MEDIA, HTTP_VERBS, ROAP, IP_VERSION} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
 
 export type MediaRequestType = 'RoapMessage' | 'LocalMute';
@@ -16,6 +16,7 @@ export type RoapRequest = {
   reachability: any;
   sequence?: any;
   joinCookie: any; // any, because this is opaque to the client, we pass whatever object we got from one backend component (Orpheus) to the other (Locus)
+  ipVersion: IP_VERSION;
 };
 
 export type LocalMuteRequest = {
@@ -27,6 +28,7 @@ export type LocalMuteRequest = {
     audioMuted?: boolean;
     videoMuted?: boolean;
   };
+  ipVersion: IP_VERSION;
 };
 
 export type Request = RoapRequest | LocalMuteRequest;
@@ -202,6 +204,7 @@ export class LocusMediaRequest extends WebexPlugin {
       correlationId: this.config.correlationId,
       clientMediaPreferences: {
         preferTranscoding: this.config.preferTranscoding,
+        ipver: request.ipVersion,
       },
     };
 

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -25,6 +25,7 @@ import {
   SEND_DTMF_ENDPOINT,
   _SLIDES_,
   ANNOTATION,
+  IP_VERSION,
 } from '../constants';
 import {SendReactionOptions, ToggleReactionsOptions} from './request.type';
 import MeetingUtil from './util';
@@ -123,6 +124,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
     locale?: string;
     deviceCapabilities?: Array<string>;
     liveAnnotationSupported: boolean;
+    ipVersion: IP_VERSION;
   }) {
     const {
       asResourceOccupant,
@@ -143,6 +145,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
       locale,
       deviceCapabilities = [],
       liveAnnotationSupported,
+      ipVersion,
     } = options;
 
     LoggerProxy.logger.info('Meeting:request#joinMeeting --> Joining a meeting', correlationId);
@@ -168,6 +171,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
       clientMediaPreferences: {
         preferTranscoding: preferTranscoding ?? true,
         joinCookie,
+        ipver: ipVersion,
       },
     };
 

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -72,6 +72,7 @@ const MeetingUtil = {
           audioMuted,
           videoMuted,
         },
+        ipVersion: meeting.getWebexObject().meetings.reachability.getIpVersion(),
       })
       .then((response) => {
         // @ts-ignore
@@ -124,6 +125,7 @@ const MeetingUtil = {
         locale: options.locale,
         deviceCapabilities: options.deviceCapabilities,
         liveAnnotationSupported: options.liveAnnotationSupported,
+        ipVersion: meeting.getWebexObject().meetings.reachability.getIpVersion(),
       })
       .then((res) => {
         // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -146,7 +146,7 @@ export default class Meetings extends WebexPlugin {
   meetingCollection: any;
   personalMeetingRoom: any;
   preferredWebexSite: any;
-  reachability: any;
+  reachability: Reachability;
   registered: any;
   request: any;
   geoHintInfo: any;
@@ -202,15 +202,17 @@ export default class Meetings extends WebexPlugin {
      * @memberof Meetings
      */
     this.personalMeetingRoom = null;
+
     /**
-     * The Reachability object to interact with server, starts as null until {@link Meeting#setReachability} is called
+     * The Reachability object to interact with server
      * starts as null
      * @instance
      * @type {Object}
      * @private
      * @memberof Meetings
      */
-    this.reachability = null;
+    // @ts-ignore
+    this.reachability = new Reachability(this.webex);
 
     /**
      * If the meetings plugin has been registered and listening via {@link Meetings#register}
@@ -928,17 +930,6 @@ export default class Meetings extends WebexPlugin {
   }
 
   /**
-   * initializes the reachability instance for Meetings
-   * @returns {undefined}
-   * @public
-   * @memberof Meetings
-   */
-  setReachability() {
-    // @ts-ignore
-    this.reachability = new Reachability(this.webex);
-  }
-
-  /**
    * gets the reachability instance for Meetings
    * @returns {Reachability}
    * @public
@@ -955,10 +946,6 @@ export default class Meetings extends WebexPlugin {
    * @memberof Meetings
    */
   startReachability() {
-    if (!this.reachability) {
-      this.setReachability();
-    }
-
     return this.getReachability().gatherReachability();
   }
 

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -7,7 +7,7 @@
 import _ from 'lodash';
 
 import LoggerProxy from '../common/logs/logger-proxy';
-import {ICE_GATHERING_STATE, CONNECTION_STATE, REACHABILITY} from '../constants';
+import {ICE_GATHERING_STATE, CONNECTION_STATE, REACHABILITY, IP_VERSION} from '../constants';
 
 import ReachabilityRequest from './request';
 
@@ -70,7 +70,9 @@ export default class Reachability {
 
     // Fetch clusters and measure latency
     try {
-      const {clusters, joinCookie} = await this.reachabilityRequest.getClusters();
+      const {clusters, joinCookie} = await this.reachabilityRequest.getClusters(
+        this.getIpVersion()
+      );
 
       // Perform Reachability Check
       const results = await this.performReachabilityCheck(clusters);
@@ -130,6 +132,14 @@ export default class Reachability {
     }
 
     return reachable;
+  }
+
+  /**
+   * Returns what we know about the IP version of the networks we're connected to.
+   * @returns {IP_VERSION}
+   */
+  getIpVersion(): IP_VERSION {
+    return IP_VERSION.unknown;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/reachability/request.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/request.ts
@@ -1,5 +1,5 @@
 import LoggerProxy from '../common/logs/logger-proxy';
-import {HTTP_VERBS, RESOURCE, API} from '../constants';
+import {HTTP_VERBS, RESOURCE, API, IP_VERSION} from '../constants';
 
 export interface ClusterNode {
   isVideoMesh: boolean;
@@ -30,9 +30,10 @@ class ReachabilityRequest {
   /**
    * Gets the cluster information
    *
+   * @param {IP_VERSION} ipVersion information about current ip network we're on
    * @returns {Promise}
    */
-  getClusters = (): Promise<{clusters: ClusterList; joinCookie: any}> =>
+  getClusters = (ipVersion: IP_VERSION): Promise<{clusters: ClusterList; joinCookie: any}> =>
     this.webex
       .request({
         method: HTTP_VERBS.GET,
@@ -41,6 +42,7 @@ class ReachabilityRequest {
         resource: RESOURCE.CLUSTERS,
         qs: {
           JCSupport: 1,
+          ipver: ipVersion,
         },
       })
       .then((res) => {
@@ -51,7 +53,9 @@ class ReachabilityRequest {
         });
 
         LoggerProxy.logger.log(
-          `Reachability:request#getClusters --> get clusters successful:${JSON.stringify(clusters)}`
+          `Reachability:request#getClusters --> get clusters (ipver=${ipVersion}) successful:${JSON.stringify(
+            clusters
+          )}`
         );
 
         return {

--- a/packages/@webex/plugin-meetings/src/roap/index.ts
+++ b/packages/@webex/plugin-meetings/src/roap/index.ts
@@ -100,6 +100,7 @@ export default class Roap extends StatelessWebexPlugin {
           mediaId: options.mediaId,
           meetingId: meeting.id,
           locusMediaRequest: meeting.locusMediaRequest,
+          ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
         })
         .then(() => {
           LoggerProxy.logger.log(`Roap:index#sendRoapOK --> ROAP OK sent with seq ${options.seq}`);
@@ -134,6 +135,7 @@ export default class Roap extends StatelessWebexPlugin {
       mediaId: options.mediaId,
       meetingId: meeting.id,
       locusMediaRequest: meeting.locusMediaRequest,
+      ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
     });
   }
 
@@ -163,6 +165,7 @@ export default class Roap extends StatelessWebexPlugin {
         mediaId: options.mediaId,
         meetingId: meeting.id,
         locusMediaRequest: meeting.locusMediaRequest,
+        ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
       })
       .then(() => {
         LoggerProxy.logger.log(
@@ -201,6 +204,7 @@ export default class Roap extends StatelessWebexPlugin {
           meetingId: meeting.id,
           preferTranscoding: !meeting.isMultistream,
           locusMediaRequest: meeting.locusMediaRequest,
+          ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
         })
         .then(({locus, mediaConnections}) => {
           if (mediaConnections) {

--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -2,7 +2,7 @@
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
 import LoggerProxy from '../common/logs/logger-proxy';
-import {REACHABILITY} from '../constants';
+import {IP_VERSION, REACHABILITY} from '../constants';
 import {LocusMediaRequest} from '../meeting/locusMediaRequest';
 
 /**
@@ -70,9 +70,10 @@ export default class RoapRequest extends StatelessWebexPlugin {
     locusSelfUrl: string;
     mediaId: string;
     meetingId: string;
+    ipVersion: IP_VERSION;
     locusMediaRequest?: LocusMediaRequest;
   }) {
-    const {roapMessage, locusSelfUrl, mediaId, meetingId, locusMediaRequest} = options;
+    const {roapMessage, locusSelfUrl, mediaId, meetingId, locusMediaRequest, ipVersion} = options;
 
     if (!mediaId) {
       LoggerProxy.logger.info('Roap:request#sendRoap --> sending empty mediaID');
@@ -109,6 +110,7 @@ export default class RoapRequest extends StatelessWebexPlugin {
         mediaId,
         roapMessage,
         reachability: localSdpWithReachabilityData.reachability,
+        ipVersion,
       })
       .then((res) => {
         // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -182,6 +182,8 @@ export default class TurnDiscovery {
         mediaId: isReconnecting ? '' : meeting.mediaId,
         meetingId: meeting.id,
         locusMediaRequest: meeting.locusMediaRequest,
+        // @ts-ignore - because of meeting.webex
+        ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
       })
       .then(({mediaConnections}) => {
         if (mediaConnections) {
@@ -212,6 +214,8 @@ export default class TurnDiscovery {
       mediaId: meeting.mediaId,
       meetingId: meeting.id,
       locusMediaRequest: meeting.locusMediaRequest,
+      // @ts-ignore - because of meeting.webex
+      ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
     });
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -27,6 +27,7 @@ import {
   PC_BAIL_TIMEOUT,
   DISPLAY_HINTS,
   SELF_POLICY,
+  IP_VERSION,
 } from '@webex/plugin-meetings/src/constants';
 import * as InternalMediaCoreModule from '@webex/internal-media-core';
 import {
@@ -1658,6 +1659,7 @@ describe('plugin-meetings', () => {
             meeting.webex.meetings.geoHintInfo = {regionCode: 'EU', countryCode: 'UK'};
             meeting.webex.meetings.reachability = {
               isAnyClusterReachable: sinon.stub().resolves(true),
+              getIpVersion: () => IP_VERSION.unknown,
             };
             meeting.roap.doTurnDiscovery = sinon
               .stub()
@@ -1797,6 +1799,7 @@ describe('plugin-meetings', () => {
                 clientMediaPreferences: {
                   preferTranscoding: !meeting.isMultistream,
                   joinCookie: undefined,
+                  ipver: 0,
                 },
               },
             });
@@ -1822,6 +1825,7 @@ describe('plugin-meetings', () => {
                 ],
                 clientMediaPreferences: {
                   preferTranscoding: !meeting.isMultistream,
+                  ipver: 0,
                 },
                 respOnlySdp: true,
                 usingResource: null,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
@@ -7,6 +7,7 @@ import Meetings from '@webex/plugin-meetings';
 import { LocalMuteRequest, LocusMediaRequest, RoapRequest } from "@webex/plugin-meetings/src/meeting/locusMediaRequest";
 import testUtils from '../../../utils/testUtils';
 import { Defer } from '@webex/common';
+import { IP_VERSION } from '../../../../src/constants';
 
 describe('LocusMediaRequest.send()', () => {
   let locusMediaRequest: LocusMediaRequest;
@@ -37,6 +38,7 @@ describe('LocusMediaRequest.send()', () => {
       clientIpAddress: 'some ip',
       timeShot: '2023-05-23T08:03:49Z',
     },
+    ipVersion: IP_VERSION.only_ipv4,
   };
 
   const createExpectedRoapBody = (expectedMessageType, expectedMute:{audioMuted: boolean, videoMuted: boolean}) => {
@@ -51,6 +53,7 @@ describe('LocusMediaRequest.send()', () => {
       ],
       clientMediaPreferences: {
         preferTranscoding: true,
+        ipver: 4,
         joinCookie: {
           anycastEntryPoint: 'aws-eu-west-1',
           clientIpAddress: 'some ip',
@@ -65,6 +68,7 @@ describe('LocusMediaRequest.send()', () => {
     mediaId: 'mediaId',
     selfUrl: 'fakeMeetingSelfUrl',
     muteOptions: {},
+    ipVersion: IP_VERSION.only_ipv6
   };
 
   const createExpectedLocalMuteBody = (expectedMute:{audioMuted: boolean, videoMuted: boolean}, sequence = undefined) => {
@@ -85,6 +89,7 @@ describe('LocusMediaRequest.send()', () => {
       ],
       clientMediaPreferences: {
         preferTranscoding: true,
+        ipver: 6,
       },
     };
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
@@ -4,7 +4,9 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import Meetings from '@webex/plugin-meetings';
 import MeetingRequest from '@webex/plugin-meetings/src/meeting/request';
 import uuid from 'uuid';
-import {merge} from 'lodash';
+import { merge } from 'lodash';
+import {IP_VERSION} from '@webex/plugin-meetings/src/constants';
+
 
 describe('plugin-meetings', () => {
   let meetingsRequest;
@@ -291,7 +293,7 @@ describe('plugin-meetings', () => {
         assert.deepEqual(requestParams.body.locale, undefined);
       });
 
-      it('includes joinCookie correctly', async () => {
+      it('includes joinCookie and ipver correctly', async () => {
         const locusUrl = 'locusURL';
         const deviceUrl = 'deviceUrl';
         const correlationId = 'random-uuid';
@@ -304,14 +306,16 @@ describe('plugin-meetings', () => {
           correlationId,
           roapMessage,
           permissionToken,
+          ipVersion: IP_VERSION.ipv4_and_ipv6
         });
         const requestParams = meetingsRequest.request.getCall(0).args[0];
 
         assert.equal(requestParams.method, 'POST');
         assert.equal(requestParams.uri, `${locusUrl}/participant?alternateRedirect=true`);
         assert.deepEqual(requestParams.body.clientMediaPreferences, {
-          joinCookie: {anycastEntryPoint: 'aws-eu-west-1'},
-          preferTranscoding: true,
+          "joinCookie": {anycastEntryPoint: "aws-eu-west-1"},
+          "preferTranscoding": true,
+          "ipver": 1
         });
       });
     });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
+import Meetings from '@webex/plugin-meetings';
 import MeetingUtil from '@webex/plugin-meetings/src/meeting/util';
 import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
@@ -15,7 +16,11 @@ describe('plugin-meetings', () => {
     const meeting = {};
 
     beforeEach(() => {
-      webex = new MockWebex({});
+      webex = new MockWebex({
+        children: {
+          meetings: Meetings,
+        },
+      });
       const logger = {
         info: sandbox.stub(),
         log: sandbox.stub(),
@@ -334,6 +339,7 @@ describe('plugin-meetings', () => {
           selfUrl: 'self url',
           sequence: {},
           type: 'LocalMute',
+          ipVersion: 0,
         });
 
         assert.calledWith(webex.internal.newMetrics.submitClientEvent, {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -452,32 +452,14 @@ describe('plugin-meetings', () => {
           it('should have #getReachability', () => {
             assert.exists(webex.meetings.getReachability);
           });
-          describe('before #setReachability', () => {
-            it('does not get a reachability instance', () => {
-              const reachability = webex.meetings.getReachability();
+          it('gets the reachability data instance from webex.meetings', () => {
+            const reachability = webex.meetings.getReachability();
 
-              assert.notExists(
-                reachability,
-                'reachability is undefined because #setReachability has not been called'
-              );
-            });
-          });
-          describe('after #setReachability', () => {
-            beforeEach(() => {
-              webex.meetings.setReachability();
-              const reachabilityMocker = webex.meetings.getReachability();
-
-              sinon.stub(reachabilityMocker, 'gatherReachability').returns(true);
-            });
-            it('gets the reachability data instance from webex.meetings', () => {
-              const reachability = webex.meetings.getReachability();
-
-              assert.exists(
-                reachability,
-                'reachability is defined because #setReachability has been called'
-              );
-              assert.instanceOf(reachability, Reachability, 'should be a reachability instance');
-            });
+            assert.exists(
+              reachability,
+              'reachability is defined'
+            );
+            assert.instanceOf(reachability, Reachability, 'should be a reachability instance');
           });
         });
         describe('#getPersonalMeetingRoom', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -2,6 +2,7 @@ import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import sinon from 'sinon';
 import Reachability, {ICECandidateResult} from '@webex/plugin-meetings/src/reachability/';
+import { IP_VERSION } from '@webex/plugin-meetings/src/constants';
 
 describe('isAnyClusterReachable', () => {
   let webex;
@@ -250,4 +251,12 @@ describe('gatherReachability', () => {
       });
     });
   });
+
+  describe('getIpVersion', () => {
+    it('returns unknown', () => {
+      const reachability = new Reachability(webex);
+
+      assert.equal(reachability.getIpVersion(), IP_VERSION.unknown);
+    })
+  })
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/request.js
@@ -3,6 +3,7 @@ import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import Meetings from '@webex/plugin-meetings';
 import ReachabilityRequest from '@webex/plugin-meetings/src/reachability/request';
+import {IP_VERSION} from '@webex/plugin-meetings/src/constants';
 
 
 describe('plugin-meetings/reachability', () => {
@@ -47,7 +48,7 @@ describe('plugin-meetings/reachability', () => {
         }
       }));
 
-      const res = await reachabilityRequest.getClusters();
+      const res = await reachabilityRequest.getClusters(IP_VERSION.only_ipv4);
 
       const requestParams = webex.request.getCall(0).args[0];
 
@@ -58,6 +59,7 @@ describe('plugin-meetings/reachability', () => {
 
       assert.deepEqual(requestParams.qs, {
         JCSupport: 1,
+        ipver: 4,
       });
       assert.deepEqual(res.clusters.clusterId, {udp: "testUDP", isVideoMesh: true})
       assert.deepEqual(res.joinCookie, {anycastEntryPoint: "aws-eu-west-1"})

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
@@ -6,6 +6,7 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import RoapRequest from '@webex/plugin-meetings/src/roap/request';
 import Roap from '@webex/plugin-meetings/src/roap/';
 import Meeting from '@webex/plugin-meetings/src/meeting';
+import { IP_VERSION } from '../../../../src/constants';
 
 describe('Roap', () => {
   describe('doTurnDiscovery', () => {
@@ -61,7 +62,7 @@ describe('Roap', () => {
         setRoapSeq: sinon.stub(),
         config: {experimental: {enableTurnDiscovery: false}},
         locusMediaRequest: {fake: true},
-        webex: { meetings: { reachability: { isAnyClusterReachable: () => true}}},
+        webex: { meetings: { reachability: { isAnyClusterReachable: () => true, getIpVersion: () => IP_VERSION.unknown}}},
       };
 
       sendRoapStub = sinon.stub(RoapRequest.prototype, 'sendRoap').resolves({});

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
@@ -3,7 +3,7 @@ import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import Meetings from '@webex/plugin-meetings';
 import RoapRequest from '@webex/plugin-meetings/src/roap/request';
-import {REACHABILITY} from '@webex/plugin-meetings/src/constants';
+import {IP_VERSION, REACHABILITY} from '@webex/plugin-meetings/src/constants';
 
 describe('plugin-meetings/roap', () => {
   let roapRequest;
@@ -109,9 +109,11 @@ describe('plugin-meetings/roap', () => {
   describe('sendRoap', () => {
     it('includes joinCookie in the request correctly', async () => {
       const locusMediaRequest = {send: sinon.stub().resolves({body: {locus: {}}})};
+      const ipVersion = IP_VERSION.unknown;
 
       await roapRequest.sendRoap({
         locusSelfUrl: locusUrl,
+        ipVersion,
         mediaId: 'mediaId',
         roapMessage: {
           seq: 'seq',
@@ -138,6 +140,7 @@ describe('plugin-meetings/roap', () => {
       assert.deepEqual(requestParams, {
         type: 'RoapMessage',
         selfUrl: locusUrl,
+        ipVersion,
         joinCookie: {
           anycastEntryPoint: 'aws-eu-west-1',
         },
@@ -180,6 +183,7 @@ describe('plugin-meetings/roap', () => {
       new: 'sdp',
       reachability: { someResult: 'whatever' }
     };
+    const ipVersion = IP_VERSION.only_ipv6;
 
     roapRequest.attachReachabilityData = sinon.stub().returns(
       Promise.resolve({
@@ -195,6 +199,7 @@ describe('plugin-meetings/roap', () => {
         seq: 1,
       },
       locusSelfUrl: 'locusSelfUrl',
+      ipVersion,
       mediaId: 'mediaId',
       meetingId: 'meetingId',
       preferTranscoding: true,
@@ -206,6 +211,7 @@ describe('plugin-meetings/roap', () => {
     assert.deepEqual(requestParams, {
       type: 'RoapMessage',
       selfUrl: 'locusSelfUrl',
+      ipVersion,
       joinCookie: {
         anycastEntryPoint: 'aws-eu-west-1',
       },

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -7,6 +7,7 @@ import BEHAVIORAL_METRICS from '@webex/plugin-meetings/src/metrics/constants';
 import RoapRequest from '@webex/plugin-meetings/src/roap/request';
 
 import testUtils from '../../../utils/testUtils';
+import { IP_VERSION } from '../../../../src/constants';
 
 describe('TurnDiscovery', () => {
   let clock;
@@ -50,7 +51,10 @@ describe('TurnDiscovery', () => {
         testMeeting.roapSeq = newSeq;
       }),
       updateMediaConnections: sinon.stub(),
-      webex: {meetings: {reachability: {isAnyClusterReachable: () => Promise.resolve(false)}}},
+      webex: {meetings: {reachability: {
+        isAnyClusterReachable: () => Promise.resolve(false),
+        getIpVersion: () => IP_VERSION.unknown,
+      }}},
       isMultistream: false,
       locusMediaRequest: { fake: true },
     };
@@ -78,7 +82,8 @@ describe('TurnDiscovery', () => {
       locusSelfUrl: testMeeting.selfUrl,
       mediaId: expectedMediaId,
       meetingId: testMeeting.id,
-      locusMediaRequest: testMeeting.locusMediaRequest
+      locusMediaRequest: testMeeting.locusMediaRequest,
+      ipVersion: 0,
     });
 
     if (messageType === 'TURN_DISCOVERY_REQUEST') {


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-460221

## This pull request addresses
The backed requires us to tell them what ip network we're on when doing API calls to /discovery and when sending clientMediaPreferences to Locus.
For now, in this PR we just send "unknown" - this should be enough to make meetings work in both ipv4 and ipv6 networks. There are more jiras in the epic to detect the ip network and send correct information - this will be done in other PRs.

More details here: https://confluence-eng-gpk2.cisco.com/conf/display/WTWC/SPARK-448167+-+IPv6+support

## by making the following changes

Added `getIpVersion()` to Reachability class. It's called from all the places that need to know the IP network version.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Manual e2e test with the web app to confirm that we send the ipver parameter and that the backend is happy with it.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
