### PR TITLE
fix(samples): correct mute state on device change

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -1117,10 +1117,14 @@ function setVideoInputDevice() {
   const {video} = getAudioVideoInput();
 
   if (meeting) {
+    const isMuted = localMedia.cameraStream?.muted;
     localMedia.cameraStream?.stop();
 
     return getUserMedia({video})
-      .then(() => meeting.publishStreams({camera: localMedia.cameraStream}));
+      .then(() => {
+        localMedia.cameraStream.setMuted(!!isMuted);
+        meeting.publishStreams({camera: localMedia.cameraStream});
+      });
   }
   else {
     console.log('MeetingControls#setVideoInputDevice() :: no valid meeting object!');
@@ -1132,10 +1136,14 @@ function setAudioInputDevice() {
   const {audio} = getAudioVideoInput();
 
   if (meeting) {
+    const isMuted = localMedia.microphoneStream?.muted;
     localMedia.microphoneStream?.stop();
 
     return getUserMedia({audio})
-      .then(() => meeting.publishStreams({microphone: localMedia.microphoneStream}));
+      .then(() => {
+        localMedia.microphoneStream.setMuted(!!isMuted);
+        meeting.publishStreams({microphone: localMedia.microphoneStream});
+      });
   }
   else {
     console.log('MeetingControls#setAudioInputDevice() :: no valid meeting object!');


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-466442](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-466442) >

## This pull request addresses

When we change the microphone device, if audio is muted, then with the next device, it starts with audio unmuted. Same for camera device.

## by making the following changes

We're setting previous mute state to new stream created before publishing the streams in the deviceChange api in samples app.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
