### PR TITLE
fix: add reachability checks for TLS

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -39,6 +39,7 @@ const breakoutTable = document.getElementById('breakout-table');
 const breakoutHostOperation = document.getElementById('breakout-host-operation');
 const getStatsButton = document.getElementById('get-stats');
 const tcpReachabilityConfigElm = document.getElementById('enable-tcp-reachability'); 
+const tlsReachabilityConfigElm = document.getElementById('enable-tls-reachability');
 
 const guestName = document.querySelector('#guest-name');
 const getGuestToken = document.querySelector('#get-guest-token');
@@ -116,6 +117,7 @@ function generateWebexConfig({credentials}) {
         enableUnifiedMeetings: true,
         enableAdhocMeetings: true,
         enableTcpReachability: tcpReachabilityConfigElm.checked,
+        enableTlsReachability: tlsReachabilityConfigElm.checked,
       },
       enableAutomaticLLM: enableLLM.checked,
     },

--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -89,6 +89,9 @@
               <input type="checkbox" id="enable-tcp-reachability">
               <label for="enable-tcp-reachability">Enable TCP reachability (experimental)</label>
               <br/>
+              <input type="checkbox" id="enable-tls-reachability">
+              <label for="enable-tls-reachability">Enable TLS reachability (experimental)</label>
+              <br/>
               <input id="meetings-enable-llm" checked type="checkbox">
               <label for="meetings-enable-llm-label">Enable LLM</label>
             </div>

--- a/packages/@webex/plugin-meetings/src/config.ts
+++ b/packages/@webex/plugin-meetings/src/config.ts
@@ -87,6 +87,7 @@ export default {
       enableUnifiedMeetings: true,
       enableAdhocMeetings: true,
       enableTcpReachability: false,
+      enableTlsReachability: false,
     },
     degradationPreferences: {
       maxMacroblocksLimit: 8192,

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -718,6 +718,24 @@ export default class Meetings extends WebexPlugin {
   }
 
   /**
+   * API to toggle TLS reachability, needs to be called before webex.meetings.register()
+   * @param {Boolean} newValue
+   * @private
+   * @memberof Meetings
+   * @returns {undefined}
+   */
+  private _toggleTlsReachability(newValue: boolean) {
+    if (typeof newValue !== 'boolean') {
+      return;
+    }
+    // @ts-ignore
+    if (this.config.experimental.enableTlsReachability !== newValue) {
+      // @ts-ignore
+      this.config.experimental.enableTlsReachability = newValue;
+    }
+  }
+
+  /**
    * Explicitly sets up the meetings plugin by registering
    * the device, connecting to mercury, and listening for locus events.
    *

--- a/packages/@webex/plugin-meetings/src/reachability/clusterReachability.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/clusterReachability.ts
@@ -204,7 +204,7 @@ export class ClusterReachability {
    * @returns {boolean} true if we have all results, false otherwise
    */
   private haveWeGotAllResults(): boolean {
-    return ['udp', 'tcp'].every(
+    return ['udp', 'tcp', 'xtls'].every(
       (protocol) =>
         this.result[protocol].result === 'reachable' || this.result[protocol].result === 'untested'
     );

--- a/packages/@webex/plugin-meetings/src/reachability/clusterReachability.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/clusterReachability.ts
@@ -21,7 +21,6 @@ export type ClusterReachabilityResult = {
   udp: TransportResult;
   tcp: TransportResult;
   xtls: TransportResult;
-  tls: TransportResult;
 };
 
 /**
@@ -30,7 +29,7 @@ export type ClusterReachabilityResult = {
 export class ClusterReachability {
   private numUdpUrls: number;
   private numTcpUrls: number;
-  private numTlsUrls: number;
+  private numXTlsUrls: number;
   private result: ClusterReachabilityResult;
   private pc?: RTCPeerConnection;
   private defer: Defer; // this defer is resolved once reachability checks for this cluster are completed
@@ -48,7 +47,7 @@ export class ClusterReachability {
     this.isVideoMesh = clusterInfo.isVideoMesh;
     this.numUdpUrls = clusterInfo.udp.length;
     this.numTcpUrls = clusterInfo.tcp.length;
-    this.numTlsUrls = clusterInfo.xtls.length;
+    this.numXTlsUrls = clusterInfo.xtls.length;
 
     this.pc = this.createPeerConnection(clusterInfo);
 
@@ -58,9 +57,6 @@ export class ClusterReachability {
         result: 'untested',
       },
       tcp: {
-        result: 'untested',
-      },
-      tls: {
         result: 'untested',
       },
       xtls: {
@@ -221,7 +217,7 @@ export class ClusterReachability {
    * @param {number} latency
    * @returns {void}
    */
-  private storeLatencyResult(protocol: 'udp' | 'tcp' | 'tls', latency: number) {
+  private storeLatencyResult(protocol: 'udp' | 'tcp' | 'xtls', latency: number) {
     const result = this.result[protocol];
 
     if (result.latencyInMilliseconds === undefined) {
@@ -254,7 +250,7 @@ export class ClusterReachability {
         }
 
         if (e.candidate.type === CANDIDATE_TYPES.RELAY) {
-          const protocol = e.candidate.port === TURN_TLS_PORT ? 'tls' : 'tcp';
+          const protocol = e.candidate.port === TURN_TLS_PORT ? 'xtls' : 'tcp';
           this.storeLatencyResult(protocol, this.getElapsedTime());
           // we don't add public IP for TCP, because in the case of relay candidates
           // e.candidate.address is the TURN server address, not the client's public IP
@@ -291,8 +287,8 @@ export class ClusterReachability {
     this.result.tcp = {
       result: this.numTcpUrls > 0 ? 'unreachable' : 'untested',
     };
-    this.result.tls = {
-      result: this.numTlsUrls > 0 ? 'unreachable' : 'untested',
+    this.result.xtls = {
+      result: this.numXTlsUrls > 0 ? 'unreachable' : 'untested',
     };
 
     try {

--- a/packages/@webex/plugin-meetings/src/reachability/clusterReachability.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/clusterReachability.ts
@@ -104,7 +104,7 @@ export class ClusterReachability {
       return {
         username: 'webexturnreachuser',
         credential: 'webexturnreachpwd',
-        urls: [convertStunUrlToTurnTls(urlString, 'tcp')],
+        urls: [convertStunUrlToTurnTls(urlString)],
       };
     });
 

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -22,10 +22,14 @@ export type ReachabilityMetrics = {
   reachability_public_udp_failed: number;
   reachability_public_tcp_success: number;
   reachability_public_tcp_failed: number;
+  reachability_public_xtls_success: number;
+  reachability_public_xtls_failed: number;
   reachability_vmn_udp_success: number;
   reachability_vmn_udp_failed: number;
   reachability_vmn_tcp_success: number;
   reachability_vmn_tcp_failed: number;
+  reachability_vmn_xtls_success: number;
+  reachability_vmn_xtls_failed: number;
 };
 
 /**
@@ -141,10 +145,14 @@ export default class Reachability {
       reachability_public_udp_failed: 0,
       reachability_public_tcp_success: 0,
       reachability_public_tcp_failed: 0,
+      reachability_public_xtls_success: 0,
+      reachability_public_xtls_failed: 0,
       reachability_vmn_udp_success: 0,
       reachability_vmn_udp_failed: 0,
       reachability_vmn_tcp_success: 0,
       reachability_vmn_tcp_failed: 0,
+      reachability_vmn_xtls_success: 0,
+      reachability_vmn_xtls_failed: 0,
     };
 
     const updateStats = (clusterType: 'public' | 'vmn', result: ClusterReachabilityResult) => {
@@ -155,6 +163,10 @@ export default class Reachability {
       if (result.tcp && result.tcp.result !== 'untested') {
         const outcome = result.tcp.result === 'reachable' ? 'success' : 'failed';
         stats[`reachability_${clusterType}_tcp_${outcome}`] += 1;
+      }
+      if (result.xtls && result.xtls.result !== 'untested') {
+        const outcome = result.xtls.result === 'reachable' ? 'success' : 'failed';
+        stats[`reachability_${clusterType}_xtls_${outcome}`] += 1;
       }
     };
 

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -338,7 +338,10 @@ export default class Reachability {
     LoggerProxy.logger.log(
       `Reachability:index#performReachabilityChecks --> doing UDP${
         // @ts-ignore
-        this.webex.config.meetings.experimental.enableTcpReachability ? ' and TCP' : ''
+        this.webex.config.meetings.experimental.enableTcpReachability ? ',TCP' : ''
+      }${
+        // @ts-ignore
+        this.webex.config.meetings.experimental.enableTlsReachability ? ',TLS' : ''
       } reachability checks`
     );
 
@@ -352,6 +355,14 @@ export default class Reachability {
 
       if (!includeTcpReachability) {
         cluster.tcp = [];
+      }
+
+      const includeTlsReachability =
+        // @ts-ignore
+        this.webex.config.meetings.experimental.enableTlsReachability && !cluster.isVideoMesh;
+
+      if (!includeTlsReachability) {
+        cluster.xtls = [];
       }
 
       this.clusterReachability[key] = new ClusterReachability(key, cluster);

--- a/packages/@webex/plugin-meetings/src/reachability/util.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/util.ts
@@ -39,7 +39,6 @@ export function convertStunUrlToTurnTls(stunUrl: string) {
   }
 
   url.protocol = 'turns:';
-  url.port = '443'; // Make sure that the port is 443
   url.searchParams.append('transport', 'tcp');
 
   return url.toString();

--- a/packages/@webex/plugin-meetings/src/reachability/util.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/util.ts
@@ -22,3 +22,27 @@ export function convertStunUrlToTurn(stunUrl: string, protocol: 'udp' | 'tcp') {
 
   return url.toString();
 }
+
+/**
+ * Converts a stun url to a turn url
+ *
+ * @param {string} stunUrl url of a stun server
+ * @param {'tcp'|'udp'} protocol what protocol to use for the turn server
+ * @returns {string} url of a turn server
+ */
+export function convertStunUrlToTurnTls(stunUrl: string, protocol: 'udp' | 'tcp') {
+  // stunUrl looks like this: "stun:external-media91.public.wjfkm-a-10.prod.infra.webex.com:5004"
+  // and we need it to be like this: "turn:external-media91.public.wjfkm-a-10.prod.infra.webex.com:5004?transport=tcp"
+  const url = new URL(stunUrl);
+
+  if (url.protocol !== 'stun:') {
+    throw new Error(`Not a STUN URL: ${stunUrl}`);
+  }
+
+  url.protocol = 'turns:';
+  if (protocol === 'tcp') {
+    url.searchParams.append('transport', 'tcp');
+  }
+
+  return url.toString();
+}

--- a/packages/@webex/plugin-meetings/src/reachability/util.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/util.ts
@@ -24,15 +24,14 @@ export function convertStunUrlToTurn(stunUrl: string, protocol: 'udp' | 'tcp') {
 }
 
 /**
- * Converts a stun url to a turn url
+ * Converts a stun url to a turns url
  *
  * @param {string} stunUrl url of a stun server
- * @param {'tcp'|'udp'} protocol what protocol to use for the turn server
- * @returns {string} url of a turn server
+ * @returns {string} url of a turns server
  */
-export function convertStunUrlToTurnTls(stunUrl: string, protocol: 'udp' | 'tcp') {
-  // stunUrl looks like this: "stun:external-media91.public.wjfkm-a-10.prod.infra.webex.com:5004"
-  // and we need it to be like this: "turn:external-media91.public.wjfkm-a-10.prod.infra.webex.com:5004?transport=tcp"
+export function convertStunUrlToTurnTls(stunUrl: string) {
+  // stunUrl looks like this: "stun:external-media1.public.wjfkm-a-15.prod.infra.webex.com:443"
+  // and we need it to be like this: "turns:external-media1.public.wjfkm-a-15.prod.infra.webex.com:443?transport=tcp"
   const url = new URL(stunUrl);
 
   if (url.protocol !== 'stun:') {
@@ -40,9 +39,8 @@ export function convertStunUrlToTurnTls(stunUrl: string, protocol: 'udp' | 'tcp'
   }
 
   url.protocol = 'turns:';
-  if (protocol === 'tcp') {
-    url.searchParams.append('transport', 'tcp');
-  }
+  url.port = '443'; // Make sure that the port is 443
+  url.searchParams.append('transport', 'tcp');
 
   return url.toString();
 }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -253,6 +253,19 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#_toggleTlsReachability', () => {
+      it('should have _toggleTlsReachability', () => {
+        assert.equal(typeof webex.meetings._toggleTlsReachability, 'function');
+      });
+
+      describe('success', () => {
+        it('should update meetings to do TLS reachability', () => {
+          webex.meetings._toggleTlsReachability(true);
+          assert.equal(webex.meetings.config.experimental.enableTlsReachability, true);
+        });
+      });
+    });
+
     describe('Public API Contracts', () => {
       describe('#register', () => {
         it('emits an event and resolves when register succeeds', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -311,7 +311,7 @@ describe('gatherReachability', () => {
       xtls: ['xtls1.1', 'xtls1.2'],
       isVideoMesh: false,
     });
-    // cluster 2 is video mesh, so we should not do TCP reachability on it
+    // cluster 2 is video mesh, so we should not do TCP or TLS reachability on it
     assert.calledWith(clusterReachabilityCtorStub, 'cluster 2', {
       udp: ['udp2.1', 'udp2.2'],
       tcp: [],
@@ -566,10 +566,14 @@ describe('getReachabilityMetrics', () => {
       reachability_public_udp_failed: 0,
       reachability_public_tcp_success: 0,
       reachability_public_tcp_failed: 0,
+      reachability_public_xtls_success: 0,
+      reachability_public_xtls_failed: 0,
       reachability_vmn_udp_success: 0,
       reachability_vmn_udp_failed: 0,
       reachability_vmn_tcp_success: 0,
       reachability_vmn_tcp_failed: 0,
+      reachability_vmn_xtls_success: 0,
+      reachability_vmn_xtls_failed: 0,
     });
   });
 
@@ -629,10 +633,14 @@ describe('getReachabilityMetrics', () => {
         reachability_public_udp_failed: 2,
         reachability_public_tcp_success: 2,
         reachability_public_tcp_failed: 1,
+        reachability_public_xtls_success: 0,
+        reachability_public_xtls_failed: 0,
         reachability_vmn_udp_success: 1,
         reachability_vmn_udp_failed: 0,
         reachability_vmn_tcp_success: 1,
         reachability_vmn_tcp_failed: 1,
+        reachability_vmn_xtls_success: 0,
+        reachability_vmn_xtls_failed: 0,
       }
     );
   });
@@ -668,7 +676,16 @@ describe('getReachabilityMetrics', () => {
         public5: {
           udp: {result: 'reachable', latencyInMilliseconds: '400', clientMediaIPs: ['10.10.10.10']},
           tcp: {result: 'untested'},
-          xtls: {result: 'untested'},
+          xtls: {result: 'unreachable'},
+        },
+        public6: {
+          udp: {result: 'untested'},
+          tcp: {result: 'untested'},
+          xtls: {
+            result: 'reachable',
+            latencyInMilliseconds: '200',
+            clientMediaIPs: ['10.10.10.10'],
+          },
         },
       },
       // expected result:
@@ -677,10 +694,14 @@ describe('getReachabilityMetrics', () => {
         reachability_public_udp_failed: 1,
         reachability_public_tcp_success: 1,
         reachability_public_tcp_failed: 2,
+        reachability_public_xtls_success: 1,
+        reachability_public_xtls_failed: 1,
         reachability_vmn_udp_success: 0,
         reachability_vmn_udp_failed: 0,
         reachability_vmn_tcp_success: 0,
         reachability_vmn_tcp_failed: 0,
+        reachability_vmn_xtls_success: 0,
+        reachability_vmn_xtls_failed: 0,
       }
     );
   });
@@ -717,9 +738,15 @@ describe('getReachabilityMetrics', () => {
         vmn5: {
           udp: {result: 'reachable', latencyInMilliseconds: 200, clientMediaIPs: ['10.10.10.10']},
           tcp: {result: 'unreachable'},
-          xtls: {result: 'untested'},
+          xtls: {result: 'unreachable'},
           isVideoMesh: true,
           someOtherField: 'any value',
+        },
+        vmn6: {
+          udp: {result: 'untested'},
+          tcp: {result: 'untested'},
+          xtls: {result: 'reachable', latencyInMilliseconds: 100, clientMediaIPs: ['10.10.10.10']},
+          isVideoMesh: true,
         },
       },
       // expected result:
@@ -728,10 +755,14 @@ describe('getReachabilityMetrics', () => {
         reachability_public_udp_failed: 0,
         reachability_public_tcp_success: 0,
         reachability_public_tcp_failed: 0,
+        reachability_public_xtls_success: 0,
+        reachability_public_xtls_failed: 0,
         reachability_vmn_udp_success: 3,
         reachability_vmn_udp_failed: 1,
         reachability_vmn_tcp_success: 1,
         reachability_vmn_tcp_failed: 3,
+        reachability_vmn_xtls_success: 1,
+        reachability_vmn_xtls_failed: 1,
       }
     );
   });

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -1,11 +1,14 @@
 import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import sinon from 'sinon';
-import Reachability, {ReachabilityResults, ReachabilityResultsForBackend} from '@webex/plugin-meetings/src/reachability/';
+import Reachability, {
+  ReachabilityResults,
+  ReachabilityResultsForBackend,
+} from '@webex/plugin-meetings/src/reachability/';
 import MeetingUtil from '@webex/plugin-meetings/src/meeting/util';
 import * as ClusterReachabilityModule from '@webex/plugin-meetings/src/reachability/clusterReachability';
 
-import { IP_VERSION } from '@webex/plugin-meetings/src/constants';
+import {IP_VERSION} from '@webex/plugin-meetings/src/constants';
 
 describe('isAnyPublicClusterReachable', () => {
   let webex;
@@ -36,19 +39,31 @@ describe('isAnyPublicClusterReachable', () => {
   };
 
   it('returns true when udp is reachable', async () => {
-    await checkIsClusterReachable({x: {udp: {result: 'reachable'}, tcp: {result: 'unreachable'}}}, true);
+    await checkIsClusterReachable(
+      {x: {udp: {result: 'reachable'}, tcp: {result: 'unreachable'}}},
+      true
+    );
   });
 
   it('returns true when tcp is reachable', async () => {
-    await checkIsClusterReachable({x: {udp: {result: 'unreachable'}, tcp: {result: 'reachable'}}}, true);
+    await checkIsClusterReachable(
+      {x: {udp: {result: 'unreachable'}, tcp: {result: 'reachable'}}},
+      true
+    );
   });
 
   it('returns true when both tcp and udp are reachable', async () => {
-    await checkIsClusterReachable({x: {udp: {result: 'reachable'}, tcp: {result: 'reachable'}}}, true);
+    await checkIsClusterReachable(
+      {x: {udp: {result: 'reachable'}, tcp: {result: 'reachable'}}},
+      true
+    );
   });
 
   it('returns false when both tcp and udp are unreachable', async () => {
-    await checkIsClusterReachable({x: {udp: {result: 'unreachable'}, tcp: {result: 'unreachable'}}}, false);
+    await checkIsClusterReachable(
+      {x: {udp: {result: 'unreachable'}, tcp: {result: 'unreachable'}}},
+      false
+    );
   });
 
   it('returns false when reachability result is empty', async () => {
@@ -61,60 +76,69 @@ describe('isAnyPublicClusterReachable', () => {
 
   describe('ignores video mesh reachability', () => {
     it('returns false if there are no public cluster results, only video mesh', async () => {
-      await checkIsClusterReachable({
-        x: {
-          udp: {result: 'reachable'},
-          tcp: {result: 'reachable'},
-          isVideoMesh: true,
+      await checkIsClusterReachable(
+        {
+          x: {
+            udp: {result: 'reachable'},
+            tcp: {result: 'reachable'},
+            isVideoMesh: true,
+          },
+          y: {
+            udp: {result: 'unreachable'},
+            tcp: {result: 'reachable'},
+            isVideoMesh: true,
+          },
         },
-        y: {
-          udp: {result: 'unreachable'},
-          tcp: {result: 'reachable'},
-          isVideoMesh: true,
-        }
-      }, false);
+        false
+      );
     });
 
     it('returns false if there public cluster reachability failed, only video mesh succeeded', async () => {
-      await checkIsClusterReachable({
-        x: {
-          udp: {result: 'unreachable'},
-          tcp: {result: 'reachable'},
-          isVideoMesh: true,
+      await checkIsClusterReachable(
+        {
+          x: {
+            udp: {result: 'unreachable'},
+            tcp: {result: 'reachable'},
+            isVideoMesh: true,
+          },
+          y: {
+            udp: {result: 'reachable'},
+            tcp: {result: 'unreachable'},
+            isVideoMesh: true,
+          },
+          publicOne: {
+            udp: {result: 'unreachable'},
+            tcp: {result: 'unreachable'},
+            isVideoMesh: false,
+          },
         },
-        y: {
-          udp: {result: 'reachable'},
-          tcp: {result: 'unreachable'},
-          isVideoMesh: true,
-        },
-        publicOne: {
-          udp: {result: 'unreachable'},
-          tcp: {result: 'unreachable'},
-          isVideoMesh: false,
-        }
-      }, false);
+        false
+      );
     });
 
     it('returns true if there is at least 1 public cluster result, while video mesh is not reachable', async () => {
-      await checkIsClusterReachable({
-        x: {
-          udp: {result: 'reachable'},
-          tcp: {result: 'reachable'},
-          isVideoMesh: true,
+      await checkIsClusterReachable(
+        {
+          x: {
+            udp: {result: 'reachable'},
+            tcp: {result: 'reachable'},
+            isVideoMesh: true,
+          },
+          y: {
+            udp: {result: 'unreachable'},
+            tcp: {result: 'reachable'},
+            isVideoMesh: true,
+          },
+          publicOne: {
+            udp: {result: 'unreachable'},
+            tcp: {result: 'reachable'},
+            isVideoMesh: false,
+          },
         },
-        y: {
-          udp: {result: 'unreachable'},
-          tcp: {result: 'reachable'},
-          isVideoMesh: true,
-        },
-        publicOne: {
-          udp: {result: 'unreachable'},
-          tcp: {result: 'reachable'},
-          isVideoMesh: false,
-        }
-      }, true);
+        true
+      );
     });
-  })
+  });
 });
 
 describe('gatherReachability', () => {
@@ -244,7 +268,10 @@ describe('gatherReachability', () => {
   });
 
   it('starts ClusterReachability on each media cluster', async () => {
-    webex.config.meetings.experimental = {enableTcpReachability: true};
+    webex.config.meetings.experimental = {
+      enableTcpReachability: true,
+      enableTlsReachability: true,
+    };
 
     const getClustersResult = {
       clusters: {
@@ -288,7 +315,7 @@ describe('gatherReachability', () => {
     assert.calledWith(clusterReachabilityCtorStub, 'cluster 2', {
       udp: ['udp2.1', 'udp2.2'],
       tcp: [],
-      xtls: ['xtls2.1', 'xtls2.2'],
+      xtls: [],
       isVideoMesh: true,
     });
 
@@ -296,7 +323,10 @@ describe('gatherReachability', () => {
   });
 
   it('does not do TCP reachability if it is disabled in config', async () => {
-    webex.config.meetings.experimental = {enableTcpReachability: false};
+    webex.config.meetings.experimental = {
+      enableTcpReachability: false,
+      enableTlsReachability: true,
+    };
 
     const getClustersResult = {
       clusters: {
@@ -327,6 +357,82 @@ describe('gatherReachability', () => {
       udp: ['testUDP1', 'testUDP2'],
       tcp: [], // empty list because TCP is disabled in config
       xtls: ['testXTLS1', 'testXTLS2'],
+    });
+  });
+
+  it('does not do TLS reachability if it is disabled in config', async () => {
+    webex.config.meetings.experimental = {
+      enableTcpReachability: true,
+      enableTlsReachability: false,
+    };
+
+    const getClustersResult = {
+      clusters: {
+        'cluster name': {
+          udp: ['testUDP1', 'testUDP2'],
+          tcp: ['testTCP1', 'testTCP2'],
+          xtls: ['testXTLS1', 'testXTLS2'],
+          isVideoMesh: false,
+        },
+      },
+      joinCookie: {id: 'id'},
+    };
+
+    const reachability = new Reachability(webex);
+
+    reachability.reachabilityRequest.getClusters = sinon.stub().returns(getClustersResult);
+
+    const clusterReachabilityCtorStub = sinon
+      .stub(ClusterReachabilityModule, 'ClusterReachability')
+      .callsFake(() => ({
+        start: sinon.stub().resolves({}),
+      }));
+
+    await reachability.gatherReachability();
+
+    assert.calledOnceWithExactly(clusterReachabilityCtorStub, 'cluster name', {
+      isVideoMesh: false,
+      udp: ['testUDP1', 'testUDP2'],
+      tcp: ['testTCP1', 'testTCP2'],
+      xtls: [], // empty list because TLS is disabled in config
+    });
+  });
+
+  it('does not do TCP or TLS reachability if it is disabled in config', async () => {
+    webex.config.meetings.experimental = {
+      enableTcpReachability: false,
+      enableTlsReachability: false,
+    };
+
+    const getClustersResult = {
+      clusters: {
+        'cluster name': {
+          udp: ['testUDP1', 'testUDP2'],
+          tcp: ['testTCP1', 'testTCP2'],
+          xtls: ['testXTLS1', 'testXTLS2'],
+          isVideoMesh: false,
+        },
+      },
+      joinCookie: {id: 'id'},
+    };
+
+    const reachability = new Reachability(webex);
+
+    reachability.reachabilityRequest.getClusters = sinon.stub().returns(getClustersResult);
+
+    const clusterReachabilityCtorStub = sinon
+      .stub(ClusterReachabilityModule, 'ClusterReachability')
+      .callsFake(() => ({
+        start: sinon.stub().resolves({}),
+      }));
+
+    await reachability.gatherReachability();
+
+    assert.calledOnceWithExactly(clusterReachabilityCtorStub, 'cluster name', {
+      isVideoMesh: false,
+      udp: ['testUDP1', 'testUDP2'],
+      tcp: [], // empty list because TCP is disabled in config
+      xtls: [], // empty list because TLS is disabled in config
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/util.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/util.ts
@@ -1,6 +1,9 @@
 import {assert} from '@webex/test-helper-chai';
 
-import {convertStunUrlToTurn} from '@webex/plugin-meetings/src/reachability/util';
+import {
+  convertStunUrlToTurn,
+  convertStunUrlToTurnTls,
+} from '@webex/plugin-meetings/src/reachability/util';
 
 describe('plugin-meetings/src/reachability/util', () => {
   describe('#convertStunUrlToTurn()', () => {
@@ -34,7 +37,48 @@ describe('plugin-meetings/src/reachability/util', () => {
     });
 
     it('show fail if stunUrl is not a STUN url', () => {
-      assert.throws(() => convertStunUrlToTurn('http://webex.com', 'tcp'), 'Not a STUN URL: http://webex.com');
+      assert.throws(
+        () => convertStunUrlToTurn('http://webex.com', 'tcp'),
+        'Not a STUN URL: http://webex.com'
+      );
+    });
+  });
+
+  describe('#convertStunUrlToTurnTls()', () => {
+    [
+      {
+        title: 'a stun url with port',
+        stunUrl: 'stun:external-media91.public.wjfkm-a-10.prod.infra.webex.com:443',
+         : 'external-media91.public.wjfkm-a-10.prod.infra.webex.com:443',
+      },
+      {
+        title: 'a stun url without port',
+        stunUrl: 'stun:something.somewhere.com',
+        expectedUrlPart: 'something.somewhere.com',
+      },
+    ].forEach(({title, stunUrl, expectedUrlPart}) => {
+      it(`should convert ${title} to a TCP turn url`, () => {
+        const turnUrl = convertStunUrlToTurnTls(stunUrl);
+
+        assert.equal(turnUrl, `turn:${expectedUrlPart}?transport=tcp`);
+      });
+
+      it(`should convert ${title} to a UDP turn url`, () => {
+        const turnUrl = convertStunUrlToTurnTls(stunUrl);
+
+        assert.equal(turnUrl, `turn:${expectedUrlPart}:443?transport=tcp`);
+      });
+    });
+
+    it('show fail if stunUrl is not a valid url', () => {
+      assert.throws(() => convertStunUrlToTurn('not a url', 'tcp'), 'Invalid URL: not a url');
+    });
+
+    it('show fail if stunUrl is not a STUN url', () => {
+      assert.throws(
+        () => convertStunUrlToTurn('http://webex.com', 'tcp'),
+        'Not a STUN URL: http://webex.com'
+      );
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/util.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/util.ts
@@ -45,29 +45,15 @@ describe('plugin-meetings/src/reachability/util', () => {
   });
 
   describe('#convertStunUrlToTurnTls()', () => {
-    [
-      {
-        title: 'a stun url with port',
-        stunUrl: 'stun:external-media91.public.wjfkm-a-10.prod.infra.webex.com:443',
-         : 'external-media91.public.wjfkm-a-10.prod.infra.webex.com:443',
-      },
-      {
-        title: 'a stun url without port',
-        stunUrl: 'stun:something.somewhere.com',
-        expectedUrlPart: 'something.somewhere.com',
-      },
-    ].forEach(({title, stunUrl, expectedUrlPart}) => {
-      it(`should convert ${title} to a TCP turn url`, () => {
-        const turnUrl = convertStunUrlToTurnTls(stunUrl);
+    it(`should convert to a turns url`, () => {
+      const turnsUrl = convertStunUrlToTurnTls(
+        'stun:external-media91.public.wjfkm-a-10.prod.infra.webex.com:443'
+      );
 
-        assert.equal(turnUrl, `turn:${expectedUrlPart}?transport=tcp`);
-      });
-
-      it(`should convert ${title} to a UDP turn url`, () => {
-        const turnUrl = convertStunUrlToTurnTls(stunUrl);
-
-        assert.equal(turnUrl, `turn:${expectedUrlPart}:443?transport=tcp`);
-      });
+      assert.equal(
+        turnsUrl,
+        'turns:external-media91.public.wjfkm-a-10.prod.infra.webex.com:443?transport=tcp'
+      );
     });
 
     it('show fail if stunUrl is not a valid url', () => {


### PR DESCRIPTION
# COMPLETES [WEBEX-384657](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-384657)

## This pull request addresses

Currently, we are doing only reachability checks for UDP and TCP.

## by making the following changes

This PR introduces a reachability check also for TurnTLS. It will allow checking before the call if client is capable of reaching to our turn servers. TurnTLS will be marked as experimental.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Tested with the JS SDK Sample app.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
