### PR TITLE
fix: ignore VMN reachability when deciding if we should use TURN-TLS or not

### DIFF
--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -301,7 +301,7 @@ export default class Reachability {
     });
 
     return Promise.all(clusters)
-      .then(this.parseIceResultsToReachabilityResults)
+      .then(this.parseIceResultsToInternalReachabilityResults)
       .then((reachabilityLatencyResults) => {
         this.logUnreachableClusters();
 
@@ -472,7 +472,7 @@ export default class Reachability {
    * @protected
    * @memberof Reachability
    */
-  protected parseIceResultsToReachabilityResults(
+  protected parseIceResultsToInternalReachabilityResults(
     iceResults: Array<ICECandidateResult>
   ): InternalReachabilityResults {
     const reachabilityMap = {};

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -19,8 +19,8 @@ const VIDEO_MESH_TIMEOUT = 1000;
 // result for a specific transport protocol (like udp or tcp)
 export type TransportResult = {
   reachable: 'true' | 'false';
-  latencyInMilliseconds: string;
-  clientMediaIPs: string[];
+  latencyInMilliseconds?: string;
+  clientMediaIPs?: string[];
   untested?: 'true';
 };
 
@@ -139,6 +139,7 @@ export default class Reachability {
   }
 
   /**
+   * Reachability results as an object in the format that backend expects
    *
    * @returns {any} reachability results that need to be sent to the backend
    */

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -112,7 +112,7 @@ export default class Reachability {
    * @public
    * @memberof Reachability
    */
-  async isAnyClusterReachable() {
+  async isAnyPublicClusterReachable() {
     let reachable = false;
     // @ts-ignore
     const reachabilityData = await this.webex.boundedStorage

--- a/packages/@webex/plugin-meetings/src/reachability/request.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/request.ts
@@ -49,7 +49,7 @@ class ReachabilityRequest {
         const {clusters, joinCookie} = res.body;
 
         Object.keys(clusters).forEach((key) => {
-          clusters[key].isVideoMesh = res.body.clusterClasses?.hybridMedia?.includes(key);
+          clusters[key].isVideoMesh = !!res.body.clusterClasses?.hybridMedia?.includes(key);
         });
 
         LoggerProxy.logger.log(

--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -18,23 +18,10 @@ export default class RoapRequest extends StatelessWebexPlugin {
     let joinCookie;
 
     // @ts-ignore
-    const reachabilityData = await this.webex.boundedStorage
-      .get(REACHABILITY.namespace, REACHABILITY.localStorageResult)
-      .catch(() => {});
+    const reachabilityResult = await this.webex.meetings.reachability.getReachabilityResults();
 
-    if (reachabilityData) {
-      try {
-        const reachabilityResult = JSON.parse(reachabilityData);
-
-        /* istanbul ignore else */
-        if (reachabilityResult && Object.keys(reachabilityResult).length) {
-          localSdp.reachability = reachabilityResult;
-        }
-      } catch (e) {
-        LoggerProxy.logger.error(
-          `Roap:request#attachReachabilityData --> Error in parsing reachability data: ${e}`
-        );
-      }
+    if (reachabilityResult && Object.keys(reachabilityResult).length) {
+      localSdp.reachability = reachabilityResult;
     }
 
     // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -226,9 +226,10 @@ export default class TurnDiscovery {
    */
   private async getSkipReason(meeting: Meeting): Promise<string> {
     // @ts-ignore - fix type
-    const isAnyClusterReachable = await meeting.webex.meetings.reachability.isAnyClusterReachable();
+    const isAnyPublicClusterReachable =
+      await meeting.webex.meetings.reachability.isAnyPublicClusterReachable();
 
-    if (isAnyClusterReachable) {
+    if (isAnyPublicClusterReachable) {
       LoggerProxy.logger.info(
         'Roap:turnDiscovery#getSkipReason --> reachability has not failed, skipping TURN discovery'
       );

--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -225,8 +225,8 @@ export default class TurnDiscovery {
    * @returns {Promise<string>} Promise with empty string if reachability is not skipped or a reason if it is skipped
    */
   private async getSkipReason(meeting: Meeting): Promise<string> {
-    // @ts-ignore - fix type
     const isAnyPublicClusterReachable =
+      // @ts-ignore - fix type
       await meeting.webex.meetings.reachability.isAnyPublicClusterReachable();
 
     if (isAnyPublicClusterReachable) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1623,6 +1623,7 @@ describe('plugin-meetings', () => {
           meeting.webex.meetings.geoHintInfo = {regionCode: 'EU', countryCode: 'UK'};
           meeting.webex.meetings.reachability = {
             isAnyPublicClusterReachable: sinon.stub().resolves(true),
+            getReachabilityResults: sinon.stub().resolves(undefined),
           };
           meeting.roap.doTurnDiscovery = sinon
             .stub()

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1622,7 +1622,7 @@ describe('plugin-meetings', () => {
           meeting.locusInfo.onFullLocus = sinon.stub();
           meeting.webex.meetings.geoHintInfo = {regionCode: 'EU', countryCode: 'UK'};
           meeting.webex.meetings.reachability = {
-            isAnyClusterReachable: sinon.stub().resolves(true),
+            isAnyPublicClusterReachable: sinon.stub().resolves(true),
           };
           meeting.roap.doTurnDiscovery = sinon
             .stub()

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -217,8 +217,8 @@ describe('gatherReachability', () => {
     let testingClass: TestReachability;
 
     class TestReachability extends Reachability {
-      public testParseIceResultsToReachabilityResults(iceResults: Array<ICECandidateResult>) {
-        return this.parseIceResultsToReachabilityResults(iceResults);
+      public testParseIceResultsToInternalReachabilityResults(iceResults: Array<ICECandidateResult>) {
+        return this.parseIceResultsToInternalReachabilityResults(iceResults);
       }
       public testAddPublicIP(peerConnection: RTCPeerConnection, publicIP?: string | null) {
         return this.addPublicIP(peerConnection, publicIP);
@@ -228,8 +228,8 @@ describe('gatherReachability', () => {
       testingClass = new TestReachability({webex});
     });
 
-    it('calls parseIceResultsToReachabilityResults correctly', () => {
-      const res = testingClass.testParseIceResultsToReachabilityResults([
+    it('calls parseIceResultsToInternalReachabilityResults correctly', () => {
+      const res = testingClass.testParseIceResultsToInternalReachabilityResults([
         {
           clusterId: 'id1',
           elapsed: '12312',

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -6,7 +6,7 @@ import MeetingUtil from '@webex/plugin-meetings/src/meeting/util';
 
 import { IP_VERSION } from '@webex/plugin-meetings/src/constants';
 
-describe('isAnyClusterReachable', () => {
+describe('isAnyPublicClusterReachable', () => {
   let webex;
 
   beforeEach(() => {
@@ -29,7 +29,7 @@ describe('isAnyClusterReachable', () => {
     }
     const reachability = new Reachability(webex);
 
-    const result = await reachability.isAnyClusterReachable();
+    const result = await reachability.isAnyPublicClusterReachable();
 
     assert.equal(result, expectedValue);
   };

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -57,6 +57,63 @@ describe('isAnyPublicClusterReachable', () => {
   it('returns false when reachability.result item is not there', async () => {
     await checkIsClusterReachable(undefined, false);
   });
+
+  describe('ignores video mesh reachability', () => {
+    it('returns false if there are no public cluster results, only video mesh', async () => {
+      await checkIsClusterReachable({
+        x: {
+          udp: {reachable: 'true'},
+          tcp: {reachable: 'true'},
+          isVideoMesh: true,
+        },
+        y: {
+          udp: {reachable: 'false'},
+          tcp: {reachable: 'true'},
+          isVideoMesh: true,
+        }
+      }, false);
+    });
+
+    it('returns false if there public cluster reachability failed, only video mesh succeeded', async () => {
+      await checkIsClusterReachable({
+        x: {
+          udp: {reachable: 'false'},
+          tcp: {reachable: 'true'},
+          isVideoMesh: true,
+        },
+        y: {
+          udp: {reachable: 'true'},
+          tcp: {reachable: 'false'},
+          isVideoMesh: true,
+        },
+        publicOne: {
+          udp: {reachable: 'false'},
+          tcp: {reachable: 'false'},
+          isVideoMesh: false,
+        }
+      }, false);
+    });
+
+    it('returns true if there is at least 1 public cluster result, while video mesh is not reachable', async () => {
+      await checkIsClusterReachable({
+        x: {
+          udp: {reachable: 'true'},
+          tcp: {reachable: 'true'},
+          isVideoMesh: true,
+        },
+        y: {
+          udp: {reachable: 'false'},
+          tcp: {reachable: 'true'},
+          isVideoMesh: true,
+        },
+        publicOne: {
+          udp: {reachable: 'false'},
+          tcp: {reachable: 'true'},
+          isVideoMesh: false,
+        }
+      }, true);
+    });
+  })
 });
 
 describe('gatherReachability', () => {
@@ -177,16 +234,19 @@ describe('gatherReachability', () => {
           clusterId: 'id1',
           elapsed: '12312',
           publicIPs: ['1.1.1.1'],
+          isVideoMesh: true,
         },
         {
           clusterId: 'id2',
           elapsed: null,
           publicIPs: ['1.1.1.1'],
+          isVideoMesh: false,
         },
         {
           clusterId: 'id2',
           elapsed: '14123',
           publicIPs: undefined,
+          isVideoMesh: false,
         },
       ]);
 
@@ -203,6 +263,7 @@ describe('gatherReachability', () => {
             latencyInMilliseconds: '12312',
             reachable: 'true',
           },
+          isVideoMesh: true,
         },
         id2: {
           xtls: {
@@ -215,6 +276,7 @@ describe('gatherReachability', () => {
             latencyInMilliseconds: '14123',
             reachable: 'true',
           },
+          isVideoMesh: false,
         },
       });
     });

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
@@ -64,7 +64,7 @@ describe('Roap', () => {
         setRoapSeq: sinon.stub(),
         config: {experimental: {enableTurnDiscovery: false}},
         locusMediaRequest: {fake: true},
-        webex: { meetings: { reachability: { isAnyClusterReachable: () => true}}},
+        webex: { meetings: { reachability: { isAnyPublicClusterReachable: () => true}}},
       };
 
       sinon.stub(MeetingUtil, 'getIpVersion').returns(IP_VERSION.unknown);

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
@@ -66,6 +66,7 @@ describe('plugin-meetings/roap', () => {
       JSON.stringify({
         clusterId: {
           udp: 'test',
+          isVideoMesh: false,
         },
       })
     );

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -54,7 +54,7 @@ describe('TurnDiscovery', () => {
       }),
       updateMediaConnections: sinon.stub(),
       webex: {meetings: {reachability: {
-        isAnyClusterReachable: () => Promise.resolve(false),
+        isAnyPublicClusterReachable: () => Promise.resolve(false),
       }}},
       isMultistream: false,
       locusMediaRequest: { fake: true },
@@ -257,8 +257,8 @@ describe('TurnDiscovery', () => {
     });
 
     it('resolves with undefined when cluster is reachable', async () => {
-      const prev = testMeeting.webex.meetings.reachability.isAnyClusterReachable;
-      testMeeting.webex.meetings.reachability.isAnyClusterReachable = () => Promise.resolve(true);
+      const prev = testMeeting.webex.meetings.reachability.isAnyPublicClusterReachable;
+      testMeeting.webex.meetings.reachability.isAnyPublicClusterReachable = () => Promise.resolve(true);
       const result = await new TurnDiscovery(mockRoapRequest).doTurnDiscovery(testMeeting);
 
       const {turnServerInfo, turnDiscoverySkippedReason} = result;
@@ -267,7 +267,7 @@ describe('TurnDiscovery', () => {
       assert.equal(turnDiscoverySkippedReason, 'reachability');
       assert.notCalled(mockRoapRequest.sendRoap);
       assert.notCalled(Metrics.sendBehavioralMetric);
-      testMeeting.webex.meetings.reachability.isAnyClusterReachable = prev;
+      testMeeting.webex.meetings.reachability.isAnyPublicClusterReachable = prev;
     });
 
     it("resolves with undefined if we don't get a response within 10s", async () => {
@@ -379,15 +379,15 @@ describe('TurnDiscovery', () => {
 
   describe('isSkipped', () => {
     [
-      {enabledInConfig: true, isAnyClusterReachable: true, expectedIsSkipped: true},
-      {enabledInConfig: true, isAnyClusterReachable: false, expectedIsSkipped: false},
-      {enabledInConfig: false, isAnyClusterReachable: true, expectedIsSkipped: true},
-      {enabledInConfig: false, isAnyClusterReachable: false, expectedIsSkipped: true},
-    ].forEach(({enabledInConfig, isAnyClusterReachable, expectedIsSkipped}) => {
-      it(`returns ${expectedIsSkipped} when TURN discovery is ${enabledInConfig ? '' : 'not '} enabled in config and isAnyClusterReachable() returns ${isAnyClusterReachable ? 'true' : 'false'}`, async () => {
+      {enabledInConfig: true, isAnyPublicClusterReachable: true, expectedIsSkipped: true},
+      {enabledInConfig: true, isAnyPublicClusterReachable: false, expectedIsSkipped: false},
+      {enabledInConfig: false, isAnyPublicClusterReachable: true, expectedIsSkipped: true},
+      {enabledInConfig: false, isAnyPublicClusterReachable: false, expectedIsSkipped: true},
+    ].forEach(({enabledInConfig, isAnyPublicClusterReachable, expectedIsSkipped}) => {
+      it(`returns ${expectedIsSkipped} when TURN discovery is ${enabledInConfig ? '' : 'not '} enabled in config and isAnyPublicClusterReachable() returns ${isAnyPublicClusterReachable ? 'true' : 'false'}`, async () => {
         testMeeting.config.experimental.enableTurnDiscovery = enabledInConfig;
 
-        sinon.stub(testMeeting.webex.meetings.reachability, 'isAnyClusterReachable').resolves(isAnyClusterReachable);
+        sinon.stub(testMeeting.webex.meetings.reachability, 'isAnyPublicClusterReachable').resolves(isAnyPublicClusterReachable);
 
         const td = new TurnDiscovery(mockRoapRequest);
 


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-477129

## This pull request addresses

We call isAnyClusterReachable() to decide if TURN-TLS should be attempted or not. That function checks if we reached any media cluster during reachability checks and that includes also video mesh nodes (VMNs). VMNs will most likely be reachable even when customer has a firewall blocking all udp and tcp to public nodes and when we join a call we might be placed on a public media node, so we should not take VMNs into account.

## by making the following changes

- renamed isAnyClusterReachable() to isAnyPublicClusterReachable() and changed the implementation so that it only checks the public nodes.
- we were sending the whole contents of stored reachability results to Locus when joining meetings, but now these results also include a `isVideoMesh` property that we don't need to send, so changed existing code that was reading local storage directly to instead use a new method `getReachabilityResults()` - that method reads results from local storage and strips isVideoMesh from them.
- also added some types to the existing reachability code to make it easier to understand. It's still not ideal, because when we read local storage we just get an "any". This could be improved by adding type guards, but I've decided it's not worth it for now. 
- any additions to metrics mentioned in the jira will be done in a separate PR.


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, also tested manually with sample app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
