### PR TITLE
fix(plugin-meetings): don't send turn latency if it fails

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5990,7 +5990,9 @@ export default class Meeting extends StatelessWebexPlugin {
         name: 'internal.client.add-media.turn-discovery.end',
       });
 
-      if (this.turnServerUsed) {
+      const {turnServerInfo} = turnDiscoveryObject;
+
+      if (this.turnServerUsed && turnServerInfo) {
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.TURN_DISCOVERY_LATENCY, {
           correlation_id: this.correlationId,
           latency: cdl.getTurnDiscoveryTime(),
@@ -5999,7 +6001,6 @@ export default class Meeting extends StatelessWebexPlugin {
         });
       }
 
-      const {turnServerInfo} = turnDiscoveryObject;
       const mc = await this.createMediaConnection(turnServerInfo, bundlePolicy);
 
       LoggerProxy.logger.info(`${LOG_HEADER} media connection created`);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-486939](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-486939)

## This pull request addresses

we currently send a latency metric for turn discovery even if it fails

## by making the following changes

check that both entries in the object returned from doTurnDiscovery are well defined before sending the metric

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
