### PR TITLE
fix(services): update timeout for waitforservice from 5 to 30sec

### DIFF
--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -595,7 +595,7 @@ const Services = WebexPlugin.extend({
    * @param {WaitForServicePTO} - The parameter transfer object.
    * @returns {Promise<string>} - Resolves to the priority host of a service.
    */
-  waitForService({name, timeout = 5, url}) {
+  waitForService({name, timeout = 30, url}) {
     const {services} = this.webex.config;
 
     // Save memory by grabbing the catalog after there isn't a priortyURL


### PR DESCRIPTION
# COMPLETES [SPARK-481044](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-481044)

## This pull request addresses

There are some false positives on the webexapp.launched missing event.

Current metrics: 791 Failures from 11/28 => 12/04, which is 7 days

## by making the following changes

Increase the maximum wait time from 5 to 30 seconds when attempting to make a request to a service that is not in the catalog. We would like to see an overall decrease in the above metric number within a 7 day interval.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

No change to tests, as it does not change the waitForService function itself

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
