### PR TITLE
fix: local linking with internal-media-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/webex/webex-js-sdk"
   },
   "scripts": {
-    "clean": "rimraf \"packages/**/.coverage\" \"packages/**/dist\" \"packages/**/types\"",
+    "clean": "rimraf \"packages/@webex/*/.coverage\" \"packages/@webex/*/dist\" \"packages/@webex/*/types\" \"packages/webex/.coverage\" \"packages/webex/dist\"",
     "prebuild": "yarn run clean",
     "build": "yarn clean && node ./tooling/index.js build && yarn run build:tsc",
     "build:tsc": "yarn run tsc -p ./config/tsconfig.typecheck.json --noEmit && yarn workspace @webex/internal-plugin-metrics run build && yarn workspace @webex/plugin-meetings run build && yarn workspace @webex/media-helpers run build:src",


### PR DESCRIPTION
## This pull request addresses

Cannot build JS-SDK when doing local linking with @webex/internal-media-core

## by making the following changes

It's because the dist folder of internal-media-core was getting deleted during the build

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

checked that it builds with local link

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
