### PR TITLE
fix(calling): remove logging of personal info

### DIFF
--- a/packages/calling/src/CallingClient/calling/CallerId/index.ts
+++ b/packages/calling/src/CallingClient/calling/CallerId/index.ts
@@ -138,10 +138,6 @@ export class CallerId implements ICallerId {
 
     if (nameMatch) {
       result.name = nameMatch[0].trimEnd();
-      log.info(`Parsed Name: ${result.name}`, {
-        file: CALLER_ID_FILE,
-        method: 'parseSipUri',
-      });
     } else {
       log.warn(`Name field not found!`, {
         file: CALLER_ID_FILE,
@@ -153,10 +149,6 @@ export class CallerId implements ICallerId {
 
     if (phoneMatch && phoneMatch[0].length === num.length) {
       result.num = num;
-      log.info(`Parsed Number: ${result.num}`, {
-        file: CALLER_ID_FILE,
-        method: 'parseSipUri',
-      });
     } else {
       log.warn(`Number field not found!`, {
         file: CALLER_ID_FILE,
@@ -183,7 +175,7 @@ export class CallerId implements ICallerId {
     this.callerInfo.num = undefined;
 
     if ('p-asserted-identity' in callerId) {
-      log.info(`Parsing p-asserted-identity:- ${callerId['p-asserted-identity']}`, {
+      log.info('Parsing p-asserted-identity within remote party information', {
         file: CALLER_ID_FILE,
         method: 'fetchCallerDetails',
       });
@@ -192,28 +184,15 @@ export class CallerId implements ICallerId {
       /* For P-Asserted-Identity, we update the callerInfo blindly, as it is of highest preference */
       this.callerInfo.name = result.name;
       this.callerInfo.num = result.num;
-
-      log.info(
-        `CallerId retrieved from p-asserted-identity: name: ${this.callerInfo.name} , num: ${this.callerInfo.num}`,
-        {
-          file: CALLER_ID_FILE,
-          method: 'fetchCallerDetails',
-        }
-      );
     }
 
     if (callerId.from) {
-      log.info(`Parsing from header:- ${callerId.from}`, {
+      log.info('Parsing from header within the remote party information', {
         file: CALLER_ID_FILE,
         method: 'fetchCallerDetails',
       });
 
       const result = this.parseSipUri(callerId.from);
-
-      log.info(`CallerId retrieved from FROM: name: ${result.name} , num: ${result.num}`, {
-        file: CALLER_ID_FILE,
-        method: 'fetchCallerDetails',
-      });
 
       /* For From header , we should only update if not filled already by P-Asserted-Identity */
       if (!this.callerInfo.name && result.name) {
@@ -241,24 +220,13 @@ export class CallerId implements ICallerId {
 
     /* We need to parse x-broadworks-remote-party-info if present asynchronously */
     if ('x-broadworks-remote-party-info' in callerId) {
-      log.info(
-        `Parsing x-broadworks-remote-party-info:- ${callerId['x-broadworks-remote-party-info']}`,
-        {
-          file: CALLER_ID_FILE,
-          method: 'fetchCallerDetails',
-        }
-      );
+      log.info('Parsing x-broadworks-remote-party-info within remote party information', {
+        file: CALLER_ID_FILE,
+        method: 'fetchCallerDetails',
+      });
 
       this.parseRemotePartyInfo(callerId['x-broadworks-remote-party-info'] as string);
     }
-
-    log.log(
-      `Intermediate callerId :- name: ${this.callerInfo.name} , num: ${this.callerInfo.num}`,
-      {
-        file: CALLER_ID_FILE,
-        method: 'fetchCallerDetails',
-      }
-    );
 
     return this.callerInfo;
   }

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -1250,14 +1250,6 @@ export async function resolveCallerIdDisplay(filter: string) {
     displayResult.avatarSrc = photo ? photo.value : 'unknown';
 
     displayResult.id = scimResource.id;
-
-    log.info(
-      `Extracted details:- name: ${displayResult.name} , number: ${displayResult.num}, photo: ${displayResult.avatarSrc}, id: ${displayResult.id}`,
-      {
-        file: UTILS_FILE,
-        method: 'resolveCallerIdDisplay',
-      }
-    );
   }
 
   return displayResult;


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # NA

## This pull request addresses
the issue of names and numbers being logged by @webex/calling during resolution of the caller ID.

## by making the following changes
Removed the logging of this information from the statements where they are printed.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

* Tested an outgoing call and ensured that the Caller ID is working fine.
* Checked the logs in the outgoing call and ensured that the name and number isn't being logged by the calling package anywhere

[remove-PII.log](https://github.com/webex/webex-js-sdk/files/13742594/remove-PII.log)

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
