### PR TITLE
feat: add API for renewal of the permission token

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -62,8 +62,10 @@ import ReconnectionError from '../common/errors/reconnection';
 import ReconnectInProgress from '../common/errors/reconnection-in-progress';
 import {
   _CALL_,
+  _CONVERSATION_URL_,
   _INCOMING_,
   _JOIN_,
+  _MEETING_LINK_,
   AUDIO,
   CONTENT,
   DISPLAY_HINTS,
@@ -514,6 +516,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
   meetingInfoFailureReason: string;
   meetingInfoFailureCode?: number;
+  meetingInfoExtraParams?: Record<string, any>;
   networkQualityMonitor: NetworkQualityMonitor;
   networkStatus: string;
   passwordStatus: string;
@@ -1279,54 +1282,26 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
-   * Fetches meeting information.
-   * @param {Object} options
-   * @param {String} [options.password] optional
-   * @param {String} [options.captchaCode] optional
-   * @param {Boolean} [options.sendCAevents] optional - Whether to submit Call Analyzer events or not. Default: false.
-   * @public
-   * @memberof Meeting
+   * Internal method for fetching meeting info
+   *
    * @returns {Promise}
    */
-  public async fetchMeetingInfo({
+  private async fetchMeetingInfoInternal({
+    destination,
+    destinationType,
     password = null,
     captchaCode = null,
     extraParams = {},
     sendCAevents = false,
-  }: {
-    password?: string;
-    captchaCode?: string;
-    extraParams?: Record<string, any>;
-    sendCAevents?: boolean;
-  }) {
-    // when fetch meeting info is called directly by the client, we want to clear out the random timer for sdk to do it
-    if (this.fetchMeetingInfoTimeoutId) {
-      clearTimeout(this.fetchMeetingInfoTimeoutId);
-      this.fetchMeetingInfoTimeoutId = undefined;
-    }
-    if (captchaCode && !this.requiredCaptcha) {
-      return Promise.reject(
-        new Error('fetchMeetingInfo() called with captchaCode when captcha was not required')
-      );
-    }
-    if (
-      password &&
-      this.passwordStatus !== PASSWORD_STATUS.REQUIRED &&
-      this.passwordStatus !== PASSWORD_STATUS.UNKNOWN
-    ) {
-      return Promise.reject(
-        new Error('fetchMeetingInfo() called with password when password was not required')
-      );
-    }
-
+  }): Promise<void> {
     try {
       const captchaInfo = captchaCode
         ? {code: captchaCode, id: this.requiredCaptcha.captchaId}
         : null;
 
       const info = await this.attrs.meetingInfoProvider.fetchMeetingInfo(
-        this.destination,
-        this.destinationType,
+        destination,
+        destinationType,
         password,
         captchaInfo,
         // @ts-ignore - config coming from registerPlugin
@@ -1418,6 +1393,92 @@ export default class Meeting extends StatelessWebexPlugin {
         throw err;
       }
     }
+  }
+
+  /**
+   * Refreshes the meeting info permission token (it's required for joining meetings)
+   *
+   * @returns {Promise}
+   */
+  public async refreshPermissionToken(): Promise<void> {
+    if (!this.meetingInfo?.permissionToken) {
+      return;
+    }
+
+    const isStartingSpaceInstantV2Meeting =
+      this.destinationType === _CONVERSATION_URL_ &&
+      // @ts-ignore - config coming from registerPlugin
+      this.config.experimental.enableAdhocMeetings &&
+      // @ts-ignore
+      this.webex.meetings.preferredWebexSite;
+
+    const destination = isStartingSpaceInstantV2Meeting
+      ? this.meetingInfo.meetingJoinUrl
+      : this.destination;
+    const destinationType = isStartingSpaceInstantV2Meeting ? _MEETING_LINK_ : this.destinationType;
+
+    await this.fetchMeetingInfoInternal({
+      destination,
+      destinationType,
+      extraParams: {
+        ...this.meetingInfoExtraParams,
+        permissionToken: this.meetingInfo.permissionToken,
+      },
+      sendCAevents: true, // because if we're refreshing the permissionToken, it means that user is intending to join that meeting, so we want CA events
+    });
+  }
+
+  /**
+   * Fetches meeting information.
+   * @param {Object} options
+   * @param {String} [options.password] optional
+   * @param {String} [options.captchaCode] optional
+   * @param {Boolean} [options.sendCAevents] optional - Whether to submit Call Analyzer events or not. Default: false.
+   * @public
+   * @memberof Meeting
+   * @returns {Promise}
+   */
+  public async fetchMeetingInfo({
+    password = null,
+    captchaCode = null,
+    extraParams = {},
+    sendCAevents = false,
+  }: {
+    password?: string;
+    captchaCode?: string;
+    extraParams?: Record<string, any>;
+    sendCAevents?: boolean;
+  }) {
+    // when fetch meeting info is called directly by the client, we want to clear out the random timer for sdk to do it
+    if (this.fetchMeetingInfoTimeoutId) {
+      clearTimeout(this.fetchMeetingInfoTimeoutId);
+      this.fetchMeetingInfoTimeoutId = undefined;
+    }
+    if (captchaCode && !this.requiredCaptcha) {
+      return Promise.reject(
+        new Error('fetchMeetingInfo() called with captchaCode when captcha was not required')
+      );
+    }
+    if (
+      password &&
+      this.passwordStatus !== PASSWORD_STATUS.REQUIRED &&
+      this.passwordStatus !== PASSWORD_STATUS.UNKNOWN
+    ) {
+      return Promise.reject(
+        new Error('fetchMeetingInfo() called with password when password was not required')
+      );
+    }
+
+    this.meetingInfoExtraParams = cloneDeep(extraParams);
+
+    return this.fetchMeetingInfoInternal({
+      destination: this.destination,
+      destinationType: this.destinationType,
+      password,
+      captchaCode,
+      extraParams,
+      sendCAevents,
+    });
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -57,6 +57,8 @@ const BEHAVIORAL_METRICS = {
   MEETING_INFO_POLICY_ERROR: 'js_sdk_meeting_info_policy_error',
   LOCUS_DELTA_SYNC_FAILED: 'js_sdk_locus_delta_sync_failed',
   LOCUS_DELTA_OUT_OF_ORDER: 'js_sdk_locus_delta_ooo',
+  PERMISSION_TOKEN_REFRESH: 'js_sdk_permission_token_refresh',
+  PERMISSION_TOKEN_REFRESH_ERROR: 'js_sdk_permission_token_refresh_error',
 };
 
 export {BEHAVIORAL_METRICS as default};


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-475304

## This pull request addresses

There is no API to refresh permission token

## by making the following changes

Added API to refresh permission token.

NOTE: currently this doesn't work correctly for cases when we start an instant space meeting - the new meeting info we get after refresh is not the same as we got from /spaceInstant API call - this is being discussed with WbxAppAPI team

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
