### PR TITLE
fix(test-users): request spark-test-account scopes when creating test…

### DIFF
--- a/packages/@webex/test-users/src/index.js
+++ b/packages/@webex/test-users/src/index.js
@@ -59,7 +59,8 @@ function getClientCredentials({clientId, clientSecret, idbrokerUrl}) {
     json: true,
     form: {
       grant_type: 'client_credentials',
-      scope: 'Identity:SCIM webexsquare:get_conversation',
+      scope:
+        'Identity:SCIM webexsquare:get_conversation spark-test-account:write spark-test-account:read',
       client_id: clientId,
       client_secret: clientSecret,
     },


### PR DESCRIPTION
COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-524579

FedRAMP environment requires these scopes to create test users through gateway/cig-service. they are enforced in FedRAMP, but not Commercial

<!-- You may include screenshots -->

<img width="1179" alt="image" src="https://github.com/webex/webex-js-sdk/assets/11569788/eb5f7ac9-2085-4955-9592-0ae4676fab13">

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
