### PR TITLE
fix: remove the logic of setting b=TIAS lines in the internal media core

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -17,7 +17,7 @@
     "node": ">=16"
   },
   "dependencies": {
-    "@webex/internal-media-core": "2.3.2",
+    "@webex/internal-media-core": "2.3.3",
     "@webex/ts-events": "^1.1.0",
     "@webex/web-media-effects": "2.18.0"
   },

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:^",
-    "@webex/internal-media-core": "2.3.2",
+    "@webex/internal-media-core": "2.3.3",
     "@webex/internal-plugin-conversation": "workspace:^",
     "@webex/internal-plugin-device": "workspace:^",
     "@webex/internal-plugin-llm": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4263,19 +4263,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:2.3.2":
-  version: 2.3.2
-  resolution: "@webex/internal-media-core@npm:2.3.2"
+"@webex/internal-media-core@npm:2.3.3":
+  version: 2.3.3
+  resolution: "@webex/internal-media-core@npm:2.3.3"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@webex/ts-sdp": "npm:1.6.0"
-    "@webex/web-client-media-engine": "npm:3.14.1"
+    "@webex/web-client-media-engine": "npm:3.15.7"
     events: "npm:^3.3.0"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
     webrtc-adapter: "npm:^8.1.2"
     xstate: "npm:^4.30.6"
-  checksum: 73ef35dfa32fa7dd4d7d1d9f0b6a275efb620f732f41c90751edf1a5c9449399cab32b4d3f4f2fb62924d868d70ae9ec7e88f727cbfe765c5b5fde40ae10d7a5
+  checksum: a7926db35c091980752ee5b380d0927010217d527dd8841023030f5f1ab1a9aa40d7f7bb376a021ce7aea1308a3e42cb0f85344a69f4b8b7e3a20c6eceb2bc84
   languageName: node
   linkType: hard
 
@@ -4746,7 +4746,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@webex/media-helpers@workspace:packages/@webex/media-helpers"
   dependencies:
-    "@webex/internal-media-core": "npm:2.3.2"
+    "@webex/internal-media-core": "npm:2.3.3"
     "@webex/test-helper-chai": "workspace:^"
     "@webex/test-helper-mock-webex": "workspace:^"
     "@webex/ts-events": "npm:^1.1.0"
@@ -4885,7 +4885,7 @@ __metadata:
   dependencies:
     "@peculiar/webcrypto": "npm:^1.4.3"
     "@webex/common": "workspace:^"
-    "@webex/internal-media-core": "npm:2.3.2"
+    "@webex/internal-media-core": "npm:2.3.3"
     "@webex/internal-plugin-conversation": "workspace:^"
     "@webex/internal-plugin-device": "workspace:^"
     "@webex/internal-plugin-llm": "workspace:^"
@@ -5311,21 +5311,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:3.14.1":
-  version: 3.14.1
-  resolution: "@webex/web-client-media-engine@npm:3.14.1"
+"@webex/web-client-media-engine@npm:3.15.7":
+  version: 3.15.7
+  resolution: "@webex/web-client-media-engine@npm:3.15.7"
   dependencies:
     "@webex/json-multistream": "npm:2.1.3"
     "@webex/rtcstats": "npm:^1.1.2"
     "@webex/ts-events": "npm:^1.0.1"
     "@webex/ts-sdp": "npm:1.6.0"
     "@webex/web-capabilities": "npm:^1.1.1"
-    "@webex/webrtc-core": "npm:2.6.0"
+    "@webex/webrtc-core": "npm:2.7.0"
     async: "npm:^3.2.4"
     js-logger: "npm:^1.6.1"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
-  checksum: ce9104a1dbdd6b37403f47759daeed0213b4a186fc6281e577a9a1d050514619f3e19d7ea33386d2ae2e272bf345f925b8981cc89afc5a6272e6def8204ef742
+  checksum: 1d34cf8c8f57985a93e1cce40241c9f9e07a58e830e8e1a8803d811a3462656fdc4c99c0417ce8bcb78886a8e795a03b60b7983957e4291cde62f5fca319d214
   languageName: node
   linkType: hard
 
@@ -5432,9 +5432,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/webrtc-core@npm:2.6.0":
-  version: 2.6.0
-  resolution: "@webex/webrtc-core@npm:2.6.0"
+"@webex/webrtc-core@npm:2.7.0":
+  version: 2.7.0
+  resolution: "@webex/webrtc-core@npm:2.7.0"
   dependencies:
     "@webex/ts-events": "npm:^1.1.0"
     "@webex/web-capabilities": "npm:^1.1.0"
@@ -5443,7 +5443,7 @@ __metadata:
     js-logger: "npm:^1.6.1"
     typed-emitter: "npm:^2.1.0"
     webrtc-adapter: "npm:^8.1.2"
-  checksum: 76ffdfcced98520caca3828dd04887910e5163e8a53f01126f2e5ee4e4e8fbd54c226ecc75a115920d2a3ab93bf61e2d2dd196537b038e91eb8211b838e071ff
+  checksum: cb86be873bbe69bdc2be7d07d236c4cf0d1a215b1f04510f1d171dab3483e4e148b85119fcebabaa3d70f3b4e055d43db61acf44c0d4ab7c00c7d588f9f066db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES [WEBEX-326842](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-326842)

## This pull request addresses

WCME munged the SDP answer and created copies of m-sections before passing the SDP to the browser via setRemoteDescription(). As a result, if there was a global b=TIAS line and b=TIAS lines at some media sections, the totals don't add up correctly in the munged SDP answer. This causes issues with audio in Chrome.

## by making the following changes

This request is about removing the logic of setting b=TIAS lines in the WCME and removing some logic fixes in the internal media core. 

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

tested manually with the web app and js-sdk app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly
