### PR TITLE
fix: added method for getting the meeting with active webrtc connection

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/collection.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/collection.ts
@@ -60,4 +60,17 @@ export default class MeetingCollection extends Collection {
 
     return null;
   }
+
+  /**
+   * Gets the meeting that has a webrtc media connection
+   * NOTE: this function assumes there is no more than 1 such meeting
+   *
+   * @returns {Meeting} first meeting found, else undefined
+   * @public
+   * @memberof MeetingCollection
+   */
+  public getActiveWebrtcMeeting() {
+    // @ts-ignore
+    return find(this.meetings, (meeting) => meeting.mediaProperties.webrtcMediaConnection);
+  }
 }

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1467,4 +1467,15 @@ export default class Meetings extends WebexPlugin {
   getLogger() {
     return LoggerProxy.get();
   }
+
+  /**
+   * Returns the first meeting it finds that has the webrtc media connection created.
+   * Useful for debugging in the console.
+   *
+   * @private
+   * @returns {Meeting} Meeting object that has a webrtc media connection, else undefined
+   */
+  getActiveWebrtcMeeting() {
+    return this.meetingCollection.getActiveWebrtcMeeting();
+  }
 }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/collection.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/collection.js
@@ -62,5 +62,17 @@ describe('plugin-meetings', () => {
           breakouts: {url: 'url', isActiveBreakout: true}, id: uuid1});
       });
     });
+
+    describe('#getActiveWebrtcMeeting', () => {
+      it('returns the meeting with a webrtc media connection', () => {
+        const activeMeeting = {value: 'test3', id: uuid.v4(), mediaProperties: { webrtcMediaConnection: 'something'}};
+
+        meetingCollection.meetings.test = {value: 'test', id: uuid1, mediaProperties: {}};
+        meetingCollection.meetings.test2 = {value: 'test2', id: uuid2, mediaProperties: {}};
+        meetingCollection.meetings.test3 = activeMeeting;
+
+        assert.equal(meetingCollection.getActiveWebrtcMeeting(), activeMeeting);
+      })
+    })
   });
 });


### PR DESCRIPTION
Added a helper method so that everyday debugging is a bit easier....

when using js console and trying to read something from the active meeting we normally have to do this:
`webex.meetings.meetingCollection.meetings[<some_uid>]`
and we have to know which uid to use if there are multiple meetings in the SDK

now we can do this instead:
`webex.meetings.getActiveWebrtcMeeting()`
