### PR TITLE
fix(plugin-meetings): fix types in plugin meetings

### DIFF
--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -90,7 +90,7 @@
               <label for="enable-tcp-reachability">Enable TCP reachability (experimental)</label>
               <br/>
               <input id="meetings-enable-llm" checked type="checkbox">
-              <label for="meetings-enable-llm-label">Enable LLM</label>
+              <label for="meetings-enable-llm-label">Connect Transcription Websocket</label>
             </div>
           </div>
 

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "scripts": {
-    "build": "yarn run -T tsc --declaration true --declarationDir ./dist",
+    "build": "yarn run -T tsc --declaration true --declarationDir ./dist/types",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps && yarn build",
     "deploy:npm": "yarn npm publish",
     "test:broken": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",


### PR DESCRIPTION
# COMPLETES #Adhoc

## This pull request addresses

Import from plugin-meetings was not working properly, We had to put a `/dist` to import methods.
example:
`import {LocalMicrophoneStream} from '@webex/plugin-meetings/dist'`

This was caused due to a mismatch in plugin-meetings/package.json. 
The build command  stores the types at './dist' but the types entry point is mentioned as 'dist/types'. Fixed the build command to store types at 'dist/types'
+
Minor text change in samples page.

## by making the following changes
Importing from plugin-meetings no longer will require us to use '/dist' in the import statement.
example
`import {LocalMicrophoneStream} from '@webex/plugin-meetings'`


<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Locally linked web-client and tested importing. 

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
