### PR TITLE
fix(plugin-meetings): listen to transcript for guests

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -563,6 +563,13 @@ function doPostMediaSetup(meeting) {
 
 async function joinMeeting({withMedia, withDevice} = {withMedia: false, withDevice: false}) {
   const meeting = webex.meetings.getAllMeetings()[selectedMeetingId];
+
+  meeting.on('meeting:llm:connected', () => {
+    if (enableTranscript.checked) {
+      toggleTranscription(true);
+    }
+  });
+
   let resourceId = null;
 
   if (!meeting) {
@@ -635,10 +642,6 @@ async function joinMeeting({withMedia, withDevice} = {withMedia: false, withDevi
       await meeting.joinWithMedia({joinOptions, mediaOptions});
 
       doPostMediaSetup(meeting);
-    }
-
-    if(webex.meetings.config.enableAutomaticLLM && enableTranscript.checked) {
-      toggleTranscription(true);
     }
 
     enableMeetingDependentButtons(true);

--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -53,6 +53,9 @@ const voiceaTranscriptionFormattedDisplay = document.querySelector('#voicea-tran
 const toggleUnifiedMeetings = document.getElementById('toggle-unified-meeting');
 const currentMeetingInfoStatus = document.getElementById('current-meeting-info-status');
 
+const enableLLM = document.getElementById('meetings-enable-llm');
+const enableTranscript = document.getElementById('meetings-enable-transcription');
+
 // Store and Grab `access-token` from localstorage
 if (localStorage.getItem('date') > new Date().getTime()) {
   tokenElm.value = localStorage.getItem('access-token');
@@ -114,7 +117,7 @@ function generateWebexConfig({credentials}) {
         enableAdhocMeetings: true,
         enableTcpReachability: tcpReachabilityConfigElm.checked,
       },
-      enableAutomaticLLM: true,
+      enableAutomaticLLM: enableLLM.checked,
     },
     credentials,
     // Any other sdk config we need
@@ -634,6 +637,10 @@ async function joinMeeting({withMedia, withDevice} = {withMedia: false, withDevi
       doPostMediaSetup(meeting);
     }
 
+    if(webex.meetings.config.enableAutomaticLLM && enableTranscript.checked) {
+      toggleTranscription(true);
+    }
+
     enableMeetingDependentButtons(true);
 
     // For meeting controls button onclick handlers
@@ -1096,7 +1103,7 @@ function setTranscriptEvents() {
     });
 
     meeting.on('meeting:receiveTranscription:stopped', () => {
-      generalToggleTranscription.innerText = "Stop Transcription";
+      generalToggleTranscription.innerText = "Start Transcription";
       generalTranscriptionContent.innerHTML = 'Transcription Content: Webex Assistant must be enabled, check the console!';
     });
   }

--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -564,7 +564,7 @@ function doPostMediaSetup(meeting) {
 async function joinMeeting({withMedia, withDevice} = {withMedia: false, withDevice: false}) {
   const meeting = webex.meetings.getAllMeetings()[selectedMeetingId];
 
-  meeting.on('meeting:llm:connected', () => {
+  meeting.on('meeting:transcription:connected', () => {
     if (enableTranscript.checked) {
       toggleTranscription(true);
     }

--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -88,6 +88,9 @@
               <legend>Meetings</legend>
               <input type="checkbox" id="enable-tcp-reachability">
               <label for="enable-tcp-reachability">Enable TCP reachability (experimental)</label>
+              <br/>
+              <input id="meetings-enable-llm" checked type="checkbox">
+              <label for="meetings-enable-llm-label">Enable LLM</label>
             </div>
           </div>
 
@@ -294,9 +297,9 @@
           <fieldset>
             <legend>Voicea Transcription</legend>
             <div class="u-mv">
-              You will see the formatted transcription below if you have <b>did one of the below</b>,
+              You will see the formatted transcription below if you have did the following,
               <ul>
-                <li>Set the <span class="inline-code">receiveTranscription</span> config to <span class="inline-code">true</span> before joining the meeting</li>
+                <li>Set the <span class="inline-code">enableAutomaticLLM</span> config to <span class="inline-code">true</span> before doing webex.init</li>
                 <li>Invoked <span class="inline-code">meeting.startTranscription()</span> after joining the meeting</li>
               </ul>
               <div id="voicea-transcription-formatted-display">
@@ -385,6 +388,8 @@
               <label for="meetings-join-breakout-enabled">Support breakout sessions</label>
               <input id="meetings-media-in-lobby-enabled" checked type="checkbox">
               <label for="meetings-media-in-lobby-enabled">Support media in lobby</label>
+              <input id="meetings-enable-transcription" type="checkbox">
+              <label for="meetings-enable-transcription-label">Enable Transcription (Sample app only)</label>
               <p id="password-captcha-status" class="status-par">Click verifyPassword for details</p>
             </div>
 

--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -299,7 +299,7 @@
             <div class="u-mv">
               You will see the formatted transcription below if you have did the following,
               <ul>
-                <li>Set the <span class="inline-code">enableAutomaticLLM</span> config to <span class="inline-code">true</span> before doing webex.init</li>
+                <li>Set the <span class="inline-code">enableAutomaticLLM</span> config to <span class="inline-code">true</span> before doing <span class="inline-code">webex.init()</span></li>
                 <li>Invoked <span class="inline-code">meeting.startTranscription()</span> after joining the meeting</li>
               </ul>
               <div id="voicea-transcription-formatted-display">

--- a/packages/@webex/http-core/src/request/request.shim.js
+++ b/packages/@webex/http-core/src/request/request.shim.js
@@ -12,7 +12,6 @@
 import {defaults, isArray, pick} from 'lodash';
 import qs from 'qs';
 
-import {Blob} from 'buffer';
 import xhr from '../lib/xhr';
 import detect from '../lib/detect';
 

--- a/packages/@webex/http-core/test/unit/spec/request/request.shim.js
+++ b/packages/@webex/http-core/test/unit/spec/request/request.shim.js
@@ -5,6 +5,11 @@ import {EventEmitter} from 'events';
 
 describe('Request shim', () => {
   describe('#setAuth()', () => {
+    beforeAll(() => {
+      global.Blob = function (content, options) {
+        return { content, options };
+      };
+    });
     it('sets auth header', () => {
 
       class DummyXMLHttpRequest {

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -375,7 +375,7 @@ export const EVENT_TRIGGERS = {
   MEETING_LOCUS_URL_UPDATE: 'meeting:locus:locusUrl:update',
   MEETING_STREAM_PUBLISH_STATE_CHANGED: 'meeting:streamPublishStateChanged',
 
-  MEETING_LLM_CONNECTED: 'meeting:llm:connected',
+  MEETING_TRANSCRIPTION_CONNECTED: 'meeting:transcription:connected',
   MEETING_STARTED_RECEIVING_TRANSCRIPTION: 'meeting:receiveTranscription:started',
   MEETING_STOPPED_RECEIVING_TRANSCRIPTION: 'meeting:receiveTranscription:stopped',
 

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -375,6 +375,7 @@ export const EVENT_TRIGGERS = {
   MEETING_LOCUS_URL_UPDATE: 'meeting:locus:locusUrl:update',
   MEETING_STREAM_PUBLISH_STATE_CHANGED: 'meeting:streamPublishStateChanged',
 
+  MEETING_LLM_CONNECTED: 'meeting:llm:connected',
   MEETING_STARTED_RECEIVING_TRANSCRIPTION: 'meeting:receiveTranscription:started',
   MEETING_STOPPED_RECEIVING_TRANSCRIPTION: 'meeting:receiveTranscription:stopped',
 

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -968,6 +968,7 @@ export const SELF_ROLES = {
   COHOST: 'COHOST',
   MODERATOR: 'MODERATOR',
   ATTENDEE: 'ATTENDEE',
+  PRESENTER: 'PRESENTER',
 };
 
 export const MEETING_STATE = {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5023,7 +5023,7 @@ export default class Meeting extends StatelessWebexPlugin {
           this.updateLLMConnection()
             .catch((error) => {
               LoggerProxy.logger.error(
-                'Meeting:index#join --> Update LLM Connection Failed',
+                'Meeting:index#join --> Transcription Socket Connection Failed',
                 error
               );
 
@@ -5034,14 +5034,16 @@ export default class Meeting extends StatelessWebexPlugin {
               });
             })
             .then(() => {
-              LoggerProxy.logger.info('Meeting:index#join --> Update LLM Connection Success');
+              LoggerProxy.logger.info(
+                'Meeting:index#join --> Transcription Socket Connection Success'
+              );
               Trigger.trigger(
                 this,
                 {
                   file: 'meeting/index',
                   function: 'join',
                 },
-                EVENT_TRIGGERS.MEETING_LLM_CONNECTED,
+                EVENT_TRIGGERS.MEETING_TRANSCRIPTION_CONNECTED,
                 undefined
               );
             });

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1966,6 +1966,9 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   private setUpVoiceaListeners() {
     // @ts-ignore
+    this.webex.internal.voicea.listenToEvents();
+
+    // @ts-ignore
     this.webex.internal.voicea.on(
       VOICEAEVENTS.VOICEA_ANNOUNCEMENT,
       this.voiceaListenerCallbacks[VOICEAEVENTS.VOICEA_ANNOUNCEMENT]
@@ -1994,6 +1997,8 @@ export default class Meeting extends StatelessWebexPlugin {
       VOICEAEVENTS.HIGHLIGHT_CREATED,
       this.voiceaListenerCallbacks[VOICEAEVENTS.HIGHLIGHT_CREATED]
     );
+
+    this.areVoiceaEventsSetup = true;
   }
 
   /**
@@ -4587,13 +4592,11 @@ export default class Meeting extends StatelessWebexPlugin {
           const {statusCode} = payload;
 
           if (statusCode === 200) {
-            const currentCaptionLanguage =
-              this.transcription.languageOptions.requestedCaptionLanguage ?? LANGUAGE_ENGLISH;
             this.transcription.languageOptions = {
               ...this.transcription.languageOptions,
-              currentCaptionLanguage,
+              currentCaptionLanguage: language,
             };
-            resolve(currentCaptionLanguage);
+            resolve(language);
           } else {
             reject(payload);
           }
@@ -4677,10 +4680,12 @@ export default class Meeting extends StatelessWebexPlugin {
       try {
         if (!this.areVoiceaEventsSetup) {
           this.setUpVoiceaListeners();
-          this.areVoiceaEventsSetup = true;
         }
-        // @ts-ignore
-        await this.webex.internal.voicea.toggleTranscribing(true, options?.spokenLanguage);
+
+        if (this.getCurUserType() === 'host') {
+          // @ts-ignore
+          await this.webex.internal.voicea.toggleTranscribing(true, options?.spokenLanguage);
+        }
       } catch (error) {
         LoggerProxy.logger.error(`Meeting:index#startTranscription --> ${error}`);
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE, {
@@ -4769,6 +4774,7 @@ export default class Meeting extends StatelessWebexPlugin {
         VOICEAEVENTS.HIGHLIGHT_CREATED,
         this.voiceaListenerCallbacks[VOICEAEVENTS.HIGHLIGHT_CREATED]
       );
+
       this.areVoiceaEventsSetup = false;
       this.triggerStopReceivingTranscriptionEvent();
     }
@@ -5011,10 +5017,10 @@ export default class Meeting extends StatelessWebexPlugin {
 
         return Promise.reject(error);
       })
-      .then((join) => {
+      .then(async (join) => {
         // @ts-ignore - config coming from registerPlugin
         if (this.config.enableAutomaticLLM) {
-          this.updateLLMConnection().catch((error) => {
+          await this.updateLLMConnection().catch((error) => {
             LoggerProxy.logger.error('Meeting:index#join --> Update LLM Connection Failed', error);
 
             Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.LLM_CONNECTION_AFTER_JOIN_FAILURE, {
@@ -7672,6 +7678,9 @@ export default class Meeting extends StatelessWebexPlugin {
       }
       if (roles.includes(SELF_ROLES.COHOST)) {
         return 'cohost';
+      }
+      if (roles.includes(SELF_ROLES.PRESENTER)) {
+        return 'presenter';
       }
       if (roles.includes(SELF_ROLES.ATTENDEE)) {
         return 'attendee';


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES Adhoc PR

## This pull request addresses

- Right now, the SDK does not listen to events until we do `startTranscription` and Guest users do not need to startTranscription to receive transcription. This event listening doesn't happen at the Voicea level too. 
- The SDK doesn't wait for the LLM connection to be established
- The `Invalid right-hand for instanceOf Blob` error

## by making the following changes

- Listening to events in Voicea from meetings by default
- Listening to LLM events from voicea by default
- Making Voicea toggle call only if the current user's role is 'host'
- Wait for LLM connection to be established and then resolve Meeting Join
- Making a toggle in the Sample app to enable transcription on login
- In http-core, for the invalid error, the Blob is mocked instead of importing it from Buffer since we imported it only for jest tests

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- Enabling Transcription after joining the meeting as a host
- Enabling Transcription after joining the meeting as a guest
- Did a regression testing for the flow where the Sample app waits for Meeting Join to complete and enables transcription. Works fine

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [] All existing and new tests passed
- [] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
