### PR TITLE
fix(calling): wdm deregister method

### DIFF
--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -456,12 +456,13 @@ function holdResume() {
   }
 }
 
-function deleteDevice() {
+async function deleteDevice() {
   line.deregister();
   line.on('unregistered', () => {
     console.log("unregistered success");
     registrationStatusElm.innerText = 'Unregistered';
-  })
+  });
+  await calling.deregister();
   registerElm.disabled = false;
   unregisterElm.disabled = true;
 }

--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -457,14 +457,10 @@ function holdResume() {
 }
 
 async function deleteDevice() {
-  line.deregister();
-  line.on('unregistered', () => {
-    console.log("unregistered success");
-    registrationStatusElm.innerText = 'Unregistered';
-  });
   await calling.deregister();
   registerElm.disabled = false;
   unregisterElm.disabled = true;
+  registrationStatusElm.innerText = "Unregistered";
 }
 
 function populateSourceDevices(mediaDevice) {

--- a/packages/webex/src/calling.js
+++ b/packages/webex/src/calling.js
@@ -85,7 +85,7 @@ class Calling extends EventEmitter {
     for (const lineId of lineIds) {
       const line = lines[lineId];
       if (line.getStatus() === 'active') {
-        const thisLinePromise = new Promise((resolve, reject) => {
+        const thisLinePromise = new Promise((resolve) => {
           line.deregister();
           line.on('unregistered', () => {
             this.log.info(
@@ -94,9 +94,6 @@ class Calling extends EventEmitter {
             );
             resolve();
           });
-          setTimeout(() => {
-            reject();
-          }, 30000);
         });
         promises.push(
           thisLinePromise.catch(() => {

--- a/packages/webex/src/calling.js
+++ b/packages/webex/src/calling.js
@@ -77,33 +77,17 @@ class Calling extends EventEmitter {
       return Promise.resolve();
     }
 
-    const promises = [];
-
     const lineIds = Object.keys(this.callingClient?.getLines());
 
     const lines = lineIds.length ? this.callingClient.getLines() : {};
     for (const lineId of lineIds) {
       const line = lines[lineId];
       if (line.getStatus() === 'active') {
-        const thisLinePromise = new Promise((resolve) => {
-          line.deregister();
-          line.on('unregistered', () => {
-            this.log.info(
-              `line.deregister() successful for the line with ID: ${lineId}`,
-              logContext
-            );
-            resolve();
-          });
-        });
-        promises.push(
-          thisLinePromise.catch(() => {
-            this.log.warn(`Timeout during line.deregister() for ${line}`, logContext);
-          })
-        );
+        line.deregister();
       }
     }
 
-    promises.push(
+    return (
       // @ts-ignore
       this.webex.internal.mercury
         .disconnect()
@@ -124,8 +108,6 @@ class Calling extends EventEmitter {
           );
         })
     );
-
-    return Promise.all(promises);
   }
 
   async initializeClients() {

--- a/packages/webex/src/calling.js
+++ b/packages/webex/src/calling.js
@@ -72,7 +72,7 @@ class Calling extends EventEmitter {
 
   async deregister() {
     if (!this.registered) {
-      this.log.info('Authentication: deregister already done', logContext);
+      this.log.info('Authentication: webex.internal.device.deregister already done', logContext);
 
       return Promise.resolve();
     }
@@ -82,13 +82,20 @@ class Calling extends EventEmitter {
       this.webex.internal.mercury
         .disconnect()
         // @ts-ignore
-        .then(() => this.webex.internal.device.unregister())
         .then(() => {
-          this.log.info('Authentication: deregister successful', logContext);
+          this.log.info('Authentication: webex.internal.mercury.disconnect successful', logContext);
+
+          return this.webex.internal.device.unregister();
+        })
+        .then(() => {
+          this.log.info('Authentication: webex.internal.device.deregister successful', logContext);
           this.registered = false;
         })
         .catch((error) => {
-          this.log.warn(`Error occurred during device.deregister() ${error}`, logContext);
+          this.log.warn(
+            `Error occurred during mercury.disconnect() or device.deregister() ${error}`,
+            logContext
+          );
         })
     );
   }

--- a/packages/webex/src/calling.js
+++ b/packages/webex/src/calling.js
@@ -78,11 +78,9 @@ class Calling extends EventEmitter {
       return Promise.resolve();
     }
 
-    const lineIds = Object.keys(this.callingClient?.getLines());
+    const lines = Object.values(this.callingClient?.getLines());
 
-    const lines = lineIds.length ? this.callingClient.getLines() : {};
-    for (const lineId of lineIds) {
-      const line = lines[lineId];
+    for (const line of lines) {
       if (line.getStatus() === 'active') {
         line.deregister();
       }


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-509669](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-509669)

## This pull request addresses

2 device registrations occur in the Calling SDK.

- `calling.register` which calls the `internal.device.register` from `webex/calling.js`
- `line.register` which does the Mobius line registration

While we have the above two methods for deregistering, we do not have a deregister method only for `line` and not for `calling` which does the WDM device deletion operation

## by making the following changes

- This PR introduces that method in `webex/calling.js` - The Calling class such that, users can do this deregister upon successful deregistering of line
- Or, they can call `calling.deregister()` method alone which will deregister all the active lines, disconnect mercury and delete WDM device as well

## Recording
In the below recordings, you can see that the WDM device and Mercury registration doesn't happen before this change and they happen in the after-change screen recording,

### Before:

https://github.com/webex/webex-js-sdk/assets/8044050/e7d7bb7a-c03f-4eac-8256-637a4f123419

### After: 

#### calling.deregister cleans up active lines automatically and deletes the WDM registration

https://github.com/webex/webex-js-sdk/assets/8044050/b0af4d86-cac5-4a56-b9ae-6d6e84b8437b 

#### calling.deregister just deletes the WDM registration

https://github.com/webex/webex-js-sdk/assets/8044050/2eb4af9f-e965-42b8-a7c6-5a0889e25da1

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- Tested if the device registers and deregisters
- Tried registering and deregistering several times to see if the "User has excessive device registrations" error pops up and it doesn't now

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
