### PR TITLE
fix(meetings): ensure non-undefined value for peripheral information property

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -198,18 +198,16 @@ export class StatsAnalyzer extends EventsScope {
     newMqa.intervalMetadata.peerReflexiveIP = this.statsResults.connectionType.local.ipAddress;
 
     // Adding peripheral information
-    newMqa.intervalMetadata.peripherals = [];
-
     newMqa.intervalMetadata.peripherals.push({information: _UNKNOWN_, name: MEDIA_DEVICES.SPEAKER});
     if (this.statsResults['audio-send']) {
       newMqa.intervalMetadata.peripherals.push({
-        information: this.statsResults['audio-send']?.trackLabel,
+        information: this.statsResults['audio-send'].trackLabel || _UNKNOWN_,
         name: MEDIA_DEVICES.MICROPHONE,
       });
     }
     if (this.statsResults['video-send']) {
       newMqa.intervalMetadata.peripherals.push({
-        information: this.statsResults['video-send']?.trackLabel,
+        information: this.statsResults['video-send'].trackLabel || _UNKNOWN_,
         name: MEDIA_DEVICES.CAMERA,
       });
     }

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -7,6 +7,7 @@ import {ConnectionState} from '@webex/internal-media-core';
 import {StatsAnalyzer, EVENTS} from '../../../../src/statsAnalyzer';
 import NetworkQualityMonitor from '../../../../src/networkQualityMonitor';
 import testUtils from '../../../utils/testUtils';
+import {MEDIA_DEVICES} from '@webex/plugin-meetings/src/constants';
 
 const {assert} = chai;
 
@@ -119,6 +120,7 @@ describe('plugin-meetings', () => {
           audio: {
             senders: [
               {
+                localTrackLabel: 'fake-microphone',
                 report: [
                   {
                     type: 'outbound-rtp',
@@ -173,6 +175,7 @@ describe('plugin-meetings', () => {
           video: {
             senders: [
               {
+                localTrackLabel: 'fake-camera',
                 report: [
                   {
                     type: 'outbound-rtp',
@@ -412,6 +415,15 @@ describe('plugin-meetings', () => {
 
         assert.strictEqual(mqeData.audioTransmit[0].common.transportType, 'TLS');
         assert.strictEqual(mqeData.videoReceive[0].common.transportType, 'TLS');
+      });
+
+      it('emits the correct peripherals in MEDIA_QUALITY events', async () => {
+        await startStatsAnalyzer({expected: {receiveVideo: true}});
+
+        await progressTime();
+
+        assert.strictEqual(mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.MICROPHONE).information, 'fake-microphone');
+        assert.strictEqual(mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.CAMERA).information, 'fake-camera');
       });
     });
   });

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -7,7 +7,7 @@ import {ConnectionState} from '@webex/internal-media-core';
 import {StatsAnalyzer, EVENTS} from '../../../../src/statsAnalyzer';
 import NetworkQualityMonitor from '../../../../src/networkQualityMonitor';
 import testUtils from '../../../utils/testUtils';
-import {MEDIA_DEVICES} from '@webex/plugin-meetings/src/constants';
+import {MEDIA_DEVICES, _UNKNOWN_} from '@webex/plugin-meetings/src/constants';
 
 const {assert} = chai;
 
@@ -424,6 +424,18 @@ describe('plugin-meetings', () => {
 
         assert.strictEqual(mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.MICROPHONE).information, 'fake-microphone');
         assert.strictEqual(mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.CAMERA).information, 'fake-camera');
+      });
+
+      it('emits the correct peripherals in MEDIA_QUALITY events when localTrackLabel is undefined', async () => {
+        fakeStats.audio.senders[0].localTrackLabel = undefined;
+        fakeStats.video.senders[0].localTrackLabel = undefined;
+
+        await startStatsAnalyzer({expected: {receiveVideo: true}});
+
+        await progressTime();
+
+        assert.strictEqual(mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.MICROPHONE).information, _UNKNOWN_);
+        assert.strictEqual(mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.CAMERA).information, _UNKNOWN_);
       });
     });
   });


### PR DESCRIPTION
## This pull request addresses

The MQE `peripherals` values are sometimes missing the `information` property.

## by making the following changes

ensuring that the `information` property is not undefined.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
