### PR TITLE
fix(call): error-handling-for-empty-track-while-answer-dial

### DIFF
--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -120,6 +120,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
 
   private connected: boolean;
 
+  private mediaInactivity: boolean;
+
   private callerInfo: DisplayInformation;
 
   private localRoapMessage: RoapMessage; // Use it for new offer
@@ -209,6 +211,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     this.correlationId = uuid();
     this.deleteCb = deleteCb;
     this.connected = false;
+    this.mediaInactivity = false;
     this.held = false;
     this.earlyMedia = false;
     this.callerInfo = {} as DisplayInformation;
@@ -218,7 +221,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     this.receivedRoapOKSeq = 0;
     this.mediaNegotiationCompleted = false;
 
-    log.info(`Mobius Url:- ${this.mobiusUrl}`, {
+    log.info(`Webex Calling Url:- ${this.mobiusUrl}`, {
       file: CALL_FILE,
       method: 'constructor',
     });
@@ -912,7 +915,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       });
       this.setCallId(response.body.callId);
     } catch (e) {
-      log.warn('Call setup failed with Mobius', {
+      log.warn('Failed to setup the call', {
         file: CALL_FILE,
         method: this.handleOutgoingCallSetup.name,
       });
@@ -981,7 +984,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         }, SUPPLEMENTARY_SERVICES_TIMEOUT);
       }
     } catch (e) {
-      log.warn('Call Hold failed with Mobius', {
+      log.warn('Failed to put the call on hold', {
         file: CALL_FILE,
         method: this.handleCallHold.name,
       });
@@ -1050,7 +1053,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         }, SUPPLEMENTARY_SERVICES_TIMEOUT);
       }
     } catch (e) {
-      log.warn('Call Resume failed with Mobius', {
+      log.warn('Failed to resume the call', {
         file: CALL_FILE,
         method: this.handleCallResume.name,
       });
@@ -1168,7 +1171,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: this.handleOutgoingCallAlerting.name,
       });
     } catch (err) {
-      log.warn('Call Progress failed with Mobius', {
+      log.warn('Failed to signal call progression', {
         file: CALL_FILE,
         method: this.handleOutgoingCallAlerting.name,
       });
@@ -1235,18 +1238,19 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       return;
     }
 
-    /* send call_connect PATCH */
     try {
+      /* Start Offer/Answer as we might have buffered the offer by now */
+      this.mediaConnection.roapMessageReceived(this.remoteRoapMessage);
+
+      /* send call_connect PATCH */
       const res = await this.patch(MobiusCallState.CONNECTED);
 
       log.log(`PATCH response: ${res.statusCode}`, {
         file: CALL_FILE,
         method: this.handleOutgoingCallConnect.name,
       });
-      /* Start Offer/Answer as we might have buffered the offer by now */
-      this.mediaConnection.roapMessageReceived(this.remoteRoapMessage);
     } catch (err) {
-      log.warn('Call Connect failed with Mobius', {
+      log.warn('Failed to connect the call', {
         file: CALL_FILE,
         method: this.handleOutgoingCallConnect.name,
       });
@@ -1291,7 +1295,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: this.handleIncomingCallDisconnect.name,
       });
     } catch (e) {
-      log.warn('Delete Call failed with Mobius', {
+      log.warn('Failed to delete the call', {
         file: CALL_FILE,
         method: this.handleIncomingCallDisconnect.name,
       });
@@ -1333,7 +1337,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: this.handleOutgoingCallDisconnect.name,
       });
     } catch (e) {
-      log.warn('Delete Call failed with Mobius', {
+      log.warn('Failed to delete the call', {
         file: CALL_FILE,
         method: this.handleOutgoingCallDisconnect.name,
       });
@@ -1467,7 +1471,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: this.handleUnknownState.name,
       });
     } catch (e) {
-      log.warn('Delete Call failed with Mobius', {
+      log.warn('Failed to delete the call', {
         file: CALL_FILE,
         method: this.handleUnknownState.name,
       });
@@ -1579,7 +1583,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
           this.sendCallStateMachineEvt({type: 'E_CALL_ESTABLISHED'});
         }
       } catch (err) {
-        log.warn('MediaOk failed with Mobius', {
+        log.warn('Failed to process MediaOk request', {
           file: CALL_FILE,
           method: 'handleRoapEstablished',
         });
@@ -1658,7 +1662,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
           method: this.handleRoapError.name,
         });
       } catch (err) {
-        log.warn('Failed to communicate ROAP error with Mobius', {
+        log.warn('Failed to communicate ROAP error to Webex Calling', {
           file: CALL_FILE,
           method: this.handleRoapError.name,
         });
@@ -1726,7 +1730,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: this.handleOutgoingRoapOffer.name,
       });
     } catch (err) {
-      log.warn('MediaOk failed with Mobius', {
+      log.warn('Failed to process MediaOk request', {
         file: CALL_FILE,
         method: this.handleOutgoingRoapOffer.name,
       });
@@ -1774,7 +1778,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: this.handleOutgoingRoapAnswer.name,
       });
     } catch (err) {
-      log.warn('MediaAnswer failed with Mobius', {
+      log.warn('Failed to send MediaAnswer request', {
         file: CALL_FILE,
         method: this.handleOutgoingRoapAnswer.name,
       });
@@ -1946,7 +1950,10 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
    *
    */
   private setDisconnectReason() {
-    if (this.connected || this.direction === CallDirection.OUTBOUND) {
+    if (this.mediaInactivity) {
+      this.disconnectReason.code = DisconnectCode.MEDIA_INACTIVITY;
+      this.disconnectReason.cause = DisconnectCause.MEDIA_INACTIVITY;
+    } else if (this.connected || this.direction === CallDirection.OUTBOUND) {
       this.disconnectReason.code = DisconnectCode.NORMAL;
       this.disconnectReason.cause = DisconnectCause.NORMAL;
     } else {
@@ -1971,6 +1978,18 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
    */
   public async answer(localAudioStream: LocalMicrophoneStream) {
     const localAudioTrack = localAudioStream.outputStream.getAudioTracks()[0];
+
+    if (!localAudioTrack) {
+      log.warn(`Did not find a local track while answering the call ${this.getCorrelationId()}`, {
+        file: CALL_FILE,
+        method: 'answer',
+      });
+      this.mediaInactivity = true;
+      this.sendCallStateMachineEvt({type: 'E_SEND_CALL_DISCONNECT'});
+
+      return;
+    }
+
     localAudioTrack.enabled = true;
 
     if (!this.mediaConnection) {
@@ -1996,6 +2015,17 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
    */
   public async dial(localAudioStream: LocalMicrophoneStream) {
     const localAudioTrack = localAudioStream.outputStream.getAudioTracks()[0];
+    if (!localAudioTrack) {
+      log.warn(`Did not find a local track while dialling the call ${this.getCorrelationId()}`, {
+        file: CALL_FILE,
+        method: 'dial',
+      });
+
+      this.deleteCb(this.getCorrelationId());
+      this.emit(CALL_EVENT_KEYS.DISCONNECT, this.getCorrelationId());
+
+      return;
+    }
     localAudioTrack.enabled = true;
 
     if (!this.mediaConnection) {
@@ -2052,7 +2082,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
    * @param state -.
    */
   private async patch(state: MobiusCallState): Promise<PatchResponse> {
-    log.info(`Send a PATCH for ${state} to mobius`, {
+    log.info(`Send a PATCH for ${state} to Webex Calling`, {
       file: CALL_FILE,
       method: this.patch.name,
     });
@@ -2296,7 +2326,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
    * @param roapMessage -.
    */
   private async postMedia(roapMessage: RoapMessage): Promise<WebexRequestPayload> {
-    log.log('Posting message to mobius', {
+    log.log('Posting message to Webex Calling', {
       file: CALL_FILE,
       method: this.postMedia.name,
     });

--- a/packages/calling/src/CallingClient/calling/callManager.test.ts
+++ b/packages/calling/src/CallingClient/calling/callManager.test.ts
@@ -275,7 +275,7 @@ describe('Call Manager Tests with respect to calls', () => {
     await waitForMsecs(50);
 
     expect(patchMock).toHaveBeenCalledWith(MobiusCallState.ALERTING);
-    expect(warnSpy).toHaveBeenCalledWith('Call Progress failed with Mobius', {
+    expect(warnSpy).toHaveBeenCalledWith('Failed to signal call progression', {
       file: 'call',
       method: 'handleOutgoingCallAlerting',
     });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-471758](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-471758)
## This pull request addresses

Developers could pass empty localAudioStream to dial and answer API which led to roapMessageReceived failing. For an incoming call, the patch is first sent to Mobius then roapMessageReceived is called, in the scenario where roapMessageReceived failed since the patch is already sent the call state changes to connected even though we do not have a localAudioTrack.

## by making the following changes

- While answering, if localAudioTrack is empty call is not connected and disconnect is sent to mobius. A warning message is also given.
- While dialing, If localAudioTrack is empty, call is cleared immediately and warning message is given
- First call roapMessageReceived and then send patch to Mobius.

[dial-flow.log](https://github.com/webex/webex-js-sdk/files/13736845/dial-flow.log)
[answer-flow.log](https://github.com/webex/webex-js-sdk/files/13736846/answer-flow.log)


<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
- I removed the await in the samples app and called the answer API
- Also harcoded an empty localAudioTrack in samples and called answer API
- UTs

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
