### PR TITLE
test(internal-plugin-dss): revert test and fix with an empty catch

### DIFF
--- a/packages/@webex/internal-plugin-dss/test/unit/spec/dss.ts
+++ b/packages/@webex/internal-plugin-dss/test/unit/spec/dss.ts
@@ -1157,7 +1157,7 @@ describe('plugin-dss', () => {
         expect(Batcher.prototype.request.getCall(1).args).to.deep.equal(['id2']);
         expect(result).to.equal(response2);
       });
-      // TODO
+      // TODO - https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-518037
       it.skip('fails fails when mercury does not respond, later batches can still pass ok', async () => {
         // Batch 1
         const {

--- a/packages/@webex/internal-plugin-dss/test/unit/spec/dss.ts
+++ b/packages/@webex/internal-plugin-dss/test/unit/spec/dss.ts
@@ -241,22 +241,24 @@ describe('plugin-dss', () => {
         expect(result).to.be.null;
       });
       it('fails with default timeout when mercury does not respond', async () => {
-        return testMakeRequest({
+        const {promise} = await testMakeRequest({
           method: 'lookupDetail',
           resource: '/lookup/orgid/userOrgId/identity/test id/detail',
           params: {id: 'test id'},
           bodyParams: {},
-        }).then(async ({promise}) => {
-          promise.catch((err) => {
-            expect(err.toString()).equal(
-              'DssTimeoutError: The DSS did not respond within 6000 ms.' +
-                '\n Request Id: randomid' +
-                '\n Resource: /lookup/orgid/userOrgId/identity/test id/detail' +
-                '\n Params: undefined'
-            );
-          });
-          await clock.tickAsync(6000);
         });
+
+        promise.catch(() => {}); // to prevent the test from failing due to unhandled promise rejection
+
+        await clock.tickAsync(6000);
+
+        return assert.isRejected(
+          promise,
+          'The DSS did not respond within 6000 ms.' +
+            '\n Request Id: randomid' +
+            '\n Resource: /lookup/orgid/userOrgId/identity/test id/detail' +
+            '\n Params: undefined'
+        );
       });
 
       it('does not fail with timeout when mercury response in time', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES AdHoc

## This pull request addresses

The PR is to revert this test back to it's original state and just add an one-line fix

## by making the following changes

The changes made are reverting the promise.then to old async/await methodology so that it doesn't diverge much with beta and add a one-line fix suggested by Marcin

Please refer to this discussion for better explanation: https://github.com/webex/webex-js-sdk/pull/3499#discussion_r1571133053

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
