### PR TITLE
fix(plugin-meetings): numberOfCores stats

### DIFF
--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -74,7 +74,7 @@
     "@webex/media-helpers": "workspace:*",
     "@webex/plugin-people": "workspace:*",
     "@webex/plugin-rooms": "workspace:*",
-    "@webex/web-capabilities": "1.3.0",
+    "@webex/web-capabilities": "^1.3.0",
     "@webex/webex-core": "workspace:*",
     "ampersand-collection": "^2.0.2",
     "bowser": "^2.11.0",

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -74,6 +74,7 @@
     "@webex/media-helpers": "workspace:*",
     "@webex/plugin-people": "workspace:*",
     "@webex/plugin-rooms": "workspace:*",
+    "@webex/web-capabilities": "1.3.0",
     "@webex/webex-core": "workspace:*",
     "ampersand-collection": "^2.0.2",
     "bowser": "^2.11.0",

--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -6,7 +6,7 @@ export const emptyMqaInterval = {
     peripherals: [],
     cpuInfo: {
       numberOfCores: 1, // default value from spec if CpuInfo.getNumLogicalCores cannot be determined
-      description: 'web client',
+      description: 'NA',
       architecture: 'unknown',
     },
     processAverageCPU: 0,

--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -4,6 +4,9 @@ export const emptyMqaInterval = {
   intervalMetadata: {
     peerReflexiveIP: '0.0.0.0',
     peripherals: [],
+    cpuInfo: {
+      numberOfCores: 0,
+    },
     processAverageCPU: 0,
     processMaximumCPU: 0,
     systemAverageCPU: 0,

--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -5,7 +5,9 @@ export const emptyMqaInterval = {
     peerReflexiveIP: '0.0.0.0',
     peripherals: [],
     cpuInfo: {
-      numberOfCores: 0,
+      numberOfCores: 1,
+      description: 'web client',
+      architecture: 'unknown',
     },
     processAverageCPU: 0,
     processMaximumCPU: 0,

--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -5,7 +5,7 @@ export const emptyMqaInterval = {
     peerReflexiveIP: '0.0.0.0',
     peripherals: [],
     cpuInfo: {
-      numberOfCores: 1, // default value from spec if web-caability cannot be determined
+      numberOfCores: 1, // default value from spec if CpuInfo.getNumLogicalCores cannot be determined
       description: 'web client',
       architecture: 'unknown',
     },

--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -5,7 +5,7 @@ export const emptyMqaInterval = {
     peerReflexiveIP: '0.0.0.0',
     peripherals: [],
     cpuInfo: {
-      numberOfCores: undefined,
+      numberOfCores: 1, // default value from spec if web-caability cannot be determined
       description: 'web client',
       architecture: 'unknown',
     },

--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -5,7 +5,7 @@ export const emptyMqaInterval = {
     peerReflexiveIP: '0.0.0.0',
     peripherals: [],
     cpuInfo: {
-      numberOfCores: 1,
+      numberOfCores: undefined,
       description: 'web client',
       architecture: 'unknown',
     },

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable prefer-destructuring */
-
 import {cloneDeep, isEmpty} from 'lodash';
+import {CpuInfo} from '@webex/web-capabilities';
 import {ConnectionState} from '@webex/internal-media-core';
-
 import EventsScope from '../common/events/events-scope';
 import {
   DEFAULT_GET_STATS_FILTER,
@@ -398,6 +396,7 @@ export class StatsAnalyzer extends EventsScope {
     });
 
     newMqa.intervalMetadata.peerReflexiveIP = this.statsResults.connectionType.local.ipAddress;
+    newMqa.intervalMetadata.cpuInfo.numberOfCores = CpuInfo.getNumLogicalCores();
 
     // Adding peripheral information
     newMqa.intervalMetadata.peripherals.push({information: _UNKNOWN_, name: MEDIA_DEVICES.SPEAKER});

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -396,7 +396,11 @@ export class StatsAnalyzer extends EventsScope {
     });
 
     newMqa.intervalMetadata.peerReflexiveIP = this.statsResults.connectionType.local.ipAddress;
-    newMqa.intervalMetadata.cpuInfo.numberOfCores = CpuInfo.getNumLogicalCores();
+
+    const numLogicalCores = CpuInfo.getNumLogicalCores();
+    if (numLogicalCores) {
+      newMqa.intervalMetadata.cpuInfo.numberOfCores = numLogicalCores;
+    }
 
     // Adding peripheral information
     newMqa.intervalMetadata.peripherals.push({information: _UNKNOWN_, name: MEDIA_DEVICES.SPEAKER});

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -397,10 +397,7 @@ export class StatsAnalyzer extends EventsScope {
 
     newMqa.intervalMetadata.peerReflexiveIP = this.statsResults.connectionType.local.ipAddress;
 
-    const numLogicalCores = CpuInfo.getNumLogicalCores();
-    if (numLogicalCores) {
-      newMqa.intervalMetadata.cpuInfo.numberOfCores = numLogicalCores;
-    }
+    newMqa.intervalMetadata.cpuInfo.numberOfCores = CpuInfo.getNumLogicalCores() || 1;
 
     // Adding peripheral information
     newMqa.intervalMetadata.peripherals.push({information: _UNKNOWN_, name: MEDIA_DEVICES.SPEAKER});

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -2119,9 +2119,6 @@ describe('plugin-meetings', () => {
         let getNumLogicalCoresStub;
 
         beforeEach(async () => {
-          if (getNumLogicalCoresStub) {
-            getNumLogicalCoresStub.restore();
-          }
           getNumLogicalCoresStub = sinon.stub(CpuInfo, 'getNumLogicalCores');
         });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -2119,7 +2119,6 @@ describe('plugin-meetings', () => {
         let getNumLogicalCoresStub;
 
         beforeEach(async () => {
-          // Ensure any previous stub is restored before creating a new one
           if (getNumLogicalCoresStub) {
             getNumLogicalCoresStub.restore();
           }
@@ -2127,7 +2126,6 @@ describe('plugin-meetings', () => {
         });
 
         afterEach(() => {
-          // Restore the stub to its original method after each test
           getNumLogicalCoresStub.restore();
         });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -2129,16 +2129,17 @@ describe('plugin-meetings', () => {
           getNumLogicalCoresStub.restore();
         });
 
-        it('reports undefined of logical CPU cores when not available', async () => {
+        it('reports 1 of logical CPU cores when not available', async () => {
           getNumLogicalCoresStub.returns(undefined);
-          await startStatsAnalyzer({expected: {receiveVideo: true}});
+          await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
+
           await progressTime();
-          assert.equal(mqeData.intervalMetadata.cpuInfo.numberOfCores, undefined);
+          assert.equal(mqeData.intervalMetadata.cpuInfo.numberOfCores, 1);
         });
 
         it('reports the number of logical CPU cores', async () => {
-          sinon.stub(CpuInfo, 'getNumLogicalCores').returns(12);
-          await startStatsAnalyzer({expected: {receiveVideo: true}});
+          getNumLogicalCoresStub.returns(12);
+          await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
           await progressTime();
           assert.equal(mqeData.intervalMetadata.cpuInfo.numberOfCores, 12);

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -2115,7 +2115,7 @@ describe('plugin-meetings', () => {
         });
       });
 
-      describe.only('CPU Information Reporting', async () => {
+      describe('CPU Information Reporting', async () => {
         let getNumLogicalCoresStub;
 
         beforeEach(async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -10,6 +10,7 @@ import testUtils from '../../../utils/testUtils';
 import {MEDIA_DEVICES, MQA_INTERVAL, _UNKNOWN_} from '@webex/plugin-meetings/src/constants';
 import LoggerProxy from '../../../../src/common/logs/logger-proxy';
 import LoggerConfig from '../../../../src/common/logs/logger-config';
+import {CpuInfo} from '@webex/web-capabilities';
 
 const {assert} = chai;
 
@@ -2113,6 +2114,14 @@ describe('plugin-meetings', () => {
           }
         });
       });
+
+      it('has correct cpu info about number of cores', async () => {
+        sinon.stub(CpuInfo, 'getNumLogicalCores').returns(12);
+        await startStatsAnalyzer({expected: {receiveVideo: true}});
+
+        await progressTime();
+        assert.equal(mqeData.intervalMetadata.cpuInfo.numberOfCores, 12);
+      })
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -2115,7 +2115,7 @@ describe('plugin-meetings', () => {
         });
       });
 
-      it('has correct cpu info about number of cores', async () => {
+      it('reports the number of logical CPU cores', async () => {
         sinon.stub(CpuInfo, 'getNumLogicalCores').returns(12);
         await startStatsAnalyzer({expected: {receiveVideo: true}});
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -2115,13 +2115,37 @@ describe('plugin-meetings', () => {
         });
       });
 
-      it('reports the number of logical CPU cores', async () => {
-        sinon.stub(CpuInfo, 'getNumLogicalCores').returns(12);
-        await startStatsAnalyzer({expected: {receiveVideo: true}});
+      describe.only('CPU Information Reporting', async () => {
+        let getNumLogicalCoresStub;
 
-        await progressTime();
-        assert.equal(mqeData.intervalMetadata.cpuInfo.numberOfCores, 12);
-      })
-    });
+        beforeEach(async () => {
+          // Ensure any previous stub is restored before creating a new one
+          if (getNumLogicalCoresStub) {
+            getNumLogicalCoresStub.restore();
+          }
+          getNumLogicalCoresStub = sinon.stub(CpuInfo, 'getNumLogicalCores');
+        });
+
+        afterEach(() => {
+          // Restore the stub to its original method after each test
+          getNumLogicalCoresStub.restore();
+        });
+
+        it('reports undefined of logical CPU cores when not available', async () => {
+          getNumLogicalCoresStub.returns(undefined);
+          await startStatsAnalyzer({expected: {receiveVideo: true}});
+          await progressTime();
+          assert.equal(mqeData.intervalMetadata.cpuInfo.numberOfCores, undefined);
+        });
+
+        it('reports the number of logical CPU cores', async () => {
+          sinon.stub(CpuInfo, 'getNumLogicalCores').returns(12);
+          await startStatsAnalyzer({expected: {receiveVideo: true}});
+
+          await progressTime();
+          assert.equal(mqeData.intervalMetadata.cpuInfo.numberOfCores, 12);
+        });
+      });
+    })
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8157,7 +8157,7 @@ __metadata:
     "@webex/test-helper-mock-webex": "workspace:*"
     "@webex/test-helper-retry": "workspace:*"
     "@webex/test-helper-test-users": "workspace:*"
-    "@webex/web-capabilities": 1.3.0
+    "@webex/web-capabilities": ^1.3.0
     "@webex/webex-core": "workspace:*"
     ampersand-collection: ^2.0.2
     bowser: ^2.11.0
@@ -8832,21 +8832,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/web-capabilities@npm:1.3.0, @webex/web-capabilities@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@webex/web-capabilities@npm:1.3.0"
-  dependencies:
-    bowser: ^2.11.0
-  checksum: 5e35c7d17cfd21762f86e16e2237d6e6c3a7b157e38f3a694ffa8e9003ada423fb85e2eca502dd7cf09560896e33007bbb244d87b04d4344152ab2049b60f812
-  languageName: node
-  linkType: hard
-
 "@webex/web-capabilities@npm:^1.1.0":
   version: 1.2.0
   resolution: "@webex/web-capabilities@npm:1.2.0"
   dependencies:
     bowser: "npm:^2.11.0"
   checksum: 69bf1521485c0a29f10edc85c06fee33a983f1363639e6662bd65389602f4e2ded8e37be6d3cf845bd6efef6712680fce7592e175d5e1e33291dc2769ac66c4c
+  languageName: node
+  linkType: hard
+
+"@webex/web-capabilities@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@webex/web-capabilities@npm:1.3.0"
+  dependencies:
+    bowser: ^2.11.0
+  checksum: 5e35c7d17cfd21762f86e16e2237d6e6c3a7b157e38f3a694ffa8e9003ada423fb85e2eca502dd7cf09560896e33007bbb244d87b04d4344152ab2049b60f812
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8157,6 +8157,7 @@ __metadata:
     "@webex/test-helper-mock-webex": "workspace:*"
     "@webex/test-helper-retry": "workspace:*"
     "@webex/test-helper-test-users": "workspace:*"
+    "@webex/web-capabilities": 1.3.0
     "@webex/webex-core": "workspace:*"
     ampersand-collection: ^2.0.2
     bowser: ^2.11.0
@@ -8831,21 +8832,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@webex/web-capabilities@npm:1.3.0, @webex/web-capabilities@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@webex/web-capabilities@npm:1.3.0"
+  dependencies:
+    bowser: ^2.11.0
+  checksum: 5e35c7d17cfd21762f86e16e2237d6e6c3a7b157e38f3a694ffa8e9003ada423fb85e2eca502dd7cf09560896e33007bbb244d87b04d4344152ab2049b60f812
+  languageName: node
+  linkType: hard
+
 "@webex/web-capabilities@npm:^1.1.0":
   version: 1.2.0
   resolution: "@webex/web-capabilities@npm:1.2.0"
   dependencies:
     bowser: "npm:^2.11.0"
   checksum: 69bf1521485c0a29f10edc85c06fee33a983f1363639e6662bd65389602f4e2ded8e37be6d3cf845bd6efef6712680fce7592e175d5e1e33291dc2769ac66c4c
-  languageName: node
-  linkType: hard
-
-"@webex/web-capabilities@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@webex/web-capabilities@npm:1.3.0"
-  dependencies:
-    bowser: ^2.11.0
-  checksum: 5e35c7d17cfd21762f86e16e2237d6e6c3a7b157e38f3a694ffa8e9003ada423fb85e2eca502dd7cf09560896e33007bbb244d87b04d4344152ab2049b60f812
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [WEBEX-379500](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-379500)

## This pull request addresses

Missing MQE stats `cpuInfo.numberOfCores` 

## by making the following changes

Adds `cpuInfo.numberOfCores` to MQE to expose the number of logical processors

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- [x] unit tests for plugin-meetings
- [x] manual testing via SDK test app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
