### PR TITLE
fix: wait for ice gathering state to complete or timeout

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -22,7 +22,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/internal-media-core": "2.3.3",
+    "@webex/internal-media-core": "2.4.0",
     "@webex/ts-events": "^1.1.0",
     "@webex/web-media-effects": "2.18.0"
   },

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:*",
-    "@webex/internal-media-core": "2.3.3",
+    "@webex/internal-media-core": "2.4.0",
     "@webex/internal-plugin-conversation": "workspace:*",
     "@webex/internal-plugin-device": "workspace:*",
     "@webex/internal-plugin-llm": "workspace:*",

--- a/packages/@webex/plugin-meetings/src/media/MediaConnectionAwaiter.ts
+++ b/packages/@webex/plugin-meetings/src/media/MediaConnectionAwaiter.ts
@@ -1,0 +1,178 @@
+import {Defer} from '@webex/common';
+import {ConnectionState, Event} from '@webex/internal-media-core';
+import LoggerProxy from '../common/logs/logger-proxy';
+import {ICE_AND_DTLS_CONNECTION_TIMEOUT} from '../constants';
+
+export interface MediaConnectionAwaiterProps {
+  webrtcMediaConnection: any;
+}
+
+/**
+ * @class MediaConnectionAwaiter
+ */
+export default class MediaConnectionAwaiter {
+  private webrtcMediaConnection: any;
+  private timer: any;
+  private defer: Defer;
+  private retried: boolean;
+  private onTimeoutCallback: () => void;
+  private connectionStateCallback: () => void;
+  private iceGatheringStateCallback: () => void;
+
+  /**
+   * @param {MediaConnectionAwaiterProps} mediaConnectionAwaiterProps
+   */
+  constructor({webrtcMediaConnection}: MediaConnectionAwaiterProps) {
+    this.webrtcMediaConnection = webrtcMediaConnection;
+    this.defer = new Defer();
+    this.retried = false;
+    this.onTimeoutCallback = this.onTimeout.bind(this);
+    this.connectionStateCallback = this.connectionStateListenerCallback.bind(this);
+    this.iceGatheringStateCallback = this.iceGatheringStateListenerCallback.bind(this);
+  }
+
+  /**
+   * Returns true if the connection is connected, false otherwise.
+   *
+   * @returns {boolean}
+   */
+  private isConnected(): boolean {
+    return this.webrtcMediaConnection.getConnectionState() === ConnectionState.Connected;
+  }
+
+  /**
+   * Returns true if the ICE Gathering is completed, false otherwise.
+   *
+   * @returns {boolean}
+   */
+  private isIceGatheringCompleted(): boolean {
+    return this.webrtcMediaConnection.getIceGatheringState() === 'complete';
+  }
+
+  /**
+   * Clears the callbacks.
+   *
+   * @returns {void}
+   */
+  private clearCallbacks(): void {
+    this.webrtcMediaConnection.off(
+      Event.ICE_GATHERING_STATE_CHANGED,
+      this.iceGatheringStateCallback
+    );
+    this.webrtcMediaConnection.off(Event.CONNECTION_STATE_CHANGED, this.connectionStateCallback);
+
+    this.onTimeoutCallback = null;
+    this.connectionStateCallback = null;
+    this.iceGatheringStateCallback = null;
+  }
+
+  /**
+   * Listener for connection state change.
+   *
+   * @returns {void}
+   */
+  connectionStateListenerCallback(): void {
+    LoggerProxy.logger.log(
+      `Media:MediaConnectionAwaiter#connectionStateListenerCallback --> connection state: ${this.webrtcMediaConnection.getConnectionState()}`
+    );
+
+    if (!this.isConnected()) {
+      return;
+    }
+
+    clearTimeout(this.timer);
+
+    this.clearCallbacks();
+
+    this.defer.resolve();
+  }
+
+  /**
+   * Listener for ICE gathering state change.
+   *
+   * @returns {void}
+   */
+  iceGatheringStateListenerCallback(): void {
+    const iceGatheringState = this.webrtcMediaConnection.getIceGatheringState();
+
+    LoggerProxy.logger.log(
+      `Media:MediaConnectionAwaiter#iceGatheringStateListenerCallback --> ICE gathering state change -> ${iceGatheringState}`
+    );
+
+    if (!this.isIceGatheringCompleted()) {
+      return;
+    }
+
+    if (this.isConnected()) {
+      return;
+    }
+
+    clearTimeout(this.timer);
+
+    this.timer = setTimeout(this.onTimeoutCallback, ICE_AND_DTLS_CONNECTION_TIMEOUT);
+  }
+
+  /**
+   * Function called when the timeout is reached.
+   *
+   * @returns {void}
+   */
+  onTimeout(): void {
+    if (this.isConnected()) {
+      this.clearCallbacks();
+
+      this.defer.resolve();
+
+      return;
+    }
+
+    if (!this.isIceGatheringCompleted()) {
+      if (!this.retried) {
+        LoggerProxy.logger.warn(
+          'Media:MediaConnectionAwaiter#onTimeout --> ICE gathering did not complete within the timeout for the first time, retrying once'
+        );
+
+        // retry once if ICE gathering is not completed
+        this.retried = true;
+        clearTimeout(this.timer);
+        this.timer = setTimeout(this.onTimeoutCallback, ICE_AND_DTLS_CONNECTION_TIMEOUT);
+
+        return;
+      }
+
+      LoggerProxy.logger.warn(
+        'Media:MediaConnectionAwaiter#onTimeout --> ICE gathering did not complete within the timeout for the second time, rejecting'
+      );
+    } else {
+      LoggerProxy.logger.warn(
+        'Media:MediaConnectionAwaiter#onTimeout --> ICE gathering completed, but connection state is not connected, rejecting'
+      );
+    }
+
+    this.clearCallbacks();
+
+    this.defer.reject();
+  }
+
+  /**
+   * Waits for the webrtc media connection to be connected.
+   *
+   * @returns {Promise}
+   */
+  waitForMediaConnectionConnected(): Promise<void> {
+    if (this.isConnected()) {
+      return Promise.resolve();
+    }
+
+    this.webrtcMediaConnection.on(Event.CONNECTION_STATE_CHANGED, this.connectionStateCallback);
+
+    this.webrtcMediaConnection.on(
+      Event.ICE_GATHERING_STATE_CHANGED,
+      this.iceGatheringStateCallback
+    );
+
+    this.timer = setTimeout(this.onTimeoutCallback, ICE_AND_DTLS_CONNECTION_TIMEOUT);
+
+    return this.defer.promise;
+  }
+}

--- a/packages/@webex/plugin-meetings/src/media/MediaConnectionAwaiter.ts
+++ b/packages/@webex/plugin-meetings/src/media/MediaConnectionAwaiter.ts
@@ -60,10 +60,6 @@ export default class MediaConnectionAwaiter {
       this.iceGatheringStateCallback
     );
     this.webrtcMediaConnection.off(Event.CONNECTION_STATE_CHANGED, this.connectionStateCallback);
-
-    this.onTimeoutCallback = null;
-    this.connectionStateCallback = null;
-    this.iceGatheringStateCallback = null;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/media/properties.ts
+++ b/packages/@webex/plugin-meetings/src/media/properties.ts
@@ -1,5 +1,3 @@
-import {ConnectionState, Event} from '@webex/internal-media-core';
-
 import {
   LocalCameraStream,
   LocalMicrophoneStream,
@@ -8,8 +6,9 @@ import {
   RemoteStream,
 } from '@webex/media-helpers';
 
-import {MEETINGS, ICE_AND_DTLS_CONNECTION_TIMEOUT, QUALITY_LEVELS} from '../constants';
+import {MEETINGS, QUALITY_LEVELS} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
+import MediaConnectionAwaiter from './MediaConnectionAwaiter';
 
 export type MediaDirection = {
   sendAudio: boolean;
@@ -175,35 +174,11 @@ export default class MediaProperties {
    * @returns {Promise<void>}
    */
   waitForMediaConnectionConnected(): Promise<void> {
-    const isConnected = () =>
-      this.webrtcMediaConnection.getConnectionState() === ConnectionState.Connected;
-
-    if (isConnected()) {
-      return Promise.resolve();
-    }
-
-    return new Promise<void>((resolve, reject) => {
-      let timer;
-
-      const connectionStateListener = () => {
-        LoggerProxy.logger.log(
-          `Media:properties#waitForMediaConnectionConnected --> connection state: ${this.webrtcMediaConnection.getConnectionState()}`
-        );
-
-        if (isConnected()) {
-          clearTimeout(timer);
-          this.webrtcMediaConnection.off(Event.CONNECTION_STATE_CHANGED, connectionStateListener);
-          resolve();
-        }
-      };
-
-      timer = setTimeout(() => {
-        this.webrtcMediaConnection.off(Event.CONNECTION_STATE_CHANGED, connectionStateListener);
-        reject();
-      }, ICE_AND_DTLS_CONNECTION_TIMEOUT);
-
-      this.webrtcMediaConnection.on(Event.CONNECTION_STATE_CHANGED, connectionStateListener);
+    const mediaConnectionAwaiter = new MediaConnectionAwaiter({
+      webrtcMediaConnection: this.webrtcMediaConnection,
     });
+
+    return mediaConnectionAwaiter.waitForMediaConnectionConnected();
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/MediaConnectionAwaiter.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/MediaConnectionAwaiter.ts
@@ -1,0 +1,340 @@
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import {ConnectionState, Event} from '@webex/internal-media-core';
+import testUtils from '../../../utils/testUtils';
+import {ICE_AND_DTLS_CONNECTION_TIMEOUT} from '@webex/plugin-meetings/src/constants';
+import MediaConnectionAwaiter from '../../../../src/media/MediaConnectionAwaiter';
+
+describe('MediaConnectionAwaiter', () => {
+  let mediaConnectionAwaiter;
+  let mockMC;
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+
+    mockMC = {
+      getStats: sinon.stub().resolves([]),
+      on: sinon.stub(),
+      off: sinon.stub(),
+      getConnectionState: sinon.stub().returns(ConnectionState.New),
+      getIceGatheringState: sinon.stub().returns('new'),
+    };
+
+    mediaConnectionAwaiter = new MediaConnectionAwaiter({
+      webrtcMediaConnection: mockMC,
+    });
+  });
+
+  afterEach(() => {
+    clock.restore();
+    sinon.restore();
+  });
+
+  describe('waitForMediaConnectionConnected', () => {
+    it('resolves immediately if connection state is connected', async () => {
+      mockMC.getConnectionState.returns(ConnectionState.Connected);
+
+      await mediaConnectionAwaiter.waitForMediaConnectionConnected();
+
+      assert.neverCalledWith(mockMC.on);
+    });
+
+    it('rejects after timeout if ice state reach connected/completed', async () => {
+      mockMC.getConnectionState.returns(ConnectionState.Connecting);
+      mockMC.getIceGatheringState.returns('gathering');
+
+      let promiseResolved = false;
+      let promiseRejected = false;
+
+      mediaConnectionAwaiter
+        .waitForMediaConnectionConnected()
+        .then(() => {
+          promiseResolved = true;
+        })
+        .catch(() => {
+          promiseRejected = true;
+        });
+
+      await testUtils.flushPromises();
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, false);
+
+      // check the right listener was registered
+      assert.calledTwice(mockMC.on);
+      assert.equal(mockMC.on.getCall(0).args[0], Event.CONNECTION_STATE_CHANGED);
+      assert.equal(mockMC.on.getCall(1).args[0], Event.ICE_GATHERING_STATE_CHANGED);
+      const listener = mockMC.on.getCall(1).args[1];
+
+      mockMC.getIceGatheringState.returns('complete');
+      listener();
+
+      await clock.tickAsync(ICE_AND_DTLS_CONNECTION_TIMEOUT);
+      await testUtils.flushPromises();
+
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, true);
+
+      assert.calledTwice(mockMC.off);
+    });
+
+    it('resolves after timeout if connection state reach connected/completed', async () => {
+      mockMC.getConnectionState.returns(ConnectionState.Connecting);
+      mockMC.getIceGatheringState.returns('gathering');
+
+      let promiseResolved = false;
+      let promiseRejected = false;
+
+      mediaConnectionAwaiter
+        .waitForMediaConnectionConnected()
+        .then(() => {
+          promiseResolved = true;
+        })
+        .catch(() => {
+          promiseRejected = true;
+        });
+
+      await testUtils.flushPromises();
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, false);
+
+      // check the right listener was registered
+      assert.calledTwice(mockMC.on);
+      assert.equal(mockMC.on.getCall(0).args[0], Event.CONNECTION_STATE_CHANGED);
+      assert.equal(mockMC.on.getCall(1).args[0], Event.ICE_GATHERING_STATE_CHANGED);
+
+      mockMC.getConnectionState.returns(ConnectionState.Connected);
+
+      await clock.tickAsync(ICE_AND_DTLS_CONNECTION_TIMEOUT);
+      await testUtils.flushPromises();
+
+      assert.equal(promiseResolved, true);
+      assert.equal(promiseRejected, false);
+
+      assert.calledTwice(mockMC.off);
+    });
+
+    it(`resolves when media connection reaches "connected" state`, async () => {
+      mockMC.getConnectionState.returns(ConnectionState.Connecting);
+      mockMC.getIceGatheringState.returns('gathering');
+
+      const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
+
+      let promiseResolved = false;
+      let promiseRejected = false;
+
+      mediaConnectionAwaiter
+        .waitForMediaConnectionConnected()
+        .then(() => {
+          promiseResolved = true;
+        })
+        .catch(() => {
+          promiseRejected = true;
+        });
+
+      await testUtils.flushPromises();
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, false);
+
+      // check the right listener was registered
+      assert.calledTwice(mockMC.on);
+      assert.equal(mockMC.on.getCall(0).args[0], Event.CONNECTION_STATE_CHANGED);
+      assert.equal(mockMC.on.getCall(1).args[0], Event.ICE_GATHERING_STATE_CHANGED);
+      const listener = mockMC.on.getCall(0).args[1];
+
+      // call the listener and pretend we are now connected
+      mockMC.getConnectionState.returns(ConnectionState.Connected);
+      listener();
+      await testUtils.flushPromises();
+
+      assert.equal(promiseResolved, true);
+      assert.equal(promiseRejected, false);
+
+      // check that listener was removed
+      assert.calledTwice(mockMC.off);
+
+      assert.calledOnce(clearTimeoutSpy);
+    });
+
+    it(`ice gathering state update to "gathering" state does not update timer`, async () => {
+      mockMC.getConnectionState.returns(ConnectionState.Connecting);
+      mockMC.getIceGatheringState.returns('new');
+
+      const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
+
+      let promiseResolved = false;
+      let promiseRejected = false;
+
+      mediaConnectionAwaiter
+        .waitForMediaConnectionConnected()
+        .then(() => {
+          promiseResolved = true;
+        })
+        .catch(() => {
+          promiseRejected = true;
+        });
+
+      await testUtils.flushPromises();
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, false);
+
+      // check the right listener was registered
+      assert.calledTwice(mockMC.on);
+      assert.equal(mockMC.on.getCall(0).args[0], Event.CONNECTION_STATE_CHANGED);
+      assert.equal(mockMC.on.getCall(1).args[0], Event.ICE_GATHERING_STATE_CHANGED);
+      const listener = mockMC.on.getCall(1).args[1];
+
+      // call the listener and pretend we are now connected
+      mockMC.getIceGatheringState.returns('gathering');
+      listener();
+
+      mockMC.getConnectionState.returns(ConnectionState.Connected);
+
+      await clock.tickAsync(ICE_AND_DTLS_CONNECTION_TIMEOUT);
+      await testUtils.flushPromises();
+
+      assert.equal(promiseResolved, true);
+      assert.equal(promiseRejected, false);
+
+      // check that listener was removed
+      assert.calledTwice(mockMC.off);
+
+      assert.neverCalledWith(clearTimeoutSpy);
+    });
+
+    it(`ice gathering update to 'complete' state update timer`, async () => {
+      mockMC.getConnectionState.returns(ConnectionState.Connecting);
+      mockMC.getIceGatheringState.returns('new');
+
+      const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
+
+      let promiseResolved = false;
+      let promiseRejected = false;
+
+      mediaConnectionAwaiter
+        .waitForMediaConnectionConnected()
+        .then(() => {
+          promiseResolved = true;
+        })
+        .catch(() => {
+          promiseRejected = true;
+        });
+
+      await testUtils.flushPromises();
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, false);
+
+      // check the right listener was registered
+      assert.calledTwice(mockMC.on);
+      assert.equal(mockMC.on.getCall(0).args[0], Event.CONNECTION_STATE_CHANGED);
+      assert.equal(mockMC.on.getCall(1).args[0], Event.ICE_GATHERING_STATE_CHANGED);
+      const listener = mockMC.on.getCall(1).args[1];
+
+      // call the listener and pretend we are now connected
+      mockMC.getIceGatheringState.returns('complete');
+      listener();
+
+      mockMC.getConnectionState.returns(ConnectionState.Connected);
+
+      await clock.tickAsync(ICE_AND_DTLS_CONNECTION_TIMEOUT);
+      await testUtils.flushPromises();
+
+      assert.equal(promiseResolved, true);
+      assert.equal(promiseRejected, false);
+
+      // check that listener was removed
+      assert.calledTwice(mockMC.off);
+
+      assert.calledOnce(clearTimeoutSpy);
+    });
+
+    it(`reject with restart timer once if gathering state is not complete`, async () => {
+      mockMC.getConnectionState.returns(ConnectionState.Connecting);
+      mockMC.getIceGatheringState.returns('new');
+
+      const setTimeoutSpy = sinon.spy(clock, 'setTimeout');
+      const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
+
+      let promiseResolved = false;
+      let promiseRejected = false;
+
+      mediaConnectionAwaiter
+        .waitForMediaConnectionConnected()
+        .then(() => {
+          promiseResolved = true;
+        })
+        .catch(() => {
+          promiseRejected = true;
+        });
+
+      await testUtils.flushPromises();
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, false);
+
+      // check the right listener was registered
+      assert.calledTwice(mockMC.on);
+      assert.equal(mockMC.on.getCall(0).args[0], Event.CONNECTION_STATE_CHANGED);
+      assert.equal(mockMC.on.getCall(1).args[0], Event.ICE_GATHERING_STATE_CHANGED);
+
+      await clock.tickAsync(ICE_AND_DTLS_CONNECTION_TIMEOUT * 3);
+      await testUtils.flushPromises();
+
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, true);
+
+      // check that listener was removed
+      assert.calledTwice(mockMC.off);
+
+      assert.calledOnce(clearTimeoutSpy);
+      assert.calledTwice(setTimeoutSpy);
+    });
+
+    it(`resolves gathering and connection state complete right after`, async () => {
+      mockMC.getConnectionState.returns(ConnectionState.Connecting);
+      mockMC.getIceGatheringState.returns('new');
+
+      const setTimeoutSpy = sinon.spy(clock, 'setTimeout');
+      const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
+
+      let promiseResolved = false;
+      let promiseRejected = false;
+
+      mediaConnectionAwaiter
+        .waitForMediaConnectionConnected()
+        .then(() => {
+          promiseResolved = true;
+        })
+        .catch(() => {
+          promiseRejected = true;
+        });
+
+      await testUtils.flushPromises();
+      assert.equal(promiseResolved, false);
+      assert.equal(promiseRejected, false);
+
+      // check the right listener was registered
+      assert.calledTwice(mockMC.on);
+      assert.equal(mockMC.on.getCall(0).args[0], Event.CONNECTION_STATE_CHANGED);
+      assert.equal(mockMC.on.getCall(1).args[0], Event.ICE_GATHERING_STATE_CHANGED);
+      const connectionStateListener = mockMC.on.getCall(0).args[1];
+      const iceGatheringListener = mockMC.on.getCall(1).args[1];
+
+      mockMC.getIceGatheringState.returns('complete');
+      iceGatheringListener();
+
+      mockMC.getConnectionState.returns(ConnectionState.Connected);
+      connectionStateListener();
+
+      await testUtils.flushPromises();
+
+      assert.equal(promiseResolved, true);
+      assert.equal(promiseRejected, false);
+
+      // check that listener was removed
+      assert.calledTwice(mockMC.off);
+
+      assert.calledTwice(clearTimeoutSpy);
+      assert.calledTwice(setTimeoutSpy);
+    });
+  });
+});

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/MediaConnectionAwaiter.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/MediaConnectionAwaiter.ts
@@ -276,7 +276,7 @@ describe('MediaConnectionAwaiter', () => {
       assert.equal(mockMC.on.getCall(0).args[0], Event.CONNECTION_STATE_CHANGED);
       assert.equal(mockMC.on.getCall(1).args[0], Event.ICE_GATHERING_STATE_CHANGED);
 
-      await clock.tickAsync(ICE_AND_DTLS_CONNECTION_TIMEOUT * 3);
+      await clock.tickAsync(ICE_AND_DTLS_CONNECTION_TIMEOUT * 2);
       await testUtils.flushPromises();
 
       assert.equal(promiseResolved, false);

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
@@ -1,5 +1,6 @@
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
+import {ConnectionState} from '@webex/internal-media-core';
 import MediaProperties from '@webex/plugin-meetings/src/media/properties';
 import testUtils from '../../../utils/testUtils';
 import {Defer} from '@webex/common';
@@ -17,6 +18,7 @@ describe('MediaProperties', () => {
       getStats: sinon.stub().resolves([]),
       on: sinon.stub(),
       off: sinon.stub(),
+      getConnectionState: sinon.stub().returns(ConnectionState.Connected),
     };
 
     mediaProperties = new MediaProperties();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7125,15 +7125,31 @@ __metadata:
   version: 2.3.3
   resolution: "@webex/internal-media-core@npm:2.3.3"
   dependencies:
-    "@babel/runtime": "npm:^7.18.9"
-    "@webex/ts-sdp": "npm:1.6.0"
-    "@webex/web-client-media-engine": "npm:3.15.7"
-    events: "npm:^3.3.0"
-    typed-emitter: "npm:^2.1.0"
-    uuid: "npm:^8.3.2"
-    webrtc-adapter: "npm:^8.1.2"
-    xstate: "npm:^4.30.6"
+    "@babel/runtime": ^7.18.9
+    "@webex/ts-sdp": 1.6.0
+    "@webex/web-client-media-engine": 3.15.7
+    events: ^3.3.0
+    typed-emitter: ^2.1.0
+    uuid: ^8.3.2
+    webrtc-adapter: ^8.1.2
+    xstate: ^4.30.6
   checksum: beff0410954fcb93f1f2f4ff8d6f7ba89c3aa743076b0b869b26e2974c0dfafb059f81814b98fab567aa10ec6cae243ad3c812b410cebd1af528be5535e91294
+  languageName: node
+  linkType: hard
+
+"@webex/internal-media-core@npm:2.4.0":
+  version: 2.4.0
+  resolution: "@webex/internal-media-core@npm:2.4.0"
+  dependencies:
+    "@babel/runtime": ^7.18.9
+    "@webex/ts-sdp": 1.6.0
+    "@webex/web-client-media-engine": 3.16.0
+    events: ^3.3.0
+    typed-emitter: ^2.1.0
+    uuid: ^8.3.2
+    webrtc-adapter: ^8.1.2
+    xstate: ^4.30.6
+  checksum: 2672f9e82034cea6147b9356e0120ee34e31b7f3660e9ed03175b5d0376b7e8b8b023f299f857824052f04b7b96c5a1cf59cb09288066c0270f680863f674908
   languageName: node
   linkType: hard
 
@@ -7903,7 +7919,7 @@ __metadata:
     "@babel/preset-typescript": 7.22.11
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.3.3
+    "@webex/internal-media-core": 2.4.0
     "@webex/jest-config-legacy": "workspace:*"
     "@webex/legacy-tools": "workspace:*"
     "@webex/test-helper-chai": "workspace:*"
@@ -8139,7 +8155,7 @@ __metadata:
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/common": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.3.3
+    "@webex/internal-media-core": 2.4.0
     "@webex/internal-plugin-conversation": "workspace:*"
     "@webex/internal-plugin-device": "workspace:*"
     "@webex/internal-plugin-llm": "workspace:*"
@@ -8846,17 +8862,35 @@ __metadata:
   version: 3.15.7
   resolution: "@webex/web-client-media-engine@npm:3.15.7"
   dependencies:
-    "@webex/json-multistream": "npm:2.1.3"
-    "@webex/rtcstats": "npm:^1.1.2"
-    "@webex/ts-events": "npm:^1.0.1"
-    "@webex/ts-sdp": "npm:1.6.0"
-    "@webex/web-capabilities": "npm:^1.1.1"
-    "@webex/webrtc-core": "npm:2.7.0"
-    async: "npm:^3.2.4"
-    js-logger: "npm:^1.6.1"
-    typed-emitter: "npm:^2.1.0"
-    uuid: "npm:^8.3.2"
+    "@webex/json-multistream": 2.1.3
+    "@webex/rtcstats": ^1.1.2
+    "@webex/ts-events": ^1.0.1
+    "@webex/ts-sdp": 1.6.0
+    "@webex/web-capabilities": ^1.1.1
+    "@webex/webrtc-core": 2.7.0
+    async: ^3.2.4
+    js-logger: ^1.6.1
+    typed-emitter: ^2.1.0
+    uuid: ^8.3.2
   checksum: 8e83ae1e469f591339d661f168222e6dc727692b953562c483c9f03ad1bf5de7323f2143e2014dc150ed3c203c8c3c6be47059547da0648bb68094f4c42760c5
+  languageName: node
+  linkType: hard
+
+"@webex/web-client-media-engine@npm:3.16.0":
+  version: 3.16.0
+  resolution: "@webex/web-client-media-engine@npm:3.16.0"
+  dependencies:
+    "@webex/json-multistream": 2.1.3
+    "@webex/rtcstats": ^1.1.2
+    "@webex/ts-events": ^1.0.1
+    "@webex/ts-sdp": 1.6.0
+    "@webex/web-capabilities": ^1.1.1
+    "@webex/webrtc-core": 2.7.0
+    async: ^3.2.4
+    js-logger: ^1.6.1
+    typed-emitter: ^2.1.0
+    uuid: ^8.3.2
+  checksum: 4170156abc0d949c328399be80253120853fe3113cac84aed2269696ed41389112657e4f4ffaff49412e240ffa8ad1996eef91d246015489224591c78d386a1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-520529](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-520529)

## This pull request addresses

Currently, MultistreamMediaConnection doesn't wait for the ICE Gathering to complete. What results in sometimes not waiting for relay candidates to be gathered. Not waiting for relay candidates to be gathered, may result in not intended media connection failure even though media could be establish through the TurnTLS.

## by making the following changes

This PR introduces functionality which on media connection will wait for ICE Gathering to be completed. What's more retry have been added in case ICE Gathering completes in requested time duration, but no DTLS connection have been established yet.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

JS SDK Multistream Connection Establishment
JS SDK Transcoded Connection Establishment
Web App

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
