### PR TITLE
fix(plugin-meetings): Fix timestamp

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -566,7 +566,7 @@ export default class Meeting extends StatelessWebexPlugin {
   meetingState: any;
   permissionToken: string;
   permissionTokenPayload: any;
-  tokenReceivedTime: number;
+  permissionTokenReceivedLocalTime: number;
   resourceId: any;
   resourceUrl: string;
   selfId: string;
@@ -3541,7 +3541,7 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   public setPermissionTokenPayload(permissionToken: string) {
     this.permissionTokenPayload = jwt.decode(permissionToken);
-    this.tokenReceivedTime = new Date().getTime();
+    this.permissionTokenReceivedLocalTime = new Date().getTime();
   }
 
   /**
@@ -7980,10 +7980,10 @@ export default class Meeting extends StatelessWebexPlugin {
       return undefined;
     }
 
-    const permissionTokenExpValue = Number(this.permissionTokenPayload.exp);
-    const permissionTokenIssuedTime = Number(this.permissionTokenPayload.iat);
+    const permissionTokenExpiryFromServer = Number(this.permissionTokenPayload.exp);
+    const permissionTokenIssuedTimeFromServer = Number(this.permissionTokenPayload.iat);
 
-    const shiftInTime = this.tokenReceivedTime - permissionTokenIssuedTime;
+    const shiftInTime = this.permissionTokenReceivedLocalTime - permissionTokenIssuedTimeFromServer;
 
     // using new Date instead of Date.now() to allow for accurate unit testing
     // https://github.com/sinonjs/fake-timers/issues/321
@@ -7992,9 +7992,9 @@ export default class Meeting extends StatelessWebexPlugin {
     // adjusted time is calculated in case your machine time is wrong
     const adjustedCurrentTime = currentTime - shiftInTime;
 
-    const timeLeft = (permissionTokenExpValue - adjustedCurrentTime) / 1000;
+    const timeLeft = (permissionTokenExpiryFromServer - adjustedCurrentTime) / 1000;
 
-    return {timeLeft, expiryTime: permissionTokenExpValue, currentTime};
+    return {timeLeft, expiryTime: permissionTokenExpiryFromServer, currentTime};
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -7973,7 +7973,10 @@ export default class Meeting extends StatelessWebexPlugin {
    * Gets permission token expiry information including timeLeft, expiryTime, currentTime
    * (from the time the function has been fired)
    *
-   * @returns {object} containing timeLeft, expiryTime, currentTime
+   * @returns {object} permissionTokenExpiryInfo
+   * @returns {number} permissionTokenExpiryInfo.timeLeft The time left for token to expire
+   * @returns {number} permissionTokenExpiryInfo.expiryTime The expiry time of permission token from the server
+   * @returns {number} permissionTokenExpiryInfo.currentTime The current time of the local machine
    */
   public getPermissionTokenExpiryInfo() {
     if (!this.permissionTokenPayload) {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -7989,7 +7989,7 @@ export default class Meeting extends StatelessWebexPlugin {
     // https://github.com/sinonjs/fake-timers/issues/321
     const currentTime = new Date().getTime();
 
-    // This is done incase your machine time is wrong
+    // adjusted time is calculated in case your machine time is wrong
     const adjustedCurrentTime = currentTime - shiftInTime;
 
     const timeLeft = (permissionTokenExpValue - adjustedCurrentTime) / 1000;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -9942,12 +9942,48 @@ describe('plugin-meetings', () => {
       assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: -1, expiryTime: Number(expiryTime), currentTime: now});
     });
 
-    describe('#getPermissionTokenExpiryInfo with wrong current Time', () => {
+    describe('#getPermissionTokenExpiryInfo with wrong current time which is in future', () => {
       let now;
       let clock;
       beforeEach(() => {
         // current time is 3 hours off
         now = Date.now() + 10800000;
+  
+        // mock `new Date()` with constant `now`
+        clock = sinon.useFakeTimers(now);
+      });
+  
+      afterEach(() => {
+        clock.restore();
+      })
+  
+      it('should return the expected positive exp when client time is wrong', () => {
+        const serverTime = Date.now();
+  
+       // set permission token as now + 1 sec
+        const expiryTime = serverTime + 1000;
+        meeting.permissionTokenPayload = {exp: (expiryTime).toString(), iat: serverTime};
+        meeting.permissionTokenReceivedLocalTime = now;
+        assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: 1, expiryTime: Number(expiryTime), currentTime: now});
+      });
+  
+      it('should return the expected negative exp when client time is wrong', () => {
+        const serverTime = Date.now();
+        // set permission token as now - 1 sec
+        const expiryTime = serverTime - 1000;
+        meeting.permissionTokenPayload = {exp: (expiryTime).toString(), iat: serverTime};
+        meeting.permissionTokenReceivedLocalTime = now;
+        assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: -1, expiryTime: Number(expiryTime), currentTime: now});
+      });
+  
+    });
+
+    describe('#getPermissionTokenExpiryInfo with wrong current Time which is in the past', () => {
+      let now;
+      let clock;
+      beforeEach(() => {
+        // current time is 3 hours off
+        now = Date.now() - 10800000;
   
         // mock `new Date()` with constant `now`
         clock = sinon.useFakeTimers(now);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -7351,7 +7351,7 @@ describe('plugin-meetings', () => {
 
           assert.calledOnce(jwtDecodeStub);
           assert.deepEqual(meeting.permissionTokenPayload, permissionTokenPayloadData);
-          assert.deepEqual(meeting.tokenReceivedTime, now);
+          assert.deepEqual(meeting.permissionTokenReceivedLocalTime, now);
         });
       });
 
@@ -9930,7 +9930,7 @@ describe('plugin-meetings', () => {
       // set permission token as now + 1 sec
       const expiryTime = now + 1000;
       meeting.permissionTokenPayload = {exp: (expiryTime).toString(), iat: now};
-      meeting.tokenReceivedTime = now;
+      meeting.permissionTokenReceivedLocalTime = now;
       assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: 1, expiryTime: Number(expiryTime), currentTime: now});
     });
 
@@ -9938,7 +9938,7 @@ describe('plugin-meetings', () => {
       // set permission token as now - 1 sec
       const expiryTime = now - 1000;
       meeting.permissionTokenPayload = {exp: (expiryTime).toString(), iat: now};
-      meeting.tokenReceivedTime = now;
+      meeting.permissionTokenReceivedLocalTime = now;
       assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: -1, expiryTime: Number(expiryTime), currentTime: now});
     });
 
@@ -9963,7 +9963,7 @@ describe('plugin-meetings', () => {
        // set permission token as now + 1 sec
         const expiryTime = serverTime + 1000;
         meeting.permissionTokenPayload = {exp: (expiryTime).toString(), iat: serverTime};
-        meeting.tokenReceivedTime = now;
+        meeting.permissionTokenReceivedLocalTime = now;
         assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: 1, expiryTime: Number(expiryTime), currentTime: now});
       });
   
@@ -9972,7 +9972,7 @@ describe('plugin-meetings', () => {
         // set permission token as now - 1 sec
         const expiryTime = serverTime - 1000;
         meeting.permissionTokenPayload = {exp: (expiryTime).toString(), iat: serverTime};
-        meeting.tokenReceivedTime = now;
+        meeting.permissionTokenReceivedLocalTime = now;
         assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: -1, expiryTime: Number(expiryTime), currentTime: now});
       });
   

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -7326,6 +7326,20 @@ describe('plugin-meetings', () => {
       });
 
       describe('#setPermissionTokenPayload', () => {
+
+        let now;
+        let clock;
+    
+        beforeEach(() => {
+          now = Date.now();
+    
+          // mock `new Date()` with constant `now`
+          clock = sinon.useFakeTimers(now);
+        });
+    
+        afterEach(() => {
+          clock.restore();
+        })
         it('sets correctly', () => {
           assert.notOk(meeting.permissionTokenPayload);
 
@@ -7337,6 +7351,7 @@ describe('plugin-meetings', () => {
 
           assert.calledOnce(jwtDecodeStub);
           assert.deepEqual(meeting.permissionTokenPayload, permissionTokenPayloadData);
+          assert.deepEqual(meeting.tokenReceivedTime, now);
         });
       });
 
@@ -9914,17 +9929,57 @@ describe('plugin-meetings', () => {
     it('should return the expected positive exp', () => {
       // set permission token as now + 1 sec
       const expiryTime = now + 1000;
-      meeting.permissionTokenPayload = {exp: (expiryTime).toString()};
+      meeting.permissionTokenPayload = {exp: (expiryTime).toString(), iat: now};
+      meeting.tokenReceivedTime = now;
       assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: 1, expiryTime: Number(expiryTime), currentTime: now});
     });
 
     it('should return the expected negative exp', () => {
       // set permission token as now - 1 sec
       const expiryTime = now - 1000;
-      meeting.permissionTokenPayload = {exp: (expiryTime).toString()};
+      meeting.permissionTokenPayload = {exp: (expiryTime).toString(), iat: now};
+      meeting.tokenReceivedTime = now;
       assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: -1, expiryTime: Number(expiryTime), currentTime: now});
     });
+
+    describe('#getPermissionTokenExpiryInfo with wrong current Time', () => {
+      let now;
+      let clock;
+      beforeEach(() => {
+        // current time is 3 hours off
+        now = Date.now() + 10800000;
+  
+        // mock `new Date()` with constant `now`
+        clock = sinon.useFakeTimers(now);
+      });
+  
+      afterEach(() => {
+        clock.restore();
+      })
+  
+      it('should return the expected positive exp when client time is wrong', () => {
+        const serverTime = Date.now();
+  
+       // set permission token as now + 1 sec
+        const expiryTime = serverTime + 1000;
+        meeting.permissionTokenPayload = {exp: (expiryTime).toString(), iat: serverTime};
+        meeting.tokenReceivedTime = now;
+        assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: 1, expiryTime: Number(expiryTime), currentTime: now});
+      });
+  
+      it('should return the expected negative exp when client time is wrong', () => {
+        const serverTime = Date.now();
+        // set permission token as now - 1 sec
+        const expiryTime = serverTime - 1000;
+        meeting.permissionTokenPayload = {exp: (expiryTime).toString(), iat: serverTime};
+        meeting.tokenReceivedTime = now;
+        assert.deepEqual(meeting.getPermissionTokenExpiryInfo(), {timeLeft: -1, expiryTime: Number(expiryTime), currentTime: now});
+      });
+  
+    });
   });
+
+
 
   describe('#checkAndRefreshPermissionToken', () => {
     it('should not fire refreshPermissionToken if permissionToken is not defined', async() => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-484765
## This pull request addresses

Issue is that if client's clock is wrong then we calculate the timeLeft for permission token to expire incorrectly hence refreshing the token when not required.
To work around this we now get the current time when we receive the token, we also extract iat (issued time) from permission token payload and workout the shift in time. We then use this to work out the adjusted current time before calculating the timeLeft for permission token to expire. This fix stops us from  refreshing the token when it' not required.

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
