### PR TITLE
fix: improve error logging for xhr

### DIFF
--- a/packages/@webex/http-core/src/lib/xhr.js
+++ b/packages/@webex/http-core/src/lib/xhr.js
@@ -106,7 +106,11 @@ function _createXHR(options) {
   function errorFunc(evt) {
     clearTimeout(timeoutTimer);
     if (!(evt instanceof Error)) {
-      evt = new Error('' + (evt || 'Unknown XMLHttpRequest Error'));
+      if (evt instanceof ProgressEvent) {
+        evt = new Error(`XMLHttpRequest Error: ProgressEvent: loaded=${evt.loaded}, total=${evt.total}, lengthComputable=${evt.lengthComputable}, target.readyState=${evt.target?.readyState}`)
+      } else {
+        evt = new Error('' + (evt || 'Unknown XMLHttpRequest Error'));
+      }
     }
     evt.statusCode = 0;
     return callback(evt, failureResponse);

--- a/packages/@webex/http-core/src/request/request.shim.js
+++ b/packages/@webex/http-core/src/request/request.shim.js
@@ -52,7 +52,10 @@ export default function _request(options) {
     const x = xhr(params, (error, response) => {
       /* istanbul ignore next */
       if (error) {
-        options.logger.warn(error);
+        options.logger.warn(
+          `XHR error for ${options.method || 'request'} to ${options.uri} :`,
+          error
+        );
       }
 
       /* istanbul ignore else */


### PR DESCRIPTION
# COMPLETES #
N/A

## This pull request addresses
SDK logs often have lines like this:
`,2023-09-21T06:55:39.397Z,wx-js-sdk,Error: [object ProgressEvent]`
which are not very useful - we know nothing about the error and is very difficult to find the code from where the error originated.

## by making the following changes

Improved the log so it will look like this now:
`,2023-09-26T11:30:28.352Z,wx-js-sdk,XHR error for GET to https://myspark.cisco.com/spark_session_check.json :,Error: XMLHttpRequest Error: ProgressEvent: loaded=0, total=0, lengthComputable=false, target.readyState=4`

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

manual run with web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
