### PR TITLE
fix(plugin-meetings): reset sendSlotsManager on meeting leave

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3711,6 +3711,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
       this.receiveSlotManager.reset();
       this.mediaProperties.webrtcMediaConnection.close();
+      this.sendSlotManager.reset();
     }
 
     this.audio = null;

--- a/packages/@webex/plugin-meetings/src/multistream/sendSlotManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/sendSlotManager.ts
@@ -159,4 +159,12 @@ export default class SendSlotManager {
       `SendSlotsManager->deleteCodecParameters#Deleted the following codec parameters -> ${parameters} for ${mediaType}`
     );
   }
+
+  /**
+   * This method is used to reset the SendSlotsManager by deleting all the sendSlots
+   * @returns {undefined}
+   */
+  public reset(): void {
+    this.slots.clear();
+  }
 }

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/sendSlotManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/sendSlotManager.ts
@@ -213,4 +213,30 @@ describe('SendSlotsManager', () => {
             });
         });
     });
+
+    describe('reset', () => {
+        let mediaConnection;
+
+        beforeEach(() => {
+            mediaConnection = {
+                createSendSlot: sinon.stub().returns({}),
+            } as MultistreamRoapMediaConnection;
+        });
+
+        it('should reset the send slot manager', () => {
+            const AudioSlot = sendSlotsManager.createSlot(mediaConnection, MediaType.AudioMain);
+            const VideoSlot = sendSlotsManager.createSlot(mediaConnection, MediaType.VideoMain);
+            const AudioSlidesSlot = sendSlotsManager.createSlot(mediaConnection, MediaType.AudioSlides);
+            const VideoSlidesSlot = sendSlotsManager.createSlot(mediaConnection, MediaType.VideoSlides);
+            expect(sendSlotsManager.getSlot(MediaType.AudioMain)).to.equal(AudioSlot);
+            expect(sendSlotsManager.getSlot(MediaType.VideoMain)).to.equal(VideoSlot);
+            expect(sendSlotsManager.getSlot(MediaType.AudioSlides)).to.equal(AudioSlidesSlot);
+            expect(sendSlotsManager.getSlot(MediaType.VideoSlides)).to.equal(VideoSlidesSlot);
+            sendSlotsManager.reset();
+            expect(() => sendSlotsManager.getSlot(MediaType.AudioMain)).to.throw();
+            expect(() => sendSlotsManager.getSlot(MediaType.VideoMain)).to.throw();
+            expect(() => sendSlotsManager.getSlot(MediaType.AudioSlides)).to.throw();
+            expect(() => sendSlotsManager.getSlot(MediaType.VideoSlides)).to.throw();
+        });
+    });
 });


### PR DESCRIPTION
# COMPLETES [SPARK-465362](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-465362)

## This pull request addresses

- The SendSlotsManager throws an error as the SendSlots in the SDK was never cleared on meeting leave

## by making the following changes

- The SendSlotsManager is introduced with a new method `deleteSlot`
- The `meeting.clearMeetingData()` method clears all the send slots by using the `deleteSlot` method above

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
