### PR TITLE
fix(plugin-meetings): mqe streams format

### DIFF
--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -44,28 +44,28 @@ export const emptyAudioReceive = {
     stunPackets: 0,
     transportType: 'UDP',
   },
-  streams: [
-    {
-      common: {
-        codec: 'opus',
-        concealedFrames: 0,
-        csi: [],
-        maxConcealRunLength: 0,
-        optimalBitrate: 0,
-        optimalFrameRate: 0,
-        receivedBitrate: 0,
-        receivedFrameRate: 0,
-        renderedFrameRate: 0,
-        requestedBitrate: 0,
-        requestedFrameRate: 0,
-        rtpEndToEndLost: 0,
-        maxRtpJitter: 0,
-        meanRtpJitter: 0,
-        rtpPackets: 0,
-        ssci: 0,
-      },
-    },
-  ],
+  streams: [],
+};
+
+export const emptyAudioReceiveStream = {
+  common: {
+    codec: 'opus',
+    concealedFrames: 0,
+    csi: [],
+    maxConcealRunLength: 0,
+    optimalBitrate: 0,
+    optimalFrameRate: 0,
+    receivedBitrate: 0,
+    receivedFrameRate: 0,
+    renderedFrameRate: 0,
+    requestedBitrate: 0,
+    requestedFrameRate: 0,
+    rtpEndToEndLost: 0,
+    maxRtpJitter: 0,
+    meanRtpJitter: 0,
+    rtpPackets: 0,
+    ssci: 0,
+  },
 };
 
 export const emptyAudioTransmit = {
@@ -98,20 +98,20 @@ export const emptyAudioTransmit = {
     stunPackets: 0,
     transportType: 'UDP',
   },
-  streams: [
-    {
-      common: {
-        codec: 'opus',
-        csi: [],
-        requestedBitrate: 0,
-        requestedFrames: 0,
-        rtpPackets: 0,
-        ssci: 0,
-        transmittedBitrate: 0,
-        transmittedFrameRate: 0,
-      },
-    },
-  ],
+  streams: [],
+};
+
+export const emptyAudioTransmitStream = {
+  common: {
+    codec: 'opus',
+    csi: [],
+    requestedBitrate: 0,
+    requestedFrames: 0,
+    rtpPackets: 0,
+    ssci: 0,
+    transmittedBitrate: 0,
+    transmittedFrameRate: 0,
+  },
 };
 
 export const emptyVideoReceive = {
@@ -143,39 +143,39 @@ export const emptyVideoReceive = {
     stunPackets: 0, // Not avaliable
     transportType: 'UDP',
   },
-  streams: [
-    {
-      common: {
-        codec: 'H264',
-        concealedFrames: 0, // Not avaliable
-        csi: [],
-        maxConcealRunLength: 0, // Not avaliable
-        optimalBitrate: 0,
-        optimalFrameRate: 0,
-        receivedBitrate: 0,
-        receivedFrameRate: 0,
-        renderedFrameRate: 0, // Not avaliable
-        requestedBitrate: 0,
-        requestedFrameRate: 0,
-        rtpEndToEndLost: 0,
-        rtpJitter: 0,
-        rtpPackets: 0,
-        ssci: 0, // Not avaliable
-      },
-      h264CodecProfile: 'BP',
-      isActiveSpeaker: true,
-      optimalFrameSize: 0, // Not avaliable
-      receivedFrameSize: 0,
-      receivedHeight: 0,
-      receivedKeyFrames: 0,
-      receivedKeyFramesForRequest: 0,
-      receivedKeyFramesSourceChange: 0,
-      receivedKeyFramesUnknown: 0,
-      receivedWidth: 0,
-      requestedFrameSize: 0,
-      requestedKeyFrames: 0,
-    },
-  ],
+  streams: [],
+};
+
+export const emptyVideoReceiveStream = {
+  common: {
+    codec: 'H264',
+    concealedFrames: 0, // Not avaliable
+    csi: [],
+    maxConcealRunLength: 0, // Not avaliable
+    optimalBitrate: 0,
+    optimalFrameRate: 0,
+    receivedBitrate: 0,
+    receivedFrameRate: 0,
+    renderedFrameRate: 0, // Not avaliable
+    requestedBitrate: 0,
+    requestedFrameRate: 0,
+    rtpEndToEndLost: 0,
+    rtpJitter: 0,
+    rtpPackets: 0,
+    ssci: 0, // Not avaliable
+  },
+  h264CodecProfile: 'BP',
+  isActiveSpeaker: true,
+  optimalFrameSize: 0, // Not avaliable
+  receivedFrameSize: 0,
+  receivedHeight: 0,
+  receivedKeyFrames: 0,
+  receivedKeyFramesForRequest: 0,
+  receivedKeyFramesSourceChange: 0,
+  receivedKeyFramesUnknown: 0,
+  receivedWidth: 0,
+  requestedFrameSize: 0,
+  requestedKeyFrames: 0,
 };
 
 export const emptyVideoTransmit = {
@@ -208,42 +208,42 @@ export const emptyVideoTransmit = {
     stunPackets: 0, // Dont have access to it
     transportType: 'UDP', // TODO: need to calculate
   },
-  streams: [
-    {
-      common: {
-        codec: 'H264',
-        csi: [],
-        duplicateSsci: 0, // Not Avaliable
-        requestedBitrate: 0, // TODO: from remote SDP
-        requestedFrames: 0, // TODO: from remote SDP
-        rtpPackets: 0, // same as rtp packets
-        ssci: 0,
-        transmittedBitrate: 0, // TODO: get in the candidate pair
-        transmittedFrameRate: 0, // TODO: from track info
-      },
-      h264CodecProfile: 'BP', // TODO: from localSDP
-      isAvatar: false, // Not Avaliable
-      isHardwareEncoded: false, // Not Avaliable
-      localConfigurationChanges: 2, // Not Avaliable
-      maxFrameQp: 0, // Not Avaliable
-      maxNoiseLevel: 0, // Not Avaliable
-      minRegionQp: 0, // Not Avaliable
-      remoteConfigurationChanges: 0, // Not Avaliable
-      requestedFrameSize: 0, // TODO: from remote SDP
-      requestedKeyFrames: 0, // outbound Fir request
-      transmittedFrameSize: 0, // Not Avaliable
-      transmittedHeight: 0,
-      transmittedKeyFrames: 0, // Key frames encoded
-      transmittedKeyFramesClient: 0, // Not Avaliable
-      transmittedKeyFramesConfigurationChange: 0, // Not Avaliable
-      transmittedKeyFramesFeedback: 0, // Not Avaliable
-      transmittedKeyFramesLocalDrop: 0, // Not Avaliable
-      transmittedKeyFramesOtherLayer: 0, // Not Avaliable
-      transmittedKeyFramesPeriodic: 0, // Not Avaliable
-      transmittedKeyFramesSceneChange: 0, // Not Avaliable
-      transmittedKeyFramesStartup: 0, // Not Avaliable
-      transmittedKeyFramesUnknown: 0, // Not Avaliable
-      transmittedWidth: 0,
-    },
-  ],
+  streams: [],
+};
+
+export const emptyVideoTransmitStream = {
+  common: {
+    codec: 'H264',
+    csi: [],
+    duplicateSsci: 0, // Not Avaliable
+    requestedBitrate: 0, // TODO: from remote SDP
+    requestedFrames: 0, // TODO: from remote SDP
+    rtpPackets: 0, // same as rtp packets
+    ssci: 0,
+    transmittedBitrate: 0, // TODO: get in the candidate pair
+    transmittedFrameRate: 0, // TODO: from track info
+  },
+  h264CodecProfile: 'BP', // TODO: from localSDP
+  isAvatar: false, // Not Avaliable
+  isHardwareEncoded: false, // Not Avaliable
+  localConfigurationChanges: 2, // Not Avaliable
+  maxFrameQp: 0, // Not Avaliable
+  maxNoiseLevel: 0, // Not Avaliable
+  minRegionQp: 0, // Not Avaliable
+  remoteConfigurationChanges: 0, // Not Avaliable
+  requestedFrameSize: 0, // TODO: from remote SDP
+  requestedKeyFrames: 0, // outbound Fir request
+  transmittedFrameSize: 0, // Not Avaliable
+  transmittedHeight: 0,
+  transmittedKeyFrames: 0, // Key frames encoded
+  transmittedKeyFramesClient: 0, // Not Avaliable
+  transmittedKeyFramesConfigurationChange: 0, // Not Avaliable
+  transmittedKeyFramesFeedback: 0, // Not Avaliable
+  transmittedKeyFramesLocalDrop: 0, // Not Avaliable
+  transmittedKeyFramesOtherLayer: 0, // Not Avaliable
+  transmittedKeyFramesPeriodic: 0, // Not Avaliable
+  transmittedKeyFramesSceneChange: 0, // Not Avaliable
+  transmittedKeyFramesStartup: 0, // Not Avaliable
+  transmittedKeyFramesUnknown: 0, // Not Avaliable
+  transmittedWidth: 0,
 };

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -18,6 +18,10 @@ import {
   emptyMqaInterval,
   emptyVideoReceive,
   emptyVideoTransmit,
+  emptyAudioReceiveStream,
+  emptyAudioTransmitStream,
+  emptyVideoReceiveStream,
+  emptyVideoTransmitStream,
 } from '../mediaQualityMetrics/config';
 import LoggerProxy from '../common/logs/logger-proxy';
 
@@ -27,6 +31,10 @@ import {
   getAudioReceiverMqa,
   getVideoSenderMqa,
   getVideoReceiverMqa,
+  getAudioSenderStreamMqa,
+  getAudioReceiverStreamMqa,
+  getVideoSenderStreamMqa,
+  getVideoReceiverStreamMqa,
 } from './mqaUtil';
 import {ReceiveSlot} from '../multistream/receiveSlot';
 
@@ -153,6 +161,7 @@ export class StatsAnalyzer extends EventsScope {
   sendMqaData() {
     const newMqa = cloneDeep(emptyMqaInterval);
 
+    // Fill in empty stats items for lastMqaDataSent
     Object.keys(this.statsResults).forEach((mediaType) => {
       if (!this.lastMqaDataSent[mediaType]) {
         this.lastMqaDataSent[mediaType] = {};
@@ -165,53 +174,178 @@ export class StatsAnalyzer extends EventsScope {
       if (!this.lastMqaDataSent[mediaType].recv && mediaType.includes('-recv')) {
         this.lastMqaDataSent[mediaType].recv = {};
       }
+    });
 
-      if (mediaType.includes('audio-send') || mediaType.includes('audio-share-send')) {
-        const audioSender = cloneDeep(emptyAudioTransmit);
+    // Create stats the first level, totals for senders and receivers
+    const audioSender = cloneDeep(emptyAudioTransmit);
+    const audioShareSender = cloneDeep(emptyAudioTransmit);
+    const audioReceiver = cloneDeep(emptyAudioReceive);
+    const audioShareReceiver = cloneDeep(emptyAudioReceive);
+    const videoSender = cloneDeep(emptyVideoTransmit);
+    const videoShareSender = cloneDeep(emptyVideoTransmit);
+    const videoReceiver = cloneDeep(emptyVideoReceive);
+    const videoShareReceiver = cloneDeep(emptyVideoReceive);
 
-        getAudioSenderMqa({
-          audioSender,
+    getAudioSenderMqa({
+      audioSender,
+      statsResults: this.statsResults,
+      lastMqaDataSent: this.lastMqaDataSent,
+      baseMediaType: 'audio-send',
+    });
+    newMqa.audioTransmit.push(audioSender);
+
+    getAudioSenderMqa({
+      audioSender: audioShareSender,
+      statsResults: this.statsResults,
+      lastMqaDataSent: this.lastMqaDataSent,
+      baseMediaType: 'audio-share-send',
+    });
+    newMqa.audioTransmit.push(audioShareSender);
+
+    getAudioReceiverMqa({
+      audioReceiver,
+      statsResults: this.statsResults,
+      lastMqaDataSent: this.lastMqaDataSent,
+      baseMediaType: 'audio-recv',
+    });
+    newMqa.audioReceive.push(audioReceiver);
+
+    getAudioReceiverMqa({
+      audioReceiver: audioShareReceiver,
+      statsResults: this.statsResults,
+      lastMqaDataSent: this.lastMqaDataSent,
+      baseMediaType: 'audio-share-recv',
+    });
+    newMqa.audioReceive.push(audioShareReceiver);
+
+    getVideoSenderMqa({
+      videoSender,
+      statsResults: this.statsResults,
+      lastMqaDataSent: this.lastMqaDataSent,
+      baseMediaType: 'video-send',
+    });
+    newMqa.videoTransmit.push(videoSender);
+
+    getVideoSenderMqa({
+      videoSender: videoShareSender,
+      statsResults: this.statsResults,
+      lastMqaDataSent: this.lastMqaDataSent,
+      baseMediaType: 'video-share-send',
+    });
+    newMqa.videoTransmit.push(videoShareSender);
+
+    getVideoReceiverMqa({
+      videoReceiver,
+      statsResults: this.statsResults,
+      lastMqaDataSent: this.lastMqaDataSent,
+      baseMediaType: 'video-recv',
+    });
+    newMqa.videoReceive.push(videoReceiver);
+
+    getVideoReceiverMqa({
+      videoReceiver: videoShareReceiver,
+      statsResults: this.statsResults,
+      lastMqaDataSent: this.lastMqaDataSent,
+      baseMediaType: 'video-share-recv',
+    });
+    newMqa.videoReceive.push(videoShareReceiver);
+
+    // Add stats for individual streams
+    Object.keys(this.statsResults).forEach((mediaType) => {
+      if (mediaType.includes('audio-send')) {
+        const audioSenderStream = cloneDeep(emptyAudioTransmitStream);
+
+        getAudioSenderStreamMqa({
+          audioSenderStream,
           statsResults: this.statsResults,
           lastMqaDataSent: this.lastMqaDataSent,
           mediaType,
         });
-        newMqa.audioTransmit.push(audioSender);
+        newMqa.audioTransmit[0].streams.push(audioSenderStream);
 
         this.lastMqaDataSent[mediaType].send = cloneDeep(this.statsResults[mediaType].send);
-      } else if (mediaType.includes('audio-recv') || mediaType.includes('audio-share-recv')) {
-        const audioReceiver = cloneDeep(emptyAudioReceive);
+      } else if (mediaType.includes('audio-share-send')) {
+        const audioSenderStream = cloneDeep(emptyAudioTransmitStream);
 
-        getAudioReceiverMqa({
-          audioReceiver,
+        getAudioSenderStreamMqa({
+          audioSenderStream,
           statsResults: this.statsResults,
           lastMqaDataSent: this.lastMqaDataSent,
           mediaType,
         });
-        newMqa.audioReceive.push(audioReceiver);
+        newMqa.audioTransmit[1].streams.push(audioSenderStream);
+
+        this.lastMqaDataSent[mediaType].send = cloneDeep(this.statsResults[mediaType].send);
+      } else if (mediaType.includes('audio-recv')) {
+        const audioReceiverStream = cloneDeep(emptyAudioReceiveStream);
+
+        getAudioReceiverStreamMqa({
+          audioReceiverStream,
+          statsResults: this.statsResults,
+          lastMqaDataSent: this.lastMqaDataSent,
+          mediaType,
+        });
+        newMqa.audioReceive[0].streams.push(audioReceiverStream);
 
         this.lastMqaDataSent[mediaType].recv = cloneDeep(this.statsResults[mediaType].recv);
-      } else if (mediaType.includes('video-send') || mediaType.includes('video-share-send')) {
-        const videoSender = cloneDeep(emptyVideoTransmit);
+      } else if (mediaType.includes('audio-share-recv')) {
+        const audioReceiverStream = cloneDeep(emptyAudioReceiveStream);
 
-        getVideoSenderMqa({
-          videoSender,
+        getAudioReceiverStreamMqa({
+          audioReceiverStream,
           statsResults: this.statsResults,
           lastMqaDataSent: this.lastMqaDataSent,
           mediaType,
         });
-        newMqa.videoTransmit.push(videoSender);
+        newMqa.audioReceive[1].streams.push(audioReceiverStream);
+
+        this.lastMqaDataSent[mediaType].recv = cloneDeep(this.statsResults[mediaType].recv);
+      } else if (mediaType.includes('video-send')) {
+        const videoSenderStream = cloneDeep(emptyVideoTransmitStream);
+
+        getVideoSenderStreamMqa({
+          videoSenderStream,
+          statsResults: this.statsResults,
+          lastMqaDataSent: this.lastMqaDataSent,
+          mediaType,
+        });
+        newMqa.videoTransmit[0].streams.push(videoSenderStream);
 
         this.lastMqaDataSent[mediaType].send = cloneDeep(this.statsResults[mediaType].send);
-      } else if (mediaType.includes('video-recv') || mediaType.includes('video-share-recv')) {
-        const videoReceiver = cloneDeep(emptyVideoReceive);
+      } else if (mediaType.includes('video-share-send')) {
+        const videoSenderStream = cloneDeep(emptyVideoTransmitStream);
 
-        getVideoReceiverMqa({
-          videoReceiver,
+        getVideoSenderStreamMqa({
+          videoSenderStream,
           statsResults: this.statsResults,
           lastMqaDataSent: this.lastMqaDataSent,
           mediaType,
         });
-        newMqa.videoReceive.push(videoReceiver);
+        newMqa.videoTransmit[1].streams.push(videoSenderStream);
+
+        this.lastMqaDataSent[mediaType].send = cloneDeep(this.statsResults[mediaType].send);
+      } else if (mediaType.includes('video-recv')) {
+        const videoReceiverStream = cloneDeep(emptyVideoReceiveStream);
+
+        getVideoReceiverStreamMqa({
+          videoReceiverStream,
+          statsResults: this.statsResults,
+          lastMqaDataSent: this.lastMqaDataSent,
+          mediaType,
+        });
+        newMqa.videoReceive[0].streams.push(videoReceiverStream);
+
+        this.lastMqaDataSent[mediaType].recv = cloneDeep(this.statsResults[mediaType].recv);
+      } else if (mediaType.includes('video-share-recv')) {
+        const videoReceiverStream = cloneDeep(emptyVideoReceiveStream);
+
+        getVideoReceiverStreamMqa({
+          videoReceiverStream,
+          statsResults: this.statsResults,
+          lastMqaDataSent: this.lastMqaDataSent,
+          mediaType,
+        });
+        newMqa.videoReceive[1].streams.push(videoReceiverStream);
 
         this.lastMqaDataSent[mediaType].recv = cloneDeep(this.statsResults[mediaType].recv);
       }
@@ -381,7 +515,6 @@ export class StatsAnalyzer extends EventsScope {
         this.parseCandidate(getStatsResult, type, isSender, false);
         break;
       case 'media-source':
-        // @ts-ignore
         this.parseAudioSource(getStatsResult, type);
         break;
       default:

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -31,67 +31,22 @@ export const getAudioReceiverMqa = ({
 }) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
-  const lastPacketsReceived = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsReceived'
-  );
-  const lastPacketsLost = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsLost'
-  );
-  const lastBytesReceived = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalBytesReceived'
-  );
-  const lastFecPacketsReceived = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'fecPacketsReceived'
-  );
-  const lastFecPacketsDiscarded = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'fecPacketsDiscarded'
-  );
+  const getLastTotalValue = (value: string) =>
+    getTotalValueFromBaseType(lastMqaDataSent, sendrecvType, baseMediaType, value);
+  const getTotalValue = (value: string) =>
+    getTotalValueFromBaseType(statsResults, sendrecvType, baseMediaType, value);
 
-  const totalPacketsReceived = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsReceived'
-  );
-  const packetsLost = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsLost'
-  );
-  const totalBytesReceived = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalBytesReceived'
-  );
-  const totalFecPacketsReceived = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'fecPacketsReceived'
-  );
-  const totalFecPacketsDiscarded = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'fecPacketsDiscarded'
-  );
+  const lastPacketsReceived = getLastTotalValue('totalPacketsReceived');
+  const lastPacketsLost = getLastTotalValue('totalPacketsLost');
+  const lastBytesReceived = getLastTotalValue('totalBytesReceived');
+  const lastFecPacketsReceived = getLastTotalValue('fecPacketsReceived');
+  const lastFecPacketsDiscarded = getLastTotalValue('fecPacketsDiscarded');
+
+  const totalPacketsReceived = getTotalValue('totalPacketsReceived');
+  const packetsLost = getTotalValue('totalPacketsLost');
+  const totalBytesReceived = getTotalValue('totalBytesReceived');
+  const totalFecPacketsReceived = getTotalValue('fecPacketsReceived');
+  const totalFecPacketsDiscarded = getTotalValue('fecPacketsDiscarded');
 
   audioReceiver.common.common.direction =
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
@@ -175,6 +130,17 @@ export const getAudioReceiverStreamMqa = ({
 export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, baseMediaType}) => {
   const sendrecvType = STATS.SEND_DIRECTION;
 
+  const getLastTotalValue = (value: string) =>
+    getTotalValueFromBaseType(lastMqaDataSent, sendrecvType, baseMediaType, value);
+  const getTotalValue = (value: string) =>
+    getTotalValueFromBaseType(statsResults, sendrecvType, baseMediaType, value);
+
+  const lastPacketsSent = getLastTotalValue('totalPacketsSent');
+  const lastPacketsLostTotal = getLastTotalValue('totalPacketsLostOnReceiver');
+
+  const totalPacketsLostOnReceiver = getTotalValue('totalPacketsLostOnReceiver');
+  const totalPacketsSent = getTotalValue('totalPacketsSent');
+
   const meanRemoteJitter = Object.keys(statsResults)
     .filter((mt) => mt.includes(baseMediaType))
     .reduce((acc, mt) => acc.concat(statsResults[mt][sendrecvType].meanRemoteJitter), []);
@@ -190,32 +156,6 @@ export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, b
 
   audioSender.common.maxRemoteJitter = max(meanRemoteJitter) * 1000 || 0;
   audioSender.common.meanRemoteJitter = mean(meanRemoteJitter) * 1000 || 0;
-
-  const lastPacketsSent = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsSent'
-  );
-  const lastPacketsLostTotal = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsLostOnReceiver'
-  );
-
-  const totalPacketsLostOnReceiver = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsLostOnReceiver'
-  );
-  const totalPacketsSent = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsSent'
-  );
 
   audioSender.common.rtpPackets = totalPacketsSent - lastPacketsSent || 0;
   // audioSender.streams[0].common.rtpPackets = audioSender.common.rtpPackets;
@@ -286,43 +226,18 @@ export const getVideoReceiverMqa = ({
 }) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
-  const lastPacketsReceived = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsReceived'
-  );
-  const lastPacketsLost = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsLost'
-  );
-  const lastBytesReceived = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalBytesReceived'
-  );
+  const getLastTotalValue = (value: string) =>
+    getTotalValueFromBaseType(lastMqaDataSent, sendrecvType, baseMediaType, value);
+  const getTotalValue = (value: string) =>
+    getTotalValueFromBaseType(statsResults, sendrecvType, baseMediaType, value);
 
-  const packetsLost = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsLost'
-  );
-  const totalPacketsReceived = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsReceived'
-  );
-  const totalBytesReceived = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalBytesReceived'
-  );
+  const lastPacketsReceived = getLastTotalValue('totalPacketsReceived');
+  const lastPacketsLost = getLastTotalValue('totalPacketsLost');
+  const lastBytesReceived = getLastTotalValue('totalBytesReceived');
+
+  const packetsLost = getTotalValue('totalPacketsLost');
+  const totalPacketsReceived = getTotalValue('totalPacketsReceived');
+  const totalBytesReceived = getTotalValue('totalBytesReceived');
 
   const meanRemoteJitter = Object.keys(statsResults)
     .filter((mt) => mt.includes(baseMediaType))
@@ -409,7 +324,7 @@ export const getVideoReceiverStreamMqa = ({
   );
 
   videoReceiverStream.common.framesDropped =
-    statsResults[mediaType][sendrecvType].framesDropped - lastFramesDropped;
+    statsResults[mediaType][sendrecvType].framesDropped - lastFramesDropped || 0;
   videoReceiverStream.receivedHeight = statsResults[mediaType][sendrecvType].height || 0;
   videoReceiverStream.receivedWidth = statsResults[mediaType][sendrecvType].width || 0;
   videoReceiverStream.receivedFrameSize =
@@ -424,49 +339,19 @@ export const getVideoReceiverStreamMqa = ({
 export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, baseMediaType}) => {
   const sendrecvType = STATS.SEND_DIRECTION;
 
-  const lastPacketsSent = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsSent'
-  );
-  const lastBytesSent = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalBylastBytesSent'
-  );
-  const lastPacketsLostTotal = getTotalValueFromBaseType(
-    lastMqaDataSent,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsLostOnReceiver'
-  );
+  const getLastTotalValue = (value: string) =>
+    getTotalValueFromBaseType(lastMqaDataSent, sendrecvType, baseMediaType, value);
+  const getTotalValue = (value: string) =>
+    getTotalValueFromBaseType(statsResults, sendrecvType, baseMediaType, value);
 
-  const totalPacketsLostOnReceiver = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsLostOnReceiver'
-  );
-  const totalPacketsSent = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalPacketsSent'
-  );
-  const totalBytesSent = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'totalBytesSent'
-  );
-  const availableOutgoingBitrate = getTotalValueFromBaseType(
-    statsResults,
-    sendrecvType,
-    baseMediaType,
-    'availableOutgoingBitrate'
-  );
+  const lastPacketsSent = getLastTotalValue('totalPacketsSent');
+  const lastBytesSent = getLastTotalValue('totalBytesSent');
+  const lastPacketsLostTotal = getLastTotalValue('totalPacketsLostOnReceiver');
+
+  const totalPacketsLostOnReceiver = getTotalValue('totalPacketsLostOnReceiver');
+  const totalPacketsSent = getTotalValue('totalPacketsSent');
+  const totalBytesSent = getTotalValue('totalBytesSent');
+  const availableOutgoingBitrate = getTotalValue('availableOutgoingBitrate');
 
   videoSender.common.common.direction =
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -4,11 +4,127 @@ import {mean, max} from 'lodash';
 
 import {STATS} from '../constants';
 
-export const getAudioReceiverMqa = ({audioReceiver, statsResults, lastMqaDataSent, mediaType}) => {
+/**
+ * Get the totals of a certain value from a certain media type.
+ *
+ * @param {object} stats - The large stats object.
+ * @param {string} sendrecvType - "send" or "recv".
+ * @param {string} baseMediaType - audio or video _and_ share or non-share.
+ * @param {string} value - The value we want to get the totals of.
+ * @returns {number}
+ */
+const getTotalValueFromBaseType = (
+  stats: object,
+  sendrecvType: string,
+  baseMediaType: string,
+  value: string
+): number =>
+  Object.keys(stats)
+    .filter((mt) => mt.includes(baseMediaType))
+    .reduce((acc, mt) => acc + (stats[mt]?.[sendrecvType]?.[value] || 0), 0);
+
+export const getAudioReceiverMqa = ({
+  audioReceiver,
+  statsResults,
+  lastMqaDataSent,
+  baseMediaType,
+}) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
-  const lastPacketsReceived = lastMqaDataSent[mediaType]?.[sendrecvType].totalPacketsReceived || 0;
-  const lastPacketsLost = lastMqaDataSent[mediaType]?.[sendrecvType].totalPacketsLost || 0;
+  const lastPacketsReceived = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsReceived'
+  );
+  const lastPacketsLost = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsLost'
+  );
+  const lastBytesReceived = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalBytesReceived'
+  );
+  const lastFecPacketsReceived = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'fecPacketsReceived'
+  );
+  const lastFecPacketsDiscarded = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'fecPacketsDiscarded'
+  );
+
+  const totalPacketsReceived = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsReceived'
+  );
+  const packetsLost = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsLost'
+  );
+  const totalBytesReceived = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalBytesReceived'
+  );
+  const totalFecPacketsReceived = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'fecPacketsReceived'
+  );
+  const totalFecPacketsDiscarded = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'fecPacketsDiscarded'
+  );
+
+  audioReceiver.common.common.direction =
+    statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
+      ?.direction || 'inactive';
+  audioReceiver.common.common.isMain = !baseMediaType.includes('-share');
+  audioReceiver.common.transportType = statsResults.connectionType.local.transport;
+
+  // add rtpPacket info inside common as also for call analyzer
+  audioReceiver.common.rtpPackets = totalPacketsReceived - lastPacketsReceived;
+
+  // Hop by hop are numbers and not percentage so we compare on what we sent the last min
+  // collect the packets received for the last min
+  const totalPacketsLost = packetsLost - lastPacketsLost;
+  audioReceiver.common.mediaHopByHopLost = totalPacketsLost;
+  audioReceiver.common.rtpHopByHopLost = totalPacketsLost;
+
+  const fecRecovered =
+    totalFecPacketsReceived -
+    lastFecPacketsReceived -
+    (totalFecPacketsDiscarded - lastFecPacketsDiscarded);
+  audioReceiver.common.fecPackets = fecRecovered;
+
+  audioReceiver.common.rtpBitrate = ((totalBytesReceived - lastBytesReceived) * 8) / 60 || 0;
+};
+
+export const getAudioReceiverStreamMqa = ({
+  audioReceiverStream,
+  statsResults,
+  lastMqaDataSent,
+  mediaType,
+}) => {
+  const sendrecvType = STATS.RECEIVE_DIRECTION;
+
   const lastPacketsDecoded = lastMqaDataSent[mediaType]?.[sendrecvType].totalSamplesDecoded || 0;
   const lastSamplesReceived = lastMqaDataSent[mediaType]?.[sendrecvType].totalSamplesReceived || 0;
   const lastConcealedSamples = lastMqaDataSent[mediaType]?.[sendrecvType].concealedSamples || 0;
@@ -16,123 +132,235 @@ export const getAudioReceiverMqa = ({audioReceiver, statsResults, lastMqaDataSen
   const lastFecPacketsReceived = lastMqaDataSent[mediaType]?.[sendrecvType].fecPacketsReceived || 0;
   const lastFecPacketsDiscarded =
     lastMqaDataSent[mediaType]?.[sendrecvType].fecPacketsDiscarded || 0;
+  const lastPacketsReceived = lastMqaDataSent[mediaType]?.[sendrecvType].totalPacketsReceived || 0;
+  const lastPacketsLost = lastMqaDataSent[mediaType]?.[sendrecvType].totalPacketsLost || 0;
 
   const {csi} = statsResults[mediaType];
-  if (csi && !audioReceiver.streams[0].common.csi.includes(csi)) {
-    audioReceiver.streams[0].common.csi.push(csi);
+  if (csi && !audioReceiverStream.common.csi.includes(csi)) {
+    audioReceiverStream.common.csi.push(csi);
   }
 
-  audioReceiver.common.common.direction = statsResults[mediaType].direction;
-  audioReceiver.common.common.isMain = !mediaType.includes('-share');
-  audioReceiver.common.transportType = statsResults.connectionType.local.transport;
-
-  // add rtpPacket info inside common as also for call analyzer
-  audioReceiver.common.rtpPackets =
+  audioReceiverStream.common.rtpPackets =
     statsResults[mediaType][sendrecvType].totalPacketsReceived - lastPacketsReceived || 0;
-  audioReceiver.streams[0].common.rtpPackets = audioReceiver.common.rtpPackets;
 
-  // Hop by hop are numbers and not percentage so we compare on what we sent the last min
-  // collect the packets received for the last min
-  const totalPacketsLost =
-    statsResults[mediaType][sendrecvType].totalPacketsLost - lastPacketsLost || 0;
-  audioReceiver.common.mediaHopByHopLost = totalPacketsLost;
-  audioReceiver.common.rtpHopByHopLost = totalPacketsLost;
-
-  audioReceiver.streams[0].common.maxRtpJitter =
+  audioReceiverStream.common.maxRtpJitter =
     // @ts-ignore
     max(statsResults[mediaType][sendrecvType].meanRtpJitter) * 1000 || 0;
-  audioReceiver.streams[0].common.meanRtpJitter =
+  audioReceiverStream.common.meanRtpJitter =
     mean(statsResults[mediaType][sendrecvType].meanRtpJitter) * 1000 || 0;
-  audioReceiver.streams[0].common.rtpJitter = audioReceiver.streams[0].common.maxRtpJitter;
+  audioReceiverStream.common.rtpJitter = audioReceiverStream.common.maxRtpJitter;
 
   // Fec packets do come in as part of the FEC only for audio
   const fecRecovered =
     statsResults[mediaType][sendrecvType].fecPacketsReceived -
     lastFecPacketsReceived -
     (statsResults[mediaType][sendrecvType].fecPacketsDiscarded - lastFecPacketsDiscarded);
-  audioReceiver.common.fecPackets = fecRecovered || 0;
 
-  audioReceiver.streams[0].common.rtpEndToEndLost =
+  audioReceiverStream.common.rtpEndToEndLost =
     statsResults[mediaType][sendrecvType].totalPacketsLost - lastPacketsLost - fecRecovered || 0;
 
-  audioReceiver.streams[0].common.framesDropped =
+  audioReceiverStream.common.framesDropped =
     statsResults[mediaType][sendrecvType].totalSamplesDecoded - lastPacketsDecoded || 0;
-  audioReceiver.streams[0].common.renderedFrameRate =
-    (audioReceiver.streams[0].common.framesDropped * 100) / 60 || 0;
+  audioReceiverStream.common.renderedFrameRate =
+    (audioReceiverStream.common.framesDropped * 100) / 60 || 0;
 
-  audioReceiver.streams[0].common.framesReceived =
+  audioReceiverStream.common.framesReceived =
     statsResults[mediaType][sendrecvType].totalSamplesReceived - lastSamplesReceived || 0;
-  audioReceiver.streams[0].common.concealedFrames =
+  audioReceiverStream.common.concealedFrames =
     statsResults[mediaType][sendrecvType].concealedSamples - lastConcealedSamples || 0;
-  audioReceiver.streams[0].common.receivedBitrate =
+  audioReceiverStream.common.receivedBitrate =
     ((statsResults[mediaType][sendrecvType].totalBytesReceived - lastBytesReceived) * 8) / 60 || 0;
-
-  audioReceiver.common.rtpBitrate = audioReceiver.streams[0].common.receivedBitrate;
 };
 
-export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, mediaType}) => {
+export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, baseMediaType}) => {
   const sendrecvType = STATS.SEND_DIRECTION;
 
-  const lastPacketsSent = lastMqaDataSent[mediaType]?.[sendrecvType].totalPacketsSent || 0;
-  const lastPacketsLost =
-    lastMqaDataSent[mediaType]?.[sendrecvType].totalPacketsLostOnReceiver || 0;
-  const lastBytesSent = lastMqaDataSent[mediaType]?.[sendrecvType].totalBytesSent || 0;
-  const lastFramesEncoded = lastMqaDataSent[mediaType]?.[sendrecvType].totalKeyFramesEncoded || 0;
-  const lastFirCount = lastMqaDataSent[mediaType]?.[sendrecvType].totalFirCount || 0;
+  const meanRemoteJitter = Object.keys(statsResults)
+    .filter((mt) => mt.includes(baseMediaType))
+    .reduce((acc, mt) => acc.concat(statsResults[mt][sendrecvType].meanRemoteJitter), []);
+  const meanRoundTripTime = Object.keys(statsResults)
+    .filter((mt) => mt.includes(baseMediaType))
+    .reduce((acc, mt) => acc.concat(statsResults[mt][sendrecvType].meanRoundTripTime), []);
 
-  const {csi} = statsResults[mediaType];
-  if (csi && !audioSender.streams[0].common.csi.includes(csi)) {
-    audioSender.streams[0].common.csi.push(csi);
-  }
-
-  audioSender.common.common.direction = statsResults[mediaType].direction;
-  audioSender.common.common.isMain = !mediaType.includes('-share');
+  audioSender.common.common.direction =
+    statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
+      ?.direction || 'inactive';
+  audioSender.common.common.isMain = !baseMediaType.includes('-share');
   audioSender.common.transportType = statsResults.connectionType.local.transport;
 
-  audioSender.common.maxRemoteJitter =
-    // @ts-ignore
-    max(statsResults[mediaType][sendrecvType].meanRemoteJitter) * 1000 || 0;
-  audioSender.common.meanRemoteJitter =
-    mean(statsResults[mediaType][sendrecvType].meanRemoteJitter) * 1000 || 0;
+  audioSender.common.maxRemoteJitter = max(meanRemoteJitter) * 1000 || 0;
+  audioSender.common.meanRemoteJitter = mean(meanRemoteJitter) * 1000 || 0;
 
-  audioSender.common.rtpPackets =
-    statsResults[mediaType][sendrecvType].totalPacketsSent - lastPacketsSent || 0;
-  audioSender.streams[0].common.rtpPackets = audioSender.common.rtpPackets;
+  const lastPacketsSent = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsSent'
+  );
+  const lastPacketsLostTotal = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsLostOnReceiver'
+  );
+
+  const totalPacketsLostOnReceiver = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsLostOnReceiver'
+  );
+  const totalPacketsSent = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsSent'
+  );
+
+  audioSender.common.rtpPackets = totalPacketsSent - lastPacketsSent || 0;
+  // audioSender.streams[0].common.rtpPackets = audioSender.common.rtpPackets;
   // From candidate-pair
-  audioSender.common.availableBitrate =
-    statsResults[mediaType][sendrecvType].availableOutgoingBitrate || 0;
+  audioSender.common.availableBitrate = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'availableOutgoingBitrate'
+  );
   // Calculate based on how much packets lost of received compated to how to the client sent
 
-  const totalpacketsLostForaMin =
-    statsResults[mediaType][sendrecvType].totalPacketsLostOnReceiver - lastPacketsLost;
-
+  const totalPacketsLostForaMin = totalPacketsLostOnReceiver - lastPacketsLostTotal;
   audioSender.common.remoteLossRate =
-    audioSender.common.rtpPackets > 0
-      ? (totalpacketsLostForaMin * 100) / audioSender.common.rtpPackets
-      : 0; // This is the packets sent with in last min || 0;
+    totalPacketsSent - lastPacketsSent > 0
+      ? (totalPacketsLostForaMin * 100) / (totalPacketsSent - lastPacketsSent)
+      : 0; // This is the packets sent with in last min
 
-  audioSender.common.maxRoundTripTime =
-    // @ts-ignore
-    max(statsResults[mediaType][sendrecvType].meanRoundTripTime) * 1000 || 0;
-  audioSender.common.meanRoundTripTime =
-    mean(statsResults[mediaType][sendrecvType].meanRoundTripTime) * 1000 || 0;
+  audioSender.common.maxRoundTripTime = max(meanRoundTripTime) * 1000 || 0;
+  audioSender.common.meanRoundTripTime = mean(meanRoundTripTime) * 1000 || 0;
   audioSender.common.roundTripTime = audioSender.common.maxRoundTripTime;
 
   // Calculate the outgoing bitrate
-  const totalBytesSentInaMin = statsResults[mediaType][sendrecvType].totalBytesSent - lastBytesSent;
+  const totalBytesSentInaMin =
+    getTotalValueFromBaseType(statsResults, sendrecvType, baseMediaType, 'totalBytesSent') -
+    getTotalValueFromBaseType(lastMqaDataSent, sendrecvType, baseMediaType, 'totalBytesSent');
 
-  audioSender.streams[0].common.transmittedBitrate = totalBytesSentInaMin
+  audioSender.common.rtpBitrate = totalBytesSentInaMin ? (totalBytesSentInaMin * 8) / 60 : 0;
+};
+
+export const getAudioSenderStreamMqa = ({
+  audioSenderStream,
+  statsResults,
+  lastMqaDataSent,
+  mediaType,
+}) => {
+  const sendrecvType = STATS.SEND_DIRECTION;
+
+  const lastBytesSent = lastMqaDataSent[mediaType]?.[sendrecvType].totalBytesSent || 0;
+  const lastFramesEncoded = lastMqaDataSent[mediaType]?.[sendrecvType].totalKeyFramesEncoded || 0;
+  const lastFirCount = lastMqaDataSent[mediaType]?.[sendrecvType].totalFirCount || 0;
+  const lastPacketsSent = lastMqaDataSent[mediaType]?.[sendrecvType].totalPacketsSent || 0;
+
+  const {csi} = statsResults[mediaType];
+  if (csi && !audioSenderStream.common.csi.includes(csi)) {
+    audioSenderStream.common.csi.push(csi);
+  }
+
+  audioSenderStream.common.rtpPackets =
+    statsResults[mediaType][sendrecvType].totalPacketsSent - lastPacketsSent || 0;
+
+  const totalBytesSentInaMin = statsResults[mediaType][sendrecvType].totalBytesSent - lastBytesSent;
+  audioSenderStream.common.transmittedBitrate = totalBytesSentInaMin
     ? (totalBytesSentInaMin * 8) / 60
     : 0;
-  audioSender.common.rtpBitrate = audioSender.streams[0].common.transmittedBitrate;
 
-  audioSender.streams[0].transmittedKeyFrames =
+  audioSenderStream.transmittedKeyFrames =
     statsResults[mediaType][sendrecvType].totalKeyFramesEncoded - lastFramesEncoded || 0;
-  audioSender.streams[0].requestedKeyFrames =
+  audioSenderStream.requestedKeyFrames =
     statsResults[mediaType][sendrecvType].totalFirCount - lastFirCount || 0;
 };
 
-export const getVideoReceiverMqa = ({videoReceiver, statsResults, lastMqaDataSent, mediaType}) => {
+export const getVideoReceiverMqa = ({
+  videoReceiver,
+  statsResults,
+  lastMqaDataSent,
+  baseMediaType,
+}) => {
+  const sendrecvType = STATS.RECEIVE_DIRECTION;
+
+  const lastPacketsReceived = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsReceived'
+  );
+  const lastPacketsLost = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsLost'
+  );
+  const lastBytesReceived = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalBytesReceived'
+  );
+
+  const packetsLost = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsLost'
+  );
+  const totalPacketsReceived = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsReceived'
+  );
+  const totalBytesReceived = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalBytesReceived'
+  );
+
+  const meanRemoteJitter = Object.keys(statsResults)
+    .filter((mt) => mt.includes(baseMediaType))
+    .reduce((acc, mt) => acc.concat(statsResults[mt][sendrecvType].meanRemoteJitter), []);
+
+  videoReceiver.common.common.direction =
+    statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
+      ?.direction || 'inactive';
+  videoReceiver.common.common.isMain = !baseMediaType.includes('-share');
+  videoReceiver.common.transportType = statsResults.connectionType.local.transport;
+
+  // collect the packets received for the last min
+  videoReceiver.common.rtpPackets = totalPacketsReceived - lastPacketsReceived || 0;
+
+  // Hop by hop are numbers and not percentage so we compare on what we sent the last min
+  // this is including packet lost
+  const totalPacketsLost = packetsLost - lastPacketsLost;
+  videoReceiver.common.mediaHopByHopLost = totalPacketsLost;
+  videoReceiver.common.rtpHopByHopLost = totalPacketsLost;
+
+  // calculate this values
+  videoReceiver.common.maxRemoteJitter = max(meanRemoteJitter) * 1000 || 0;
+  videoReceiver.common.meanRemoteJitter = mean(meanRemoteJitter) * 1000 || 0;
+
+  // Calculate the outgoing bitrate
+  const totalBytesReceivedInaMin = totalBytesReceived - lastBytesReceived;
+
+  videoReceiver.common.rtpBitrate = totalBytesReceivedInaMin
+    ? (totalBytesReceivedInaMin * 8) / 60
+    : 0;
+};
+
+export const getVideoReceiverStreamMqa = ({
+  videoReceiverStream,
+  statsResults,
+  lastMqaDataSent,
+  mediaType,
+}) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
   const lastPacketsReceived = lastMqaDataSent[mediaType]?.[sendrecvType].totalPacketsReceived || 0;
@@ -145,148 +373,183 @@ export const getVideoReceiverMqa = ({videoReceiver, statsResults, lastMqaDataSen
   const lastPliCount = lastMqaDataSent[mediaType]?.[sendrecvType].totalPliCount || 0;
 
   const {csi} = statsResults[mediaType];
-  if (csi && !videoReceiver.streams[0].common.csi.includes(csi)) {
-    videoReceiver.streams[0].common.csi.push(csi);
+  if (csi && !videoReceiverStream.common.csi.includes(csi)) {
+    videoReceiverStream.common.csi.push(csi);
   }
 
-  videoReceiver.common.common.direction = statsResults[mediaType].direction;
-  videoReceiver.common.common.isMain = !mediaType.includes('-share');
-  videoReceiver.common.transportType = statsResults.connectionType.local.transport;
-
-  // collect the packets received for the last min
-  videoReceiver.common.rtpPackets =
+  videoReceiverStream.common.rtpPackets =
     statsResults[mediaType][sendrecvType].totalPacketsReceived - lastPacketsReceived || 0;
-  videoReceiver.streams[0].common.rtpPackets = videoReceiver.common.rtpPackets;
 
-  // Hop by hop are numbers and not percentage so we compare on what we sent the last min
-  // this is including packet lost
-  const totalPacketsLost =
+  const totalPacketLoss =
     statsResults[mediaType][sendrecvType].totalPacketsLost - lastPacketsLost || 0;
-  videoReceiver.common.mediaHopByHopLost = totalPacketsLost;
-  videoReceiver.common.rtpHopByHopLost = totalPacketsLost;
 
   // End to end packetloss is after recovery
-  videoReceiver.streams[0].common.rtpEndToEndLost = totalPacketsLost;
+  videoReceiverStream.common.rtpEndToEndLost = totalPacketLoss;
 
-  // calculate this values
-
-  videoReceiver.common.maxRemoteJitter =
+  videoReceiverStream.common.rtpJitter =
     // @ts-ignore
     max(statsResults[mediaType][sendrecvType].meanRemoteJitter) * 1000 || 0;
-  videoReceiver.common.meanRemoteJitter =
-    mean(statsResults[mediaType][sendrecvType].meanRemoteJitter) * 1000 || 0;
 
-  videoReceiver.streams[0].common.rtpJitter = videoReceiver.common.maxRemoteJitter;
-
-  // Calculate the outgoing bitrate
   const totalBytesReceivedInaMin =
     statsResults[mediaType][sendrecvType].totalBytesReceived - lastBytesReceived;
-
-  videoReceiver.streams[0].common.receivedBitrate = totalBytesReceivedInaMin
+  videoReceiverStream.common.receivedBitrate = totalBytesReceivedInaMin
     ? (totalBytesReceivedInaMin * 8) / 60
     : 0;
-  videoReceiver.common.rtpBitrate = videoReceiver.streams[0].common.receivedBitrate;
 
-  // From tracks //TODO: calculate a proper one
   const totalFrameReceivedInaMin =
     statsResults[mediaType][sendrecvType].framesReceived - lastFramesReceived;
   const totalFrameDecodedInaMin =
     statsResults[mediaType][sendrecvType].framesDecoded - lastFramesDecoded;
 
-  videoReceiver.streams[0].common.receivedFrameRate = Math.round(
+  videoReceiverStream.common.receivedFrameRate = Math.round(
     totalFrameReceivedInaMin ? totalFrameReceivedInaMin / 60 : 0
   );
-  videoReceiver.streams[0].common.renderedFrameRate = Math.round(
+  videoReceiverStream.common.renderedFrameRate = Math.round(
     totalFrameDecodedInaMin ? totalFrameDecodedInaMin / 60 : 0
   );
 
-  videoReceiver.streams[0].common.framesDropped =
+  videoReceiverStream.common.framesDropped =
     statsResults[mediaType][sendrecvType].framesDropped - lastFramesDropped;
-  videoReceiver.streams[0].receivedHeight = statsResults[mediaType][sendrecvType].height || 0;
-  videoReceiver.streams[0].receivedWidth = statsResults[mediaType][sendrecvType].width || 0;
-  videoReceiver.streams[0].receivedFrameSize =
-    (videoReceiver.streams[0].receivedHeight * videoReceiver.streams[0].receivedWidth) / 256;
+  videoReceiverStream.receivedHeight = statsResults[mediaType][sendrecvType].height || 0;
+  videoReceiverStream.receivedWidth = statsResults[mediaType][sendrecvType].width || 0;
+  videoReceiverStream.receivedFrameSize =
+    (videoReceiverStream.receivedHeight * videoReceiverStream.receivedWidth) / 256;
 
-  videoReceiver.streams[0].receivedKeyFrames =
+  videoReceiverStream.receivedKeyFrames =
     statsResults[mediaType][sendrecvType].keyFramesDecoded - lastKeyFramesDecoded || 0;
-  videoReceiver.streams[0].requestedKeyFrames =
+  videoReceiverStream.requestedKeyFrames =
     statsResults[mediaType][sendrecvType].totalPliCount - lastPliCount || 0;
 };
 
-export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, mediaType}) => {
+export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, baseMediaType}) => {
+  const sendrecvType = STATS.SEND_DIRECTION;
+
+  const lastPacketsSent = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsSent'
+  );
+  const lastBytesSent = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalBylastBytesSent'
+  );
+  const lastPacketsLostTotal = getTotalValueFromBaseType(
+    lastMqaDataSent,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsLostOnReceiver'
+  );
+
+  const totalPacketsLostOnReceiver = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsLostOnReceiver'
+  );
+  const totalPacketsSent = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalPacketsSent'
+  );
+  const totalBytesSent = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'totalBytesSent'
+  );
+  const availableOutgoingBitrate = getTotalValueFromBaseType(
+    statsResults,
+    sendrecvType,
+    baseMediaType,
+    'availableOutgoingBitrate'
+  );
+
+  videoSender.common.common.direction =
+    statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
+      ?.direction || 'inactive';
+  videoSender.common.common.isMain = !baseMediaType.includes('-share');
+  videoSender.common.transportType = statsResults.connectionType.local.transport;
+
+  const meanRemoteJitter = Object.keys(statsResults)
+    .filter((mt) => mt.includes(baseMediaType))
+    .reduce((acc, mt) => acc.concat(statsResults[mt][sendrecvType].meanRemoteJitter), []);
+  const meanRoundTripTime = Object.keys(statsResults)
+    .filter((mt) => mt.includes(baseMediaType))
+    .reduce((acc, mt) => acc.concat(statsResults[mt][sendrecvType].meanRoundTripTime), []);
+
+  // @ts-ignore
+  videoSender.common.maxRemoteJitter = max(meanRemoteJitter) * 1000 || 0;
+  videoSender.common.meanRemoteJitter = mean(meanRemoteJitter) * 1000 || 0;
+
+  videoSender.common.rtpPackets = totalPacketsSent - lastPacketsSent;
+  videoSender.common.availableBitrate = availableOutgoingBitrate;
+
+  // Calculate based on how much packets lost of received compated to how to the client sent
+  const totalPacketsLostForaMin = totalPacketsLostOnReceiver - lastPacketsLostTotal;
+
+  videoSender.common.remoteLossRate =
+    totalPacketsSent - lastPacketsSent > 0
+      ? (totalPacketsLostForaMin * 100) / (totalPacketsSent - lastPacketsSent)
+      : 0; // This is the packets sent with in last min || 0;
+
+  videoSender.common.maxRoundTripTime = max(meanRoundTripTime) * 1000 || 0;
+  videoSender.common.meanRoundTripTime = mean(meanRoundTripTime) * 1000 || 0;
+  videoSender.common.roundTripTime = videoSender.common.maxRoundTripTime;
+
+  // Calculate the outgoing bitrate
+  const totalBytesSentInaMin = totalBytesSent - lastBytesSent;
+
+  videoSender.common.rtpBitrate = totalBytesSentInaMin ? (totalBytesSentInaMin * 8) / 60 : 0;
+};
+
+export const getVideoSenderStreamMqa = ({
+  videoSenderStream,
+  statsResults,
+  lastMqaDataSent,
+  mediaType,
+}) => {
   const sendrecvType = STATS.SEND_DIRECTION;
 
   const lastPacketsSent = lastMqaDataSent[mediaType]?.[sendrecvType].totalPacketsSent || 0;
-  const lastPacketsLost =
-    lastMqaDataSent[mediaType]?.[sendrecvType].totalPacketsLostOnReceiver || 0;
   const lastBytesSent = lastMqaDataSent[mediaType]?.[sendrecvType].totalBytesSent || 0;
   const lastKeyFramesEncoded =
     lastMqaDataSent[mediaType]?.[sendrecvType].totalKeyFramesEncoded || 0;
   const lastFirCount = lastMqaDataSent[mediaType]?.[sendrecvType].totalFirCount || 0;
   const lastFramesSent = lastMqaDataSent[mediaType]?.[sendrecvType].framesSent || 0;
+
   const {csi} = statsResults[mediaType];
-  if (csi && !videoSender.streams[0].common.csi.includes(csi)) {
-    videoSender.streams[0].common.csi.push(csi);
+  if (csi && !videoSenderStream.common.csi.includes(csi)) {
+    videoSenderStream.common.csi.push(csi);
   }
 
-  videoSender.common.common.direction = statsResults[mediaType].direction;
-  videoSender.common.common.isMain = !mediaType.includes('-share');
-  videoSender.common.transportType = statsResults.connectionType.local.transport;
-
-  // @ts-ignore
-  videoSender.common.maxRemoteJitter =
-    // @ts-ignore
-    max(statsResults[mediaType][sendrecvType].meanRemoteJitter) * 1000 || 0;
-  videoSender.common.meanRemoteJitter =
-    mean(statsResults[mediaType][sendrecvType].meanRemoteJitter) * 1000 || 0;
-
-  videoSender.common.rtpPackets =
-    statsResults[mediaType][sendrecvType].totalPacketsSent - lastPacketsSent || 0;
-  videoSender.common.availableBitrate =
-    statsResults[mediaType][sendrecvType].availableOutgoingBitrate || 0;
-  // Calculate based on how much packets lost of received compated to how to the client sent
-
-  const totalpacketsLostForaMin =
-    statsResults[mediaType][sendrecvType].totalPacketsLostOnReceiver - lastPacketsLost;
-
-  videoSender.common.remoteLossRate =
-    videoSender.common.rtpPackets > 0
-      ? (totalpacketsLostForaMin * 100) / videoSender.common.rtpPackets
-      : 0; // This is the packets sent with in last min || 0;
-
-  videoSender.common.maxRoundTripTime =
-    // @ts-ignore
-    max(statsResults[mediaType][sendrecvType].meanRoundTripTime) * 1000 || 0;
-  videoSender.common.meanRoundTripTime =
-    mean(statsResults[mediaType][sendrecvType].meanRoundTripTime) * 1000 || 0;
-  videoSender.common.roundTripTime = videoSender.common.maxRoundTripTime;
-
-  videoSender.streams[0].common.rtpPackets =
+  videoSenderStream.common.rtpPackets =
     statsResults[mediaType][sendrecvType].totalPacketsSent - lastPacketsSent || 0;
 
   // Calculate the outgoing bitrate
   const totalBytesSentInaMin = statsResults[mediaType][sendrecvType].totalBytesSent - lastBytesSent;
 
-  videoSender.streams[0].common.transmittedBitrate = totalBytesSentInaMin
+  videoSenderStream.common.transmittedBitrate = totalBytesSentInaMin
     ? (totalBytesSentInaMin * 8) / 60
     : 0;
 
-  videoSender.common.rtpBitrate = videoSender.streams[0].common.transmittedBitrate;
-
-  videoSender.streams[0].transmittedKeyFrames =
+  videoSenderStream.transmittedKeyFrames =
     statsResults[mediaType][sendrecvType].totalKeyFramesEncoded - lastKeyFramesEncoded || 0;
-  videoSender.streams[0].requestedKeyFrames =
+  videoSenderStream.requestedKeyFrames =
     statsResults[mediaType][sendrecvType].totalFirCount - lastFirCount || 0;
 
   // From tracks //TODO: calculate a proper one
   const totalFrameSentInaMin =
     statsResults[mediaType][sendrecvType].framesSent - (lastFramesSent || 0);
 
-  videoSender.streams[0].common.transmittedFrameRate = Math.round(
+  videoSenderStream.common.transmittedFrameRate = Math.round(
     totalFrameSentInaMin ? totalFrameSentInaMin / 60 : 0
   );
-  videoSender.streams[0].transmittedHeight = statsResults[mediaType][sendrecvType].height || 0;
-  videoSender.streams[0].transmittedWidth = statsResults[mediaType][sendrecvType].width || 0;
-  videoSender.streams[0].transmittedFrameSize =
-    (videoSender.streams[0].transmittedHeight * videoSender.streams[0].transmittedWidth) / 256;
+  videoSenderStream.transmittedHeight = statsResults[mediaType][sendrecvType].height || 0;
+  videoSenderStream.transmittedWidth = statsResults[mediaType][sendrecvType].width || 0;
+  videoSenderStream.transmittedFrameSize =
+    (videoSenderStream.transmittedHeight * videoSenderStream.transmittedWidth) / 256;
 };

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -955,6 +955,66 @@ describe('plugin-meetings', () => {
 
         assert.neverCalledWith(loggerSpy, 'StatsAnalyzer:index#processInboundRTPResult --> No packets received for receive slot "". Total packets received on slot: ', 0);
       });
+
+      it('has the correct number of senders and receivers (2)', async () => {
+        await startStatsAnalyzer({expected: {receiveVideo: true}});
+
+        await progressTime();
+
+        assert.lengthOf(mqeData.audioTransmit, 2);
+        assert.lengthOf(mqeData.audioReceive, 2);
+        assert.lengthOf(mqeData.videoTransmit, 2);
+        assert.lengthOf(mqeData.videoReceive, 2);
+      });
+
+      it('has one stream per sender/reciever', async () => {
+        await startStatsAnalyzer({expected: {receiveVideo: true}});
+
+        await progressTime();
+
+        assert.lengthOf(mqeData.audioTransmit[0].streams, 1);
+        assert.lengthOf(mqeData.audioReceive[0].streams, 1);
+        assert.lengthOf(mqeData.videoTransmit[0].streams, 1);
+        assert.lengthOf(mqeData.videoReceive[0].streams, 1);
+        assert.lengthOf(mqeData.audioTransmit[1].streams, 1);
+        assert.lengthOf(mqeData.audioReceive[1].streams, 1);
+        assert.lengthOf(mqeData.videoTransmit[1].streams, 1);
+        assert.lengthOf(mqeData.videoReceive[1].streams, 1);
+      });
+      
+      it('has three streams for video receivers when three exist', async () => {
+        pc.getTransceiverStats = sinon.stub().resolves({
+          audio: {
+            senders: [fakeStats.audio.senders[0]],
+            receivers: [fakeStats.audio.receivers[0]],
+          },
+          video: {
+            senders: [fakeStats.video.senders[0]],
+            receivers: [fakeStats.video.receivers[0], fakeStats.video.receivers[0], fakeStats.video.receivers[0]],
+          },
+          screenShareAudio: {
+            senders: [fakeStats.audio.senders[0]],
+            receivers: [fakeStats.audio.receivers[0]],
+          },
+          screenShareVideo: {
+            senders: [fakeStats.video.senders[0]],
+            receivers: [fakeStats.video.receivers[0]],
+          },
+        });
+
+        await startStatsAnalyzer({expected: {receiveVideo: true}});
+
+        await progressTime();
+
+        assert.lengthOf(mqeData.audioTransmit[0].streams, 1);
+        assert.lengthOf(mqeData.audioReceive[0].streams, 1);
+        assert.lengthOf(mqeData.videoTransmit[0].streams, 1);
+        assert.lengthOf(mqeData.videoReceive[0].streams, 3);
+        assert.lengthOf(mqeData.audioTransmit[1].streams, 1);
+        assert.lengthOf(mqeData.audioReceive[1].streams, 1);
+        assert.lengthOf(mqeData.videoTransmit[1].streams, 1);
+        assert.lengthOf(mqeData.videoReceive[1].streams, 1);
+      });
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -972,14 +972,256 @@ describe('plugin-meetings', () => {
 
         await progressTime();
 
-        assert.lengthOf(mqeData.audioTransmit[0].streams, 1);
-        assert.lengthOf(mqeData.audioReceive[0].streams, 1);
-        assert.lengthOf(mqeData.videoTransmit[0].streams, 1);
-        assert.lengthOf(mqeData.videoReceive[0].streams, 1);
-        assert.lengthOf(mqeData.audioTransmit[1].streams, 1);
-        assert.lengthOf(mqeData.audioReceive[1].streams, 1);
-        assert.lengthOf(mqeData.videoTransmit[1].streams, 1);
-        assert.lengthOf(mqeData.videoReceive[1].streams, 1);
+        assert.deepEqual(
+          mqeData.audioTransmit[0].streams,
+          [
+            {
+              common: {
+                codec: 'opus',
+                csi: [],
+                requestedBitrate: 0,
+                requestedFrames: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                transmittedBitrate: 0.13333333333333333,
+                transmittedFrameRate: 0
+              },
+              transmittedKeyFrames: 0,
+              requestedKeyFrames: 0
+            }
+          ]
+        );
+        assert.deepEqual(
+          mqeData.audioTransmit[1].streams,
+          [
+            {
+              common: {
+                codec: 'opus',
+                csi: [],
+                requestedBitrate: 0,
+                requestedFrames: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                transmittedBitrate: 0.13333333333333333,
+                transmittedFrameRate: 0
+              },
+              transmittedKeyFrames: 0,
+              requestedKeyFrames: 0
+            }
+          ]
+        );
+        assert.deepEqual(
+          mqeData.audioReceive[0].streams,
+          [
+            {
+              common: {
+                codec: 'opus',
+                concealedFrames: 0,
+                csi: [],
+                maxConcealRunLength: 0,
+                optimalBitrate: 0,
+                optimalFrameRate: 0,
+                receivedBitrate: 0.13333333333333333,
+                receivedFrameRate: 0,
+                renderedFrameRate: 0,
+                requestedBitrate: 0,
+                requestedFrameRate: 0,
+                rtpEndToEndLost: 0,
+                maxRtpJitter: 0,
+                meanRtpJitter: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                rtpJitter: 0,
+                framesDropped: 0,
+                framesReceived: 0
+              }
+            }
+          ]
+        );
+        assert.deepEqual(
+          mqeData.audioReceive[1].streams,
+          [
+            {
+              common: {
+                codec: 'opus',
+                concealedFrames: 0,
+                csi: [],
+                maxConcealRunLength: 0,
+                optimalBitrate: 0,
+                optimalFrameRate: 0,
+                receivedBitrate: 0.13333333333333333,
+                receivedFrameRate: 0,
+                renderedFrameRate: 0,
+                requestedBitrate: 0,
+                requestedFrameRate: 0,
+                rtpEndToEndLost: 0,
+                maxRtpJitter: 0,
+                meanRtpJitter: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                rtpJitter: 0,
+                framesDropped: 0,
+                framesReceived: 0
+              }
+            }
+          ]
+        );
+        assert.deepEqual(
+          mqeData.videoTransmit[0].streams,
+          [
+            {
+              common: {
+                codec: 'H264',
+                csi: [],
+                duplicateSsci: 0,
+                requestedBitrate: 0,
+                requestedFrames: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                transmittedBitrate: 0.13333333333333333,
+                transmittedFrameRate: 0
+              },
+              h264CodecProfile: 'BP',
+              isAvatar: false,
+              isHardwareEncoded: false,
+              localConfigurationChanges: 2,
+              maxFrameQp: 0,
+              maxNoiseLevel: 0,
+              minRegionQp: 0,
+              remoteConfigurationChanges: 0,
+              requestedFrameSize: 0,
+              requestedKeyFrames: 0,
+              transmittedFrameSize: 0,
+              transmittedHeight: 0,
+              transmittedKeyFrames: 0,
+              transmittedKeyFramesClient: 0,
+              transmittedKeyFramesConfigurationChange: 0,
+              transmittedKeyFramesFeedback: 0,
+              transmittedKeyFramesLocalDrop: 0,
+              transmittedKeyFramesOtherLayer: 0,
+              transmittedKeyFramesPeriodic: 0,
+              transmittedKeyFramesSceneChange: 0,
+              transmittedKeyFramesStartup: 0,
+              transmittedKeyFramesUnknown: 0,
+              transmittedWidth: 0
+            }
+          ]
+        );
+        assert.deepEqual(
+          mqeData.videoTransmit[1].streams,
+          [
+            {
+              common: {
+                codec: 'H264',
+                csi: [],
+                duplicateSsci: 0,
+                requestedBitrate: 0,
+                requestedFrames: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                transmittedBitrate: 0.13333333333333333,
+                transmittedFrameRate: 0
+              },
+              h264CodecProfile: 'BP',
+              isAvatar: false,
+              isHardwareEncoded: false,
+              localConfigurationChanges: 2,
+              maxFrameQp: 0,
+              maxNoiseLevel: 0,
+              minRegionQp: 0,
+              remoteConfigurationChanges: 0,
+              requestedFrameSize: 0,
+              requestedKeyFrames: 0,
+              transmittedFrameSize: 0,
+              transmittedHeight: 0,
+              transmittedKeyFrames: 0,
+              transmittedKeyFramesClient: 0,
+              transmittedKeyFramesConfigurationChange: 0,
+              transmittedKeyFramesFeedback: 0,
+              transmittedKeyFramesLocalDrop: 0,
+              transmittedKeyFramesOtherLayer: 0,
+              transmittedKeyFramesPeriodic: 0,
+              transmittedKeyFramesSceneChange: 0,
+              transmittedKeyFramesStartup: 0,
+              transmittedKeyFramesUnknown: 0,
+              transmittedWidth: 0
+            }
+          ]
+        );
+        assert.deepEqual(
+          mqeData.videoReceive[0].streams,
+          [
+            {
+              common: {
+                codec: 'H264',
+                concealedFrames: 0,
+                csi: [],
+                maxConcealRunLength: 0,
+                optimalBitrate: 0,
+                optimalFrameRate: 0,
+                receivedBitrate: 0.13333333333333333,
+                receivedFrameRate: 0,
+                renderedFrameRate: 0,
+                requestedBitrate: 0,
+                requestedFrameRate: 0,
+                rtpEndToEndLost: 0,
+                rtpJitter: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                framesDropped: 0
+              },
+              h264CodecProfile: 'BP',
+              isActiveSpeaker: true,
+              optimalFrameSize: 0,
+              receivedFrameSize: 3600,
+              receivedHeight: 720,
+              receivedKeyFrames: 0,
+              receivedKeyFramesForRequest: 0,
+              receivedKeyFramesSourceChange: 0,
+              receivedKeyFramesUnknown: 0,
+              receivedWidth: 1280,
+              requestedFrameSize: 0,
+              requestedKeyFrames: 0
+            }
+          ]
+        );
+        assert.deepEqual(
+          mqeData.videoReceive[1].streams,
+          [
+            {
+              common: {
+                codec: 'H264',
+                concealedFrames: 0,
+                csi: [],
+                maxConcealRunLength: 0,
+                optimalBitrate: 0,
+                optimalFrameRate: 0,
+                receivedBitrate: 0.13333333333333333,
+                receivedFrameRate: 0,
+                renderedFrameRate: 0,
+                requestedBitrate: 0,
+                requestedFrameRate: 0,
+                rtpEndToEndLost: 0,
+                rtpJitter: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                framesDropped: 0
+              },
+              h264CodecProfile: 'BP',
+              isActiveSpeaker: true,
+              optimalFrameSize: 0,
+              receivedFrameSize: 3600,
+              receivedHeight: 720,
+              receivedKeyFrames: 0,
+              receivedKeyFramesForRequest: 0,
+              receivedKeyFramesSourceChange: 0,
+              receivedKeyFramesUnknown: 0,
+              receivedWidth: 1280,
+              requestedFrameSize: 0,
+              requestedKeyFrames: 0
+            }
+          ]
+        );
       });
       
       it('has three streams for video receivers when three exist', async () => {
@@ -1006,14 +1248,107 @@ describe('plugin-meetings', () => {
 
         await progressTime();
 
-        assert.lengthOf(mqeData.audioTransmit[0].streams, 1);
-        assert.lengthOf(mqeData.audioReceive[0].streams, 1);
-        assert.lengthOf(mqeData.videoTransmit[0].streams, 1);
-        assert.lengthOf(mqeData.videoReceive[0].streams, 3);
-        assert.lengthOf(mqeData.audioTransmit[1].streams, 1);
-        assert.lengthOf(mqeData.audioReceive[1].streams, 1);
-        assert.lengthOf(mqeData.videoTransmit[1].streams, 1);
-        assert.lengthOf(mqeData.videoReceive[1].streams, 1);
+        assert.deepEqual(
+          mqeData.videoReceive[0].streams,
+          [
+            {
+              common: {
+                codec: 'H264',
+                concealedFrames: 0,
+                csi: [],
+                maxConcealRunLength: 0,
+                optimalBitrate: 0,
+                optimalFrameRate: 0,
+                receivedBitrate: 0.13333333333333333,
+                receivedFrameRate: 0,
+                renderedFrameRate: 0,
+                requestedBitrate: 0,
+                requestedFrameRate: 0,
+                rtpEndToEndLost: 0,
+                rtpJitter: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                framesDropped: 0
+              },
+              h264CodecProfile: 'BP',
+              isActiveSpeaker: true,
+              optimalFrameSize: 0,
+              receivedFrameSize: 3600,
+              receivedHeight: 720,
+              receivedKeyFrames: 0,
+              receivedKeyFramesForRequest: 0,
+              receivedKeyFramesSourceChange: 0,
+              receivedKeyFramesUnknown: 0,
+              receivedWidth: 1280,
+              requestedFrameSize: 0,
+              requestedKeyFrames: 0
+            },
+            {
+              common: {
+                codec: 'H264',
+                concealedFrames: 0,
+                csi: [],
+                maxConcealRunLength: 0,
+                optimalBitrate: 0,
+                optimalFrameRate: 0,
+                receivedBitrate: 0.13333333333333333,
+                receivedFrameRate: 0,
+                renderedFrameRate: 0,
+                requestedBitrate: 0,
+                requestedFrameRate: 0,
+                rtpEndToEndLost: 0,
+                rtpJitter: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                framesDropped: 0
+              },
+              h264CodecProfile: 'BP',
+              isActiveSpeaker: true,
+              optimalFrameSize: 0,
+              receivedFrameSize: 3600,
+              receivedHeight: 720,
+              receivedKeyFrames: 0,
+              receivedKeyFramesForRequest: 0,
+              receivedKeyFramesSourceChange: 0,
+              receivedKeyFramesUnknown: 0,
+              receivedWidth: 1280,
+              requestedFrameSize: 0,
+              requestedKeyFrames: 0
+            },
+            {
+              common: {
+                codec: 'H264',
+                concealedFrames: 0,
+                csi: [],
+                maxConcealRunLength: 0,
+                optimalBitrate: 0,
+                optimalFrameRate: 0,
+                receivedBitrate: 0.13333333333333333,
+                receivedFrameRate: 0,
+                renderedFrameRate: 0,
+                requestedBitrate: 0,
+                requestedFrameRate: 0,
+                rtpEndToEndLost: 0,
+                rtpJitter: 0,
+                rtpPackets: 0,
+                ssci: 0,
+                framesDropped: 0
+              },
+              h264CodecProfile: 'BP',
+              isActiveSpeaker: true,
+              optimalFrameSize: 0,
+              receivedFrameSize: 3600,
+              receivedHeight: 720,
+              receivedKeyFrames: 0,
+              receivedKeyFramesForRequest: 0,
+              receivedKeyFramesSourceChange: 0,
+              receivedKeyFramesUnknown: 0,
+              receivedWidth: 1280,
+              requestedFrameSize: 0,
+              requestedKeyFrames: 0
+            }
+          ]
+        );
       });
     });
   });


### PR DESCRIPTION
# COMPLETES [SPARK-500578](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-500578)

## This pull request addresses

The mis-formatting of browser MQEs.

## by making the following changes

changing the event shape from this:
```
audioReceive: [
  {
    streams: [{...}], // main audio
    common: {...},
  },
  {
    streams: [{...}], // main audio
    common: {...},
  },
  {
    streams: [{...}], // main audio
    common: {...},
  },
  {
    streams: [{...}], // slides audio
    common: {...},
  },
]
```

to this:
```
audioReceive: [
  {
    streams: [
      {...}, // main audio
      {...}, // main audio
      {...}, // main audio
    ],
    common: {...}
  },
  {
    streams: [{...}], // slides audio
    common: {...}
  }
]
```

for all audio and video; senders and receivers.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Testing the new MQE shape is accurate

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
