### PR TITLE
test: test-user set preferred webexsite

### DIFF
--- a/packages/@webex/test-users/src/index.js
+++ b/packages/@webex/test-users/src/index.js
@@ -321,6 +321,52 @@ export function removeTestUser(options = {}) {
   });
 }
 
+/**
+ * Sets the preferredWebexSite for the provided user
+ * @param {Object} options
+ * @param {string} options.userId user id to set site
+ * @param {string} options.preferredSite new preferred webexsite
+ * @param {string} options.orgId orgId of the site
+ * @param {string} options.identityServiceUrl url of identity service
+ * @param {string} options.authorization
+ * @param {string} options.clientId
+ * @param {string} options.clientSecret
+ * @returns {Promise}
+ */
+export function setPreferredSite(options = {}) {
+  const clientId = options.clientId || process.env.WEBEX_CLIENT_ID;
+  const clientSecret = options.clientSecret || process.env.WEBEX_CLIENT_SECRET;
+
+  if (!clientId) {
+    throw new Error('options.clientId or process.env.WEBEX_CLIENT_ID must be defined');
+  }
+
+  if (!clientSecret) {
+    throw new Error('options.clientSecret or process.env.WEBEX_CLIENT_SECRET must be defined');
+  }
+
+  /* eslint-disable no-useless-escape */
+  const body = {
+    schemas: ['urn:scim:schemas:core:1.0', 'urn:scim:schemas:extension:cisco:commonidentity:1.0'],
+    userPreferences: [
+      {
+        value: `\"preferredWebExSite\":\"${options.preferredSite}\"`,
+      },
+    ],
+  };
+  /* eslint-enable no-useless-escape */
+
+  return request({
+    method: 'PATCH',
+    headers: {
+      authorization: options.authorization,
+    },
+    uri: `${options.identityServiceUrl}/identity/scim/${options.orgId}/v1/Users/${options.userId}`,
+    json: true,
+    body,
+  });
+}
+
 export {
   default as createWhistlerTestUser,
   removeTestUser as removeWhistlerTestUser,


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

- Setting the preferred WebexSite of a created Test User

## by making the following changes

- Adding a new `setPreferredSite` function in test-users package, to allow for setting the preferred webexsite after a test user has been created
- Didn't add integration tests, since they are not testable / there is an issue currently that test-users package doesn't allow running the integration tests (saying "Found 0 tests" when running).
![image](https://github.com/webex/webex-js-sdk/assets/29776408/4f3ac738-e5ef-4dbf-b98a-b143f49af30c)


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- Tested the function locally

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
