### PR TITLE
fix(plugin-meetings): revert peripherals MQE back to array

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1249,6 +1249,12 @@ export const AVAILABLE_RESOLUTIONS = {
 
 export const MQA_INTERVAL = 60000; // mqa analyzer interval its fixed to 60000
 
+export const MEDIA_DEVICES = {
+  MICROPHONE: 'microphone',
+  SPEAKER: 'speaker',
+  CAMERA: 'camera',
+};
+
 export const PSTN_STATUS = {
   JOINED: 'JOINED', // we have provisioned a pstn device, which can be used to connect
   CONNECTED: 'CONNECTED', // user is connected to audio with pstn device

--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -1,19 +1,9 @@
-import {_UNKNOWN_} from '../constants';
-
 export const emptyMqaInterval = {
   audioReceive: [],
   audioTransmit: [],
   intervalMetadata: {
     peerReflexiveIP: '0.0.0.0',
-    speakerInfo: {
-      deviceName: _UNKNOWN_,
-    },
-    microphoneInfo: {
-      deviceName: _UNKNOWN_,
-    },
-    cameraInfo: {
-      deviceName: _UNKNOWN_,
-    },
+    peripherals: [],
     processAverageCPU: 0,
     processMaximumCPU: 0,
     systemAverageCPU: 0,

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -4,7 +4,14 @@ import {cloneDeep, isEmpty} from 'lodash';
 import {ConnectionState} from '@webex/internal-media-core';
 
 import EventsScope from '../common/events/events-scope';
-import {DEFAULT_GET_STATS_FILTER, STATS, MQA_INTERVAL, NETWORK_TYPE, _UNKNOWN_} from '../constants';
+import {
+  DEFAULT_GET_STATS_FILTER,
+  STATS,
+  MQA_INTERVAL,
+  NETWORK_TYPE,
+  MEDIA_DEVICES,
+  _UNKNOWN_,
+} from '../constants';
 import {
   emptyAudioReceive,
   emptyAudioTransmit,
@@ -360,13 +367,12 @@ export class StatsAnalyzer extends EventsScope {
     newMqa.intervalMetadata.peerReflexiveIP = this.statsResults.connectionType.local.ipAddress;
 
     // Adding peripheral information
-    newMqa.intervalMetadata.speakerInfo = {
-      deviceName: _UNKNOWN_,
-    };
+    newMqa.intervalMetadata.peripherals.push({information: _UNKNOWN_, name: MEDIA_DEVICES.SPEAKER});
     if (this.statsResults['audio-send']) {
-      newMqa.intervalMetadata.microphoneInfo = {
-        deviceName: this.statsResults['audio-send'].trackLabel || _UNKNOWN_,
-      };
+      newMqa.intervalMetadata.peripherals.push({
+        information: this.statsResults['audio-send'].trackLabel || _UNKNOWN_,
+        name: MEDIA_DEVICES.MICROPHONE,
+      });
     }
 
     const existingVideoSender = Object.keys(this.statsResults).find((item) =>
@@ -374,9 +380,10 @@ export class StatsAnalyzer extends EventsScope {
     );
 
     if (existingVideoSender) {
-      newMqa.intervalMetadata.cameraInfo = {
-        deviceName: this.statsResults[existingVideoSender].trackLabel || _UNKNOWN_,
-      };
+      newMqa.intervalMetadata.peripherals.push({
+        information: this.statsResults[existingVideoSender].trackLabel || _UNKNOWN_,
+        name: MEDIA_DEVICES.CAMERA,
+      });
     }
 
     newMqa.networkType = this.statsResults.connectionType.local.networkType;

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -776,11 +776,13 @@ describe('plugin-meetings', () => {
         await progressTime();
 
         assert.strictEqual(
-          mqeData.intervalMetadata.microphoneInfo.deviceName,
+          mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.MICROPHONE)
+            .information,
           'fake-microphone'
         );
         assert.strictEqual(
-          mqeData.intervalMetadata.cameraInfo.deviceName,
+          mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.CAMERA)
+            .information,
           'fake-camera'
         );
       });
@@ -794,11 +796,13 @@ describe('plugin-meetings', () => {
         await progressTime();
 
         assert.strictEqual(
-          mqeData.intervalMetadata.microphoneInfo.deviceName,
+          mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.MICROPHONE)
+            .information,
           _UNKNOWN_
         );
         assert.strictEqual(
-          mqeData.intervalMetadata.cameraInfo.deviceName,
+          mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.CAMERA)
+            .information,
           _UNKNOWN_
         );
       });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-529781](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-529781)

Revert "feat(plugin-meetings): use [peripheralName]Info instead of peripherals in MQE (#3565)"

This reversion is necessary because the new MQE format was causing validation errors, since the MQA team has not actually adopted the new format yet (we've discussed with the MQA team to make sure such an issue won't happen again).

## by making the following changes

This reverts commit bd29ca809ca04e244e163fe81d99db10ee91e941.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Manually checked MQEs sent from the SDK sample app and verified that they are correct on OpenSearch.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
