### PR TITLE
fix(plugin-meetings): export-meetinginfoutil-as-class

### DIFF
--- a/packages/@webex/plugin-meetings/src/index.ts
+++ b/packages/@webex/plugin-meetings/src/index.ts
@@ -15,6 +15,8 @@ import {
   ReclaimHostNotSupportedError,
 } from './common/errors/reclaim-host-role-errors';
 import Meeting from './meeting';
+import MeetingInfoUtil from './meeting-info/utilv2';
+import JoinMeetingError from './common/errors/join-meeting';
 
 registerPlugin('meetings', Meetings, {
   config,
@@ -51,13 +53,13 @@ export default Meetings;
 export * as CONSTANTS from './constants';
 export * as REACTIONS from './reactions/reactions';
 export * as sdkAnnotationTypes from './annotation/annotation.types';
-export * as MeetingInfoUtil from './meeting-info/utilv2';
 export * as MeetingInfoV2 from './meeting-info/meeting-info-v2';
 export {type Reaction} from './reactions/reactions.type';
 
 export {
   CaptchaError,
   IntentToJoinError,
+  JoinMeetingError,
   PasswordError,
   PermissionError,
   ReclaimHostIsHostAlreadyError,
@@ -65,6 +67,7 @@ export {
   ReclaimHostNotSupportedError,
   ReclaimHostEmptyWrongKeyError,
   Meeting,
+  MeetingInfoUtil,
 };
 
 export {RemoteMedia} from './multistream/remoteMedia';


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-502998](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-502998)

## This pull request addresses

1. After [PR-3602](https://github.com/webex/webex-js-sdk/pull/3602) all imports were working fine except MeetingInfoUtil. Methods inside  MeetingInfoUtil were not accessible directly in web-client 
 What went wrong? Using `export * as MeetingInfoUtil from './meeting-info/utilv2';` exported everything under `MeetingInfoUtil` namespace. To utilize methods in MeetingInfoUtils we would have to do `MeetingInfoUtil.default` in web-client
 Fix - import the default export from 'meetingsInfoUtils.ts' and then export the class.

2. JoinMeetingError was not exported.

## by making the following changes

MeetingInfoUtil is accessible as before. JoinMeetingError is exported.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

-Locally linked these changes and ran tests in web-client.
<img width="1511" alt="Screenshot 2024-06-05 at 11 53 15 PM" src="https://github.com/webex/webex-js-sdk/assets/72344404/81c6a424-09a2-4014-b833-16d2c0377144">

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
