### PR TITLE
fix: refresh permission token on meetingjoin

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1250,5 +1250,6 @@ export const IP_VERSION = {
 
 export type IP_VERSION = (typeof IP_VERSION)[keyof typeof IP_VERSION];
 
-// constant for if the permissionToken is about to expire in the next 10 seconds, refresh it
-export const MEETING_PERMISSION_TOKEN_REFRESH_THRESHOLD_IN_SEC = 10;
+// constant for if the permissionToken is about to expire in the next 30 seconds, refresh it
+export const MEETING_PERMISSION_TOKEN_REFRESH_THRESHOLD_IN_SEC = 30;
+export const MEETING_PERMISSION_TOKEN_REFRESH_REASON = 'ttl-join';

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1249,3 +1249,6 @@ export const IP_VERSION = {
 } as const;
 
 export type IP_VERSION = (typeof IP_VERSION)[keyof typeof IP_VERSION];
+
+// constant for if the permissionToken is about to expire in the next 10 seconds, refresh it
+export const MEETING_PERMISSION_TOKEN_REFRESH_THRESHOLD_IN_SEC = 10;

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4562,7 +4562,7 @@ export default class Meeting extends StatelessWebexPlugin {
           error instanceof PermissionError
         ) {
           // if refresh permission token requires captcha, password or permission, we are throwing the errors
-          // and bubbble it up to Cantina
+          // and bubble it up to Cantina
           throw error;
         }
       })

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4550,7 +4550,11 @@ export default class Meeting extends StatelessWebexPlugin {
     this.isMultistream = !!options.enableMultistream;
 
     try {
-      await this.checkAndRefreshPermissionToken();
+      // refresh the permission token if its about to expire in 10sec
+      await this.checkAndRefreshPermissionToken(
+        MEETING_PERMISSION_TOKEN_REFRESH_THRESHOLD_IN_SEC,
+        'ttl-join'
+      );
     } catch (error) {
       LoggerProxy.logger.error('Meeting:index#join --> Failed to refresh permission token:', error);
 
@@ -7423,13 +7427,15 @@ export default class Meeting extends StatelessWebexPlugin {
    * Check if there is enough time left till the permission token expires
    * If not - refresh the permission token
    *
+   * @param {number} threshold - time in seconds
+   * @param {string} reason - reason for refreshing the permission token
    * @returns {Promise<void>}
    */
-  public checkAndRefreshPermissionToken(): Promise<void> {
+  public checkAndRefreshPermissionToken(threshold: number, reason: string): Promise<void> {
     const permissionTokenTimeLeft = this.getPermissionTokenTimeLeftInSec();
 
-    if (permissionTokenTimeLeft <= MEETING_PERMISSION_TOKEN_REFRESH_THRESHOLD_IN_SEC) {
-      return this.refreshPermissionToken('ttl-join');
+    if (permissionTokenTimeLeft <= threshold) {
+      return this.refreshPermissionToken(reason);
     }
 
     return Promise.resolve();

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1052,6 +1052,7 @@ describe('plugin-meetings', () => {
 
             it('should throw if permissionTokenRefresh fails with a captcha error', async () => { 
               meeting.checkAndRefreshPermissionToken = sinon.stub().rejects(new CaptchaError('bad captcha'));
+              const joinMeetingOptionsSpy = sinon.spy(MeetingUtil.joinMeetingOptions);
 
               try {
                 await meeting.join();
@@ -1059,11 +1060,14 @@ describe('plugin-meetings', () => {
               } catch (error) {
                 assert.instanceOf(error, CaptchaError);
                 assert.equal(error.message, 'bad captcha');
+                // should not get to the end promise chain, which does do the join
+                assert.notCalled(joinMeetingOptionsSpy);
               }
             })
 
             it('should throw if permissionTokenRefresh fails with a password error', async () => { 
               meeting.checkAndRefreshPermissionToken = sinon.stub().rejects(new PasswordError('bad password'));
+              const joinMeetingOptionsSpy = sinon.spy(MeetingUtil.joinMeetingOptions);
 
               try {
                 await meeting.join();
@@ -1071,11 +1075,14 @@ describe('plugin-meetings', () => {
               } catch (error) {
                 assert.instanceOf(error, PasswordError);
                 assert.equal(error.message, 'bad password');
+                // should not get to the end promise chain, which does do the join
+                assert.notCalled(joinMeetingOptionsSpy);
               }
             })
 
             it('should throw if permissionTokenRefresh fails with a permission error', async () => { 
               meeting.checkAndRefreshPermissionToken = sinon.stub().rejects(new PermissionError('bad permission'));
+              const joinMeetingOptionsSpy = sinon.spy(MeetingUtil.joinMeetingOptions);
 
               try {
                 await meeting.join();
@@ -1083,6 +1090,8 @@ describe('plugin-meetings', () => {
               } catch (error) {
                 assert.instanceOf(error, PermissionError);
                 assert.equal(error.message, 'bad permission');
+                // should not get to the end promise chain, which does do the join
+                assert.notCalled(joinMeetingOptionsSpy);
               }
             })
           })

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -29,6 +29,7 @@ import {
   DISPLAY_HINTS,
   SELF_POLICY,
   IP_VERSION,
+  ERROR_DICTIONARY,
 } from '@webex/plugin-meetings/src/constants';
 import * as InternalMediaCoreModule from '@webex/internal-media-core';
 import {
@@ -798,6 +799,7 @@ describe('plugin-meetings', () => {
           webex.meetings.registered = true;
           meeting.updateLLMConnection = sinon.stub();
         });
+
         describe('successful', () => {
           beforeEach(() => {
             sandbox.stub(MeetingUtil, 'joinMeeting').returns(Promise.resolve(joinMeetingResult));
@@ -918,7 +920,7 @@ describe('plugin-meetings', () => {
             });
           });
         });
-        describe('lmm and transcription decoupling', () => {
+        describe('lmm, transcription & permissionTokenRefresh decoupling', () => {
           beforeEach(() => {
             sandbox.stub(MeetingUtil, 'joinMeeting').returns(Promise.resolve(joinMeetingResult));
           });
@@ -1021,7 +1023,6 @@ describe('plugin-meetings', () => {
               try {
                 await defer.promise;
               } catch (err) {
-                console.log(Metrics.sendBehavioralMetric.getCalls())
                 assert.deepEqual(Metrics.sendBehavioralMetric.getCalls()[0].args, [
                   BEHAVIORAL_METRICS.JOIN_SUCCESS, {correlation_id: meeting.correlationId}
                 ])
@@ -1033,6 +1034,55 @@ describe('plugin-meetings', () => {
                     stack: err.stack,
                   }
                 ]);
+              }
+            })
+          })
+
+          describe('refreshPermissionToken', () => { 
+            it('should continue if permissionTokenRefresh fails with a generic error', async () => { 
+              meeting.checkAndRefreshPermissionToken = sinon.stub().rejects(new Error('bad day'));
+
+              try {
+                const result = await meeting.join();
+                assert.equal(result, joinMeetingResult);
+              } catch (error) {
+                assert.fail('join should not throw an Error');
+              }
+            })
+
+            it('should throw if permissionTokenRefresh fails with a captcha error', async () => { 
+              meeting.checkAndRefreshPermissionToken = sinon.stub().rejects(new CaptchaError('bad captcha'));
+
+              try {
+                await meeting.join();
+                assert.fail('join should have thrown a Captcha Error.');
+              } catch (error) {
+                assert.instanceOf(error, CaptchaError);
+                assert.equal(error.message, 'bad captcha');
+              }
+            })
+
+            it('should throw if permissionTokenRefresh fails with a password error', async () => { 
+              meeting.checkAndRefreshPermissionToken = sinon.stub().rejects(new PasswordError('bad password'));
+
+              try {
+                await meeting.join();
+                assert.fail('join should have thrown a Password Error.');
+              } catch (error) {
+                assert.instanceOf(error, PasswordError);
+                assert.equal(error.message, 'bad password');
+              }
+            })
+
+            it('should throw if permissionTokenRefresh fails with a permission error', async () => { 
+              meeting.checkAndRefreshPermissionToken = sinon.stub().rejects(new PermissionError('bad permission'));
+
+              try {
+                await meeting.join();
+                assert.fail('join should have thrown a Permission Error.');
+              } catch (error) {
+                assert.instanceOf(error, PermissionError);
+                assert.equal(error.message, 'bad permission');
               }
             })
           })
@@ -8306,6 +8356,41 @@ describe('plugin-meetings', () => {
       // set permission token as now - 1 sec
       meeting.permissionTokenPayload = {exp: (now - 1000).toString()};
       assert.equal(meeting.getPermissionTokenTimeLeftInSec(), -1);
+    });
+  });
+
+  describe('#checkAndRefreshPermissionToken', () => {
+    it('should fire refreshPermissionToken if time left is below 10sec', async() => { 
+      meeting.getPermissionTokenTimeLeftInSec = sinon.stub().returns(9)
+      meeting.refreshPermissionToken = sinon.stub().returns(Promise.resolve('test return value'));
+
+      const returnValue = await meeting.checkAndRefreshPermissionToken();
+
+      assert.calledOnce(meeting.getPermissionTokenTimeLeftInSec);
+      assert.calledOnceWithExactly(meeting.refreshPermissionToken, 'ttl-join');
+      assert.equal(returnValue, 'test return value');
+    });
+
+    it('should fire refreshPermissionToken if time left is equal 10sec', async () => { 
+      meeting.getPermissionTokenTimeLeftInSec = sinon.stub().returns(10)
+      meeting.refreshPermissionToken = sinon.stub().returns(Promise.resolve('test return value'));
+
+      const returnValue = await meeting.checkAndRefreshPermissionToken();
+
+      assert.calledOnce(meeting.getPermissionTokenTimeLeftInSec);
+      assert.calledOnceWithExactly(meeting.refreshPermissionToken, 'ttl-join');
+      assert.equal(returnValue, 'test return value');
+    });
+
+    it('should not fire refreshPermissionToken if time left is higher than 10sec', async () => { 
+      meeting.getPermissionTokenTimeLeftInSec = sinon.stub().returns(11)
+      meeting.refreshPermissionToken = sinon.stub().returns(Promise.resolve('test return value'));
+
+      const returnValue = await meeting.checkAndRefreshPermissionToken();
+      
+      assert.calledOnce(meeting.getPermissionTokenTimeLeftInSec);
+      assert.notCalled(meeting.refreshPermissionToken);
+      assert.equal(returnValue, undefined);
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1045,6 +1045,7 @@ describe('plugin-meetings', () => {
               try {
                 const result = await meeting.join();
                 assert.equal(result, joinMeetingResult);
+                assert.calledOnceWithExactly(meeting.checkAndRefreshPermissionToken, 10, 'ttl-join');
               } catch (error) {
                 assert.fail('join should not throw an Error');
               }
@@ -1058,6 +1059,7 @@ describe('plugin-meetings', () => {
                 await meeting.join();
                 assert.fail('join should have thrown a Captcha Error.');
               } catch (error) {
+                assert.calledOnceWithExactly(meeting.checkAndRefreshPermissionToken, 10, 'ttl-join');
                 assert.instanceOf(error, CaptchaError);
                 assert.equal(error.message, 'bad captcha');
                 // should not get to the end promise chain, which does do the join
@@ -1073,6 +1075,7 @@ describe('plugin-meetings', () => {
                 await meeting.join();
                 assert.fail('join should have thrown a Password Error.');
               } catch (error) {
+                assert.calledOnceWithExactly(meeting.checkAndRefreshPermissionToken, 10, 'ttl-join');
                 assert.instanceOf(error, PasswordError);
                 assert.equal(error.message, 'bad password');
                 // should not get to the end promise chain, which does do the join
@@ -1088,6 +1091,7 @@ describe('plugin-meetings', () => {
                 await meeting.join();
                 assert.fail('join should have thrown a Permission Error.');
               } catch (error) {
+                assert.calledOnceWithExactly(meeting.checkAndRefreshPermissionToken, 10, 'ttl-join');
                 assert.instanceOf(error, PermissionError);
                 assert.equal(error.message, 'bad permission');
                 // should not get to the end promise chain, which does do the join
@@ -8373,7 +8377,7 @@ describe('plugin-meetings', () => {
       meeting.getPermissionTokenTimeLeftInSec = sinon.stub().returns(9)
       meeting.refreshPermissionToken = sinon.stub().returns(Promise.resolve('test return value'));
 
-      const returnValue = await meeting.checkAndRefreshPermissionToken();
+      const returnValue = await meeting.checkAndRefreshPermissionToken(10, 'ttl-join');
 
       assert.calledOnce(meeting.getPermissionTokenTimeLeftInSec);
       assert.calledOnceWithExactly(meeting.refreshPermissionToken, 'ttl-join');
@@ -8384,7 +8388,7 @@ describe('plugin-meetings', () => {
       meeting.getPermissionTokenTimeLeftInSec = sinon.stub().returns(10)
       meeting.refreshPermissionToken = sinon.stub().returns(Promise.resolve('test return value'));
 
-      const returnValue = await meeting.checkAndRefreshPermissionToken();
+      const returnValue = await meeting.checkAndRefreshPermissionToken(10, 'ttl-join');
 
       assert.calledOnce(meeting.getPermissionTokenTimeLeftInSec);
       assert.calledOnceWithExactly(meeting.refreshPermissionToken, 'ttl-join');
@@ -8395,7 +8399,7 @@ describe('plugin-meetings', () => {
       meeting.getPermissionTokenTimeLeftInSec = sinon.stub().returns(11)
       meeting.refreshPermissionToken = sinon.stub().returns(Promise.resolve('test return value'));
 
-      const returnValue = await meeting.checkAndRefreshPermissionToken();
+      const returnValue = await meeting.checkAndRefreshPermissionToken(10, 'ttl-join');
       
       assert.calledOnce(meeting.getPermissionTokenTimeLeftInSec);
       assert.notCalled(meeting.refreshPermissionToken);


### PR DESCRIPTION
## This pull request addresses

refresh permission token when meetingJoin happens

## by making the following changes

- combine `getPermissionTokenTimeLeft` and `refreshPermissionToken` to refresh the token on join if the token is about to expire in the next 10 seconds
- added unit tests

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- checkAndRefreshPermissionToken method unit tests
- additional join unit tests (catching errors, etc.)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly
