### PR TITLE
feat(meetings): add ability to reclaim host role with hostKey

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -1805,7 +1805,13 @@ function reclaimHost(reclaimHostBtn) {
     hostKey,
   };
 
-  meeting.members.assignRoles(selfId, [role]);
+  meeting.members.assignRoles(selfId, [role])
+  .then(() => {
+    console.log('Host role reclaimed');
+  })
+  .catch((error) => {
+    console.log('Error reclaiming host role', error);
+  });
 }
 
 function viewParticipants() {

--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -1795,6 +1795,19 @@ function transferHostToMember(transferButton) {
   }
 }
 
+function reclaimHost(reclaimHostBtn) {
+  const hostKey = reclaimHostBtn.previousElementSibling.value;
+  const meeting = getCurrentMeeting();
+  const selfId = meeting.members.selfId;
+  const role = {
+    type: 'MODERATOR',
+    hasRole: true,
+    hostKey,
+  };
+
+  meeting.members.assignRoles(selfId, [role]);
+}
+
 function viewParticipants() {
   function createLabel(id, value = '') {
     const label = document.createElement('label');
@@ -1923,6 +1936,19 @@ function viewParticipants() {
     inviteDiv.appendChild(inviteBtn);
 
     participantButtons.appendChild(inviteDiv);
+
+    const reclaimHostDiv = document.createElement('div');
+    const reclaimHostInput = document.createElement('input');
+    const reclaimHostBtn = createButton('Reclaim Host', reclaimHost);
+
+    reclaimHostDiv.style.display = 'flex';
+    reclaimHostInput.type = 'text';
+    reclaimHostInput.placeholder = 'Host Key';
+
+    reclaimHostDiv.appendChild(reclaimHostInput);
+    reclaimHostDiv.appendChild(reclaimHostBtn);
+
+    participantButtons.appendChild(reclaimHostDiv);
   }
 }
 

--- a/packages/@webex/plugin-meetings/src/common/errors/reclaim-host-role-error.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/reclaim-host-role-error.ts
@@ -1,0 +1,134 @@
+import * as MEETINGCONSTANTS from '../../constants';
+
+/**
+ * Extended Error object for reclaim host role empty or wrong key
+ */
+export class ReclaimHostEmptyWrongKeyError extends Error {
+  sdkMessage: string;
+  error: null;
+  code: number;
+
+  /**
+   *
+   * @constructor
+   * @param {String} [message]
+   * @param {Object} [error]
+   */
+  constructor(
+    message: string = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_EMPTY_OR_WRONG_KEY
+      .MESSAGE,
+    error: any = null
+  ) {
+    super(message);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ReclaimHostEmptyWrongKeyError);
+    }
+
+    this.name = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_EMPTY_OR_WRONG_KEY.NAME;
+    this.sdkMessage =
+      message || MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_EMPTY_OR_WRONG_KEY.MESSAGE;
+    this.error = error;
+
+    this.code = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_EMPTY_OR_WRONG_KEY.CODE;
+  }
+}
+
+/**
+ * Extended Error object for reclaim host role not supported
+ */
+export class ReclaimHostNotSupportedError extends Error {
+  sdkMessage: string;
+  error: null;
+  code: number;
+
+  /**
+   *
+   * @constructor
+   * @param {String} [message]
+   * @param {Object} [error]
+   */
+  constructor(
+    message: string = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_SUPPORTED.MESSAGE,
+    error: any = null
+  ) {
+    super(message);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ReclaimHostNotSupportedError);
+    }
+
+    this.name = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_SUPPORTED.NAME;
+    this.sdkMessage =
+      message || MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_SUPPORTED.MESSAGE;
+    this.error = error;
+
+    this.code = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_SUPPORTED.CODE;
+  }
+}
+
+/**
+ * Extended Error object for reclaim host role not allowed for other participants
+ */
+export class ReclaimHostNotAllowedError extends Error {
+  sdkMessage: string;
+  error: null;
+  code: number;
+
+  /**
+   *
+   * @constructor
+   * @param {String} [message]
+   * @param {Object} [error]
+   */
+  constructor(
+    message: string = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_ALLOWED.MESSAGE,
+    error: any = null
+  ) {
+    super(message);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ReclaimHostNotAllowedError);
+    }
+
+    this.name = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_ALLOWED.NAME;
+    this.sdkMessage =
+      message || MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_ALLOWED.MESSAGE;
+    this.error = error;
+
+    this.code = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_NOT_ALLOWED.CODE;
+  }
+}
+
+/**
+ * Extended Error object for reclaim host role when user is host already
+ */
+export class ReclaimHostIsHostAlreadyError extends Error {
+  sdkMessage: string;
+  error: null;
+  code: number;
+
+  /**
+   *
+   * @constructor
+   * @param {String} [message]
+   * @param {Object} [error]
+   */
+  constructor(
+    message: string = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_IS_ALREADY_HOST.MESSAGE,
+    error: any = null
+  ) {
+    super(message);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ReclaimHostIsHostAlreadyError);
+    }
+
+    this.name = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_IS_ALREADY_HOST.NAME;
+    this.sdkMessage =
+      message || MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_IS_ALREADY_HOST.MESSAGE;
+    this.error = error;
+
+    this.code = MEETINGCONSTANTS.ERROR_DICTIONARY.RECLAIM_HOST_ROLE_IS_ALREADY_HOST.CODE;
+  }
+}

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -239,6 +239,13 @@ export const CALENDAR_EVENTS = {
   DELETE: 'event:calendar.meeting.delete',
 };
 
+export const ASSIGN_ROLES_ERROR_CODES = {
+  ReclaimHostNotSupportedErrorCode: 2400127,
+  ReclaimHostNotAllowedErrorCode: 2403135,
+  ReclaimHostEmptyWrongKeyErrorCode: 2403136,
+  ReclaimHostIsHostAlreadyErrorCode: 2409150,
+};
+
 export const DEFAULT_GET_STATS_FILTER = {
   types: [
     'track',
@@ -448,6 +455,30 @@ export const ERROR_DICTIONARY = {
     NAME: 'CaptchaError',
     MESSAGE: 'Captcha is required.',
     CODE: 8,
+  },
+  RECLAIM_HOST_ROLE_NOT_SUPPORTED: {
+    NAME: 'ReclaimHostRoleNotSupported',
+    MESSAGE:
+      'Non converged meetings, PSTN or SIP users in converged meetings are not supported currently.',
+    CODE: 9,
+  },
+  RECLAIM_HOST_ROLE_NOT_ALLOWED: {
+    NAME: 'ReclaimHostRoleNotAllowed',
+    MESSAGE:
+      'Reclaim Host Role Not Allowed For Other Participants. Participants cannot claim host role in PMR meeting, space instant meeting or escalated instant meeting. However, the original host still can reclaim host role when it manually makes another participant to be the host.',
+    CODE: 10,
+  },
+  RECLAIM_HOST_ROLE_EMPTY_OR_WRONG_KEY: {
+    NAME: 'ReclaimHostRoleEmptyOrWrongKey',
+    MESSAGE:
+      'Host Key Not Specified Or Matched. The original host can reclaim the host role without entering the host key. However, any other person who claims the host role must enter the host key to get it.',
+    CODE: 11,
+  },
+  RECLAIM_HOST_ROLE_IS_ALREADY_HOST: {
+    NAME: 'ReclaimHostRoleIsAlreadyHost',
+    MESSAGE:
+      'Participant Having Host Role Already. Participant who sends request to reclaim host role has already a host role.',
+    CODE: 12,
   },
 };
 

--- a/packages/@webex/plugin-meetings/src/member/index.ts
+++ b/packages/@webex/plugin-meetings/src/member/index.ts
@@ -11,6 +11,7 @@ import MemberUtil from './util';
  */
 export default class Member {
   associatedUser: any;
+  canReclaimHost: boolean;
   id: any;
   isAudioMuted: any;
   isContentSharing: any;
@@ -57,6 +58,13 @@ export default class Member {
         }
       | any = {}
   ) {
+    /**
+     * @instance
+     * @type {Boolean}
+     * @public
+     * @memberof Member
+     */
+    this.canReclaimHost = false;
     /**
      * The server participant object
      * @instance
@@ -250,6 +258,7 @@ export default class Member {
   private processParticipant(participant: object) {
     this.participant = participant;
     if (participant) {
+      this.canReclaimHost = MemberUtil.canReclaimHost(participant);
       this.id = MemberUtil.extractId(participant);
       this.name = MemberUtil.extractName(participant);
       this.isAudioMuted = MemberUtil.isAudioMuted(participant);

--- a/packages/@webex/plugin-meetings/src/member/util.ts
+++ b/packages/@webex/plugin-meetings/src/member/util.ts
@@ -24,6 +24,20 @@ const MemberUtil: any = {};
  * @param {Object} participant the locus participant
  * @returns {Boolean}
  */
+MemberUtil.canReclaimHost = (participant) => {
+  if (!participant) {
+    throw new ParameterError(
+      'canReclaimHostRole could not be processed, participant is undefined.'
+    );
+  }
+
+  return participant.canReclaimHostRole || false;
+};
+
+/**
+ * @param {Object} participant the locus participant
+ * @returns {Boolean}
+ */
 MemberUtil.isUser = (participant: any) => participant && participant.type === _USER_;
 
 MemberUtil.isModerator = (participant) => participant && participant.moderator;

--- a/packages/@webex/plugin-meetings/src/members/index.ts
+++ b/packages/@webex/plugin-meetings/src/members/index.ts
@@ -14,6 +14,7 @@ import ParameterError from '../common/errors/parameter';
 import MembersCollection from './collection';
 import MembersRequest from './request';
 import MembersUtil from './util';
+import {ServerRoleShape} from './types';
 
 /**
  * Members Update Event
@@ -684,6 +685,32 @@ export default class Members extends StatelessWebexPlugin {
     const options = MembersUtil.generateAddMemberOptions(invitee, this.locusUrl, alertIfActive);
 
     return this.membersRequest.addMembers(options);
+  }
+
+  /**
+   * Assign role(s) to a member in the meeting
+   * @param {String} memberId
+   * @param {[ServerRoleShape]} roles - to assign an array of roles
+   * @returns {Promise}
+   * @public
+   * @memberof Members
+   */
+  public assignRoles(memberId: string, roles: Array<ServerRoleShape>) {
+    if (!this.locusUrl) {
+      return Promise.reject(
+        new ParameterError(
+          'The associated locus url for this meetings members object must be defined.'
+        )
+      );
+    }
+    if (!memberId) {
+      return Promise.reject(
+        new ParameterError('The member id must be defined to assign the roles to a member.')
+      );
+    }
+    const options = MembersUtil.generateRoleAssignmentMemberOptions(memberId, roles, this.locusUrl);
+
+    return this.membersRequest.assignRolesMember(options);
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/members/index.ts
+++ b/packages/@webex/plugin-meetings/src/members/index.ts
@@ -5,7 +5,14 @@ import {isEmpty} from 'lodash';
 // @ts-ignore
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
-import {MEETINGS, EVENT_TRIGGERS, FLOOR_ACTION, CONTENT, WHITEBOARD} from '../constants';
+import {
+  MEETINGS,
+  EVENT_TRIGGERS,
+  FLOOR_ACTION,
+  CONTENT,
+  WHITEBOARD,
+  ASSIGN_ROLES_ERROR_CODES,
+} from '../constants';
 import Trigger from '../common/events/trigger-proxy';
 import Member from '../member';
 import LoggerProxy from '../common/logs/logger-proxy';
@@ -15,6 +22,12 @@ import MembersCollection from './collection';
 import MembersRequest from './request';
 import MembersUtil from './util';
 import {ServerRoleShape} from './types';
+import {
+  ReclaimHostEmptyWrongKeyError,
+  ReclaimHostIsHostAlreadyError,
+  ReclaimHostNotAllowedError,
+  ReclaimHostNotSupportedError,
+} from '../common/errors/reclaim-host-role-error';
 
 /**
  * Members Update Event
@@ -710,7 +723,21 @@ export default class Members extends StatelessWebexPlugin {
     }
     const options = MembersUtil.generateRoleAssignmentMemberOptions(memberId, roles, this.locusUrl);
 
-    return this.membersRequest.assignRolesMember(options);
+    return this.membersRequest.assignRolesMember(options).catch((error: any) => {
+      const errorCode = error.body?.errorCode;
+      switch (errorCode) {
+        case ASSIGN_ROLES_ERROR_CODES.ReclaimHostNotSupportedErrorCode:
+          return Promise.reject(new ReclaimHostNotSupportedError());
+        case ASSIGN_ROLES_ERROR_CODES.ReclaimHostNotAllowedErrorCode:
+          return Promise.reject(new ReclaimHostNotAllowedError());
+        case ASSIGN_ROLES_ERROR_CODES.ReclaimHostEmptyWrongKeyErrorCode:
+          return Promise.reject(new ReclaimHostEmptyWrongKeyError());
+        case ASSIGN_ROLES_ERROR_CODES.ReclaimHostIsHostAlreadyErrorCode:
+          return Promise.reject(new ReclaimHostIsHostAlreadyError());
+        default:
+          return Promise.reject(error);
+      }
+    });
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/members/request.ts
+++ b/packages/@webex/plugin-meetings/src/members/request.ts
@@ -59,6 +59,26 @@ export default class MembersRequest extends StatelessWebexPlugin {
     return this.request(requestParams);
   }
 
+  /**
+   * Sends a request to assign roles to a member
+   * @param {Object} options
+   * @param {String} options.locusUrl
+   * @param {String} options.memberId ID of PSTN user
+   * @returns {Promise}
+   */
+  assignRolesMember(options: any) {
+    if (!options || !options.locusUrl || !options.memberId) {
+      throw new ParameterError(
+        'memberId must be defined, and the associated locus url for this meeting object must be defined.'
+      );
+    }
+
+    const requestParams = MembersUtil.getRoleAssignmentMemberRequestParams(options);
+
+    // @ts-ignore
+    return this.request(requestParams);
+  }
+
   removeMember(options) {
     if (!options || !options.locusUrl || !options.memberId) {
       throw new ParameterError(

--- a/packages/@webex/plugin-meetings/src/members/types.ts
+++ b/packages/@webex/plugin-meetings/src/members/types.ts
@@ -1,0 +1,29 @@
+export enum ServerRoles {
+  Cohost = 'COHOST',
+  Moderator = 'MODERATOR',
+  Presenter = 'PRESENTER',
+}
+
+export type ServerRoleShape = {
+  type: ServerRoles;
+  hasRole: boolean;
+  hostKey?: string;
+};
+
+export type RoleAssignmentOptions = {
+  roles: Array<ServerRoleShape>;
+  locusUrl: string;
+  memberId: string;
+};
+
+export type RoleAssignmentBody = {
+  role: {
+    roles: Array<ServerRoleShape>;
+  };
+};
+
+export type RoleAssignmentRequest = {
+  method: string;
+  uri: string;
+  body: RoleAssignmentBody;
+};

--- a/packages/@webex/plugin-meetings/src/members/util.ts
+++ b/packages/@webex/plugin-meetings/src/members/util.ts
@@ -11,6 +11,7 @@ import {
   SEND_DTMF_ENDPOINT,
   _REMOVE_,
 } from '../constants';
+import {RoleAssignmentOptions, ServerRoleShape} from './types';
 
 const MembersUtil: any = {};
 
@@ -91,6 +92,20 @@ MembersUtil.getAddMemberRequestParams = (format: any) => {
   return requestParams;
 };
 
+/**
+ * @param {ServerRoleShape} role
+ * @returns {ServerRoleShape} the role shape to be added to the body
+ */
+MembersUtil.getAddedRoleShape = (role: ServerRoleShape) => {
+  const roleShape: ServerRoleShape = {type: role.type, hasRole: role.hasRole};
+
+  if (role.hostKey) {
+    roleShape.hostKey = role.hostKey;
+  }
+
+  return roleShape;
+};
+
 MembersUtil.isInvalidInvitee = (invitee) => {
   if (!(invitee && (invitee.email || invitee.emailAddress || invitee.phoneNumber))) {
     return true;
@@ -111,6 +126,41 @@ MembersUtil.getRemoveMemberRequestParams = (options) => {
 
   return {
     method: HTTP_VERBS.PUT,
+    uri,
+    body,
+  };
+};
+
+/**
+ * @param {String} memberId
+ * @param {[ServerRoleShape]} roles
+ * @param {String} locusUrl
+ * @returns {RoleAssignmentOptions}
+ */
+MembersUtil.generateRoleAssignmentMemberOptions = (
+  memberId: string,
+  roles: Array<ServerRoleShape>,
+  locusUrl: string
+) => ({
+  memberId,
+  roles,
+  locusUrl,
+});
+
+/**
+ * @param {RoleAssignmentOptions} options
+ * @returns {RoleAssignmentRequest} the request parameters (method, uri, body) needed to make a addMember request
+ */
+MembersUtil.getRoleAssignmentMemberRequestParams = (options: RoleAssignmentOptions) => {
+  const body = {role: {roles: []}};
+  options.roles.forEach((role) => {
+    body.role.roles.push(MembersUtil.getAddedRoleShape(role));
+  });
+
+  const uri = `${options.locusUrl}/${PARTICIPANT}/${options.memberId}/${CONTROLS}`;
+
+  return {
+    method: HTTP_VERBS.PATCH,
     uri,
     body,
   };

--- a/packages/@webex/plugin-meetings/src/members/util.ts
+++ b/packages/@webex/plugin-meetings/src/members/util.ts
@@ -141,7 +141,7 @@ MembersUtil.generateRoleAssignmentMemberOptions = (
   memberId: string,
   roles: Array<ServerRoleShape>,
   locusUrl: string
-) => ({
+): RoleAssignmentOptions => ({
   memberId,
   roles,
   locusUrl,

--- a/packages/@webex/plugin-meetings/src/members/util.ts
+++ b/packages/@webex/plugin-meetings/src/members/util.ts
@@ -11,7 +11,7 @@ import {
   SEND_DTMF_ENDPOINT,
   _REMOVE_,
 } from '../constants';
-import {RoleAssignmentOptions, ServerRoleShape} from './types';
+import {RoleAssignmentOptions, RoleAssignmentRequest, ServerRoleShape} from './types';
 
 const MembersUtil: any = {};
 
@@ -151,7 +151,9 @@ MembersUtil.generateRoleAssignmentMemberOptions = (
  * @param {RoleAssignmentOptions} options
  * @returns {RoleAssignmentRequest} the request parameters (method, uri, body) needed to make a addMember request
  */
-MembersUtil.getRoleAssignmentMemberRequestParams = (options: RoleAssignmentOptions) => {
+MembersUtil.getRoleAssignmentMemberRequestParams = (
+  options: RoleAssignmentOptions
+): RoleAssignmentRequest => {
   const body = {role: {roles: []}};
   options.roles.forEach((role) => {
     body.role.roles.push(MembersUtil.getAddedRoleShape(role));

--- a/packages/@webex/plugin-meetings/test/unit/spec/member/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/member/index.js
@@ -20,6 +20,13 @@ describe('member', () => {
   
       assert.calledOnceWithExactly(MemberUtil.isHandRaised, participant);
     });
+
+    it('checks that processParticipant calls canReclaimHost', () => {
+      sinon.spy(MemberUtil, 'canReclaimHost');
+      member.processParticipant(participant);
+
+      assert.calledOnceWithExactly(MemberUtil.canReclaimHost, participant);
+    });
   })
 
   describe('#processMember', ()=>{

--- a/packages/@webex/plugin-meetings/test/unit/spec/member/util.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/member/util.js
@@ -78,3 +78,35 @@ describe('extractMediaStatus', () => {
     assert.deepEqual(mediaStatus, {audio: 'RECVONLY', video: 'SENDRECV'});
   });
 });
+
+describe('MemberUtil.canReclaimHost', () => {
+  it('throws error when there is no participant', () => {
+    assert.throws(() => {
+      MemberUtil.canReclaimHost();
+    }, 'canReclaimHostRole could not be processed, participant is undefined.');
+  });
+
+  it('returns true when canReclaimHostRole is true', () => {
+    const participant = {
+      canReclaimHostRole: true,
+    };
+
+    assert.isTrue(MemberUtil.canReclaimHost(participant));
+  });
+
+  it('returns false when canReclaimHostRole is false', () => {
+    const participant = {
+      canReclaimHostRole: false,
+    };
+
+    assert.isFalse(MemberUtil.canReclaimHost(participant));
+  });
+
+  it('returns false when canReclaimHostRole is falsy', () => {
+    const participant = {
+      canReclaimHostRole: undefined,
+    };
+
+    assert.isFalse(MemberUtil.canReclaimHost(participant));
+  });
+});

--- a/packages/@webex/plugin-meetings/test/unit/spec/members/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/index.js
@@ -16,6 +16,13 @@ import ParameterError from '@webex/plugin-meetings/src/common/errors/parameter';
 import Members from '@webex/plugin-meetings/src/members';
 import MembersUtil from '@webex/plugin-meetings/src/members/util';
 
+import {
+  ReclaimHostEmptyWrongKeyError,
+  ReclaimHostIsHostAlreadyError,
+  ReclaimHostNotAllowedError,
+  ReclaimHostNotSupportedError,
+} from '../../../../src/common/errors/reclaim-host-role-error';
+
 const {assert} = chai;
 
 chai.use(chaiAsPromised);

--- a/packages/@webex/plugin-meetings/test/unit/spec/members/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/index.js
@@ -192,6 +192,204 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#assignRoles', () => {
+      const fakeRoles = [
+        {type: 'PRESENTER', hasRole: true},
+        {type: 'MODERATOR', hasRole: false},
+        {type: 'COHOST', hasRole: true},
+      ];
+
+      const resolvedValue = "it worked";
+
+      const genericMessage = 'Generic error from the API';
+
+      const setup = (locusUrl, errorCode) => {
+        const members = createMembers({url: locusUrl});
+
+        const spies = {
+          generateRoleAssignmentMemberOptions: sandbox.spy(
+            MembersUtil,
+            'generateRoleAssignmentMemberOptions'
+          ),
+        };
+
+        if (errorCode) {
+          spies.assignRolesMember = sandbox.stub(members.membersRequest, 'assignRolesMember').rejects({body: {errorCode}, message: genericMessage});
+        } else {
+          spies.assignRolesMember = sandbox.stub(members.membersRequest, 'assignRolesMember').resolves(resolvedValue);
+        }
+
+        return {members, spies};
+      };
+
+      const checkInvalid = async (resultPromise, expectedMessage, spies) => {
+        await assert.isRejected(resultPromise, ParameterError, expectedMessage);
+        assert.notCalled(spies.generateRoleAssignmentMemberOptions);
+        assert.notCalled(spies.assignRolesMember);
+      };
+
+      const checkError = async (error, expectedMemberId, expectedRoles, expectedLocusUrl, resultPromise, expectedMessage, spies) => {
+        await assert.isRejected(resultPromise, error, expectedMessage);
+        assert.calledOnceWithExactly(
+          spies.generateRoleAssignmentMemberOptions,
+          expectedMemberId,
+          expectedRoles,
+          expectedLocusUrl
+        );
+        assert.calledOnceWithExactly(spies.assignRolesMember, {
+          memberId: expectedMemberId,
+          roles: expectedRoles,
+          locusUrl: expectedLocusUrl,
+        });
+      };
+
+      const checkValid = async (
+        resultPromise,
+        spies,
+        expectedMemberId,
+        expectedRoles,
+        expectedLocusUrl
+      ) => {
+        const resolvedValue = await assert.isFulfilled(resultPromise);
+        assert.calledOnceWithExactly(
+          spies.generateRoleAssignmentMemberOptions,
+          expectedMemberId,
+          expectedRoles,
+          expectedLocusUrl
+        );
+        assert.calledOnceWithExactly(spies.assignRolesMember, {
+          memberId: expectedMemberId,
+          roles: expectedRoles,
+          locusUrl: expectedLocusUrl,
+        });
+        assert.strictEqual(resolvedValue, resolvedValue);
+      };
+
+      it('should not make a request if there is no member id', async () => {
+        const {members, spies} = setup(url1);
+
+        const resultPromise = members.assignRoles();
+
+        await checkInvalid(
+          resultPromise,
+          'The member id must be defined to assign the roles to a member.',
+          spies,
+        );
+      });
+
+      it('should not make a request if there is no locus url', async () => {
+        const {members, spies} = setup();
+
+        const resultPromise = members.assignRoles(uuid.v4());
+
+        await checkInvalid(
+          resultPromise,
+          'The associated locus url for this meetings members object must be defined.',
+          spies,
+        );
+      });
+
+      it('should not make a request if locus throws ReclaimHostNotSupportedError', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1, 2400127);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkError(
+          ReclaimHostNotSupportedError,
+          memberId,
+          fakeRoles,
+          url1,
+          resultPromise,
+          'Non converged meetings, PSTN or SIP users in converged meetings are not supported currently.',
+          spies,
+        );
+      });
+
+      it('should not make a request if locus throws ReclaimHostNotAllowedError', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1, 2403135);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkError(
+          ReclaimHostNotAllowedError,
+          memberId,
+          fakeRoles,
+          url1,
+          resultPromise,
+          'Reclaim Host Role Not Allowed For Other Participants. Participants cannot claim host role in PMR meeting, space instant meeting or escalated instant meeting. However, the original host still can reclaim host role when it manually makes another participant to be the host.',
+          spies,
+        );
+      });
+
+      it('should not make a request if locus throws ReclaimHostEmptyWrongKeyError', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1, 2403136);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkError(
+          ReclaimHostEmptyWrongKeyError,
+          memberId,
+          fakeRoles,
+          url1,
+          resultPromise,
+          'Host Key Not Specified Or Matched. The original host can reclaim the host role without entering the host key. However, any other person who claims the host role must enter the host key to get it.',
+          spies,
+        );
+      });
+
+      it('should not make a request if locus throws ReclaimHostIsHostAlreadyError', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1, 2409150);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkError(
+          ReclaimHostIsHostAlreadyError,
+          memberId,
+          fakeRoles,
+          url1,
+          resultPromise,
+          'Participant Having Host Role Already. Participant who sends request to reclaim host role has already a host role.',
+          spies,
+        );
+      });
+
+      it('should not make a request if locus throws a different error', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1, 1234);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkError(
+          {body: {errorCode: 1234}, message: genericMessage},
+          memberId,
+          fakeRoles,
+          url1,
+          resultPromise,
+          genericMessage,
+          spies,
+        );
+      });
+
+      it('should make the correct request when called with roles', async () => {
+        const memberId = uuid.v4();
+        const {members, spies} = setup(url1);
+
+        const resultPromise = members.assignRoles(memberId, fakeRoles);
+
+        await checkValid(
+          resultPromise,
+          spies,
+          memberId,
+          fakeRoles,
+          url1,
+        );
+      });
+    });
+
     describe('#raiseOrLowerHand', () => {
       const setup = (locusUrl) => {
         const members = createMembers({url: locusUrl});

--- a/packages/@webex/plugin-meetings/test/unit/spec/members/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/utils.js
@@ -39,6 +39,26 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#getAddedRoleShape', () => {
+      it('returns the correct shape with hostkey', () => {
+        const format = {type: 'PRESENTER', hasRole: true, hostKey: '123456'};
+        assert.deepEqual(MembersUtil.getAddedRoleShape(format), {
+          type: 'PRESENTER',
+          hasRole: true,
+          hostKey: '123456',
+        });
+      });
+
+      it('returns the correct shape without hostkey', () => {
+        const format = {type: 'PRESENTER', hasRole: true};
+        assert.deepEqual(MembersUtil.getAddedRoleShape(format), {
+          type: 'PRESENTER',
+          hasRole: true,
+        });
+      });
+    });
+
+
     describe('#getRoleAssignmentMemberRequestParams', () => {
       it('returns the correct request params', () => {
         const format = {

--- a/packages/@webex/plugin-meetings/test/unit/spec/members/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/utils.js
@@ -4,6 +4,8 @@ import chaiAsPromised from 'chai-as-promised';
 
 import MembersUtil from '@webex/plugin-meetings/src/members/util';
 
+import {CONTROLS, PARTICIPANT} from '@webex/plugin-meetings/src/constants';
+
 const {assert} = chai;
 
 chai.use(chaiAsPromised);

--- a/packages/@webex/plugin-meetings/test/unit/spec/members/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/utils.js
@@ -38,5 +38,58 @@ describe('plugin-meetings', () => {
         );
       });
     });
+
+    describe('#getRoleAssignmentMemberRequestParams', () => {
+      it('returns the correct request params', () => {
+        const format = {
+          locusUrl: 'locusUrl',
+          memberId: 'test',
+          roles: [
+            {type: 'PRESENTER', hasRole: true},
+            {type: 'MODERATOR', hasRole: false},
+            {type: 'COHOST', hasRole: true},
+          ],
+        };
+        assert.deepEqual(MembersUtil.getRoleAssignmentMemberRequestParams(format), {
+          method: 'PATCH',
+          uri: `locusUrl/${PARTICIPANT}/test/${CONTROLS}`,
+          body: {
+            role: {
+              roles: [
+                {type: 'PRESENTER', hasRole: true},
+                {type: 'MODERATOR', hasRole: false},
+                {type: 'COHOST', hasRole: true},
+              ],
+            },
+          },
+        });
+      });
+
+      it('returns the correct request params with a hostKey', () => {
+        const format = {
+          locusUrl: 'locusUrl',
+          memberId: 'test',
+          roles: [
+            {type: 'PRESENTER', hasRole: true, hostKey: '123456'},
+            {type: 'MODERATOR', hasRole: false, hostKey: '123456'},
+            {type: 'COHOST', hasRole: true, hostKey: '123456'},
+          ],
+        };
+
+        assert.deepEqual(MembersUtil.getRoleAssignmentMemberRequestParams(format), {
+          method: 'PATCH',
+          uri: `locusUrl/${PARTICIPANT}/test/${CONTROLS}`,
+          body: {
+            role: {
+              roles: [
+                {type: 'PRESENTER', hasRole: true, hostKey: '123456'},
+                {type: 'MODERATOR', hasRole: false, hostKey: '123456'},
+                {type: 'COHOST', hasRole: true, hostKey: '123456'},
+              ],
+            },
+          },
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [SPARK-486926](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-486926)

## This pull request addresses
The need to be able to reclaim the host role by any other participant in the meeting. This is especially useful in meetings where hosts of the meeting don't join and one of the guests has to take up the role of a host.

Refer #3272 and #3289 for the same functionality being added in the `beta` branch. This needed to be done in the `master` branch due to the release of USM.

[Confluence document](https://confluence-eng-gpk2.cisco.com/conf/pages/viewpage.action?spaceKey=LOCUS&title=Reclaim+Host+Role) for reclaiming host.

## by making the following changes
1. Added the types required in members for the ServerRoleShape
2. Added utility functions to create the required role object in the body from a member's parameters
3. Added the assignRoles function to the members object which eventually triggers the request to assign caller as Host.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
1. Started a meeting using API
2. Joined the meeting using the host on Webex desktop app
3. Created a guest user and token. Joined the same meeting in Step 1 using this guest
4. Triggered the new reclaim function using a button on the kitchen sink app along with the guest user's participant ID and hostKey. The desktop app now reflected the guest user as the host.
5. Transferred host back to the original host of the meeting (desktop app)
6. Triggered the reclaim action again using the kitchen sink page. Checked if the guest user was made host again.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

**Test Results**
 plugin-meetings
    members
      ...
      #assignRoles
        ✔ should not make a request if there is no member id
        ✔ should not make a request if there is no locus url
        ✔ should not make a request if locus throws ReclaimHostNotSupportedError
        ✔ should not make a request if locus throws ReclaimHostNotAllowedError
        ✔ should not make a request if locus throws ReclaimHostEmptyWrongKeyError
        ✔ should not make a request if locus throws ReclaimHostIsHostAlreadyError
        ✔ should not make a request if locus throws a different error
        ✔ should make the correct request when called with roles
      ...


  plugin-meetings
    members utils library
      #generateRaiseHandMemberOptions
        ✔ returns the correct options
      #generateLowerAllHandsMemberOptions
        ✔ returns the correct options
      #getAddedRoleShape
        ✔ returns the correct shape with hostkey
        ✔ returns the correct shape without hostkey
      #getRoleAssignmentMemberRequestParams
        ✔ returns the correct request params
        ✔ returns the correct request params with a hostKey

Result
 914 passing (2m)
  11 pending
  3 failing

  1) TurnDiscovery
       doTurnDiscovery
         resolves with undefined if the response does not have all the headers we expect:
     Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (C:\Users\sreenara\stuff\webex-js-sdk\packages\@webex\plugin-meetings\test\unit\spec\roap\turnDiscovery.ts)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)

  2) TurnDiscovery
       doTurnDiscovery
         resolves with undefined if the response does not have any headers:
     Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (C:\Users\sreenara\stuff\webex-js-sdk\packages\@webex\plugin-meetings\test\unit\spec\roap\turnDiscovery.ts)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)

  3) TurnDiscovery
       doTurnDiscovery
         resolves with undefined if the response has empty headers array:
     Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (C:\Users\sreenara\stuff\webex-js-sdk\packages\@webex\plugin-meetings\test\unit\spec\roap\turnDiscovery.ts)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
