### PR TITLE
fix(plugin-meetings): downgrade jwtDecode for node 16 usage

### DIFF
--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -82,10 +82,13 @@
     "global": "^4.4.0",
     "ip-anonymize": "^0.1.0",
     "javascript-state-machine": "^3.1.0",
-    "jwt-decode": "^4.0.0",
+    "jwt-decode": "3.1.2",
     "lodash": "^4.17.21",
     "sdp-transform": "^2.12.0",
     "uuid": "^3.3.2",
     "webrtc-adapter": "^8.1.2"
-  }
+  },
+  "//": [
+    "TODO: upgrade jwt-decode when moving to node 18"
+  ]
 }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1,6 +1,6 @@
 import uuid from 'uuid';
 import {cloneDeep, isEqual, isEmpty} from 'lodash';
-import {jwtDecode as decode} from 'jwt-decode';
+import jwtDecode from 'jwt-decode';
 // @ts-ignore - Fix this
 import {StatelessWebexPlugin} from '@webex/webex-core';
 // @ts-ignore - Types not available for @webex/common
@@ -3549,7 +3549,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {void}
    */
   public setPermissionTokenPayload(permissionToken: string) {
-    this.permissionTokenPayload = decode(permissionToken);
+    this.permissionTokenPayload = jwtDecode(permissionToken);
     this.permissionTokenReceivedLocalTime = new Date().getTime();
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7948,7 +7948,7 @@ __metadata:
     javascript-state-machine: ^3.1.0
     jsdom: 19.0.0
     jsdom-global: 3.0.2
-    jwt-decode: ^4.0.0
+    jwt-decode: 3.1.2
     lodash: ^4.17.21
     prettier: ^2.7.1
     sdp-transform: ^2.12.0
@@ -20908,10 +20908,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jwt-decode@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jwt-decode@npm:4.0.0"
-  checksum: 390e2edcb31a92e86c8cbdd1edeea4c0d62acd371f8a8f0a8878e499390c0ecf4c658b365c4e941e4ef37d0170e4ca650aaa49f99a45c0b9695a235b210154b0
+"jwt-decode@npm:3.1.2":
+  version: 3.1.2
+  resolution: "jwt-decode@npm:3.1.2"
+  checksum: 20a4b072d44ce3479f42d0d2c8d3dabeb353081ba4982e40b83a779f2459a70be26441be6c160bfc8c3c6eadf9f6380a036fbb06ac5406b5674e35d8c4205eeb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES AdHoc PR

## This pull request addresses

- `jwtDecode@4.x` requires node 18 and the SDK doesn't need node 18.

## by making the following changes

- Downgrading the jwtDecode's version to an older one where the node version isn't a requirement

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
