### PR TITLE
fix: manual version change to 3.0.0-beta.344 due to failed publish step

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex-js-sdk",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "JavaScript SDK for interacting with the Webex API",
   "homepage": "https://github.com/webex/webex-js-sdk",
   "bugs": {

--- a/packages/@webex/common-evented/package.json
+++ b/packages/@webex/common-evented/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/common-evented",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "Class property decorator the adds change events to properties",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/common-timers/package.json
+++ b/packages/@webex/common-timers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/common-timers",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "Timer wrappers to prevent wedging a process open",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/common/package.json
+++ b/packages/@webex/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/common",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "Common utilities for Cisco Webex",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/helper-html/package.json
+++ b/packages/@webex/helper-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/helper-html",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "HTML Utiltities",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/helper-image/package.json
+++ b/packages/@webex/helper-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/helper-image",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Saurabh Jain <saurjai3@cisco.com>",

--- a/packages/@webex/http-core/package.json
+++ b/packages/@webex/http-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/http-core",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "Core HTTP library for the Cisco Webex",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/internal-plugin-avatar/package.json
+++ b/packages/@webex/internal-plugin-avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-avatar",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Joe Fuhrman <jofuhrma@cisco.com>",

--- a/packages/@webex/internal-plugin-board/package.json
+++ b/packages/@webex/internal-plugin-board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-board",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Greg Hewett <ghewett@cisco.com>",

--- a/packages/@webex/internal-plugin-calendar/package.json
+++ b/packages/@webex/internal-plugin-calendar/package.json
@@ -19,7 +19,7 @@
       "envify"
     ]
   },
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "devDependencies": {
     "@webex/test-helper-chai": "workspace:^",
     "@webex/test-helper-mock-webex": "workspace:^",

--- a/packages/@webex/internal-plugin-conversation/package.json
+++ b/packages/@webex/internal-plugin-conversation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-conversation",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/internal-plugin-device/package.json
+++ b/packages/@webex/internal-plugin-device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-device",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Timothy Scheuering <timsch@cisco.com>",

--- a/packages/@webex/internal-plugin-dss/package.json
+++ b/packages/@webex/internal-plugin-dss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-dss",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Colin Read <coread@cisco.com>",

--- a/packages/@webex/internal-plugin-ediscovery/package.json
+++ b/packages/@webex/internal-plugin-ediscovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-ediscovery",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/@webex/internal-plugin-encryption/package.json
+++ b/packages/@webex/internal-plugin-encryption/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-encryption",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/internal-plugin-feature/package.json
+++ b/packages/@webex/internal-plugin-feature/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-feature",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Aimee <aimma@cisco.com>",

--- a/packages/@webex/internal-plugin-flag/package.json
+++ b/packages/@webex/internal-plugin-flag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-flag",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Saurabh Jain <saurjai3@cisco.com>",

--- a/packages/@webex/internal-plugin-llm/package.json
+++ b/packages/@webex/internal-plugin-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-llm",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "Cisco EULA (https://www.cisco.com/c/en/us/products/end-user-license-agreement.html)",
   "main": "dist/index.js",

--- a/packages/@webex/internal-plugin-locus/package.json
+++ b/packages/@webex/internal-plugin-locus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-locus",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/internal-plugin-lyra/package.json
+++ b/packages/@webex/internal-plugin-lyra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-lyra",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Tran Tu <tratu@cisco.com>",

--- a/packages/@webex/internal-plugin-mercury/package.json
+++ b/packages/@webex/internal-plugin-mercury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-mercury",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/internal-plugin-metrics/package.json
+++ b/packages/@webex/internal-plugin-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-metrics",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/internal-plugin-presence/package.json
+++ b/packages/@webex/internal-plugin-presence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-presence",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/internal-plugin-search/package.json
+++ b/packages/@webex/internal-plugin-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-search",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Michael Wegman <mwegman@cisco.com>",

--- a/packages/@webex/internal-plugin-support/package.json
+++ b/packages/@webex/internal-plugin-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-support",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "nickclar <nickclar@cisco.com>",

--- a/packages/@webex/internal-plugin-team/package.json
+++ b/packages/@webex/internal-plugin-team/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-team",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Josh Dykstra <jodykstr@cisco.com>",

--- a/packages/@webex/internal-plugin-user/package.json
+++ b/packages/@webex/internal-plugin-user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-user",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/internal-plugin-voicea/package.json
+++ b/packages/@webex/internal-plugin-voicea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-voicea",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "Cisco EULA (https://www.cisco.com/c/en/us/products/end-user-license-agreement.html)",
   "main": "dist/index.js",

--- a/packages/@webex/internal-plugin-wdm/package.json
+++ b/packages/@webex/internal-plugin-wdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/internal-plugin-wdm",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/jsdoctrinetest/package.json
+++ b/packages/@webex/jsdoctrinetest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/jsdoctrinetest",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/media-helpers",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "Cisco EULA (https://www.cisco.com/c/en/us/products/end-user-license-agreement.html)",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-attachment-actions/package.json
+++ b/packages/@webex/plugin-attachment-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-attachment-actions",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/@webex/plugin-authorization-browser-first-party/package.json
+++ b/packages/@webex/plugin-authorization-browser-first-party/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-authorization-browser-first-party",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Ian W. Remmel <iremmel@cisco.com>",

--- a/packages/@webex/plugin-authorization-browser/package.json
+++ b/packages/@webex/plugin-authorization-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-authorization-browser",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-authorization-node/package.json
+++ b/packages/@webex/plugin-authorization-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-authorization-node",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-authorization/package.json
+++ b/packages/@webex/plugin-authorization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-authorization",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-device-manager/package.json
+++ b/packages/@webex/plugin-device-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-device-manager",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/@webex/plugin-logger/package.json
+++ b/packages/@webex/plugin-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-logger",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-meetings",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "Cisco EULA (https://www.cisco.com/c/en/us/products/end-user-license-agreement.html)",
   "contributors": [

--- a/packages/@webex/plugin-memberships/package.json
+++ b/packages/@webex/plugin-memberships/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-memberships",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-messages/package.json
+++ b/packages/@webex/plugin-messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-messages",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-people/package.json
+++ b/packages/@webex/plugin-people/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-people",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-rooms/package.json
+++ b/packages/@webex/plugin-rooms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-rooms",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-team-memberships/package.json
+++ b/packages/@webex/plugin-team-memberships/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-team-memberships",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-teams/package.json
+++ b/packages/@webex/plugin-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-teams",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/plugin-webhooks/package.json
+++ b/packages/@webex/plugin-webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/plugin-webhooks",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/recipe-private-web-client/package.json
+++ b/packages/@webex/recipe-private-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/recipe-private-web-client",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "This is a plugin recipe for the Cisco Webex JS SDK. This recipe uses internal APIs to provide the features needed by the Cisco Webex Teams Client. There is no guarantee of non-breaking changes. Non-Cisco engineers should stick to the `webex` package.",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/storage-adapter-local-forage/package.json
+++ b/packages/@webex/storage-adapter-local-forage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/storage-adapter-local-forage",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Matt Norris <matthew.g.norris@gmail.com>",

--- a/packages/@webex/storage-adapter-local-storage/package.json
+++ b/packages/@webex/storage-adapter-local-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/storage-adapter-local-storage",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/storage-adapter-session-storage/package.json
+++ b/packages/@webex/storage-adapter-session-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/storage-adapter-session-storage",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "author": "Andrew Holsted <holsted@cisco.com>",

--- a/packages/@webex/storage-adapter-spec/package.json
+++ b/packages/@webex/storage-adapter-spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/storage-adapter-spec",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-appid/package.json
+++ b/packages/@webex/test-helper-appid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-appid",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-automation/package.json
+++ b/packages/@webex/test-helper-automation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-automation",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-chai/package.json
+++ b/packages/@webex/test-helper-chai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-chai",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "chai extended with webex specific assertions",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-file/package.json
+++ b/packages/@webex/test-helper-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-file",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "File helpers for writing isomorphicish mocha tests",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-make-local-url/package.json
+++ b/packages/@webex/test-helper-make-local-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-make-local-url",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-mocha/package.json
+++ b/packages/@webex/test-helper-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-mocha",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "Helpers for controlling where tests run",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-mock-web-socket/package.json
+++ b/packages/@webex/test-helper-mock-web-socket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-mock-web-socket",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-mock-webex/package.json
+++ b/packages/@webex/test-helper-mock-webex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-mock-webex",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-refresh-callback/package.json
+++ b/packages/@webex/test-helper-refresh-callback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-refresh-callback",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-retry/package.json
+++ b/packages/@webex/test-helper-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-retry",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-server/package.json
+++ b/packages/@webex/test-helper-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-server",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-helper-test-users/package.json
+++ b/packages/@webex/test-helper-test-users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-helper-test-users",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/test-users/package.json
+++ b/packages/@webex/test-users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/test-users",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "Cisco Webex Test Users",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/@webex/webex-core/package.json
+++ b/packages/@webex/webex-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/webex-core",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "Plugin handling for Cisco Webex",
   "license": "MIT",
   "contributors": [

--- a/packages/@webex/webrtc/package.json
+++ b/packages/@webex/webrtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/webrtc",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "contributors": [

--- a/packages/@webex/xunit-with-logs/package.json
+++ b/packages/@webex/xunit-with-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webex/xunit-with-logs",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/webex/package.json
+++ b/packages/webex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex",
-  "version": "3.0.0-beta.343",
+  "version": "3.0.0-beta.344",
   "description": "SDK for Cisco Webex",
   "license": "Cisco EULA (https://www.cisco.com/c/en/us/products/end-user-license-agreement.html)",
   "contributors": [


### PR DESCRIPTION
## This pull request addresses

Manual version change from 3.0.0-beta.343 to 3.0.0-beta.344 due to a failed publish step, where the new version should have been pushed back into the branch (see [this CircleCI workflow](https://app.circleci.com/pipelines/github/webex/webex-js-sdk/14930/workflows/07221c0e-e0cb-4532-9137-9281bcdc1863/jobs/86372) for details).

## by making the following changes

Changing the version string in all `package.json` files in the repo.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
