### PR TITLE
fix: only sending ipver when it's really needed

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -16,7 +16,7 @@ export type RoapRequest = {
   reachability: any;
   sequence?: any;
   joinCookie: any; // any, because this is opaque to the client, we pass whatever object we got from one backend component (Orpheus) to the other (Locus)
-  ipVersion: IP_VERSION;
+  ipVersion?: IP_VERSION;
 };
 
 export type LocalMuteRequest = {
@@ -28,7 +28,6 @@ export type LocalMuteRequest = {
     audioMuted?: boolean;
     videoMuted?: boolean;
   };
-  ipVersion: IP_VERSION;
 };
 
 export type Request = RoapRequest | LocalMuteRequest;
@@ -204,7 +203,7 @@ export class LocusMediaRequest extends WebexPlugin {
       correlationId: this.config.correlationId,
       clientMediaPreferences: {
         preferTranscoding: this.config.preferTranscoding,
-        ipver: request.ipVersion,
+        ipver: request.type === 'RoapMessage' ? request.ipVersion : undefined,
       },
     };
 

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -72,7 +72,6 @@ const MeetingUtil = {
           audioMuted,
           videoMuted,
         },
-        ipVersion: meeting.getWebexObject().meetings.reachability.getIpVersion(),
       })
       .then((response) => {
         // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/roap/index.ts
+++ b/packages/@webex/plugin-meetings/src/roap/index.ts
@@ -100,7 +100,6 @@ export default class Roap extends StatelessWebexPlugin {
           mediaId: options.mediaId,
           meetingId: meeting.id,
           locusMediaRequest: meeting.locusMediaRequest,
-          ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
         })
         .then(() => {
           LoggerProxy.logger.log(`Roap:index#sendRoapOK --> ROAP OK sent with seq ${options.seq}`);
@@ -135,7 +134,6 @@ export default class Roap extends StatelessWebexPlugin {
       mediaId: options.mediaId,
       meetingId: meeting.id,
       locusMediaRequest: meeting.locusMediaRequest,
-      ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
     });
   }
 
@@ -165,7 +163,6 @@ export default class Roap extends StatelessWebexPlugin {
         mediaId: options.mediaId,
         meetingId: meeting.id,
         locusMediaRequest: meeting.locusMediaRequest,
-        ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
       })
       .then(() => {
         LoggerProxy.logger.log(

--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -63,6 +63,7 @@ export default class RoapRequest extends StatelessWebexPlugin {
    * @param {String} options.mediaId
    * @param {String} options.correlationId
    * @param {String} options.meetingId
+   * @param {IP_VERSION} options.ipVersion only required for offers
    * @returns {Promise} returns the response/failure of the request
    */
   async sendRoap(options: {
@@ -70,7 +71,7 @@ export default class RoapRequest extends StatelessWebexPlugin {
     locusSelfUrl: string;
     mediaId: string;
     meetingId: string;
-    ipVersion: IP_VERSION;
+    ipVersion?: IP_VERSION;
     locusMediaRequest?: LocusMediaRequest;
   }) {
     const {roapMessage, locusSelfUrl, mediaId, meetingId, locusMediaRequest, ipVersion} = options;

--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -214,8 +214,6 @@ export default class TurnDiscovery {
       mediaId: meeting.mediaId,
       meetingId: meeting.id,
       locusMediaRequest: meeting.locusMediaRequest,
-      // @ts-ignore - because of meeting.webex
-      ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
     });
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1828,7 +1828,7 @@ describe('plugin-meetings', () => {
                 ],
                 clientMediaPreferences: {
                   preferTranscoding: !meeting.isMultistream,
-                  ipver: 0,
+                  ipver: undefined
                 },
                 respOnlySdp: true,
                 usingResource: null,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
@@ -68,7 +68,6 @@ describe('LocusMediaRequest.send()', () => {
     mediaId: 'mediaId',
     selfUrl: 'fakeMeetingSelfUrl',
     muteOptions: {},
-    ipVersion: IP_VERSION.only_ipv6
   };
 
   const createExpectedLocalMuteBody = (expectedMute:{audioMuted: boolean, videoMuted: boolean}, sequence = undefined) => {
@@ -89,7 +88,7 @@ describe('LocusMediaRequest.send()', () => {
       ],
       clientMediaPreferences: {
         preferTranscoding: true,
-        ipver: 6,
+        ipver: undefined,
       },
     };
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -339,7 +339,6 @@ describe('plugin-meetings', () => {
           selfUrl: 'self url',
           sequence: {},
           type: 'LocalMute',
-          ipVersion: 0,
         });
 
         assert.calledWith(webex.internal.newMetrics.submitClientEvent, {

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -73,7 +73,8 @@ describe('TurnDiscovery', () => {
     await testUtils.flushPromises();
 
     assert.calledOnce(mockRoapRequest.sendRoap);
-    assert.calledWith(mockRoapRequest.sendRoap, {
+
+    const expectedSendRoapArgs: any = {
       roapMessage: {
         messageType,
         version: '2',
@@ -83,8 +84,13 @@ describe('TurnDiscovery', () => {
       mediaId: expectedMediaId,
       meetingId: testMeeting.id,
       locusMediaRequest: testMeeting.locusMediaRequest,
-      ipVersion: 0,
-    });
+    };
+
+    if (messageType === 'TURN_DISCOVERY_REQUEST') {
+      expectedSendRoapArgs.ipVersion = 0;
+    }
+    
+    assert.calledWith(mockRoapRequest.sendRoap, expectedSendRoapArgs);
 
     if (messageType === 'TURN_DISCOVERY_REQUEST') {
       // check also that we've applied the media connections from the response


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-466192

## This pull request addresses
It's been confirmed with the backend team that ipver parameter only needs to be sent with roap offer and turn_discovery_request when calling the /media API

## by making the following changes

Removed the ipver parameter from other calls to /media API (like other roap messages and local mute/unmute)


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

updated unit tests, also checked manually with sample app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
