### PR TITLE
feat(ca-metrics): use correct error payload for 2409062

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
@@ -99,6 +99,7 @@ const ERROR_DESCRIPTIONS = {
   STREAM_ERROR_NO_MEDIA: 'StreamErrorNoMedia',
   CAMERA_PERMISSION_DENIED: 'CameraPermissionDenied',
   FRAUD_DETECTION: 'FraudDetection',
+  E2EE_NOT_SUPPORTED: 'E2EENotSupported',
 };
 
 export const SERVICE_ERROR_CODES_TO_CLIENT_ERROR_CODES_MAP = {
@@ -238,6 +239,8 @@ export const SERVICE_ERROR_CODES_TO_CLIENT_ERROR_CODES_MAP = {
   2405001: 4029,
   // LOCUS_RECORDING_NOT_ENABLED
   2409005: 4029,
+  // E2EE_NOT_SUPPORTED
+  2409062: 12002,
 
   // ---- U2C Sign in catalog ------
   // The user exists, but hasn't completed activation. Needs to visit Atlas for more processing.
@@ -580,6 +583,13 @@ export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEv
   },
   12000: {
     errorDescription: ERROR_DESCRIPTIONS.FRAUD_DETECTION,
+    category: 'expected',
+    fatal: true,
+    name: 'locus.response',
+    shownToUser: true,
+  },
+  12002: {
+    errorDescription: ERROR_DESCRIPTIONS.E2EE_NOT_SUPPORTED,
     category: 'expected',
     fatal: true,
     name: 'locus.response',

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -1123,6 +1123,19 @@ describe('internal-plugin-metrics', () => {
           errorCode: 12000,
         });
       });
+      it('should generate event error payload correctly for locus error 2409062', () => {
+        const res = cd.generateClientEventErrorPayload({body: {errorCode: 2409062}});
+        assert.deepEqual(res, {
+          category: 'expected',
+          errorDescription: 'E2EENotSupported',
+          fatal: true,
+          name: 'locus.response',
+          shownToUser: true,
+          serviceErrorCode: 2409062,
+          errorCode: 12002,
+        });
+      });
+
     });
 
     describe('#getCurLoginType', () => {
@@ -1311,7 +1324,7 @@ describe('internal-plugin-metrics', () => {
       });
     });
 
-    describe.only('#isServiceErrorExpected', () => {
+    describe('#isServiceErrorExpected', () => {
       it('returns true for code mapped to "expected"', () => {
         assert.isTrue(cd.isServiceErrorExpected(2423012));
       });


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-471367
## This pull request addresses

Locus error 2409062 was not mapped in the error catalog, so defaults were being used.

## by making the following changes

Add locus error 2409062 mapped to 12002 along with error payloads.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Unit test added.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
