### PR TITLE
fix(calling): extend eventing class on ILine interface 

### DIFF
--- a/packages/calling/src/CallingClient/line/index.ts
+++ b/packages/calling/src/CallingClient/line/index.ts
@@ -43,6 +43,8 @@ export default class Line extends Eventing<LineEventTypes> implements ILine {
 
   public mobiusDeviceId?: string;
 
+  private mobiusUri?: string;
+
   public phoneNumber?: string;
 
   public extension?: string;
@@ -159,7 +161,7 @@ export default class Line extends Eventing<LineEventTypes> implements ILine {
     this.mobiusDeviceId = device?.deviceId;
     this.mobiusUri = device?.uri;
     this.lastSeen = device?.lastSeen;
-    this.sipAddresses = device?.addresses;
+    this.sipAddresses = device?.addresses ?? [];
     this.keepaliveInterval = keepaliveInterval;
     this.callKeepaliveInterval = callKeepaliveInterval;
     this.rehomingIntervalMin = rehomingIntervalMin;

--- a/packages/calling/src/CallingClient/line/index.ts
+++ b/packages/calling/src/CallingClient/line/index.ts
@@ -9,7 +9,7 @@ import {
   RegistrationStatus,
   ServiceIndicator,
 } from '../../common/types';
-import {ILine, LINE_EVENTS, LineEventTypes} from './types';
+import {ILine, LINE_EVENTS} from './types';
 import {LINE_FILE, VALID_PHONE} from '../constants';
 import log from '../../Logger';
 import {IRegistration} from '../registration/types';
@@ -21,7 +21,7 @@ import {LineError} from '../../Errors/catalog/LineError';
 import {LOGGER} from '../../Logger/types';
 import {validateServiceData} from '../../common';
 import SDKConnector from '../../SDKConnector';
-import {LINE_EVENT_KEYS} from '../../Events/types';
+import {LINE_EVENT_KEYS, LineEventTypes} from '../../Events/types';
 import {ICall, ICallManager} from '../calling/types';
 import {getCallManager} from '../calling/callManager';
 import {ERROR_TYPE} from '../../Errors/types';
@@ -43,13 +43,11 @@ export default class Line extends Eventing<LineEventTypes> implements ILine {
 
   public mobiusDeviceId?: string;
 
-  private mobiusUri?: string;
-
   public phoneNumber?: string;
 
   public extension?: string;
 
-  public sipAddresses?: string[];
+  public sipAddresses: string[] = [];
 
   public voicemail?: string;
 

--- a/packages/calling/src/CallingClient/line/types.ts
+++ b/packages/calling/src/CallingClient/line/types.ts
@@ -1,3 +1,5 @@
+import {LineEventTypes} from '../../Events/types';
+import {Eventing} from '../../Events/impl';
 import {IRegistration} from '../registration/types';
 import {LineError} from '../../Errors/catalog/LineError';
 import {
@@ -22,7 +24,7 @@ export enum LINE_EVENTS {
 /**
  * Represents an interface for managing a telephony line.
  */
-export interface ILine {
+export interface ILine extends Eventing<LineEventTypes> {
   /**
    * The unique identifier of the user associated with the line.
    */
@@ -171,16 +173,6 @@ export interface ILine {
    */
   getCall(correlationId: CorrelationId): ICall;
 }
-
-export type LineEventTypes = {
-  [LINE_EVENTS.CONNECTING]: () => void;
-  [LINE_EVENTS.ERROR]: (error: LineError) => void;
-  [LINE_EVENTS.RECONNECTED]: () => void;
-  [LINE_EVENTS.RECONNECTING]: () => void;
-  [LINE_EVENTS.REGISTERED]: (lineInfo: ILine) => void;
-  [LINE_EVENTS.UNREGISTERED]: () => void;
-  [LINE_EVENTS.INCOMING_CALL]: (callObj: ICall) => void;
-};
 
 export type LineEmitterCallback = (
   event: LINE_EVENTS,

--- a/packages/calling/src/Errors/index.ts
+++ b/packages/calling/src/Errors/index.ts
@@ -1,2 +1,3 @@
 export {CallingClientError} from './catalog/CallingDeviceError';
 export {CallError} from './catalog/CallError';
+export {LineError} from './catalog/LineError';

--- a/packages/calling/src/Events/types.ts
+++ b/packages/calling/src/Events/types.ts
@@ -219,8 +219,6 @@ export type CallHistoryEventTypes = {
 /* External Eventing End */
 
 /** Internal Eventing Start */
-// https://sqbu-github.cisco.com/pages/webrtc-calling/mobius/mobius-api-spec/docs/async.html#operation-publish-calls
-
 enum CALL_STATE {
   HELD = 'held',
   REMOTE_HELD = 'remoteheld',

--- a/packages/calling/src/Events/types.ts
+++ b/packages/calling/src/Events/types.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */ // TODO: remove once we define the payloads
+import {ILine} from '../api';
+import {LINE_EVENTS} from '../CallingClient/line/types';
 import type {ICall} from '../CallingClient/calling/types';
 import {CallId, DisplayInformation} from '../common/types';
-import {CallError, CallingClientError} from '../Errors';
+import {CallError, CallingClientError, LineError} from '../Errors';
 
 /** External Eventing Start */
 export enum COMMON_EVENT_KEYS {
@@ -178,6 +180,16 @@ export enum MEDIA_CONNECTION_EVENT_KEYS {
 export type CallerIdDisplay = {
   correlationId: string;
   callerId: DisplayInformation;
+};
+
+export type LineEventTypes = {
+  [LINE_EVENTS.CONNECTING]: () => void;
+  [LINE_EVENTS.ERROR]: (error: LineError) => void;
+  [LINE_EVENTS.RECONNECTED]: () => void;
+  [LINE_EVENTS.RECONNECTING]: () => void;
+  [LINE_EVENTS.REGISTERED]: (lineInfo: ILine) => void;
+  [LINE_EVENTS.UNREGISTERED]: () => void;
+  [LINE_EVENTS.INCOMING_CALL]: (callObj: ICall) => void;
 };
 
 export type CallEventTypes = {

--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -1,26 +1,4 @@
 import {NoiseReductionEffect, createMicrophoneStream} from '@webex/media-helpers';
-import {ERROR_LAYER, ERROR_TYPE} from './Errors/types';
-import {ICallingClient} from './CallingClient/types';
-import {ICallHistory, JanusResponseEvent} from './CallHistory/types';
-import {
-  CallForwardSetting,
-  CallSettingResponse,
-  ICallSettings,
-  VoicemailSetting,
-} from './CallSettings/types';
-import {Contact, ContactResponse, GroupType, IContacts} from './Contacts/types';
-import {IVoicemail, SummaryInfo, VoicemailResponseEvent} from './Voicemail/types';
-import {ILine, LINE_EVENTS} from './CallingClient/line/types';
-import {
-  CALLING_CLIENT_EVENT_KEYS,
-  CALL_EVENT_KEYS,
-  CallerIdDisplay,
-  Disposition,
-  LINE_EVENT_KEYS,
-} from './Events/types';
-import {CallDetails, CallDirection, CallType, DisplayInformation, SORT} from './common/types';
-import {CallError, LineError} from './Errors';
-import {ICall, TransferType} from './CallingClient/calling/types';
 import {createCallSettingsClient} from './CallSettings/CallSettings';
 import {createContactsClient} from './Contacts/ContactsClient';
 import {createClient} from './CallingClient/CallingClient';
@@ -39,33 +17,25 @@ export {
   NoiseReductionEffect,
 };
 
-// Interfaces
-export {ICallingClient, ICallHistory, ICallSettings, IContacts, IVoicemail, ICall, ILine};
-
+export {ERROR_LAYER, ERROR_TYPE} from './Errors/types';
+export {ICallingClient} from './CallingClient/types';
+export {ICallHistory, JanusResponseEvent} from './CallHistory/types';
 export {
-  CallDetails,
-  CallDirection,
-  CallerIdDisplay,
-  CallError,
-  CALL_EVENT_KEYS,
-  CALLING_CLIENT_EVENT_KEYS,
-  CallType,
-  DisplayInformation,
-  Disposition,
-  ERROR_LAYER,
-  ERROR_TYPE,
-  LINE_EVENTS,
-  LINE_EVENT_KEYS,
-  LineError,
-  SORT,
-  SummaryInfo,
-  TransferType,
   CallForwardSetting,
   CallSettingResponse,
-  Contact,
-  ContactResponse,
-  GroupType,
-  JanusResponseEvent,
+  ICallSettings,
   VoicemailSetting,
-  VoicemailResponseEvent,
-};
+} from './CallSettings/types';
+export {Contact, ContactResponse, GroupType, IContacts} from './Contacts/types';
+export {IVoicemail, SummaryInfo, VoicemailResponseEvent} from './Voicemail/types';
+export {ILine, LINE_EVENTS} from './CallingClient/line/types';
+export {
+  CALLING_CLIENT_EVENT_KEYS,
+  CALL_EVENT_KEYS,
+  CallerIdDisplay,
+  Disposition,
+  LINE_EVENT_KEYS,
+} from './Events/types';
+export {CallDetails, CallDirection, CallType, DisplayInformation, SORT} from './common/types';
+export {CallError, LineError} from './Errors';
+export {ICall, TransferType} from './CallingClient/calling/types';

--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -22,8 +22,10 @@ export {ICallingClient} from './CallingClient/types';
 export {ICallHistory, JanusResponseEvent} from './CallHistory/types';
 export {
   CallForwardSetting,
+  CallForwardAlwaysSetting,
   CallSettingResponse,
   ICallSettings,
+  ToggleSetting,
   VoicemailSetting,
 } from './CallSettings/types';
 export {Contact, ContactResponse, GroupType, IContacts} from './Contacts/types';

--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -35,7 +35,16 @@ export {
   CallerIdDisplay,
   Disposition,
   LINE_EVENT_KEYS,
+  COMMON_EVENT_KEYS,
+  UserSession,
 } from './Events/types';
-export {CallDetails, CallDirection, CallType, DisplayInformation, SORT} from './common/types';
+export {
+  CallDetails,
+  CallDirection,
+  CallType,
+  DisplayInformation,
+  SORT,
+  SORT_BY,
+} from './common/types';
 export {CallError, LineError} from './Errors';
 export {ICall, TransferType} from './CallingClient/calling/types';

--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -50,3 +50,4 @@ export {
 } from './common/types';
 export {CallError, LineError} from './Errors';
 export {ICall, TransferType} from './CallingClient/calling/types';
+export {LOGGER} from './Logger/types';

--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -1,5 +1,5 @@
 import {NoiseReductionEffect, createMicrophoneStream} from '@webex/media-helpers';
-import {ERROR_LAYER} from './Errors/types';
+import {ERROR_LAYER, ERROR_TYPE} from './Errors/types';
 import {ICallingClient} from './CallingClient/types';
 import {ICallHistory, JanusResponseEvent} from './CallHistory/types';
 import {
@@ -19,7 +19,7 @@ import {
   LINE_EVENT_KEYS,
 } from './Events/types';
 import {CallDetails, CallDirection, CallType, DisplayInformation, SORT} from './common/types';
-import {CallError} from './Errors';
+import {CallError, LineError} from './Errors';
 import {ICall, TransferType} from './CallingClient/calling/types';
 import {createCallSettingsClient} from './CallSettings/CallSettings';
 import {createContactsClient} from './Contacts/ContactsClient';
@@ -53,8 +53,10 @@ export {
   DisplayInformation,
   Disposition,
   ERROR_LAYER,
+  ERROR_TYPE,
   LINE_EVENTS,
   LINE_EVENT_KEYS,
+  LineError,
   SORT,
   SummaryInfo,
   TransferType,

--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -1,4 +1,26 @@
 import {NoiseReductionEffect, createMicrophoneStream} from '@webex/media-helpers';
+import {ERROR_LAYER} from './Errors/types';
+import {ICallingClient} from './CallingClient/types';
+import {ICallHistory, JanusResponseEvent} from './CallHistory/types';
+import {
+  CallForwardSetting,
+  CallSettingResponse,
+  ICallSettings,
+  VoicemailSetting,
+} from './CallSettings/types';
+import {Contact, ContactResponse, GroupType, IContacts} from './Contacts/types';
+import {IVoicemail, SummaryInfo, VoicemailResponseEvent} from './Voicemail/types';
+import {ILine, LINE_EVENTS} from './CallingClient/line/types';
+import {
+  CALLING_CLIENT_EVENT_KEYS,
+  CALL_EVENT_KEYS,
+  CallerIdDisplay,
+  Disposition,
+  LINE_EVENT_KEYS,
+} from './Events/types';
+import {CallDetails, CallDirection, CallType, DisplayInformation, SORT} from './common/types';
+import {CallError} from './Errors';
+import {ICall, TransferType} from './CallingClient/calling/types';
 import {createCallSettingsClient} from './CallSettings/CallSettings';
 import {createContactsClient} from './Contacts/ContactsClient';
 import {createClient} from './CallingClient/CallingClient';
@@ -15,4 +37,33 @@ export {
   createVoicemailClient,
   Logger,
   NoiseReductionEffect,
+};
+
+// Interfaces
+export {ICallingClient, ICallHistory, ICallSettings, IContacts, IVoicemail, ICall, ILine};
+
+export {
+  CallDetails,
+  CallDirection,
+  CallerIdDisplay,
+  CallError,
+  CALL_EVENT_KEYS,
+  CALLING_CLIENT_EVENT_KEYS,
+  CallType,
+  DisplayInformation,
+  Disposition,
+  ERROR_LAYER,
+  LINE_EVENTS,
+  LINE_EVENT_KEYS,
+  SORT,
+  SummaryInfo,
+  TransferType,
+  CallForwardSetting,
+  CallSettingResponse,
+  Contact,
+  ContactResponse,
+  GroupType,
+  JanusResponseEvent,
+  VoicemailSetting,
+  VoicemailResponseEvent,
 };


### PR DESCRIPTION
# COMPLETES #[SPARK-479560](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-479560)

## This pull request addresses
There were compilation errors on the ILine interface due to which we weren't able to receive events on line object.

## by making the following changes
Addition of extending eventing class on ILine interface and small corrections.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
I ran the build and unit tests locally to check everything was passing after the changes.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
