### PR TITLE
Spark 481793 metric payload overrides

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -410,16 +410,19 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
    * @param arg - get error arg
    * @param arg.clientErrorCode
    * @param arg.serviceErrorCode
+   * @param arg.payloadOverrides
    * @returns
    */
   public getErrorPayloadForClientErrorCode({
     clientErrorCode,
     serviceErrorCode,
     serviceErrorName,
+    payloadOverrides,
   }: {
     clientErrorCode: number;
     serviceErrorCode: any;
     serviceErrorName?: any;
+    payloadOverrides?: any;
   }): ClientEventError {
     let error: ClientEventError;
 
@@ -432,7 +435,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
           {errorCode: clientErrorCode},
           serviceErrorName ? {errorData: {errorName: serviceErrorName}} : {},
           {serviceErrorCode},
-          partialParsedError
+          partialParsedError,
+          payloadOverrides || {}
         );
 
         return error;
@@ -489,6 +493,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       const payload = this.getErrorPayloadForClientErrorCode({
         clientErrorCode: NETWORK_ERROR,
         serviceErrorCode,
+        payloadOverrides: rawError.payloadOverrides,
       });
       payload.errorDescription = rawError.message;
 
@@ -499,6 +504,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       const payload = this.getErrorPayloadForClientErrorCode({
         clientErrorCode: AUTHENTICATION_FAILED_CODE,
         serviceErrorCode,
+        payloadOverrides: rawError.payloadOverrides,
       });
       payload.errorDescription = rawError.message;
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -1586,6 +1586,33 @@ describe('internal-plugin-metrics', () => {
         });
       });
 
+      it('should override custom properties for a NetworkOrCORSERror', () => {
+        const error = new WebexHttpError.NetworkOrCORSError({
+          url: 'https://example.com',
+          statusCode: 0,
+          body: {},
+          options: {headers: {}, url: 'https://example.com'},
+        });
+
+        error.payloadOverrides = {
+          shownToUser: true,
+          category: 'expected'
+        };
+
+        const res = cd.generateClientEventErrorPayload(
+          error
+        );
+        assert.deepEqual(res, {
+          category: 'expected',
+          errorDescription: '{}\nundefined https://example.com\nWEBEX_TRACKING_ID: undefined\n',
+          fatal: true,
+          name: 'other',
+          shownToUser: true,
+          serviceErrorCode: undefined,
+          errorCode: 1026,
+        });
+      });
+
       it('should return AuthenticationFailed code for an Unauthorized error', () => {
         const res = cd.generateClientEventErrorPayload(
           new WebexHttpError.Unauthorized({
@@ -1601,6 +1628,33 @@ describe('internal-plugin-metrics', () => {
           fatal: true,
           name: 'other',
           shownToUser: false,
+          serviceErrorCode: undefined,
+          errorCode: 1010,
+        });
+      });
+
+      it('should override custom properties for an Unauthorized error', () => {
+        const error = new WebexHttpError.Unauthorized({
+          url: 'https://example.com',
+          statusCode: 0,
+          body: {},
+          options: {headers: {}, url: 'https://example.com'},
+        });
+        
+        error.payloadOverrides = {
+          shownToUser: true,
+          category: 'expected'
+        };
+
+        const res = cd.generateClientEventErrorPayload(
+          error
+        );
+        assert.deepEqual(res, {
+          category: 'expected',
+          errorDescription: '{}\nundefined https://example.com\nWEBEX_TRACKING_ID: undefined\n',
+          fatal: true,
+          name: 'other',
+          shownToUser: true,
           serviceErrorCode: undefined,
           errorCode: 1010,
         });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Add payload overrides to the CA metric errors. This way we can customize the metric e.g. shownToUser without needing to update the definition in the sdk.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
