### PR TITLE
fix: add correct correlation id to rtcmetrics

### DIFF
--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -105,6 +105,7 @@ Media.getDirection = (forceSendRecv: boolean, receive: boolean, send: boolean) =
  * @param {string} debugId string useful for debugging (will appear in media connection logs)
  * @param {object} webex main `webex` object.
  * @param {string} meetingId id for the meeting using this connection
+ * @param {string} correlationId id used in requests to correlate to this session
  * @param {Object} options
  * @param {Object} [options.mediaProperties] contains mediaDirection and local tracks:
  *                                 audioTrack, videoTrack, shareVideoTrack, and shareAudioTrack
@@ -120,6 +121,7 @@ Media.createMediaConnection = (
   debugId: string,
   webex: object,
   meetingId: string,
+  correlationId: string,
   options: {
     mediaProperties: {
       mediaDirection?: {
@@ -178,7 +180,7 @@ Media.createMediaConnection = (
       config.bundlePolicy = bundlePolicy;
     }
 
-    const rtcMetrics = new RtcMetrics(webex, meetingId);
+    const rtcMetrics = new RtcMetrics(webex, meetingId, correlationId);
 
     return new MultistreamRoapMediaConnection(
       config,

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5286,6 +5286,7 @@ export default class Meeting extends StatelessWebexPlugin {
       // @ts-ignore
       this.webex,
       this.id,
+      this.correlationId,
       {
         mediaProperties: this.mediaProperties,
         remoteQualityLevel: this.mediaProperties.remoteQualityLevel,

--- a/packages/@webex/plugin-meetings/src/rtcMetrics/index.ts
+++ b/packages/@webex/plugin-meetings/src/rtcMetrics/index.ts
@@ -1,4 +1,3 @@
-import uuid from 'uuid';
 import RTC_METRICS from './constants';
 
 /**
@@ -23,13 +22,14 @@ export default class RtcMetrics {
    *
    * @param {object} webex - The main `webex` object.
    * @param {string} meetingId - The meeting id.
+   * @param {string} correlationId - The correlation id.
    */
-  constructor(webex, meetingId) {
+  constructor(webex, meetingId, correlationId) {
     // `window` is used to prevent typescript from returning a NodeJS.Timer.
     this.intervalId = window.setInterval(this.checkMetrics.bind(this), 30 * 1000);
     this.meetingId = meetingId;
     this.webex = webex;
-    this.correlationId = uuid.v4();
+    this.correlationId = correlationId;
     // Send the first set of metrics at 5 seconds in the case of a user leaving the call shortly after joining.
     setTimeout(this.checkMetrics.bind(this), 5 * 1000);
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
@@ -43,7 +43,7 @@ describe('createMediaConnection', () => {
     const ENABLE_EXTMAP = false;
     const ENABLE_RTX = true;
 
-    Media.createMediaConnection(false, 'some debug id', webex, 'meetingId', {
+    Media.createMediaConnection(false, 'some debug id', webex, 'meetingId', 'correlationId', {
       mediaProperties: {
         mediaDirection: {
           sendAudio: false,
@@ -115,7 +115,7 @@ describe('createMediaConnection', () => {
       .stub(internalMediaModule, 'MultistreamRoapMediaConnection')
       .returns(fakeRoapMediaConnection);
 
-    Media.createMediaConnection(true, 'some debug id', webex, 'meeting id', {
+    Media.createMediaConnection(true, 'some debug id', webex, 'meeting id', 'correlationId', {
       mediaProperties: {
         mediaDirection: {
           sendAudio: true,
@@ -163,7 +163,7 @@ describe('createMediaConnection', () => {
         .stub(internalMediaModule, 'MultistreamRoapMediaConnection')
         .returns(fakeRoapMediaConnection);
 
-        Media.createMediaConnection(true, 'some debug id', webex, 'meeting id', {
+        Media.createMediaConnection(true, 'some debug id', webex, 'meeting id', 'correlationId', {
           mediaProperties: {
             mediaDirection: {
               sendAudio,
@@ -194,7 +194,7 @@ describe('createMediaConnection', () => {
       .stub(internalMediaModule, 'MultistreamRoapMediaConnection')
       .returns(fakeRoapMediaConnection);
 
-    Media.createMediaConnection(true, 'debug string', webex, 'meeting id', {
+    Media.createMediaConnection(true, 'debug string', webex, 'meeting id', 'correlationId', {
       mediaProperties: {
         mediaDirection: {
           sendAudio: true,
@@ -222,7 +222,7 @@ describe('createMediaConnection', () => {
         .stub(internalMediaModule, 'MultistreamRoapMediaConnection')
         .returns(fakeRoapMediaConnection);
 
-      Media.createMediaConnection(true, 'debug string', webex, 'meeting id', {
+      Media.createMediaConnection(true, 'debug string', webex, 'meeting id', 'correlationId', {
         mediaProperties: {
           mediaDirection: {
             sendAudio: true,
@@ -258,7 +258,7 @@ describe('createMediaConnection', () => {
     const ENABLE_EXTMAP = false;
     const ENABLE_RTX = true;
 
-    Media.createMediaConnection(false, 'some debug id', webex, 'meeting id', {
+    Media.createMediaConnection(false, 'some debug id', webex, 'meeting id', 'correlationId', {
       mediaProperties: {
         mediaDirection: {
           sendAudio: true,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1266,6 +1266,7 @@ describe('plugin-meetings', () => {
             meeting.getMediaConnectionDebugId(),
             webex,
             meeting.id,
+            meeting.correlationId,
             sinon.match({turnServerInfo: undefined})
           );
           assert.calledOnce(meeting.setMercuryListener);
@@ -1338,6 +1339,7 @@ describe('plugin-meetings', () => {
             meeting.getMediaConnectionDebugId(),
             webex,
             meeting.id,
+            meeting.correlationId,
             sinon.match({
               turnServerInfo: {
                 url: FAKE_TURN_URL,
@@ -1593,6 +1595,7 @@ describe('plugin-meetings', () => {
             meeting.getMediaConnectionDebugId(),
             webex,
             meeting.id,
+            meeting.correlationId,
             sinon.match({
               turnServerInfo: {
                 url: FAKE_TURN_URL,

--- a/packages/@webex/plugin-meetings/test/unit/spec/rtcMetrics/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/rtcMetrics/index.ts
@@ -2,6 +2,7 @@ import RtcMetrics from '@webex/plugin-meetings/src/rtcMetrics';
 import MockWebex from '@webex/test-helper-mock-webex';
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
+import RTC_METRICS from '../../../../src/rtcMetrics/constants';
 
 const FAKE_METRICS_ITEM = {payload: ['fake-metrics']};
 
@@ -23,6 +24,13 @@ describe('RtcMetrics', () => {
     (metrics as any).sendMetrics();
 
     assert.callCount(webex.request, 1);
+    assert.calledWithMatch(webex.request, sinon.match.has('headers', {
+      type: 'webrtcMedia',
+      appId: RTC_METRICS.APP_ID,
+    }));
+    assert.calledWithMatch(webex.request, sinon.match.hasNested('body.metrics[0].data[0].payload', FAKE_METRICS_ITEM.payload));
+    assert.calledWithMatch(webex.request, sinon.match.hasNested('body.metrics[0].meetingId', 'mock-meeting-id'));
+    assert.calledWithMatch(webex.request, sinon.match.hasNested('body.metrics[0].correlationId', 'mock-correlation-id'));
   });
 
   it('should send metrics requests over time', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/rtcMetrics/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/rtcMetrics/index.ts
@@ -13,7 +13,7 @@ describe('RtcMetrics', () => {
   beforeEach(() => {
     clock = sinon.useFakeTimers();
     webex = new MockWebex();
-    metrics = new RtcMetrics(webex, 'mock-meeting-id');
+    metrics = new RtcMetrics(webex, 'mock-meeting-id', 'mock-correlation-id');
   });
 
   it('sendMetrics should send a webex request', () => {


### PR DESCRIPTION
# COMPLETES [SPARK-462083](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-462083)

## This pull request addresses

Using the correct correlation id in RtcMetrics requests.

## by making the following changes

Pulls in the `correlationId` from the meeting object

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
