### PR TITLE
feat(plugin-meetings): error on create if meeting info not found

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1043,6 +1043,8 @@ export default class Meetings extends WebexPlugin {
    * @param {Boolean} useRandomDelayForInfo - whether a random delay should be added to fetching meeting info
    * @param {Object} infoExtraParams extra parameters to be provided when fetching meeting info
    * @param {string} correlationId - the optional specified correlationId
+   * @param {Boolean} failOnMissingMeetingInformation - fail if meeting info not found
+
    * @returns {Promise<Meeting>} A new Meeting.
    * @public
    * @memberof Meetings
@@ -1052,7 +1054,8 @@ export default class Meetings extends WebexPlugin {
     type: string = null,
     useRandomDelayForInfo = false,
     infoExtraParams = {},
-    correlationId: string = undefined
+    correlationId: string = undefined,
+    failOnMissingMeetingInformation = false
   ) {
     // TODO: type should be from a dictionary
 
@@ -1106,7 +1109,8 @@ export default class Meetings extends WebexPlugin {
               type,
               useRandomDelayForInfo,
               infoExtraParams,
-              correlationId
+              correlationId,
+              failOnMissingMeetingInformation
             ).then((createdMeeting: any) => {
               // If the meeting was successfully created.
               if (createdMeeting && createdMeeting.on) {
@@ -1161,6 +1165,7 @@ export default class Meetings extends WebexPlugin {
    * @param {Boolean} useRandomDelayForInfo whether a random delay should be added to fetching meeting info
    * @param {Object} infoExtraParams extra parameters to be provided when fetching meeting info
    * @param {String} correlationId the optional specified correlationId
+   * @param {Boolean} failOnMissingMeetingInformation fail to create if meeting info not found
    * @returns {Promise} a new meeting instance complete with meeting info and destination
    * @private
    * @memberof Meetings
@@ -1170,7 +1175,8 @@ export default class Meetings extends WebexPlugin {
     type: string = null,
     useRandomDelayForInfo = false,
     infoExtraParams = {},
-    correlationId: string = undefined
+    correlationId: string = undefined,
+    failOnMissingMeetingInformation = false
   ) {
     const meeting = new Meeting(
       {
@@ -1232,6 +1238,10 @@ export default class Meetings extends WebexPlugin {
         !(err instanceof PasswordError) &&
         !(err instanceof PermissionError)
       ) {
+        if (failOnMissingMeetingInformation) {
+          // TODO: Remove meeting from collection and delete it
+          throw new Error('meeting information not found');
+        }
         // if there is no meeting info we assume its a 1:1 call or wireless share
         LoggerProxy.logger.info(
           `Meetings:index#createMeeting --> Info Unable to fetch meeting info for ${destination}.`


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Sometimes, when you create a meeting, you want it to error if the meeting info isn't found.

## by making the following changes

Added a new argument failOnMissingMeetingInformation, which causes the create to throw an error if meeting information is missing. This is just a draft PR. The error raised here could be a new type like we have PasswordError etc.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
