### PR TITLE
feat(metrics): allow metric fields to be passed to meetings.register()

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -721,11 +721,12 @@ export default class Meetings extends WebexPlugin {
    * Explicitly sets up the meetings plugin by registering
    * the device, connecting to mercury, and listening for locus events.
    *
+   * @param {object} metricFields - optional fields to use when sending metrics
    * @returns {Promise}
    * @public
    * @memberof Meetings
    */
-  public register() {
+  public register(metricFields: object = {}) {
     // @ts-ignore
     if (!this.webex.canAuthorize) {
       LoggerProxy.logger.error(
@@ -774,7 +775,10 @@ export default class Meetings extends WebexPlugin {
           EVENT_TRIGGERS.MEETINGS_REGISTERED
         );
         this.registered = true;
-        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_SUCCESS);
+        Metrics.sendBehavioralMetric(
+          BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_SUCCESS,
+          metricFields
+        );
       })
       .catch((error) => {
         LoggerProxy.logger.error(
@@ -784,6 +788,7 @@ export default class Meetings extends WebexPlugin {
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETINGS_REGISTRATION_FAILED, {
           reason: error.message,
           stack: error.stack,
+          ...metricFields,
         });
 
         return Promise.reject(error);


### PR DESCRIPTION
# COMPLETES #[SPARK-510169](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-510169)

## This pull request addresses

Allow metric fields to be passed to meetings.register() to be included in the success and failure metrics.  This is to allow cantina to pass the correlation id when crosslaunched to assist in debugging meetings registration failures.

## by making the following changes

meetings.register() now accepts an object of metric fields to be included when the success/failure metric is submitting.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Added tests and tested manually with Cantina.

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly
