### PR TITLE
fix(plugin-meetings): requestedBitrate and requestedFrameSize stats

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -1004,6 +1004,8 @@ export class StatsAnalyzer extends EventsScope {
       this.statsResults[mediaType][sendrecvType].headerBytesSent = result.headerBytesSent;
       this.statsResults[mediaType][sendrecvType].retransmittedBytesSent =
         result.retransmittedBytesSent;
+      this.statsResults[mediaType][sendrecvType].requestedBitrate = result.requestedBitrate;
+      this.statsResults[mediaType][sendrecvType].requestedFrameSize = result.requestedFrameSize;
     }
   }
 
@@ -1116,6 +1118,8 @@ export class StatsAnalyzer extends EventsScope {
 
       this.statsResults[mediaType][sendrecvType].lastPacketReceivedTimestamp =
         result.lastPacketReceivedTimestamp;
+      this.statsResults[mediaType][sendrecvType].requestedBitrate = result.requestedBitrate;
+      this.statsResults[mediaType][sendrecvType].requestedFrameSize = result.requestedFrameSize;
 
       // From Thin
       this.statsResults[mediaType][sendrecvType].totalNackCount = result.nackCount;

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -216,6 +216,8 @@ export const getAudioSenderStreamMqa = ({
     statsResults[mediaType][sendrecvType].totalKeyFramesEncoded - lastFramesEncoded || 0;
   audioSenderStream.requestedKeyFrames =
     statsResults[mediaType][sendrecvType].totalFirCount - lastFirCount || 0;
+
+  audioSenderStream.requestedBitrate = statsResults[mediaType][sendrecvType].requestedBitrate || 0;
 };
 
 export const getVideoReceiverMqa = ({
@@ -437,4 +439,7 @@ export const getVideoSenderStreamMqa = ({
   videoSenderStream.transmittedWidth = statsResults[mediaType][sendrecvType].width || 0;
   videoSenderStream.transmittedFrameSize =
     (videoSenderStream.transmittedHeight * videoSenderStream.transmittedWidth) / 256;
+  videoSenderStream.requestedBitrate = statsResults[mediaType][sendrecvType].requestedBitrate || 0;
+  videoSenderStream.requestedFrameSize =
+    statsResults[mediaType][sendrecvType].requestedFrameSize || 0;
 };

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -88,6 +88,7 @@ describe('plugin-meetings', () => {
             trackId: 'RTCMediaStreamTrack_sender_2',
             transportId: 'RTCTransport_0_1',
             type: 'outbound-rtp',
+            requestedBitrate: 10000,
           },
           'audio-send',
           true
@@ -97,6 +98,7 @@ describe('plugin-meetings', () => {
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.totalBytesSent, 50000);
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.totalNackCount, 1);
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.totalPacketsSent, 3600);
+        assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.requestedBitrate, 10000);
         assert.strictEqual(
           statsAnalyzer.statsResults['audio-send'].send.retransmittedPacketsSent,
           2
@@ -143,6 +145,7 @@ describe('plugin-meetings', () => {
             trackId: 'RTCMediaStreamTrack_receiver_76',
             transportId: 'RTCTransport_0_1',
             type: 'inbound-rtp',
+            requestedBitrate: 10000,
           },
           'audio-recv-1',
           false
@@ -155,6 +158,7 @@ describe('plugin-meetings', () => {
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.fecPacketsDiscarded, 1);
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.fecPacketsReceived, 1);
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.totalBytesReceived, 509);
+        assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.requestedBitrate, 10000);
         assert.strictEqual(
           statsAnalyzer.statsResults['audio-recv-1'].recv.headerBytesReceived,
           250
@@ -1202,6 +1206,7 @@ describe('plugin-meetings', () => {
             },
             transmittedKeyFrames: 0,
             requestedKeyFrames: 0,
+            requestedBitrate: 0,
           },
         ]);
         assert.deepEqual(mqeData.audioTransmit[1].streams, [
@@ -1218,6 +1223,7 @@ describe('plugin-meetings', () => {
             },
             transmittedKeyFrames: 0,
             requestedKeyFrames: 0,
+            requestedBitrate: 0,
           },
         ]);
         assert.deepEqual(mqeData.audioReceive[0].streams, [
@@ -1306,6 +1312,7 @@ describe('plugin-meetings', () => {
             transmittedKeyFramesStartup: 0,
             transmittedKeyFramesUnknown: 0,
             transmittedWidth: 0,
+            requestedBitrate: 0,
           },
         ]);
         assert.deepEqual(mqeData.videoTransmit[1].streams, [
@@ -1329,6 +1336,7 @@ describe('plugin-meetings', () => {
             maxNoiseLevel: 0,
             minRegionQp: 0,
             remoteConfigurationChanges: 0,
+            requestedBitrate: 0,
             requestedFrameSize: 0,
             requestedKeyFrames: 0,
             transmittedFrameSize: 0,
@@ -1647,6 +1655,7 @@ describe('plugin-meetings', () => {
             transmittedKeyFramesStartup: 0,
             transmittedKeyFramesUnknown: 0,
             transmittedWidth: 0,
+            requestedBitrate: 0,
           },
           {
             common: {
@@ -1683,6 +1692,7 @@ describe('plugin-meetings', () => {
             transmittedKeyFramesStartup: 0,
             transmittedKeyFramesUnknown: 0,
             transmittedWidth: 0,
+            requestedBitrate: 0,
           },
           {
             common: {
@@ -1719,6 +1729,7 @@ describe('plugin-meetings', () => {
             transmittedKeyFramesStartup: 0,
             transmittedKeyFramesUnknown: 0,
             transmittedWidth: 0,
+            requestedBitrate: 0,
           }
         ]);
       });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-491229](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-491229)

## This pull request addresses

Missing MQE stats (`requestedBitrate`, `requestedFrameSize`) from web client

It's a follow to PR #3526 (previously to beta branch)

## by making the following changes

Filled missing stats in `statsAnalyzer` (`plugin-meetings`)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- meeting with 2 people using `samples:serve` correctly reads stats from WCME (logs)
- meeting with 2 people using `samples:serve` correctly sends MQE requested with filled requestedBitrate and requestedFrameSize ([curl](https://gist.github.com/SomeBody16/d0597ae2a5b11c920d1b73b57633302a))

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
