### PR TITLE
fix(media-helpers): vbg effect on local stream

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@webex/internal-media-core": "2.3.2",
     "@webex/ts-events": "^1.1.0",
-    "@webex/web-media-effects": "^2.15.6"
+    "@webex/web-media-effects": "2.18.0"
   },
   "browserify": {
     "transform": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4733,6 +4733,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/ladon-ts@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "@webex/ladon-ts@npm:4.3.0"
+  dependencies:
+    onnxruntime-web: "npm:^1.15.1"
+  checksum: 681361084325b2af27965bcb77f0747da0503ecce20d8ae8e04386bb06827ec148ab9ae911bef0a1888f4b7fe5dcda30bb0b707aa866d0a69a2fc622c768fe08
+  languageName: node
+  linkType: hard
+
 "@webex/media-helpers@workspace:^, @webex/media-helpers@workspace:packages/@webex/media-helpers":
   version: 0.0.0-use.local
   resolution: "@webex/media-helpers@workspace:packages/@webex/media-helpers"
@@ -4741,7 +4750,7 @@ __metadata:
     "@webex/test-helper-chai": "workspace:^"
     "@webex/test-helper-mock-webex": "workspace:^"
     "@webex/ts-events": "npm:^1.1.0"
-    "@webex/web-media-effects": "npm:^2.15.6"
+    "@webex/web-media-effects": "npm:2.18.0"
     jsdom-global: "npm:3.0.2"
     sinon: "npm:^9.2.4"
   languageName: unknown
@@ -5317,6 +5326,19 @@ __metadata:
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
   checksum: ce9104a1dbdd6b37403f47759daeed0213b4a186fc6281e577a9a1d050514619f3e19d7ea33386d2ae2e272bf345f925b8981cc89afc5a6272e6def8204ef742
+  languageName: node
+  linkType: hard
+
+"@webex/web-media-effects@npm:2.18.0":
+  version: 2.18.0
+  resolution: "@webex/web-media-effects@npm:2.18.0"
+  dependencies:
+    "@webex/ladon-ts": "npm:^4.3.0"
+    events: "npm:^3.3.0"
+    js-logger: "npm:^1.6.1"
+    typed-emitter: "npm:^1.4.0"
+    uuid: "npm:^9.0.1"
+  checksum: 63c86214f7a6869e3384cc1ed7ff6dbadb7990216db5b7c83f3126fe40f5848aa4383d427bccc381ca2dad51b249b58de81022eeb97701c0ff95d960571c49de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-502882](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-502882) >

## This pull request addresses

When a VBG image/video is enabled and the user toggles off the video, only the Camera source gets shut and the effect tends to stay in the Local Stream.

## by making the following changes

Fixes the issue mentioned

<!-- You may include screenshots -->

https://github.com/webex/webex-js-sdk/assets/131742425/e64a69eb-f023-4dfc-8601-f423cb3f3ec5


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
