### PR TITLE
feat(ca-metrics): use correct error payload for 2423012

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
@@ -98,6 +98,7 @@ const ERROR_DESCRIPTIONS = {
   NO_MEDIA_FOUND: 'NoMediaFound',
   STREAM_ERROR_NO_MEDIA: 'StreamErrorNoMedia',
   CAMERA_PERMISSION_DENIED: 'CameraPermissionDenied',
+  POSSIBLE_LICENSE_FRAUD: 'PossibleLicenseFraud',
 };
 
 export const SERVICE_ERROR_CODES_TO_CLIENT_ERROR_CODES_MAP = {
@@ -191,6 +192,8 @@ export const SERVICE_ERROR_CODES_TO_CLIENT_ERROR_CODES_MAP = {
   2423016: 4005,
   2423017: 4005,
   2423018: 4005,
+  // LOCUS_OWNER_CONCURRENT_ACTIVE_MEETING_LIMIT_EXCEEDED
+  2423012: 12000,
   // LOCUS_REQUIRES_MODERATOR_ROLE
   2423007: 4006,
   // LOCUS_JOIN_RESTRICTED_USER_NOT_IN_ROOM
@@ -574,6 +577,13 @@ export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEv
     errorDescription: ERROR_DESCRIPTIONS.UNKNOWN_ERROR,
     category: 'other',
     fatal: true,
+  },
+  12000: {
+    errorDescription: ERROR_DESCRIPTIONS.POSSIBLE_LICENSE_FRAUD,
+    category: 'expected',
+    fatal: true,
+    name: 'locus.response',
+    shownToUser: true,
   },
 };
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -64,7 +64,7 @@ describe('internal-plugin-metrics', () => {
             metrics: {
               clientType: 'TEAMS_CLIENT',
               subClientType: 'WEB_APP',
-              clientName: 'Cantina'
+              clientName: 'Cantina',
             },
           },
           meetingCollection: {
@@ -134,7 +134,12 @@ describe('internal-plugin-metrics', () => {
 
         //@ts-ignore
         const res = cd.getOrigin(
-          {subClientType: 'WEB_APP', clientType: 'TEAMS_CLIENT', newEnvironment: 'test-new-env', clientLaunchMethod: 'url-handler'},
+          {
+            subClientType: 'WEB_APP',
+            clientType: 'TEAMS_CLIENT',
+            newEnvironment: 'test-new-env',
+            clientLaunchMethod: 'url-handler',
+          },
           fakeMeeting.id
         );
 
@@ -163,7 +168,12 @@ describe('internal-plugin-metrics', () => {
 
         //@ts-ignore
         const res = cd.getOrigin(
-          {subClientType: 'WEB_APP', clientType: 'TEAMS_CLIENT', clientLaunchMethod: 'url-handler', environment: 'test-env'},
+          {
+            subClientType: 'WEB_APP',
+            clientType: 'TEAMS_CLIENT',
+            clientLaunchMethod: 'url-handler',
+            environment: 'test-env',
+          },
           fakeMeeting.id
         );
 
@@ -177,7 +187,7 @@ describe('internal-plugin-metrics', () => {
             os: getOSNameInternal(),
             osVersion: getOSVersion(),
             subClientType: 'WEB_APP',
-            clientLaunchMethod: 'url-handler'
+            clientLaunchMethod: 'url-handler',
           },
           environment: 'test-env',
           name: 'endpoint',
@@ -417,7 +427,7 @@ describe('internal-plugin-metrics', () => {
         assert.deepEqual(webexLoggerLogCalls[1].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @createClientEventObjectInMeeting. Creating in meeting event object.',
-          `name: client.alert.displayed`
+          `name: client.alert.displayed`,
         ]);
 
         assert.deepEqual(webexLoggerLogCalls[2].args, [
@@ -425,7 +435,6 @@ describe('internal-plugin-metrics', () => {
           'CallDiagnosticMetrics: @submitToCallDiagnostics. Preparing to send the request',
           `finalEvent: {"eventPayload":{"eventId":"my-fake-id","version":1,"origin":{"origin":"fake-origin"},"originTime":{"triggered":"${now.toISOString()}","sent":"not_defined_yet"},"senderCountryCode":"UK","event":{"name":"client.alert.displayed","canProceed":true,"identifiers":{"correlationId":"correlationId","userId":"userId","deviceId":"deviceUrl","orgId":"orgId","locusUrl":"locus/url","locusId":"url","locusStartTime":"lastActive","mediaAgentAlias":"alias","mediaAgentGroupId":"1"},"eventData":{"webClientDomain":"whatever"},"userType":"host","loginType":"login-ci"}},"type":["diagnostic-event"]}`,
         ]);
-
       });
 
       it('should submit client event successfully with correlationId', () => {
@@ -509,7 +518,7 @@ describe('internal-plugin-metrics', () => {
         assert.deepEqual(webexLoggerLogCalls[1].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @createClientEventObjectPreMeeting. Creating pre meeting event object.',
-          `name: client.alert.displayed`
+          `name: client.alert.displayed`,
         ]);
 
         assert.deepEqual(webexLoggerLogCalls[2].args, [
@@ -517,8 +526,6 @@ describe('internal-plugin-metrics', () => {
           'CallDiagnosticMetrics: @submitToCallDiagnostics. Preparing to send the request',
           `finalEvent: {"eventPayload":{"eventId":"my-fake-id","version":1,"origin":{"origin":"fake-origin"},"originTime":{"triggered":"${now.toISOString()}","sent":"not_defined_yet"},"senderCountryCode":"UK","event":{"name":"client.alert.displayed","canProceed":true,"identifiers":{"correlationId":"correlationId","userId":"userId","deviceId":"deviceUrl","orgId":"orgId","locusUrl":"locus-url"},"eventData":{"webClientDomain":"whatever"},"loginType":"login-ci"}},"type":["diagnostic-event"]}`,
         ]);
-
-
       });
 
       it('it should include errors if provided with meetingId', () => {
@@ -594,24 +601,23 @@ describe('internal-plugin-metrics', () => {
           `options: ${JSON.stringify(options)}`,
         ]);
 
-
         assert.deepEqual(webexLoggerLogCalls[1].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @prepareClientEvent. Error detected, attempting to map and attach it to the event...',
           `name: client.alert.displayed`,
-          `rawError: ${options.rawError}`
+          `rawError: ${options.rawError}`,
         ]);
 
         assert.deepEqual(webexLoggerLogCalls[2].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @prepareClientEvent. Generated errors:',
-          `generatedError: {"fatal":true,"shownToUser":false,"name":"other","category":"expected","errorCode":4029,"serviceErrorCode":2409005,"errorDescription":"StartRecordingFailed"}`
-        ])
+          `generatedError: {"fatal":true,"shownToUser":false,"name":"other","category":"expected","errorCode":4029,"serviceErrorCode":2409005,"errorDescription":"StartRecordingFailed"}`,
+        ]);
 
         assert.deepEqual(webexLoggerLogCalls[3].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @createClientEventObjectInMeeting. Creating in meeting event object.',
-          `name: client.alert.displayed`
+          `name: client.alert.displayed`,
         ]);
 
         assert.deepEqual(webexLoggerLogCalls[4].args, [
@@ -688,24 +694,23 @@ describe('internal-plugin-metrics', () => {
           `options: ${JSON.stringify(options)}`,
         ]);
 
-
         assert.deepEqual(webexLoggerLogCalls[1].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @prepareClientEvent. Error detected, attempting to map and attach it to the event...',
           `name: client.alert.displayed`,
-          `rawError: ${options.rawError}`
+          `rawError: ${options.rawError}`,
         ]);
 
         assert.deepEqual(webexLoggerLogCalls[2].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @prepareClientEvent. Generated errors:',
-          `generatedError: {"fatal":true,"shownToUser":false,"name":"other","category":"expected","errorCode":4029,"serviceErrorCode":2409005,"errorDescription":"StartRecordingFailed"}`
-        ])
+          `generatedError: {"fatal":true,"shownToUser":false,"name":"other","category":"expected","errorCode":4029,"serviceErrorCode":2409005,"errorDescription":"StartRecordingFailed"}`,
+        ]);
 
         assert.deepEqual(webexLoggerLogCalls[3].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @createClientEventObjectPreMeeting. Creating pre meeting event object.',
-          `name: client.alert.displayed`
+          `name: client.alert.displayed`,
         ]);
 
         assert.deepEqual(webexLoggerLogCalls[4].args, [
@@ -1110,6 +1115,19 @@ describe('internal-plugin-metrics', () => {
           errorCode: 9999,
         });
       });
+
+      it('should generate event error payload correctly for locus error 2423012', () => {
+        const res = cd.generateClientEventErrorPayload({body: {errorCode: 2423012}});
+        assert.deepEqual(res, {
+          category: 'expected',
+          errorDescription: 'PossibleLicenseFraud',
+          fatal: true,
+          name: 'locus.response',
+          shownToUser: true,
+          serviceErrorCode: 2423012,
+          errorCode: 12000,
+        });
+      });
     });
 
     describe('#getCurLoginType', () => {
@@ -1146,68 +1164,68 @@ describe('internal-plugin-metrics', () => {
         it('returns expected options without preLoginId', async () => {
           const options = {
             meetingId: fakeMeeting.id,
-            preLoginId
+            preLoginId,
           };
 
           const triggered = new Date();
           const fetchOptions = await cd.buildClientEventFetchRequestOptions({
             name: 'client.exit.app',
-            payload: { trigger: 'user-interaction', canProceed: false },
+            payload: {trigger: 'user-interaction', canProceed: false},
             options,
           });
 
           assert.deepEqual(fetchOptions.body, {
-              metrics: [
-                {
-                  eventPayload: {
-                    event: {
-                      canProceed: false,
-                      eventData: {
-                        webClientDomain: 'whatever',
-                      },
-                      identifiers: {
-                        correlationId: 'correlationId',
-                        deviceId: 'deviceUrl',
-                        locusId: 'url',
-                        locusStartTime: 'lastActive',
-                        locusUrl: 'locus/url',
-                        orgId: 'orgId',
-                        userId: 'userId',
-                      },
-                      loginType: 'login-ci',
-                      name: 'client.exit.app',
-                      trigger: 'user-interaction',
-                      userType: 'host',
-                      isConvergedArchitectureEnabled: undefined,
+            metrics: [
+              {
+                eventPayload: {
+                  event: {
+                    canProceed: false,
+                    eventData: {
+                      webClientDomain: 'whatever',
                     },
-                    eventId: 'my-fake-id',
-                    origin: {
-                      buildType: 'test',
-                      clientInfo: {
-                        clientType: 'TEAMS_CLIENT',
-                        clientVersion: 'webex-js-sdk/webex-version',
-                        localNetworkPrefix:
-                          Utils.anonymizeIPAddress(webex.meetings.geoHintInfo?.clientAddress) ||
-                          undefined,
-                        os: getOSNameInternal() || 'unknown',
-                        osVersion: getOSVersion(),
-                        subClientType: 'WEB_APP',
-                      },
-                      environment: 'meeting_evn',
-                      name: 'endpoint',
-                      networkType: 'unknown',
-                      userAgent,
+                    identifiers: {
+                      correlationId: 'correlationId',
+                      deviceId: 'deviceUrl',
+                      locusId: 'url',
+                      locusStartTime: 'lastActive',
+                      locusUrl: 'locus/url',
+                      orgId: 'orgId',
+                      userId: 'userId',
                     },
-                    originTime: {
-                      sent: 'not_defined_yet',
-                      triggered: triggered.toISOString(),
-                    },
-                    senderCountryCode: webex.meetings.geoHintInfo?.countryCode,
-                    version: 1,
+                    loginType: 'login-ci',
+                    name: 'client.exit.app',
+                    trigger: 'user-interaction',
+                    userType: 'host',
+                    isConvergedArchitectureEnabled: undefined,
                   },
-                  type: ['diagnostic-event'],
+                  eventId: 'my-fake-id',
+                  origin: {
+                    buildType: 'test',
+                    clientInfo: {
+                      clientType: 'TEAMS_CLIENT',
+                      clientVersion: 'webex-js-sdk/webex-version',
+                      localNetworkPrefix:
+                        Utils.anonymizeIPAddress(webex.meetings.geoHintInfo?.clientAddress) ||
+                        undefined,
+                      os: getOSNameInternal() || 'unknown',
+                      osVersion: getOSVersion(),
+                      subClientType: 'WEB_APP',
+                    },
+                    environment: 'meeting_evn',
+                    name: 'endpoint',
+                    networkType: 'unknown',
+                    userAgent,
+                  },
+                  originTime: {
+                    sent: 'not_defined_yet',
+                    triggered: triggered.toISOString(),
+                  },
+                  senderCountryCode: webex.meetings.geoHintInfo?.countryCode,
+                  version: 1,
                 },
-              ],
+                type: ['diagnostic-event'],
+              },
+            ],
           });
 
           const rest = omit(fetchOptions, 'body');
@@ -1221,16 +1239,16 @@ describe('internal-plugin-metrics', () => {
               headers: {
                 authorization: false,
                 'x-prelogin-userid': preLoginId,
-              }
-            })
+              },
+            });
           } else {
             assert.deepEqual(rest, {
               foo: 'bar',
               method: 'POST',
               resource: 'clientmetrics',
               service: 'metrics',
-              headers: {}
-            })
+              headers: {},
+            });
           }
 
           const webexLoggerLogCalls = webex.logger.log.getCalls();
@@ -1246,7 +1264,7 @@ describe('internal-plugin-metrics', () => {
           assert.deepEqual(webexLoggerLogCalls[1].args, [
             'call-diagnostic-events -> ',
             'CallDiagnosticMetrics: @createClientEventObjectInMeeting. Creating in meeting event object.',
-            `name: client.exit.app`
+            `name: client.exit.app`,
           ]);
         });
       });


### PR DESCRIPTION
# COMPLETES
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-471364

## This pull request addresses

Added constants and mappings to properly generate the error payload for locus error 2423012.

Discussed with Meera and created a new CA error code (12000 - PossibleLicenseFraud) and error_type (JoinMeetingFailure) for JMF issues. Will get feedback on this in the Engineering space.

Most of the diffs are lint/prettier formatting changes.  I'll mark which changes are actually "real".

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
