### PR TITLE
feat(metrics): added debug metrics for meetings registration

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -726,11 +726,19 @@ export default class Meetings extends WebexPlugin {
    * @memberof Meetings
    */
   public register() {
+    Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
+      step: '[sdk] begin registration',
+    });
+
     // @ts-ignore
     if (!this.webex.canAuthorize) {
       LoggerProxy.logger.error(
         'Meetings:index#register --> ERROR, Unable to register, SDK cannot authorize'
       );
+
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
+        step: '[sdk] cannot authorize',
+      });
 
       return Promise.reject(new Error('SDK cannot authorize'));
     }
@@ -740,8 +748,16 @@ export default class Meetings extends WebexPlugin {
         'Meetings:index#register --> INFO, Meetings plugin already registered'
       );
 
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
+        step: '[sdk] already registered',
+      });
+
       return Promise.resolve();
     }
+
+    Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
+      step: '[sdk] begin Promise.all()',
+    });
 
     return Promise.all([
       this.fetchUserPreferredWebexSite(),
@@ -764,6 +780,9 @@ export default class Meetings extends WebexPlugin {
       MeetingsUtil.checkH264Support.call(this),
     ])
       .then(() => {
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
+          step: '[sdk] end Promise.all()',
+        });
         this.listenForEvents();
         Trigger.trigger(
           this,
@@ -773,6 +792,9 @@ export default class Meetings extends WebexPlugin {
           },
           EVENT_TRIGGERS.MEETINGS_REGISTERED
         );
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
+          step: '[sdk] registration complete, triggered MEETINGS_REGISTERED event',
+        });
         this.registered = true;
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_SUCCESS);
       })

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -3,6 +3,7 @@
 const BEHAVIORAL_METRICS = {
   MEETINGS_REGISTRATION_FAILED: 'js_sdk_meetings_registration_failed',
   MEETINGS_REGISTRATION_SUCCESS: 'js_sdk_meetings_registration_success',
+  MEETINGS_REGISTRATION_STEP: 'meetings_registration_step',
   MERCURY_CONNECTION_FAILURE: 'js_sdk_mercury_connection_failure',
   MERCURY_CONNECTION_RESTORED: 'js_sdk_mercury_connection_restored',
   JOIN_SUCCESS: 'js_sdk_join_success',


### PR DESCRIPTION
# COMPLETES

https://sqbu-github.cisco.com/WebExSquared/webex-web-client/pull/5421

## This pull request addresses

Adds debug "step" metrics for the meetings registration process.

![image](https://github.com/webex/webex-js-sdk/assets/15893389/91c4b8f4-905e-4fb4-891a-781094b849a2)


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Tested manually, see screenshot.

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
