### PR TITLE
fix(services): added hostCatalog inside webex

### DIFF
--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -58,6 +58,8 @@ const Services = WebexPlugin.extend({
 
   _serviceUrls: null,
 
+  _hostCatalog: null,
+
   /**
    * Get the registry associated with this webex instance.
    *
@@ -164,6 +166,15 @@ const Services = WebexPlugin.extend({
    */
   _updateServiceUrls(serviceUrls) {
     this._serviceUrls = {...this._serviceUrls, ...serviceUrls};
+  },
+
+  /**
+   * saves the hostCatalog object
+   * @param {Object} hostCatalog
+   * @returns {void}
+   */
+  _updateHostCatalog(hostCatalog) {
+    this._hostCatalog = {...this._hostCatalog, ...hostCatalog};
   },
 
   /**
@@ -729,6 +740,7 @@ const Services = WebexPlugin.extend({
     // update all the service urls in the host catalog
 
     this._updateServiceUrls(serviceHostmap.serviceLinks);
+    this._updateHostCatalog(serviceHostmap.hostCatalog);
 
     return formattedHostmap;
   },

--- a/packages/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/services.js
@@ -298,6 +298,12 @@ describe('webex-core', () => {
           formattedHM.map((item) => item.name)
         );
       });
+
+      it('has hostCatalog updated', () => {
+        services._formatReceivedHostmap(serviceHostmap);
+
+        assert.deepStrictEqual(services._hostCatalog, serviceHostmap.hostCatalog);
+      });
     });
 
     describe('#updateCredentialsConfig()', () => {


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-470778

## This pull request addresses
Adding hostCatalog object inside webex

## by making the following changes
Created new field: _hostCatalog in services.js file as part of services object
Under _formatReceivedHostMap, updating the _hostCatalog with what is present in serviceHostmap(response from get request to u2c service)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested
Initialized Webex and checked if hostCatalog object was populated
<img width="742" alt="Screenshot 2023-11-15 at 19 24 35" src="https://github.com/webex/webex-js-sdk/assets/65543166/0ee89161-bee4-4b15-b804-5ceec1c72461">


### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
