### PR TITLE
fix(plugin-meetings): do not sync meetings if unverified guest

### DIFF
--- a/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
@@ -443,17 +443,19 @@ export default class ReconnectionManager {
       }
     }
 
-    try {
-      LoggerProxy.logger.info(
-        'ReconnectionManager:index#executeReconnection --> Updating meeting data from server.'
-      );
-      await this.webex.meetings.syncMeetings();
-    } catch (syncError) {
-      LoggerProxy.logger.info(
-        'ReconnectionManager:index#executeReconnection --> Unable to sync meetings, reconnecting.',
-        syncError
-      );
-      throw new NeedsRetryError(syncError);
+    if (!this.webex.credentials.isUnverifiedGuest) {
+      try {
+        LoggerProxy.logger.info(
+          'ReconnectionManager:index#executeReconnection --> Updating meeting data from server.'
+        );
+        await this.webex.meetings.syncMeetings();
+      } catch (syncError) {
+        LoggerProxy.logger.info(
+          'ReconnectionManager:index#executeReconnection --> Unable to sync meetings, reconnecting.',
+          syncError
+        );
+        throw new NeedsRetryError(syncError);
+      }
     }
 
     // TODO: try to improve this logic as the reconnection manager saves the instance of deleted meeting object

--- a/packages/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
@@ -58,6 +58,9 @@ describe('plugin-meetings', () => {
           updateMediaConnection: sinon.stub(),
         },
         webex: {
+          credentials: {
+            isUnverifiedGuest: false,
+          },
           meetings: {
             getMeetingByType: sinon.stub().returns(true),
             syncMeetings: sinon.stub().resolves({}),
@@ -69,6 +72,24 @@ describe('plugin-meetings', () => {
           }
         },
       };
+    });
+
+    it('syncs meetings if it is not an unverified guest', async () => {
+      const rm = new ReconnectionManager(fakeMeeting);
+
+      await rm.reconnect();
+
+      assert.calledOnce(rm.webex.meetings.syncMeetings);
+    });
+
+    it('does not sync meetings if it is an unverified guest', async () => {
+      const rm = new ReconnectionManager(fakeMeeting);
+
+      rm.webex.credentials.isUnverifiedGuest = true;
+
+      await rm.reconnect();
+
+      assert.notCalled(rm.webex.meetings.syncMeetings);
     });
 
     it('uses correct TURN TLS information on the reconnection', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Guest users failed to reconnect because reconnect attempted to syncMeetings

## by making the following changes

Only syncMeetings during reconnect if user is not an unverified guest

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
