### PR TITLE
fix(plugin-meetings): start transcription when guest user is admitted

### DIFF
--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -3589,6 +3589,38 @@ describe('plugin-meetings', () => {
         });
       });
 
+      describe('#setupLocusControlsListener', () => {
+        it('transcription should start when meeting transcribe state is updated with active transcribing', (done) => {
+          const payload = {caption: true, transcribing: true};
+          meeting.startTranscription = sinon.stub();
+          meeting.config.receiveTranscription = true;
+          meeting.transcription = null;
+
+          meeting.locusInfo.emit({function: 'meeting/index', file: 'setupLocusControlsListener'}, 'CONTROLS_MEETING_TRANSCRIBE_UPDATED', payload);
+          assert.calledOnce(meeting.startTranscription);
+          done();
+        })
+
+        it('transcription should stop when meeting transcribe state is updated with inactive transcribing', (done) => {
+          const payload = {caption: false, transcribing: false};
+          meeting.startTranscription = sinon.stub();
+          meeting.config.receiveTranscription = true;
+          meeting.transcription = {};
+
+          meeting.locusInfo.emit({function: 'meeting/index', file: 'setupLocusControlsListener'}, 'CONTROLS_MEETING_TRANSCRIBE_UPDATED', payload);
+          assert.notCalled(meeting.startTranscription);
+          assert.calledTwice(TriggerProxy.trigger);
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {file: 'meeting/index', function: 'setupLocusControlsListener'},
+            'meeting:receiveTranscription:stopped',
+            payload
+          );
+          done();
+        })
+      })
+
       describe('#setUpLocusUrlListener', () => {
         it('listens to the locus url update event', (done) => {
           const newLocusUrl = 'newLocusUrl/12345';

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -770,12 +770,12 @@ describe('plugin-meetings', () => {
           assert.equal(meeting.isTranscriptionSupported(), true);
         });
       });
-      describe('#receiveTranscription', () => {
+      describe('#startTranscription', () => {
         it('should invoke subscribe method to invoke the callback', () => {
           meeting.monitorTranscriptionSocketConnection = sinon.stub();
           meeting.initializeTranscription = sinon.stub();
 
-          meeting.receiveTranscription().then(() => {
+          meeting.startTranscription().then(() => {
             assert.equal(true, false);
             assert.calledOnce(meeting.initializeTranscription);
             assert.calledOnce(meeting.monitorTranscriptionSocketConnection);
@@ -786,7 +786,7 @@ describe('plugin-meetings', () => {
           meeting.request = sinon.stub().returns(Promise.reject());
 
           try {
-            await meeting.receiveTranscription();
+            await meeting.startTranscription();
           } catch (err) {
             assert(err, {});
           }
@@ -840,12 +840,12 @@ describe('plugin-meetings', () => {
             assert.calledOnce(MeetingUtil.joinMeeting);
             assert.calledOnce(meeting.setLocus);
           });
-          it('should invoke `receiveTranscription()` if receiveTranscription is set to true', async () => {
+          it('should invoke `startTranscription()` if receiveTranscription is set to true', async () => {
             meeting.isTranscriptionSupported = sinon.stub().returns(true);
-            meeting.receiveTranscription = sinon.stub().returns(Promise.resolve());
+            meeting.startTranscription = sinon.stub().returns(Promise.resolve());
 
             await meeting.join({receiveTranscription: true});
-            assert.calledOnce(meeting.receiveTranscription);
+            assert.calledOnce(meeting.startTranscription);
           });
 
           it('should not create new correlation ID on join immediately after create', async () => {
@@ -3576,6 +3576,15 @@ describe('plugin-meetings', () => {
             'meeting:self:guestAdmitted',
             {payload: test1}
           );
+          done();
+        });
+        it('transcription should start when configured when guest admitted', (done) => {
+          meeting.isTranscriptionSupported = sinon.stub().returns(true);
+          meeting.receiveTranscription = sinon.stub().returns(true);
+          meeting.startTranscription = sinon.stub();
+
+          meeting.locusInfo.emit({function: 'test', file: 'test'}, 'SELF_ADMITTED_GUEST', test1);
+          assert.calledOnce(meeting.startTranscription);
           done();
         });
       });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-466845](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-466845) >

## This pull request addresses

Transcriptions do not work if user get placed in lobby and then is admitted into the meeting

## by making the following changes

Issue was happening because transcription method requires a `datachannelUrl` to generate a `webSocketUrl` which is then used to create transcription object. Until guest user is not admitted into the meeting, `datachannelUrl` is not generated and so the method fails to start the transcription.

As a part of this issue fix, we have an event triggered when guest is admitted into the meeting which is "SELF_ADMITTED_GUEST" so added the logic there to retry for transcription if not started earlier.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

After this fix, following 2 scenarios will start working which were not working previously. Below scenarios are tested on web SDK samples app.
1. When guest user wants to join meeting with transcription:
  1.1 guest user registers after putting access_token
  1.2 guest user clicks on `startReceivingTranscription()` in the samples before joining a meeting or sends 
       `receiveTranscription` as true in join options
  1.3 guest user is placed in the lobby until host admits guest in the meeting
  1.4 if Webex Assistant is enabled for the meeting, guest user will start receiving transcription once admitted in the 
        meeting which was not the case before this fix.

2. When guest user wants to start transcription after joining a meeting:
  2.1 guest user registers after putting access_token. For this case, user initialises webex with a config object where he 
       needs to add a property which is `receiveTranscription: true`. User clicks on join meeting
  2.2 guest user is placed in the lobby until host admits guest in the meeting
  2.3 host admits the user in the meeting. At this point, webex assistant is not enabled so user won't receive any 
        transcription. Once host enables webex assistant, user will start receiving transcription which was not the case 
        previously

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
