### PR TITLE
feat(plugin-metrics): add error handling to assign role function

### DIFF
--- a/packages/@webex/plugin-meetings/src/common/errors/reclaim-host-empty-wrong-key.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/reclaim-host-empty-wrong-key.ts
@@ -1,0 +1,35 @@
+import * as MEETINGCONSTANTS from '../../constants';
+
+/**
+ * Extended Error object for reclaim host role empty or wrong key
+ */
+export default class ReclaimHostEmptyWrongKeyError extends Error {
+  sdkMessage: string;
+  error: null;
+  code: number;
+
+  /**
+   *
+   * @constructor
+   * @param {String} [message]
+   * @param {Object} [error]
+   */
+  constructor(
+    message: string = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_EMPTY_OR_WRONG_KEY
+      .MESSAGE,
+    error: any = null
+  ) {
+    super(message);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ReclaimHostEmptyWrongKeyError);
+    }
+
+    this.name = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_EMPTY_OR_WRONG_KEY.NAME;
+    this.sdkMessage =
+      message || MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_EMPTY_OR_WRONG_KEY.MESSAGE;
+    this.error = error;
+
+    this.code = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_EMPTY_OR_WRONG_KEY.CODE;
+  }
+}

--- a/packages/@webex/plugin-meetings/src/common/errors/reclaim-host-is-host-already.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/reclaim-host-is-host-already.ts
@@ -1,0 +1,34 @@
+import * as MEETINGCONSTANTS from '../../constants';
+
+/**
+ * Extended Error object for reclaim host role when user is host already
+ */
+export default class ReclaimHostIsHostAlreadyError extends Error {
+  sdkMessage: string;
+  error: null;
+  code: number;
+
+  /**
+   *
+   * @constructor
+   * @param {String} [message]
+   * @param {Object} [error]
+   */
+  constructor(
+    message: string = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_IS_ALREADY_HOST.MESSAGE,
+    error: any = null
+  ) {
+    super(message);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ReclaimHostIsHostAlreadyError);
+    }
+
+    this.name = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_IS_ALREADY_HOST.NAME;
+    this.sdkMessage =
+      message || MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_IS_ALREADY_HOST.MESSAGE;
+    this.error = error;
+
+    this.code = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_IS_ALREADY_HOST.CODE;
+  }
+}

--- a/packages/@webex/plugin-meetings/src/common/errors/reclaim-host-not-allowed.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/reclaim-host-not-allowed.ts
@@ -1,0 +1,34 @@
+import * as MEETINGCONSTANTS from '../../constants';
+
+/**
+ * Extended Error object for reclaim host role not allowed for other participants
+ */
+export default class ReclaimHostNotAllowedError extends Error {
+  sdkMessage: string;
+  error: null;
+  code: number;
+
+  /**
+   *
+   * @constructor
+   * @param {String} [message]
+   * @param {Object} [error]
+   */
+  constructor(
+    message: string = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_ALLOWED.MESSAGE,
+    error: any = null
+  ) {
+    super(message);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ReclaimHostNotAllowedError);
+    }
+
+    this.name = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_ALLOWED.NAME;
+    this.sdkMessage =
+      message || MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_ALLOWED.MESSAGE;
+    this.error = error;
+
+    this.code = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_ALLOWED.CODE;
+  }
+}

--- a/packages/@webex/plugin-meetings/src/common/errors/reclaim-host-not-supported.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/reclaim-host-not-supported.ts
@@ -1,0 +1,34 @@
+import * as MEETINGCONSTANTS from '../../constants';
+
+/**
+ * Extended Error object for reclaim host role not supported
+ */
+export default class ReclaimHostNotSupportedError extends Error {
+  sdkMessage: string;
+  error: null;
+  code: number;
+
+  /**
+   *
+   * @constructor
+   * @param {String} [message]
+   * @param {Object} [error]
+   */
+  constructor(
+    message: string = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_NOT_SUPPORTED.MESSAGE,
+    error: any = null
+  ) {
+    super(message);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ReclaimHostNotSupportedError);
+    }
+
+    this.name = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_NOT_SUPPORTED.NAME;
+    this.sdkMessage =
+      message || MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_NOT_SUPPORTED.MESSAGE;
+    this.error = error;
+
+    this.code = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_NOT_SUPPORTED.CODE;
+  }
+}

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -237,6 +237,14 @@ export const CALENDAR_EVENTS = {
   DELETE: 'event:calendar.meeting.delete',
 };
 
+// Specificied here: https://confluence-eng-gpk2.cisco.com/conf/display/LOCUS/Reclaim+Host+Role#:~:text=Note-,2400127,-Reclaim%20Host%20Role
+export const ASSIGN_ROLES_ERROR_CODES = {
+  ReclaimHostNotSupportedErrorCode: 2400127,
+  ReclaimHostNotAllowedErrorCode: 2403135,
+  ReclaimHostEmptyWrongKeyErrorCode: 2403136,
+  ReclaimHostIsHostAlreadyErrorCode: 2409150,
+};
+
 export const DEFAULT_GET_STATS_FILTER = {
   types: [
     'track',
@@ -491,6 +499,30 @@ export const ERROR_DICTIONARY = {
     NAME: 'NoMeetingInfo',
     MESSAGE: 'No meeting info found for the meeting',
     CODE: 10,
+  },
+  RECLAIM_HOST_NOT_SUPPORTED: {
+    NAME: 'ReclaimHostRoleNotSupported',
+    MESSAGE:
+      'Non converged meetings, PSTN or SIP users in converged meetings are not supported currently.',
+    CODE: 11,
+  },
+  RECLAIM_HOST_ROLE_NOT_ALLOWED: {
+    NAME: 'ReclaimHostRoleNotAllowed',
+    MESSAGE:
+      'Reclaim Host Role Not Allowed For Other Participants. Participants cannot claim host role in PMR meeting, space instant meeting or escalated instant meeting. However, the original host still can reclaim host role when it manually makes another participant to be the host.',
+    CODE: 12,
+  },
+  RECLAIM_HOST_ROLE_EMPTY_OR_WRONG_KEY: {
+    NAME: 'ReclaimHostRoleEmptyOrWrongKey',
+    MESSAGE:
+      'Host Key Not Specified Or Matched. The original host can reclaim the host role without entering the host key. However, any other person who claims the host role must enter the host key to get it.',
+    CODE: 13,
+  },
+  RECLAIM_HOST_ROLE_IS_ALREADY_HOST: {
+    NAME: 'ReclaimHostRoleIsAlreadyHost',
+    MESSAGE:
+      'Participant Having Host Role Already. Participant who sends request to reclaim host role has already a host role.',
+    CODE: 14,
   },
 };
 

--- a/packages/@webex/plugin-meetings/src/members/index.ts
+++ b/packages/@webex/plugin-meetings/src/members/index.ts
@@ -5,11 +5,22 @@ import {isEmpty} from 'lodash';
 // @ts-ignore
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
-import {MEETINGS, EVENT_TRIGGERS, FLOOR_ACTION, CONTENT, WHITEBOARD} from '../constants';
+import {
+  MEETINGS,
+  EVENT_TRIGGERS,
+  FLOOR_ACTION,
+  CONTENT,
+  WHITEBOARD,
+  ASSIGN_ROLES_ERROR_CODES,
+} from '../constants';
 import Trigger from '../common/events/trigger-proxy';
 import Member from '../member';
 import LoggerProxy from '../common/logs/logger-proxy';
 import ParameterError from '../common/errors/parameter';
+import ReclaimHostEmptyWrongKeyError from '../common/errors/reclaim-host-empty-wrong-key';
+import ReclaimHostIsHostAlreadyError from '../common/errors/reclaim-host-is-host-already';
+import ReclaimHostNotAllowedError from '../common/errors/reclaim-host-not-allowed';
+import ReclaimHostNotSupportedError from '../common/errors/reclaim-host-not-supported';
 
 import MembersCollection from './collection';
 import MembersRequest from './request';
@@ -856,7 +867,21 @@ export default class Members extends StatelessWebexPlugin {
     }
     const options = MembersUtil.generateRoleAssignmentMemberOptions(memberId, roles, this.locusUrl);
 
-    return this.membersRequest.assignRolesMember(options);
+    return this.membersRequest.assignRolesMember(options).catch((error: any) => {
+      const errorCode = error.body?.errorCode;
+      switch (errorCode) {
+        case ASSIGN_ROLES_ERROR_CODES.ReclaimHostNotSupportedErrorCode:
+          return Promise.reject(new ReclaimHostNotSupportedError());
+        case ASSIGN_ROLES_ERROR_CODES.ReclaimHostNotAllowedErrorCode:
+          return Promise.reject(new ReclaimHostNotAllowedError());
+        case ASSIGN_ROLES_ERROR_CODES.ReclaimHostEmptyWrongKeyErrorCode:
+          return Promise.reject(new ReclaimHostEmptyWrongKeyError());
+        case ASSIGN_ROLES_ERROR_CODES.ReclaimHostIsHostAlreadyErrorCode:
+          return Promise.reject(new ReclaimHostIsHostAlreadyError());
+        default:
+          return Promise.reject(error);
+      }
+    });
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/members/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/index.js
@@ -17,6 +17,10 @@ import MembersUtil from '@webex/plugin-meetings/src/members/util';
 import * as MembersRequestImport from '@webex/plugin-meetings/src/members/request';
 import Trigger from '@webex/plugin-meetings/src/common/events/trigger-proxy';
 import {EVENT_TRIGGERS} from '@webex/plugin-meetings/src/constants';
+import ReclaimHostEmptyWrongKeyError from '../../../../src/common/errors/reclaim-host-empty-wrong-key';
+import ReclaimHostIsHostAlreadyError from '../../../../src/common/errors/reclaim-host-is-host-already';
+import ReclaimHostNotAllowedError from '../../../../src/common/errors/reclaim-host-not-allowed';
+import ReclaimHostNotSupportedError from '../../../../src/common/errors/reclaim-host-not-supported';
 
 const {assert} = chai;
 
@@ -336,8 +340,18 @@ describe('plugin-meetings', () => {
       });
     });
 
-    describe('#assignRoles', () => {
-      const setup = (locusUrl) => {
+    describe.only('#assignRoles', () => {
+      const fakeRoles = [
+        {type: 'PRESENTER', hasRole: true},
+        {type: 'MODERATOR', hasRole: false},
+        {type: 'COHOST', hasRole: true},
+      ];
+
+      const resolvedValue = "it worked";
+
+      const genericMessage = 'Generic error from the API';
+
+      const setup = (locusUrl, errorCode) => {
         const members = createMembers({url: locusUrl});
 
         const spies = {
@@ -345,8 +359,13 @@ describe('plugin-meetings', () => {
             MembersUtil,
             'generateRoleAssignmentMemberOptions'
           ),
-          assignRolesMember: sandbox.spy(members.membersRequest, 'assignRolesMember'),
         };
+
+        if (errorCode) {
+          spies.assignRolesMember = sandbox.stub(members.membersRequest, 'assignRolesMember').rejects({body: {errorCode}, message: genericMessage});
+        } else {
+          spies.assignRolesMember = sandbox.stub(members.membersRequest, 'assignRolesMember').resolves(resolvedValue);
+        }
 
         return {members, spies};
       };
@@ -357,14 +376,8 @@ describe('plugin-meetings', () => {
         assert.notCalled(spies.assignRolesMember);
       };
 
-      const checkValid = async (
-        resultPromise,
-        spies,
-        expectedMemberId,
-        expectedRoles,
-        expectedLocusUrl
-      ) => {
-        await assert.isFulfilled(resultPromise);
+      const checkError = async (error, expectedMemberId, expectedRoles, expectedLocusUrl, resultPromise, expectedMessage, spies) => {
+        await assert.isRejected(resultPromise, error, expectedMessage);
         assert.calledOnceWithExactly(
           spies.generateRoleAssignmentMemberOptions,
           expectedMemberId,
@@ -376,7 +389,28 @@ describe('plugin-meetings', () => {
           roles: expectedRoles,
           locusUrl: expectedLocusUrl,
         });
-        assert.strictEqual(resultPromise, spies.assignRolesMember.getCall(0).returnValue);
+      };
+
+      const checkValid = async (
+        resultPromise,
+        spies,
+        expectedMemberId,
+        expectedRoles,
+        expectedLocusUrl
+      ) => {
+        const resolvedValue = await assert.isFulfilled(resultPromise);
+        assert.calledOnceWithExactly(
+          spies.generateRoleAssignmentMemberOptions,
+          expectedMemberId,
+          expectedRoles,
+          expectedLocusUrl
+        );
+        assert.calledOnceWithExactly(spies.assignRolesMember, {
+          memberId: expectedMemberId,
+          roles: expectedRoles,
+          locusUrl: expectedLocusUrl,
+        });
+        assert.strictEqual(resolvedValue, resolvedValue);
       };
 
       it('should not make a request if there is no member id', async () => {
@@ -387,7 +421,7 @@ describe('plugin-meetings', () => {
         await checkInvalid(
           resultPromise,
           'The member id must be defined to assign the roles to a member.',
-          spies
+          spies,
         );
       });
 
@@ -399,7 +433,92 @@ describe('plugin-meetings', () => {
         await checkInvalid(
           resultPromise,
           'The associated locus url for this meetings members object must be defined.',
-          spies
+          spies,
+        );
+      });
+
+      it('should not make a request if locus throws ReclaimHostNotSupportedError', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1, 2400127);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkError(
+          ReclaimHostNotSupportedError,
+          memberId,
+          fakeRoles,
+          url1,
+          resultPromise,
+          'Non converged meetings, PSTN or SIP users in converged meetings are not supported currently.',
+          spies,
+        );
+      });
+
+      it('should not make a request if locus throws ReclaimHostNotAllowedError', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1, 2403135);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkError(
+          ReclaimHostNotAllowedError,
+          memberId,
+          fakeRoles,
+          url1,
+          resultPromise,
+          'Reclaim Host Role Not Allowed For Other Participants. Participants cannot claim host role in PMR meeting, space instant meeting or escalated instant meeting. However, the original host still can reclaim host role when it manually makes another participant to be the host.',
+          spies,
+        );
+      });
+
+      it('should not make a request if locus throws ReclaimHostEmptyWrongKeyError', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1, 2403136);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkError(
+          ReclaimHostEmptyWrongKeyError,
+          memberId,
+          fakeRoles,
+          url1,
+          resultPromise,
+          'Host Key Not Specified Or Matched. The original host can reclaim the host role without entering the host key. However, any other person who claims the host role must enter the host key to get it.',
+          spies,
+        );
+      });
+
+      it('should not make a request if locus throws ReclaimHostIsHostAlreadyError', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1, 2409150);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkError(
+          ReclaimHostIsHostAlreadyError,
+          memberId,
+          fakeRoles,
+          url1,
+          resultPromise,
+          'Participant Having Host Role Already. Participant who sends request to reclaim host role has already a host role.',
+          spies,
+        );
+      });
+
+      it('should not make a request if locus throws a different error', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1, 1234);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkError(
+          {body: {errorCode: 1234}, message: genericMessage},
+          memberId,
+          fakeRoles,
+          url1,
+          resultPromise,
+          genericMessage,
+          spies,
         );
       });
 
@@ -407,22 +526,14 @@ describe('plugin-meetings', () => {
         const memberId = uuid.v4();
         const {members, spies} = setup(url1);
 
-        const resultPromise = members.assignRoles(memberId, [
-          {type: 'PRESENTER', hasRole: true},
-          {type: 'MODERATOR', hasRole: false},
-          {type: 'COHOST', hasRole: true},
-        ]);
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
 
         await checkValid(
           resultPromise,
           spies,
           memberId,
-          [
-            {type: 'PRESENTER', hasRole: true},
-            {type: 'MODERATOR', hasRole: false},
-            {type: 'COHOST', hasRole: true},
-          ],
-          url1
+          fakeRoles,
+          url1,
         );
       });
     });


### PR DESCRIPTION
# COMPLETES #[SPARK-485092](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-485092)

## This pull request addresses

Catching errors from assign role function and classify them into known Reclaim host errors as stated here: https://confluence-eng-gpk2.cisco.com/conf/display/LOCUS/Reclaim+Host+Role#:~:text=RECLAIM_HOST_ROLE%20for%20rollout.-,Locus%20Error%20Code,-Locus%20Error%20Code

## by making the following changes

1. Add catch function to assignRole
2. Trying to see if raw api error matches any of the known reclaim host error and, if it does, throw that error class
3. Adding new error classes for the known error cases here https://confluence-eng-gpk2.cisco.com/conf/display/LOCUS/Reclaim+Host+Role#:~:text=RECLAIM_HOST_ROLE%20for%20rollout.-,Locus%20Error%20Code,-Locus%20Error%20Code

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request
- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
