### PR TITLE
fix(internal-plugin-mercury): use-mocha-for-uts

### DIFF
--- a/packages/@webex/internal-plugin-mercury/package.json
+++ b/packages/@webex/internal-plugin-mercury/package.json
@@ -62,6 +62,6 @@
     "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:style": "eslint ./src/**/*.*",
-    "test:unit": "webex-legacy-tools test --unit --runner jest"
+    "test:unit": "webex-legacy-tools test --unit --runner mocha"
   }
 }

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury-events.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury-events.js
@@ -142,7 +142,7 @@ describe('plugin-mercury', () => {
         });
       });
 
-      describe.skip('when `mercury.buffer_state` is received', () => {
+      describe('when `mercury.buffer_state` is received', () => {
         // This test is here because the buffer states message may arrive before
         // the mercury Promise resolves.
         it('gets emitted', (done) => {

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -381,7 +381,7 @@ describe('plugin-mercury', () => {
         });
       });
 
-      describe.skip('when webSocketUrl is provided', () => {
+      describe('when webSocketUrl is provided', () => {
         it('connects to Mercury with provided url', () => {
           const webSocketUrl = 'ws://providedurl.com';
           const promise = mercury.connect(webSocketUrl);
@@ -403,7 +403,7 @@ describe('plugin-mercury', () => {
       });
     });
 
-    describe.skip('Websocket proxy agent', () => {
+    describe('Websocket proxy agent', () => {
       afterEach(() => {
         delete webex.config.defaultMercuryOptions;
       });
@@ -451,7 +451,7 @@ describe('plugin-mercury', () => {
       });
     });
 
-    describe.skip('#disconnect()', () => {
+    describe('#disconnect()', () => {
       it('disconnects the WebSocket', () =>
         mercury
           .connect()

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
@@ -40,8 +40,10 @@ describe('plugin-mercury', () => {
     });
 
     beforeEach(() => {
-      sinon.stub(Socket, 'getWebSocketConstructor').callsFake(() => function (...args) {
-        mockWebSocket = new MockWebSocket(...args);
+      sinon.stub(Socket, 'getWebSocketConstructor').callsFake(
+        () =>
+          function (...args) {
+            mockWebSocket = new MockWebSocket(...args);
 
             return mockWebSocket;
           }
@@ -69,7 +71,7 @@ describe('plugin-mercury', () => {
       });
     });
 
-    describe.skip('#open()', () => {
+    describe('#open()', () => {
       let socket;
 
       beforeEach(() => {
@@ -213,7 +215,7 @@ describe('plugin-mercury', () => {
       });
     });
 
-    describe.skip('#open()', () => {
+    describe('#open()', () => {
       it('requires a url parameter', () => {
         const s = new Socket();
 
@@ -566,7 +568,7 @@ describe('plugin-mercury', () => {
       });
     });
 
-    describe.skip('#onclose()', () => {
+    describe('#onclose()', () => {
       it('stops further ping checks', () => {
         socket._ping.resetHistory();
         assert.notCalled(socket._ping);
@@ -750,7 +752,7 @@ describe('plugin-mercury', () => {
       });
     });
 
-    describe.skip('#_ping()', () => {
+    describe('#_ping()', () => {
       let id;
 
       beforeEach(() => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-513491](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-513491)

## This pull request addresses

Uts were failling in next. Reverted internal-plugin-mercury to use Mocha.

## by making the following changes

Tests run using mocha.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
