### PR TITLE
fix: use candidate pairs to identify correct local candidate

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -77,6 +77,7 @@ export class StatsAnalyzer extends EventsScope {
   statsInterval: NodeJS.Timeout;
   statsResults: any;
   statsStarted: any;
+  successfulCandidatePair: any;
   receiveSlotCallback: ReceiveSlotCallback;
 
   /**
@@ -105,6 +106,7 @@ export class StatsAnalyzer extends EventsScope {
     this.lastMqaDataSent = {};
     this.lastEmittedStartStopEvent = {};
     this.receiveSlotCallback = receiveSlotCallback;
+    this.successfulCandidatePair = {};
   }
 
   /**
@@ -392,6 +394,12 @@ export class StatsAnalyzer extends EventsScope {
   filterAndParseGetStatsResults(statsItem: any, type: string, isSender: boolean) {
     const {types} = DEFAULT_GET_STATS_FILTER;
 
+    const reports = [];
+    statsItem.report.forEach((report) => reports.push(report));
+    this.successfulCandidatePair = reports.find(
+      (report) => report.type === 'candidate-pair' && report.state === 'succeeded'
+    );
+
     statsItem.report.forEach((result) => {
       if (types.includes(result.type)) {
         this.parseGetStatsResult(result, type, isSender);
@@ -402,6 +410,8 @@ export class StatsAnalyzer extends EventsScope {
       this.statsResults[type].direction = statsItem.currentDirection;
       this.statsResults[type].trackLabel = statsItem.localTrackLabel;
       this.statsResults[type].csi = statsItem.csi;
+      // reset the successful candidate pair.
+      this.successfulCandidatePair = {};
     }
   }
 
@@ -1092,6 +1102,11 @@ export class StatsAnalyzer extends EventsScope {
    */
   parseCandidate = (result: any, type: any, isSender: boolean, isRemote: boolean) => {
     if (!result || !result.id) {
+      return;
+    }
+
+    // We only care about the successful local candidate
+    if (this.successfulCandidatePair?.localCandidateId !== result.id) {
       return;
     }
 

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -394,11 +394,12 @@ export class StatsAnalyzer extends EventsScope {
   filterAndParseGetStatsResults(statsItem: any, type: string, isSender: boolean) {
     const {types} = DEFAULT_GET_STATS_FILTER;
 
-    const reports = [];
-    statsItem.report.forEach((report) => reports.push(report));
-    this.successfulCandidatePair = reports.find(
-      (report) => report.type === 'candidate-pair' && report.state === 'succeeded'
-    );
+    // get the successful candidate pair before parsing stats.
+    statsItem.report.forEach((report) => {
+      if (report.type === 'candidate-pair' && report.state === 'succeeded') {
+        this.successfulCandidatePair = report;
+      }
+    });
 
     statsItem.report.forEach((result) => {
       if (types.includes(result.type)) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -126,6 +126,16 @@ describe('plugin-meetings', () => {
                     bytesSent: 1,
                   },
                   {
+                    type: 'candidate-pair',
+                    state: 'succeeded',
+                    localCandidateId: 'fake-candidate-id'
+                  },
+                  {
+                    type: 'candidate-pair',
+                    state: 'failed',
+                    localCandidateId: 'bad-candidate-id'
+                  },
+                  {
                     type: 'local-candidate',
                     id: 'fake-candidate-id',
                     protocol: 'tcp'
@@ -140,6 +150,16 @@ describe('plugin-meetings', () => {
                     type: 'inbound-rtp',
                     packetsReceived: 0,
                     bytesReceived: 1,
+                  },
+                  {
+                    type: 'candidate-pair',
+                    state: 'succeeded',
+                    localCandidateId: 'fake-candidate-id'
+                  },
+                  {
+                    type: 'candidate-pair',
+                    state: 'failed',
+                    localCandidateId: 'bad-candidate-id'
                   },
                   {
                     type: 'local-candidate',
@@ -160,6 +180,16 @@ describe('plugin-meetings', () => {
                     bytesSent: 1,
                   },
                   {
+                    type: 'candidate-pair',
+                    state: 'succeeded',
+                    localCandidateId: 'fake-candidate-id'
+                  },
+                  {
+                    type: 'candidate-pair',
+                    state: 'failed',
+                    localCandidateId: 'bad-candidate-id'
+                  },
+                  {
                     type: 'local-candidate',
                     id: 'fake-candidate-id',
                     protocol: 'tcp'
@@ -177,6 +207,16 @@ describe('plugin-meetings', () => {
                     frameHeight: 720,
                     frameWidth: 1280,
                     framesReceived: 1,
+                  },
+                  {
+                    type: 'candidate-pair',
+                    state: 'succeeded',
+                    localCandidateId: 'fake-candidate-id'
+                  },
+                  {
+                    type: 'candidate-pair',
+                    state: 'failed',
+                    localCandidateId: 'bad-candidate-id'
                   },
                   {
                     type: 'local-candidate',
@@ -261,13 +301,6 @@ describe('plugin-meetings', () => {
         assert.strictEqual(mqeData.videoReceive[0].streams[0].receivedHeight, 720);
         assert.strictEqual(mqeData.videoReceive[0].streams[0].receivedWidth, 1280);
       };
-
-      const checkMqeTransportType = () => {
-        console.log(mqeData.audioTransmit[0])
-        console.log(mqeData.videoReceive[0])
-        assert.strictEqual(mqeData.audioTransmit[0].common.transportType, 'TCP');
-        assert.strictEqual(mqeData.videoReceive[0].common.transportType, 'TCP');
-      }
 
       it('emits LOCAL_MEDIA_STARTED and LOCAL_MEDIA_STOPPED events for audio', async () => {
         await startStatsAnalyzer({expected: {sendAudio: true}});
@@ -363,7 +396,22 @@ describe('plugin-meetings', () => {
 
         await progressTime();
 
-        checkMqeTransportType();
+        assert.strictEqual(mqeData.audioTransmit[0].common.transportType, 'TCP');
+        assert.strictEqual(mqeData.videoReceive[0].common.transportType, 'TCP');
+      });
+
+      it('emits the correct transportType in MEDIA_QUALITY events when using a TURN server', async () => {
+        fakeStats.audio.senders[0].report[3].relayProtocol = 'tls';
+        fakeStats.video.senders[0].report[3].relayProtocol = 'tls';
+        fakeStats.audio.receivers[0].report[3].relayProtocol = 'tls';
+        fakeStats.video.receivers[0].report[3].relayProtocol = 'tls';
+
+        await startStatsAnalyzer({expected: {receiveVideo: true}});
+
+        await progressTime();
+
+        assert.strictEqual(mqeData.audioTransmit[0].common.transportType, 'TLS');
+        assert.strictEqual(mqeData.videoReceive[0].common.transportType, 'TLS');
       });
     });
   });


### PR DESCRIPTION
# COMPLETES [SPARK-477380](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-477380)

## This pull request addresses

The missing "TLS" transport type when calling while using a TLS connection. Adds on to this PR: https://github.com/webex/webex-js-sdk/pull/3243 by using the successful `candidate-pair` to get the correct `local-candidate`.

## by making the following changes

Using only local candidates to determine the transport type and using the `relayProtocol` stats item when it exists.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly
