### PR TITLE
fix(plugin-meetings): adding fix done in PR 2782 in next branch

### DIFF
--- a/packages/@webex/plugin-meetings/src/roap/index.ts
+++ b/packages/@webex/plugin-meetings/src/roap/index.ts
@@ -287,17 +287,20 @@ export default class Roap extends StatelessWebexPlugin {
     // When reconnecting, it's important that the first roap message being sent out has empty media id.
     // Normally this is the roap offer, but when TURN discovery is enabled,
     // then this is the TURN discovery request message
-    const sendEmptyMediaId = reconnect && !meeting.config.experimental.enableTurnDiscovery;
+    return this.turnDiscovery
+      .isSkipped(meeting)
+      .then((isTurnDiscoverySkipped) => {
+        const sendEmptyMediaId = reconnect && isTurnDiscoverySkipped;
 
-    return this.roapRequest
-      .sendRoap({
-        roapMessage,
-        correlationId: meeting.correlationId,
-        locusSelfUrl: meeting.selfUrl,
-        mediaId: sendEmptyMediaId ? '' : meeting.mediaId,
-        audioMuted: meeting.audio?.isLocallyMuted(),
-        videoMuted: meeting.video?.isLocallyMuted(),
-        meetingId: meeting.id,
+        return this.roapRequest.sendRoap({
+          roapMessage,
+          correlationId: meeting.correlationId,
+          locusSelfUrl: meeting.selfUrl,
+          mediaId: sendEmptyMediaId ? '' : meeting.mediaId,
+          audioMuted: meeting.audio?.isLocallyMuted(),
+          videoMuted: meeting.video?.isLocallyMuted(),
+          meetingId: meeting.id,
+        });
       })
       .then(({locus, mediaConnections}) => {
         this.roapHandler.submit({

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
@@ -42,87 +42,92 @@ describe('Roap', () => {
     let sendRoapStub;
     let roapHandlerSubmitStub;
 
-    const meeting = {
-      id: 'some meeting id',
-      correlationId: 'correlation id',
-      selfUrl: 'self url',
-      mediaId: 'media id',
-      audio:{
-        isLocallyMuted: () => true,
-      },
-      video:{
-        isLocallyMuted: () => false,
-      },
-      setRoapSeq: sinon.stub(),
-      config: {experimental: {enableTurnDiscovery: false}},
-    };
+    let meeting;
 
     beforeEach(() => {
-      sendRoapStub = sinon.stub(RoapRequest.prototype, 'sendRoap').resolves({});
-      roapHandlerSubmitStub = sinon.stub(RoapHandler.prototype, 'submit');
-      meeting.setRoapSeq.resetHistory();
+      meeting = {
+        id: 'some meeting id',
+        correlationId: 'correlation id',
+        selfUrl: 'self url',
+        mediaId: 'media id',
+        audio: {
+          isLocallyMuted: () => true,
+        },
+        video: {
+          isLocallyMuted: () => false,
+        },
+        setRoapSeq: sinon.stub(),
+        config: {experimental: {enableTurnDiscovery: false}},
+        webex: {meetings: {reachability: {isAnyClusterReachable: () => true}}},
+      };
+
+      beforeEach(() => {
+        sendRoapStub = sinon.stub(RoapRequest.prototype, 'sendRoap').resolves({});
+        roapHandlerSubmitStub = sinon.stub(RoapHandler.prototype, 'submit');
+        meeting.setRoapSeq.resetHistory();
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      [
+        {reconnect: true, turnDiscoverySkipped: false, expectEmptyMediaId: false},
+        {reconnect: true, turnDiscoverySkipped: true, expectEmptyMediaId: true},
+        {reconnect: false, turnDiscoverySkipped: false, expectEmptyMediaId: false},
+        {reconnect: false, turnDiscoverySkipped: true, expectEmptyMediaId: false},
+      ].forEach(({reconnect, turnDiscoverySkipped, expectEmptyMediaId}) =>
+        it(`sends roap OFFER with ${expectEmptyMediaId ? 'empty ' : ''}mediaId when ${
+          reconnect ? '' : 'not '
+        }reconnecting and TURN discovery is ${
+          turnDiscoverySkipped ? 'skipped' : 'not skipped'
+        }`, async () => {
+          const roap = new Roap({}, {parent: 'fake'});
+
+          sinon.stub(roap.turnDiscovery, 'isSkipped').resolves(turnDiscoverySkipped);
+
+          await roap.sendRoapMediaRequest({
+            meeting,
+            sdp: 'sdp',
+            reconnect,
+            roapSeq: 1,
+          });
+
+          const expectedRoapMessage = {
+            messageType: 'OFFER',
+            sdps: ['sdp'],
+            version: '2',
+            seq: 2,
+            tieBreaker: 4294967294,
+          };
+
+          assert.calledOnce(sendRoapStub);
+          assert.calledWith(sendRoapStub, {
+            roapMessage: expectedRoapMessage,
+            correlationId: meeting.correlationId,
+            locusSelfUrl: meeting.selfUrl,
+            mediaId: expectEmptyMediaId ? '' : meeting.mediaId,
+            audioMuted: meeting.audio?.isLocallyMuted(),
+            videoMuted: meeting.video?.isLocallyMuted(),
+            meetingId: meeting.id,
+          });
+
+          assert.calledTwice(roapHandlerSubmitStub);
+          assert.calledWith(roapHandlerSubmitStub, {
+            type: ROAP.SEND_ROAP_MSG,
+            msg: expectedRoapMessage,
+            correlationId: meeting.correlationId,
+          });
+          assert.calledWith(roapHandlerSubmitStub, {
+            type: ROAP.SEND_ROAP_MSG_SUCCESS,
+            seq: 2,
+            correlationId: meeting.correlationId,
+          });
+
+          assert.calledOnce(meeting.setRoapSeq);
+          assert.calledWith(meeting.setRoapSeq, 2);
+        })
+      );
     });
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    [
-      {reconnect: true, enableTurnDiscovery: true, expectEmptyMediaId: false},
-      {reconnect: true, enableTurnDiscovery: false, expectEmptyMediaId: true},
-      {reconnect: false, enableTurnDiscovery: true, expectEmptyMediaId: false},
-      {reconnect: false, enableTurnDiscovery: false, expectEmptyMediaId: false},
-    ].forEach(({reconnect, enableTurnDiscovery, expectEmptyMediaId}) =>
-      it(`sends roap OFFER with ${expectEmptyMediaId ? 'empty ' : ''}mediaId when ${
-        reconnect ? '' : 'not '
-      }reconnecting and TURN discovery is ${
-        enableTurnDiscovery ? 'enabled' : 'disabled'
-      }`, async () => {
-        meeting.config.experimental.enableTurnDiscovery = enableTurnDiscovery;
-
-        const roap = new Roap({}, {parent: 'fake'});
-
-        await roap.sendRoapMediaRequest({
-          meeting,
-          sdp: 'sdp',
-          reconnect,
-          roapSeq: 1,
-        });
-
-        const expectedRoapMessage = {
-          messageType: 'OFFER',
-          sdps: ['sdp'],
-          version: '2',
-          seq: 2,
-          tieBreaker: 4294967294,
-        };
-
-        assert.calledOnce(sendRoapStub);
-        assert.calledWith(sendRoapStub, {
-          roapMessage: expectedRoapMessage,
-          correlationId: meeting.correlationId,
-          locusSelfUrl: meeting.selfUrl,
-          mediaId: expectEmptyMediaId ? '' : meeting.mediaId,
-          audioMuted: meeting.audio?.isLocallyMuted(),
-          videoMuted: meeting.video?.isLocallyMuted(),
-          meetingId: meeting.id,
-        });
-
-        assert.calledTwice(roapHandlerSubmitStub);
-        assert.calledWith(roapHandlerSubmitStub, {
-          type: ROAP.SEND_ROAP_MSG,
-          msg: expectedRoapMessage,
-          correlationId: meeting.correlationId,
-        });
-        assert.calledWith(roapHandlerSubmitStub, {
-          type: ROAP.SEND_ROAP_MSG_SUCCESS,
-          seq: 2,
-          correlationId: meeting.correlationId,
-        });
-
-        assert.calledOnce(meeting.setRoapSeq);
-        assert.calledWith(meeting.setRoapSeq, 2);
-      })
-    );
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/turnDiscovery.ts
@@ -352,6 +352,27 @@ describe('TurnDiscovery', () => {
     });
   });
 
+  describe('isSkipped', () => {
+    [
+      {enabledInConfig: true, isAnyClusterReachable: true, expectedIsSkipped: true},
+      {enabledInConfig: true, isAnyClusterReachable: false, expectedIsSkipped: false},
+      {enabledInConfig: false, isAnyClusterReachable: true, expectedIsSkipped: true},
+      {enabledInConfig: false, isAnyClusterReachable: false, expectedIsSkipped: true},
+    ].forEach(({enabledInConfig, isAnyClusterReachable, expectedIsSkipped}) => {
+      it(`returns ${expectedIsSkipped} when TURN discovery is ${enabledInConfig ? '' : 'not '} enabled in config and isAnyClusterReachable() returns ${isAnyClusterReachable ? 'true' : 'false'}`, async () => {
+        testMeeting.config.experimental.enableTurnDiscovery = enabledInConfig;
+
+        sinon.stub(testMeeting.webex.meetings.reachability, 'isAnyClusterReachable').resolves(isAnyClusterReachable);
+
+        const td = new TurnDiscovery(mockRoapRequest);
+
+        const isSkipped = await td.isSkipped(testMeeting);
+
+        assert.equal(isSkipped, expectedIsSkipped);
+      })
+    })
+  })
+
   describe('handleTurnDiscoveryResponse', () => {
     it("doesn't do anything if turn discovery was not started", () => {
       const td = new TurnDiscovery(mockRoapRequest);

--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -5,6 +5,7 @@
   ],
   "contributors": [
     "Bhargav Chinta (bchinta@cisco.com)",
+    "Karthik Raji (karaji@cisco.com)",
     "Priya Kesari (pkesari@cisco.com)",
     "Rajesh Kumar (rarajes2@cisco.com)",
     "Shreyas Sharma (shreysh2@cisco.com)",

--- a/packages/webex/package.json
+++ b/packages/webex/package.json
@@ -9,6 +9,7 @@
     "Kesava Krishnan Madavan <kmadavan@cisco.com>",
     "Priya Kesari <pkesari@cisco.com>",
     "Rajesh Kumar <rarajes2@cisco.com>",
+    "Shreyas Sharma <shreysh2@cisco.com>",
     "Sreekanth Narayanan <sreenara@cisco.com>"
   ],
   "main": "dist/index.js",


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-481819

## This pull request addresses
While in a meeting if the internet is disconnected for some amount of time the remote video and audio stops. In the samples page, remote video shows "undefined 0fps". 

This is caused because while reconnection locus doesn't expect the media ID to be passed. We only take into account the config value for enableTurnDiscovery and don't take into account that TURN discovery is skipped if reachability succeeds.

## by making the following changes
Made sure that when Roap checks if TURN discovery is being done or not it checks all the conditions and not just the config

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
Joined the scheduled meeting as guest, switched off wifi for 10 seconds and resumed wifi before the guest is out of the meeting. Once the reconnect to the meeting is successful, audio and video is working now.
Logs: 
[Bems_Issue_Reproduction_console2.log](https://github.com/webex/webex-js-sdk/files/13656230/Bems_Issue_Reproduction_console2.log)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
