### PR TITLE
test(metrics): revert jest changes for metrics and mercury plugins

### DIFF
--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -716,99 +716,17 @@ describe('plugin-mercury', () => {
             .then((wsUrl) => assert.match(wsUrl, /multipleConnections/)));
       });
     });
-  });
-  describe('ping pong latency event is forwarded', () => {
-    let clock, mercury, mockWebSocket, socketOpenStub, webex;
 
-    const statusStartTypingMessage = JSON.stringify({
-      id: uuid.v4(),
-      data: {
-        eventType: 'status.start_typing',
-        actor: {
-          id: 'actorId',
-        },
-        conversationId: uuid.v4(),
-      },
-      timestamp: Date.now(),
-      trackingId: `suffix_${uuid.v4()}_${Date.now()}`,
-    });
+    describe('ping pong latency event is forwarded', () => {
+      it('should forward ping pong latency event', () => {
+        const spy = sinon.spy();
 
-    beforeEach(() => {
-      clock = FakeTimers.install({now: Date.now()});
-    });
+        mercury.on('ping-pong-latency', spy);
 
-    afterEach(() => {
-      clock.uninstall();
-    });
-
-    beforeEach(() => {
-      webex = new MockWebex({
-        children: {
-          mercury: Mercury,
-        },
-      });
-      webex.credentials = {
-        refresh: sinon.stub().returns(Promise.resolve()),
-        getUserToken: sinon.stub().returns(
-          Promise.resolve({
-            toString() {
-              return 'Bearer FAKE';
-            },
-          })
-        ),
-      };
-      webex.internal.device = {
-        register: sinon.stub().returns(Promise.resolve()),
-        refresh: sinon.stub().returns(Promise.resolve()),
-        webSocketUrl: 'ws://example.com',
-        getWebSocketUrl: sinon.stub().returns(Promise.resolve('ws://example-2.com')),
-        useServiceCatalogUrl: sinon
-          .stub()
-          .returns(Promise.resolve('https://service-catalog-url.com')),
-      };
-      webex.internal.services = {
-        convertUrlToPriorityHostUrl: sinon.stub().returns(Promise.resolve('ws://example-2.com')),
-        markFailedUrl: sinon.stub().returns(Promise.resolve()),
-      };
-      webex.internal.metrics.submitClientMetrics = sinon.stub();
-      webex.trackingId = 'fakeTrackingId';
-      webex.config.mercury = mercuryConfig.mercury;
-
-      webex.logger = console;
-
-      mockWebSocket = new MockWebSocket();
-      sinon.stub(Socket, 'getWebSocketConstructor').returns(() => mockWebSocket);
-
-      const origOpen = Socket.prototype.open;
-
-      socketOpenStub = sinon.stub(Socket.prototype, 'open').callsFake(function (...args) {
-        const promise = Reflect.apply(origOpen, this, args);
-
-        process.nextTick(() => mockWebSocket.open());
-
-        return promise;
-      });
-
-      mercury = webex.internal.mercury;
-    });
-
-    afterEach(() => {
-      if (socketOpenStub) {
-        socketOpenStub.restore();
-      }
-
-      if (Socket.getWebSocketConstructor.restore) {
-        Socket.getWebSocketConstructor.restore();
-      }
-    });
-    it('should forward ping pong latency event', () => {
-      const spy = sinon.spy();
-
-      mercury.on('ping-pong-latency', spy);
-
-      return mercury.connect().then(() => {
-        assert.calledWith(spy, 0);
-        assert.calledOnce(spy);
+        return mercury.connect().then(() => {
+          assert.calledWith(spy, 0);
+          assert.calledOnce(spy);
+        });
       });
     });
   });

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -357,9 +357,9 @@ describe('plugin-metrics', () => {
         });
       });
 
-      //TODO: The following two skipped tests needs investigation: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-485382
+      //TODO: The following two skipped tests are failling when run using jest, needs investigation: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-485382
       describe('when the request fails', () => {
-        it.skip('does not clear the queue', async () => {
+        it('does not clear the queue', async () => {
           // avoid setting .sent timestamp
           webex.internal.newMetrics.callDiagnosticMetrics.callDiagnosticEventsBatcher.prepareRequest =
             (q) => Promise.resolve(q);
@@ -406,7 +406,7 @@ describe('plugin-metrics', () => {
     });
 
     describe('prepareItem', () => {
-      it.skip('calls prepareDiagnosticMetricItem correctly', async () => {
+      it('calls prepareDiagnosticMetricItem correctly', async () => {
         // avoid setting .sent timestamp
         webex.internal.newMetrics.callDiagnosticMetrics.callDiagnosticEventsBatcher.prepareRequest =
           (q) => Promise.resolve(q);

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -361,7 +361,6 @@ describe('plugin-metrics', () => {
         });
       });
 
-      //TODO: The following two skipped tests are failling when run using jest, needs investigation: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-485382
       describe('when the request fails', () => {
         it('does not clear the queue', async () => {
           // avoid setting .sent timestamp

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -721,7 +721,7 @@ describe('internal-plugin-metrics', () => {
         ]);
       });
 
-      it('should submit client event successfully with correlationId, webexConferenceIdStr and globalMeetingId', async () => {
+      it('should submit client event successfully with correlationId, webexConferenceIdStr and globalMeetingId', () => {
         const prepareDiagnosticEventSpy = sinon.spy(cd, 'prepareDiagnosticEvent');
         const submitToCallDiagnosticsSpy = sinon.spy(cd, 'submitToCallDiagnostics');
         const generateClientEventErrorPayloadSpy = sinon.spy(cd, 'generateClientEventErrorPayload');

--- a/packages/@webex/internal-plugin-presence/test/unit/spec/presence-worker.js
+++ b/packages/@webex/internal-plugin-presence/test/unit/spec/presence-worker.js
@@ -16,7 +16,6 @@ describe.skip('presence-worker', () => {
     const id = '1234';
 
     beforeEach(() => {
-      console.log(process.env.WEBEX_CLIENT_ID);
       webex = new MockWebex({
         children: {
           mercury: Mercury,
@@ -28,10 +27,31 @@ describe.skip('presence-worker', () => {
     });
 
     describe('#initialize()', () => {
-      it('requires webex', () =>
-        expect(() => worker.initialize()).toThrow(/Must initialize Presence Worker with webex!/));
-      it('requires webex internal', () =>
-        expect(() => worker.initialize({})).toThrow(/Must initialize Presence Worker with webex!/));
+      it('requires webex', () =>{
+        let err=null
+        try{
+          worker.initialize()
+        }
+        catch(e){
+          err=e
+        }
+        assert.equal(err?.message, 'Must initialize Presence Worker with webex!'); 
+
+      });
+        
+
+      it('requires webex internal', () =>{
+        let err=null
+        try{
+          worker.initialize({})
+        }
+        catch(e){
+          err=e
+        }
+        assert.equal(err?.message, 'Must initialize Presence Worker with webex!'); 
+
+      });
+
     });
 
     // This selection of tests fail due to `webex-core`'s batcher config being missing.


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [SPARK-513491](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-513491)

Revert skipped test in plugin-metrics and plugin-mercury because those tests were failling when we run in jest. Since we have moved them back to mocha those tests are passing.

internal-plugin-presence, changes the test so that it can run in both jest and mocha. Easier to migrate to beta. We dont run these tests in next this is solely for the migration process. 

## Testing
Made the same changes in beta branch and all tests are passing there. Plugin-metric and plugin-mercury tests are passing in next as well as beta

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
