### PR TITLE
fix(calling): export LocalMicrophoneStream

### DIFF
--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -51,3 +51,4 @@ export {
 export {CallError, LineError} from './Errors';
 export {ICall, TransferType} from './CallingClient/calling/types';
 export {LOGGER} from './Logger/types';
+export {LocalMicrophoneStream} from '@webex/media-helpers';


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-479560 

## This pull request addresses
Need to pass the local audio stream while invoking dial/answer API. It is giving type error in web client so need to import LocalMicrophoneStream for typecasting the stream.

## by making the following changes
Exporting LocalMicrophoneStream from media-helpers package so that it is available in web client under @webex/calling.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
