### PR TITLE
feat(meetings): refactor public join method

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4419,39 +4419,13 @@ export default class Meeting extends StatelessWebexPlugin {
         this.meetingFiniteStateMachine.join();
         LoggerProxy.logger.log('Meeting:index#join --> Success');
 
-        return join;
-      })
-      .then((join) => {
-        joinSuccess(join);
-        this.deferJoin = undefined;
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.JOIN_SUCCESS, {
           correlation_id: this.correlationId,
         });
 
-        return join;
-      })
-      .then(async (join) => {
-        // @ts-ignore - config coming from registerPlugin
-        if (this.config.enableAutomaticLLM) {
-          await this.updateLLMConnection();
-        }
+        joinSuccess(join);
 
-        return join;
-      })
-      .then(async (join) => {
-        if (isBrowser) {
-          // @ts-ignore - config coming from registerPlugin
-          if (this.config.receiveTranscription || options.receiveTranscription) {
-            if (this.isTranscriptionSupported()) {
-              await this.receiveTranscription();
-              LoggerProxy.logger.info('Meeting:index#join --> enabled to recieve transcription!');
-            }
-          }
-        } else {
-          LoggerProxy.logger.error(
-            'Meeting:index#join --> Receving transcription is not supported on this platform'
-          );
-        }
+        this.deferJoin = undefined;
 
         return join;
       })
@@ -4487,9 +4461,59 @@ export default class Meeting extends StatelessWebexPlugin {
         );
 
         joinFailed(error);
+
         this.deferJoin = undefined;
 
         return Promise.reject(error);
+      })
+      .then((join) => {
+        // @ts-ignore - config coming from registerPlugin
+        if (this.config.enableAutomaticLLM) {
+          this.updateLLMConnection().catch((error) => {
+            LoggerProxy.logger.error('Meeting:index#join --> Update LLM Connection Failed', error);
+
+            Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.LLM_CONNECTION_AFTER_JOIN_FAILURE, {
+              correlation_id: this.correlationId,
+              reason: error?.message,
+              stack: error.stack,
+            });
+          });
+        }
+
+        return join;
+      })
+      .then((join) => {
+        if (isBrowser) {
+          // @ts-ignore - config coming from registerPlugin
+          if (this.config.receiveTranscription || options.receiveTranscription) {
+            if (this.isTranscriptionSupported()) {
+              LoggerProxy.logger.info(
+                'Meeting:index#join --> Attempting to enabled to recieve transcription!'
+              );
+              this.receiveTranscription().catch((error) => {
+                LoggerProxy.logger.error(
+                  'Meeting:index#join --> Receive Transcription Failed',
+                  error
+                );
+
+                Metrics.sendBehavioralMetric(
+                  BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_AFTER_JOIN_FAILURE,
+                  {
+                    correlation_id: this.correlationId,
+                    reason: error?.message,
+                    stack: error.stack,
+                  }
+                );
+              });
+            }
+          }
+        } else {
+          LoggerProxy.logger.error(
+            'Meeting:index#join --> Receving transcription is not supported on this platform'
+          );
+        }
+
+        return join;
       });
   }
 

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -18,6 +18,8 @@ const BEHAVIORAL_METRICS = {
   GET_USER_MEDIA_FAILURE: 'js_sdk_get_user_media_failures',
   GET_DISPLAY_MEDIA_FAILURE: 'js_sdk_get_display_media_failures',
   JOIN_WITH_MEDIA_FAILURE: 'js_sdk_join_with_media_failures',
+  LLM_CONNECTION_AFTER_JOIN_FAILURE: 'js_sdk_llm_connection_after_join_failure',
+  RECEIVE_TRANSCRIPTION_AFTER_JOIN_FAILURE: 'js_sdk_receive_transcription_after_join_failure',
 
   DISCONNECT_DUE_TO_INACTIVITY: 'js_sdk_disconnect_due_to_inactivity',
   MEETING_MEDIA_INACTIVE: 'js_sdk_meeting_media_inactive',

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -13,6 +13,7 @@ import {Credentials, Token, WebexPlugin} from '@webex/webex-core';
 import Support from '@webex/internal-plugin-support';
 import MockWebex from '@webex/test-helper-mock-webex';
 import StaticConfig from '@webex/plugin-meetings/src/common/config';
+import { Defer } from '@webex/common';
 import {
   FLOOR_ACTION,
   SHARE_STATUS,
@@ -92,6 +93,7 @@ import {
   MeetingInfoV2PolicyError,
 } from '../../../../src/meeting-info/meeting-info-v2';
 import {ANNOTATION_POLICY} from '../../../../src/annotation/constants';
+
 
 // Non-stubbed function
 const {getDisplayMedia} = Media;
@@ -786,27 +788,6 @@ describe('plugin-meetings', () => {
             assert.equal(result, joinMeetingResult);
           });
 
-          it('should call updateLLMConnection upon joining if config value is set', async () => {
-            meeting.config.enableAutomaticLLM = true;
-            await meeting.join();
-
-            assert.calledOnce(meeting.updateLLMConnection);
-          });
-
-          it('should not call updateLLMConnection upon joining if config value is not set', async () => {
-            await meeting.join();
-
-            assert.notCalled(meeting.updateLLMConnection);
-          });
-
-          it('should invoke `receiveTranscription()` if receiveTranscription is set to true', async () => {
-            meeting.isTranscriptionSupported = sinon.stub().returns(true);
-            meeting.receiveTranscription = sinon.stub().returns(Promise.resolve());
-
-            await meeting.join({receiveTranscription: true});
-            assert.calledOnce(meeting.receiveTranscription);
-          });
-
           it('should not create new correlation ID on join immediately after create', async () => {
             await meeting.join();
             sinon.assert.notCalled(setCorrelationIdSpy);
@@ -972,6 +953,125 @@ describe('plugin-meetings', () => {
             });
           });
         });
+        describe('lmm and transcription decoupling', () => {
+          beforeEach(() => {
+            sandbox.stub(MeetingUtil, 'joinMeeting').returns(Promise.resolve(joinMeetingResult));
+          });
+
+          describe('llm', () => {
+            it('makes sure that join does not wait for update llm connection promise', async () => {
+              const defer = new Defer();
+
+              meeting.config.enableAutomaticLLM = true;
+              meeting.updateLLMConnection = sinon.stub().returns(defer.promise);
+
+              const result = await meeting.join();
+
+              assert.equal(result, joinMeetingResult);
+
+              defer.resolve();
+            });
+
+            it('should call updateLLMConnection as part of joining if config value is set', async () => {
+              meeting.config.enableAutomaticLLM = true;
+              meeting.updateLLMConnection = sinon.stub().resolves();
+
+              await meeting.join();
+
+              assert.calledOnce(meeting.updateLLMConnection);
+            });
+
+            it('should not call updateLLMConnection as part of joining if config value is not set', async () => {
+              meeting.updateLLMConnection = sinon.stub().resolves();
+              await meeting.join();
+
+              assert.notCalled(meeting.updateLLMConnection);
+            });
+
+            it('handles catching error of llm connection later, and join still resolves', async () => {
+              const defer = new Defer();
+
+              meeting.config.enableAutomaticLLM = true;
+              meeting.updateLLMConnection = sinon.stub().returns(defer.promise);
+
+              const result = await meeting.join();
+
+              assert.equal(result, joinMeetingResult);
+
+              defer.reject(new Error("bad day", {cause: 'bad weather'}));
+
+              try {
+                await defer.promise;
+              } catch (err) {
+
+                assert.deepEqual(Metrics.sendBehavioralMetric.getCalls()[0].args, [
+                  BEHAVIORAL_METRICS.JOIN_SUCCESS, {correlation_id: meeting.correlationId}
+                ])
+
+                assert.deepEqual(Metrics.sendBehavioralMetric.getCalls()[1].args, [
+                  BEHAVIORAL_METRICS.LLM_CONNECTION_AFTER_JOIN_FAILURE, {
+                    correlation_id: meeting.correlationId,
+                    reason: err.message,
+                    stack: err.stack,
+                  }
+                ]);
+              }
+            });
+          });
+
+          describe('receive transcription', () => {
+            it('should invoke `receiveTranscription()` if receiveTranscription is set to true', async () => {
+              meeting.isTranscriptionSupported = sinon.stub().returns(true);
+              meeting.receiveTranscription = sinon.stub().returns(Promise.resolve());
+
+              await meeting.join({receiveTranscription: true});
+              assert.calledOnce(meeting.receiveTranscription);
+            });
+
+            it('make sure that join does not wait for setting up receive transcriptions', async () => {
+              const defer = new Defer();
+
+              meeting.isTranscriptionSupported = sinon.stub().returns(true);
+              meeting.receiveTranscription = sinon.stub().returns(defer.promise);
+
+              const result = await meeting.join({receiveTranscription: true});
+
+              assert.equal(result, joinMeetingResult);
+
+              defer.resolve();
+            });
+
+            it('handles catching error of receiveTranscription(), and join still resolves', async () => {
+              const defer = new Defer();
+
+              meeting.isTranscriptionSupported = sinon.stub().returns(true);
+              meeting.receiveTranscription = sinon.stub().returns(defer.promise);
+
+              const result = await meeting.join({receiveTranscription: true});
+
+              assert.equal(result, joinMeetingResult);
+
+              defer.reject(new Error("bad day", {cause: 'bad weather'}));
+
+              try {
+                await defer.promise;
+              } catch (err) {
+                console.log(Metrics.sendBehavioralMetric.getCalls())
+                assert.deepEqual(Metrics.sendBehavioralMetric.getCalls()[0].args, [
+                  BEHAVIORAL_METRICS.JOIN_SUCCESS, {correlation_id: meeting.correlationId}
+                ])
+
+                assert.deepEqual(Metrics.sendBehavioralMetric.getCalls()[1].args, [
+                  BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_AFTER_JOIN_FAILURE, {
+                    correlation_id: meeting.correlationId,
+                    reason: err.message,
+                    stack: err.stack,
+                  }
+                ]);
+              }
+            })
+          })
+        })
       });
 
       describe('#addMedia', () => {
@@ -5568,9 +5668,9 @@ describe('plugin-meetings', () => {
           assert.notOk(meeting.permissionTokenPayload);
 
           const permissionTokenPayloadData = {permission: {userPolicies: {a: true}}, exp: '1234'};
-          
+
           const jwtDecodeStub = sinon.stub(jwt, 'decode').returns(permissionTokenPayloadData);
-          
+
           meeting.setPermissionTokenPayload();
 
           assert.calledOnce(jwtDecodeStub);
@@ -5667,7 +5767,7 @@ describe('plugin-meetings', () => {
           assert.equal(meeting.owner, expectedInfoToParse.owner);
           assert.equal(meeting.permissionToken, expectedInfoToParse.permissionToken);
           assert.deepEqual(meeting.selfUserPolicies, expectedInfoToParse.selfUserPolicies);
-          
+
           if(expectedInfoToParse.permissionTokenPayload) {
             assert.deepEqual(meeting.permissionTokenPayload, expectedInfoToParse.permissionTokenPayload);
           }
@@ -5686,9 +5786,9 @@ describe('plugin-meetings', () => {
             }
           };
 
-          // generated permissionToken with secret `secret` and 
+          // generated permissionToken with secret `secret` and
           // value `JSON.stringify(expectedPermissionTokenPayload)`
-          const permissionToken = 
+          const permissionToken =
             'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxMjM0NTYiLCJwZXJtaXNzaW9uIjp7InVzZXJQb2xpY2llcyI6eyJhIjp0cnVlfX19.wkTk0Hp8sUlq2wi2nP4-Ym4Xb7aEUHzyXA1kzk6f0V0';
 
           const FAKE_MEETING_INFO = {
@@ -8038,20 +8138,20 @@ describe('plugin-meetings', () => {
     });
 
     afterEach(() => {
-      clock.restore();  
+      clock.restore();
     })
 
-    it('should return undefined if exp is undefined', () => { 
+    it('should return undefined if exp is undefined', () => {
       assert.equal(meeting.getPermissionTokenTimeLeftInSec(), undefined)
     });
 
-    it('should return the expected positive exp', () => { 
+    it('should return the expected positive exp', () => {
       // set permission token as now + 1 sec
       meeting.permissionTokenPayload = {exp: (now + 1000).toString()};
       assert.equal(meeting.getPermissionTokenTimeLeftInSec(), 1);
     });
 
-    it('should return the expected negative exp', () => { 
+    it('should return the expected negative exp', () => {
       // set permission token as now - 1 sec
       meeting.permissionTokenPayload = {exp: (now - 1000).toString()};
       assert.equal(meeting.getPermissionTokenTimeLeftInSec(), -1);


### PR DESCRIPTION
# COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-475778

## This pull request addresses

- refactors join to no longer wait for llm connection and receive transcribing
- there is a relatively big side effect caused by this refactor
- - before we did not allow users to join the meeting if either of these 2 failed
- - with the new refactor, now the users will always be able to join the meeting regardless if llm or transcribing succeeds. When this happens, the user will experience a smaller set of features in the meeting. 
- - future improvements will include to retry this operations in case they fail, but for now we agreed to not do it

## by making the following changes

- refactor public join method
- add unit tests

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- unit test, manual test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
