### PR TITLE
fix(plugin-meetings): cherry-picked-PR-2782-from-beta

### DIFF
--- a/packages/@webex/plugin-meetings/src/roap/index.ts
+++ b/packages/@webex/plugin-meetings/src/roap/index.ts
@@ -287,18 +287,22 @@ export default class Roap extends StatelessWebexPlugin {
     // When reconnecting, it's important that the first roap message being sent out has empty media id.
     // Normally this is the roap offer, but when TURN discovery is enabled,
     // then this is the TURN discovery request message
-    const sendEmptyMediaId = reconnect && !meeting.config.experimental.enableTurnDiscovery;
+    return this.turnDiscovery
+      .isSkipped(meeting)
+      .then((isTurnDiscoverySkipped) => {
+        const sendEmptyMediaId = reconnect && isTurnDiscoverySkipped;
 
-    return this.roapRequest
-      .sendRoap({
-        roapMessage,
-        correlationId: meeting.correlationId,
-        locusSelfUrl: meeting.selfUrl,
-        mediaId: sendEmptyMediaId ? '' : meeting.mediaId,
-        audioMuted: meeting.audio?.isLocallyMuted(),
-        videoMuted: meeting.video?.isLocallyMuted(),
-        meetingId: meeting.id,
+        return this.roapRequest.sendRoap({
+          roapMessage,
+          correlationId: meeting.correlationId,
+          locusSelfUrl: meeting.selfUrl,
+          mediaId: sendEmptyMediaId ? '' : meeting.mediaId,
+          audioMuted: meeting.audio?.isLocallyMuted(),
+          videoMuted: meeting.video?.isLocallyMuted(),
+          meetingId: meeting.id,
+        });
       })
+
       .then(({locus, mediaConnections}) => {
         this.roapHandler.submit({
           type: ROAP.SEND_ROAP_MSG_SUCCESS,

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
@@ -41,88 +41,92 @@ describe('Roap', () => {
   describe('sendRoapMediaRequest', () => {
     let sendRoapStub;
     let roapHandlerSubmitStub;
-
-    const meeting = {
-      id: 'some meeting id',
-      correlationId: 'correlation id',
-      selfUrl: 'self url',
-      mediaId: 'media id',
-      audio:{
-        isLocallyMuted: () => true,
-      },
-      video:{
-        isLocallyMuted: () => false,
-      },
-      setRoapSeq: sinon.stub(),
-      config: {experimental: {enableTurnDiscovery: false}},
-    };
+    let meeting;
 
     beforeEach(() => {
-      sendRoapStub = sinon.stub(RoapRequest.prototype, 'sendRoap').resolves({});
-      roapHandlerSubmitStub = sinon.stub(RoapHandler.prototype, 'submit');
-      meeting.setRoapSeq.resetHistory();
+      meeting = {
+        id: 'some meeting id',
+        correlationId: 'correlation id',
+        selfUrl: 'self url',
+        mediaId: 'media id',
+        audio: {
+          isLocallyMuted: () => true,
+        },
+        video: {
+          isLocallyMuted: () => false,
+        },
+        setRoapSeq: sinon.stub(),
+        config: {experimental: {enableTurnDiscovery: false}},
+        webex: {meetings: {reachability: {isAnyClusterReachable: () => true}}},
+      };
+
+      beforeEach(() => {
+        sendRoapStub = sinon.stub(RoapRequest.prototype, 'sendRoap').resolves({});
+        roapHandlerSubmitStub = sinon.stub(RoapHandler.prototype, 'submit');
+        meeting.setRoapSeq.resetHistory();
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      [
+        {reconnect: true, turnDiscoverySkipped: false, expectEmptyMediaId: false},
+        {reconnect: true, turnDiscoverySkipped: true, expectEmptyMediaId: true},
+        {reconnect: false, turnDiscoverySkipped: false, expectEmptyMediaId: false},
+        {reconnect: false, turnDiscoverySkipped: true, expectEmptyMediaId: false},
+      ].forEach(({reconnect, turnDiscoverySkipped, expectEmptyMediaId}) =>
+        it(`sends roap OFFER with ${expectEmptyMediaId ? 'empty ' : ''}mediaId when ${
+          reconnect ? '' : 'not '
+        }reconnecting and TURN discovery is ${
+          turnDiscoverySkipped ? 'skipped' : 'not skipped'
+        }`, async () => {
+          const roap = new Roap({}, {parent: 'fake'});
+
+          sinon.stub(roap.turnDiscovery, 'isSkipped').resolves(turnDiscoverySkipped);
+
+          await roap.sendRoapMediaRequest({
+            meeting,
+            sdp: 'sdp',
+            reconnect,
+            roapSeq: 1,
+          });
+
+          const expectedRoapMessage = {
+            messageType: 'OFFER',
+            sdps: ['sdp'],
+            version: '2',
+            seq: 2,
+            tieBreaker: 4294967294,
+          };
+
+          assert.calledOnce(sendRoapStub);
+          assert.calledWith(sendRoapStub, {
+            roapMessage: expectedRoapMessage,
+            correlationId: meeting.correlationId,
+            locusSelfUrl: meeting.selfUrl,
+            mediaId: expectEmptyMediaId ? '' : meeting.mediaId,
+            audioMuted: meeting.audio?.isLocallyMuted(),
+            videoMuted: meeting.video?.isLocallyMuted(),
+            meetingId: meeting.id,
+          });
+
+          assert.calledTwice(roapHandlerSubmitStub);
+          assert.calledWith(roapHandlerSubmitStub, {
+            type: ROAP.SEND_ROAP_MSG,
+            msg: expectedRoapMessage,
+            correlationId: meeting.correlationId,
+          });
+          assert.calledWith(roapHandlerSubmitStub, {
+            type: ROAP.SEND_ROAP_MSG_SUCCESS,
+            seq: 2,
+            correlationId: meeting.correlationId,
+          });
+
+          assert.calledOnce(meeting.setRoapSeq);
+          assert.calledWith(meeting.setRoapSeq, 2);
+        })
+      );
     });
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    [
-      {reconnect: true, enableTurnDiscovery: true, expectEmptyMediaId: false},
-      {reconnect: true, enableTurnDiscovery: false, expectEmptyMediaId: true},
-      {reconnect: false, enableTurnDiscovery: true, expectEmptyMediaId: false},
-      {reconnect: false, enableTurnDiscovery: false, expectEmptyMediaId: false},
-    ].forEach(({reconnect, enableTurnDiscovery, expectEmptyMediaId}) =>
-      it(`sends roap OFFER with ${expectEmptyMediaId ? 'empty ' : ''}mediaId when ${
-        reconnect ? '' : 'not '
-      }reconnecting and TURN discovery is ${
-        enableTurnDiscovery ? 'enabled' : 'disabled'
-      }`, async () => {
-        meeting.config.experimental.enableTurnDiscovery = enableTurnDiscovery;
-
-        const roap = new Roap({}, {parent: 'fake'});
-
-        await roap.sendRoapMediaRequest({
-          meeting,
-          sdp: 'sdp',
-          reconnect,
-          roapSeq: 1,
-        });
-
-        const expectedRoapMessage = {
-          messageType: 'OFFER',
-          sdps: ['sdp'],
-          version: '2',
-          seq: 2,
-          tieBreaker: 4294967294,
-        };
-
-        assert.calledOnce(sendRoapStub);
-        assert.calledWith(sendRoapStub, {
-          roapMessage: expectedRoapMessage,
-          correlationId: meeting.correlationId,
-          locusSelfUrl: meeting.selfUrl,
-          mediaId: expectEmptyMediaId ? '' : meeting.mediaId,
-          audioMuted: meeting.audio?.isLocallyMuted(),
-          videoMuted: meeting.video?.isLocallyMuted(),
-          meetingId: meeting.id,
-        });
-
-        assert.calledTwice(roapHandlerSubmitStub);
-        assert.calledWith(roapHandlerSubmitStub, {
-          type: ROAP.SEND_ROAP_MSG,
-          msg: expectedRoapMessage,
-          correlationId: meeting.correlationId,
-        });
-        assert.calledWith(roapHandlerSubmitStub, {
-          type: ROAP.SEND_ROAP_MSG_SUCCESS,
-          seq: 2,
-          correlationId: meeting.correlationId,
-        });
-
-        assert.calledOnce(meeting.setRoapSeq);
-        assert.calledWith(meeting.setRoapSeq, 2);
-      })
-    );
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -352,6 +352,27 @@ describe('TurnDiscovery', () => {
     });
   });
 
+  describe('isSkipped', () => {
+    [
+      {enabledInConfig: true, isAnyClusterReachable: true, expectedIsSkipped: true},
+      {enabledInConfig: true, isAnyClusterReachable: false, expectedIsSkipped: false},
+      {enabledInConfig: false, isAnyClusterReachable: true, expectedIsSkipped: true},
+      {enabledInConfig: false, isAnyClusterReachable: false, expectedIsSkipped: true},
+    ].forEach(({enabledInConfig, isAnyClusterReachable, expectedIsSkipped}) => {
+      it(`returns ${expectedIsSkipped} when TURN discovery is ${enabledInConfig ? '' : 'not '} enabled in config and isAnyClusterReachable() returns ${isAnyClusterReachable ? 'true' : 'false'}`, async () => {
+        testMeeting.config.experimental.enableTurnDiscovery = enabledInConfig;
+
+        sinon.stub(testMeeting.webex.meetings.reachability, 'isAnyClusterReachable').resolves(isAnyClusterReachable);
+
+        const td = new TurnDiscovery(mockRoapRequest);
+
+        const isSkipped = await td.isSkipped(testMeeting);
+
+        assert.equal(isSkipped, expectedIsSkipped);
+      })
+    })
+  })
+
   describe('handleTurnDiscoveryResponse', () => {
     it("doesn't do anything if turn discovery was not started", () => {
       const td = new TurnDiscovery(mockRoapRequest);


### PR DESCRIPTION
# COMPLETES #[SPARK-441781](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-441781)

## This pull request addresses

While in a meeting if the internet is disconnected for some amount of time the remote video and audio stops. In samples page remote video shows "undefined 0fps". While the internet is disconnected if the connection status fails the newly created connection never reaches the 'connected' state it gets stuck in connecting. 

This is caused because while reconnection locus doesn't expect the media ID to be passed. We only take into account the config value for enableTurnDiscovery and doesn't take into account that TURN discovery is skipped if reachability succeeds. 

## by making the following changes

Made sure that when Roap checks if TURN discovery is being done or not it checks all the conditions and not just the config.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios  tested
After all the following scenarios, the meeting is successfully joined with two-way audio and video.

- While in a meeting VPN was turned on.
- While in a meeting VPN was turned off

With VPN
- Internet was disconnected and reconnected in a short period of time, here the connection state changes to disconnect.
- Internet was disconnected and reconnected in a period of time where the connection state  changes to failed..
- Internet was disconnected for a longer period of time where the meetting was disconnected and a rejoin happened.


Without VPN
- Internet was disconnected and reconnected in a short period of time, here the connection state changes to disconnect.
- Internet was disconnected and reconnected in a period of time where the connection state  changes to failed..
- Internet was disconnected for a longer period of time where the meetting was disconnected and a rejoin happened.


### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
