### PR TITLE
feat: added IpNetworkDetector to webex.internal.device

### DIFF
--- a/packages/@webex/internal-plugin-device/src/device.js
+++ b/packages/@webex/internal-plugin-device/src/device.js
@@ -6,6 +6,7 @@ import {safeSetTimeout} from '@webex/common-timers';
 import METRICS from './metrics';
 import {FEATURE_COLLECTION_NAMES, DEVICE_EVENT_REGISTRATION_SUCCESS} from './constants';
 import FeaturesModel from './features/features-model';
+import IpNetworkDetector from './ipNetworkDetector';
 
 /**
  * Determine if the plugin should be initialized based on cached storage.
@@ -34,6 +35,12 @@ const Device = WebexPlugin.extend({
      * @type {FeaturesModel}
      */
     features: FeaturesModel,
+    /**
+     * Helper class for detecting what IP network version (ipv4, ipv6) we're on.
+     *
+     * @type {IpNetworkDetector}
+     */
+    ipNetworkDetector: IpNetworkDetector,
   },
 
   /**

--- a/packages/@webex/internal-plugin-device/src/ipNetworkDetector.ts
+++ b/packages/@webex/internal-plugin-device/src/ipNetworkDetector.ts
@@ -1,0 +1,176 @@
+/*!
+ * Copyright (c) 2015-2023 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {WebexPlugin} from '@webex/webex-core';
+
+/**
+ * @class
+ */
+const IpNetworkDetector = WebexPlugin.extend({
+  idAttribute: 'IpNetworkDetectorId',
+
+  namespace: 'Device',
+
+  props: {
+    firstIpV4: ['number', true, -1], // time [ms] it took to receive first IPv4 candidate
+    firstIpV6: ['number', true, -1], // time [ms] it took to receive first IPv6 candidate
+    firstMdns: ['number', true, -1], // time [ms] it took to receive first mDNS candidate
+    totalTime: ['number', true, -1], // total time [ms] it took to do the last IP network detection
+  },
+
+  derived: {
+    /**
+     * True if we know we're on an IPv4 network,
+     * False if we know that we are not on an IPv4 network,
+     * undefined if we are not sure
+     */
+    supportsIpV4: {
+      deps: ['firstIpV4', 'firstIpV6', 'firstMdns', 'totalTime'],
+      /**
+       * Function for calculating the value of supportsIpV4 prop
+       * @returns {boolean | undefined}
+       */
+      fn() {
+        if (this.firstIpV4 >= 0) {
+          return true;
+        }
+        if (this.totalTime < 0) {
+          // we haven't completed the detection, yet
+          return undefined;
+        }
+        if (this.receivedOnlyMDnsCandidates()) {
+          return undefined;
+        }
+
+        return false;
+      },
+    },
+    /**
+     * True if we know we're on an IPv6 network,
+     * False if we know that we are not on an IPv6 network,
+     * undefined if we are not sure
+     */
+    supportsIpV6: {
+      deps: ['firstIpV4', 'firstIpV6', 'firstMdns', 'totalTime'],
+      /**
+       * Function for calculating the value of supportsIpV6 prop
+       * @returns {boolean | undefined}
+       */ fn() {
+        if (this.firstIpV6 >= 0) {
+          return true;
+        }
+        if (this.totalTime < 0) {
+          // we haven't completed the detection, yet
+          return undefined;
+        }
+        if (this.receivedOnlyMDnsCandidates()) {
+          return undefined;
+        }
+
+        return false;
+      },
+    },
+  },
+
+  /**
+   * Returns true if we have received only mDNS candidates - browsers usually do that if we don't have any user media permissions
+   *
+   * @private
+   * @returns {boolean}
+   */
+  receivedOnlyMDnsCandidates() {
+    return this.totalTime >= 0 && this.firstMdns >= 0 && this.firstIpV4 < 0 && this.firstIpV6 < 0;
+  },
+
+  /**
+   *
+   * @param {RTCPeerConnection} pc Peer connection to use
+   * @private
+   * @returns {Promise<void>}
+   */
+  async gatherLocalCandidates(pc: RTCPeerConnection): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let done = false;
+
+      this.firstIpV4 = -1;
+      this.firstIpV6 = -1;
+      this.firstMdns = -1;
+      this.totalTime = -1;
+      const startTime = performance.now();
+
+      const doneGatheringIceCandidates = () => {
+        if (done) {
+          return;
+        }
+        done = true;
+
+        this.totalTime = performance.now() - startTime;
+
+        resolve();
+      };
+
+      pc.onicecandidate = (event) => {
+        if (event.candidate?.address) {
+          if (event.candidate.address.endsWith('.local')) {
+            // if we don't have camera/mic permissions, browser just gives us mDNS candidates
+            if (this.firstMdns === -1) {
+              this.firstMdns = performance.now() - startTime;
+            }
+          } else if (event.candidate.address.includes(':')) {
+            if (this.firstIpV6 === -1) {
+              this.firstIpV6 = performance.now() - startTime;
+            }
+          } else if (this.firstIpV4 === -1) {
+            this.firstIpV4 = performance.now() - startTime;
+          }
+
+          if (this.firstIpV4 >= 0 && this.firstIpV6 >= 0) {
+            // if we've got both ipv4 and ipv6 candidates, there is no need to wait for any more candidates, we can resolve now
+            resolve();
+          }
+        } else if (event.candidate === null) {
+          doneGatheringIceCandidates();
+        }
+      };
+
+      pc.onicegatheringstatechange = () => {
+        if (pc.iceGatheringState === 'complete') {
+          doneGatheringIceCandidates();
+        }
+      };
+
+      pc.createDataChannel('data');
+
+      pc.createOffer()
+        .then((offer) => pc.setLocalDescription(offer))
+        .catch((e) => {
+          this.webex.logger.error('Failed to detect ip network version:', e);
+          reject(e);
+        });
+    });
+  },
+
+  /**
+   * Detects if we are on IPv4 and/or IPv6 network. Once it resolves, read the
+   * supportsIpV4 and supportsIpV6 props to find out the result.
+   *
+   * @returns {Promise<Object>}
+   */
+  async detect() {
+    let results;
+    let pc;
+
+    try {
+      pc = new RTCPeerConnection();
+
+      results = await this.gatherLocalCandidates(pc);
+    } finally {
+      pc.close();
+    }
+
+    return results;
+  },
+});
+
+export default IpNetworkDetector;

--- a/packages/@webex/internal-plugin-device/test/unit/spec/ipNetworkDetector.js
+++ b/packages/@webex/internal-plugin-device/test/unit/spec/ipNetworkDetector.js
@@ -1,0 +1,410 @@
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import IpNetworkDetector from '@webex/internal-plugin-device/src/ipNetworkDetector';
+import MockWebex from '@webex/test-helper-mock-webex';
+
+describe('plugin-device', () => {
+  describe('IpNetworkDetector', () => {
+    let webex;
+    let ipNetworkDetector;
+
+    beforeEach(() => {
+      webex = new MockWebex({});
+
+      ipNetworkDetector = new IpNetworkDetector({}, {parent: webex});
+    });
+
+    it('is initialized correctly', () => {
+      assert.equal(ipNetworkDetector.supportsIpV4, undefined);
+      assert.equal(ipNetworkDetector.supportsIpV6, undefined);
+      assert.equal(ipNetworkDetector.firstIpV4, -1);
+      assert.equal(ipNetworkDetector.firstIpV6, -1);
+      assert.equal(ipNetworkDetector.firstMdns, -1);
+      assert.equal(ipNetworkDetector.totalTime, -1);
+    });
+
+    describe('detect', () => {
+      let previousRTCPeerConnection;
+      let clock;
+      let fakePeerConnection;
+
+      const FAKE_OFFER = {type: 'offer', sdp: 'some sdp'};
+
+      beforeEach(() => {
+        clock = sinon.useFakeTimers();
+
+        previousRTCPeerConnection = global.RTCPeerConnection;
+
+        fakePeerConnection = {
+          createDataChannel: sinon.stub(),
+          createOffer: sinon.stub().resolves(FAKE_OFFER),
+          setLocalDescription: sinon.stub().resolves(),
+          close: sinon.stub(),
+          iceGatheringState: 'new',
+        };
+        global.RTCPeerConnection = sinon.stub().returns(fakePeerConnection);
+      });
+
+      afterEach(() => {
+        global.RTCPeerConnection = previousRTCPeerConnection;
+        clock.restore();
+      });
+
+      const simulateCandidate = (delay, address) => {
+        clock.tick(delay);
+
+        fakePeerConnection.onicecandidate({
+          candidate: {address},
+        });
+      };
+
+      const simulateEndOfCandidateGathering = (delay, useGatheringStateChange = true) => {
+        clock.tick(delay);
+
+        // browsers have 2 ways of notifying about ICE candidate gathering being completed
+        // 1. through gathering state change
+        // 2. by sending a null candidate
+        if (useGatheringStateChange) {
+          fakePeerConnection.iceGatheringState = 'complete';
+          fakePeerConnection.onicegatheringstatechange();
+        } else {
+          fakePeerConnection.onicecandidate({
+            candidate: null,
+          });
+        }
+      };
+
+      const checkResults = (expectedResults) => {
+        assert.equal(ipNetworkDetector.supportsIpV4, expectedResults.supportsIpV4);
+        assert.equal(ipNetworkDetector.supportsIpV6, expectedResults.supportsIpV6);
+        assert.equal(ipNetworkDetector.firstIpV4, expectedResults.timings.ipv4);
+        assert.equal(ipNetworkDetector.firstIpV6, expectedResults.timings.ipv6);
+        assert.equal(ipNetworkDetector.firstMdns, expectedResults.timings.mdns);
+        assert.equal(ipNetworkDetector.totalTime, expectedResults.timings.totalTime);
+      };
+
+      it('creates an RTCPeerConnection with a data channel and does ice candidate gathering', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        simulateEndOfCandidateGathering();
+
+        await promise;
+
+        assert.calledOnceWithExactly(fakePeerConnection.createDataChannel, 'data');
+        assert.calledOnceWithExactly(fakePeerConnection.createOffer);
+        assert.calledOnceWithExactly(fakePeerConnection.setLocalDescription, FAKE_OFFER);
+      });
+
+      it('works correctly when we get only ipv4 candidates', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        simulateCandidate(70, '192.168.0.1');
+        simulateCandidate(30, '192.168.16.1');
+        simulateEndOfCandidateGathering(50);
+
+        await promise;
+
+        checkResults({
+          supportsIpV4: true,
+          supportsIpV6: false,
+          timings: {
+            totalTime: 150,
+            ipv4: 70, // this should match the first ipv4 candidate's delay
+            ipv6: -1,
+            mdns: -1,
+          },
+        });
+      });
+
+      it('works correctly when we get only ipv6 candidates (chrome, safari)', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        // chrome and safari for some reason wrap the ipv6 addresses with []
+        simulateCandidate(150, '[2a02:c7c:a0d0:8a00:db9b:d4de:d1f7:4c49]');
+        simulateCandidate(50, '[2a02:c7c:a0d0:8a00:d089:7baf:ceef:b9d8]');
+        simulateEndOfCandidateGathering(100);
+
+        await promise;
+
+        checkResults({
+          supportsIpV4: false,
+          supportsIpV6: true,
+          timings: {
+            totalTime: 300,
+            ipv4: -1,
+            ipv6: 150, // this should match the first ipv6 candidate's delay
+            mdns: -1,
+          },
+        });
+      });
+
+      it('works correctly when we get only ipv6 candidates (Firefox)', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        simulateCandidate(150, '2a02:c7c:a0d0:8a00:db9b:d4de:d1f7:4c49');
+        simulateCandidate(50, '2a02:c7c:a0d0:8a00:d089:7baf:ceef:b9d8');
+        simulateEndOfCandidateGathering(100);
+
+        await promise;
+
+        checkResults({
+          supportsIpV4: false,
+          supportsIpV6: true,
+          timings: {
+            totalTime: 300,
+            ipv4: -1,
+            ipv6: 150, // this should match the first ipv6 candidate's delay
+            mdns: -1,
+          },
+        });
+      });
+
+      it('works correctly when we get both ipv6 and ipv4 candidates', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        simulateCandidate(50, '2a02:c7c:a0d0:8a00:db9b:d4de:d1f7:4c49');
+        simulateCandidate(50, '192.168.10.10');
+
+        // at this point, as we've got at least 1 IPv4 and IPv6 candidate the promise should already be resolved
+        await promise;
+
+        checkResults({
+          supportsIpV4: true,
+          supportsIpV6: true,
+          timings: {
+            totalTime: -1, // ice gathering has not finished, so this one is still -1
+            ipv4: 100,
+            ipv6: 50,
+            mdns: -1,
+          },
+        });
+
+        // receiving any more candidates should not cause any problems
+        simulateCandidate(50, '192.168.1.1');
+        simulateCandidate(50, '2a02:c7c:a0d0:8a00:d089:7baf:ceef:b9d8');
+        simulateEndOfCandidateGathering(100);
+
+        // check final results haven't changed (except for totalTime)
+        checkResults({
+          supportsIpV4: true,
+          supportsIpV6: true,
+          timings: {
+            totalTime: 300,
+            ipv4: 100,
+            ipv6: 50,
+            mdns: -1,
+          },
+        });
+      });
+
+      it('works correctly when we get only mDNS candidates', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        // simulate some mDNS candidates (this happens if we don't have user media permissions)
+        simulateCandidate(50, '686a3cac-2840-4c62-9f85-9f0b03e84298.local');
+        simulateCandidate(50, '12f3ab4a3-4741-48c8-b1c9-8dd93d123aa1.local');
+        simulateEndOfCandidateGathering(100);
+
+        await promise;
+
+        checkResults({
+          supportsIpV4: undefined,
+          supportsIpV6: undefined,
+          timings: {
+            totalTime: 200,
+            ipv4: -1,
+            ipv6: -1,
+            mdns: 50,
+          },
+        });
+      });
+
+      it('works correctly when we get no candidates at all', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        simulateEndOfCandidateGathering(100);
+
+        await promise;
+
+        checkResults({
+          supportsIpV4: false,
+          supportsIpV6: false,
+          timings: {
+            totalTime: 100,
+            ipv4: -1,
+            ipv6: -1,
+            mdns: -1,
+          },
+        });
+      });
+
+      // this never happens right now, but in theory browsers might change and if we get
+      // mDNS candidates with IPv4, but without IPv6, it is probably safe to assume that we're only on IPv4 network
+      it('works correctly when we get mDNS and ipv4 candidates', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        simulateCandidate(50, '686a3cac-2840-4c62-9f85-9f0b03e84298.local');
+        simulateCandidate(50, '192.168.0.0');
+        simulateEndOfCandidateGathering(100);
+
+        await promise;
+
+        checkResults({
+          supportsIpV4: true,
+          supportsIpV6: false,
+          timings: {
+            totalTime: 200,
+            ipv4: 100,
+            ipv6: -1,
+            mdns: 50,
+          },
+        });
+      });
+
+      // this never happens right now, but in theory browsers might change and if we get
+      // mDNS candidates with IPv6, but without IPv4, it is probably safe to assume that we're only on IPv6 network
+      it('works correctly when we get mDNS and ipv6 candidates', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        simulateCandidate(50, '686a3cac-2840-4c62-9f85-9f0b03e84298.local');
+        simulateCandidate(50, '2a02:c7c:a0d0:8a00:db9b:d4de:d1f7:4c49');
+        simulateEndOfCandidateGathering(100);
+
+        await promise;
+
+        checkResults({
+          supportsIpV4: false,
+          supportsIpV6: true,
+          timings: {
+            totalTime: 200,
+            ipv4: -1,
+            ipv6: 100,
+            mdns: 50,
+          },
+        });
+      });
+
+      it('works correctly when we get null candidate at the end instead of gathering state change event', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        simulateCandidate(50, '2a02:c7c:a0d0:8a00:db9b:d4de:d1f7:4c49');
+        simulateCandidate(50, '192.168.10.10');
+        simulateEndOfCandidateGathering(100, false);
+
+        await promise;
+
+        checkResults({
+          supportsIpV4: true,
+          supportsIpV6: true,
+          timings: {
+            totalTime: 200,
+            ipv4: 100,
+            ipv6: 50,
+            mdns: -1,
+          },
+        });
+      });
+
+      it('resets all the props when called again', async () => {
+        const promise = ipNetworkDetector.detect();
+
+        simulateCandidate(50, '192.168.0.1');
+        simulateCandidate(50, '2a02:c7c:a0d0:8a00:db9b:d4de:d1f7:4c49');
+        simulateEndOfCandidateGathering(10);
+
+        await promise;
+
+        checkResults({
+          supportsIpV4: true,
+          supportsIpV6: true,
+          timings: {
+            totalTime: 110,
+            ipv4: 50,
+            ipv6: 100,
+            mdns: -1,
+          },
+        });
+
+        // now call detect() again
+        const promise2 = ipNetworkDetector.detect();
+
+        // everything should have been reset
+        assert.equal(ipNetworkDetector.supportsIpV4, undefined);
+        assert.equal(ipNetworkDetector.supportsIpV6, undefined);
+        assert.equal(ipNetworkDetector.firstIpV4, -1);
+        assert.equal(ipNetworkDetector.firstIpV6, -1);
+        assert.equal(ipNetworkDetector.firstMdns, -1);
+        assert.equal(ipNetworkDetector.totalTime, -1);
+
+        simulateEndOfCandidateGathering(10);
+        await promise2;
+      });
+
+      it('rejects if one of RTCPeerConnection operations fails', async () => {
+        const fakeError = new Error('fake error');
+
+        fakePeerConnection.createOffer.rejects(fakeError);
+
+        await assert.isRejected(ipNetworkDetector.detect(), fakeError);
+
+        assert.calledOnce(fakePeerConnection.close);
+      });
+
+      describe('while detection is in progress', () => {
+        describe('supportsIpv4 prop', () => {
+          it('returns undefined before any ipv4 candidate is received and true afterwards', async () => {
+            const promise = ipNetworkDetector.detect();
+
+            assert.equal(ipNetworkDetector.supportsIpV4, undefined);
+            assert.equal(ipNetworkDetector.firstIpV4, -1);
+
+            simulateCandidate(50, 'fd64:17cf:f4ad:0:d089:7baf:ceef:b9d8');
+            // still no ipv4 candidates...
+            assert.equal(ipNetworkDetector.supportsIpV4, undefined);
+            assert.equal(ipNetworkDetector.firstIpV4, -1);
+
+            simulateCandidate(50, '686a3cac-2840-4c62-9f85-9f0b03e84298.local');
+            // still no ipv4 candidates...
+            assert.equal(ipNetworkDetector.supportsIpV4, undefined);
+            assert.equal(ipNetworkDetector.firstIpV4, -1);
+
+            simulateCandidate(50, '192.168.0.0');
+            // now we've got one
+            assert.equal(ipNetworkDetector.supportsIpV4, true);
+            assert.equal(ipNetworkDetector.firstIpV4, 150);
+
+            simulateEndOfCandidateGathering(1);
+            await promise;
+          });
+        });
+
+        describe('supportsIpv6 prop', () => {
+          it('returns undefined before any ipv6 candidate is received and true afterwards', async () => {
+            const promise = ipNetworkDetector.detect();
+
+            assert.equal(ipNetworkDetector.supportsIpV6, undefined);
+            assert.equal(ipNetworkDetector.firstIpV6, -1);
+
+            simulateCandidate(50, '192.168.0.0');
+            // still no ipv6 candidates...
+            assert.equal(ipNetworkDetector.supportsIpV6, undefined);
+            assert.equal(ipNetworkDetector.firstIpV6, -1);
+
+            simulateCandidate(50, '686a3cac-2860-6c62-9f85-9f0b03e86298.local');
+            // still no ipv6 candidates...
+            assert.equal(ipNetworkDetector.supportsIpV6, undefined);
+            assert.equal(ipNetworkDetector.firstIpV6, -1);
+
+            simulateCandidate(50, 'fd64:17cf:f4ad:0:d089:7baf:ceef:b9d8');
+            // now we've got one
+            assert.equal(ipNetworkDetector.supportsIpV6, true);
+            assert.equal(ipNetworkDetector.firstIpV6, 150);
+
+            simulateEndOfCandidateGathering(1);
+            await promise;
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-460571

## This pull request addresses
We need to detect if we're on IPv4 or IPv6 network (or both)

## by making the following changes
Added IpNetworkDetector to webex.internal.device as described in the tech breakdown page:
https://confluence-eng-gpk2.cisco.com/conf/display/WTWC/SPARK-448167+-+IPv6+support

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests + tested manually with sample app and modified meetings plugin that calls webex.internal.device.ipNetworkDetector.detect() to see if it works correctly in real browser

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
