### PR TITLE
feat(plugin-metrics): use network category for relevant errors

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
@@ -316,12 +316,12 @@ export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEv
   },
   [AUTHENTICATION_FAILED_CODE]: {
     errorDescription: ERROR_DESCRIPTIONS.AUTHENTICATION_FAILED,
-    category: 'signaling',
+    category: 'network',
     fatal: true,
   },
   1026: {
     errorDescription: ERROR_DESCRIPTIONS.NETWORK_ERROR,
-    category: 'signaling',
+    category: 'network',
     fatal: true,
   },
   2001: {
@@ -433,7 +433,7 @@ export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEv
   },
   4009: {
     errorDescription: ERROR_DESCRIPTIONS.NETWORK_UNAVAILABLE,
-    category: 'expected',
+    category: 'network',
     fatal: true,
   },
   4010: {

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -1169,6 +1169,22 @@ describe('internal-plugin-metrics', () => {
         });
       });
 
+      it('should generate the correct payload for client error 4009', () => {
+        const res = cd.getErrorPayloadForClientErrorCode({
+          clientErrorCode: 4009,
+          serviceErrorCode: undefined,
+        });
+        assert.deepEqual(res, {
+          category: 'network',
+          errorDescription: 'NetworkUnavailable',
+          fatal: true,
+          name: 'other',
+          shownToUser: false,
+          errorCode: 4009,
+          serviceErrorCode: undefined,
+        });
+      })
+
       it('it should return undefined if trying to get payload for client error code that doesnt exist', () => {
         const res = cd.getErrorPayloadForClientErrorCode({
           clientErrorCode: 123456,
@@ -1305,7 +1321,7 @@ describe('internal-plugin-metrics', () => {
           })
         );
         assert.deepEqual(res, {
-          category: 'signaling',
+          category: 'network',
           errorDescription: '{}\nundefined https://example.com\nWEBEX_TRACKING_ID: undefined\n',
           fatal: true,
           name: 'other',
@@ -1325,7 +1341,7 @@ describe('internal-plugin-metrics', () => {
           })
         );
         assert.deepEqual(res, {
-          category: 'signaling',
+          category: 'network',
           errorDescription: '{}\nundefined https://example.com\nWEBEX_TRACKING_ID: undefined\n',
           fatal: true,
           name: 'other',


### PR DESCRIPTION
## This pull request addresses

Make use of the new network CA category

## by making the following changes

Changing the category to network for the following errors:

- 1010 (AuthenticationFailed)
- 1026 (NetworkError)
- 4009 (NetworkUnavailable)

See [SPARK-478597](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-478597) for details.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
