### PR TITLE
fix(meetings): fix to avoid llm connection update when its not enabled

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -202,7 +202,11 @@ const MeetingUtil = {
         meeting.reconnectionManager.cleanUp();
       })
       .then(() => meeting.stopKeepAlive())
-      .then(() => meeting.updateLLMConnection());
+      .then(() => {
+        if (meeting.config.enableAutomaticLLM) {
+          meeting.updateLLMConnection();
+        }
+      });
   },
 
   disconnectPhoneAudio: (meeting, phoneUrl) => {

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -203,7 +203,7 @@ const MeetingUtil = {
       })
       .then(() => meeting.stopKeepAlive())
       .then(() => {
-        if (meeting.config.enableAutomaticLLM) {
+        if (meeting.config?.enableAutomaticLLM) {
           meeting.updateLLMConnection();
         }
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -57,7 +57,8 @@ describe('plugin-meetings', () => {
     });
 
     describe('#cleanup', () => {
-      it('do clean up on meeting object', async () => {
+      it('do clean up on meeting object with LLM enabled', async () => {
+        meeting.config = {enableAutomaticLLM : true};
         await MeetingUtil.cleanUp(meeting);
         assert.calledOnce(meeting.cleanupLocalStreams);
         assert.calledOnce(meeting.closeRemoteStreams);
@@ -68,6 +69,22 @@ describe('plugin-meetings', () => {
         assert.calledOnce(meeting.reconnectionManager.cleanUp);
         assert.calledOnce(meeting.stopKeepAlive);
         assert.calledOnce(meeting.updateLLMConnection);
+        assert.calledOnce(meeting.breakouts.cleanUp);
+        assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
+      });
+
+      it('do clean up on meeting object with LLM disabled', async () => {
+        meeting.config = {enableAutomaticLLM : false};
+        await MeetingUtil.cleanUp(meeting);
+        assert.calledOnce(meeting.cleanupLocalStreams);
+        assert.calledOnce(meeting.closeRemoteStreams);
+        assert.calledOnce(meeting.closePeerConnections);
+
+        assert.calledOnce(meeting.unsetRemoteStreams);
+        assert.calledOnce(meeting.unsetPeerConnections);
+        assert.calledOnce(meeting.reconnectionManager.cleanUp);
+        assert.calledOnce(meeting.stopKeepAlive);
+        assert.notCalled(meeting.updateLLMConnection);
         assert.calledOnce(meeting.breakouts.cleanUp);
         assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -88,6 +88,21 @@ describe('plugin-meetings', () => {
         assert.calledOnce(meeting.breakouts.cleanUp);
         assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
       });
+
+      it('do clean up on meeting object with no config', async () => {
+        await MeetingUtil.cleanUp(meeting);
+        assert.calledOnce(meeting.cleanupLocalStreams);
+        assert.calledOnce(meeting.closeRemoteStreams);
+        assert.calledOnce(meeting.closePeerConnections);
+
+        assert.calledOnce(meeting.unsetRemoteStreams);
+        assert.calledOnce(meeting.unsetPeerConnections);
+        assert.calledOnce(meeting.reconnectionManager.cleanUp);
+        assert.calledOnce(meeting.stopKeepAlive);
+        assert.notCalled(meeting.updateLLMConnection);
+        assert.calledOnce(meeting.breakouts.cleanUp);
+        assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
+      });
     });
 
     describe('logging', () => {


### PR DESCRIPTION
# COMPLETES 

## This pull request addresses
In scenarios where LLM is not enabled before Webex initialization, we are sending a POST request to update the LLM connection during meeting cleanup.

## by making the following changes
Added a check in the cleanup function to check if meeting.config.enableAutomaticLLM  is set to true. If not, we do not invoke updateLLMConnection().

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
Unchecked EnableLLM in Kitchen Sink App before webex initialization and joined the meeting. Triggered meeting.endMeetingForAll() from the console and verified that the registration request to the data channel url is not sent out post the end API call.
[Network_logs_with_fix.txt](https://github.com/webex/webex-js-sdk/files/14741974/Network_logs_with_fix.txt)


### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
