### PR TITLE
fix(plugin-meetings): add tls transport type

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -1126,7 +1126,9 @@ export class StatsAnalyzer extends EventsScope {
       RemoteCandidateType[result.id].push(result.candidateType);
     }
 
-    if (result.protocol && RemoteTransport[result.id].indexOf(result.protocol) === -1) {
+    if (result.relayProtocol && RemoteTransport[result.id].indexOf(result.relayProtocol) === -1) {
+      RemoteTransport[result.id].push(result.relayProtocol.toUpperCase());
+    } else if (result.protocol && RemoteTransport[result.id].indexOf(result.protocol) === -1) {
       RemoteTransport[result.id].push(result.protocol.toUpperCase());
     }
 

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -193,7 +193,7 @@ export class StatsAnalyzer extends EventsScope {
       }
     });
 
-    newMqa.intervalMetadata.peerReflexiveIP = this.statsResults.connectionType.local.ipAddress[0];
+    newMqa.intervalMetadata.peerReflexiveIP = this.statsResults.connectionType.local.ipAddress;
 
     // Adding peripheral information
     newMqa.intervalMetadata.peripherals = [];
@@ -1094,75 +1094,35 @@ export class StatsAnalyzer extends EventsScope {
     if (!result || !result.id) {
       return;
     }
-    const RemoteCandidateType = {};
-    const RemoteTransport = {};
-    const RemoteIpAddress = {};
-    const RemoteNetworkType = {};
 
-    if (!result.id) return;
+    let transport;
+    if (result.relayProtocol) {
+      transport = result.relayProtocol.toUpperCase();
+    } else if (result.protocol) {
+      transport = result.protocol.toUpperCase();
+    }
 
     const sendRecvType = isSender ? STATS.SEND_DIRECTION : STATS.RECEIVE_DIRECTION;
     const ipType = isRemote ? STATS.REMOTE : STATS.LOCAL;
 
-    if (!RemoteCandidateType[result.id]) {
-      RemoteCandidateType[result.id] = [];
-    }
-
-    if (!RemoteTransport[result.id]) {
-      RemoteTransport[result.id] = [];
-    }
-
-    if (!RemoteIpAddress[result.id]) {
-      RemoteIpAddress[result.id] = [];
-    }
-    if (!RemoteNetworkType[result.id]) {
-      RemoteNetworkType[result.id] = [];
-    }
-
-    if (
-      result.candidateType &&
-      RemoteCandidateType[result.id].indexOf(result.candidateType) === -1
-    ) {
-      RemoteCandidateType[result.id].push(result.candidateType);
-    }
-
-    if (result.relayProtocol && RemoteTransport[result.id].indexOf(result.relayProtocol) === -1) {
-      RemoteTransport[result.id].push(result.relayProtocol.toUpperCase());
-    } else if (result.protocol && RemoteTransport[result.id].indexOf(result.protocol) === -1) {
-      RemoteTransport[result.id].push(result.protocol.toUpperCase());
-    }
-
-    if (
-      result.ip &&
-      RemoteIpAddress[result.id].indexOf(`${result.ip}:${result.portNumber}`) === -1
-    ) {
-      RemoteIpAddress[result.id].push(`${result.ip}`); // TODO: Add ports
-    }
-
-    if (result.networkType && RemoteNetworkType[result.id].indexOf(result.networkType) === -1) {
-      RemoteNetworkType[result.id].push(result.networkType);
-    }
-
     this.statsResults.internal.candidates[result.id] = {
-      candidateType: RemoteCandidateType[result.id],
-      ipAddress: RemoteIpAddress[result.id],
+      candidateType: result.candidateType,
+      ipAddress: result.ip, // TODO: add ports
       portNumber: result.port,
-      networkType: RemoteNetworkType[result.id],
+      networkType: result.networkType,
       priority: result.priority,
-      transport: RemoteTransport[result.id],
+      transport,
       timestamp: result.time,
       id: result.id,
       type: result.type,
     };
 
-    this.statsResults.connectionType[ipType].candidateType = RemoteCandidateType[result.id];
-    this.statsResults.connectionType[ipType].ipAddress = RemoteIpAddress[result.id];
+    this.statsResults.connectionType[ipType].candidateType = result.candidateType;
+    this.statsResults.connectionType[ipType].ipAddress = result.ipAddress;
 
     this.statsResults.connectionType[ipType].networkType =
-      RemoteNetworkType[result.id][0] === NETWORK_TYPE.VPN
-        ? NETWORK_TYPE.UNKNOWN
-        : RemoteNetworkType[result.id][0];
-    this.statsResults.connectionType[ipType].transport = RemoteTransport[result.id];
+      result.networkType === NETWORK_TYPE.VPN ? NETWORK_TYPE.UNKNOWN : result.networkType;
+    this.statsResults.connectionType[ipType].transport = transport;
 
     this.statsResults[type][sendRecvType].totalRoundTripTime = result.totalRoundTripTime;
   };

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -23,7 +23,7 @@ export const getAudioReceiverMqa = ({audioReceiver, statsResults, lastMqaDataSen
   }
 
   audioReceiver.common.common.direction = statsResults[mediaType].direction;
-  audioReceiver.common.transportType = statsResults.connectionType.local.transport[0];
+  audioReceiver.common.transportType = statsResults.connectionType.local.transport;
 
   // add rtpPacket info inside common as also for call analyzer
   audioReceiver.common.rtpPackets =
@@ -83,7 +83,7 @@ export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, m
   }
 
   audioSender.common.common.direction = statsResults[mediaType].direction;
-  audioSender.common.transportType = statsResults.connectionType.local.transport[0];
+  audioSender.common.transportType = statsResults.connectionType.local.transport;
 
   audioSender.common.maxRemoteJitter =
     // @ts-ignore
@@ -146,7 +146,7 @@ export const getVideoReceiverMqa = ({videoReceiver, statsResults, lastMqaDataSen
   }
 
   videoReceiver.common.common.direction = statsResults[mediaType].direction;
-  videoReceiver.common.transportType = statsResults.connectionType.local.transport[0];
+  videoReceiver.common.transportType = statsResults.connectionType.local.transport;
 
   // collect the packets received for the last min
   videoReceiver.common.rtpPackets =
@@ -229,7 +229,7 @@ export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, m
   }
 
   videoSender.common.common.direction = statsResults[mediaType].direction;
-  videoSender.common.transportType = statsResults.connectionType.local.transport[0];
+  videoSender.common.transportType = statsResults.connectionType.local.transport;
 
   // @ts-ignore
   videoSender.common.maxRemoteJitter =

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -23,7 +23,7 @@ export const getAudioReceiverMqa = ({audioReceiver, statsResults, lastMqaDataSen
   }
 
   audioReceiver.common.common.direction = statsResults[mediaType].direction;
-  audioReceiver.common.transportType = statsResults.connectionType.remote.transport[0];
+  audioReceiver.common.transportType = statsResults.connectionType.local.transport[0];
 
   // add rtpPacket info inside common as also for call analyzer
   audioReceiver.common.rtpPackets =
@@ -146,7 +146,8 @@ export const getVideoReceiverMqa = ({videoReceiver, statsResults, lastMqaDataSen
   }
 
   videoReceiver.common.common.direction = statsResults[mediaType].direction;
-  videoReceiver.common.transportType = statsResults.connectionType.remote.transport[0];
+  videoReceiver.common.transportType = statsResults.connectionType.local.transport[0];
+
   // collect the packets received for the last min
   videoReceiver.common.rtpPackets =
     statsResults[mediaType][sendrecvType].totalPacketsReceived - lastPacketsReceived || 0;

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -125,6 +125,11 @@ describe('plugin-meetings', () => {
                     packetsSent: 0,
                     bytesSent: 1,
                   },
+                  {
+                    type: 'local-candidate',
+                    id: 'fake-candidate-id',
+                    protocol: 'tcp'
+                  },
                 ],
               },
             ],
@@ -135,6 +140,11 @@ describe('plugin-meetings', () => {
                     type: 'inbound-rtp',
                     packetsReceived: 0,
                     bytesReceived: 1,
+                  },
+                  {
+                    type: 'local-candidate',
+                    id: 'fake-candidate-id',
+                    protocol: 'tcp'
                   },
                 ],
               },
@@ -149,6 +159,11 @@ describe('plugin-meetings', () => {
                     framesSent: 0,
                     bytesSent: 1,
                   },
+                  {
+                    type: 'local-candidate',
+                    id: 'fake-candidate-id',
+                    protocol: 'tcp'
+                  },
                 ],
               },
             ],
@@ -162,6 +177,11 @@ describe('plugin-meetings', () => {
                     frameHeight: 720,
                     frameWidth: 1280,
                     framesReceived: 1,
+                  },
+                  {
+                    type: 'local-candidate',
+                    id: 'fake-candidate-id',
+                    protocol: 'tcp'
                   },
                 ],
               },
@@ -241,6 +261,13 @@ describe('plugin-meetings', () => {
         assert.strictEqual(mqeData.videoReceive[0].streams[0].receivedHeight, 720);
         assert.strictEqual(mqeData.videoReceive[0].streams[0].receivedWidth, 1280);
       };
+
+      const checkMqeTransportType = () => {
+        console.log(mqeData.audioTransmit[0])
+        console.log(mqeData.videoReceive[0])
+        assert.strictEqual(mqeData.audioTransmit[0].common.transportType, 'TCP');
+        assert.strictEqual(mqeData.videoReceive[0].common.transportType, 'TCP');
+      }
 
       it('emits LOCAL_MEDIA_STARTED and LOCAL_MEDIA_STOPPED events for audio', async () => {
         await startStatsAnalyzer({expected: {sendAudio: true}});
@@ -329,6 +356,14 @@ describe('plugin-meetings', () => {
 
         // Check that the mqe data has been emitted and is correctly computed.
         checkMqeData();
+      });
+
+      it('emits the correct transportType in MEDIA_QUALITY events', async () => {
+        await startStatsAnalyzer({expected: {receiveVideo: true}});
+
+        await progressTime();
+
+        checkMqeTransportType();
       });
     });
   });


### PR DESCRIPTION
# COMPLETES [SPARK-477380](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-477380)

## This pull request addresses

The missing "TLS" transport type when calling while using a TLS connection.

## by making the following changes

Using only local candidates to determine the transport type and using the `relayProtocol` stats item when it exists.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly
