### PR TITLE
fix(plugin-meetings): unpublish streams on moveTo

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5436,6 +5436,7 @@ export default class Meeting extends StatelessWebexPlugin {
         // when a move to is intiated by the client , Locus delets the existing media node from the server as soon the DX answers the meeting
         // once the DX answers we establish connection back the media server with only receiveShare enabled
         this.closePeerConnections();
+        this.unsetPeerConnections();
 
         await this.unpublishStreams([
           this.mediaProperties.audioStream,
@@ -5444,7 +5445,6 @@ export default class Meeting extends StatelessWebexPlugin {
           this.mediaProperties.shareVideoStream,
         ]);
 
-        this.unsetPeerConnections();
         await this.addMedia({
           audioEnabled: false,
           videoEnabled: false,

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5440,7 +5440,9 @@ export default class Meeting extends StatelessWebexPlugin {
 
         // when a move to is intiated by the client , Locus delets the existing media node from the server as soon the DX answers the meeting
         // once the DX answers we establish connection back the media server with only receiveShare enabled
-        await this.reconnectionManager.reconnectMedia().then(() => {
+        this.closePeerConnections();
+        this.unsetPeerConnections();
+        await this.createMediaConnection({}).then(() => {
           Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_SUCCESS);
         });
       } catch (error) {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5489,6 +5489,28 @@ export default class Meeting extends StatelessWebexPlugin {
           },
         };
 
+        const streamsToUnpublish = [];
+
+        if (this.mediaProperties?.audioStream) {
+          streamsToUnpublish.push(this.mediaProperties?.audioStream);
+        }
+
+        if (this.mediaProperties?.videoStream) {
+          streamsToUnpublish.push(this.mediaProperties?.videoStream);
+        }
+
+        if (this.mediaProperties?.shareAudioStream) {
+          streamsToUnpublish.push(this.mediaProperties?.shareAudioStream);
+        }
+
+        if (this.mediaProperties?.shareVideoStream) {
+          streamsToUnpublish.push(this.mediaProperties?.shareVideoStream);
+        }
+
+        if (streamsToUnpublish.length) {
+          this.unpublishStreams(streamsToUnpublish);
+        }
+
         this.cleanupLocalStreams();
 
         this.mediaProperties.setMediaDirection(mediaSettings.mediaDirection);
@@ -5496,10 +5518,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
         // when a move to is intiated by the client , Locus delets the existing media node from the server as soon the DX answers the meeting
         // once the DX answers we establish connection back the media server with only receiveShare enabled
-        // @ts-ignore - reconnectMedia does not accept any argument
-        await this.reconnectionManager.reconnectMedia(mediaSettings).then(() => {
-          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_SUCCESS);
-        });
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_SUCCESS);
       } catch (error) {
         LoggerProxy.logger.error('Meeting:index#moveTo --> Failed to moveTo resourceId', error);
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_FAILURE, {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5439,13 +5439,6 @@ export default class Meeting extends StatelessWebexPlugin {
         this.closePeerConnections();
         this.unsetPeerConnections();
 
-        await this.unpublishStreams([
-          this.mediaProperties.audioStream,
-          this.mediaProperties.videoStream,
-          this.mediaProperties.shareAudioStream,
-          this.mediaProperties.shareVideoStream,
-        ]);
-
         await this.addMedia({
           audioEnabled: false,
           videoEnabled: false,

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3986,7 +3986,7 @@ export default class Meeting extends StatelessWebexPlugin {
     // we don't update this.mediaProperties.mediaDirection.sendVideo, because we always keep it as true to avoid extra SDP exchanges
     this.mediaProperties.setLocalVideoStream(localStream);
 
-    this.video.handleLocalStreamChange(this);
+    this.video?.handleLocalStreamChange(this);
 
     localStream?.on(
       LocalStreamEventNames.UserMuteStateChange,
@@ -7037,7 +7037,7 @@ export default class Meeting extends StatelessWebexPlugin {
     if (videoEnabled !== undefined) {
       this.mediaProperties.mediaDirection.sendVideo = videoEnabled;
       this.mediaProperties.mediaDirection.receiveVideo = videoEnabled;
-      this.video.enable(this, videoEnabled);
+      this.video?.enable(this, videoEnabled);
       if (this.isMultistream) {
         this.sendSlotManager.setActive(MediaType.VideoMain, videoEnabled);
       }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1391,11 +1391,11 @@ export default class Meeting extends StatelessWebexPlugin {
     this.remoteMediaManager = null;
 
     this.localAudioStreamMuteStateHandler = () => {
-      this.audio.handleLocalStreamMuteStateChange(this);
+      this.audio?.handleLocalStreamMuteStateChange(this);
     };
 
     this.localVideoStreamMuteStateHandler = () => {
-      this.video.handleLocalStreamMuteStateChange(this);
+      this.video?.handleLocalStreamMuteStateChange(this);
     };
 
     // The handling of output track changes should be done inside
@@ -3944,7 +3944,7 @@ export default class Meeting extends StatelessWebexPlugin {
     // we don't update this.mediaProperties.mediaDirection.sendAudio, because we always keep it as true to avoid extra SDP exchanges
     this.mediaProperties.setLocalAudioStream(localStream);
 
-    this.audio.handleLocalStreamChange(this);
+    this.audio?.handleLocalStreamChange(this);
 
     localStream?.on(
       LocalStreamEventNames.UserMuteStateChange,
@@ -5428,13 +5428,6 @@ export default class Meeting extends StatelessWebexPlugin {
           },
         };
 
-        this.unpublishStreams([
-          this.mediaProperties.audioStream,
-          this.mediaProperties.videoStream,
-          this.mediaProperties.shareAudioStream,
-          this.mediaProperties.shareVideoStream,
-        ]);
-
         this.cleanupLocalStreams();
 
         this.mediaProperties.setMediaDirection(mediaSettings.mediaDirection);
@@ -5443,6 +5436,14 @@ export default class Meeting extends StatelessWebexPlugin {
         // when a move to is intiated by the client , Locus delets the existing media node from the server as soon the DX answers the meeting
         // once the DX answers we establish connection back the media server with only receiveShare enabled
         this.closePeerConnections();
+
+        await this.unpublishStreams([
+          this.mediaProperties.audioStream,
+          this.mediaProperties.videoStream,
+          this.mediaProperties.shareAudioStream,
+          this.mediaProperties.shareVideoStream,
+        ]);
+
         this.unsetPeerConnections();
         await this.addMedia({
           audioEnabled: false,
@@ -7027,7 +7028,7 @@ export default class Meeting extends StatelessWebexPlugin {
     if (audioEnabled !== undefined) {
       this.mediaProperties.mediaDirection.sendAudio = audioEnabled;
       this.mediaProperties.mediaDirection.receiveAudio = audioEnabled;
-      this.audio.enable(this, audioEnabled);
+      this.audio?.enable(this, audioEnabled);
       if (this.isMultistream) {
         this.sendSlotManager.setActive(MediaType.AudioMain, audioEnabled);
       }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5432,8 +5432,8 @@ export default class Meeting extends StatelessWebexPlugin {
         this.mediaProperties.setMediaDirection(mediaSettings.mediaDirection);
         this.mediaProperties.unsetRemoteMedia();
 
-        // when a move to is intiated by the client , Locus delets the existing media node from the server as soon the DX answers the meeting
-        // once the DX answers we close the old connection and create new media server connection with only share enabled
+        // when a move to is intiated by the client , Locus delets the existing media node from the server as soon the device answers the meeting
+        // once the device answers we close the old connection and create new media server connection with only share enabled
         if (this.statsAnalyzer) {
           await this.statsAnalyzer.stopAnalyzer();
         }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5468,6 +5468,8 @@ export default class Meeting extends StatelessWebexPlugin {
       resourceId
     );
 
+    // TODO: Check with locus if SELF_OBSERVING event would ever be not emitted
+    // If yes, introduce a timeout mechanism
     this.isMoveToInProgress = true;
 
     return MeetingUtil.joinMeetingOptions(this, {resourceId, moveToResource: true})

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5501,8 +5501,6 @@ export default class Meeting extends StatelessWebexPlugin {
         this.mediaProperties.setMediaDirection(mediaSettings.mediaDirection);
         this.mediaProperties.unsetRemoteMedia();
 
-        // when a move to is intiated by the client , Locus delets the existing media node from the server as soon the DX answers the meeting
-        // once the DX answers we establish connection back the media server with only receiveShare enabled
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_SUCCESS);
       } catch (error) {
         LoggerProxy.logger.error('Meeting:index#moveTo --> Failed to moveTo resourceId', error);

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5438,7 +5438,11 @@ export default class Meeting extends StatelessWebexPlugin {
         this.mediaProperties.setMediaDirection(mediaSettings.mediaDirection);
         this.mediaProperties.unsetRemoteMedia();
 
-        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_SUCCESS);
+        // when a move to is intiated by the client , Locus delets the existing media node from the server as soon the DX answers the meeting
+        // once the DX answers we establish connection back the media server with only receiveShare enabled
+        await this.reconnectionManager.reconnectMedia().then(() => {
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_SUCCESS);
+        });
       } catch (error) {
         LoggerProxy.logger.error('Meeting:index#moveTo --> Failed to moveTo resourceId', error);
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MOVE_TO_FAILURE, {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6526,6 +6526,11 @@ export default class Meeting extends StatelessWebexPlugin {
     const LOG_HEADER = 'Meeting:index#addMedia():establishMediaConnection -->';
     const isRetry = this.isMoveTo || this.retriedWithTurnServer;
 
+    // We are forcing turn discovery if the case is moveTo and a turn server was used already
+    if (this.isMoveTo && this.turnServerUsed) {
+      isForced = true;
+    }
+
     try {
       if (!turnServerInfo) {
         ({turnServerInfo} = await this.doTurnDiscovery(isRetry, isForced));

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5437,15 +5437,13 @@ export default class Meeting extends StatelessWebexPlugin {
         const stopStatsAnalyzer = this.statsAnalyzer
           ? this.statsAnalyzer.stopAnalyzer()
           : Promise.resolve();
-        await stopStatsAnalyzer
-          .then(() => this.closeRemoteStreams())
-          .then(() => this.closePeerConnections())
-          .then(() => {
-            this.cleanupLocalStreams();
-            this.unsetRemoteStreams();
-            this.unsetPeerConnections();
-            this.reconnectionManager.cleanUp();
-          });
+        await stopStatsAnalyzer;
+        await this.closeRemoteStreams();
+        await this.closePeerConnections();
+        this.cleanupLocalStreams();
+        this.unsetRemoteStreams();
+        this.unsetPeerConnections();
+        this.reconnectionManager.cleanUp();
 
         await this.addMedia({
           audioEnabled: false,

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5489,27 +5489,12 @@ export default class Meeting extends StatelessWebexPlugin {
           },
         };
 
-        const streamsToUnpublish = [];
-
-        if (this.mediaProperties?.audioStream) {
-          streamsToUnpublish.push(this.mediaProperties?.audioStream);
-        }
-
-        if (this.mediaProperties?.videoStream) {
-          streamsToUnpublish.push(this.mediaProperties?.videoStream);
-        }
-
-        if (this.mediaProperties?.shareAudioStream) {
-          streamsToUnpublish.push(this.mediaProperties?.shareAudioStream);
-        }
-
-        if (this.mediaProperties?.shareVideoStream) {
-          streamsToUnpublish.push(this.mediaProperties?.shareVideoStream);
-        }
-
-        if (streamsToUnpublish.length) {
-          this.unpublishStreams(streamsToUnpublish);
-        }
+        this.unpublishStreams([
+          this.mediaProperties.audioStream,
+          this.mediaProperties.videoStream,
+          this.mediaProperties.shareAudioStream,
+          this.mediaProperties.shareVideoStream,
+        ]);
 
         this.cleanupLocalStreams();
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6260,9 +6260,9 @@ describe('plugin-meetings', () => {
           // Verify that the event handler behaves as expected
           expect(meeting.statsAnalyzer.stopAnalyzer.calledOnce).to.be.true;
           expect(meeting.closeRemoteStreams.calledOnce).to.be.true;
-          await Promise.resolve();
+          await testUtils.flushPromises();
           expect(meeting.closePeerConnections.calledOnce).to.be.true;
-          await Promise.resolve();
+          await testUtils.flushPromises();
           expect(meeting.cleanupLocalStreams.calledOnce).to.be.true;
           expect(meeting.unsetRemoteStreams.calledOnce).to.be.true;
           expect(meeting.unsetPeerConnections.calledOnce).to.be.true;
@@ -6273,7 +6273,7 @@ describe('plugin-meetings', () => {
             videoEnabled: false,
             shareVideoEnabled: true
           })).to.be.true;
-          await Promise.resolve();
+          await testUtils.flushPromises();
           assert.equal(meeting.isMoveToInProgress, false);
         });
 
@@ -6282,6 +6282,7 @@ describe('plugin-meetings', () => {
           try {
             await meeting.moveTo('resourceId');
           } catch {
+            assert.equal(meeting.isMoveToInProgress, false);
             assert.calledOnce(Metrics.sendBehavioralMetric);
             assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.MOVE_TO_FAILURE, {
               correlation_id: meeting.correlationId,
@@ -6303,6 +6304,7 @@ describe('plugin-meetings', () => {
               'SELF_OBSERVING'
             );
           } catch {
+            assert.equal(meeting.isMoveToInProgress, false);
             assert.calledOnce(Metrics.sendBehavioralMetric);
             assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.MOVE_TO_FAILURE, {
               correlation_id: meeting.correlationId,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6169,6 +6169,10 @@ describe('plugin-meetings', () => {
           sandbox.stub(meeting, 'unpublishStreams');
 
           sandbox.stub(meeting.mediaProperties, 'setMediaDirection');
+          meeting.mediaProperties.audioStream = 'audioStream';
+          meeting.mediaProperties.videoStream = 'videoStream';
+          meeting.mediaProperties.shareAudioStream = 'shareAudioStream';
+          meeting.mediaProperties.shareVideoStream = 'shareVideoStream';
 
           sandbox.stub(meeting.reconnectionManager, 'reconnectMedia').returns(Promise.resolve());
           sandbox

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6246,7 +6246,7 @@ describe('plugin-meetings', () => {
         it('should cleanup on moveTo & addMedia after', async () => {
           await meeting.moveTo('resourceId');
 
-          assert.equal(meeting.isMoveTo, true);
+          assert.equal(meeting.isMoveToInProgress, true);
 
           await meeting.locusInfo.emitScoped(
             {
@@ -6273,6 +6273,8 @@ describe('plugin-meetings', () => {
             videoEnabled: false,
             shareVideoEnabled: true
           })).to.be.true;
+          await Promise.resolve();
+          assert.equal(meeting.isMoveToInProgress, false);
         });
 
         it('should throw an error if moveTo call fails', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6237,7 +6237,7 @@ describe('plugin-meetings', () => {
           });
         });
 
-        it('should unpublishStreams on moveTo', async () => {
+        it('should unpublishStreams on moveTo & reconnect after', async () => {
           await meeting.moveTo('resourceId');
 
           await meeting.locusInfo.emitScoped(
@@ -6262,6 +6262,7 @@ describe('plugin-meetings', () => {
           await Promise.resolve();
 
           assert.called(meeting.mediaProperties.setMediaDirection);
+          assert.called(meeting.reconnectionManager.reconnectMedia);
         });
 
         it('should throw an error if moveTo call fails', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6166,6 +6166,7 @@ describe('plugin-meetings', () => {
         beforeEach(() => {
           sandbox = sinon.createSandbox();
           sandbox.stub(meeting, 'cleanupLocalStreams');
+          sandbox.stub(meeting, 'unpublishStreams');
 
           sandbox.stub(meeting.mediaProperties, 'setMediaDirection');
 
@@ -6231,7 +6232,7 @@ describe('plugin-meetings', () => {
           });
         });
 
-        it('should reconnectMedia after DX joins after moveTo', async () => {
+        it('should unpublishStreams on moveTo', async () => {
           await meeting.moveTo('resourceId');
 
           await meeting.locusInfo.emitScoped(
@@ -6243,6 +6244,12 @@ describe('plugin-meetings', () => {
           );
 
           // beacuse we are calling callback so we need to wait
+          assert.calledWith(meeting.unpublishStreams,[
+            meeting.mediaProperties.audioStream,
+            meeting.mediaProperties.videoStream,
+            meeting.mediaProperties.shareAudioStream,
+            meeting.mediaProperties.shareVideoStream,
+          ]);
 
           assert.called(meeting.cleanupLocalStreams);
 
@@ -6250,17 +6257,6 @@ describe('plugin-meetings', () => {
           await Promise.resolve();
 
           assert.called(meeting.mediaProperties.setMediaDirection);
-
-          assert.calledWith(meeting.reconnectionManager.reconnectMedia, {
-            mediaDirection: {
-              sendVideo: false,
-              receiveVideo: false,
-              sendAudio: false,
-              receiveAudio: false,
-              sendShare: false,
-              receiveShare: true,
-            },
-          });
         });
 
         it('should throw an error if moveTo call fails', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6175,7 +6175,9 @@ describe('plugin-meetings', () => {
           meeting.mediaProperties.shareAudioStream = 'shareAudioStream';
           meeting.mediaProperties.shareVideoStream = 'shareVideoStream';
 
-          sandbox.stub(meeting.reconnectionManager, 'reconnectMedia').returns(Promise.resolve());
+          meeting.closePeerConnections = sinon.stub();
+          meeting.unsetPeerConnections = sinon.stub();
+          meeting.createMediaConnection = sinon.stub();
           sandbox
             .stub(MeetingUtil, 'joinMeeting')
             .returns(
@@ -6262,7 +6264,9 @@ describe('plugin-meetings', () => {
           await Promise.resolve();
 
           assert.called(meeting.mediaProperties.setMediaDirection);
-          assert.called(meeting.reconnectionManager.reconnectMedia);
+          assert.called(meeting.closePeerConnections);
+          assert.called(meeting.unsetPeerConnections);
+          assert.called(meeting.createMediaConnection);
         });
 
         it('should throw an error if moveTo call fails', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-533903](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-533903)

## This pull request addresses

Instant connected reported that, the `moveTo` API doesn't unpublish the localStreams. This is because the method `closeRemoteStreams` that was there before `cleanupLocalStreams` handled it appropriately and `cleanupLocalStreams` doesn't

## by making the following changes

- Added the cleanup logic in `moveTo` method that closes the existing media connection, cleans up remote and local streams and also stops statsAnalyzer from sending any data
- Removed reconnect logic as that is not required anymore
- Instead we do `addMedia` with a forced retry to do turn discovery (`isMoveToInProgress` flag ensures of that in the `establishMediaConnection` method)

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- Join a Meeting with Audio and Video > Pair to a device > `moveTo` - This ensured the Video and Audio gets cut off
- Join a Meeting with Audio and Video > Share Screen > Pair to a device > `moveTo` - This ensured the screenshare is properly cut off on `moveTo`

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
