### PR TITLE
fix: improved logging of receive slots, muted local audio by default in the sample app

### DIFF
--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -507,7 +507,7 @@
 
                 <fieldset style="display: flex; align-items: center;">
                   <legend>Local Audio</legend>
-                  <audio id="local-audio" controls autoplay></audio>
+                  <audio id="local-audio" muted controls></audio>
                 </fieldset>
               </div>
               <div class="flex">
@@ -578,7 +578,7 @@
               </fieldset>
               <fieldset>
                 <legend>Local Screenshare Audio</legend>
-                <audio id="local-screenshare-audio" controls autoplay></audio>
+                <audio id="local-screenshare-audio" muted controls></audio>
               </fieldset>
               <div class="btn-group">
                 <button id="ts-start-screenshare" type="button" onclick="startScreenShare()"

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5601,6 +5601,11 @@ export default class Meeting extends StatelessWebexPlugin {
             meetingId: this.id,
           },
         });
+        LoggerProxy.logger.info(
+          `${LOG_HEADER} successfully established media connection, type=${connectionType}`
+        );
+
+        this.remoteMediaManager?.logAllReceiveSlots();
       })
       .catch((error) => {
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE, {
@@ -5642,10 +5647,7 @@ export default class Meeting extends StatelessWebexPlugin {
             this.unsetPeerConnections();
           }
 
-          LoggerProxy.logger.error(
-            `${LOG_HEADER} Error adding media failed to initiate PC and send request, `,
-            error
-          );
+          LoggerProxy.logger.error(`${LOG_HEADER} failed to establish media connection: `, error);
 
           // Upload logs on error while adding media
           Trigger.trigger(

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
@@ -473,6 +473,8 @@ export class RemoteMediaManager extends EventsScope {
     if (!this.started) {
       throw new Error('setLayout() called before start()');
     }
+    LoggerProxy.logger.log(`RemoteMediaManager#setLayout --> new layout selected: ${layoutId}`);
+
     this.currentLayoutId = layoutId;
     this.currentLayout = cloneDeep(this.config.video.layouts[this.currentLayoutId]);
 
@@ -725,10 +727,12 @@ export class RemoteMediaManager extends EventsScope {
   /**
    * Logs the state of the receive slots
    */
-  private logReceieveSlots() {
+  private logMainVideoReceiveSlots() {
     let logMessage = '';
     forEach(this.receiveSlotAllocations.activeSpeaker, (group, groupName) => {
-      logMessage += `group: ${groupName}\n${group.slots.map((slot) => slot.logString).join(' ')}`;
+      logMessage += `\ngroup: ${groupName}\n${group.slots
+        .map((slot) => slot.logString)
+        .join(', ')}`;
     });
 
     logMessage += '\nreceiverSelected:\n';
@@ -737,7 +741,28 @@ export class RemoteMediaManager extends EventsScope {
     });
 
     LoggerProxy.logger.log(
-      `RemoteMediaManager#updateVideoReceiveSlots --> receive slots updated: unused=${this.slots.video.unused.length}, activeSpeaker=${this.slots.video.activeSpeaker.length}, receiverSelected=${this.slots.video.receiverSelected.length}\n${logMessage}`
+      `RemoteMediaManager#logMainVideoReceiveSlots --> MAIN VIDEO receive slots: unused=${this.slots.video.unused.length}, activeSpeaker=${this.slots.video.activeSpeaker.length}, receiverSelected=${this.slots.video.receiverSelected.length}${logMessage}`
+    );
+  }
+
+  /** Logs all current receive slots */
+  public logAllReceiveSlots() {
+    LoggerProxy.logger.log(
+      `RemoteMediaManager#logAllReceiveSlots --> MAIN AUDIO receive slots: ${this.slots.audio
+        .map((slot) => slot.logString)
+        .join(', ')}`
+    );
+
+    this.logMainVideoReceiveSlots();
+
+    LoggerProxy.logger.log(
+      `RemoteMediaManager#logAllReceiveSlots --> SLIDES VIDEO receive slot: ${this.slots.screenShare.video?.logString}`
+    );
+
+    LoggerProxy.logger.log(
+      `RemoteMediaManager#logAllReceiveSlots --> SLIDES AUDIO receive slots: ${this.slots.screenShare.audio
+        .map((slot) => slot.logString)
+        .join(', ')}`
     );
   }
 
@@ -765,7 +790,7 @@ export class RemoteMediaManager extends EventsScope {
     // allocate receiver selected
     this.allocateSlotsToReceiverSelectedVideoPaneGroups();
 
-    this.logReceieveSlots();
+    this.logMainVideoReceiveSlots();
 
     // If this is the initial layout, there may be some "unused" slots left because of the preallocation
     // done in this.preallocateVideoReceiveSlots(), so release them now


### PR DESCRIPTION
## This pull request addresses

Logs from RemoteMediaManager for initial layout didn't include the SSRC values for the receive slots, because they are only possible to obtain from WCME after initial SDP offer-answer is exchanged.

In the sample app, by default local audio is always played and this causes unpleasant audio feedback, most of the time you don't really want to play your local audio.

## by making the following changes

- improved logging
- muted local audio in sample app (same fix was already done on SDK master by Arun a few months ago)


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

manually used the sample app to check logs

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
