### PR TITLE
fix(new-metrics): add TypeError

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -19,6 +19,7 @@ import {
   isNetworkError,
   isUnauthorizedError,
   isSdpOfferCreationError,
+  isTypeError,
 } from './call-diagnostic-metrics.util';
 import {CLIENT_NAME} from '../config';
 import {
@@ -56,6 +57,7 @@ import {
   AUTHENTICATION_FAILED_CODE,
   WEBEX_SUB_SERVICE_TYPES,
   SDP_OFFER_CREATION_ERROR_MAP,
+  TYPE_ERROR_CLIENT_CODE,
 } from './config';
 
 const {getOSVersion, getBrowserName, getBrowserVersion} = BrowserDetection();
@@ -526,6 +528,17 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
   generateClientEventErrorPayload(rawError: any) {
     const rawErrorMessage = rawError.message;
     const httpStatusCode = rawError.statusCode;
+
+    if (isTypeError) {
+      return this.getErrorPayloadForClientErrorCode({
+        serviceErrorCode: undefined,
+        clientErrorCode: TYPE_ERROR_CLIENT_CODE,
+        serviceErrorName: rawError.name,
+        rawErrorMessage,
+        httpStatusCode,
+      });
+    }
+
     if (rawError.name) {
       if (isBrowserMediaErrorName(rawError.name)) {
         return this.getErrorPayloadForClientErrorCode({

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -179,6 +179,15 @@ export const isSdpOfferCreationError = (rawError: any) => {
 };
 
 /**
+ * Any service can return a TypeError, which tells little about the service it came from
+ * Documentation can be found here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError/TypeError
+ *
+ * @param errorCode
+ * @returns
+ */
+export const isTypeError = (error: any) => error instanceof TypeError;
+
+/**
  * MDN Media Devices getUserMedia() method returns a name if it errs
  * Documentation can be found here: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
  *

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
@@ -16,6 +16,7 @@ export const MISSING_ROAP_ANSWER_CLIENT_CODE = 2007;
 export const DTLS_HANDSHAKE_FAILED_CLIENT_CODE = 2008;
 export const ICE_FAILED_WITH_TURN_TLS_CLIENT_CODE = 2010;
 export const ICE_FAILED_WITHOUT_TURN_TLS_CLIENT_CODE = 2009;
+export const TYPE_ERROR_CLIENT_CODE = 2011;
 export const WBX_APP_API_URL = 'wbxappapi'; // MeetingInfo WebexAppApi response object normally contains a body.url that includes the string 'wbxappapi'
 
 export const WEBEX_SUB_SERVICE_TYPES: Record<string, ClientSubServiceType> = {
@@ -33,7 +34,6 @@ const BROWSER_MEDIA_ERROR_NAMES = {
   NOT_FOUND_ERROR: 'NotFoundError',
   OVERCONSTRAINED_ERROR: 'OverconstrainedError',
   SECURITY_ERROR: 'SecurityError',
-  TYPE_ERROR: 'TypeError',
 };
 
 export const BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP = {
@@ -44,7 +44,6 @@ export const BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP = {
   [BROWSER_MEDIA_ERROR_NAMES.NOT_FOUND_ERROR]: 2729, // User did not grant permission
   [BROWSER_MEDIA_ERROR_NAMES.OVERCONSTRAINED_ERROR]: 2729, // Thrown if the specified constraints resulted in no candidate devices which met the criteria requested.
   [BROWSER_MEDIA_ERROR_NAMES.SECURITY_ERROR]: 2729, // Thrown if user media support is disabled on the Document on which getUserMedia() was called. The mechanism by which user media support is enabled and disabled is left up to the individual user agent.
-  [BROWSER_MEDIA_ERROR_NAMES.TYPE_ERROR]: 2729, // Thrown if the list of constraints specified is empty, or has all constraints set to false. This can also happen if you try to call getUserMedia() in an insecure context, since navigator.mediaDevices is undefined in an insecure context.
 };
 
 export const SDP_OFFER_CREATION_ERROR_MAP = {
@@ -127,6 +126,7 @@ export const ERROR_DESCRIPTIONS = {
   ICE_FAILED_WITH_TURN_TLS: 'ICEFailedWithTURN_TLS',
   SDP_OFFER_CREATION_ERROR: 'SdpOfferCreationError',
   SDP_OFFER_CREATION_ERROR_MISSING_CODEC: 'SdpOfferCreationErrorMissingCodec',
+  TYPE_ERROR: 'TypeError',
 };
 
 export const SERVICE_ERROR_CODES_TO_CLIENT_ERROR_CODES_MAP = {
@@ -393,6 +393,11 @@ export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEv
   [ICE_FAILED_WITH_TURN_TLS_CLIENT_CODE]: {
     errorDescription: ERROR_DESCRIPTIONS.ICE_FAILED_WITH_TURN_TLS,
     category: 'network',
+    fatal: true,
+  },
+  [TYPE_ERROR_CLIENT_CODE]: {
+    errorDescription: ERROR_DESCRIPTIONS.TYPE_ERROR,
+    category: 'other',
     fatal: true,
   },
   2050: {


### PR DESCRIPTION
## This pull request addresses

Right now, if a client metric event contains a TypeError error, it gets classified as 'BrowserMediaError' because TypeError is one of the possible error that can result from MediaDevices: getUserMedia() method (https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#aborterror:~:text=individual%20user%20agent.-,TypeError,-Thrown%20if%20the)

## by making the following changes

That assumption is wrong, as any service can return a TypeError and, unfortunately, we do not have a way of identifying the service this error comes from. So this PR classifies it as a TypeError of category 'other'.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
