### PR TITLE
fix(metrics): getInterstitialToMediaOKJMT calculation

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -308,15 +308,12 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
     );
 
     // get the first timestamp
-    const mediaFlowStartedTimestamp = Math.min(
-      this.latencyTimestamps.get('client.media.rx.start'),
-      this.latencyTimestamps.get('client.media.tx.start')
-    );
+    const connectedMedia = this.latencyTimestamps.get('client.ice.end');
 
     const lobbyTime = this.getStayLobbyTime() || 0;
 
-    if (interstitialJoinClickTimestamp && mediaFlowStartedTimestamp) {
-      return mediaFlowStartedTimestamp - interstitialJoinClickTimestamp - lobbyTime;
+    if (interstitialJoinClickTimestamp && connectedMedia) {
+      return connectedMedia - interstitialJoinClickTimestamp - lobbyTime;
     }
 
     return undefined;

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -488,18 +488,22 @@ describe('internal-plugin-metrics', () => {
         value: 12,
       });
       cdl.saveTimestamp({
-        key: 'client.media.rx.start',
+        key: 'client.ice.end',
         value: 14,
       });
-      cdl.saveTimestamp({
-        key: 'client.media.tx.start',
-        value: 15,
-      });
-      cdl.saveTimestamp({
-        key: 'client.media.rx.start',
-        value: 16,
-      });
       assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 8);
+    });
+
+    it('calculates getInterstitialToMediaOKJMT correctly without lobby', () => {
+      cdl.saveTimestamp({
+        key: 'internal.client.interstitial-window.click.joinbutton',
+        value: 4,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.end',
+        value: 14,
+      });
+      assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 10);
     });
   });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-465907](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-465907)

## This pull request addresses

`getInterstitialToMediaOKJMT` returned with `undefined` 99.9% of the cases because the media flow did not started because at the time when media engine ready event emitted.

## by making the following changes

used `client.ice.end` latency instead of the media started values. This is what UCF use as well.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
