### PR TITLE
Catalog failure handling

### DIFF
--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -52,7 +52,7 @@ const Services = WebexPlugin.extend({
 
   props: {
     validateDomains: ['boolean', false, true],
-    initFailed: 'boolean',
+    initFailed: ['boolean', false, true],
   },
 
   _catalogs: new WeakMap(),
@@ -1011,7 +1011,6 @@ const Services = WebexPlugin.extend({
     // to update the service catalogs
     this.listenToOnce(this.webex, 'ready', () => {
       const {supertoken} = this.webex.credentials;
-
       // Validate if the supertoken exists.
       if (supertoken && supertoken.access_token) {
         this.initServiceCatalogs()
@@ -1019,15 +1018,19 @@ const Services = WebexPlugin.extend({
             catalog.isReady = true;
           })
           .catch((error) => {
-            this.logger.error(`services: failed to init initial services, ${error.message}`);
             this.initFailed = true;
+            this.logger.error(
+              `services: failed to init initial services when credentials available, ${error?.message}`
+            );
           });
       } else {
         const {email} = this.webex.config;
 
         this.collectPreauthCatalog(email ? {email} : undefined).catch((error) => {
           this.initFailed = true;
-          this.logger.error(`services: failed to init initial services, ${error.message}`);
+          this.logger.error(
+            `services: failed to init initial services when no credentials available, ${error?.message}`
+          );
         });
       }
     });

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -52,6 +52,7 @@ const Services = WebexPlugin.extend({
 
   props: {
     validateDomains: ['boolean', false, true],
+    initFailed: 'boolean',
   },
 
   _catalogs: new WeakMap(),
@@ -1017,13 +1018,17 @@ const Services = WebexPlugin.extend({
           .then(() => {
             catalog.isReady = true;
           })
-          .catch((error) =>
-            this.logger.error(`services: failed to init initial services, ${error.message}`)
-          );
+          .catch((error) => {
+            this.logger.error(`services: failed to init initial services, ${error.message}`);
+            this.initFailed = true;
+          });
       } else {
         const {email} = this.webex.config;
 
-        this.collectPreauthCatalog(email ? {email} : undefined);
+        this.collectPreauthCatalog(email ? {email} : undefined).catch((error) => {
+          this.initFailed = true;
+          this.logger.error(`services: failed to init initial services, ${error.message}`);
+        });
       }
     });
   },


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

If the service catalog fails to initialize for whatever reason, e.g. network failure, the consuming application doesn't know

## by making the following changes

Added a new attribute on the services called initFailed which is set if the catalog fails to init in the on webex ready handler. Consuming applications can either check webex.internal.services.initFailed directly or can listen for the change:initFailed event to spot when this occurs.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
