### PR TITLE
fix: sending selectedCandidatePairChanges metric

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6812,7 +6812,8 @@ export default class Meeting extends StatelessWebexPlugin {
         await this.enqueueScreenShareFloorRequest();
       }
 
-      const connectionType = await this.mediaProperties.getCurrentConnectionType();
+      const {connectionType, selectedCandidatePairChanges, numTransports} =
+        await this.mediaProperties.getCurrentConnectionInfo();
       // @ts-ignore
       const reachabilityStats = await this.webex.meetings.reachability.getReachabilityMetrics();
 
@@ -6820,6 +6821,8 @@ export default class Meeting extends StatelessWebexPlugin {
         correlation_id: this.correlationId,
         locus_id: this.locusUrl.split('/').pop(),
         connectionType,
+        selectedCandidatePairChanges,
+        numTransports,
         isMultistream: this.isMultistream,
         retriedWithTurnServer: this.retriedWithTurnServer,
         isJoinWithMediaRetry: this.joinWithMediaRetryInfo.isRetry,
@@ -6844,12 +6847,17 @@ export default class Meeting extends StatelessWebexPlugin {
       // @ts-ignore
       const reachabilityMetrics = await this.webex.meetings.reachability.getReachabilityMetrics();
 
+      const {selectedCandidatePairChanges, numTransports} =
+        await this.mediaProperties.getCurrentConnectionInfo();
+
       Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_MEDIA_FAILURE, {
         correlation_id: this.correlationId,
         locus_id: this.locusUrl.split('/').pop(),
         reason: error.message,
         stack: error.stack,
         code: error.code,
+        selectedCandidatePairChanges,
+        numTransports,
         turnDiscoverySkippedReason: this.turnDiscoverySkippedReason,
         turnServerUsed: this.turnServerUsed,
         retriedWithTurnServer: this.retriedWithTurnServer,

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
@@ -54,189 +54,194 @@ describe('MediaProperties', () => {
     });
   });
 
-  describe('getCurrentConnectionType', () => {
-    it('calls waitForMediaConnectionConnected', async () => {
-      const spy = sinon.stub(mediaProperties, 'waitForMediaConnectionConnected');
-
-      await mediaProperties.getCurrentConnectionType();
-
-      assert.calledOnce(spy);
-    });
-    it('calls getStats() only after waitForMediaConnectionConnected resolves', async () => {
-      const waitForMediaConnectionConnectedResult = new Defer();
-
-      const waitForMediaConnectionConnectedStub = sinon
-        .stub(mediaProperties, 'waitForMediaConnectionConnected')
-        .returns(waitForMediaConnectionConnectedResult.promise);
-
-      const result = mediaProperties.getCurrentConnectionType();
-
-      await testUtils.flushPromises();
-
-      assert.called(waitForMediaConnectionConnectedStub);
-      assert.notCalled(mockMC.getStats);
-
-      waitForMediaConnectionConnectedResult.resolve();
-      await testUtils.flushPromises();
-
-      assert.called(mockMC.getStats);
-      await result;
-    });
-    it('rejects if waitForMediaConnectionConnected rejects', async () => {
-      const waitForMediaConnectionConnectedResult = new Defer();
-
-      const waitForMediaConnectionConnectedStub = sinon
-        .stub(mediaProperties, 'waitForMediaConnectionConnected')
-        .returns(waitForMediaConnectionConnectedResult.promise);
-
-      const result = mediaProperties.getCurrentConnectionType();
-
-      await testUtils.flushPromises();
-
-      assert.called(waitForMediaConnectionConnectedStub);
-
-      waitForMediaConnectionConnectedResult.reject(new Error('fake error'));
-      await testUtils.flushPromises();
-
-      assert.notCalled(mockMC.getStats);
-
-      await assert.isRejected(result);
-    });
-    it('returns "unknown" if getStats() fails', async () => {
+  describe('getCurrentConnectionInfo', () => {
+    it('handles the case when getStats() fails', async () => {
       mockMC.getStats.rejects(new Error());
 
-      const connectionType = await mediaProperties.getCurrentConnectionType();
+      const {connectionType, selectedCandidatePairChanges, numTransports} =
+        await mediaProperties.getCurrentConnectionInfo();
+
       assert.equal(connectionType, 'unknown');
+      assert.equal(selectedCandidatePairChanges, -1);
+      assert.equal(numTransports, 0);
     });
 
-    it('returns "unknown" if getStats() returns no candidate pairs', async () => {
-      mockMC.getStats.resolves([{type: 'something', id: '1234'}]);
+    describe('selectedCandidatePairChanges and numTransports', () => {
+      it('returns correct values when getStats() returns no transport stats at all', async () => {
+        mockMC.getStats.resolves([{type: 'something', id: '1234'}]);
 
-      const connectionType = await mediaProperties.getCurrentConnectionType();
-      assert.equal(connectionType, 'unknown');
+        const {selectedCandidatePairChanges, numTransports} =
+          await mediaProperties.getCurrentConnectionInfo();
+
+        assert.equal(selectedCandidatePairChanges, -1);
+        assert.equal(numTransports, 0);
+      });
+
+      it('returns correct values when getStats() returns transport stats without selectedCandidatePairChanges', async () => {
+        mockMC.getStats.resolves([{type: 'transport', id: '1234'}]);
+
+        const {selectedCandidatePairChanges, numTransports} =
+          await mediaProperties.getCurrentConnectionInfo();
+
+        assert.equal(selectedCandidatePairChanges, -1);
+        assert.equal(numTransports, 1);
+      });
+
+      it('returns correct values when getStats() returns transport stats with selectedCandidatePairChanges', async () => {
+        mockMC.getStats.resolves([
+          {type: 'transport', id: '1234', selectedCandidatePairChanges: 13},
+        ]);
+
+        const {selectedCandidatePairChanges, numTransports} =
+          await mediaProperties.getCurrentConnectionInfo();
+
+        assert.equal(selectedCandidatePairChanges, 13);
+        assert.equal(numTransports, 1);
+      });
+
+      it('returns correct values when getStats() returns multiple transport stats', async () => {
+        mockMC.getStats.resolves([
+          {type: 'transport', id: '1', selectedCandidatePairChanges: 11},
+          {type: 'transport', id: '2', selectedCandidatePairChanges: 12},
+        ]);
+
+        const {selectedCandidatePairChanges, numTransports} =
+          await mediaProperties.getCurrentConnectionInfo();
+
+        assert.equal(selectedCandidatePairChanges, 11); // we expect stats from the first transport to be returned
+        assert.equal(numTransports, 2);
+      });
     });
+    describe('connectionType', () => {
+      it('returns "unknown" if getStats() returns no candidate pairs', async () => {
+        mockMC.getStats.resolves([{type: 'something', id: '1234'}]);
 
-    it('returns "unknown" if getStats() returns no successful candidate pair', async () => {
-      mockMC.getStats.resolves([{type: 'candidate-pair', id: '1234', state: 'inprogress'}]);
+        const {connectionType} = await mediaProperties.getCurrentConnectionInfo();
+        assert.equal(connectionType, 'unknown');
+      });
 
-      const connectionType = await mediaProperties.getCurrentConnectionType();
-      assert.equal(connectionType, 'unknown');
-    });
+      it('returns "unknown" if getStats() returns no successful candidate pair', async () => {
+        mockMC.getStats.resolves([{type: 'candidate-pair', id: '1234', state: 'inprogress'}]);
 
-    it('returns "unknown" if getStats() returns a successful candidate pair but local candidate is missing', async () => {
-      mockMC.getStats.resolves([
-        {type: 'candidate-pair', id: '1234', state: 'succeeded', localCandidateId: 'wrong id'},
-      ]);
+        const {connectionType} = await mediaProperties.getCurrentConnectionInfo();
+        assert.equal(connectionType, 'unknown');
+      });
 
-      const connectionType = await mediaProperties.getCurrentConnectionType();
-      assert.equal(connectionType, 'unknown');
-    });
+      it('returns "unknown" if getStats() returns a successful candidate pair but local candidate is missing', async () => {
+        mockMC.getStats.resolves([
+          {type: 'candidate-pair', id: '1234', state: 'succeeded', localCandidateId: 'wrong id'},
+        ]);
 
-    it('returns "UDP" if getStats() returns a successful candidate pair with udp local candidate', async () => {
-      mockMC.getStats.resolves([
-        {
-          type: 'candidate-pair',
-          id: 'some candidate pair id',
-          state: 'succeeded',
-          localCandidateId: 'local candidate id',
-        },
-        {type: 'local-candidate', id: 'some other candidate id', protocol: 'tcp'},
-        {type: 'local-candidate', id: 'local candidate id', protocol: 'udp'},
-      ]);
+        const {connectionType} = await mediaProperties.getCurrentConnectionInfo();
+        assert.equal(connectionType, 'unknown');
+      });
 
-      const connectionType = await mediaProperties.getCurrentConnectionType();
-      assert.equal(connectionType, 'UDP');
-    });
-
-    it('returns "TCP" if getStats() returns a successful candidate pair with tcp local candidate', async () => {
-      mockMC.getStats.resolves([
-        {
-          type: 'candidate-pair',
-          id: 'some candidate pair id',
-          state: 'succeeded',
-          localCandidateId: 'some candidate id',
-        },
-        {type: 'local-candidate', id: 'some other candidate id', protocol: 'udp'},
-        {type: 'local-candidate', id: 'some candidate id', protocol: 'tcp'},
-      ]);
-
-      const connectionType = await mediaProperties.getCurrentConnectionType();
-      assert.equal(connectionType, 'TCP');
-    });
-
-    [
-      {relayProtocol: 'tls', expectedConnectionType: 'TURN-TLS'},
-      {relayProtocol: 'tcp', expectedConnectionType: 'TURN-TCP'},
-      {relayProtocol: 'udp', expectedConnectionType: 'TURN-UDP'},
-    ].forEach(({relayProtocol, expectedConnectionType}) =>
-      it(`returns "${expectedConnectionType}" if getStats() returns a successful candidate pair with a local candidate with relayProtocol=${relayProtocol}`, async () => {
+      it('returns "UDP" if getStats() returns a successful candidate pair with udp local candidate', async () => {
         mockMC.getStats.resolves([
           {
             type: 'candidate-pair',
             id: 'some candidate pair id',
             state: 'succeeded',
-            localCandidateId: 'selected candidate id',
+            localCandidateId: 'local candidate id',
+          },
+          {type: 'local-candidate', id: 'some other candidate id', protocol: 'tcp'},
+          {type: 'local-candidate', id: 'local candidate id', protocol: 'udp'},
+        ]);
+
+        const {connectionType} = await mediaProperties.getCurrentConnectionInfo();
+        assert.equal(connectionType, 'UDP');
+      });
+
+      it('returns "TCP" if getStats() returns a successful candidate pair with tcp local candidate', async () => {
+        mockMC.getStats.resolves([
+          {
+            type: 'candidate-pair',
+            id: 'some candidate pair id',
+            state: 'succeeded',
+            localCandidateId: 'some candidate id',
+          },
+          {type: 'local-candidate', id: 'some other candidate id', protocol: 'udp'},
+          {type: 'local-candidate', id: 'some candidate id', protocol: 'tcp'},
+        ]);
+
+        const {connectionType} = await mediaProperties.getCurrentConnectionInfo();
+        assert.equal(connectionType, 'TCP');
+      });
+
+      [
+        {relayProtocol: 'tls', expectedConnectionType: 'TURN-TLS'},
+        {relayProtocol: 'tcp', expectedConnectionType: 'TURN-TCP'},
+        {relayProtocol: 'udp', expectedConnectionType: 'TURN-UDP'},
+      ].forEach(({relayProtocol, expectedConnectionType}) =>
+        it(`returns "${expectedConnectionType}" if getStats() returns a successful candidate pair with a local candidate with relayProtocol=${relayProtocol}`, async () => {
+          mockMC.getStats.resolves([
+            {
+              type: 'candidate-pair',
+              id: 'some candidate pair id',
+              state: 'succeeded',
+              localCandidateId: 'selected candidate id',
+            },
+            {
+              type: 'candidate-pair',
+              id: 'some other candidate pair id',
+              state: 'failed',
+              localCandidateId: 'some other candidate id 1',
+            },
+            {type: 'local-candidate', id: 'some other candidate id 1', protocol: 'udp'},
+            {type: 'local-candidate', id: 'some other candidate id 2', protocol: 'tcp'},
+            {
+              type: 'local-candidate',
+              id: 'selected candidate id',
+              protocol: 'udp',
+              relayProtocol,
+            },
+          ]);
+
+          const {connectionType} = await mediaProperties.getCurrentConnectionInfo();
+          assert.equal(connectionType, expectedConnectionType);
+        })
+      );
+
+      it('returns connection type of the first successful candidate pair', async () => {
+        // in real life this will never happen and all active candidate pairs will have same transport,
+        // but here we're simulating a situation where they have different transports and just checking
+        // that the code still works and just returns the first one
+        mockMC.getStats.resolves([
+          {
+            type: 'inbound-rtp',
+            id: 'whatever',
+          },
+          {
+            type: 'candidate-pair',
+            id: 'some candidate pair id',
+            state: 'succeeded',
+            localCandidateId: '1st selected candidate id',
           },
           {
             type: 'candidate-pair',
             id: 'some other candidate pair id',
-            state: 'failed',
-            localCandidateId: 'some other candidate id 1',
+            state: 'succeeded',
+            localCandidateId: '2nd selected candidate id',
           },
           {type: 'local-candidate', id: 'some other candidate id 1', protocol: 'udp'},
           {type: 'local-candidate', id: 'some other candidate id 2', protocol: 'tcp'},
           {
             type: 'local-candidate',
-            id: 'selected candidate id',
+            id: '1st selected candidate id',
             protocol: 'udp',
-            relayProtocol,
+            relayProtocol: 'tls',
+          },
+          {
+            type: 'local-candidate',
+            id: '2nd selected candidate id',
+            protocol: 'udp',
+            relayProtocol: 'tcp',
           },
         ]);
 
-        const connectionType = await mediaProperties.getCurrentConnectionType();
-        assert.equal(connectionType, expectedConnectionType);
-      })
-    );
-
-    it('returns connection type of the first successful candidate pair', async () => {
-      // in real life this will never happen and all active candidate pairs will have same transport,
-      // but here we're simulating a situation where they have different transports and just checking
-      // that the code still works and just returns the first one
-      mockMC.getStats.resolves([
-        {
-          type: 'inbound-rtp',
-          id: 'whatever',
-        },
-        {
-          type: 'candidate-pair',
-          id: 'some candidate pair id',
-          state: 'succeeded',
-          localCandidateId: '1st selected candidate id',
-        },
-        {
-          type: 'candidate-pair',
-          id: 'some other candidate pair id',
-          state: 'succeeded',
-          localCandidateId: '2nd selected candidate id',
-        },
-        {type: 'local-candidate', id: 'some other candidate id 1', protocol: 'udp'},
-        {type: 'local-candidate', id: 'some other candidate id 2', protocol: 'tcp'},
-        {
-          type: 'local-candidate',
-          id: '1st selected candidate id',
-          protocol: 'udp',
-          relayProtocol: 'tls',
-        },
-        {
-          type: 'local-candidate',
-          id: '2nd selected candidate id',
-          protocol: 'udp',
-          relayProtocol: 'tcp',
-        },
-      ]);
-
-      const connectionType = await mediaProperties.getCurrentConnectionType();
-      assert.equal(connectionType, 'TURN-TLS');
+        const {connectionType} = await mediaProperties.getCurrentConnectionInfo();
+        assert.equal(connectionType, 'TURN-TLS');
+      });
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1649,7 +1649,7 @@ describe('plugin-meetings', () => {
           };
           meeting.mediaProperties.setMediaDirection = sinon.stub().returns(true);
           meeting.mediaProperties.waitForMediaConnectionConnected = sinon.stub().resolves();
-          meeting.mediaProperties.getCurrentConnectionType = sinon.stub().resolves('udp');
+          meeting.mediaProperties.getCurrentConnectionInfo = sinon.stub().resolves({connectionType: 'udp', selectedCandidatePairChanges: 2, numTransports: 1});
           meeting.audio = muteStateStub;
           meeting.video = muteStateStub;
           sinon.stub(Media, 'createMediaConnection').returns(fakeMediaConnection);
@@ -1755,6 +1755,8 @@ describe('plugin-meetings', () => {
               iceConnectionState: 'unknown',
               someReachabilityMetric1: 'some value1',
               someReachabilityMetric2: 'some value2',
+              selectedCandidatePairChanges: 2,
+              numTransports: 1,
             }
           );
         });
@@ -1860,6 +1862,8 @@ describe('plugin-meetings', () => {
               iceConnectionState: 'unknown',
               someReachabilityMetric1: 'some value1',
               someReachabilityMetric2: 'some value2',
+              selectedCandidatePairChanges: 2,
+              numTransports: 1,
             }
           );
         });
@@ -2337,6 +2341,8 @@ describe('plugin-meetings', () => {
               signalingState: 'unknown',
               connectionState: 'unknown',
               iceConnectionState: 'unknown',
+              selectedCandidatePairChanges: 2,
+              numTransports: 1,
             },
           ]);
 
@@ -2515,6 +2521,8 @@ describe('plugin-meetings', () => {
               correlation_id: meeting.correlationId,
               locus_id: meeting.locusUrl.split('/').pop(),
               connectionType: 'udp',
+              selectedCandidatePairChanges: 2,
+              numTransports: 1,
               isMultistream: false,
               retriedWithTurnServer: true,
               isJoinWithMediaRetry: false,
@@ -2658,6 +2666,8 @@ describe('plugin-meetings', () => {
               correlation_id: meeting.correlationId,
               locus_id: meeting.locusUrl.split('/').pop(),
               connectionType: 'udp',
+              selectedCandidatePairChanges: 2,
+              numTransports: 1,
               isMultistream: false,
               retriedWithTurnServer: false,
               isJoinWithMediaRetry: false,
@@ -2723,6 +2733,8 @@ describe('plugin-meetings', () => {
               signalingState: 'unknown',
               connectionState: 'unknown',
               iceConnectionState: 'unknown',
+              selectedCandidatePairChanges: 2,
+              numTransports: 1,
             }
           );
 
@@ -3141,7 +3153,7 @@ describe('plugin-meetings', () => {
             meeting.mediaId = 'fake media id';
             meeting.selfUrl = 'selfUrl';
             meeting.mediaProperties.waitForMediaConnectionConnected = sinon.stub().resolves();
-            meeting.mediaProperties.getCurrentConnectionType = sinon.stub().resolves('udp');
+            meeting.mediaProperties.getCurrentConnectionInfo = sinon.stub().resolves({connectionType: 'udp', selectedCandidatePairChanges: 2, numTransports: 1});
             meeting.setMercuryListener = sinon.stub();
             meeting.locusInfo.onFullLocus = sinon.stub();
             meeting.webex.meetings.geoHintInfo = {regionCode: 'EU', countryCode: 'UK'};


### PR DESCRIPTION
# COMPLETES #[SPARK-532530](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-532530)

## This pull request addresses

We have a suspicion that DTLS handshake failures are caused by Linus not handling correctly the switching of the selected ICE candidate pair.

## by making the following changes

Sending `selectedCandidatePairChanges` with the add media success and failure metrics so that we can prove that it's always greater than 1 when DTLS handshake fails and equal to 1 when we connect without issues.

Unfortunately, selectedCandidatePairChanges is not supported by Firefox and Safari, so we'll get these metrics only on Chrome and Edge.

Implementation details:
- I've renamed `getCurrentConnectionType()` to `getCurrentConnectionInfo()`, because now it returns more properties
- `getCurrentConnectionType()` used to wait for the connection to be established, I've removed that, because we need to call it now in failure cases when connection is not established and anyway the only place it was ever called from so far was from addMedia() which already calls `waitForMediaConnectionConnected()` before calling `getCurrentConnectionType()`, so the wait inside `getCurrentConnectionType()` was redundant. 
- we're only interested in `selectedCandidatePairChanges` but I'm also sending `numTransports`, because I want to be absolutely sure we send the correct value for `selectedCandidatePairChanges` and we never have more than 1 transport
 
### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

manually with locally linked web app + unit tests 

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
