### PR TITLE
Fix mercury log

### DIFF
--- a/packages/@webex/internal-plugin-llm/src/constants.ts
+++ b/packages/@webex/internal-plugin-llm/src/constants.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export const LLM = 'LowLatencyMercury';
+export const LLM = 'llm';

--- a/packages/@webex/internal-plugin-llm/src/constants.ts
+++ b/packages/@webex/internal-plugin-llm/src/constants.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export const LLM = 'llm';
+export const LLM = 'LowLatencyMercury';

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -49,17 +49,27 @@ const Mercury = WebexPlugin.extend({
   @oneFlight
   connect(webSocketUrl) {
     if (this.connected) {
-      this.logger.info('mercury: already connected, will not connect again');
+      this.logger.info(`mercury,${this.domain}: already connected, will not connect again`);
 
       return Promise.resolve();
     }
 
+    if (!webSocketUrl) {
+      webSocketUrl = this.webex.internal.device.webSocketUrl;
+    }
+
     this.connecting = true;
+
+    try {
+      this.domain = new URL(webSocketUrl).hostname;
+    } catch {
+      this.domain = webSocketUrl;
+    }
 
     return Promise.resolve(
       this.webex.internal.device.registered || this.webex.internal.device.register()
     ).then(() => {
-      this.logger.info('mercury: connecting');
+      this.logger.info(`mercury,${this.domain}: connecting`);
 
       return this._connectWithBackoff(webSocketUrl);
     });
@@ -69,7 +79,7 @@ const Mercury = WebexPlugin.extend({
   disconnect() {
     return new Promise((resolve) => {
       if (this.backoffCall) {
-        this.logger.info('mercury: aborting connection');
+        this.logger.info(`mercury,${this.domain}: aborting connection`);
         this.backoffCall.abort();
       }
 
@@ -113,10 +123,6 @@ const Mercury = WebexPlugin.extend({
   },
 
   _prepareUrl(webSocketUrl) {
-    if (!webSocketUrl) {
-      webSocketUrl = this.webex.internal.device.webSocketUrl;
-    }
-
     return this.webex.internal.feature
       .getFeature('developer', 'web-high-availability')
       .then((haMessagingEnabled) => {
@@ -165,7 +171,7 @@ const Mercury = WebexPlugin.extend({
     Promise.all([this._prepareUrl(socketUrl), this.webex.credentials.getUserToken()])
       .then(([webSocketUrl, token]) => {
         if (!this.backoffCall) {
-          const msg = 'mercury: prevent socket open when backoffCall no longer defined';
+          const msg = `mercury,${this.domain}: prevent socket open when backoffCall no longer defined`;
 
           this.logger.info(msg);
 
@@ -181,11 +187,12 @@ const Mercury = WebexPlugin.extend({
           token: token.toString(),
           trackingId: `${this.webex.sessionId}_${Date.now()}`,
           logger: this.logger,
+          domain: this.domain,
         };
 
         // if the consumer has supplied request options use them
         if (this.webex.config.defaultMercuryOptions) {
-          this.logger.info('mercury: setting custom options');
+          this.logger.info(`mercury,${this.domain}: setting custom options`);
           options = {...options, ...this.webex.config.defaultMercuryOptions};
         }
 
@@ -225,19 +232,19 @@ const Mercury = WebexPlugin.extend({
         if (reason.code !== 1006 && this.backoffCall && this.backoffCall.getNumRetries() > 0) {
           this._emit('connection_failed', reason, {retries: this.backoffCall.getNumRetries()});
         }
-        this.logger.info('mercury: connection attempt failed', reason);
+        this.logger.info(`mercury,${this.domain}: connection attempt failed`, reason);
         // UnknownResponse is produced by IE for any 4XXX; treated it like a bad
         // web socket url and let WDM handle the token checking
         if (reason instanceof UnknownResponse) {
           this.logger.info(
-            'mercury: received unknown response code, refreshing device registration'
+            `mercury,${this.domain}: received unknown response code, refreshing device registration`
           );
 
           return this.webex.internal.device.refresh().then(() => callback(reason));
         }
         // NotAuthorized implies expired token
         if (reason instanceof NotAuthorized) {
-          this.logger.info('mercury: received authorization error, reauthorizing');
+          this.logger.info(`mercury,${this.domain}: received authorization error, reauthorizing`);
 
           return this.webex.credentials.refresh({force: true}).then(() => callback(reason));
         }
@@ -250,7 +257,7 @@ const Mercury = WebexPlugin.extend({
         // BadRequest implies current credentials are for a Service Account
         // Forbidden implies current user is not entitle for Webex
         if (reason instanceof BadRequest || reason instanceof Forbidden) {
-          this.logger.warn('mercury: received unrecoverable response from mercury');
+          this.logger.warn(`mercury,${this.domain}: received unrecoverable response from mercury`);
           this.backoffCall.abort();
 
           return callback(reason);
@@ -261,7 +268,7 @@ const Mercury = WebexPlugin.extend({
             .then((haMessagingEnabled) => {
               if (haMessagingEnabled) {
                 this.logger.info(
-                  'mercury: received a generic connection error, will try to connect to another datacenter'
+                  `mercury,${this.domain}: received a generic connection error, will try to connect to another datacenter`
                 );
                 this.webex.internal.metrics.submitClientMetrics('web-ha-mercury', {
                   fields: {
@@ -285,7 +292,7 @@ const Mercury = WebexPlugin.extend({
         return callback(reason);
       })
       .catch((reason) => {
-        this.logger.error('mercury: failed to handle connection failure', reason);
+        this.logger.error(`mercury,${this.domain}: failed to handle connection failure`, reason);
         callback(reason);
       });
   },
@@ -301,7 +308,9 @@ const Mercury = WebexPlugin.extend({
         this.backoffCall = undefined;
         if (err) {
           this.logger.info(
-            `mercury: failed to connect after ${call.getNumRetries()} retries; log statement about next retry was inaccurate; ${err}`
+            `mercury,${
+              this.domain
+            }: failed to connect after ${call.getNumRetries()} retries; log statement about next retry was inaccurate; ${err}`
           );
 
           return reject(err);
@@ -314,7 +323,9 @@ const Mercury = WebexPlugin.extend({
 
       // eslint-disable-next-line prefer-reflect
       call = backoff.call((callback) => {
-        this.logger.info(`mercury: executing connection attempt ${call.getNumRetries()}`);
+        this.logger.info(
+          `mercury,${this.domain}: executing connection attempt ${call.getNumRetries()}`
+        );
         this._attemptConnection(webSocketUrl, callback);
       }, onComplete);
 
@@ -330,7 +341,7 @@ const Mercury = WebexPlugin.extend({
       }
 
       call.on('abort', () => {
-        this.logger.info('mercury: connection aborted');
+        this.logger.info(`mercury,${this.domain}: connection aborted`);
         reject(new Error('Mercury Connection Aborted'));
       });
 
@@ -340,16 +351,18 @@ const Mercury = WebexPlugin.extend({
           const delay = Math.min(call.strategy_.nextBackoffDelay_, this.config.backoffTimeMax);
 
           this.logger.info(
-            `mercury: failed to connect; attempting retry ${number + 1} in ${delay} ms`
+            `mercury,${this.domain}: failed to connect; attempting retry ${
+              number + 1
+            } in ${delay} ms`
           );
           /* istanbul ignore if */
           if (process.env.NODE_ENV === 'development') {
-            this.logger.debug('mercury: ', err, err.stack);
+            this.logger.debug(`mercury,${this.domain}: `, err, err.stack);
           }
 
           return;
         }
-        this.logger.info('mercury: connected');
+        this.logger.info(`mercury,${this.domain}: connected`);
       });
 
       call.start();
@@ -362,7 +375,7 @@ const Mercury = WebexPlugin.extend({
     try {
       this.trigger(...args);
     } catch (error) {
-      this.logger.error('mercury: error occurred in event handler', {
+      this.logger.error(`mercury,${this.domain}: error occurred in event handler`, {
         error,
         arguments: args,
       });
@@ -406,20 +419,20 @@ const Mercury = WebexPlugin.extend({
         case 1003:
           // metric: disconnect
           this.logger.info(
-            `mercury: Mercury service rejected last message; will not reconnect: ${event.reason}`
+            `mercury,${this.domain}: Mercury service rejected last message; will not reconnect: ${event.reason}`
           );
           this._emit('offline.permanent', event);
           break;
         case 4000:
           // metric: disconnect
-          this.logger.info('mercury: socket replaced; will not reconnect');
+          this.logger.info(`mercury,${this.domain}: socket replaced; will not reconnect`);
           this._emit('offline.replaced', event);
           break;
         case 1001:
         case 1005:
         case 1006:
         case 1011:
-          this.logger.info('mercury: socket disconnected; reconnecting');
+          this.logger.info(`mercury,${this.domain}: socket disconnected; reconnecting`);
           this._emit('offline.transient', event);
           this._reconnect(socketUrl);
           // metric: disconnect
@@ -427,23 +440,25 @@ const Mercury = WebexPlugin.extend({
           break;
         case 1000:
           if (normalReconnectReasons.includes(reason)) {
-            this.logger.info('mercury: socket disconnected; reconnecting');
+            this.logger.info(`mercury,${this.domain}: socket disconnected; reconnecting`);
             this._emit('offline.transient', event);
             this._reconnect(socketUrl);
             // metric: disconnect
             // if (reason === done forced) metric: force closure
           } else {
-            this.logger.info('mercury: socket disconnected; will not reconnect');
+            this.logger.info(`mercury,${this.domain}: socket disconnected; will not reconnect`);
             this._emit('offline.permanent', event);
           }
           break;
         default:
-          this.logger.info('mercury: socket disconnected unexpectedly; will not reconnect');
+          this.logger.info(
+            `mercury,${this.domain}: socket disconnected unexpectedly; will not reconnect`
+          );
           // unexpected disconnect
           this._emit('offline.permanent', event);
       }
     } catch (error) {
-      this.logger.error('mercury: error occurred in close handler', error);
+      this.logger.error(`mercury,${this.domain}: error occurred in close handler`, error);
     }
   },
 
@@ -451,7 +466,7 @@ const Mercury = WebexPlugin.extend({
     const envelope = event.data;
 
     if (process.env.ENABLE_MERCURY_LOGGING) {
-      this.logger.debug('mercury: message envelope: ', envelope);
+      this.logger.debug(`mercury,${this.domain}: message envelope: `, envelope);
     }
 
     const {data} = envelope;
@@ -468,7 +483,7 @@ const Mercury = WebexPlugin.extend({
               resolve((this.webex[namespace] || this.webex.internal[namespace])[name](data))
             ).catch((reason) =>
               this.logger.error(
-                `mercury: error occurred in autowired event handler for ${data.eventType}`,
+                `mercury,${this.domain}: error occurred in autowired event handler for ${data.eventType}`,
                 reason
               )
             );
@@ -487,12 +502,15 @@ const Mercury = WebexPlugin.extend({
         }
       })
       .catch((reason) => {
-        this.logger.error('mercury: error occurred processing socket message', reason);
+        this.logger.error(
+          `mercury,${this.domain}: error occurred processing socket message`,
+          reason
+        );
       });
   },
 
   _reconnect(webSocketUrl) {
-    this.logger.info('mercury: reconnecting');
+    this.logger.info(`mercury,${this.domain}: reconnecting`);
 
     return this.connect(webSocketUrl);
   },

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -22,7 +22,7 @@ import {
 const normalReconnectReasons = ['idle', 'done (forced)', 'pong not received', 'pong mismatch'];
 
 const Mercury = WebexPlugin.extend({
-  namespace: 'mercury',
+  namespace: 'Mercury',
 
   session: {
     connected: {
@@ -76,9 +76,7 @@ const Mercury = WebexPlugin.extend({
       if (this.socket) {
         this.socket.removeAllListeners('message');
         this.once('offline', resolve);
-        this.socket.close();
-
-        return;
+        resolve(this.socket.close());
       }
 
       resolve();

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -203,6 +203,7 @@ const Mercury = WebexPlugin.extend({
             success: true,
           },
           tags: {
+            namespace: this.namespace,
             action: 'connected',
             url: attemptWSUrl,
           },
@@ -270,6 +271,7 @@ const Mercury = WebexPlugin.extend({
                     success: false,
                   },
                   tags: {
+                    namespace: this.namespace,
                     action: 'failed',
                     error: reason.message,
                     url: attemptWSUrl,

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -111,10 +111,10 @@ export default class Socket extends EventEmitter {
         return;
       }
       // logger is defined once open is called
-      this.logger.info('socket: closing');
+      this.logger.info(`socket,${this.domain}: closing`);
 
       if (socket.readyState === 2 || socket.readyState === 3) {
-        this.logger.info('socket: already closed');
+        this.logger.info(`socket,${this.domain}: already closed`);
         resolve();
 
         return;
@@ -134,7 +134,7 @@ export default class Socket extends EventEmitter {
 
       const closeTimer = safeSetTimeout(() => {
         try {
-          this.logger.info('socket: no close event received, forcing closure');
+          this.logger.info(`socket,${this.domain}: no close event received, forcing closure`);
           resolve(
             this.onclose({
               code: 1000,
@@ -142,12 +142,12 @@ export default class Socket extends EventEmitter {
             })
           );
         } catch (error) {
-          this.logger.warn('socket: force-close failed', error);
+          this.logger.warn(`socket,${this.domain}: force-close failed`, error);
         }
       }, this.forceCloseDelay);
 
       socket.onclose = (event) => {
-        this.logger.info('socket: close event fired', event.code, event.reason);
+        this.logger.info(`socket,${this.domain}: close event fired`, event.code, event.reason);
         clearTimeout(closeTimer);
         this.onclose(event);
         resolve(event);
@@ -168,9 +168,12 @@ export default class Socket extends EventEmitter {
    * @param {string} options.trackingId (required)
    * @param {Logger} options.logger (required)
    * @param {string} options.logLevelToken
+   * @param {string} options.domain
    * @returns {Promise}
    */
   open(url, options) {
+    this.domain = options.domain || '';
+
     return new Promise((resolve, reject) => {
       /* eslint complexity: [0] */
       if (!url) {
@@ -201,7 +204,7 @@ export default class Socket extends EventEmitter {
 
       const WebSocket = Socket.getWebSocketConstructor();
 
-      this.logger.info('socket: creating WebSocket');
+      this.logger.info(`socket,${this.domain}: creating WebSocket`);
       const socket = new WebSocket(url, [], options);
 
       socket.binaryType = 'arraybuffer';
@@ -209,7 +212,7 @@ export default class Socket extends EventEmitter {
 
       socket.onclose = (event) => {
         event = this._fixCloseCode(event);
-        this.logger.info('socket: closed before open', event.code, event.reason);
+        this.logger.info(`socket,${this.domain}: closed before open`, event.code, event.reason);
         switch (event.code) {
           case 1005:
             // IE 11 doesn't seem to allow 4XXX codes, so if we get a 1005, assume
@@ -231,10 +234,10 @@ export default class Socket extends EventEmitter {
       };
 
       socket.onopen = () => {
-        this.logger.info('socket: connected');
+        this.logger.info(`socket,${this.domain}: connected`);
         this._authorize()
           .then(() => {
-            this.logger.info('socket: authorized');
+            this.logger.info(`socket,${this.domain}: authorized`);
             socket.onclose = this.onclose;
             resolve();
           })
@@ -242,11 +245,11 @@ export default class Socket extends EventEmitter {
       };
 
       socket.onerror = (event) => {
-        this.logger.warn('socket: error event fired', event);
+        this.logger.warn(`socket,${this.domain}: error event fired`, event);
       };
 
       sockets.set(this, socket);
-      this.logger.info('socket: waiting for server');
+      this.logger.info(`socket,${this.domain}: waiting for server`);
     });
   }
 
@@ -256,7 +259,7 @@ export default class Socket extends EventEmitter {
    * @returns {undefined}
    */
   onclose(event) {
-    this.logger.info('socket: closed', event.code, event.reason);
+    this.logger.info(`socket,${this.domain}: closed`, event.code, event.reason);
     clearTimeout(this.pongTimer);
     clearTimeout(this.pingTimer);
 
@@ -278,10 +281,10 @@ export default class Socket extends EventEmitter {
       const data = JSON.parse(event.data);
       const sequenceNumber = parseInt(data.sequenceNumber, 10);
 
-      this.logger.debug('socket: sequence number: ', sequenceNumber);
+      this.logger.debug(`socket,${this.domain}: sequence number: `, sequenceNumber);
       if (this.expectedSequenceNumber && sequenceNumber !== this.expectedSequenceNumber) {
         this.logger.debug(
-          `socket: sequence number mismatch indicates lost mercury message. expected: ${this.expectedSequenceNumber}, actual: ${sequenceNumber}`
+          `socket,${this.domain}: sequence number mismatch indicates lost mercury message. expected: ${this.expectedSequenceNumber}, actual: ${sequenceNumber}`
         );
         this.emit('sequence-mismatch', sequenceNumber, this.expectedSequenceNumber);
       }
@@ -303,7 +306,7 @@ export default class Socket extends EventEmitter {
       // message from Mercury. At this time, the only action we have is to
       // ignore it and move on.
       /* istanbul ignore next */
-      this.logger.warn('socket: error while receiving WebSocket message', error);
+      this.logger.warn(`socket,${this.domain}: error while receiving WebSocket message`, error);
     }
   }
 
@@ -357,7 +360,7 @@ export default class Socket extends EventEmitter {
    */
   _authorize() {
     return new Promise((resolve) => {
-      this.logger.info('socket: authorizing');
+      this.logger.info(`socket,${this.domain}: authorizing`);
       this.send({
         id: uuid.v4(),
         type: 'authorization',
@@ -395,12 +398,18 @@ export default class Socket extends EventEmitter {
     if (event.code === 1005 && event.reason) {
       switch (event.reason.toLowerCase()) {
         case 'replaced':
-          this.logger.info('socket: fixing CloseEvent code for reason: ', event.reason);
+          this.logger.info(
+            `socket,${this.domain}: fixing CloseEvent code for reason: `,
+            event.reason
+          );
           event.code = 4000;
           break;
         case 'authentication failed':
         case 'authentication did not happen within the timeout window of 30000 seconds.':
-          this.logger.info('socket: fixing CloseEvent code for reason: ', event.reason);
+          this.logger.info(
+            `socket,${this.domain}: fixing CloseEvent code for reason: `,
+            event.reason
+          );
           event.code = 1008;
           break;
         default:
@@ -420,10 +429,12 @@ export default class Socket extends EventEmitter {
   _ping(id) {
     const confirmPongId = (event) => {
       try {
-        this.logger.debug('socket: pong', event.data.id);
+        this.logger.debug(`socket,${this.domain}: pong`, event.data.id);
         if (event.data && event.data.id !== id) {
-          this.logger.info('socket: received pong for wrong ping id, closing socket');
-          this.logger.debug('socket: expected', id, 'received', event.data.id);
+          this.logger.info(
+            `socket,${this.domain}: received pong for wrong ping id, closing socket`
+          );
+          this.logger.debug(`socket,${this.domain}: expected`, id, 'received', event.data.id);
           this.close({
             code: 1000,
             reason: 'Pong mismatch',
@@ -433,24 +444,29 @@ export default class Socket extends EventEmitter {
         // This try/catch block was added as a debugging step; to the best of my
         // knowledge, the above can never throw.
         /* istanbul ignore next */
-        this.logger.error('socket: error occurred in confirmPongId', error);
+        this.logger.error(`socket,${this.domain}: error occurred in confirmPongId`, error);
       }
     };
 
     const onPongNotReceived = () => {
       try {
-        this.logger.info('socket: pong not receive in expected period, closing socket');
+        this.logger.info(
+          `socket,${this.domain}: pong not receive in expected period, closing socket`
+        );
         this.close({
           code: 1000,
           reason: 'Pong not received',
         }).catch((reason) => {
-          this.logger.warn('socket: failed to close socket after missed pong', reason);
+          this.logger.warn(
+            `socket,${this.domain}: failed to close socket after missed pong`,
+            reason
+          );
         });
       } catch (error) {
         // This try/catch block was added as a debugging step; to the best of my
         // knowledge, the above can never throw.
         /* istanbul ignore next */
-        this.logger.error('socket: error occurred in onPongNotReceived', error);
+        this.logger.error(`socket,${this.domain}: error occurred in onPongNotReceived`, error);
       }
     };
 
@@ -462,7 +478,10 @@ export default class Socket extends EventEmitter {
         // This try/catch block was added as a debugging step; to the best of my
         // knowledge, the above can never throw.
         /* istanbul ignore next */
-        this.logger.error('socket: error occurred in scheduleNextPingAndCancelPongTimer', error);
+        this.logger.error(
+          `socket,${this.domain}: error occurred in scheduleNextPingAndCancelPongTimer`,
+          error
+        );
       }
     };
 
@@ -471,7 +490,7 @@ export default class Socket extends EventEmitter {
     this.once('pong', scheduleNextPingAndCancelPongTimer);
     this.once('pong', confirmPongId);
 
-    this.logger.debug(`socket: ping ${id}`);
+    this.logger.debug(`socket,${this.domain}: ping ${id}`);
 
     return this.send({
       id,

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -169,7 +169,6 @@ export default class Socket extends EventEmitter {
    * @param {string} options.trackingId (required)
    * @param {Logger} options.logger (required)
    * @param {string} options.logLevelToken
-   * @param {string} options.domain
    * @returns {Promise}
    */
   open(url, options) {

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -30,7 +30,7 @@ export default class Socket extends EventEmitter {
    */
   constructor() {
     super();
-    this.domain = 'unknown-domain';
+    this._domain = 'unknown-domain';
     this.onmessage = this.onmessage.bind(this);
     this.onclose = this.onclose.bind(this);
   }
@@ -112,10 +112,10 @@ export default class Socket extends EventEmitter {
         return;
       }
       // logger is defined once open is called
-      this.logger.info(`socket,${this.domain}: closing`);
+      this.logger.info(`socket,${this._domain}: closing`);
 
       if (socket.readyState === 2 || socket.readyState === 3) {
-        this.logger.info(`socket,${this.domain}: already closed`);
+        this.logger.info(`socket,${this._domain}: already closed`);
         resolve();
 
         return;
@@ -135,7 +135,7 @@ export default class Socket extends EventEmitter {
 
       const closeTimer = safeSetTimeout(() => {
         try {
-          this.logger.info(`socket,${this.domain}: no close event received, forcing closure`);
+          this.logger.info(`socket,${this._domain}: no close event received, forcing closure`);
           resolve(
             this.onclose({
               code: 1000,
@@ -143,12 +143,12 @@ export default class Socket extends EventEmitter {
             })
           );
         } catch (error) {
-          this.logger.warn(`socket,${this.domain}: force-close failed`, error);
+          this.logger.warn(`socket,${this._domain}: force-close failed`, error);
         }
       }, this.forceCloseDelay);
 
       socket.onclose = (event) => {
-        this.logger.info(`socket,${this.domain}: close event fired`, event.code, event.reason);
+        this.logger.info(`socket,${this._domain}: close event fired`, event.code, event.reason);
         clearTimeout(closeTimer);
         this.onclose(event);
         resolve(event);
@@ -174,7 +174,7 @@ export default class Socket extends EventEmitter {
    */
   open(url, options) {
     try {
-      this.domain = new URL(url).hostname;
+      this._domain = new URL(url).hostname;
     } catch {
       /* Ignore error */
     }
@@ -209,7 +209,7 @@ export default class Socket extends EventEmitter {
 
       const WebSocket = Socket.getWebSocketConstructor();
 
-      this.logger.info(`socket,${this.domain}: creating WebSocket`);
+      this.logger.info(`socket,${this._domain}: creating WebSocket`);
       const socket = new WebSocket(url, [], options);
 
       socket.binaryType = 'arraybuffer';
@@ -217,7 +217,7 @@ export default class Socket extends EventEmitter {
 
       socket.onclose = (event) => {
         event = this._fixCloseCode(event);
-        this.logger.info(`socket,${this.domain}: closed before open`, event.code, event.reason);
+        this.logger.info(`socket,${this._domain}: closed before open`, event.code, event.reason);
         switch (event.code) {
           case 1005:
             // IE 11 doesn't seem to allow 4XXX codes, so if we get a 1005, assume
@@ -239,10 +239,10 @@ export default class Socket extends EventEmitter {
       };
 
       socket.onopen = () => {
-        this.logger.info(`socket,${this.domain}: connected`);
+        this.logger.info(`socket,${this._domain}: connected`);
         this._authorize()
           .then(() => {
-            this.logger.info(`socket,${this.domain}: authorized`);
+            this.logger.info(`socket,${this._domain}: authorized`);
             socket.onclose = this.onclose;
             resolve();
           })
@@ -250,11 +250,11 @@ export default class Socket extends EventEmitter {
       };
 
       socket.onerror = (event) => {
-        this.logger.warn(`socket,${this.domain}: error event fired`, event);
+        this.logger.warn(`socket,${this._domain}: error event fired`, event);
       };
 
       sockets.set(this, socket);
-      this.logger.info(`socket,${this.domain}: waiting for server`);
+      this.logger.info(`socket,${this._domain}: waiting for server`);
     });
   }
 
@@ -264,7 +264,7 @@ export default class Socket extends EventEmitter {
    * @returns {undefined}
    */
   onclose(event) {
-    this.logger.info(`socket,${this.domain}: closed`, event.code, event.reason);
+    this.logger.info(`socket,${this._domain}: closed`, event.code, event.reason);
     clearTimeout(this.pongTimer);
     clearTimeout(this.pingTimer);
 
@@ -286,10 +286,10 @@ export default class Socket extends EventEmitter {
       const data = JSON.parse(event.data);
       const sequenceNumber = parseInt(data.sequenceNumber, 10);
 
-      this.logger.debug(`socket,${this.domain}: sequence number: `, sequenceNumber);
+      this.logger.debug(`socket,${this._domain}: sequence number: `, sequenceNumber);
       if (this.expectedSequenceNumber && sequenceNumber !== this.expectedSequenceNumber) {
         this.logger.debug(
-          `socket,${this.domain}: sequence number mismatch indicates lost mercury message. expected: ${this.expectedSequenceNumber}, actual: ${sequenceNumber}`
+          `socket,${this._domain}: sequence number mismatch indicates lost mercury message. expected: ${this.expectedSequenceNumber}, actual: ${sequenceNumber}`
         );
         this.emit('sequence-mismatch', sequenceNumber, this.expectedSequenceNumber);
       }
@@ -311,7 +311,7 @@ export default class Socket extends EventEmitter {
       // message from Mercury. At this time, the only action we have is to
       // ignore it and move on.
       /* istanbul ignore next */
-      this.logger.warn(`socket,${this.domain}: error while receiving WebSocket message`, error);
+      this.logger.warn(`socket,${this._domain}: error while receiving WebSocket message`, error);
     }
   }
 
@@ -365,7 +365,7 @@ export default class Socket extends EventEmitter {
    */
   _authorize() {
     return new Promise((resolve) => {
-      this.logger.info(`socket,${this.domain}: authorizing`);
+      this.logger.info(`socket,${this._domain}: authorizing`);
       this.send({
         id: uuid.v4(),
         type: 'authorization',
@@ -404,7 +404,7 @@ export default class Socket extends EventEmitter {
       switch (event.reason.toLowerCase()) {
         case 'replaced':
           this.logger.info(
-            `socket,${this.domain}: fixing CloseEvent code for reason: `,
+            `socket,${this._domain}: fixing CloseEvent code for reason: `,
             event.reason
           );
           event.code = 4000;
@@ -412,7 +412,7 @@ export default class Socket extends EventEmitter {
         case 'authentication failed':
         case 'authentication did not happen within the timeout window of 30000 seconds.':
           this.logger.info(
-            `socket,${this.domain}: fixing CloseEvent code for reason: `,
+            `socket,${this._domain}: fixing CloseEvent code for reason: `,
             event.reason
           );
           event.code = 1008;
@@ -434,12 +434,12 @@ export default class Socket extends EventEmitter {
   _ping(id) {
     const confirmPongId = (event) => {
       try {
-        this.logger.debug(`socket,${this.domain}: pong`, event.data.id);
+        this.logger.debug(`socket,${this._domain}: pong`, event.data.id);
         if (event.data && event.data.id !== id) {
           this.logger.info(
-            `socket,${this.domain}: received pong for wrong ping id, closing socket`
+            `socket,${this._domain}: received pong for wrong ping id, closing socket`
           );
-          this.logger.debug(`socket,${this.domain}: expected`, id, 'received', event.data.id);
+          this.logger.debug(`socket,${this._domain}: expected`, id, 'received', event.data.id);
           this.close({
             code: 1000,
             reason: 'Pong mismatch',
@@ -449,21 +449,21 @@ export default class Socket extends EventEmitter {
         // This try/catch block was added as a debugging step; to the best of my
         // knowledge, the above can never throw.
         /* istanbul ignore next */
-        this.logger.error(`socket,${this.domain}: error occurred in confirmPongId`, error);
+        this.logger.error(`socket,${this._domain}: error occurred in confirmPongId`, error);
       }
     };
 
     const onPongNotReceived = () => {
       try {
         this.logger.info(
-          `socket,${this.domain}: pong not receive in expected period, closing socket`
+          `socket,${this._domain}: pong not receive in expected period, closing socket`
         );
         this.close({
           code: 1000,
           reason: 'Pong not received',
         }).catch((reason) => {
           this.logger.warn(
-            `socket,${this.domain}: failed to close socket after missed pong`,
+            `socket,${this._domain}: failed to close socket after missed pong`,
             reason
           );
         });
@@ -471,7 +471,7 @@ export default class Socket extends EventEmitter {
         // This try/catch block was added as a debugging step; to the best of my
         // knowledge, the above can never throw.
         /* istanbul ignore next */
-        this.logger.error(`socket,${this.domain}: error occurred in onPongNotReceived`, error);
+        this.logger.error(`socket,${this._domain}: error occurred in onPongNotReceived`, error);
       }
     };
 
@@ -484,7 +484,7 @@ export default class Socket extends EventEmitter {
         // knowledge, the above can never throw.
         /* istanbul ignore next */
         this.logger.error(
-          `socket,${this.domain}: error occurred in scheduleNextPingAndCancelPongTimer`,
+          `socket,${this._domain}: error occurred in scheduleNextPingAndCancelPongTimer`,
           error
         );
       }
@@ -495,7 +495,7 @@ export default class Socket extends EventEmitter {
     this.once('pong', scheduleNextPingAndCancelPongTimer);
     this.once('pong', confirmPongId);
 
-    this.logger.debug(`socket,${this.domain}: ping ${id}`);
+    this.logger.debug(`socket,${this._domain}: ping ${id}`);
 
     return this.send({
       id,

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -30,6 +30,7 @@ export default class Socket extends EventEmitter {
    */
   constructor() {
     super();
+    this.domain = 'unknown-domain';
     this.onmessage = this.onmessage.bind(this);
     this.onclose = this.onclose.bind(this);
   }
@@ -172,7 +173,11 @@ export default class Socket extends EventEmitter {
    * @returns {Promise}
    */
   open(url, options) {
-    this.domain = options.domain || '';
+    try {
+      this.domain = new URL(url).hostname;
+    } catch {
+      /* Ignore error */
+    }
 
     return new Promise((resolve, reject) => {
       /* eslint complexity: [0] */

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -175,7 +175,7 @@ export default class Socket extends EventEmitter {
     try {
       this._domain = new URL(url).hostname;
     } catch {
-      /* Ignore error */
+      this._domain = url;
     }
 
     return new Promise((resolve, reject) => {

--- a/packages/@webex/internal-plugin-mercury/test/integration/spec/webex.js
+++ b/packages/@webex/internal-plugin-mercury/test/integration/spec/webex.js
@@ -32,12 +32,13 @@ describe('plugin-mercury', function () {
   );
 
   describe('onBeforeLogout()', () => {
-    it('disconnects the web socket', () =>
+    it('disconnects the web socket', () => {
       webex.logout({noRedirect: true}).then(() => {
         assert.called(webex.internal.mercury.disconnect);
         assert.isFalse(webex.internal.mercury.connected);
         assert.called(webex.internal.device.unregister);
         assert.isFalse(webex.internal.device.registered);
-      }));
+      });
+    });
   });
 });

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -560,7 +560,7 @@ describe('plugin-mercury', () => {
           return promiseTick(webex.internal.mercury.config.backoffTimeReset).then(() => {
             assert.equal(
               reason.message,
-              'mercury: prevent socket open when backoffCall no longer defined'
+              'Mercury: prevent socket open when backoffCall no longer defined'
             );
           });
         });
@@ -577,7 +577,7 @@ describe('plugin-mercury', () => {
         sinon.stub(mercury.logger, 'error');
 
         return Promise.resolve(mercury._emit('break', event)).then((res) => {
-          assert.calledWith(mercury.logger.error, 'mercury: error occurred in event handler', {
+          assert.calledWith(mercury.logger.error, 'Mercury: error occurred in event handler', {
             error,
             arguments: ['break', event],
           });


### PR DESCRIPTION

# COMPLETES SPARK-481862

## This pull request addresses

Cantina use 2 mercury connection via the mercury plugin, but it is not shown in the logs

## by making the following changes

Adding the domain of the mercury connection to the log helps to identify the connection.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
