### PR TITLE
fix(plugin-meetings): remove logs and circular dependency with voicea

### DIFF
--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -1,5 +1,4 @@
 import uuid from 'uuid';
-import {TriggerProxy as Trigger} from '@webex/plugin-meetings';
 import {WebexPlugin, config} from '@webex/webex-core';
 
 import {
@@ -110,90 +109,50 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
   private processTranscription = (voiceaPayload: TranscriptionResponse): void => {
     switch (voiceaPayload.type) {
       case TRANSCRIPTION_TYPE.TRANSCRIPT_INTERIM_RESULTS:
-        Trigger.trigger(
-          this,
-          {
-            file: 'voicea',
-            function: 'processTranscription',
-          },
-          EVENT_TRIGGERS.NEW_CAPTION,
-          {
-            isFinal: false,
-            transcriptId: voiceaPayload.transcript_id,
-            transcripts: voiceaPayload.transcripts,
-          }
-        );
+        this.trigger(EVENT_TRIGGERS.NEW_CAPTION, {
+          isFinal: false,
+          transcriptId: voiceaPayload.transcript_id,
+          transcripts: voiceaPayload.transcripts,
+        });
         break;
 
       case TRANSCRIPTION_TYPE.TRANSCRIPT_FINAL_RESULT:
-        Trigger.trigger(
-          this,
-          {
-            file: 'voicea',
-            function: 'processTranscription',
+        this.trigger(EVENT_TRIGGERS.NEW_CAPTION, {
+          isFinal: true,
+          transcriptId: voiceaPayload.transcript_id,
+          translations: voiceaPayload.translations,
+          transcript: {
+            csis: voiceaPayload.csis,
+            text: voiceaPayload.transcript.text,
+            transcriptLanguageCode: voiceaPayload.transcript.transcript_language_code,
           },
-          EVENT_TRIGGERS.NEW_CAPTION,
-          {
-            isFinal: true,
-            transcriptId: voiceaPayload.transcript_id,
-            translations: voiceaPayload.translations,
-            transcript: {
-              csis: voiceaPayload.csis,
-              text: voiceaPayload.transcript.text,
-              transcriptLanguageCode: voiceaPayload.transcript.transcript_language_code,
-            },
-            timestamp: millisToMinutesAndSeconds(voiceaPayload.transcript.end_millis),
-          }
-        );
+          timestamp: millisToMinutesAndSeconds(voiceaPayload.transcript.end_millis),
+        });
         break;
 
       case TRANSCRIPTION_TYPE.HIGHLIGHT_CREATED:
-        Trigger.trigger(
-          this,
-          {
-            file: 'voicea',
-            function: 'processTranscription',
-          },
-          EVENT_TRIGGERS.HIGHLIGHT_CREATED,
-          {
-            csis: voiceaPayload.highlight.csis,
-            highlightId: voiceaPayload.highlight.highlight_id,
-            text: voiceaPayload.highlight.transcript,
-            highlightLabel: voiceaPayload.highlight.highlight_label,
-            highlightSource: voiceaPayload.highlight.highlight_source,
-            timestamp: millisToMinutesAndSeconds(voiceaPayload.highlight.end_millis),
-          }
-        );
+        this.trigger(EVENT_TRIGGERS.HIGHLIGHT_CREATED, {
+          csis: voiceaPayload.highlight.csis,
+          highlightId: voiceaPayload.highlight.highlight_id,
+          text: voiceaPayload.highlight.transcript,
+          highlightLabel: voiceaPayload.highlight.highlight_label,
+          highlightSource: voiceaPayload.highlight.highlight_source,
+          timestamp: millisToMinutesAndSeconds(voiceaPayload.highlight.end_millis),
+        });
         break;
 
       case TRANSCRIPTION_TYPE.EVA_THANKS:
-        Trigger.trigger(
-          this,
-          {
-            file: 'voicea',
-            function: 'processTranscription',
-          },
-          EVENT_TRIGGERS.EVA_COMMAND,
-          {
-            isListening: false,
-            text: voiceaPayload.command_response,
-          }
-        );
+        this.trigger(EVENT_TRIGGERS.EVA_COMMAND, {
+          isListening: false,
+          text: voiceaPayload.command_response,
+        });
         break;
 
       case TRANSCRIPTION_TYPE.EVA_WAKE:
       case TRANSCRIPTION_TYPE.EVA_CANCEL:
-        Trigger.trigger(
-          this,
-          {
-            file: 'voicea',
-            function: 'processTranscription',
-          },
-          EVENT_TRIGGERS.EVA_COMMAND,
-          {
-            isListening: voiceaPayload.type === TRANSCRIPTION_TYPE.EVA_WAKE,
-          }
-        );
+        this.trigger(EVENT_TRIGGERS.EVA_COMMAND, {
+          isListening: voiceaPayload.type === TRANSCRIPTION_TYPE.EVA_WAKE,
+        });
         break;
 
       default:
@@ -208,25 +167,12 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
    */
   private processCaptionLanguageResponse = (voiceaPayload: CaptionLanguageResponse): void => {
     if (voiceaPayload.statusCode === 200) {
-      Trigger.trigger(
-        this,
-        {
-          file: 'voicea',
-          function: 'processCaptionLanguageResponse',
-        },
-        EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE,
-        {statusCode: 200}
-      );
+      this.trigger(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, {statusCode: 200});
     } else {
-      Trigger.trigger(
-        this,
-        {
-          file: 'voicea',
-          function: 'processCaptionLanguageResponse',
-        },
-        EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE,
-        {statusCode: voiceaPayload.errorCode, errorMessage: voiceaPayload.message}
-      );
+      this.trigger(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, {
+        statusCode: voiceaPayload.errorCode,
+        errorMessage: voiceaPayload.message,
+      });
     }
   };
 
@@ -242,15 +188,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
       spokenLanguages: voiceaPayload?.ASR?.spoken_languages ?? [],
     };
 
-    Trigger.trigger(
-      this,
-      {
-        file: 'voicea',
-        function: 'processAnnouncementMessage',
-      },
-      EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT,
-      voiceaLanguageOptions
-    );
+    this.trigger(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, voiceaLanguageOptions);
   };
 
   /**
@@ -298,15 +236,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
         },
       },
     }).then(() => {
-      Trigger.trigger(
-        this,
-        {
-          file: 'voicea',
-          function: 'setSpokenLanguage',
-        },
-        EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE,
-        {languageCode}
-      );
+      this.trigger(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, {languageCode});
     });
 
   /**
@@ -364,14 +294,8 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
       body,
     })
       .then(() => {
-        Trigger.trigger(
-          this,
-          {
-            file: 'voicea',
-            function: 'turnOnCaptions',
-          },
-          EVENT_TRIGGERS.CAPTIONS_TURNED_ON
-        );
+        this.trigger(EVENT_TRIGGERS.CAPTIONS_TURNED_ON);
+
         this.areCaptionsEnabled = true;
         this.captionStatus = TURN_ON_CAPTION_STATUS.ENABLED;
         this.announce();

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -109,6 +109,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
   private processTranscription = (voiceaPayload: TranscriptionResponse): void => {
     switch (voiceaPayload.type) {
       case TRANSCRIPTION_TYPE.TRANSCRIPT_INTERIM_RESULTS:
+        // @ts-ignore
         this.trigger(EVENT_TRIGGERS.NEW_CAPTION, {
           isFinal: false,
           transcriptId: voiceaPayload.transcript_id,
@@ -117,6 +118,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
         break;
 
       case TRANSCRIPTION_TYPE.TRANSCRIPT_FINAL_RESULT:
+        // @ts-ignore
         this.trigger(EVENT_TRIGGERS.NEW_CAPTION, {
           isFinal: true,
           transcriptId: voiceaPayload.transcript_id,
@@ -131,6 +133,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
         break;
 
       case TRANSCRIPTION_TYPE.HIGHLIGHT_CREATED:
+        // @ts-ignore
         this.trigger(EVENT_TRIGGERS.HIGHLIGHT_CREATED, {
           csis: voiceaPayload.highlight.csis,
           highlightId: voiceaPayload.highlight.highlight_id,
@@ -142,6 +145,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
         break;
 
       case TRANSCRIPTION_TYPE.EVA_THANKS:
+        // @ts-ignore
         this.trigger(EVENT_TRIGGERS.EVA_COMMAND, {
           isListening: false,
           text: voiceaPayload.command_response,
@@ -150,6 +154,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
 
       case TRANSCRIPTION_TYPE.EVA_WAKE:
       case TRANSCRIPTION_TYPE.EVA_CANCEL:
+        // @ts-ignore
         this.trigger(EVENT_TRIGGERS.EVA_COMMAND, {
           isListening: voiceaPayload.type === TRANSCRIPTION_TYPE.EVA_WAKE,
         });
@@ -167,8 +172,10 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
    */
   private processCaptionLanguageResponse = (voiceaPayload: CaptionLanguageResponse): void => {
     if (voiceaPayload.statusCode === 200) {
+      // @ts-ignore
       this.trigger(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, {statusCode: 200});
     } else {
+      // @ts-ignore
       this.trigger(EVENT_TRIGGERS.CAPTION_LANGUAGE_UPDATE, {
         statusCode: voiceaPayload.errorCode,
         errorMessage: voiceaPayload.message,
@@ -188,6 +195,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
       spokenLanguages: voiceaPayload?.ASR?.spoken_languages ?? [],
     };
 
+    // @ts-ignore
     this.trigger(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, voiceaLanguageOptions);
   };
 
@@ -236,6 +244,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
         },
       },
     }).then(() => {
+      // @ts-ignore
       this.trigger(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, {languageCode});
     });
 
@@ -294,6 +303,7 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
       body,
     })
       .then(() => {
+        // @ts-ignore
         this.trigger(EVENT_TRIGGERS.CAPTIONS_TURNED_ON);
 
         this.areCaptionsEnabled = true;

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -243,7 +243,7 @@ describe('plugin-voicea', () => {
           })
         );
 
-        assert.calledOnceWithExactly(triggerSpy, undefined);
+        assert.calledOnceWithExactly(triggerSpy);
 
         assert.calledOnce(announcementSpy);
       });

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -52,6 +52,7 @@ import {
 import {StatsAnalyzer, EVENTS as StatsAnalyzerEvents} from '../statsAnalyzer';
 import NetworkQualityMonitor from '../networkQualityMonitor';
 import LoggerProxy from '../common/logs/logger-proxy';
+import EventsUtil from '../common/events/util';
 import Trigger from '../common/events/trigger-proxy';
 import Roap, {
   type TurnDiscoveryResult,
@@ -630,18 +631,20 @@ export default class Meeting extends StatelessWebexPlugin {
   turnDiscoverySkippedReason: TurnDiscoverySkipReason;
   turnServerUsed: boolean;
   areVoiceaEventsSetup = false;
+
   voiceaListenerCallbacks: object = {
     [VOICEAEVENTS.VOICEA_ANNOUNCEMENT]: (payload: Transcription['languageOptions']) => {
       this.transcription.languageOptions = payload;
-      Trigger.trigger(
-        this,
-        {
+
+      LoggerProxy.logger.debug(
+        `${EventsUtil.getScopeLog({
           file: 'meeting/index',
           function: 'setUpVoiceaListeners',
-        },
-        EVENT_TRIGGERS.MEETING_STARTED_RECEIVING_TRANSCRIPTION,
-        payload
+        })}event#${EVENT_TRIGGERS.MEETING_STARTED_RECEIVING_TRANSCRIPTION}`
       );
+
+      // @ts-ignore
+      this.trigger(EVENT_TRIGGERS.MEETING_STARTED_RECEIVING_TRANSCRIPTION, payload);
     },
     [VOICEAEVENTS.CAPTIONS_TURNED_ON]: () => {
       this.transcription.status = TURN_ON_CAPTION_STATUS.ENABLED;
@@ -654,18 +657,19 @@ export default class Meeting extends StatelessWebexPlugin {
     },
     [VOICEAEVENTS.NEW_CAPTION]: (data) => {
       processNewCaptions({data, meeting: this});
-      Trigger.trigger(
-        this,
-        {
+
+      LoggerProxy.logger.debug(
+        `${EventsUtil.getScopeLog({
           file: 'meeting/index',
           function: 'setUpVoiceaListeners',
-        },
-        EVENT_TRIGGERS.MEETING_CAPTION_RECEIVED,
-        {
-          captions: this.transcription.captions,
-          interimCaptions: this.transcription.interimCaptions,
-        }
+        })}event#${EVENT_TRIGGERS.MEETING_CAPTION_RECEIVED}`
       );
+
+      // @ts-ignore
+      this.trigger(EVENT_TRIGGERS.MEETING_CAPTION_RECEIVED, {
+        captions: this.transcription.captions,
+        interimCaptions: this.transcription.interimCaptions,
+      });
     },
   };
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1011,15 +1011,14 @@ describe('plugin-meetings', () => {
       });
 
       describe('transcription events', () => {
+        beforeEach(() => {
+          meeting.trigger = sinon.stub();
+        });
+
         it('should trigger meeting:caption-received event', () => {
           meeting.voiceaListenerCallbacks[VOICEAEVENTS.NEW_CAPTION]({});
           assert.calledWith(
-            TriggerProxy.trigger,
-            sinon.match.instanceOf(Meeting),
-            {
-              file: 'meeting/index',
-              function: 'setUpVoiceaListeners',
-            },
+            meeting.trigger,
             EVENT_TRIGGERS.MEETING_CAPTION_RECEIVED
           );
         });
@@ -1027,12 +1026,7 @@ describe('plugin-meetings', () => {
         it('should trigger meeting:receiveTranscription:started event', () => {
           meeting.voiceaListenerCallbacks[VOICEAEVENTS.VOICEA_ANNOUNCEMENT]({});
           assert.calledWith(
-            TriggerProxy.trigger,
-            sinon.match.instanceOf(Meeting),
-            {
-              file: 'meeting/index',
-              function: 'setUpVoiceaListeners',
-            },
+            meeting.trigger,
             EVENT_TRIGGERS.MEETING_STARTED_RECEIVING_TRANSCRIPTION
           );
         });
@@ -1040,12 +1034,7 @@ describe('plugin-meetings', () => {
         it('should trigger meeting:caption-received event', () => {
           meeting.voiceaListenerCallbacks[VOICEAEVENTS.NEW_CAPTION]({});
           assert.calledWith(
-            TriggerProxy.trigger,
-            sinon.match.instanceOf(Meeting),
-            {
-              file: 'meeting/index',
-              function: 'setUpVoiceaListeners',
-            },
+            meeting.trigger,
             EVENT_TRIGGERS.MEETING_CAPTION_RECEIVED
           );
         });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# PARTIALLY COMPLETES [SPARK-515520](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-515520) and FULLY COMPLETES [SPARK-523031](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-523031)

## This pull request addresses

- PII Information is being logged from Voicea
- There are Circular Dependency between Voicea and Meetings because of using TriggerProxy in Voicea

## by making the following changes

- Removed Circular Dependency by getting rid of TriggerProxy usage in Voicea
- In plugin-meetings, again got rid of TriggerProxy and started logging in place

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

- Tested all the Voicea-based events for Closed Captions
- Ensured sample app is working fine for the newest changes and that the user-facing events are emitted appropriately
- Checked logs through Sample applications for any of the Voicea events not logging any Payload/PII information

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
