### PR TITLE
feat(plugin-meetings): initialConnectionMaxRetries

### DIFF
--- a/packages/@webex/internal-plugin-mercury/README.md
+++ b/packages/@webex/internal-plugin-mercury/README.md
@@ -29,7 +29,9 @@ const webex = new WebexCore();
 webex.internal.mercury.WHATEVER;
 ```
 
-## Using A Proxy Agent To Open A Websocket Connection
+## Config Options
+
+### Using A Proxy Agent To Open A Websocket Connection
 
 For consumers who are not using the SDK via the browser it may be necessary to configure a proxy agent in order to connect with Mercury and open a Websocket in a proxy environment.
 
@@ -50,6 +52,16 @@ webex.init({
 	}
 });
 ```
+
+### Retries
+
+The default behaviour is for Mercury to continue to try to connect with an exponential back-off. This behavior can be adjusted with the following config params:
+
+- `maxRetries` - the number of times it will retry before error. Default: 0
+- `initialConnectionMaxRetries` - the number of times it will retry before error on the first connection. Once a connection has been established, any further connection attempts will use `maxRetries`. Default: 0
+- `backoffTimeMax` - The maximum time between connection attempts in ms. Default: 32000
+- `backoffTimeReset` - The time before the first retry in ms. Default: 1000
+
 
 ## Maintainers
 

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -33,6 +33,10 @@ const Mercury = WebexPlugin.extend({
       default: false,
       type: 'boolean',
     },
+    hasEverConnected: {
+      default: false,
+      type: 'boolean',
+    },
     socket: 'object',
     localClusterServiceUrls: 'object',
   },
@@ -294,6 +298,7 @@ const Mercury = WebexPlugin.extend({
           return reject(err);
         }
         this.connected = true;
+        this.hasEverConnected = true;
         this._emit('online');
 
         return resolve();
@@ -312,7 +317,9 @@ const Mercury = WebexPlugin.extend({
         })
       );
 
-      if (this.config.maxRetries) {
+      if (this.config.initialConnectionMaxRetries && !this.hasEverConnected) {
+        call.failAfter(this.config.initialConnectionMaxRetries);
+      } else if (this.config.maxRetries) {
         call.failAfter(this.config.maxRetries);
       }
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

This allows users to configure the number of retries to be used on the first connection only. It preserves the existing behavior of maxRetries for subsequent connections

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
