### PR TITLE
fix: when reconnecting, JS-SDK calls Locus /media API with empty mediaId twice

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5390,7 +5390,6 @@ export default class Meeting extends StatelessWebexPlugin {
                 seq: event.roapMessage.seq,
                 tieBreaker: event.roapMessage.tieBreaker,
                 meeting: this, // or can pass meeting ID
-                reconnect: this.reconnectionManager.isReconnectInProgress(),
               })
               .then(({roapAnswer}) => {
                 if (roapAnswer) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6765,7 +6765,6 @@ describe('plugin-meetings', () => {
               sdp: 'fake sdp',
               tieBreaker: 12345,
               meeting,
-              reconnect: false,
             });
             assert.notCalled(meeting.roapMessageReceived);
           });
@@ -6792,7 +6791,6 @@ describe('plugin-meetings', () => {
               sdp: 'fake sdp',
               tieBreaker: 12345,
               meeting,
-              reconnect: false,
             });
             assert.calledWith(meeting.roapMessageReceived, fakeAnswer);
           });
@@ -6822,7 +6820,6 @@ describe('plugin-meetings', () => {
               sdp: 'fake sdp',
               tieBreaker: 12345,
               meeting,
-              reconnect: false,
             });
             assert.notCalled(meeting.roapMessageReceived);
             assert.calledOnce(meeting.deferSDPAnswer.reject);


### PR DESCRIPTION
# COMPLETES #[SPARK-500905](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-500905)

## This pull request addresses
When we reconnect, we send some roap messages and 2 of them (TURN_DISCOVERY_REQUEST and OFFER) are being sent with empty media Id. Only the first one of them should be sent with empty media id. Empty media id indicates to Locus that this is a new connection and that they should create a new confluence in the server

## by making the following changes
As we are now hardcoded to always send TURN_DISCOVERY_REQUEST as the first Roap message when reconnecting, we can now also hardcode the code for sending offer to never use empty media id.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
