### PR TITLE
fix: log call parameters when mercury _emit fails

### DIFF
--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -362,7 +362,10 @@ const Mercury = WebexPlugin.extend({
     try {
       this.trigger(...args);
     } catch (error) {
-      this.logger.error('mercury: error occurred in event handler', error);
+      this.logger.error('mercury: error occurred in event handler', {
+        error,
+        arguments: args,
+      });
     }
   },
 

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -568,12 +568,21 @@ describe('plugin-mercury', () => {
     });
 
     describe('#_emit()', () => {
-      it('emits Error-safe events', () => {
+      it('emits Error-safe events and log the error with the call parameters', () => {
+        const error = 'error';
+        const event = {data: 'some data'};
         mercury.on('break', () => {
-          throw new Error();
+          throw error;
         });
+        sinon.stub(mercury.logger, 'error');
 
-        return Promise.resolve(mercury._emit('break'));
+        return Promise.resolve(mercury._emit('break', event)).then((res) => {
+          assert.calledWith(mercury.logger.error, 'mercury: error occurred in event handler', {
+            error,
+            arguments: ['break', event],
+          });
+          return res;
+        });
       });
     });
 


### PR DESCRIPTION
# COMPLETES SPARK-480931

## This pull request addresses

When mercury's `_emit` fails it logs empty error like:
`mercury: error occurred in event handler {}`.

This does not help with the investigation what cause the issue.

## by making the following changes

Log the `_emit` call arguments with the error.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
