### PR TITLE
feat(ca-metrics): fix negative timestamps

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -77,7 +77,12 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
     }
     // for some events we're only interested in the first timestamp not last
     // as these events can happen multiple times
-    if (key === 'client.media.rx.start' || key === 'client.media.tx.start') {
+    if (
+      key === 'client.media.rx.start' ||
+      key === 'client.media.tx.start' ||
+      key === 'internal.client.meetinginfo.request' ||
+      key === 'internal.client.meetinginfo.response'
+    ) {
       this.saveFirstTimestampOnly(key, value);
     } else {
       this.latencyTimestamps.set(key, value);

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -122,7 +122,6 @@ describe('internal-plugin-metrics', () => {
         cdl.saveTimestamp({key: 'internal.client.meetinginfo.request', value: 10});
         cdl.saveTimestamp({key: 'client.alert.displayed', value: 15});
         assert.deepEqual(saveFirstTimestamp.callCount, 1);
-        sinon.restore();
       });
 
       it('calls saveFirstTimestamp for meeting info response', () => {
@@ -130,7 +129,6 @@ describe('internal-plugin-metrics', () => {
         cdl.saveTimestamp({key: 'client.alert.displayed', value: 15});
         cdl.saveTimestamp({key: 'internal.client.meetinginfo.response', value: 20});
         assert.deepEqual(saveFirstTimestamp.callCount, 1);
-        sinon.restore();
       });
     });
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -103,6 +103,37 @@ describe('internal-plugin-metrics', () => {
       assert.deepEqual(cdl.getMeetingInfoReqResp(), 10);
     });
 
+    it('calculates getMeetingInfoReqResp correctly when duplicate requests/responses are sent', () => {
+      cdl.saveTimestamp({key: 'internal.client.meetinginfo.request', value: 8});
+      cdl.saveTimestamp({key: 'internal.client.meetinginfo.response', value: 18});
+      cdl.saveTimestamp({key: 'internal.client.meetinginfo.request', value: 47});
+      cdl.saveTimestamp({key: 'internal.client.meetinginfo.response', value: 48});
+      assert.deepEqual(cdl.getMeetingInfoReqResp(), 10);
+    });
+
+    describe('saveTimestamp', () => {
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('calls saveFirstTimestamp for meeting info request', () => {
+        const saveFirstTimestamp = sinon.stub(cdl, 'saveFirstTimestampOnly');
+        cdl.saveTimestamp({key: 'internal.client.meetinginfo.request', value: 10});
+        cdl.saveTimestamp({key: 'client.alert.displayed', value: 15});
+        assert.deepEqual(saveFirstTimestamp.callCount, 1);
+        sinon.restore();
+      });
+
+      it('calls saveFirstTimestamp for meeting info response', () => {
+        const saveFirstTimestamp = sinon.stub(cdl, 'saveFirstTimestampOnly');
+        cdl.saveTimestamp({key: 'client.alert.displayed', value: 15});
+        cdl.saveTimestamp({key: 'internal.client.meetinginfo.response', value: 20});
+        assert.deepEqual(saveFirstTimestamp.callCount, 1);
+        sinon.restore();
+      });
+    });
+
     it('calculates getShowInterstitialTime correctly', () => {
       cdl.saveTimestamp({key: 'client.interstitial-window.start-launch', value: 10});
       cdl.saveTimestamp({key: 'internal.client.interstitial-window.click.joinbutton', value: 20});


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[< INSERT LINK TO ISSUE >](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-479762)

## This pull request addresses

Negative join times in ca-events result in them being dropped. It happens because sometimes (and we aren't sure why), there happens to be more than one `internal.client.meetinginfo.request` and more than one `internal.client.meetinginfo.response`. When calculating the timestamp difference between the response and request, sometimes the newest request time causes the timestamp to evaluate to a negative number.

## by making the following changes

We no longer let the `internal.client.meetinginfo.request` or `internal.client.meetinginfo.response` be put into the map twice. We only need the first timestamp values of each.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
