### PR TITLE
fix(plugin-meetings): fix check for whether domain is exempted

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
@@ -292,8 +292,9 @@ MeetingInfoUtil.getRequestBody = (options: {type: string; destination: object} |
 MeetingInfoUtil.getWebexSite = (uri: string) => {
   const exceptedDomains = ['meet.webex.com', 'meetup.webex.com', 'ciscospark.com'];
   const site = uri?.match(/.+@([^.]+\.[^.]+\.[^.]+)$/)?.[1];
+  const isExceptedDomain = exceptedDomains.some((domain) => site.includes(domain));
 
-  return exceptedDomains.includes(site) ? null : site;
+  return isExceptedDomain ? null : site;
 };
 
 /**


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [SPARK-525193](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-525193)

## This pull request addresses
the issue in current logic of recognizing an exempted domain while populating the Direct Meeting Information. The current logic doesn't recognize that `meet-intb.ciscospark.com` is still part of the domain `ciscospark.com`.

Due to the above issue in the logic, we see a problem on Webex Instant Connect during the consultation. Currently, the meeting information is unavailable for the application.

The `getDirectMeetingInfoURI` function does not use the catalog to populate the URI for fetching the meeting information. It simply tries to validate from an allow list of known domains and appends /wbxappapi/meetingInfo to the URL.
In the Instant Connect, this results in the application sending out a `GET https://meet.ciscospark.com/wbxappapi/v1/meetingInfo` or `GET https://meet-intb.ciscospark.com/wbxappapi/v1/meetingInfo` to fetch the meeting information.

Both of the above URLs are incorrect and not present in the catalog. Therefore, this breaks the meeting information in Instant Connect.

## by making the following changes

Change the logic to correctly check for a substring so subdomains under the exempted domain array are also covered.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

1. Try `webex.meetings.create('77892476598@meet-intb.ciscospark.com')` using an INT token from Instant Connect in our Kitchen Sink and ensure that the `meetingInfo` object is correctly populated.
2. Try to generate guest token in Kitchen Sink app and do a `webex.meetings.create()` for a production webex meeting.

Logs and HAR files for working and non-working scenarios:
[meetingInfo-issue-fix.zip](https://github.com/webex/webex-js-sdk/files/15311945/meetingInfo-issue-fix.zip)

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
