### PR TITLE
fix(meeting): allow unmute request from user when unmuteAllowed becomes null

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -82,8 +82,6 @@ class MuteState {
       `Meeting:muteState#handleClientRequest --> ${this.type}: user requesting new mute state: ${mute}`
     );
 
-    // customer reported that sometimes the unmuteAllowed value is not available, so we need to check for it
-    // we would skip to true if the value is not available, because it's the safest option
     if (!mute && this.state.server.unmuteAllowed !== null && !this.state.server.unmuteAllowed) {
       return Promise.reject(
         new PermissionError('User is not allowed to unmute self (hard mute feature is being used)')

--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -82,7 +82,9 @@ class MuteState {
       `Meeting:muteState#handleClientRequest --> ${this.type}: user requesting new mute state: ${mute}`
     );
 
-    if (!mute && !this.state.server.unmuteAllowed) {
+    // customer reported that sometimes the unmuteAllowed value is not available, so we need to check for it
+    // we would skip to true if the value is not available, because it's the safest option
+    if (!mute && this.state.server.unmuteAllowed !== null && !this.state.server.unmuteAllowed) {
       return Promise.reject(
         new PermissionError('User is not allowed to unmute self (hard mute feature is being used)')
       );


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # BEMS01708233

## This pull request addresses

ExtCare has reported that participants lose mute control after X mins in a session.  A user will join and is muted, after a while they cannot unmute or mute themselves.  

Snippet of the error on the JS SDK logs
```
,2024-02-12T16:05:03.779Z,wx-js-sdk,Meeting:index#unmuteAudio --> unmuting audio
,2024-02-12T16:05:03.783Z,wx-js-sdk,Meeting:index#unmuteAudio --> unmuting audio failed, ,Error
at new r (https://assets.extcareop.com/mirror/cisco/webex/teams/sdk/2.57.1/webex.min.js:2:872506)
at e.value (https://assets.extcareop.com/mirror/cisco/webex/teams/sdk/2.57.1/webex.min.js:2:1079021)
at a.value (https://assets.extcareop.com/mirror/cisco/webex/teams/sdk/2.57.1/webex.min.js:2:1232249)
at VCRWebexMeeting.unmuteAudio (webpack://encounterui/./src/components/VideoCollaboration/Webex/WebexMeetings.jsx?:1144:29)
at CallControls.toggleAudioMute (webpack://encounterui/./src/view/collaboration/CallControls.jsx?:224:107)
at onClick (webpack://encounterui/./src/view/collaboration/CallControls.jsx?:447:25)
at Object.Nb (webpack://encounterui/./node_modules/react-dom/cjs/react-dom.production.min.js?:54:317)
at Tb (webpack://encounterui/./node_modules/react-dom/cjs/react-dom.production.min.js?:54:471)
at Ub (webpack://encounterui/./node_modules/react-dom/cjs/react-dom.production.min.js?:55:35)
at nf (webpack://encounterui/./node_modules/react-dom/cjs/react-dom.production.min.js?:105:68)
,2024-02-12T16:05:05.685Z,wx-js-sdk,StatsAnalyzer:index#compareLastStatsResult --> No video Frames sent
```

During troubleshooting, it looks like the unmuteAllowed variable is set to null sometimes. Due to this, even though the user should be able to unmute themselves, the code ends up going into a condition that rejects the mute request with a permissions error.

## by making the following changes

We now check if unmuteAllowed is not null, and only then verify if a permissions error needs to be thrown for the mute/unmute request. This way, due to any race conditions if the unmuteAllowed becomes `null`, we can still allow the user to unmute.
One side effect is that if the unmuteAllowed is set to true, we will still not throw a permissions error and allow the user to attempt the unmute, but the request to unmute will fail at the server side and we'll catch this error in the JS SDK. So there is no impact to functionality. 

This fix will only exist for the master branch, as the next branch has an improved implementation of the mute/unmute functionality.


<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

ExtCare has taken the zip file provided by @arun3528 and tried to recreate the issue with the mute. Across 20 calls, the issue was not reproducible.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
