### PR TITLE
fix(plugin-meetings): Mute issue with host and "mute all" action

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
@@ -428,6 +428,11 @@ SelfUtils.mutedByOthersChanged = (oldSelf, changedSelf) => {
     return false;
   }
 
+  // there is no need to trigger user update if no one muted user
+  if (changedSelf.selfIdentity === changedSelf.modifiedBy) {
+    return false;
+  }
+
   return (
     changedSelf.remoteMuted !== null &&
     (oldSelf.remoteMuted !== changedSelf.remoteMuted ||

--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -256,9 +256,6 @@ export class MuteState {
 
         // need to check if a new sync is required, because this.state.client may have changed while we were doing the current sync
         this.applyClientStateToServer(meeting);
-
-        // need to update the user's mute state to align it in case the last server sync was unmuted, and it mutes the client.
-        meeting.mediaProperties.audioStream?.setUserMuted(this.state.client.localMute);
       })
       .catch((e) => {
         this.state.syncToServerInProgress = false;

--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -256,6 +256,9 @@ export class MuteState {
 
         // need to check if a new sync is required, because this.state.client may have changed while we were doing the current sync
         this.applyClientStateToServer(meeting);
+
+        // need to update the user's mute state to align it in case the last server sync was unmuted, and it mutes the client.
+        meeting.mediaProperties.audioStream?.setUserMuted(this.state.client.localMute);
       })
       .catch((e) => {
         this.state.syncToServerInProgress = false;

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
@@ -344,6 +344,41 @@ describe('plugin-meetings', () => {
     });
   });
 
+  describe('mutedByOthersChanged', () => {
+    it('throws an error if changedSelf is not provided', function() {
+      assert.throws(() => SelfUtils.mutedByOthersChanged({}, null), 'New self must be defined to determine if self was muted by others.');
+    });
+
+    it('return false when oldSelf is not defined', function() {
+      assert.equal(SelfUtils.mutedByOthersChanged(null, { remoteMuted: false }), false);
+    });
+
+    it('should return true when remoteMuted is true on entry', function() {
+      assert.equal(SelfUtils.mutedByOthersChanged(null, { remoteMuted: true }), true);
+    });
+
+    it('should return false when selfIdentity and modifiedBy are the same', function() {
+      assert.equal(SelfUtils.mutedByOthersChanged(
+        { remoteMuted: false },
+        { remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user1' }
+      ), false);
+    });
+
+    it('should return true when remoteMuted values are different', function() {
+      assert.equal(SelfUtils.mutedByOthersChanged(
+        { remoteMuted: false },
+        { remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user2' }
+      ), true);
+    });
+
+    it('should return true when remoteMuted is true and unmuteAllowed has changed', function() {
+      assert.equal(SelfUtils.mutedByOthersChanged(
+        { remoteMuted: true, unmuteAllowed: false },
+        { remoteMuted: true, unmuteAllowed: true, selfIdentity: 'user1', modifiedBy: 'user2' }
+      ), true);
+    });
+  });
+
   describe('videoMutedByOthersChanged', () => {
     it('returns true if changed', () => {
       assert.equal(


### PR DESCRIPTION
# COMPLETES # [WEBEX-382445](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-382445)

## This pull request addresses

The issue arises from `mutedByOthersChanged` in `selfUtils`. This function should not trigger a user mute update when the user receives a notification from the server that the server has been updated remotely to a muted state but not from another person. 

## by making the following changes

I have added the fix to `mutedByOthersChanged` that will avoid updating the mute state when the server state doesn't change by others and added testcases for `selfUtils.mutedByOthersChanged`

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- [x] automated tests for plugin-meetings
- [x] manually tested with client app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
