### PR TITLE
fix(media-helpers): vbg effect on local stream

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@webex/internal-media-core": "2.2.9",
     "@webex/ts-events": "^1.1.0",
-    "@webex/web-media-effects": "^2.15.6"
+    "@webex/web-media-effects": "2.18.0"
   },
   "browserify": {
     "transform": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7618,6 +7618,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/ladon-ts@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "@webex/ladon-ts@npm:4.3.0"
+  dependencies:
+    onnxruntime-web: ^1.15.1
+  checksum: d606e2d4d2875380ba58bc29f31a26b126a49c8d6a9ad807b6274ee91704043853078f1009a78639becc096c4b408370b23b2028ecf537d592ee0aaeacbd0e18
+  languageName: node
+  linkType: hard
+
 "@webex/legacy-tools@workspace:*, @webex/legacy-tools@workspace:packages/legacy/tools":
   version: 0.0.0-use.local
   resolution: "@webex/legacy-tools@workspace:packages/legacy/tools"
@@ -7700,7 +7709,7 @@ __metadata:
     "@webex/test-helper-chai": "workspace:*"
     "@webex/test-helper-mock-webex": "workspace:*"
     "@webex/ts-events": ^1.1.0
-    "@webex/web-media-effects": ^2.15.6
+    "@webex/web-media-effects": 2.18.0
     eslint: ^8.24.0
     sinon: ^9.2.4
   languageName: unknown
@@ -8671,6 +8680,19 @@ __metadata:
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
   checksum: aa83f5214bcf3c3d0889d1b7aa40151dd81a3b894cb48445753a2a3f125793ac16daf3f64441e69f18e7b01de383c51823fe709a3c6b01863bf1e74848707dee
+  languageName: node
+  linkType: hard
+
+"@webex/web-media-effects@npm:2.18.0":
+  version: 2.18.0
+  resolution: "@webex/web-media-effects@npm:2.18.0"
+  dependencies:
+    "@webex/ladon-ts": ^4.3.0
+    events: ^3.3.0
+    js-logger: ^1.6.1
+    typed-emitter: ^1.4.0
+    uuid: ^9.0.1
+  checksum: d2b4bcdcc2af87c0bed9c753fa06a34ac663e703c7a1e0bbf542558e23667b9a15b3c4ca594c9b4c8af1a28445f0afd7b4e622c411b0a8c567c84997f2fe44c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-502882](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-502882) >

## This pull request addresses

When a VBG image/video is enabled and the user toggles off the video, only the Camera source gets shut and the effect tends to stay in the Local Stream.

## by making the following changes

Fixes the issue mentioned

<!-- You may include screenshots -->

https://github.com/webex/webex-js-sdk/assets/131742425/e64a69eb-f023-4dfc-8601-f423cb3f3ec5


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
