### PR TITLE
fix: 2 reconnections started in parallel

### DIFF
--- a/packages/@webex/plugin-meetings/src/common/errors/reconnection-in-progress.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/reconnection-in-progress.ts
@@ -1,8 +1,0 @@
-/**
- *
- *
- * @export
- * @class ReconnectInProgress
- * @extends {Error}
- */
-export default class ReconnectInProgress extends Error {}

--- a/packages/@webex/plugin-meetings/src/common/errors/reconnection-not-started.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/reconnection-not-started.ts
@@ -2,7 +2,7 @@ import {ERROR_DICTIONARY} from '../../constants';
 import ReconnectionError from './reconnection';
 
 /**
- * Extended Error object to signify the intent to join for unclaimed PMR scenarios
+ * Error object for cases when new reconnection cannot be started
  */
 export default class ReconnectionNotStartedError extends ReconnectionError {
   /**

--- a/packages/@webex/plugin-meetings/src/common/errors/reconnection-not-started.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/reconnection-not-started.ts
@@ -1,0 +1,25 @@
+import {ERROR_DICTIONARY} from '../../constants';
+import ReconnectionError from './reconnection';
+
+/**
+ * Extended Error object to signify the intent to join for unclaimed PMR scenarios
+ */
+export default class ReconnectionNotStartedError extends ReconnectionError {
+  /**
+   *
+   * @constructor
+   * @param {String} [message]
+   * @param {Object} [error]
+   */
+  constructor(
+    message: string = ERROR_DICTIONARY.RECONNECTION_NOT_STARTED.MESSAGE,
+    error: any = null
+  ) {
+    super(message, error);
+    this.name = ERROR_DICTIONARY.RECONNECTION_NOT_STARTED.NAME;
+    this.sdkMessage = ERROR_DICTIONARY.RECONNECTION_NOT_STARTED.MESSAGE;
+    this.error = error;
+    this.stack = error ? error.stack : new Error().stack;
+    this.code = ERROR_DICTIONARY.RECONNECTION_NOT_STARTED.CODE;
+  }
+}

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -535,6 +535,12 @@ export const ERROR_DICTIONARY = {
       'Participant Having Host Role Already. Participant who sends request to reclaim host role has already a host role.',
     CODE: 14,
   },
+  RECONNECTION_NOT_STARTED: {
+    NAME: 'ReconnectionNotStartedError',
+    MESSAGE:
+      'Reconnection was not started, because there is one already in progress or reconnections are disabled in config.',
+    CODE: 15,
+  },
 };
 
 export const FLOOR_ACTION = {
@@ -1047,9 +1053,7 @@ export const PEER_CONNECTION_STATE = {
 export const RECONNECTION = {
   STATE: {
     IN_PROGRESS: 'IN_PROGRESS',
-    COMPLETE: 'COMPLETE',
     FAILURE: 'FAILURE',
-    DEFAULT_TRY_COUNT: 0,
     DEFAULT_STATUS: '',
   },
 } as const;

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -66,6 +66,7 @@ import {createMuteState} from './muteState';
 import LocusInfo from '../locus-info';
 import Metrics from '../metrics';
 import ReconnectionManager from '../reconnection-manager';
+import ReconnectionNotStartedError from '../common/errors/reconnection-not-started';
 import MeetingRequest from './request';
 import Members from '../members/index';
 import MeetingUtil from './util';
@@ -76,8 +77,6 @@ import MediaUtil from '../media/util';
 import {Reactions, SkinTones} from '../reactions/reactions';
 import PasswordError from '../common/errors/password-error';
 import CaptchaError from '../common/errors/captcha-error';
-import ReconnectionError from '../common/errors/reconnection';
-import ReconnectInProgress from '../common/errors/reconnection-in-progress';
 import {
   _CONVERSATION_URL_,
   _INCOMING_,
@@ -4664,90 +4663,28 @@ export default class Meeting extends StatelessWebexPlugin {
       );
     }
 
-    try {
-      LoggerProxy.logger.info('Meeting:index#reconnect --> Validating reconnect ability.');
-      // @ts-ignore
-      this.reconnectionManager.validate();
-    } catch (error) {
-      // Unable to reconnect this call
-      if (error instanceof ReconnectInProgress) {
-        LoggerProxy.logger.info(
-          'Meeting:index#reconnect --> Unable to reconnect, reconnection in progress.'
-        );
-      } else {
-        LoggerProxy.logger.log('Meeting:index#reconnect --> Unable to reconnect.', error);
-      }
-
-      return Promise.resolve();
-    }
-
-    Trigger.trigger(
-      this,
-      {
-        file: 'meeting/index',
-        function: 'reconnect',
-      },
-      EVENT_TRIGGERS.MEETING_RECONNECTION_STARTING
-    );
-
     return this.reconnectionManager
-      .reconnect(options)
-      .then(() => this.waitForRemoteSDPAnswer())
-      .then(() => this.waitForMediaConnectionConnected())
+      .reconnect(options, async () => {
+        await this.waitForRemoteSDPAnswer();
+        await this.waitForMediaConnectionConnected();
+      })
       .then(() => {
-        Trigger.trigger(
-          this,
-          {
-            file: 'meeting/index',
-            function: 'reconnect',
-          },
-          EVENT_TRIGGERS.MEETING_RECONNECTION_SUCCESS
-        );
         LoggerProxy.logger.log('Meeting:index#reconnect --> Meeting reconnect success');
-
-        // @ts-ignore
-        this.webex.internal.newMetrics.submitClientEvent({
-          name: 'client.media.recovered',
-          payload: {
-            recoveredBy: 'new',
-          },
-          options: {
-            meetingId: this.id,
-          },
-        });
-        this.reconnectionManager.setStatus(RECONNECTION.STATE.COMPLETE);
       })
       .catch((error) => {
-        Trigger.trigger(
-          this,
-          {
-            file: 'meeting/index',
-            function: 'reconnect',
-          },
-          EVENT_TRIGGERS.MEETING_RECONNECTION_FAILURE,
-          {
-            error: new ReconnectionError('Reconnection failure event', error),
-          }
-        );
+        if (error instanceof ReconnectionNotStartedError) {
+          LoggerProxy.logger.log('Meeting:index#reconnect --> Meeting reconnect not started');
 
+          return Promise.resolve();
+        }
         LoggerProxy.logger.error('Meeting:index#reconnect --> Meeting reconnect failed', error);
-
-        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_RECONNECT_FAILURE, {
-          correlation_id: this.correlationId,
-          locus_id: this.locusUrl.split('/').pop(),
-          reason: error.message,
-          stack: error.stack,
-        });
 
         this.uploadLogs({
           file: 'meeting/index',
           function: 'reconnect',
         });
 
-        return Promise.reject(new ReconnectionError('Reconnection failure event', error));
-      })
-      .finally(() => {
-        this.reconnectionManager.reset();
+        return Promise.reject(error);
       });
   }
 


### PR DESCRIPTION
# COMPLETES #[SPARK-531442](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-531442)

## This pull request addresses

When a reconnection is started, we first do reachability checks and if during that time we get a FAILED connection state notification, we end up starting another reconnection. We should only do 1 reconnection at a time.

## by making the following changes

Setting ReconnectionManager.status to IN_PROGRESS sooner and also refactored the code a bit so that the status is private and only ReconnectionManager changes it. Also moved sending of some metrics and emitting events from Meeting into ReconnectionManager so that now ReconnectionManager really is the one managing the reconnection.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
