### PR TITLE
fix: increased timeout for SDP answer

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -191,7 +191,7 @@ export const ICE_FAIL_TIMEOUT = 3000;
 export const RETRY_TIMEOUT = 3000;
 
 export const ICE_AND_DTLS_CONNECTION_TIMEOUT = 10000;
-export const ROAP_OFFER_ANSWER_EXCHANGE_TIMEOUT = 10000;
+export const ROAP_OFFER_ANSWER_EXCHANGE_TIMEOUT = 35000;
 
 // ******************** REGEX **********************
 // Please alphabetize


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-487651

## This pull request addresses

From metrics we can see there are many cases where SDP answer comes after more than 10s:
https://app.eu.amplitude.com/analytics/cisco-cross-project/chart/e-acjwdrfp?source=copy+url

also there are some cases where setting the answer in the browser takes 30s, see https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-486942

so I've increased the timeout to 35s

BTW, this jira description talks also about checking the default timeout in SDK for http requests - I've checked it and there is no default value set, so the /media requests to Locus don't have any SDK timeout

## by making the following changes

increased the timeout to 35s

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
