### PR TITLE
feat(plugin-meetings): use [peripheralName]Info instead of peripherals in MQE

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1249,12 +1249,6 @@ export const AVAILABLE_RESOLUTIONS = {
 
 export const MQA_INTERVAL = 60000; // mqa analyzer interval its fixed to 60000
 
-export const MEDIA_DEVICES = {
-  MICROPHONE: 'microphone',
-  SPEAKER: 'speaker',
-  CAMERA: 'camera',
-};
-
 export const PSTN_STATUS = {
   JOINED: 'JOINED', // we have provisioned a pstn device, which can be used to connect
   CONNECTED: 'CONNECTED', // user is connected to audio with pstn device

--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -1,9 +1,19 @@
+import {_UNKNOWN_} from '../constants';
+
 export const emptyMqaInterval = {
   audioReceive: [],
   audioTransmit: [],
   intervalMetadata: {
     peerReflexiveIP: '0.0.0.0',
-    peripherals: [],
+    speakerInfo: {
+      deviceName: _UNKNOWN_,
+    },
+    microphoneInfo: {
+      deviceName: _UNKNOWN_,
+    },
+    cameraInfo: {
+      deviceName: _UNKNOWN_,
+    },
     processAverageCPU: 0,
     processMaximumCPU: 0,
     systemAverageCPU: 0,

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -4,14 +4,7 @@ import {cloneDeep, isEmpty} from 'lodash';
 import {ConnectionState} from '@webex/internal-media-core';
 
 import EventsScope from '../common/events/events-scope';
-import {
-  DEFAULT_GET_STATS_FILTER,
-  STATS,
-  MQA_INTERVAL,
-  NETWORK_TYPE,
-  MEDIA_DEVICES,
-  _UNKNOWN_,
-} from '../constants';
+import {DEFAULT_GET_STATS_FILTER, STATS, MQA_INTERVAL, NETWORK_TYPE, _UNKNOWN_} from '../constants';
 import {
   emptyAudioReceive,
   emptyAudioTransmit,
@@ -367,12 +360,13 @@ export class StatsAnalyzer extends EventsScope {
     newMqa.intervalMetadata.peerReflexiveIP = this.statsResults.connectionType.local.ipAddress;
 
     // Adding peripheral information
-    newMqa.intervalMetadata.peripherals.push({information: _UNKNOWN_, name: MEDIA_DEVICES.SPEAKER});
+    newMqa.intervalMetadata.speakerInfo = {
+      deviceName: _UNKNOWN_,
+    };
     if (this.statsResults['audio-send']) {
-      newMqa.intervalMetadata.peripherals.push({
-        information: this.statsResults['audio-send'].trackLabel || _UNKNOWN_,
-        name: MEDIA_DEVICES.MICROPHONE,
-      });
+      newMqa.intervalMetadata.microphoneInfo = {
+        deviceName: this.statsResults['audio-send'].trackLabel || _UNKNOWN_,
+      };
     }
 
     const existingVideoSender = Object.keys(this.statsResults).find((item) =>
@@ -380,10 +374,9 @@ export class StatsAnalyzer extends EventsScope {
     );
 
     if (existingVideoSender) {
-      newMqa.intervalMetadata.peripherals.push({
-        information: this.statsResults[existingVideoSender].trackLabel || _UNKNOWN_,
-        name: MEDIA_DEVICES.CAMERA,
-      });
+      newMqa.intervalMetadata.cameraInfo = {
+        deviceName: this.statsResults[existingVideoSender].trackLabel || _UNKNOWN_,
+      };
     }
 
     newMqa.networkType = this.statsResults.connectionType.local.networkType;

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -776,13 +776,11 @@ describe('plugin-meetings', () => {
         await progressTime();
 
         assert.strictEqual(
-          mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.MICROPHONE)
-            .information,
+          mqeData.intervalMetadata.microphoneInfo.deviceName,
           'fake-microphone'
         );
         assert.strictEqual(
-          mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.CAMERA)
-            .information,
+          mqeData.intervalMetadata.cameraInfo.deviceName,
           'fake-camera'
         );
       });
@@ -796,13 +794,11 @@ describe('plugin-meetings', () => {
         await progressTime();
 
         assert.strictEqual(
-          mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.MICROPHONE)
-            .information,
+          mqeData.intervalMetadata.microphoneInfo.deviceName,
           _UNKNOWN_
         );
         assert.strictEqual(
-          mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.CAMERA)
-            .information,
+          mqeData.intervalMetadata.cameraInfo.deviceName,
           _UNKNOWN_
         );
       });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [WEBEX-381729](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-381729)

## This pull request addresses

MQA team has announced that they are removing the peripherals property in MQE and will only use cameraInfo/microphoneInfo/speakerInfo instead. Currently, on the web client, we are only populating the peripherals property and are not populating cameraInfo/microphoneInfo/speakerInfo. This PR addresses this issue

See pinned message in the Ask MQA space for more details.
[webexteams://im?space=e291a140-f2a2-11ea-a094-5519499aaa4d&message=e1895b50-0133-11ef-9b2a-b19ef59b66fb](webexteams://im?space=e291a140-f2a2-11ea-a094-5519499aaa4d&message=e1895b50-0133-11ef-9b2a-b19ef59b66fb)

## by making the following changes

Changes filling peripherals field in MQE to cameraInfo/ microphoneInfo/ speakerInfo

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- Meeting with 2 people using `samples:serve` [correctly emitted](https://gist.github.com/SomeBody16/140f62495c0e6ea21f43d02546feff6b) changed stats
- Automated tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
