### PR TITLE
fix: do a full Locus sync if a delta sync fails

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -386,6 +386,7 @@ export const MEETING_REMOVED_REASON = {
   USER_ENDED_SHARE_STREAMS: 'USER_ENDED_SHARE_STREAMS', // user triggered stop share
   NO_MEETINGS_TO_SYNC: 'NO_MEETINGS_TO_SYNC', // After the syncMeeting no meeting exists
   MEETING_CONNECTION_FAILED: 'MEETING_CONNECTION_FAILED', // meeting failed to connect due to ice failures or firewall issue
+  LOCUS_DTO_SYNC_FAILED: 'LOCUS_DTO_SYNC_FAILED', // failed to get any Locus DTO for that meeting
 };
 
 // One one one calls ends for the following reasons

--- a/packages/@webex/plugin-meetings/src/locus-info/parser.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/parser.ts
@@ -3,6 +3,9 @@ import {difference} from 'lodash';
 import SortedQueue from '../common/queue';
 import LoggerProxy from '../common/logs/logger-proxy';
 
+import Metrics from '../metrics';
+import BEHAVIORAL_METRICS from '../metrics/constants';
+
 const MAX_OOO_DELTA_COUNT = 5; // when we receive an out-of-order delta and the queue builds up to MAX_OOO_DELTA_COUNT, we do a sync with Locus
 const OOO_DELTA_WAIT_TIME = 10000; // [ms] minimum wait time before we do a sync if we get out-of-order deltas
 const OOO_DELTA_WAIT_TIME_RANDOM_DELAY = 5000; // [ms] max random delay added to OOO_DELTA_WAIT_TIME
@@ -293,6 +296,10 @@ export default class Parser {
           // the incoming locus has baseSequence from the future, so it is out-of-order,
           // we are missing 1 or more locus that should be in front of it, we need to wait for it
           comparison = WAIT;
+
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.LOCUS_DELTA_OUT_OF_ORDER, {
+            stack: new Error().stack,
+          });
         }
         break;
       default:

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -416,7 +416,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
           `Meeting:request#getLocusDTO --> Error getting latest locus, error ${err}`
         );
 
-        return err;
+        throw err;
       });
     }
 

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -55,6 +55,8 @@ const BEHAVIORAL_METRICS = {
   MOVE_FROM_FAILURE: 'js_sdk_move_from_failure',
   TURN_DISCOVERY_FAILURE: 'js_sdk_turn_discovery_failure',
   MEETING_INFO_POLICY_ERROR: 'js_sdk_meeting_info_policy_error',
+  LOCUS_DELTA_SYNC_FAILED: 'js_sdk_locus_delta_sync_failed',
+  LOCUS_DELTA_OUT_OF_ORDER: 'js_sdk_locus_delta_ooo',
 };
 
 export {BEHAVIORAL_METRICS as default};


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-472336

## This pull request addresses

When we get out of order delta events we start a timer and we do a Locus delta sync when that timer expires. We are seeing a large number of cases where that Locus delta sync request fails - it's not clear why, but when this happens SDK is stuck in a state where it will keep re-trying the delta sync every 10-15s until it succeeds or until we get the missing delta events from Locus, which seems to never happen.

## by making the following changes

If delta sync fails, do a full sync - this should get us out of the state where we keep retrying the delta sync.

Also added some metrics to help us investigate further what is causing the problem of failing delta syncs in the first place.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
