### PR TITLE
fix(plugin-meetings): do reachability before every reconnect attempt

### DIFF
--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -95,12 +95,6 @@ export default class Reachability {
    * @memberof Reachability
    */
   public async gatherReachability(): Promise<ReachabilityResults> {
-    // Remove stored reachability results to ensure no stale data
-    // @ts-ignore
-    await this.webex.boundedStorage.del(this.namespace, REACHABILITY.localStorageResult);
-    // @ts-ignore
-    await this.webex.boundedStorage.del(this.namespace, REACHABILITY.localStorageJoinCookie);
-
     // Fetch clusters and measure latency
     try {
       const {clusters, joinCookie} = await this.reachabilityRequest.getClusters(

--- a/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
@@ -349,7 +349,14 @@ export default class ReconnectionManager {
       });
     }
 
-    await this.webex.meetings.startReachability();
+    try {
+      await this.webex.meetings.startReachability();
+    } catch (err) {
+      LoggerProxy.logger.info(
+        'ReconnectionManager:index#reconnect --> Reachability failed, continuing with reconnection attempt, err: ',
+        err
+      );
+    }
 
     try {
       const media = await this.executeReconnection({networkDisconnect});
@@ -376,7 +383,7 @@ export default class ReconnectionManager {
         'ReconnectionManager:index#reconnect --> Sending reconnect abort metric.'
       );
 
-      // send call aborded event with catogery as expected as we are trying to rejoin
+      // send call aborted event with catogery as expected as we are trying to rejoin
       // @ts-ignore
       this.webex.internal.newMetrics.submitClientEvent({
         name: 'client.call.aborted',

--- a/packages/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reconnection-manager/index.js
@@ -65,6 +65,7 @@ describe('plugin-meetings', () => {
           meetings: {
             getMeetingByType: sinon.stub().returns(true),
             syncMeetings: sinon.stub().resolves({}),
+            startReachability: sinon.stub().resolves({}),
           },
           internal: {
             newMetrics: {
@@ -92,6 +93,14 @@ describe('plugin-meetings', () => {
       await rm.reconnect();
 
       assert.notCalled(rm.webex.meetings.syncMeetings);
+    });
+
+    it('calls startReachability on reconnect', async () => {
+      const rm = new ReconnectionManager(fakeMeeting);
+
+      await rm.reconnect();
+
+      assert.calledOnce(rm.webex.meetings.startReachability);
     });
 
     it('uses correct TURN TLS information on the reconnection', async () => {
@@ -141,7 +150,6 @@ describe('plugin-meetings', () => {
       assert.calledOnce(fakeMeeting.mediaRequestManagers.audio.commit);
       assert.calledOnce(fakeMeeting.mediaRequestManagers.video.commit);
     });
-
 
     it('sends the correct client event when reconnection fails', async () => {
       sinon.stub(ReconnectionManager.prototype, 'executeReconnection').rejects();


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-500921](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-500921)

## This pull request addresses

users who had had reachability done while on VPN would not be able to reconnect properly if their VPN disconnected during a meeting

## by making the following changes

perform reachability before reconnection to give users the best chance at reconnecting

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
