### PR TITLE
fix(integration): fix waitForPublished() in SDK integration tests

### DIFF
--- a/packages/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -44,7 +44,7 @@ const localStreams = {
   },
 };
 
-
+// Updated expectedPublished from a boolean value to an object containing the stream and status properties
 const waitForPublished = (meeting, expectedPublished, description) => {
   return testUtils.waitForEvents([{
     scope: meeting,

--- a/packages/@webex/plugin-meetings/test/integration/spec/journey.js
+++ b/packages/@webex/plugin-meetings/test/integration/spec/journey.js
@@ -51,7 +51,7 @@ const waitForPublished = (meeting, expectedPublished, description) => {
     event: EVENT_TRIGGERS.MEETING_STREAM_PUBLISH_STATE_CHANGED,
     match: (event) => {
       console.log(`${description} is now ${event.isPublished ? 'published': 'not published'}`);
-      return (event.isPublished === expectedPublished);
+      return (event.isPublished === expectedPublished.status && event.stream.id === expectedPublished.stream.id) ;
     }
   }]);
 };
@@ -498,7 +498,7 @@ skipInNode(describe)('plugin-meetings', () => {
 
       it('alice update Audio', async () => {
         const newMicrophoneStream = await createMicrophoneStream();
-        const newStreamPublished = waitForPublished(alice.meeting, true, "Alice AUDIO: new microphone stream");
+        const newStreamPublished = waitForPublished(alice.meeting, {stream: newMicrophoneStream, status: true}, "Alice AUDIO: new microphone stream");
 
         await testUtils.delayedPromise(
             alice.meeting
@@ -521,7 +521,7 @@ skipInNode(describe)('plugin-meetings', () => {
 
       it('alice update video', async () => {
         const newCameraStream = await createCameraStream();
-        const newStreamPublished = waitForPublished(alice.meeting, true, "Alice VIDEO: new camera stream");
+        const newStreamPublished = waitForPublished(alice.meeting, {stream: newCameraStream, status:  true}, "Alice VIDEO: new camera stream");
 
         await testUtils.delayedPromise(
             alice.meeting
@@ -630,7 +630,7 @@ skipInNode(describe)('plugin-meetings', () => {
             );
           });
 
-        const screenShareVideoPublished = waitForPublished(alice.meeting, true, "alice's screen share video stream");
+        const screenShareVideoPublished = waitForPublished(alice.meeting, {stream: localStreams.alice.screenShare.video, status: true}, "alice's screen share video stream");
 
         await testUtils.delayedPromise(alice.meeting.publishStreams({screenShare: {video: localStreams.alice.screenShare.video}}));
 
@@ -666,8 +666,8 @@ skipInNode(describe)('plugin-meetings', () => {
               JSON.stringify(response, testUtils.getCircularReplacer())
             );
           });
-        const aliceScreenShareVideoUnpublished = waitForPublished(alice.meeting, false, "alice's screen share video stream");
-        const bobScreenShareVideoPublished = waitForPublished(bob.meeting, true, "bob's screen share video stream");
+        const aliceScreenShareVideoUnpublished = waitForPublished(alice.meeting, {stream: localStreams.alice.screenShare.video, status: false}, "alice's screen share video stream");
+        const bobScreenShareVideoPublished = waitForPublished(bob.meeting, {stream: localStreams.bob.screenShare.video, status: true}, "bob's screen share video stream");
 
         await testUtils.delayedPromise(bob.meeting.publishStreams({screenShare: {video: localStreams.bob.screenShare.video}}));
 
@@ -689,7 +689,7 @@ skipInNode(describe)('plugin-meetings', () => {
       });
 
       it('bob stops sharing', async () => {
-        const screenShareVideoUnpublished = waitForPublished(bob.meeting, false, "bob's screen share video stream");
+        const screenShareVideoUnpublished = waitForPublished(bob.meeting, {stream: localStreams.bob.screenShare.video, status: false}, "bob's screen share video stream");
         const stoppedSharingLocal = testUtils.waitForEvents([{scope: bob.meeting, event: 'meeting:stoppedSharingLocal'}]);
         const stoppedSharingRemote = testUtils.waitForEvents([{scope: alice.meeting, event: 'meeting:stoppedSharingRemote'}]);
 
@@ -826,7 +826,7 @@ skipInNode(describe)('plugin-meetings', () => {
               JSON.stringify(response, testUtils.getCircularReplacer())
             );
           });
-        const bobScreenShareVideoPublished = waitForPublished(bob.meeting, true, "bob's screen share video stream");
+        const bobScreenShareVideoPublished = waitForPublished(bob.meeting, {stream: localStreams.bob.screenShare.video, status: true}, "bob's screen share video stream");
 
         await testUtils.delayedPromise(bob.meeting.publishStreams({screenShare: {video: localStreams.bob.screenShare.video}}));
 


### PR DESCRIPTION
# COMPLETES #[SPARK-477377](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-477377)

## This pull request addresses
https://github.com/webex/webex-js-sdk/pull/3185#discussion_r1397110588 

## by making the following changes
Passing stream in the parameter list of waitForPublished() and comparing the stream received inside the triggered event with the the stream present in the parameter list

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
