### PR TITLE
feat(ca): add temporary flag for buildType

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -143,7 +143,15 @@ export const isBrowserMediaErrorName = (errorName: any) => {
  * @param webClientDomain
  * @returns
  */
-export const getBuildType = (webClientDomain): Event['origin']['buildType'] => {
+export const getBuildType = (
+  webClientDomain,
+  markAsTestEvent = false
+): Event['origin']['buildType'] => {
+  // used temporary to test pre join in production without creating noise data, SPARK-468456
+  if (markAsTestEvent) {
+    return 'test';
+  }
+
   if (
     webClientDomain?.includes('localhost') ||
     webClientDomain?.includes('127.0.0.1') ||
@@ -163,7 +171,10 @@ export const getBuildType = (webClientDomain): Event['origin']['buildType'] => {
  */
 export const prepareDiagnosticMetricItem = (webex: any, item: any) => {
   const origin: Partial<Event['origin']> = {
-    buildType: getBuildType(item.event?.eventData?.webClientDomain),
+    buildType: exports.getBuildType(
+      item.eventPayload?.event?.eventData?.webClientDomain,
+      item.eventPayload?.event?.eventData?.markAsTestEvent
+    ),
     networkType: 'unknown',
   };
 

--- a/packages/@webex/internal-plugin-metrics/src/index.ts
+++ b/packages/@webex/internal-plugin-metrics/src/index.ts
@@ -20,6 +20,7 @@ import {
   SubmitMQE,
 } from './metrics.types';
 import * as CALL_DIAGNOSTIC_CONFIG from './call-diagnostic/config';
+import * as CallDiagnosticUtils from './call-diagnostic/call-diagnostic-metrics.util';
 
 registerInternalPlugin('metrics', Metrics, {
   config,
@@ -30,7 +31,7 @@ registerInternalPlugin('newMetrics', NewMetrics, {
 });
 
 export {default, getOSNameInternal} from './metrics';
-export {config, CALL_DIAGNOSTIC_CONFIG, NewMetrics, Utils};
+export {config, CALL_DIAGNOSTIC_CONFIG, NewMetrics, Utils, CallDiagnosticUtils};
 export type {
   ClientEvent,
   ClientEventLeaveReason,


### PR DESCRIPTION
# COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-468456

## This pull request addresses

- add temporary flag to mark buildType as test for pre join events
- avoids noise data while testing this in prod
- fix event property in prepare util function

## by making the following changes

- refactor, add new flag

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

-unit test, manual test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
