### PR TITLE
feat(plugin-meetings): fix .only test

### DIFF
--- a/packages/@webex/plugin-meetings/test/unit/spec/members/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/index.js
@@ -342,7 +342,7 @@ describe('plugin-meetings', () => {
       });
     });
 
-    describe.only('#assignRoles', () => {
+    describe('#assignRoles', () => {
       const fakeRoles = [
         {type: 'PRESENTER', hasRole: true},
         {type: 'MODERATOR', hasRole: false},


### PR DESCRIPTION
# COMPLETES #[SPARK-485092](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-485092)

## This pull request addresses

Fixing a .only in plugin-meetings unit test

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
