### PR TITLE
feat(pluging-meetings): sync all meetings from Meeting Collection when reconnecting

### DIFF
--- a/packages/@webex/plugin-meetings/README.md
+++ b/packages/@webex/plugin-meetings/README.md
@@ -98,7 +98,7 @@ return webex.meetings.create(locusObj, 'LOCUS_ID').then((meeting) ==> {...});
 
 We want to sync our meetings collection with the server.
 
-To keep only Locus meetings with an active locus url:
+To keep only Locus meetings with an locus url that is still active:
 
 ```js
 let existingMeetings;
@@ -109,11 +109,11 @@ webex.meetings.syncMeetings().then(() => {
 });
 ```
 
-Or, to keep Locus meetings with an active Locus url or any meeting without a locus url:
+Or, to keep meetings with an locus url that is still active and any meeting without a locus url:
 ```js
 let existingMeetings;
 // Sync Meetings From Server
-webex.meetings.syncMeetings(false).then(() => {
+webex.meetings.syncMeetings({keepOnlyLocusMeetings: false}).then(() => {
   // Existing meetings live in the meeting collection
   existingMeetings = webex.meetings.getAllMeetings();
 });

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -584,7 +584,7 @@ export default class Meetings extends WebexPlugin {
 
     // @ts-ignore
     this.webex.internal.mercury.on(ONLINE, () => {
-      this.syncMeetings({keepOnlyLocusMeetings: true});
+      this.syncMeetings({keepOnlyLocusMeetings: false});
     });
 
     // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
@@ -442,7 +442,7 @@ export default class ReconnectionManager {
         LoggerProxy.logger.info(
           'ReconnectionManager:index#executeReconnection --> Updating meeting data from server.'
         );
-        await this.webex.meetings.syncMeetings();
+        await this.webex.meetings.syncMeetings({keepOnlyLocusMeetings: false});
       } catch (syncError) {
         LoggerProxy.logger.info(
           'ReconnectionManager:index#executeReconnection --> Unable to sync meetings, reconnecting.',

--- a/packages/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
@@ -81,6 +81,7 @@ describe('plugin-meetings', () => {
       await rm.reconnect();
 
       assert.calledOnce(rm.webex.meetings.syncMeetings);
+      assert.calledWith(rm.webex.meetings.syncMeetings, {keepOnlyLocusMeetings: false});
     });
 
     it('does not sync meetings if it is an unverified guest', async () => {


### PR DESCRIPTION
# COMPLETES #SPARK-484517

## This pull request addresses

When Mercury reconnection occurs, we want to sync all meetings from Meetings Collection. In syncMeetings, the default of keepOnlyLocusMeetings is true to not cause breaking changes as the old behaviour of syncMeetings was to keeping only Locus Meetings and destroying any other.

## by making the following changes

Set keepOnlyLocusMeetings to false on reconnection cases. This means that, on reconnection, meetings without an active locus url would NOT be destroyed, and thus, will be kept on the sync.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request
- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
