### PR TITLE
fix(cart): add backward compatibility voicea data format

### DIFF
--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -148,6 +148,13 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
           isFinal: true,
           transcriptId: voiceaPayload.transcript_id,
           transcripts: voiceaPayload.transcripts,
+          translations: voiceaPayload.transcripts[0]?.translations,
+          transcript: {
+            csis: voiceaPayload.transcripts[0]?.csis,
+            text: voiceaPayload.transcripts[0]?.text,
+            transcriptLanguageCode: voiceaPayload.transcripts[0]?.transcript_language_code,
+          },
+          timestamp: millisToMinutesAndSeconds(voiceaPayload.transcripts[0]?.end_millis),
         });
         break;
 

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -654,6 +654,15 @@ describe('plugin-voicea', () => {
           isFinal: true,
           transcriptId: '3ec73890-bffb-f28b-e77f-99dc13caea7e',
           transcripts: voiceaPayload.transcripts,
+          translations: {
+            fr: 'Bonjour.'
+          },
+          transcript: {
+            csis: [3556942592],
+            text: 'Hello.',
+            transcriptLanguageCode: 'en',
+          },
+          timestamp: '0:13',
         });
       });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

We have two major customers (Davra, Instant Connect) who use the Closed Captions through the new V3 SDK already and are actively testing and migrating to the V3 SDK. They rely on these events and the payload format.

## by making the following changes

add backward compatibility voicea transcript data format

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
