### PR TITLE
fix(plugin-meetings): add connection id to rtcmetrics

### DIFF
--- a/packages/@webex/plugin-meetings/test/unit/spec/rtcMetrics/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/rtcMetrics/index.ts
@@ -95,6 +95,14 @@ describe('RtcMetrics', () => {
     assert.callCount(webex.request, 1);
   });
 
+  it('should have the same connectionId on success', () => {
+    const originalId = metrics.connectionId;
+
+    metrics.addMetrics(FAKE_METRICS_ITEM);
+
+    assert.strictEqual(originalId, metrics.connectionId);
+  });
+
   it('should have a new connectionId on failure', () => {
     const originalId = metrics.connectionId;
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/rtcMetrics/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/rtcMetrics/index.ts
@@ -4,10 +4,15 @@ import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
 import RTC_METRICS from '../../../../src/rtcMetrics/constants';
 
-const FAKE_METRICS_ITEM = {payload: ['fake-metrics']};
+const FAKE_METRICS_ITEM = {payload: ['{"type":"string","value":"fake-metrics","id":""}']};
+const FAILURE_METRICS_ITEM = {
+  name: "onconnectionstatechange",
+  payload: ['{"type":"string","value":"failed","id":""}'],
+  timestamp: 1707929986667
+};
 
-const STATS_WITH_IP = '{\"id\":\"RTCIceCandidate_/kQs0ZNU\",\"type\":\"remote-candidate\",\"transportId\":\"RTCTransport_0_1\",\"isRemote\":true,\"ip\":\"11.22.111.255\",\"address\":\"11.22.111.255\",\"port\":5004,\"protocol\":\"udp\",\"candidateType\":\"host\",\"priority\":2130706431}';
-const STATS_WITH_IP_RESULT = '{\"id\":\"RTCIceCandidate_/kQs0ZNU\",\"type\":\"remote-candidate\",\"transportId\":\"RTCTransport_0_1\",\"isRemote\":true,\"ip\":\"11.22.111.240\",\"address\":\"11.22.111.240\",\"port\":5004,\"protocol\":\"udp\",\"candidateType\":\"host\",\"priority\":2130706431}';
+const STATS_WITH_IP = '{"id":"RTCIceCandidate_/kQs0ZNU","type":"remote-candidate","transportId":"RTCTransport_0_1","isRemote":true,"ip":"11.22.111.255","address":"11.22.111.255","port":5004,"protocol":"udp","candidateType":"host","priority":2130706431}';
+const STATS_WITH_IP_RESULT = '{"id":"RTCIceCandidate_/kQs0ZNU","type":"remote-candidate","transportId":"RTCTransport_0_1","isRemote":true,"ip":"11.22.111.240","address":"11.22.111.240","port":5004,"protocol":"udp","candidateType":"host","priority":2130706431}';
 
 describe('RtcMetrics', () => {
   let metrics: RtcMetrics;
@@ -80,6 +85,22 @@ describe('RtcMetrics', () => {
     metrics.closeMetrics();
 
     assert.callCount(webex.request, 1);
+  });
+
+  it('should clear out metrics on failure', () => {
+    assert.notCalled(webex.request);
+
+    metrics.addMetrics(FAILURE_METRICS_ITEM);
+
+    assert.callCount(webex.request, 1);
+  });
+
+  it('should have a new connectionId on failure', () => {
+    const originalId = metrics.connectionId;
+
+    metrics.addMetrics(FAILURE_METRICS_ITEM);
+
+    assert.notEqual(originalId, metrics.connectionId);
   });
 
   it('should anonymize IP addresses', () => {


### PR DESCRIPTION
# COMPLETES [SPARK-487284](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-487284) and [SPARK-487252](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-487252)

## This pull request addresses

Reconnections ruining telemetry dumps. This PR in conjunction with work on the job will show multiple connections in calls where a reconnect happens.

## by making the following changes

Adding a connection id to metrics payloads and resetting the connection id on RTCPeerConnection `connectionstatechange` events.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Sending queued metrics and creating a new `connectionId` on a `connectionstatechange` failure event.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
