### PR TITLE
fix(plugin-meetings-samples): fix remote screen re-share

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -622,6 +622,18 @@ async function joinMeeting({withMedia, withDevice} = {withMedia: false, withDevi
       viewBreakouts();
     });
 
+    meeting.on('meeting:stoppedSharingRemote', () => {
+      /**
+       * Here we first remove the media to stop showing the remote stream being received and again
+       * attach the remote media stream (which gets added during addMedia() call) but since the remote 
+       * is not sending the frames anymore it does not show the screenshare but keeps the event attached. 
+       * Hence, when we again start sharing the screen, the media flows correctly to the video element.
+       */
+      const remoteShareTemp = meetingStreamsRemoteShare.srcObject;
+      meetingStreamsRemoteShare.srcObject = null;
+      meetingStreamsRemoteShare.srcObject = remoteShareTemp;
+    });
+
     eventsList.innerText = '';
     meeting.on('all', (payload) => {
       updatePublishedEvents(payload);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-500552](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-500552) >

## This pull request addresses

**Bugs**

- **Remote Screenshare** - When a remote participant stops sharing, the sample app takes out the Remote Share Video. However, when the remote share is on again, we are not able to see it in the sample app - **ISSUE IS JUST WITH THE LOCAL STREAM WHILE DISPLAYING IN video ELEMENT LOCALLY IN CASE OF IMAGE/VIDEO BACKGROUND, WITH BLUR IT WORKS AS EXPECTED.**
- **VBG Video** - When a VBG image/video is enabled and the user toggles the video, only the Camera source gets shut and the effect tends to stay in the Local Stream
- **Screen recording** - These buttons are disabled even though a user who joined the meeting is a Host - **THIS ISSUE IS NOT REPRODUCIBLE**

## by making the following changes

Fixes the bugs in the samples page mentioned above

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
