### PR TITLE
fix(metrics): catalog delay

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/config.js
+++ b/packages/@webex/internal-plugin-metrics/src/config.js
@@ -19,7 +19,7 @@ export default {
     batcherMaxCalls: 50,
     batcherMaxWait: 1500,
     batcherRetryPlateau: 32000,
-    waitForServiceTimeout: 15,
+    waitForServiceTimeout: 30,
   },
 };
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/batcher.js
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/batcher.js
@@ -37,7 +37,7 @@ describe('plugin-metrics', () => {
         return Promise.resolve({
           statusCode: 204,
           body: undefined,
-          waitForServiceTimeout: 15,
+          waitForServiceTimeout: 30,
           options,
         });
       };
@@ -98,7 +98,7 @@ describe('plugin-metrics', () => {
             return Promise.resolve({
               statusCode: 204,
               body: undefined,
-              waitForServiceTimeout: 15,
+              waitForServiceTimeout: 30,
               options,
             });
           });

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/client-metrics-batcher.js
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/client-metrics-batcher.js
@@ -37,7 +37,7 @@ describe('plugin-metrics', () => {
         return Promise.resolve({
           statusCode: 204,
           body: undefined,
-          waitForServiceTimeout: 15,
+          waitForServiceTimeout: 30,
           options,
         });
       };
@@ -98,7 +98,7 @@ describe('plugin-metrics', () => {
             return Promise.resolve({
               statusCode: 204,
               body: undefined,
-              waitForServiceTimeout: 15,
+              waitForServiceTimeout: 30,
               options,
             });
           });

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/metrics.js
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/metrics.js
@@ -85,7 +85,7 @@ describe('plugin-metrics', () => {
         return Promise.resolve({
           statusCode: 204,
           body: undefined,
-          waitForServiceTimeout: 15,
+          waitForServiceTimeout: 30,
           options,
         });
       };


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [INSERT LINK TO ISSUE](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-490885) >

## This pull request addresses

Currently, there is a 15 second timer that is triggered when waiting for the metrics service to populate in our catalog. We want to extend this to cover the additional users with slower internet connections. Because we are not waiting long enough, we are getting pre join meeting failures, this should hopefully fix that.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
