### PR TITLE
fix: added metric for succesful log upload

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -887,6 +887,7 @@ export default class Meetings extends WebexPlugin {
           'Meetings:index#uploadLogs --> Upload logs for meeting completed.',
           uploadResult
         );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.UPLOAD_LOGS_SUCCESS, options);
         Trigger.trigger(
           this,
           {
@@ -921,8 +922,7 @@ export default class Meetings extends WebexPlugin {
         );
 
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.UPLOAD_LOGS_FAILURE, {
-          // @ts-ignore - seems like typo
-          meetingId: options.meetingsId,
+          ...options,
           reason: uploadError.message,
           stack: uploadError.stack,
           code: uploadError.code,

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -40,6 +40,7 @@ const BEHAVIORAL_METRICS = {
   PEERCONNECTION_FAILURE: 'js_sdk_peerConnection_failures',
   INVALID_ICE_CANDIDATE: 'js_sdk_invalid_ice_candidate',
   UPLOAD_LOGS_FAILURE: 'js_sdk_upload_logs_failure',
+  UPLOAD_LOGS_SUCCESS: 'js_sdk_upload_logs_success',
   RECEIVE_TRANSCRIPTION_FAILURE: 'js_sdk_receive_transcription_failure',
   FETCH_MEETING_INFO_V1_SUCCESS: 'js_sdk_fetch_meeting_info_v1_success',
   FETCH_MEETING_INFO_V1_FAILURE: 'js_sdk_fetch_meeting_info_v1_failure',


### PR DESCRIPTION
We often see logs missing in mats.webex.com, we have a metric for log upload failure, but not for success.

Also, noticed the metric for failure was always sending meetingId=undefined 