### PR TITLE
test(internal-plugin-dss): revert test and fix with an empty catch

### DIFF
--- a/packages/@webex/internal-plugin-dss/test/unit/spec/dss.ts
+++ b/packages/@webex/internal-plugin-dss/test/unit/spec/dss.ts
@@ -620,22 +620,24 @@ describe('plugin-dss', () => {
       });
 
       it('fails with default timeout when mercury does not respond', async () => {
-        return testMakeRequest({
+        const {promise} = await testMakeRequest({
           method: 'lookup',
           resource: '/lookup/orgid/userOrgId/identities',
           params: {id: 'id1', shouldBatch: false},
           bodyParams: {lookupValues: ['id1']},
-        }).then(async ({promise}) => {
-          promise.catch((err) => {
-            expect(err.toString()).equal(
-              'DssTimeoutError: The DSS did not respond within 6000 ms.' +
-                '\n Request Id: randomid' +
-                '\n Resource: /lookup/orgid/userOrgId/identities' +
-                '\n Params: {"lookupValues":["id1"]}'
-            );
-          });
-          await clock.tickAsync(6000);
         });
+
+        promise.catch(() => {}); // to prevent the test from failing due to unhandled promise rejection
+
+        await clock.tickAsync(6000);
+
+        return assert.isRejected(
+          promise,
+          'The DSS did not respond within 6000 ms.' +
+            '\n Request Id: randomid' +
+            '\n Resource: /lookup/orgid/userOrgId/identities' +
+            '\n Params: {"lookupValues":["id1"]}'
+        );
       });
 
       it('does not fail with timeout when mercury response in time', async () => {
@@ -719,22 +721,24 @@ describe('plugin-dss', () => {
       });
 
       it('fails with default timeout when mercury does not respond', async () => {
-        return testMakeRequest({
+        const {promise} = await testMakeRequest({
           method: 'lookupByEmail',
           resource: '/lookup/orgid/userOrgId/emails',
           params: {email: 'email1'},
           bodyParams: {lookupValues: ['email1']},
-        }).then(async ({promise}) => {
-          promise.catch((err) => {
-            expect(err.toString()).equal(
-              'DssTimeoutError: The DSS did not respond within 6000 ms.' +
-                '\n Request Id: randomid' +
-                '\n Resource: /lookup/orgid/userOrgId/emails' +
-                '\n Params: {"lookupValues":["email1"]}'
-            );
-          });
-          await clock.tickAsync(6000);
         });
+
+        promise.catch(() => {}); // to prevent the test from failing due to unhandled promise rejection
+
+        await clock.tickAsync(6000);
+
+        return assert.isRejected(
+          promise,
+          'The DSS did not respond within 6000 ms.' +
+            '\n Request Id: randomid' +
+            '\n Resource: /lookup/orgid/userOrgId/emails' +
+            '\n Params: {"lookupValues":["email1"]}'
+        );
       });
 
       it('does not fail with timeout when mercury response in time', async () => {
@@ -813,7 +817,7 @@ describe('plugin-dss', () => {
       });
 
       it('fails with default timeout when mercury does not respond', async () => {
-        return testMakeRequest({
+        const {promise} = await testMakeRequest({
           method: 'search',
           resource: '/search/orgid/userOrgId/entities',
           params: {
@@ -826,17 +830,19 @@ describe('plugin-dss', () => {
             resultSize: 100,
             queryString: 'query',
           },
-        }).then(async ({promise}) => {
-          promise.catch((err) => {
-            expect(err.toString()).equal(
-              'DssTimeoutError: The DSS did not respond within 6000 ms.' +
-                '\n Request Id: randomid' +
-                '\n Resource: /search/orgid/userOrgId/entities' +
-                '\n Params: {"queryString":"query","resultSize":100,"requestedTypes":["PERSON","ROBOT"]}'
-            );
-          });
-          await clock.tickAsync(6000);
         });
+
+        promise.catch(() => {}); // to prevent the test from failing due to unhandled promise rejection
+
+        await clock.tickAsync(6000);
+
+        return assert.isRejected(
+          promise,
+          'The DSS did not respond within 6000 ms.' +
+            '\n Request Id: randomid' +
+            '\n Resource: /search/orgid/userOrgId/entities' +
+            '\n Params: {"queryString":"query","resultSize":100,"requestedTypes":["PERSON","ROBOT"]}'
+        );
       });
 
       it('does not fail with timeout when mercury response in time', async () => {
@@ -871,7 +877,7 @@ describe('plugin-dss', () => {
       });
 
       it('fails with timeout when request only partially resolved', async () => {
-        return testMakeRequest({
+        const {requestId, promise} = await testMakeRequest({
           method: 'search',
           resource: '/search/orgid/userOrgId/entities',
           params: {
@@ -884,24 +890,26 @@ describe('plugin-dss', () => {
             resultSize: 100,
             queryString: 'query',
           },
-        }).then(async ({requestId, promise}) => {
-          mercuryCallbacks['event:directory.search'](
-            createData(requestId, 2, true, 'directoryEntities', ['data2'])
-          );
-          mercuryCallbacks['event:directory.search'](
-            createData(requestId, 0, false, 'directoryEntities', ['data0'])
-          );
-
-          promise.catch((err) => {
-            expect(err.toString()).equal(
-              'DssTimeoutError: The DSS did not respond within 6000 ms.' +
-                '\n Request Id: randomid' +
-                '\n Resource: /search/orgid/userOrgId/entities' +
-                '\n Params: {"queryString":"query","resultSize":100,"requestedTypes":["PERSON","ROBOT"]}'
-            );
-          });
-          await clock.tickAsync(6000);
         });
+
+        mercuryCallbacks['event:directory.search'](
+          createData(requestId, 2, true, 'directoryEntities', ['data2'])
+        );
+        mercuryCallbacks['event:directory.search'](
+          createData(requestId, 0, false, 'directoryEntities', ['data0'])
+        );
+
+        promise.catch(() => {}); // to prevent the test from failing due to unhandled promise rejection
+
+        await clock.tickAsync(6000);
+
+        return assert.isRejected(
+          promise,
+          'The DSS did not respond within 6000 ms.' +
+            '\n Request Id: randomid' +
+            '\n Resource: /search/orgid/userOrgId/entities' +
+            '\n Params: {"queryString":"query","resultSize":100,"requestedTypes":["PERSON","ROBOT"]}'
+        );
       });
     });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES AdHoc

## This pull request addresses

The PR is to revert this test back to it's original state and just add an one-line fix

## by making the following changes

The changes made are reverting the promise.then to old async/await methodology so that it doesn't diverge much with beta and add a one-line fix suggested by Marcin

Please refer to this discussion for better explanation: https://github.com/webex/webex-js-sdk/pull/3499#discussion_r1571133053

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
