### PR TITLE
feat(plugin-meetings): use locus cluster url to avoid the redirect

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -216,13 +216,16 @@ export default class MeetingRequest extends StatelessWebexPlugin {
       url = `${locusUrl}/${PARTICIPANT}`;
     } else if (inviteeAddress || meetingNumber) {
       try {
-        // @ts-ignore
-        await this.webex.internal.services.waitForCatalog('postauth');
+        let clusterUrl;
 
-        const clusterUrl = locusClusterUrl
-          ? `https://${locusClusterUrl}/locus/api/v1`
-          : // @ts-ignore
-            this.webex.internal.services.get('locus');
+        if (locusClusterUrl) {
+          clusterUrl = `https://${locusClusterUrl}/locus/api/v1`;
+        } else {
+          // @ts-ignore
+          await this.webex.internal.services.waitForCatalog('postauth');
+          // @ts-ignore
+          clusterUrl = this.webex.internal.services.get('locus');
+        }
 
         url = `${clusterUrl}/${LOCI}/${CALL}`;
         body.invitee = {

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -108,6 +108,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
     sipUri: string;
     deviceUrl: string;
     locusUrl: string;
+    locusClusterUrl: string;
     resourceId: string;
     correlationId: string;
     ensureConversation: boolean;
@@ -133,6 +134,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
       permissionToken,
       deviceUrl,
       locusUrl,
+      locusClusterUrl,
       resourceId,
       correlationId,
       ensureConversation,
@@ -216,8 +218,13 @@ export default class MeetingRequest extends StatelessWebexPlugin {
       try {
         // @ts-ignore
         await this.webex.internal.services.waitForCatalog('postauth');
-        // @ts-ignore
-        url = `${this.webex.internal.services.get('locus')}/${LOCI}/${CALL}`;
+
+        const clusterUrl = locusClusterUrl
+          ? `https://${locusClusterUrl}/locus/api/v1`
+          : // @ts-ignore
+            this.webex.internal.services.get('locus');
+
+        url = `${clusterUrl}/${LOCI}/${CALL}`;
         body.invitee = {
           address: inviteeAddress || `wbxmn:${meetingNumber}`,
         };

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -112,6 +112,7 @@ const MeetingUtil = {
         meetingNumber: meeting.meetingNumber,
         deviceUrl: meeting.deviceUrl,
         locusUrl: meeting.locusUrl,
+        locusClusterUrl: meeting.meetingInfo?.locusClusterUrl,
         correlationId: meeting.correlationId,
         roapMessage: options.roapMessage,
         permissionToken: meeting.permissionToken,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
@@ -237,6 +237,29 @@ describe('plugin-meetings', () => {
         assert.equal(requestParams.body.invitee.address, 'sipUrl');
       });
 
+      it('sends uses the locusClusterUrl if available', async () => {
+        const deviceUrl = 'deviceUrl';
+        const correlationId = 'random-uuid';
+        const roapMessage = 'roap-message';
+        const inviteeAddress = 'sipUrl';
+        const locusClusterUrl = 'locusClusterUrl';
+
+        await meetingsRequest.joinMeeting({
+          deviceUrl,
+          correlationId,
+          roapMessage,
+          locusClusterUrl,
+          inviteeAddress,
+        });
+        const requestParams = meetingsRequest.request.getCall(0).args[0];
+
+        assert.equal(requestParams.method, 'POST');
+        assert.equal(
+          requestParams.uri,
+          'https://locusClusterUrl/locus/api/v1/loci/call?alternateRedirect=true'
+        );
+      });
+
       it('adds deviceCapabilities to request when breakouts are supported', async () => {
         await meetingsRequest.joinMeeting({
           breakoutsSupported: true,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -519,6 +519,26 @@ describe('plugin-meetings', () => {
         assert.isUndefined(parameter.inviteeAddress);
         assert.equal(parameter.meetingNumber, 'meetingNumber');
       });
+
+      it('should pass in the locusClusterUrl from meetingInfo', async () => {
+        const meeting = {
+          meetingInfo: {
+            locusClusterUrl: 'locusClusterUrl',
+          },
+          meetingRequest: {
+            joinMeeting: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
+          },
+          getWebexObject: sinon.stub().returns(webex),
+        };
+
+        MeetingUtil.parseLocusJoin = sinon.stub();
+        await MeetingUtil.joinMeeting(meeting, {});
+
+        assert.calledOnce(meeting.meetingRequest.joinMeeting);
+        const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
+
+        assert.equal(parameter.locusClusterUrl, 'locusClusterUrl');
+      });
     });
 
     describe('joinMeetingOptions', () => {


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Avoid the need for a redirect by using the locusClusterUrl from meetingInfo

## by making the following changes

The locusClusterUrl is passed to the request from the joinMeeting util.
I've only made the change for the `/call` route since when we join a meeting using `/participant` we already know the cluster

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
