### PR TITLE
feat(meetings): space id depreciation code change

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -257,6 +257,8 @@ const meetingsJoinCaptchaElm = document.querySelector('#meetings-join-captcha-in
 const passwordCaptchaStatusElm = document.querySelector('#password-captcha-status');
 const refreshCaptchaElm = document.querySelector('#meetings-join-captcha-refresh');
 const verifyPasswordElm = document.querySelector('#btn-verify-password');
+const displayMeetingStatusElm = document.querySelector('#display-meeting-status');
+const spaceIDError = `Using the space ID as a destination is no longer supported. Please refer to the <a href="https://github.com/webex/webex-js-sdk/wiki/Migration-guide-for-USM-meeting" target="_blank">migration guide</a> to migrate to use the meeting ID or SIP address.`;
 
 let selectedMeetingId = null;
 
@@ -347,8 +349,13 @@ function createMeeting(e) {
   webex.meetings.create(value, type)
     .then((meeting) => {
       createMeetingDestinationElm.value = '';
+      displayMeetingStatusElm.innerHTML = '';
       generalStartReceivingTranscription.disabled = false; // eslint-disable-line no-use-before-define
       refreshMeetings();
+    }).catch((error) => {
+      if(error.code === 30105){
+        displayMeetingStatusElm.innerHTML = spaceIDError;
+      }
     });
 
   return false;

--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -261,7 +261,6 @@
                       <select name="createMeetingDest" id="createMeetingDest">
                         <option value="">Email</option>
                         <option value="">Person ID</option>
-                        <option value="">Room ID</option>
                         <option value="">SIP URI</option>
                         <option value="CONVERSATION_URL">Conversation URL</option>
                       </select>
@@ -270,6 +269,12 @@
                   </div>
                 </form>
               </div>
+
+              <!-- meetings / create meeting status error -->
+              <div class="u-mv">
+                <p id="display-meeting-status" class="webex-error"></p>
+              </div>
+
               <!-- meetings / active list -->
               <div class="u-mv">
                 <button id="meetings-list-collect" type="button" onclick="collectMeetings()">Sync Meetings</button>

--- a/docs/samples/browser-plugin-meetings/style.css
+++ b/docs/samples/browser-plugin-meetings/style.css
@@ -370,3 +370,7 @@ legend {
   background-color: rgb(255 255 255);
   padding: 0.3rem;
 }
+
+.webex-error {
+  color: #de3434;
+}

--- a/packages/@webex/plugin-meetings/src/common/errors/webex-errors.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/webex-errors.ts
@@ -108,6 +108,27 @@ export {UserInLobbyError};
 WebExMeetingsErrors[UserInLobbyError.CODE] = UserInLobbyError;
 
 /**
+ * @class SpaceIDDeprecatedError
+ * @classdesc Raised whenever the user passes Space ID as destination for create meeting.
+ * @extends WebexMeetingsError
+ * @property {number} code - 30105
+ * @property {string} message - Using the space ID as a destination is no longer supported. Please refer to the [migration guide](https://github.com/webex/webex-js-sdk/wiki/Migration-guide-for-USM-meeting) to migrate to use the meeting ID or SIP address.'
+ */
+class SpaceIDDeprecatedError extends WebexMeetingsError {
+  static CODE = 30105;
+
+  constructor() {
+    super(
+      SpaceIDDeprecatedError.CODE,
+      'Using the space ID as a destination is no longer supported. Please refer to the [migration guide](https://github.com/webex/webex-js-sdk/wiki/Migration-guide-for-USM-meeting) to migrate to use the meeting ID or SIP address.'
+    );
+  }
+}
+
+export {SpaceIDDeprecatedError};
+WebExMeetingsErrors[SpaceIDDeprecatedError.CODE] = SpaceIDDeprecatedError;
+
+/**
  * @class IceGatheringFailed
  * @classdesc Raised whenever ice gathering fails.
  * @extends WebexMeetingsError

--- a/packages/@webex/plugin-meetings/src/config.ts
+++ b/packages/@webex/plugin-meetings/src/config.ts
@@ -86,8 +86,8 @@ export default {
     installedOrgID: undefined,
     experimental: {
       enableMediaNegotiatedEvent: false,
-      enableUnifiedMeetings: false,
-      enableAdhocMeetings: false,
+      enableUnifiedMeetings: true,
+      enableAdhocMeetings: true,
       enableTurnDiscovery: true,
     },
     degradationPreferences: {

--- a/packages/@webex/plugin-meetings/src/meeting-info/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/util.ts
@@ -233,7 +233,7 @@ MeetingInfoUtil.generateOptions = async (from) => {
     }
   } else {
     throw new ParameterError(
-      'MeetingInfo is fetched with meeting link, sip uri, phone number, hydra room id, hydra people id, or a conversation url.'
+      'MeetingInfo is fetched with the meeting link, SIP URI, phone number, Hydra people ID, or a conversation URL.'
     );
   }
 

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -60,6 +60,7 @@ import MeetingCollection from './collection';
 import MeetingsUtil from './util';
 import PermissionError from '../common/errors/permission';
 import {INoiseReductionEffect, IVirtualBackgroundEffect} from './meetings.types';
+import {SpaceIDDeprecatedError} from '../common/errors/webex-errors';
 
 let mediaLogger;
 
@@ -1037,7 +1038,7 @@ export default class Meetings extends WebexPlugin {
 
   /**
    * Create a meeting.
-   * @param {string} destination - sipURL, spaceId, phonenumber, or locus object}
+   * @param {string} destination - sipURL, phonenumber, or locus object}
    * @param {string} [type] - the optional specified type, such as locusId
    * @param {Boolean} useRandomDelayForInfo - whether a random delay should be added to fetching meeting info
    * @param {Object} infoExtraParams extra parameters to be provided when fetching meeting info
@@ -1064,9 +1065,12 @@ export default class Meetings extends WebexPlugin {
         .fetchInfoOptions(destination, type)
         // Catch a failure to fetch info options.
         .catch((error) => {
-          LoggerProxy.logger.info(
-            `Meetings:index#create --> INFO, unable to determine info options: ${error.message}`
+          LoggerProxy.logger.error(
+            `Meetings:index#create --> ERROR, unable to determine info options: ${error.message}`
           );
+          if (error instanceof SpaceIDDeprecatedError) {
+            throw new SpaceIDDeprecatedError();
+          }
         })
         .then((options: any = {}) => {
           // Normalize the destination.
@@ -1284,7 +1288,7 @@ export default class Meetings extends WebexPlugin {
     //
     // Our job is to determine the appropriate one
     // and its corresponding service so that developers
-    // need only sipURL or spaceID to get a meeting
+    // need only sipURL to get a meeting
     // and its ID, but have the option to use createWithType()
     // and specify those types to get meetingInfo
   }


### PR DESCRIPTION
Space ID Depreciation code change
Error code 30105 added as Space ID deprecated as of beta, Please refer migration guide. Updated samples code
enableUnifiedMeetings and enableAdhocMeetings is true for beta

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
