### PR TITLE
fix(plugin-meetings): trigger meeting info available on meeting info update

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -341,6 +341,7 @@ export const EVENT_TRIGGERS = {
   MEETING_UNLOCKED: 'meeting:unlocked',
   MEETING_LOCKED: 'meeting:locked',
   MEETING_INFO_AVAILABLE: 'meeting:meetingInfoAvailable',
+  MEETING_INFO_UPDATED: 'meeting:meetingInfoUpdated',
   MEETING_LOG_UPLOAD_SUCCESS: 'meeting:logUpload:success',
   MEETING_LOG_UPLOAD_FAILURE: 'meeting:logUpload:failure',
   MEETING_ACTIONS_UPDATE: 'meeting:actionsUpdate',

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -1169,7 +1169,10 @@ export default class LocusInfo extends EventsScope {
           file: 'locus-info',
           function: 'updateMeetingInfo',
         },
-        LOCUSINFO.EVENTS.MEETING_INFO_UPDATED
+        LOCUSINFO.EVENTS.MEETING_INFO_UPDATED,
+        {
+          isInitializing: !self, // if self is undefined, then the update is caused by locus init
+        }
       );
     }
     this.roles = roles;

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -2758,21 +2758,24 @@ export default class Meeting extends StatelessWebexPlugin {
         );
       }
     });
-    this.locusInfo.on(LOCUSINFO.EVENTS.MEETING_INFO_UPDATED, () => {
+    this.locusInfo.on(LOCUSINFO.EVENTS.MEETING_INFO_UPDATED, ({isInitializing}) => {
       this.updateMeetingActions();
       this.recordingController.setDisplayHints(this.userDisplayHints);
       this.recordingController.setUserPolicy(this.selfUserPolicies);
       this.controlsOptionsManager.setDisplayHints(this.userDisplayHints);
       this.handleDataChannelUrlChange(this.datachannelUrl);
 
-      Trigger.trigger(
-        this,
-        {
-          file: 'meetings',
-          function: 'setUpLocusInfoMeetingInfoListener',
-        },
-        EVENT_TRIGGERS.MEETING_INFO_AVAILABLE
-      );
+      if (!isInitializing) {
+        // send updated trigger only if locus is not initializing the meeting
+        Trigger.trigger(
+          this,
+          {
+            file: 'meetings',
+            function: 'setUpLocusInfoMeetingInfoListener',
+          },
+          EVENT_TRIGGERS.MEETING_INFO_UPDATED
+        );
+      }
     });
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -2764,6 +2764,15 @@ export default class Meeting extends StatelessWebexPlugin {
       this.recordingController.setUserPolicy(this.selfUserPolicies);
       this.controlsOptionsManager.setDisplayHints(this.userDisplayHints);
       this.handleDataChannelUrlChange(this.datachannelUrl);
+
+      Trigger.trigger(
+        this,
+        {
+          file: 'meetings',
+          function: 'setUpLocusInfoMeetingInfoListener',
+        },
+        EVENT_TRIGGERS.MEETING_INFO_AVAILABLE
+      );
     });
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -1377,7 +1377,7 @@ describe('plugin-meetings', () => {
         );
       });
 
-      const checkMeetingInfoUpdatedCalled = (expected) => {
+      const checkMeetingInfoUpdatedCalled = (expected, payload) => {
         const expectedArgs = [
           locusInfo.emitScoped,
           {
@@ -1385,6 +1385,7 @@ describe('plugin-meetings', () => {
             function: 'updateMeetingInfo',
           },
           LOCUSINFO.EVENTS.MEETING_INFO_UPDATED,
+          payload
         ];
 
         if (expected) {
@@ -1395,7 +1396,7 @@ describe('plugin-meetings', () => {
         locusInfo.emitScoped.resetHistory();
       };
 
-      const checkMeetingInfoUpdatedCalledForRoles = (expected) => {
+      const checkMeetingInfoUpdatedCalledForRoles = (expected, payload) => {
         const expectedArgs = [
           locusInfo.emitScoped,
           {
@@ -1403,6 +1404,7 @@ describe('plugin-meetings', () => {
             function: 'updateMeetingInfo',
           },
           LOCUSINFO.EVENTS.MEETING_INFO_UPDATED,
+          payload
         ];
 
         if (expected) {
@@ -1447,7 +1449,7 @@ describe('plugin-meetings', () => {
 
         // since it was initially undefined, this should trigger the event
 
-        checkMeetingInfoUpdatedCalled(true);
+        checkMeetingInfoUpdatedCalled(true, {isInitializing: false});
 
         const newInfo = cloneDeep(meetingInfo);
 
@@ -1472,7 +1474,7 @@ describe('plugin-meetings', () => {
         };
         locusInfo.updateMeetingInfo(newInfo, self);
 
-        checkMeetingInfoUpdatedCalled(true);
+        checkMeetingInfoUpdatedCalled(true, {isInitializing: false});
 
         // update it with the same info
         expectedMeeting = {
@@ -1494,7 +1496,7 @@ describe('plugin-meetings', () => {
         locusInfo.updateMeetingInfo(newInfo, self);
 
         // since the info is the same it should not call trigger the event
-        checkMeetingInfoUpdatedCalled(false);
+        checkMeetingInfoUpdatedCalled(false, {isInitializing: false});
 
         // update it with the same info, but roles changed
         const updateSelf = cloneDeep(self);
@@ -1525,7 +1527,7 @@ describe('plugin-meetings', () => {
         };
         locusInfo.updateMeetingInfo(newInfo, updateSelf);
         // since the info is the same but roles changed, it should call trigger the event
-        checkMeetingInfoUpdatedCalledForRoles(true);
+        checkMeetingInfoUpdatedCalledForRoles(true, {isInitializing: false});
       });
 
       it('gets roles from self if available', () => {
@@ -1546,12 +1548,17 @@ describe('plugin-meetings', () => {
           roles: ['MODERATOR', 'COHOST'],
         };
 
+        sinon.stub(locusInfo, 'emitScoped');
+
         const parsedLocusInfo = cloneDeep(locusInfo.parsedLocus.info);
 
         locusInfo.updateMeetingInfo(initialInfo);
         assert.calledWith(isJoinedSpy, locusInfo.parsedLocus.self);
         assert.neverCalledWith(getRolesSpy, self);
         assert.calledWith(getInfosSpy, parsedLocusInfo, initialInfo, ['MODERATOR', 'COHOST']);
+
+        // since self is not passed to updateMeetingInfo, MEETING_INFO_UPDATED should be triggered with isIntializing: true
+        checkMeetingInfoUpdatedCalledForRoles(true, {isInitializing: true});
       });
     });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -8155,13 +8155,41 @@ describe('plugin-meetings', () => {
           assert.equal(locusInfoOnSpy.thirdCall.args[0], 'MEETING_INFO_UPDATED');
           const callback = locusInfoOnSpy.thirdCall.args[1];
 
-          callback();
+          callback({isInitializing: true});
 
           assert.calledWith(updateMeetingActionsSpy);
           assert.calledWith(setRecordingDisplayHintsSpy, userDisplayHints);
           assert.calledWith(setUserPolicySpy, userDisplayPolicy);
           assert.calledWith(setControlsDisplayHintsSpy, userDisplayHints);
           assert.calledWith(handleDataChannelUrlChangeSpy, datachannelUrl);
+
+          assert.neverCalledWith(
+            TriggerProxy.trigger,
+            meeting,
+            {
+              file: 'meetings',
+              function: 'setUpLocusInfoMeetingInfoListener',
+            },
+            'meeting:meetingInfoUpdated'
+          )
+
+          callback({isIntialized: false});
+
+          assert.calledWith(updateMeetingActionsSpy);
+          assert.calledWith(setRecordingDisplayHintsSpy, userDisplayHints);
+          assert.calledWith(setUserPolicySpy, userDisplayPolicy);
+          assert.calledWith(setControlsDisplayHintsSpy, userDisplayHints);
+          assert.calledWith(handleDataChannelUrlChangeSpy, datachannelUrl);
+
+          assert.calledWith(
+            TriggerProxy.trigger,
+            meeting,
+            {
+              file: 'meetings',
+              function: 'setUpLocusInfoMeetingInfoListener',
+            },
+            'meeting:meetingInfoUpdated'
+          )
         });
       });
 


### PR DESCRIPTION
# COMPLETES #[SPARK-477899](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-477899)

## This pull request addresses

When a user leaves a breakout session, locus is initialized again for the main session and the sdk meeting object is updated accordingly with locus-info line 1165
```
this.updateMeeting(parsedInfo.current);
```
However, the client does not receive a trigger for this update, so it stays with outdated meeting info. 

## by making the following changes

Triggering MEETING INFO AVAILABLE on MEETING_INFO_UPDATE, which is only triggered by locus' updateMeetingInfo method.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
