### PR TITLE
fix(metrics): add try/catch around debug metrics

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -726,9 +726,17 @@ export default class Meetings extends WebexPlugin {
    * @memberof Meetings
    */
   public register() {
-    Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
-      step: '[sdk] begin registration',
-    });
+    const submitStepMetric = (step) => {
+      try {
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
+          step,
+        });
+      } catch (error) {
+        // do nothing because these are just debug metrics
+      }
+    };
+
+    submitStepMetric('[sdk] begin registration');
 
     // @ts-ignore
     if (!this.webex.canAuthorize) {
@@ -736,9 +744,7 @@ export default class Meetings extends WebexPlugin {
         'Meetings:index#register --> ERROR, Unable to register, SDK cannot authorize'
       );
 
-      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
-        step: '[sdk] cannot authorize',
-      });
+      submitStepMetric('[sdk] cannot authorize');
 
       return Promise.reject(new Error('SDK cannot authorize'));
     }
@@ -748,16 +754,12 @@ export default class Meetings extends WebexPlugin {
         'Meetings:index#register --> INFO, Meetings plugin already registered'
       );
 
-      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
-        step: '[sdk] already registered',
-      });
+      submitStepMetric('[sdk] already registered');
 
       return Promise.resolve();
     }
 
-    Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
-      step: '[sdk] begin Promise.all()',
-    });
+    submitStepMetric('[sdk] begin Promise.all()');
 
     return Promise.all([
       this.fetchUserPreferredWebexSite(),
@@ -780,9 +782,7 @@ export default class Meetings extends WebexPlugin {
       MeetingsUtil.checkH264Support.call(this),
     ])
       .then(() => {
-        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
-          step: '[sdk] end Promise.all()',
-        });
+        submitStepMetric('[sdk] end Promise.all()');
         this.listenForEvents();
         Trigger.trigger(
           this,
@@ -792,9 +792,7 @@ export default class Meetings extends WebexPlugin {
           },
           EVENT_TRIGGERS.MEETINGS_REGISTERED
         );
-        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_STEP, {
-          step: '[sdk] registration complete, triggered MEETINGS_REGISTERED event',
-        });
+        submitStepMetric('[sdk] registration complete, triggered MEETINGS_REGISTERED event');
         this.registered = true;
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_SUCCESS);
       })


### PR DESCRIPTION
# COMPLETES #[SPARK-509570](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-509570)

## This pull request addresses

Adds try/catches around meetings registration step metrics, in case metrics haven't been initialized yet.  This is not a final fix but it will solve the immediate problem for meeting demo app.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Tested manually.

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
