### PR TITLE
fix(plugin-meetings): reverted-redundant-change

### DIFF
--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -123,7 +123,7 @@ export default class RoapRequest extends StatelessWebexPlugin {
         );
         const {locus} = res.body;
 
-        locus.roapSeq = roapMessage.seq;
+        locus.roapSeq = options.roapMessage.seq;
 
         return {
           locus,


### PR DESCRIPTION
# COMPLETES #ADHOC

## This pull request addresses
A small change in plugin-meetings/src/roap. This change is not required. No change in logic

## by making the following changes

options in passed as an argument to sendRoap. options has roapMessage in it. So it doesnt matter if we take options.roapMessage.seq or roapMessage.seq, roapMessage is not modified.
<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
