### PR TITLE
feat: moved getIpVersion() to meeting util and implemented it

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1240,8 +1240,8 @@ export const DEFAULT_MEETING_INFO_REQUEST_BODY = {
 /** the values for IP_VERSION are fixed and defined in Orpheus API */
 export const IP_VERSION = {
   unknown: 0,
-  only_ipv4: 4,
-  only_ipv6: 6,
+  only_ipv4: 4, // we know we have ipv4, we don't know or we don't have ipv6
+  only_ipv6: 6, // we know we have ipv6, we don't know or we don't have ipv4
   ipv4_and_ipv6: 1,
 } as const;
 

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -125,7 +125,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
     locale?: string;
     deviceCapabilities?: Array<string>;
     liveAnnotationSupported: boolean;
-    ipVersion: IP_VERSION;
+    ipVersion?: IP_VERSION;
   }) {
     const {
       asResourceOccupant,

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -7,7 +7,9 @@
 import _ from 'lodash';
 
 import LoggerProxy from '../common/logs/logger-proxy';
-import {ICE_GATHERING_STATE, CONNECTION_STATE, REACHABILITY, IP_VERSION} from '../constants';
+import MeetingUtil from '../meeting/util';
+
+import {ICE_GATHERING_STATE, CONNECTION_STATE, REACHABILITY} from '../constants';
 
 import ReachabilityRequest from './request';
 
@@ -71,7 +73,7 @@ export default class Reachability {
     // Fetch clusters and measure latency
     try {
       const {clusters, joinCookie} = await this.reachabilityRequest.getClusters(
-        this.getIpVersion()
+        MeetingUtil.getIpVersion(this.webex)
       );
 
       // Perform Reachability Check
@@ -132,14 +134,6 @@ export default class Reachability {
     }
 
     return reachable;
-  }
-
-  /**
-   * Returns what we know about the IP version of the networks we're connected to.
-   * @returns {IP_VERSION}
-   */
-  getIpVersion(): IP_VERSION {
-    return IP_VERSION.unknown;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/reachability/request.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/request.ts
@@ -33,7 +33,7 @@ class ReachabilityRequest {
    * @param {IP_VERSION} ipVersion information about current ip network we're on
    * @returns {Promise}
    */
-  getClusters = (ipVersion: IP_VERSION): Promise<{clusters: ClusterList; joinCookie: any}> =>
+  getClusters = (ipVersion?: IP_VERSION): Promise<{clusters: ClusterList; joinCookie: any}> =>
     this.webex
       .request({
         method: HTTP_VERBS.GET,

--- a/packages/@webex/plugin-meetings/src/roap/index.ts
+++ b/packages/@webex/plugin-meetings/src/roap/index.ts
@@ -7,6 +7,7 @@ import LoggerProxy from '../common/logs/logger-proxy';
 import RoapRequest from './request';
 import TurnDiscovery from './turnDiscovery';
 import Meeting from '../meeting';
+import MeetingUtil from '../meeting/util';
 
 /**
  * Roap options
@@ -201,7 +202,7 @@ export default class Roap extends StatelessWebexPlugin {
           meetingId: meeting.id,
           preferTranscoding: !meeting.isMultistream,
           locusMediaRequest: meeting.locusMediaRequest,
-          ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
+          ipVersion: MeetingUtil.getIpVersion(meeting.webex),
         })
         .then(({locus, mediaConnections}) => {
           if (mediaConnections) {

--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -8,6 +8,7 @@ import {ROAP} from '../constants';
 
 import RoapRequest from './request';
 import Meeting from '../meeting';
+import MeetingUtil from '../meeting/util';
 
 const TURN_DISCOVERY_TIMEOUT = 10; // in seconds
 
@@ -183,7 +184,7 @@ export default class TurnDiscovery {
         meetingId: meeting.id,
         locusMediaRequest: meeting.locusMediaRequest,
         // @ts-ignore - because of meeting.webex
-        ipVersion: meeting.webex.meetings.reachability.getIpVersion(),
+        ipVersion: MeetingUtil.getIpVersion(meeting.webex),
       })
       .then(({mediaConnections}) => {
         if (mediaConnections) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1649,6 +1649,8 @@ describe('plugin-meetings', () => {
           beforeEach(() => {
             clock = sinon.useFakeTimers();
 
+            sinon.stub(MeetingUtil, 'getIpVersion').returns(IP_VERSION.unknown);
+
             meeting.deviceUrl = 'deviceUrl';
             meeting.config.deviceType = 'web';
             meeting.isMultistream = isMultistream;
@@ -1662,7 +1664,6 @@ describe('plugin-meetings', () => {
             meeting.webex.meetings.geoHintInfo = {regionCode: 'EU', countryCode: 'UK'};
             meeting.webex.meetings.reachability = {
               isAnyClusterReachable: sinon.stub().resolves(true),
-              getIpVersion: () => IP_VERSION.unknown,
             };
             meeting.roap.doTurnDiscovery = sinon
               .stub()
@@ -1739,6 +1740,7 @@ describe('plugin-meetings', () => {
 
           afterEach(() => {
             clock.restore();
+            sinon.restore();
           });
 
           // helper function that waits until all promises are resolved and any queued up /media requests to Locus are sent out

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -6,6 +6,7 @@ import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
 import {SELF_POLICY, IP_VERSION} from '@webex/plugin-meetings/src/constants';
 import MockWebex from '@webex/test-helper-mock-webex';
+import * as BrowserDetectionModule from '@webex/plugin-meetings/src/common/browser-detection';
 
 describe('plugin-meetings', () => {
   let webex;
@@ -984,23 +985,54 @@ describe('plugin-meetings', () => {
     });
 
     describe('getIpVersion', () => {
+      let isBrowserStub;
+      beforeEach(() => {
+        isBrowserStub = sinon.stub().returns(false);
+
+        sinon.stub(BrowserDetectionModule, 'default').returns({
+          isBrowser: isBrowserStub,
+        });
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
       [
-        { supportsIpV4: undefined, supportsIpV6: undefined, expectedOutput: IP_VERSION.unknown},
-        { supportsIpV4: undefined, supportsIpV6: true, expectedOutput: IP_VERSION.only_ipv6},
-        { supportsIpV4: undefined, supportsIpV6: false, expectedOutput: IP_VERSION.unknown},
-        { supportsIpV4: true, supportsIpV6: undefined, expectedOutput: IP_VERSION.only_ipv4},
-        { supportsIpV4: true, supportsIpV6: true, expectedOutput: IP_VERSION.ipv4_and_ipv6},
-        { supportsIpV4: true, supportsIpV6: false, expectedOutput: IP_VERSION.only_ipv4},
-        { supportsIpV4: false, supportsIpV6: undefined, expectedOutput: IP_VERSION.unknown},
-        { supportsIpV4: false, supportsIpV6: true, expectedOutput: IP_VERSION.only_ipv6},
-        { supportsIpV4: false, supportsIpV6: false, expectedOutput: IP_VERSION.unknown},
-      ].forEach(({supportsIpV4, supportsIpV6, expectedOutput}) =>
+        {supportsIpV4: undefined, supportsIpV6: undefined, expectedOutput: IP_VERSION.unknown},
+        {supportsIpV4: undefined, supportsIpV6: true, expectedOutput: IP_VERSION.only_ipv6},
+        {supportsIpV4: undefined, supportsIpV6: false, expectedOutput: IP_VERSION.unknown},
+        {supportsIpV4: true, supportsIpV6: undefined, expectedOutput: IP_VERSION.only_ipv4},
+        {supportsIpV4: true, supportsIpV6: true, expectedOutput: IP_VERSION.ipv4_and_ipv6},
+        {supportsIpV4: true, supportsIpV6: false, expectedOutput: IP_VERSION.only_ipv4},
+        {supportsIpV4: false, supportsIpV6: undefined, expectedOutput: IP_VERSION.unknown},
+        {supportsIpV4: false, supportsIpV6: true, expectedOutput: IP_VERSION.only_ipv6},
+        {supportsIpV4: false, supportsIpV6: false, expectedOutput: IP_VERSION.unknown},
+      ].forEach(({supportsIpV4, supportsIpV6, expectedOutput}) => {
         it(`returns ${expectedOutput} when supportsIpV4=${supportsIpV4} and supportsIpV6=${supportsIpV6}`, () => {
-          sinon.stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4').get(() => supportsIpV4);
-          sinon.stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6').get(() => supportsIpV6);
+          sinon
+            .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4')
+            .get(() => supportsIpV4);
+          sinon
+            .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6')
+            .get(() => supportsIpV6);
 
           assert.equal(MeetingUtil.getIpVersion(webex), expectedOutput);
-      }));
+        });
+
+        it(`returns undefined when supportsIpV4=${supportsIpV4} and supportsIpV6=${supportsIpV6} and browser is firefox`, () => {
+          sinon
+            .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4')
+            .get(() => supportsIpV4);
+          sinon
+            .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6')
+            .get(() => supportsIpV6);
+
+          isBrowserStub.callsFake((name) => name === 'firefox');
+
+          assert.equal(MeetingUtil.getIpVersion(webex), undefined);
+        });
+      });
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -4,9 +4,7 @@ import Meetings from '@webex/plugin-meetings';
 import MeetingUtil from '@webex/plugin-meetings/src/meeting/util';
 import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
-import Metrics from '@webex/plugin-meetings/src/metrics/index';
-import {SELF_POLICY} from '@webex/plugin-meetings/src/constants';
-import {DISPLAY_HINTS} from '@webex/plugin-meetings/src/constants';
+import {SELF_POLICY, IP_VERSION} from '@webex/plugin-meetings/src/constants';
 import MockWebex from '@webex/test-helper-mock-webex';
 
 describe('plugin-meetings', () => {
@@ -983,6 +981,26 @@ describe('plugin-meetings', () => {
         result = buildLocusDeltaRequestOptions(input);
         assert.equal(result, input);
       });
+    });
+
+    describe('getIpVersion', () => {
+      [
+        { supportsIpV4: undefined, supportsIpV6: undefined, expectedOutput: IP_VERSION.unknown},
+        { supportsIpV4: undefined, supportsIpV6: true, expectedOutput: IP_VERSION.only_ipv6},
+        { supportsIpV4: undefined, supportsIpV6: false, expectedOutput: IP_VERSION.unknown},
+        { supportsIpV4: true, supportsIpV6: undefined, expectedOutput: IP_VERSION.only_ipv4},
+        { supportsIpV4: true, supportsIpV6: true, expectedOutput: IP_VERSION.ipv4_and_ipv6},
+        { supportsIpV4: true, supportsIpV6: false, expectedOutput: IP_VERSION.only_ipv4},
+        { supportsIpV4: false, supportsIpV6: undefined, expectedOutput: IP_VERSION.unknown},
+        { supportsIpV4: false, supportsIpV6: true, expectedOutput: IP_VERSION.only_ipv6},
+        { supportsIpV4: false, supportsIpV6: false, expectedOutput: IP_VERSION.unknown},
+      ].forEach(({supportsIpV4, supportsIpV6, expectedOutput}) =>
+        it(`returns ${expectedOutput} when supportsIpV4=${supportsIpV4} and supportsIpV6=${supportsIpV6}`, () => {
+          sinon.stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4').get(() => supportsIpV4);
+          sinon.stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6').get(() => supportsIpV6);
+
+          assert.equal(MeetingUtil.getIpVersion(webex), expectedOutput);
+      }));
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -2,6 +2,8 @@ import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import sinon from 'sinon';
 import Reachability, {ICECandidateResult} from '@webex/plugin-meetings/src/reachability/';
+import MeetingUtil from '@webex/plugin-meetings/src/meeting/util';
+
 import { IP_VERSION } from '@webex/plugin-meetings/src/constants';
 
 describe('isAnyClusterReachable', () => {
@@ -9,6 +11,12 @@ describe('isAnyClusterReachable', () => {
 
   beforeEach(() => {
     webex = new MockWebex();
+
+    sinon.stub(MeetingUtil, 'getIpVersion').returns(IP_VERSION.unknown);
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   const checkIsClusterReachable = async (mockStorage: any, expectedValue: boolean) => {
@@ -251,12 +259,4 @@ describe('gatherReachability', () => {
       });
     });
   });
-
-  describe('getIpVersion', () => {
-    it('returns unknown', () => {
-      const reachability = new Reachability(webex);
-
-      assert.equal(reachability.getIpVersion(), IP_VERSION.unknown);
-    })
-  })
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
@@ -6,6 +6,8 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import RoapRequest from '@webex/plugin-meetings/src/roap/request';
 import Roap from '@webex/plugin-meetings/src/roap/';
 import Meeting from '@webex/plugin-meetings/src/meeting';
+import MeetingUtil from '@webex/plugin-meetings/src/meeting/util';
+
 import { IP_VERSION } from '../../../../src/constants';
 
 describe('Roap', () => {
@@ -62,8 +64,10 @@ describe('Roap', () => {
         setRoapSeq: sinon.stub(),
         config: {experimental: {enableTurnDiscovery: false}},
         locusMediaRequest: {fake: true},
-        webex: { meetings: { reachability: { isAnyClusterReachable: () => true, getIpVersion: () => IP_VERSION.unknown}}},
+        webex: { meetings: { reachability: { isAnyClusterReachable: () => true}}},
       };
+
+      sinon.stub(MeetingUtil, 'getIpVersion').returns(IP_VERSION.unknown);
 
       sendRoapStub = sinon.stub(RoapRequest.prototype, 'sendRoap').resolves({});
       meeting.setRoapSeq.resetHistory();

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -5,6 +5,7 @@ import TurnDiscovery from '@webex/plugin-meetings/src/roap/turnDiscovery';
 import Metrics from '@webex/plugin-meetings/src/metrics';
 import BEHAVIORAL_METRICS from '@webex/plugin-meetings/src/metrics/constants';
 import RoapRequest from '@webex/plugin-meetings/src/roap/request';
+import MeetingUtil from '@webex/plugin-meetings/src/meeting/util';
 
 import testUtils from '../../../utils/testUtils';
 import { IP_VERSION } from '../../../../src/constants';
@@ -24,6 +25,7 @@ describe('TurnDiscovery', () => {
     clock = sinon.useFakeTimers();
 
     sinon.stub(Metrics, 'sendBehavioralMetric');
+    sinon.stub(MeetingUtil, 'getIpVersion').returns(IP_VERSION.unknown);
 
     mockRoapRequest = {
       sendRoap: sinon.fake.resolves({mediaConnections: FAKE_MEDIA_CONNECTIONS_FROM_LOCUS}),
@@ -53,7 +55,6 @@ describe('TurnDiscovery', () => {
       updateMediaConnections: sinon.stub(),
       webex: {meetings: {reachability: {
         isAnyClusterReachable: () => Promise.resolve(false),
-        getIpVersion: () => IP_VERSION.unknown,
       }}},
       isMultistream: false,
       locusMediaRequest: { fake: true },

--- a/packages/@webex/test-helper-mock-webex/src/index.js
+++ b/packages/@webex/test-helper-mock-webex/src/index.js
@@ -269,6 +269,14 @@ function makeWebex(options) {
       },
       registered: true,
       register: sinon.stub().returns(Promise.resolve()),
+      ipNetworkDetector: {
+        get supportsIpV4() {
+          return true;
+        },
+        get supportsIpV6() {
+          return true;
+        },
+      },
     },
     feature: {
       setFeature: sinon.stub().returns(Promise.resolve(false)),


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-461655
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-466194

## This pull request addresses

getIpVersion() was in Reachability class and always returned "unknown"

## by making the following changes

As agreed in tech breakdown, moved the function to meeting util and implemented it to call webex.internal.device.ipNetworkDetector or return undefined for Firefox


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual run of sample app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
