### PR TITLE
feat(tools/packages): update command

### DIFF
--- a/packages/tools/cli/package.json
+++ b/packages/tools/cli/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@webex/cli-tools",
-  "private": true,
   "packageManager": "yarn@3.4.1",
   "engines": {
     "node": ">=16.0.0",

--- a/packages/tools/package/README.md
+++ b/packages/tools/package/README.md
@@ -1,4 +1,4 @@
-# @webex/cli-tools
+# @webex/package-tools
 
 [![icense: mit](https://img.shields.io/badge/License-MIT-blueviolet?style=flat-square)](https://github.com/webex/webex-js-sdk/blob/master/LICENSE)
 ![state: beta](https://img.shields.io/badge/State\-Beta-blue?style=flat-square)

--- a/packages/tools/package/index.js
+++ b/packages/tools/package/index.js
@@ -8,6 +8,7 @@ const main = () => {
   commands.mount(PackageTools.list);
   commands.mount(PackageTools.scripts);
   commands.mount(PackageTools.sync);
+  commands.mount(PackageTools.update);
 
   commands.process();
 };

--- a/packages/tools/package/package.json
+++ b/packages/tools/package/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@webex/package-tools",
-  "private": true,
   "packageManager": "yarn@3.4.1",
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=16.0.0",
     "npm": ">=8.0.0",
     "yarn": ">=3.0.0"
   },

--- a/packages/tools/package/src/commands/index.ts
+++ b/packages/tools/package/src/commands/index.ts
@@ -2,6 +2,7 @@ export { default as increment } from './increment';
 export { default as list } from './list';
 export { default as scripts } from './scripts';
 export { default as sync } from './sync';
+export { default as update } from './update';
 
 export type {
   IncrementOptions,
@@ -19,3 +20,7 @@ export type {
 export type {
   SyncOptions,
 } from './sync';
+
+export type {
+  UpdateOptions,
+} from './update';

--- a/packages/tools/package/src/commands/sync/sync.ts
+++ b/packages/tools/package/src/commands/sync/sync.ts
@@ -20,10 +20,10 @@ import type { Options } from './sync.types';
  * @example
  * ```js
  * const { Commands } = require('@webex/cli-tools');
- * const increment = require('./relative/path/increment.js');
+ * const sync = require('./relative/path/sync.js');
  *
  * const commands = new Commands();
- * commands.mount(increment);
+ * commands.mount(sync);
  * commands.mount(otherCommandConfig);
  * commands.process();
  * ```

--- a/packages/tools/package/src/commands/update/index.ts
+++ b/packages/tools/package/src/commands/update/index.ts
@@ -1,0 +1,7 @@
+import update from './update';
+
+export type {
+  Options as UpdateOptions,
+} from './update.types';
+
+export default update;

--- a/packages/tools/package/src/commands/update/update.constants.ts
+++ b/packages/tools/package/src/commands/update/update.constants.ts
@@ -1,22 +1,22 @@
 import type { CommandsConfig } from '@webex/cli-tools';
 
 /**
- * `Commands.mount()` Commands Configuration Object for the sync Command
+ * `Commands.mount()` Commands Configuration Object for the update Command
  * Configuration Object.
  *
  * @public
  */
 const CONFIG: CommandsConfig = {
-  name: 'sync',
-  description: 'Synchronize the dependencies of filtered packages with npm',
+  name: 'update',
+  description: 'Update the dependencies for this local package',
   options: [
     {
-      description: 'Packages to synchronize with npm',
+      description: 'Packages to be updated',
       name: 'packages',
       type: 'string...',
     },
     {
-      description: 'Tag to synchronize the package with on npm',
+      description: 'Tag to update this local package with on npm',
       name: 'tag',
       type: 'string',
     },

--- a/packages/tools/package/src/commands/update/update.ts
+++ b/packages/tools/package/src/commands/update/update.ts
@@ -1,0 +1,104 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import type { CommandsCommand } from '@webex/cli-tools';
+
+import { Package } from '../../models';
+
+import CONSTANTS from './update.constants';
+import type { Options } from './update.types';
+
+/**
+ * The update Command configuration Object. This Command is used to update
+ * the versions of the provided dependencies within the repository.
+ *
+ * @remarks
+ * This Object is used as a mountable configuration for `@webex/cli-tools`
+ * Commands class instances, using the `new Commands().mount()` method.
+ *
+ * @example
+ * ```js
+ * const { Commands } = require('@webex/cli-tools');
+ * const update = require('./relative/path/update.js');
+ *
+ * const commands = new Commands();
+ * commands.mount(update);
+ * commands.mount(otherCommandConfig);
+ * commands.process();
+ * ```
+ *
+ * @public
+ */
+const update: CommandsCommand<Options> = {
+  /**
+   * Configuration Object for this update Command configuration.
+   */
+  config: CONSTANTS.CONFIG,
+
+  /**
+   * Handles synchonization of dependency versions within packages.
+   *
+   * @param options - Options provided from the CLI interface.
+   * @returns - Promise that resolves once the process is complete.
+   */
+  handler: (options: Options) => {
+    const rootDir = process.cwd();
+
+    const { packages = [], tag = Package.CONSTANTS.STABLE_TAG } = options;
+    const definitionPath = path.join(rootDir, Package.CONSTANTS.PACKAGE_DEFINITION_FILE);
+
+    let packageDefinition: any;
+
+    return Package.readDefinition({ definitionPath })
+      .then((definition: Record<string, any>) => {
+        packageDefinition = definition;
+
+        const groups = [
+          'dependencies',
+          'devDependencies',
+          'peerDependencies',
+          'bundleDependencies',
+          'optionalDependencies',
+        ];
+
+        const dependencies = groups.reduce(
+          (output: Array<any>, group) => {
+            const groupDependencies: Record<string, string> = definition[group] || {};
+
+            return [
+              ...output,
+              ...Object.entries(groupDependencies).map(([name, version]) => ({ group, name, version })),
+            ];
+          },
+          [] as Array<any>,
+        ).filter((dependency) => packages.includes(dependency.name));
+
+        return Promise.all(dependencies.map((dependency) => Package.inspect({ package: dependency.name })
+          .then((result) => ({
+            ...dependency,
+            previous: dependency.version,
+            version: result['dist-tags'][tag] || dependency.version,
+          }))));
+      })
+      .then((dependencies) => {
+        dependencies.forEach((dependency) => {
+          const { group, name, version } = dependency;
+          const target = packageDefinition[group];
+
+          target[name] = version;
+        });
+
+        const data = `${JSON.stringify(packageDefinition, null, 2)}\n`;
+        const output = dependencies.map((dependency) => (dependency.previous !== dependency.version
+          ? `${dependency.name}: ${dependency.previous} => ${dependency.version}`
+          : '')).filter((line) => !!line).join('\n');
+
+        return fs.writeFile(definitionPath, data, { encoding: 'utf-8' })
+          .then(() => {
+            process.stdout.write(output);
+          });
+      });
+  },
+};
+
+export default update;

--- a/packages/tools/package/src/commands/update/update.types.ts
+++ b/packages/tools/package/src/commands/update/update.types.ts
@@ -1,0 +1,16 @@
+/**
+ * Update Command Options interface.
+ *
+ * @public
+ */
+export interface Options {
+  /**
+   * Packages to update.
+   */
+  packages: Array<string>;
+
+  /**
+   * Tag to update the versions on.
+   */
+  tag?: string;
+}

--- a/packages/tools/package/src/index.ts
+++ b/packages/tools/package/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 export {
-  increment, list, scripts, sync,
+  increment, list, scripts, sync, update,
 } from './commands';
 export { Package } from './models';
 export { Yarn } from './utils';
@@ -28,4 +28,5 @@ export type {
   ListOptions,
   ScriptsOptions,
   SyncOptions,
+  UpdateOptions,
 } from './commands';

--- a/packages/tools/package/test/module/update/update.test.js
+++ b/packages/tools/package/test/module/update/update.test.js
@@ -1,0 +1,163 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+const { Package, update } = require('@webex/package-tools');
+
+describe('update', () => {
+  describe('config', () => {
+    it('should include all expected top-level keys', () => {
+      expect(Object.keys(update.config)).toEqual([
+        'name',
+        'description',
+        'options',
+      ]);
+    });
+
+    it('should include the fully qualified "packages" option', () => {
+      const found = update.config.options.find((option) => option.name === 'packages');
+
+      expect(!!found).toBeTruthy();
+      expect(found.type).toBe('string...');
+      expect(typeof found.description).toBe('string');
+    });
+
+    it('should include the fully qualified "tag" option', () => {
+      const found = update.config.options.find((option) => option.name === 'tag');
+
+      expect(!!found).toBeTruthy();
+      expect(found.type).toBe('string');
+      expect(typeof found.description).toBe('string');
+    });
+  });
+
+  describe('handler', () => {
+    const rootDir = '/path/to/project';
+    const spies = {};
+    const packages = ['example-package-a', '@scope/example-package-b', 'invalid-package-f'];
+    const tag = 'example-tag';
+    const options = { tag, packages };
+
+    const inspectedVersion = '1.1.1';
+    const inspectedTagVersion = `100.50.0-${tag}.1000`;
+
+    const inspectResolve = {
+      version: inspectedVersion,
+      'dist-tags': {
+        latest: inspectedVersion,
+        [tag]: inspectedTagVersion,
+      },
+    };
+
+    const readDefinitionResolve = {
+      name: 'example-name',
+      dependencies: {
+        [packages[0]]: '1.2.3',
+      },
+      devDependencies: {
+        [packages[1]]: '4.5.6',
+      },
+      peerDependencies: {
+        'unknown-package-c': '7.8.9',
+      },
+      bundleDependencies: {
+        'unknown-package-d': '10.11.12',
+      },
+      optionalDependencies: {
+        'unknown-package-e': '13.14.15',
+      },
+    };
+
+    beforeEach(() => {
+      spies.fs = {
+        writeFile: jest.spyOn(fs, 'writeFile').mockResolvedValue(undefined),
+      };
+
+      spies.Package = {
+        inspect: jest.spyOn(Package, 'inspect').mockResolvedValue(inspectResolve),
+        readDefinition: jest.spyOn(Package, 'readDefinition').mockResolvedValue(readDefinitionResolve),
+      };
+
+      spies.path = {
+        join: jest.spyOn(path, 'join'),
+      };
+
+      spies.process = {
+        cwd: jest.spyOn(process, 'cwd').mockReturnValue(rootDir),
+        stdout: {
+          write: jest.spyOn(process.stdout, 'write').mockReturnValue(undefined),
+        },
+      };
+    });
+
+    it('should attempt to read the definition file at the definition path', () => update.handler(options).then(() => {
+      const expected = {
+        definitionPath: path.join(rootDir, Package.CONSTANTS.PACKAGE_DEFINITION_FILE),
+      };
+
+      expect(spies.Package.readDefinition).toHaveBeenCalledTimes(1);
+      expect(spies.Package.readDefinition).toHaveBeenCalledWith(expected);
+    }));
+
+    it('should attempt to inspect all valid packages', () => update.handler(options).then(() => {
+      const validPackages = ['example-package-a', '@scope/example-package-b'];
+
+      validPackages.forEach((pack) => {
+        expect(spies.Package.inspect).toHaveBeenCalledWith({ package: pack });
+      });
+
+      expect(spies.Package.inspect).toHaveBeenCalledTimes(validPackages.length);
+    }));
+
+    it('should attempt to write the file to the target destination correctly', () => {
+      const definitionPath = path.join(rootDir, Package.CONSTANTS.PACKAGE_DEFINITION_FILE);
+
+      return update.handler(options)
+        .then(() => {
+          expect(spies.fs.writeFile).toHaveBeenCalledWith(definitionPath, expect.any(String), { encoding: 'utf-8' });
+        });
+    });
+
+    it('should attempt to write output to terminal', () => update.handler(options).then(() => {
+      expect(spies.process.stdout.write).toHaveBeenCalledWith(expect.any(String));
+    }));
+
+    it('should use the latest tag with no tag is provided', () => {
+      const customizedOptions = { ...options, tag: undefined };
+
+      return update.handler(customizedOptions).then(() => {
+        expect(spies.fs.writeFile.mock.calls[0][1].includes(`"${packages[0]}": "${inspectedVersion}"`)).toBeTruthy();
+        expect(spies.fs.writeFile.mock.calls[0][1].includes(`"${packages[1]}": "${inspectedVersion}"`)).toBeTruthy();
+      });
+    });
+
+    it('should not make any changes when provided with no packages', () => {
+      const customOptions = { ...options, packages: undefined };
+
+      return update.handler(customOptions).then(() => {
+        expect(spies.Package.inspect).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    it('should not throw in the case that a definition dependency group is not defined', () => {
+      spies.Package.readDefinition.mockResolvedValue({});
+
+      return expect(() => update.handler(options)).not.toThrow(expect.any(Error));
+    });
+
+    it('should not update a dependency who does not have a version for the provided tag', () => {
+      const customOptions = { ...options, tag: 'invalid' };
+
+      return update.handler(customOptions).then(() => {
+        expect(
+          spies.fs.writeFile.mock.calls[0][1]
+            .includes(`"${packages[0]}": "${readDefinitionResolve.dependencies[packages[0]]}"`),
+        ).toBeTruthy();
+
+        expect(
+          spies.fs.writeFile.mock.calls[0][1]
+            .includes(`"${packages[1]}": "${readDefinitionResolve.dependencies[packages[0]]}"`),
+        ).toBeTruthy();
+      });
+    });
+  });
+});


### PR DESCRIPTION
# NOTE

When this pull request is merged, this will publish the `@webex/cli-tools` and `@webex/package-tools` packages to **NPM** for consumption within down-stream clients.

# Description

The scope of the changes in this pull request are to add the `update` command to the `@webex/package-tools` package. This new command allows for consumers of the JS SDK to update their dependencies based on the latest available from `NPMJS`.

# Example

## Before

```jsonc
/* ./package.json */
{
  /* ... */
  "dependencies": {
    /* ... */
    "querystring-es3": "^0.2.1"
  },
  "devDependencies": {
    /* ... */
    "@babel/cli": "^7.17.10",
    "@babel/core": "^7.17.10"
  }
}
```

## Command

```bash
# Input
# package.json script `webex-package-tools` calls `webex-package-tools`
yarn webex-package-tools update --packages @babel/cli querystring-es3 --tag next

# Output
querystring-es3: ^0.2.1 => 1.0.0-0
@babel/cli: ^7.17.10 => 8.0.0-alpha.6
```

## After

```jsonc
/* ./package.json */
{
  /* ... */
  "dependencies": {
    /* ... */
    "querystring-es3": "1.0.0-0" /* updates to eplicit exact */
  },
  "devDependencies": {
    /* ... */
    "@babel/cli": "8.0.0-alpha.6", /* updates all dependency groups */
    "@babel/core": "^7.17.10" /* does not impact non-provided packages */
  }
}
```

# Links

* [Task](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-497350)