### PR TITLE
fix(scripts): build clean skip prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "url": "https://github.com/webex/webex-js-sdk"
   },
   "scripts": {
-    "clean": "rimraf packages/**/.coverage packages/**/dist packages/**/types",
+    "clean": "rimraf \"packages/**/.coverage\" \"packages/**/dist\" \"packages/**/types\"",
     "prebuild": "yarn run clean",
-    "build": "node ./tooling/index.js build && yarn run build:tsc",
+    "build": "yarn clean && node ./tooling/index.js build && yarn run build:tsc",
     "build:tsc": "yarn run tsc -p ./config/tsconfig.typecheck.json --noEmit && yarn workspace @webex/internal-plugin-metrics run build && yarn workspace @webex/plugin-meetings run build",
     "build:script": "node ./tooling/index.js build --umd",
     "build:skip-samples": "node ./tooling/index.js build --skip-samples && yarn workspace @webex/internal-plugin-metrics run build && yarn workspace @webex/plugin-meetings run build",


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to fix the existing `build`, `prebuild` and `clean` scripts to properly trigger. as of the current yarn version, `pre` and `post` script lifecycle hooks [are not supported](https://yarnpkg.com/advanced/lifecycle-scripts) by yarn (with a few small exceptions). `build` now explicitly calls `clean`. Additionally, the glob patterns in `clean` were not wrapped in `"`, which caused the `clean` command to fail when no files were found. This has also been fixed as a part of this PR.