### PR TITLE
fix(plugin-meetings): filled missing MQE requested bitrate and frame size stats

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -17,7 +17,7 @@
     "node": ">=16"
   },
   "dependencies": {
-    "@webex/internal-media-core": "2.3.3",
+    "@webex/internal-media-core": "2.3.4",
     "@webex/ts-events": "^1.1.0",
     "@webex/web-media-effects": "2.18.0"
   },

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:^",
-    "@webex/internal-media-core": "2.3.3",
+    "@webex/internal-media-core": "2.3.4",
     "@webex/internal-plugin-conversation": "workspace:^",
     "@webex/internal-plugin-device": "workspace:^",
     "@webex/internal-plugin-llm": "workspace:^",

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -997,6 +997,8 @@ export class StatsAnalyzer extends EventsScope {
       this.statsResults[mediaType][sendrecvType].headerBytesSent = result.headerBytesSent;
       this.statsResults[mediaType][sendrecvType].retransmittedBytesSent =
         result.retransmittedBytesSent;
+      this.statsResults[mediaType][sendrecvType].requestedBitrate = result.requestedBitrate;
+      this.statsResults[mediaType][sendrecvType].requestedFrameSize = result.requestedFrameSize;
     }
   }
 
@@ -1096,6 +1098,7 @@ export class StatsAnalyzer extends EventsScope {
         this.statsResults[mediaType][sendrecvType].width = result.frameWidth;
         this.statsResults[mediaType][sendrecvType].height = result.frameHeight;
         this.statsResults[mediaType][sendrecvType].framesReceived = result.framesReceived;
+        this.statsResults[mediaType][sendrecvType].requestedFrameSize = result.requestedFrameSize;
       }
 
       // TODO: check the packet loss value is negative values here
@@ -1109,6 +1112,7 @@ export class StatsAnalyzer extends EventsScope {
 
       this.statsResults[mediaType][sendrecvType].lastPacketReceivedTimestamp =
         result.lastPacketReceivedTimestamp;
+      this.statsResults[mediaType][sendrecvType].requestedBitrate = result.requestedBitrate;
 
       // From Thin
       this.statsResults[mediaType][sendrecvType].totalNackCount = result.nackCount;

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -1098,7 +1098,6 @@ export class StatsAnalyzer extends EventsScope {
         this.statsResults[mediaType][sendrecvType].width = result.frameWidth;
         this.statsResults[mediaType][sendrecvType].height = result.frameHeight;
         this.statsResults[mediaType][sendrecvType].framesReceived = result.framesReceived;
-        this.statsResults[mediaType][sendrecvType].requestedFrameSize = result.requestedFrameSize;
       }
 
       // TODO: check the packet loss value is negative values here
@@ -1113,6 +1112,7 @@ export class StatsAnalyzer extends EventsScope {
       this.statsResults[mediaType][sendrecvType].lastPacketReceivedTimestamp =
         result.lastPacketReceivedTimestamp;
       this.statsResults[mediaType][sendrecvType].requestedBitrate = result.requestedBitrate;
+      this.statsResults[mediaType][sendrecvType].requestedFrameSize = result.requestedFrameSize;
 
       // From Thin
       this.statsResults[mediaType][sendrecvType].totalNackCount = result.nackCount;

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -216,6 +216,8 @@ export const getAudioSenderStreamMqa = ({
     statsResults[mediaType][sendrecvType].totalKeyFramesEncoded - lastFramesEncoded || 0;
   audioSenderStream.requestedKeyFrames =
     statsResults[mediaType][sendrecvType].totalFirCount - lastFirCount || 0;
+
+  audioSenderStream.requestedBitrate = statsResults[mediaType][sendrecvType].requestedBitrate || 0;
 };
 
 export const getVideoReceiverMqa = ({
@@ -437,4 +439,8 @@ export const getVideoSenderStreamMqa = ({
   videoSenderStream.transmittedWidth = statsResults[mediaType][sendrecvType].width || 0;
   videoSenderStream.transmittedFrameSize =
     (videoSenderStream.transmittedHeight * videoSenderStream.transmittedWidth) / 256;
+
+  videoSenderStream.requestedBitrate = statsResults[mediaType][sendrecvType].requestedBitrate || 0;
+  videoSenderStream.requestedFrameSize =
+    statsResults[mediaType][sendrecvType].requestedFrameSize || 0;
 };

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -88,6 +88,7 @@ describe('plugin-meetings', () => {
             trackId: 'RTCMediaStreamTrack_sender_2',
             transportId: 'RTCTransport_0_1',
             type: 'outbound-rtp',
+            requestedBitrate: 10000,
           },
           'audio-send',
           true
@@ -97,6 +98,7 @@ describe('plugin-meetings', () => {
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.totalBytesSent, 50000);
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.totalNackCount, 1);
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.totalPacketsSent, 3600);
+        assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.requestedBitrate, 10000);
         assert.strictEqual(
           statsAnalyzer.statsResults['audio-send'].send.retransmittedPacketsSent,
           2
@@ -143,6 +145,7 @@ describe('plugin-meetings', () => {
             trackId: 'RTCMediaStreamTrack_receiver_76',
             transportId: 'RTCTransport_0_1',
             type: 'inbound-rtp',
+            requestedBitrate: 10000,
           },
           'audio-recv-1',
           false
@@ -155,6 +158,7 @@ describe('plugin-meetings', () => {
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.fecPacketsDiscarded, 1);
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.fecPacketsReceived, 1);
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.totalBytesReceived, 509);
+        assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.requestedBitrate, 10000);
         assert.strictEqual(
           statsAnalyzer.statsResults['audio-recv-1'].recv.headerBytesReceived,
           250

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -1202,6 +1202,7 @@ describe('plugin-meetings', () => {
             },
             transmittedKeyFrames: 0,
             requestedKeyFrames: 0,
+            requestedBitrate: 0,
           },
         ]);
         assert.deepEqual(mqeData.audioTransmit[1].streams, [
@@ -1218,6 +1219,7 @@ describe('plugin-meetings', () => {
             },
             transmittedKeyFrames: 0,
             requestedKeyFrames: 0,
+            requestedBitrate: 0,
           },
         ]);
         assert.deepEqual(mqeData.audioReceive[0].streams, [
@@ -1306,6 +1308,7 @@ describe('plugin-meetings', () => {
             transmittedKeyFramesStartup: 0,
             transmittedKeyFramesUnknown: 0,
             transmittedWidth: 0,
+            requestedBitrate: 0,
           },
         ]);
         assert.deepEqual(mqeData.videoTransmit[1].streams, [
@@ -1329,6 +1332,7 @@ describe('plugin-meetings', () => {
             maxNoiseLevel: 0,
             minRegionQp: 0,
             remoteConfigurationChanges: 0,
+            requestedBitrate: 0,
             requestedFrameSize: 0,
             requestedKeyFrames: 0,
             transmittedFrameSize: 0,

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -1651,6 +1651,7 @@ describe('plugin-meetings', () => {
             transmittedKeyFramesStartup: 0,
             transmittedKeyFramesUnknown: 0,
             transmittedWidth: 0,
+            requestedBitrate: 0,
           },
           {
             common: {
@@ -1687,6 +1688,7 @@ describe('plugin-meetings', () => {
             transmittedKeyFramesStartup: 0,
             transmittedKeyFramesUnknown: 0,
             transmittedWidth: 0,
+            requestedBitrate: 0,
           },
           {
             common: {
@@ -1723,6 +1725,7 @@ describe('plugin-meetings', () => {
             transmittedKeyFramesStartup: 0,
             transmittedKeyFramesUnknown: 0,
             transmittedWidth: 0,
+            requestedBitrate: 0,
           }
         ]);
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4483,19 +4483,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:2.3.3":
-  version: 2.3.3
-  resolution: "@webex/internal-media-core@npm:2.3.3"
+"@webex/internal-media-core@npm:2.3.4":
+  version: 2.3.4
+  resolution: "@webex/internal-media-core@npm:2.3.4"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@webex/ts-sdp": "npm:1.6.0"
-    "@webex/web-client-media-engine": "npm:3.15.7"
+    "@webex/web-client-media-engine": "npm:3.15.8"
     events: "npm:^3.3.0"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
     webrtc-adapter: "npm:^8.1.2"
     xstate: "npm:^4.30.6"
-  checksum: a7926db35c091980752ee5b380d0927010217d527dd8841023030f5f1ab1a9aa40d7f7bb376a021ce7aea1308a3e42cb0f85344a69f4b8b7e3a20c6eceb2bc84
+  checksum: 11fcd52d46b5ea0843ae70b8f1500ba9a974f681377bd24459a71c1330196631cde3354a2a990acbaab1ac9ccee7957ce02b6eaf8e1959571b69dab226551e0b
   languageName: node
   linkType: hard
 
@@ -4965,7 +4965,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webex/media-helpers@workspace:packages/@webex/media-helpers"
   dependencies:
-    "@webex/internal-media-core": "npm:2.3.3"
+    "@webex/internal-media-core": "npm:2.3.4"
     "@webex/test-helper-chai": "workspace:^"
     "@webex/test-helper-mock-webex": "workspace:^"
     "@webex/ts-events": "npm:^1.1.0"
@@ -5104,7 +5104,7 @@ __metadata:
   dependencies:
     "@peculiar/webcrypto": "npm:^1.4.3"
     "@webex/common": "workspace:^"
-    "@webex/internal-media-core": "npm:2.3.3"
+    "@webex/internal-media-core": "npm:2.3.4"
     "@webex/internal-plugin-conversation": "workspace:^"
     "@webex/internal-plugin-device": "workspace:^"
     "@webex/internal-plugin-llm": "workspace:^"
@@ -5530,9 +5530,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:3.15.7":
-  version: 3.15.7
-  resolution: "@webex/web-client-media-engine@npm:3.15.7"
+"@webex/web-client-media-engine@npm:3.15.8":
+  version: 3.15.8
+  resolution: "@webex/web-client-media-engine@npm:3.15.8"
   dependencies:
     "@webex/json-multistream": "npm:2.1.3"
     "@webex/rtcstats": "npm:^1.1.2"
@@ -5544,7 +5544,7 @@ __metadata:
     js-logger: "npm:^1.6.1"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
-  checksum: 1d34cf8c8f57985a93e1cce40241c9f9e07a58e830e8e1a8803d811a3462656fdc4c99c0417ce8bcb78886a8e795a03b60b7983957e4291cde62f5fca319d214
+  checksum: 37cdf98944b8f8692b77a5e3d089c1d4c4dab4c24dfe994be727150507eaad5a4372fff4bafec43275c44848501c8c7ffcf29ba64c6cfc28e3a252d3aaa68750
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-491229](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-491229)

## This pull request addresses

Missing MQE stats (`requestedBitrate`, `requestedFrameSize`) from web client

## by making the following changes

Filled missing stats in `statsAnalyzer` (`plugin-meetings`)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- meeting with 2 people using `samples:serve` correctly reads stats from WCME (logs)
- meeting with 2 people using `samples:serve` correctly sends MQE requested with filled requestedBitrate and requestedFrameSize ([curl](https://gist.github.com/SomeBody16/d0597ae2a5b11c920d1b73b57633302a))

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
