### PR TITLE
fix(calling): added new janus event in Call History module

### DIFF
--- a/packages/calling/src/CallHistory/CallHistory.ts
+++ b/packages/calling/src/CallHistory/CallHistory.ts
@@ -139,6 +139,14 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
         }
       }
     );
+    this.sdkConnector.registerListener<CallSessionEvent>(
+      MOBIUS_EVENT_KEYS.LOCUS_CALL_SESSION_EVENT,
+      async (event?: CallSessionEvent) => {
+        if (event && event.data.userSessions.userSessions) {
+          this.emit(COMMON_EVENT_KEYS.CALL_HISTORY_USER_SESSION_INFO, event as CallSessionEvent);
+        }
+      }
+    );
   }
 }
 /**

--- a/packages/calling/src/Events/types.ts
+++ b/packages/calling/src/Events/types.ts
@@ -155,6 +155,7 @@ export type Item = {
 export enum MOBIUS_EVENT_KEYS {
   SERVER_EVENT_INCLUSIVE = 'event:mobius',
   CALL_SESSION_EVENT_INCLUSIVE = 'event:janus.user_recent_sessions',
+  LOCUS_CALL_SESSION_EVENT = 'event:janus.user_sessions',
 }
 
 export type CallSessionData = {


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses
For Call on Webex(Locus call) option, Janus triggers a different event(janus.user_sessions) which is not being listened for in Calling SDK hence no event is triggered for this type of call from the SDK. Salesforce need an event for Locus call as well from Calling SDK.

## by making the following changes
Added listening for janus.user_sessions event in CallHistory module and emitting callHistory:user_reecent_sessions for locus call as well.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
Testcase: Triggered Call On Webex option and verified in the logs event being received.

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
