### PR TITLE
fix(calling): exporting interfaces, types from index.ts file

### DIFF
--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -1,4 +1,26 @@
 import {NoiseReductionEffect, createMicrophoneStream} from '@webex/media-helpers';
+import {ERROR_LAYER} from './Errors/types';
+import {ICallingClient} from './CallingClient/types';
+import {ICallHistory, JanusResponseEvent} from './CallHistory/types';
+import {
+  CallForwardSetting,
+  CallSettingResponse,
+  ICallSettings,
+  VoicemailSetting,
+} from './CallSettings/types';
+import {Contact, ContactResponse, GroupType, IContacts} from './Contacts/types';
+import {IVoicemail, SummaryInfo, VoicemailResponseEvent} from './Voicemail/types';
+import {ILine, LINE_EVENTS} from './CallingClient/line/types';
+import {
+  CALLING_CLIENT_EVENT_KEYS,
+  CALL_EVENT_KEYS,
+  CallerIdDisplay,
+  Disposition,
+  LINE_EVENT_KEYS,
+} from './Events/types';
+import {CallDetails, CallDirection, CallType, DisplayInformation, SORT} from './common/types';
+import {CallError} from './Errors';
+import {ICall, TransferType} from './CallingClient/calling/types';
 import {createCallSettingsClient} from './CallSettings/CallSettings';
 import {createContactsClient} from './Contacts/ContactsClient';
 import {createClient} from './CallingClient/CallingClient';
@@ -15,4 +37,33 @@ export {
   createVoicemailClient,
   Logger,
   NoiseReductionEffect,
+};
+
+// Interfaces
+export {ICallingClient, ICallHistory, ICallSettings, IContacts, IVoicemail, ICall, ILine};
+
+export {
+  CallDetails,
+  CallDirection,
+  CallerIdDisplay,
+  CallError,
+  CALL_EVENT_KEYS,
+  CALLING_CLIENT_EVENT_KEYS,
+  CallType,
+  DisplayInformation,
+  Disposition,
+  ERROR_LAYER,
+  LINE_EVENTS,
+  LINE_EVENT_KEYS,
+  SORT,
+  SummaryInfo,
+  TransferType,
+  CallForwardSetting,
+  CallSettingResponse,
+  Contact,
+  ContactResponse,
+  GroupType,
+  JanusResponseEvent,
+  VoicemailSetting,
+  VoicemailResponseEvent,
 };


### PR DESCRIPTION
# COMPLETES #[SPARK-479560](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-479560) 

## This pull request addresses
Exporting interfaces, types from Calling SDK so that in web client imports can be done directly from @webex/calling instead of accessing @webex/calling/dist/types and having different paths for each type.

## by making the following changes


<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
