### PR TITLE
fix(meetings): pass encrypted title based on APPI API for conversation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,9 @@ jobs:
       COVERAGE: true
     steps:
       - checkout_and_fetch_tags
+      - run: sudo apt-get update
+      - browser-tools/install-chrome:
+          chrome-version: "114.0.5735.90" # https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-browser-tools
       - install_graphicsmagick_and_libgcrypt
       - restore_node_modules

--- a/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
@@ -151,7 +151,7 @@ export default class MeetingInfoV2 {
     };
 
     return this.webex
-      .request(conversationUrl)
+      .request({uri: conversationUrl, qs: {includeParticipants: true}, disableTransform: true})
       .then(({body: conversation}) => {
         const body = {
           title: conversation.displayName,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -354,7 +354,7 @@ describe('plugin-meetings', () => {
 
         assert.calledWith(
           webex.request,
-          conversationUrl,
+          {uri:conversationUrl, qs: {includeParticipants: true}, disableTransform: true}
         )
 
         assert.calledWith(webex.request, {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-469170](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-469170)

## This pull request addresses

Experiencing a failure when attempting to start an instant space meeting URL: https://co.webex.com/wbxappapi/v2/meetings/spaceInstant.

The error message received is '416 Range Not Satisfiable' with the response '416020' and message 'e2ee decrypt error.'


## by making the following changes

should pass encrypted title based on APPI API ("/wbxappapi/v2/meetings/spaceInstant) Team.
Updated the code and tests for this.

<!-- You may include screenshots -->

https://github.com/webex/webex-js-sdk/assets/3918217/cd095b24-d8a0-45b2-a6a9-8ee79420c5c8

<img width="1696" alt="Screenshot 2023-11-03 at 3 04 17 PM" src="https://github.com/webex/webex-js-sdk/assets/3918217/bb136776-c282-4f2c-81f1-23a3d9f682ac">
<img width="1716" alt="Screenshot 2023-11-03 at 3 03 50 PM" src="https://github.com/webex/webex-js-sdk/assets/3918217/54515257-eafc-42e6-9cb3-a1c5b11ec7ce">
<img width="1703" alt="Screenshot 2023-11-03 at 3 03 28 PM" src="https://github.com/webex/webex-js-sdk/assets/3918217/10a0e7d7-c152-42c8-91c7-e3b31d8b0e6d">


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

Tested some basic manual flow and also attached the screen recording -
- Register
- Create ad-hoc meeting with conv URL
- Join with media
- Checked participants
- checked if meeting is started in space or not
- leave

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
