### PR TITLE
fix(): adding retry timer for locus service unavailable

### DIFF
--- a/packages/@webex/plugin-meetings/src/index.ts
+++ b/packages/@webex/plugin-meetings/src/index.ts
@@ -3,9 +3,13 @@ import {registerPlugin} from '@webex/webex-core';
 
 import Meetings from './meetings';
 import config from './config';
+import {LocusRetryStatusInterceptor} from './interceptors';
 
 registerPlugin('meetings', Meetings, {
   config,
+  interceptors: {
+    LocusRetryStatusInterceptor: LocusRetryStatusInterceptor.create,
+  },
 });
 
 export {

--- a/packages/@webex/plugin-meetings/src/interceptors/index.ts
+++ b/packages/@webex/plugin-meetings/src/interceptors/index.ts
@@ -1,0 +1,3 @@
+import LocusRetryStatusInterceptor from './locusRetry';
+
+export {LocusRetryStatusInterceptor};

--- a/packages/@webex/plugin-meetings/src/interceptors/locusRetry.ts
+++ b/packages/@webex/plugin-meetings/src/interceptors/locusRetry.ts
@@ -24,7 +24,7 @@ export default class LocusRetryStatusInterceptor extends Interceptor {
    * @returns {Promise<WebexHttpError>}
    */
   onResponseError(options, reason) {
-    if (reason.statusCode === 503 && options.uri.includes('locus')) {
+    if ((reason.statusCode === 503 || reason.statusCode === 429) && options.uri.includes('locus')) {
       const hasRetriedLocusRequest = rateLimitExpiryTime.get(this);
       const retryAfterTime = options.headers['retry-after'] || 2000;
 

--- a/packages/@webex/plugin-meetings/src/interceptors/locusRetry.ts
+++ b/packages/@webex/plugin-meetings/src/interceptors/locusRetry.ts
@@ -1,0 +1,67 @@
+/*!
+ * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {Interceptor} from '@webex/http-core';
+
+const rateLimitExpiryTime = new WeakMap();
+/**
+ * @class
+ */
+export default class LocusRetryStatusInterceptor extends Interceptor {
+  /**
+   * @returns {LocusRetryStatusInterceptor}
+   */
+  static create() {
+    // @ts-ignore
+    return new LocusRetryStatusInterceptor({webex: this});
+  }
+
+  /**
+   * Handle response errors
+   * @param {Object} options
+   * @param {WebexHttpError} reason
+   * @returns {Promise<WebexHttpError>}
+   */
+  onResponseError(options, reason) {
+    if (reason.statusCode === 503 && options.uri.includes('locus')) {
+      const hasRetriedLocusRequest = rateLimitExpiryTime.get(this);
+      const retryAfterTime = options.headers['retry-after'] || 2000;
+
+      if (hasRetriedLocusRequest) {
+        rateLimitExpiryTime.set(this, false);
+
+        return Promise.reject(options);
+      }
+      rateLimitExpiryTime.set(this, true);
+
+      return this.handleRetryRequestLocusServiceError(options, retryAfterTime);
+    }
+
+    return Promise.reject(reason);
+  }
+
+  /**
+   * Handle retries for locus service unavailable errors
+   * @param {Object} options associated with the request
+   * @param {number} retryAfterTime retry after time in milliseconds
+   * @returns {Promise}
+   */
+  handleRetryRequestLocusServiceError(options, retryAfterTime) {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        clearTimeout(timeout);
+
+        // @ts-ignore
+        this.webex
+          .request({
+            method: options.method,
+            uri: options.uri,
+            body: options.body,
+          })
+          .then(resolve)
+          .catch(reject);
+      }, retryAfterTime);
+    });
+  }
+}

--- a/packages/@webex/plugin-meetings/test/unit/spec/interceptors/locusRetry.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/interceptors/locusRetry.ts
@@ -128,3 +128,4 @@ describe('plugin-meetings', () => {
     });
     });
 });
+

--- a/packages/@webex/plugin-meetings/test/unit/spec/interceptors/locusRetry.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/interceptors/locusRetry.ts
@@ -1,0 +1,130 @@
+/*!
+ * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
+ */
+
+/* eslint-disable camelcase */
+import {assert} from '@webex/test-helper-chai';
+import { expect } from "@webex/test-helper-chai";
+import MockWebex from '@webex/test-helper-mock-webex';
+import {LocusRetryStatusInterceptor} from "@webex/plugin-meetings/src/interceptors";
+import {WebexHttpError} from '@webex/webex-core';
+import Meetings from '@webex/plugin-meetings';
+import sinon from 'sinon';
+
+describe('plugin-meetings', () => {
+    describe('Interceptors', () => {
+      describe('LocusRetryStatusInterceptor', () => { 
+        let interceptor, webex;
+        beforeEach(() => {
+            webex = new MockWebex({
+                children: {
+                    meeting: Meetings,
+                  },
+            });
+            interceptor = Reflect.apply(LocusRetryStatusInterceptor.create, {
+                sessionId: 'mock-webex_uuid',
+              }, []);
+          });  
+        describe('#onResponseError', () => {
+            const options = {
+                method: 'POST',
+                headers: {
+                    trackingid: 'test',
+                    'retry-after': 1000,
+                },
+                uri: `https://locus-test.webex.com/locus/api/v1/loci/call`,
+                body: 'foo'
+                };
+            const reason1 = new WebexHttpError.MethodNotAllowed({
+                statusCode: 403,
+                options: {
+                    headers: {
+                        trackingid: 'test',
+                        'retry-after': 1000,
+                    },    
+                    uri: `https://locus-test.webex.com/locus/api/v1/loci/call`,
+                    },
+                body: {
+                    error: 'POST not allwed',
+                },
+                });
+            const reason2 = new WebexHttpError.MethodNotAllowed({
+                statusCode: 503,
+                options: {
+                    headers: {
+                        trackingid: 'test',
+                        'retry-after': 1000,
+                    },    
+                    uri: `https://locus-test.webex.com/locus/api/v1/loci/call`,
+                    },
+                body: {
+                    error: 'Service Unavailable',
+                    },
+                });
+
+            it('rejects when not locus service unavailable error', () => {
+                return assert.isRejected(interceptor.onResponseError(options, reason1));
+            });
+
+            it('calls handleRetryRequestLocusServiceError with correct retry time when locus service unavailable error', () => {
+                interceptor.webex.request = sinon.stub().returns(Promise.resolve());
+                const handleRetryStub = sinon.stub(interceptor, 'handleRetryRequestLocusServiceError');
+                handleRetryStub.returns(Promise.resolve());
+
+                return interceptor.onResponseError(options, reason2).then(() => {
+                    expect(handleRetryStub.calledWith(options, 1000)).to.be.true;
+                    
+                });
+            });
+        });
+
+        describe('#handleRetryRequestLocusServiceError', () => {
+            const options = {
+                method: 'POST',
+                headers: {
+                    trackingid: 'test',
+                },
+                uri: `https://locus-test.webex.com/locus/api/v1/loci/call`,
+                body: 'foo'
+                };
+            const retryAfterTime = 2000;
+
+            it('returns the correct resolved value when the request is successful', () => {
+                const mockResponse = 'mock response'
+                interceptor.webex.request = sinon.stub().returns(Promise.resolve(mockResponse));
+          
+                return interceptor.handleRetryRequestLocusServiceError(options, retryAfterTime)
+                  .then((response) => {
+                    expect(response).to.equal(mockResponse);
+                  });
+              });
+
+            it('rejects the promise when the request is unsuccessful', () => {
+              const rejectionReason = 'Service Unavaialble after retry';
+    
+              interceptor.webex.request = sinon.stub().returns(Promise.reject(rejectionReason));
+        
+              return interceptor.handleRetryRequestLocusServiceError(options, retryAfterTime)
+                .catch((error) => {
+                  expect(error).to.equal(rejectionReason);
+                });
+            });
+
+            it('retries the request after the specified time', () => {
+                let clock;
+                clock = sinon.useFakeTimers();
+                const mockResponse = 'mock response'
+      
+                interceptor.webex.request = sinon.stub().returns(Promise.resolve(mockResponse));
+                const promise = interceptor.handleRetryRequestLocusServiceError(options, retryAfterTime);
+      
+                clock.tick(retryAfterTime);
+
+                return promise.then(() => {
+                    expect(interceptor.webex.request.calledOnce).to.be.true;
+                    });
+            });
+        });
+    });
+    });
+});


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-474918

## This pull request addresses

If the client receives a 503 error message and if the Retry-After header is present, then client will retry with the same request based on the estimated time, if there is no Retry-After header, then client will immediately retry the exact same request one more time before it notifies the user of the error.

## by making the following changes

Added an interceptor to catch locus 503 errors and added a retry logic using setTimer to retry same request after Retry-After time (if given) or 2000ms (default)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
