### PR TITLE
fix: remove command to run all tests together

### DIFF
--- a/packages/@webex/common-evented/package.json
+++ b/packages/@webex/common-evented/package.json
@@ -40,7 +40,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"
   }

--- a/packages/@webex/common-timers/package.json
+++ b/packages/@webex/common-timers/package.json
@@ -22,7 +22,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"
   },

--- a/packages/@webex/common/package.json
+++ b/packages/@webex/common/package.json
@@ -51,7 +51,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"
   }

--- a/packages/@webex/helper-html/package.json
+++ b/packages/@webex/helper-html/package.json
@@ -42,7 +42,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --unit --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/helper-image/package.json
+++ b/packages/@webex/helper-image/package.json
@@ -52,7 +52,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --unit --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner mocha"

--- a/packages/@webex/http-core/package.json
+++ b/packages/@webex/http-core/package.json
@@ -57,7 +57,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",
     "test:style": "eslint ./src/**/*.*",

--- a/packages/@webex/internal-plugin-avatar/package.json
+++ b/packages/@webex/internal-plugin-avatar/package.json
@@ -47,7 +47,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-board/package.json
+++ b/packages/@webex/internal-plugin-board/package.json
@@ -51,7 +51,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-calendar/package.json
+++ b/packages/@webex/internal-plugin-calendar/package.json
@@ -46,7 +46,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-conversation/package.json
+++ b/packages/@webex/internal-plugin-conversation/package.json
@@ -51,7 +51,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-device/package.json
+++ b/packages/@webex/internal-plugin-device/package.json
@@ -49,7 +49,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-dss/package.json
+++ b/packages/@webex/internal-plugin-dss/package.json
@@ -44,7 +44,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-ediscovery/package.json
+++ b/packages/@webex/internal-plugin-ediscovery/package.json
@@ -50,7 +50,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-encryption/package.json
+++ b/packages/@webex/internal-plugin-encryption/package.json
@@ -61,7 +61,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",
     "test:style": "eslint ./src/**/*.*",

--- a/packages/@webex/internal-plugin-feature/package.json
+++ b/packages/@webex/internal-plugin-feature/package.json
@@ -17,7 +17,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-flag/package.json
+++ b/packages/@webex/internal-plugin-flag/package.json
@@ -17,7 +17,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-llm/package.json
+++ b/packages/@webex/internal-plugin-llm/package.json
@@ -39,7 +39,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-locus/package.json
+++ b/packages/@webex/internal-plugin-locus/package.json
@@ -30,7 +30,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-lyra/package.json
+++ b/packages/@webex/internal-plugin-lyra/package.json
@@ -52,7 +52,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-mercury/package.json
+++ b/packages/@webex/internal-plugin-mercury/package.json
@@ -59,7 +59,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner mocha"

--- a/packages/@webex/internal-plugin-metrics/package.json
+++ b/packages/@webex/internal-plugin-metrics/package.json
@@ -51,7 +51,6 @@
     "build": " yarn run -T tsc --declaration true --declarationDir ./dist/types",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps && yarn build",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner mocha"
   }

--- a/packages/@webex/internal-plugin-presence/package.json
+++ b/packages/@webex/internal-plugin-presence/package.json
@@ -46,7 +46,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-scheduler/package.json
+++ b/packages/@webex/internal-plugin-scheduler/package.json
@@ -51,7 +51,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-search/package.json
+++ b/packages/@webex/internal-plugin-search/package.json
@@ -46,7 +46,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/internal-plugin-support/package.json
+++ b/packages/@webex/internal-plugin-support/package.json
@@ -34,7 +34,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:integratio:broken": "webex-legacy-tools test --integration --runner mocha",
     "test:style": "eslint ./src/**/*.*",

--- a/packages/@webex/internal-plugin-team/package.json
+++ b/packages/@webex/internal-plugin-team/package.json
@@ -46,7 +46,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-user/package.json
+++ b/packages/@webex/internal-plugin-user/package.json
@@ -46,7 +46,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-voicea/package.json
+++ b/packages/@webex/internal-plugin-voicea/package.json
@@ -44,7 +44,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/internal-plugin-wdm/package.json
+++ b/packages/@webex/internal-plugin-wdm/package.json
@@ -28,7 +28,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/jsdoctrinetest/package.json
+++ b/packages/@webex/jsdoctrinetest/package.json
@@ -60,7 +60,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -15,7 +15,6 @@
   "scripts": {
     "build": "yarn run -T tsc --declaration true --declarationDir ./dist",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps && yarn run -T tsc --declaration true --declarationDir ./dist",
-    "test:broken": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint 'src/**/*.ts' --fix",
     "test:unit": "webex-legacy-tools test --unit --runner jest",

--- a/packages/@webex/plugin-attachment-actions/package.json
+++ b/packages/@webex/plugin-attachment-actions/package.json
@@ -38,7 +38,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/plugin-authorization-browser-first-party/package.json
+++ b/packages/@webex/plugin-authorization-browser-first-party/package.json
@@ -51,7 +51,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/plugin-authorization-browser/package.json
+++ b/packages/@webex/plugin-authorization-browser/package.json
@@ -49,7 +49,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/plugin-authorization-node/package.json
+++ b/packages/@webex/plugin-authorization-node/package.json
@@ -45,7 +45,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --unit --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",
     "test:style": "eslint ./src/**/*.*",

--- a/packages/@webex/plugin-authorization/package.json
+++ b/packages/@webex/plugin-authorization/package.json
@@ -30,7 +30,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/plugin-device-manager/package.json
+++ b/packages/@webex/plugin-device-manager/package.json
@@ -37,7 +37,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/plugin-logger/package.json
+++ b/packages/@webex/plugin-logger/package.json
@@ -44,7 +44,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --unit --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -31,7 +31,6 @@
     "build": "yarn run -T tsc --declaration true --declarationDir ./dist",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps && yarn build",
     "deploy:npm": "yarn npm publish",
-    "test:broken": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner mocha"

--- a/packages/@webex/plugin-memberships/package.json
+++ b/packages/@webex/plugin-memberships/package.json
@@ -48,7 +48,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/plugin-messages/package.json
+++ b/packages/@webex/plugin-messages/package.json
@@ -49,7 +49,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",
     "test:style": "eslint ./src/**/*.*"

--- a/packages/@webex/plugin-people/package.json
+++ b/packages/@webex/plugin-people/package.json
@@ -41,7 +41,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/plugin-presence/package.json
+++ b/packages/@webex/plugin-presence/package.json
@@ -49,7 +49,6 @@
     "build:docs": "typedoc --out ../../../docs/presence",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/plugin-rooms/package.json
+++ b/packages/@webex/plugin-rooms/package.json
@@ -48,7 +48,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/plugin-team-memberships/package.json
+++ b/packages/@webex/plugin-team-memberships/package.json
@@ -43,7 +43,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/plugin-teams/package.json
+++ b/packages/@webex/plugin-teams/package.json
@@ -46,7 +46,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/plugin-webhooks/package.json
+++ b/packages/@webex/plugin-webhooks/package.json
@@ -42,7 +42,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/recipe-private-web-client/package.json
+++ b/packages/@webex/recipe-private-web-client/package.json
@@ -47,7 +47,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/storage-adapter-local-forage/package.json
+++ b/packages/@webex/storage-adapter-local-forage/package.json
@@ -42,7 +42,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --unit --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/storage-adapter-local-storage/package.json
+++ b/packages/@webex/storage-adapter-local-storage/package.json
@@ -27,7 +27,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --unit --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/storage-adapter-session-storage/package.json
+++ b/packages/@webex/storage-adapter-session-storage/package.json
@@ -28,7 +28,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --unit --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/storage-adapter-spec/package.json
+++ b/packages/@webex/storage-adapter-spec/package.json
@@ -25,7 +25,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/test-helper-appid/package.json
+++ b/packages/@webex/test-helper-appid/package.json
@@ -31,7 +31,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/test-helper-automation/package.json
+++ b/packages/@webex/test-helper-automation/package.json
@@ -36,7 +36,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/test-helper-chai/package.json
+++ b/packages/@webex/test-helper-chai/package.json
@@ -35,7 +35,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/test-helper-file/package.json
+++ b/packages/@webex/test-helper-file/package.json
@@ -26,7 +26,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/test-helper-make-local-url/package.json
+++ b/packages/@webex/test-helper-make-local-url/package.json
@@ -20,7 +20,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/test-helper-mocha/package.json
+++ b/packages/@webex/test-helper-mocha/package.json
@@ -18,7 +18,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/test-helper-mock-web-socket/package.json
+++ b/packages/@webex/test-helper-mock-web-socket/package.json
@@ -36,7 +36,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/test-helper-mock-webex/package.json
+++ b/packages/@webex/test-helper-mock-webex/package.json
@@ -33,7 +33,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/@webex/test-helper-refresh-callback/package.json
+++ b/packages/@webex/test-helper-refresh-callback/package.json
@@ -22,7 +22,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*",
     "test:unit": "webex-legacy-tools test --unit --runner jest"

--- a/packages/@webex/test-helper-retry/package.json
+++ b/packages/@webex/test-helper-retry/package.json
@@ -18,7 +18,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/test-helper-server/package.json
+++ b/packages/@webex/test-helper-server/package.json
@@ -32,7 +32,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/test-helper-test-users/package.json
+++ b/packages/@webex/test-helper-test-users/package.json
@@ -28,7 +28,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/test-users/package.json
+++ b/packages/@webex/test-users/package.json
@@ -45,7 +45,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",
     "test:style": "eslint ./src/**/*.*"

--- a/packages/@webex/webex-core/package.json
+++ b/packages/@webex/webex-core/package.json
@@ -67,7 +67,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",
     "test:style": "eslint ./src/**/*.*",

--- a/packages/@webex/webex-server/package.json
+++ b/packages/@webex/webex-server/package.json
@@ -81,7 +81,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",
     "test:style": "eslint ./src/**/*.*"

--- a/packages/@webex/webrtc/package.json
+++ b/packages/@webex/webrtc/package.json
@@ -31,7 +31,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   },

--- a/packages/@webex/xunit-with-logs/package.json
+++ b/packages/@webex/xunit-with-logs/package.json
@@ -33,7 +33,6 @@
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration && yarn test:browser",
     "test:browser": "webex-legacy-tools test --integration --runner karma",
     "test:style": "eslint ./src/**/*.*"
   }

--- a/packages/legacy/tools/package.json
+++ b/packages/legacy/tools/package.json
@@ -33,7 +33,6 @@
     "clean:coverage": "rimraf ./test/coverage",
     "clean:dist": "rimraf ./dist",
     "start": "node ./dist/cli/index.js",
-    "test": "yarn test:style && yarn test:syntax && yarn test:integration && yarn test:coverage",
     "test:coverage": "nyc node ./jasmine.config.js test --integration --silent",
     "test:coverage:report": "nyc --reporter=lcov yarn test:coverage",
     "test:integration": "node ./jasmine.config.js test --integration",

--- a/packages/tools/cli/package.json
+++ b/packages/tools/cli/package.json
@@ -23,7 +23,6 @@
     "clean": "yarn clean:dist",
     "clean:dist": "rimraf ./dist",
     "deploy:npm": "yarn npm publish",
-    "test": "yarn test:style && yarn test:syntax && yarn test:integration && yarn test:coverage",
     "test:coverage": "yarn test:integration --coverage --reporters=\"jest-silent-reporter\"",
     "test:integration": "jest",
     "test:style": "eslint ./src/**/*.*",

--- a/packages/tools/package/package.json
+++ b/packages/tools/package/package.json
@@ -28,7 +28,6 @@
     "clean:dist": "rimraf ./dist",
     "deploy:npm": "yarn npm publish",
     "start": "node ./index.js",
-    "test": "yarn test:style && yarn test:syntax && yarn test:integration && yarn test:coverage",
     "test:coverage": "yarn test:integration --coverage --reporters=\"jest-silent-reporter\"",
     "test:integration": "jest",
     "test:style": "eslint ./test/**/*.* ./src/**/*.*",

--- a/packages/webex/package.json
+++ b/packages/webex/package.json
@@ -42,7 +42,6 @@
   "scripts": {
     "build": "yarn build:src",
     "build:src": "webex-legacy-tools build -dest \"./dist\" -src \"./src\" -js -ts -maps",
-    "test": "yarn test:style && yarn test:unit && yarn test:integration",
     "test:browser:broken": "webex-legacy-tools test --integration --runner karma",
     "test:integration": "webex-legacy-tools test --integration --runner mocha",
     "test:style": "eslint ./src/**/*.*",


### PR DESCRIPTION
# COMPLETES #Adhoc

## This pull request addresses

In all the packages, there is a command that runs all the tests (i.e. styles, unit, integration, browser) for those packages. Since we never run all the tests together, this command is not needed. 

## by making the following changes

Removed the comand

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
