### PR TITLE
feat(fedramp):  only add domains if commercial

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1,5 +1,5 @@
 /* eslint no-shadow: ["error", { "allow": ["eventType"] }] */
-
+import {union} from 'lodash';
 import '@webex/internal-plugin-mercury';
 import '@webex/internal-plugin-conversation';
 import '@webex/internal-plugin-metrics';
@@ -1001,7 +1001,15 @@ export default class Meetings extends WebexPlugin {
   fetchUserPreferredWebexSite() {
     return this.request.getMeetingPreferences().then((res) => {
       if (res) {
-        this.preferredWebexSite = MeetingsUtil.parseDefaultSiteFromMeetingPreferences(res);
+        const preferredWebexSite = MeetingsUtil.parseDefaultSiteFromMeetingPreferences(res);
+        this.preferredWebexSite = preferredWebexSite;
+        // @ts-ignore
+        this.webex.internal.services._getCatalog().setAllowedDomains(
+          // @ts-ignore
+          union(this.webex.internal.services._getCatalog().getAllowedDomains(), [
+            preferredWebexSite,
+          ])
+        );
       }
 
       // fall back to getting the preferred site from the user information
@@ -1014,6 +1022,13 @@ export default class Meetings extends WebexPlugin {
               user?.userPreferences?.userPreferencesItems?.preferredWebExSite;
             if (preferredWebexSite) {
               this.preferredWebexSite = preferredWebexSite;
+              // @ts-ignore
+              this.webex.internal.services._getCatalog().setAllowedDomains(
+                // @ts-ignore
+                union(this.webex.internal.services._getCatalog().getAllowedDomains(), [
+                  preferredWebexSite,
+                ])
+              );
             } else {
               throw new Error('site not found');
             }

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1004,12 +1004,7 @@ export default class Meetings extends WebexPlugin {
         const preferredWebexSite = MeetingsUtil.parseDefaultSiteFromMeetingPreferences(res);
         this.preferredWebexSite = preferredWebexSite;
         // @ts-ignore
-        this.webex.internal.services._getCatalog().setAllowedDomains(
-          // @ts-ignore
-          union(this.webex.internal.services._getCatalog().getAllowedDomains(), [
-            preferredWebexSite,
-          ])
-        );
+        this.webex.internal.services._getCatalog().addAllowedDomains([preferredWebexSite]);
       }
 
       // fall back to getting the preferred site from the user information
@@ -1023,12 +1018,7 @@ export default class Meetings extends WebexPlugin {
             if (preferredWebexSite) {
               this.preferredWebexSite = preferredWebexSite;
               // @ts-ignore
-              this.webex.internal.services._getCatalog().setAllowedDomains(
-                // @ts-ignore
-                union(this.webex.internal.services._getCatalog().getAllowedDomains(), [
-                  preferredWebexSite,
-                ])
-              );
+              this.webex.internal.services._getCatalog().addAllowedDomains([preferredWebexSite]);
             } else {
               throw new Error('site not found');
             }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1953,10 +1953,6 @@ describe('plugin-meetings', () => {
         it('should not fail if UserPreferred info is not fetched ', async () => {
           setup();
 
-          Object.assign(webex.internal.services, {
-            getMeetingPreferences: sinon.stub().returns(Promise.resolve({})),
-          });
-
           await webex.meetings.fetchUserPreferredWebexSite().then(() => {
             assert.equal(webex.meetings.preferredWebexSite, '');
           });
@@ -2369,12 +2365,14 @@ describe('plugin-meetings', () => {
           sessionType: 'MAIN',
         };
         newLocus.self.state = 'JOINED';
-        newLocus.self.devices = [{
-          intent: {
-            reason: 'ON_HOLD_LOBBY',
-            type: 'WAIT',
-          }
-        }];
+        newLocus.self.devices = [
+          {
+            intent: {
+              reason: 'ON_HOLD_LOBBY',
+              type: 'WAIT',
+            },
+          },
+        ];
         LoggerProxy.logger.log = sinon.stub();
         const result = webex.meetings.isNeedHandleLocusDTO(meeting, newLocus);
         assert.equal(result, true);

--- a/packages/@webex/webex-core/src/config.js
+++ b/packages/@webex/webex-core/src/config.js
@@ -58,16 +58,7 @@ export default {
      *
      * @type {Array<string>}
      */
-    allowedDomains: [
-      'wbx2.com',
-      'ciscospark.com',
-      'webex.com',
-      'webexapis.com',
-      'broadcloudpbx.com',
-      'broadcloud.eu',
-      'broadcloud.com.au',
-      'broadcloudpbx.net',
-    ],
+    allowedDomains: [],
   },
   device: {
     preDiscoveryServices: {

--- a/packages/@webex/webex-core/src/lib/services/constants.js
+++ b/packages/@webex/webex-core/src/lib/services/constants.js
@@ -6,4 +6,15 @@ const SERVICE_CATALOGS_ENUM_TYPES = {
   NUMBER: 'SERVICE_CATALOGS_ENUM_TYPES_NUMBER',
 };
 
-export {SERVICE_CATALOGS_ENUM_TYPES, NAMESPACE, SERVICE_CATALOGS};
+const COMMERCIAL_ALLOWED_DOMAINS = [
+  'wbx2.com',
+  'ciscospark.com',
+  'webex.com',
+  'webexapis.com',
+  'broadcloudpbx.com',
+  'broadcloud.eu',
+  'broadcloud.com.au',
+  'broadcloudpbx.net',
+];
+
+export {SERVICE_CATALOGS_ENUM_TYPES, NAMESPACE, SERVICE_CATALOGS, COMMERCIAL_ALLOWED_DOMAINS};

--- a/packages/@webex/webex-core/src/lib/services/constants.js
+++ b/packages/@webex/webex-core/src/lib/services/constants.js
@@ -6,6 +6,7 @@ const SERVICE_CATALOGS_ENUM_TYPES = {
   NUMBER: 'SERVICE_CATALOGS_ENUM_TYPES_NUMBER',
 };
 
+// The default allowed domains that SDK can make requests to outside of service catalog
 const COMMERCIAL_ALLOWED_DOMAINS = [
   'wbx2.com',
   'ciscospark.com',

--- a/packages/@webex/webex-core/src/lib/services/service-catalog.js
+++ b/packages/@webex/webex-core/src/lib/services/service-catalog.js
@@ -2,6 +2,7 @@ import Url from 'url';
 
 import AmpState from 'ampersand-state';
 
+import {union} from 'lodash';
 import ServiceUrl from './service-url';
 
 /* eslint-disable no-underscore-dangle */
@@ -359,6 +360,15 @@ const ServiceCatalog = AmpState.extend({
    */
   setAllowedDomains(allowedDomains) {
     this.allowedDomains = [...allowedDomains];
+  },
+
+  /**
+   *
+   * @param {Array<string>} newAllowedDomains - new alllowed doamins to add to existing set of allowed domains
+   * @returns {void}
+   */
+  addAllowedDomains(newAllowedDomains) {
+    this.allowedDomains = union(this.allowedDomains, newAllowedDomains);
   },
 
   /**

--- a/packages/@webex/webex-core/src/lib/services/service-catalog.js
+++ b/packages/@webex/webex-core/src/lib/services/service-catalog.js
@@ -364,7 +364,7 @@ const ServiceCatalog = AmpState.extend({
 
   /**
    *
-   * @param {Array<string>} newAllowedDomains - new alllowed doamins to add to existing set of allowed domains
+   * @param {Array<string>} newAllowedDomains - new allowed domains to add to existing set of allowed domains
    * @returns {void}
    */
   addAllowedDomains(newAllowedDomains) {

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -928,7 +928,7 @@ const Services = WebexPlugin.extend({
     // Validate that the services configuration exists.
     if (services) {
       if (fedramp) {
-        services.discovery = {...fedRampServices, ...services.discovery};
+        services.discovery = fedRampServices;
       }
       // Check for discovery services.
       if (services.discovery) {

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -9,6 +9,7 @@ import ServiceCatalog from './service-catalog';
 import ServiceRegistry from './service-registry';
 import ServiceState from './service-state';
 import fedRampServices from './service-fed-ramp';
+import {COMMERCIAL_ALLOWED_DOMAINS} from './constants';
 
 const trailingSlashes = /(?:^\/)|(?:\/$)/;
 
@@ -18,16 +19,6 @@ export const DEFAULT_CLUSTER = 'urn:TEAM:us-east-2_a';
 export const DEFAULT_CLUSTER_SERVICE = 'identityLookup';
 
 // The default allowed domains that SDK can make requests to outside of service catalog
-const commercialAllowedDomains = [
-  'wbx2.com',
-  'ciscospark.com',
-  'webex.com',
-  'webexapis.com',
-  'broadcloudpbx.com',
-  'broadcloud.eu',
-  'broadcloud.com.au',
-  'broadcloudpbx.net',
-];
 
 const CLUSTER_SERVICE = process.env.WEBEX_CONVERSATION_CLUSTER_SERVICE || DEFAULT_CLUSTER_SERVICE;
 const DEFAULT_CLUSTER_IDENTIFIER =
@@ -955,7 +946,7 @@ const Services = WebexPlugin.extend({
 
       // if not fedramp, append on the commercialAllowedDomains
       if (!fedramp) {
-        services.allowedDomains = [...services.allowedDomains, ...commercialAllowedDomains];
+        services.allowedDomains = [...services.allowedDomains, ...COMMERCIAL_ALLOWED_DOMAINS];
       }
 
       // Check for allowed host domains.

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -2,6 +2,7 @@ import Url from 'url';
 
 import sha256 from 'crypto-js/sha256';
 
+import {union} from 'lodash';
 import WebexPlugin from '../webex-plugin';
 
 import METRICS from './metrics';
@@ -17,8 +18,6 @@ const trailingSlashes = /(?:^\/)|(?:\/$)/;
 export const DEFAULT_CLUSTER = 'urn:TEAM:us-east-2_a';
 // The default service name for convo (currently identityLookup due to some weird CSB issue)
 export const DEFAULT_CLUSTER_SERVICE = 'identityLookup';
-
-// The default allowed domains that SDK can make requests to outside of service catalog
 
 const CLUSTER_SERVICE = process.env.WEBEX_CONVERSATION_CLUSTER_SERVICE || DEFAULT_CLUSTER_SERVICE;
 const DEFAULT_CLUSTER_IDENTIFIER =
@@ -946,7 +945,7 @@ const Services = WebexPlugin.extend({
 
       // if not fedramp, append on the commercialAllowedDomains
       if (!fedramp) {
-        services.allowedDomains = [...services.allowedDomains, ...COMMERCIAL_ALLOWED_DOMAINS];
+        services.allowedDomains = union(services.allowedDomains, COMMERCIAL_ALLOWED_DOMAINS);
       }
 
       // Check for allowed host domains.

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -17,6 +17,18 @@ export const DEFAULT_CLUSTER = 'urn:TEAM:us-east-2_a';
 // The default service name for convo (currently identityLookup due to some weird CSB issue)
 export const DEFAULT_CLUSTER_SERVICE = 'identityLookup';
 
+// The default allowed domains that SDK can make requests to outside of service catalog
+const commercialAllowedDomains = [
+  'wbx2.com',
+  'ciscospark.com',
+  'webex.com',
+  'webexapis.com',
+  'broadcloudpbx.com',
+  'broadcloud.eu',
+  'broadcloud.com.au',
+  'broadcloudpbx.net',
+];
+
 const CLUSTER_SERVICE = process.env.WEBEX_CONVERSATION_CLUSTER_SERVICE || DEFAULT_CLUSTER_SERVICE;
 const DEFAULT_CLUSTER_IDENTIFIER =
   process.env.WEBEX_CONVERSATION_DEFAULT_CLUSTER || `${DEFAULT_CLUSTER}:${CLUSTER_SERVICE}`;
@@ -916,7 +928,7 @@ const Services = WebexPlugin.extend({
     // Validate that the services configuration exists.
     if (services) {
       if (fedramp) {
-        services.discovery = fedRampServices;
+        services.discovery = {...fedRampServices, ...services.discovery};
       }
       // Check for discovery services.
       if (services.discovery) {
@@ -939,6 +951,11 @@ const Services = WebexPlugin.extend({
 
         // Inject formatted override services into services catalog.
         catalog.updateServiceUrls('override', formattedOverrideServices);
+      }
+
+      // if not fedramp, append on the commercialAllowedDomains
+      if (!fedramp) {
+        services.allowedDomains = [...services.allowedDomains, ...commercialAllowedDomains];
       }
 
       // Check for allowed host domains.

--- a/packages/@webex/webex-core/test/integration/spec/services/services.js
+++ b/packages/@webex/webex-core/test/integration/spec/services/services.js
@@ -11,6 +11,7 @@ import WebexCore, {
   ServiceRegistry,
   ServiceState,
   ServiceUrl,
+  serviceConstants,
 } from '@webex/webex-core';
 import testUsers from '@webex/test-helper-test-users';
 import uuid from 'uuid';
@@ -363,7 +364,9 @@ describe('webex-core', () => {
 
         services.initConfig();
 
-        assert.deepEqual(allowedDomains, services._getCatalog().allowedDomains);
+        const expectedResult = [...allowedDomains, ...serviceConstants.COMMERCIAL_ALLOWED_DOMAINS];
+
+        assert.deepEqual(expectedResult, services._getCatalog().allowedDomains);
       });
     });
 

--- a/packages/@webex/webex-core/test/unit/spec/interceptors/auth.js
+++ b/packages/@webex/webex-core/test/unit/spec/interceptors/auth.js
@@ -10,7 +10,14 @@ import sinon from 'sinon';
 import {browserOnly, nodeOnly} from '@webex/test-helper-mocha';
 import Logger from '@webex/plugin-logger';
 import MockWebex from '@webex/test-helper-mock-webex';
-import {AuthInterceptor, config, Credentials, WebexHttpError, Token} from '@webex/webex-core';
+import {
+  AuthInterceptor,
+  config,
+  Credentials,
+  WebexHttpError,
+  Token,
+  serviceConstants,
+} from '@webex/webex-core';
 import {cloneDeep, merge} from 'lodash';
 import Metrics from '@webex/internal-plugin-metrics';
 
@@ -122,7 +129,7 @@ describe('webex-core', () => {
               hasService: (service) => Object.keys(services).includes(service),
               hasAllowedDomains: () => true,
               isAllowedDomainUrl: (uri) =>
-                !!config.services.allowedDomains.find((host) => uri.includes(host)),
+                !!serviceConstants.COMMERCIAL_ALLOWED_DOMAINS.find((host) => uri.includes(host)),
               getServiceFromUrl: (uri) => {
                 let targetKey;
 
@@ -249,7 +256,7 @@ describe('webex-core', () => {
             hasService: (service) => Object.keys(services).includes(service),
             hasAllowedDomains: () => true,
             isAllowedDomainUrl: (uri) =>
-              !!config.services.allowedDomains.find((host) => uri.includes(host)),
+              !!serviceConstants.COMMERCIAL_ALLOWED_DOMAINS.find((host) => uri.includes(host)),
             validateDomains: true,
           };
 
@@ -323,7 +330,7 @@ describe('webex-core', () => {
         it('resolves to true with an allowed domain uri', () =>
           interceptor
             .requiresCredentials({
-              uri: `https://${config.services.allowedDomains[0]}/resource`,
+              uri: `https://${serviceConstants.COMMERCIAL_ALLOWED_DOMAINS[0]}/resource`,
             })
             .then((response) => assert.isTrue(response)));
 
@@ -339,7 +346,7 @@ describe('webex-core', () => {
           const {isAllowedDomainUrl} = webex.internal.services;
 
           const result = isAllowedDomainUrl(
-            `https://${config.services.allowedDomains[0]}/resource`
+            `https://${serviceConstants.COMMERCIAL_ALLOWED_DOMAINS[0]}/resource`
           );
 
           assert.equal(result, true);
@@ -350,7 +357,7 @@ describe('webex-core', () => {
 
           return interceptor
             .requiresCredentials({
-              uri: `https://${config.services.allowedDomains[0]}/resource`,
+              uri: `https://${serviceConstants.COMMERCIAL_ALLOWED_DOMAINS[0]}/resource`,
             })
             .then((res) => {
               assert.equal(res, true);
@@ -361,7 +368,9 @@ describe('webex-core', () => {
           webex.internal.services.waitForService = sinon.stub();
           const {waitForService} = webex.internal.services;
 
-          waitForService.resolves(`https://${config.services.allowedDomains[0]}/resource`);
+          waitForService.resolves(
+            `https://${serviceConstants.COMMERCIAL_ALLOWED_DOMAINS[0]}/resource`
+          );
 
           return interceptor
             .requiresCredentials({

--- a/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/service-catalog.js
@@ -101,11 +101,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push(
-          'example-a',
-          'example-b',
-          'example-c'
-        );
+        domains.push('example-a', 'example-b', 'example-c');
 
         catalog.setAllowedDomains(domains);
       });
@@ -125,11 +121,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push(
-          'example-a',
-          'example-b',
-          'example-c'
-        );
+        domains.push('example-a', 'example-b', 'example-c');
 
         catalog.setAllowedDomains(domains);
       });
@@ -168,11 +160,7 @@ describe('webex-core', () => {
       const domains = [];
 
       beforeEach(() => {
-        domains.push(
-          'example-a',
-          'example-b',
-          'example-c'
-        );
+        domains.push('example-a', 'example-b', 'example-c');
 
         catalog.setAllowedDomains(domains);
       });
@@ -187,6 +175,30 @@ describe('webex-core', () => {
         catalog.setAllowedDomains(newValues);
 
         assert.notDeepInclude(domains, newValues);
+      });
+    });
+
+    describe('#addAllowedDomains()', () => {
+      const domains = [];
+
+      beforeEach(() => {
+        domains.push('example-a', 'example-b', 'example-c');
+
+        catalog.setAllowedDomains(domains);
+      });
+
+      afterEach(() => {
+        domains.length = 0;
+      });
+
+      it('merge the allowed domain entries with new values', () => {
+        const newValues = ['example-c', 'example-e', 'example-f'];
+
+        catalog.addAllowedDomains(newValues);
+
+        const list = catalog.getAllowedDomains();
+
+        assert.match(['example-a', 'example-b', 'example-c', 'example-e', 'example-f'], list);
       });
     });
   });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-531900

## This pull request addresses

in fedramp, it's important that clients do not send auth token to resources outside of the "fedramp" boundary. therefore, we should only send auth headers in the following cases
1. the resource is in the u2c catalog
2. the resource is in the list of allowed domains

## by making the following changes
i changed the allowedDomains to be empty in FedRAMP by default. if the user wants more domains in fedramp, they can pass them through config or by `setAllowedDomains()`. in commercial, we keep the existing list of allowedDomains.
the reason webex.com cannot be a default allowedDomain in fedramp is because there are commercial sites, like cisco.webex.com and we don't want fedramp users sending their auth tokens to arbitrary commercial *.webex sites

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

1. manually tested with config value `fedramp: false`
2. manually tested with config value `fedramp: true`
3. ran web client automated playwright E2E tests with config value `fedramp: false`
4. ran web client automated playwright E2E tests with config value `fedramp: true`
5. in commercial make request to cisco.webex.com (request added auth headers since within `*.webex` allowed domains
6. in commercial make request to cisco.webex.com (SDK does not add auth header) since it's not within catalog/not allowed domain


### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
