### PR TITLE
fix(tooling): fix the version injection plugin to pull version from right location

### DIFF
--- a/tooling/babel-plugin-inject-package-version.js
+++ b/tooling/babel-plugin-inject-package-version.js
@@ -4,7 +4,7 @@
 
 const t = require('@babel/types');
 
-const {version} = require('../package.json');
+const {version} = require('../packages/webex/package.json');
 
 /**
  * Simple babel transform for ensuring that every WebexPlugin (and WebexCore)


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # NA

## This pull request addresses
the issue of the sdk_version being set to "undefined" while sending metrics using the webex.min.js or the other min.js files.

## by making the following changes
The babel plugin that injects a version was using the wrong file to inject the version. The root package.json no longer has a `version` parameter in `next` branch. The package.json inside `packages/webex/` is the place where `version` will be populated during deploy. Changed the path in the plugin file so it picks the right version.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
Built the CDN files after making the change to the plugin. Hosted these locally and ran webex initialization and meetings.register. The clientmetrics sent to the metrics service has the right version.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---
[metrics-version-fixed.har.txt](https://github.com/webex/webex-js-sdk/files/13645203/metrics-version-fixed.har.txt)


Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
