### PR TITLE
fix(plugin-meetings): update transcription for new voicea payload

### DIFF
--- a/packages/@webex/internal-plugin-voicea/src/index.ts
+++ b/packages/@webex/internal-plugin-voicea/src/index.ts
@@ -1,8 +1,10 @@
 import * as WebexCore from '@webex/webex-core';
 
 import VoiceaChannel from './voicea';
+import type {MeetingTranscriptPayload} from './voicea.types';
 
 WebexCore.registerInternalPlugin('voicea', VoiceaChannel, {});
 
 export {default} from './voicea';
+export {type MeetingTranscriptPayload};
 export {EVENT_TRIGGERS, TURN_ON_CAPTION_STATUS} from './constants';

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -147,7 +147,11 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
         this.trigger(EVENT_TRIGGERS.NEW_CAPTION, {
           isFinal: true,
           transcriptId: voiceaPayload.transcript_id,
-          transcripts: voiceaPayload.transcripts,
+          transcripts: voiceaPayload.transcripts.map((transcript) => {
+            transcript.timestamp = millisToMinutesAndSeconds(transcript.end_millis);
+
+            return transcript;
+          }),
         });
         break;
 

--- a/packages/@webex/internal-plugin-voicea/src/voicea.types.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.types.ts
@@ -84,6 +84,25 @@ interface IVoiceaChannel {
   deregisterEvents: () => void;
 }
 
+type MeetingTranscripts = {
+  start_mills?: number;
+  end_mills?: number;
+  text: string;
+  last_packet_timestamp_ms?: number;
+  csis: Array<number>;
+  transcript_language_code: string;
+  translations?: {
+    [key: string]: string;
+  };
+  timestamp?: string;
+};
+
+type MeetingTranscriptPayload = {
+  isFinal: boolean;
+  transcriptId: string;
+  transcripts: Array<MeetingTranscripts>;
+};
+
 export type {
   AnnouncementPayload,
   CaptionLanguageResponse,
@@ -91,4 +110,5 @@ export type {
   Transcription,
   Highlight,
   IVoiceaChannel,
+  MeetingTranscriptPayload,
 };

--- a/packages/@webex/internal-plugin-voicea/src/voicea.types.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.types.ts
@@ -36,6 +36,7 @@ interface Transcription {
   translations: {[x: string]: string};
   csis: number[];
   last_packet_timestamp_ms: number;
+  timestamp: string;
 }
 
 /**

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -618,6 +618,7 @@ describe('plugin-voicea', () => {
             start_millis: 12204,
             text: 'Hello?',
             transcript_language_code: 'en',
+            timestamp: '0:13'
           },
           transcripts: [
             {
@@ -629,6 +630,7 @@ describe('plugin-voicea', () => {
               translations: {
                 fr: 'Bonjour.',
               },
+              timestamp: '0:13'
             },
             {
               start_millis: 12204,
@@ -639,6 +641,7 @@ describe('plugin-voicea', () => {
               translations: {
                 fr: "C'est Webex",
               },
+              timestamp: '0:13'
             },
           ],
         };

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4757,12 +4757,12 @@ export default class Meeting extends StatelessWebexPlugin {
    * @throws TranscriptionNotSupportedError
    */
   isTranscriptionSupported() {
-    if (this.locusInfo.controls.transcribe?.transcribing) {
+    if (this.locusInfo.controls.transcribe?.caption) {
       return true;
     }
 
     LoggerProxy.logger.error(
-      'Meeting:index#isTranscriptionSupported --> Webex Assistant is not enabled/supported'
+      'Meeting:index#isTranscriptionSupported --> Closed Captions is not enabled/supported'
     );
 
     return false;

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -38,6 +38,7 @@ import {
 import {
   EVENT_TRIGGERS as VOICEAEVENTS,
   TURN_ON_CAPTION_STATUS,
+  type MeetingTranscriptPayload,
 } from '@webex/internal-plugin-voicea';
 import {processNewCaptions} from './voicea-meeting';
 
@@ -654,7 +655,7 @@ export default class Meeting extends StatelessWebexPlugin {
       this.transcription.isListening = !!data.isListening;
       this.transcription.commandText = data.text ?? '';
     },
-    [VOICEAEVENTS.NEW_CAPTION]: (data) => {
+    [VOICEAEVENTS.NEW_CAPTION]: (data: MeetingTranscriptPayload) => {
       processNewCaptions({data, meeting: this});
 
       LoggerProxy.logger.debug(

--- a/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
@@ -1,3 +1,22 @@
+type VoiceaTranscripts = {
+  start_mills?: number;
+  end_mills?: number;
+  text: string;
+  last_packet_timestamp_ms?: number;
+  csis: Array<number>;
+  transcript_language_code: string;
+  translations?: {
+    [key: string]: string;
+  };
+  timestamp?: string;
+};
+
+type VoiceaTranscriptPayload = {
+  isFinal: boolean;
+  transcriptId: string;
+  transcripts: Array<VoiceaTranscripts>;
+};
+
 export const getSpeaker = (members, csis = []) =>
   Object.values(members).find((member: any) => {
     const memberCSIs = member.participant.status.csis ?? [];
@@ -31,7 +50,13 @@ export const getSpeakerFromProxyOrStore = ({csisKey, meetingMembers, transcriptD
   return {speaker, needsCaching};
 };
 
-export const processNewCaptions = ({data, meeting}) => {
+export const processNewCaptions = ({
+  data,
+  meeting,
+}: {
+  data: VoiceaTranscriptPayload;
+  meeting: any;
+}) => {
   const {transcriptId} = data;
   const transcriptData = meeting.transcription;
 

--- a/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
@@ -47,7 +47,6 @@ export const processNewCaptions = ({data, meeting}) => {
 
     const newCaption = `${transcriptsPerCsis.get(csisMember)?.text ?? ''} ${text}`.trim();
 
-    // eslint-disable-next-line camelcase
     transcriptsPerCsis.set(csisMember, {
       ...transcript,
       text: newCaption,

--- a/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
@@ -1,21 +1,4 @@
-type VoiceaTranscripts = {
-  start_mills?: number;
-  end_mills?: number;
-  text: string;
-  last_packet_timestamp_ms?: number;
-  csis: Array<number>;
-  transcript_language_code: string;
-  translations?: {
-    [key: string]: string;
-  };
-  timestamp?: string;
-};
-
-type VoiceaTranscriptPayload = {
-  isFinal: boolean;
-  transcriptId: string;
-  transcripts: Array<VoiceaTranscripts>;
-};
+import {type MeetingTranscriptPayload} from '@webex/internal-plugin-voicea';
 
 export const getSpeaker = (members, csis = []) =>
   Object.values(members).find((member: any) => {
@@ -54,7 +37,7 @@ export const processNewCaptions = ({
   data,
   meeting,
 }: {
-  data: VoiceaTranscriptPayload;
+  data: MeetingTranscriptPayload;
   meeting: any;
 }) => {
   const {transcriptId} = data;

--- a/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
@@ -35,39 +35,6 @@ export const processNewCaptions = ({data, meeting}) => {
   const {transcriptId} = data;
   const transcriptData = meeting.transcription;
 
-  if (data.isFinal) {
-    transcriptData.interimCaptions[transcriptId].forEach((interimId) => {
-      const interimTranscriptIndex = transcriptData.captions.findIndex(
-        (transcript) => transcript.id === interimId
-      );
-
-      if (interimTranscriptIndex !== -1) {
-        transcriptData.captions.splice(interimTranscriptIndex, 1);
-      }
-    });
-    delete transcriptData.interimCaptions[transcriptId];
-    const csisKey = data.transcript?.csis[0];
-
-    const {needsCaching, speaker} = getSpeakerFromProxyOrStore({
-      meetingMembers: meeting.members.membersCollection.members,
-      transcriptData,
-      csisKey,
-    });
-
-    if (needsCaching) {
-      transcriptData.speakerProxy[csisKey] = speaker;
-    }
-    const captionData = {
-      id: transcriptId,
-      isFinal: data.isFinal,
-      translations: data.translations,
-      text: data.transcript?.text,
-      currentSpokenLanguage: data.transcript?.transcript_language_code,
-      timestamp: data.timestamp,
-      speaker,
-    };
-    transcriptData.captions.push(captionData);
-  }
   const {transcripts = []} = data;
   const transcriptsPerCsis = new Map();
 
@@ -81,7 +48,11 @@ export const processNewCaptions = ({data, meeting}) => {
     const newCaption = `${transcriptsPerCsis.get(csisMember)?.text ?? ''} ${text}`.trim();
 
     // eslint-disable-next-line camelcase
-    transcriptsPerCsis.set(csisMember, {text: newCaption, currentSpokenLanguage});
+    transcriptsPerCsis.set(csisMember, {
+      ...transcript,
+      text: newCaption,
+      currentSpokenLanguage,
+    });
   }
   const interimTranscriptionIds = [];
 
@@ -91,12 +62,13 @@ export const processNewCaptions = ({data, meeting}) => {
       transcriptData,
       csisKey: key,
     });
+    const {speakerId} = speaker;
+    const interimId = `${transcriptId}_${speakerId}`;
 
     if (needsCaching) {
       transcriptData.speakerProxy[key] = speaker;
     }
-    const {speakerId} = speaker;
-    const interimId = `${transcriptId}_${speakerId}`;
+
     const captionData = {
       id: interimId,
       isFinal: data.isFinal,
@@ -107,15 +79,28 @@ export const processNewCaptions = ({data, meeting}) => {
       speaker,
     };
 
-    const interimTranscriptIndex = transcriptData.captions.findIndex(
-      (transcript) => transcript.id === interimId
-    );
+    if (!data.isFinal) {
+      const interimTranscriptIndex = transcriptData.captions.findIndex(
+        (transcript) => transcript.id === interimId
+      );
 
-    if (interimTranscriptIndex !== -1) {
-      transcriptData.captions.splice(interimTranscriptIndex, 1);
+      if (interimTranscriptIndex !== -1) {
+        transcriptData.captions.splice(interimTranscriptIndex, 1);
+      }
+
+      interimTranscriptionIds.push(interimId);
+    } else {
+      transcriptData.interimCaptions[transcriptId].forEach((innerInterimId) => {
+        const interimTranscriptIndex = transcriptData.captions.findIndex(
+          (transcript) => transcript.id === innerInterimId
+        );
+
+        if (interimTranscriptIndex !== -1) {
+          transcriptData.captions.splice(interimTranscriptIndex, 1);
+        }
+      });
+      delete transcriptData.interimCaptions[transcriptId];
     }
-
-    interimTranscriptionIds.push(interimId);
     transcriptData.captions.push(captionData);
   }
   transcriptData.interimCaptions[transcriptId] = interimTranscriptionIds;

--- a/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/voicea-meeting.ts
@@ -74,7 +74,12 @@ export const processNewCaptions = ({data, meeting}) => {
       isFinal: data.isFinal,
       translations: value.translations,
       text: value.text,
-      currentCaptionLanguage: value.currentSpokenLanguage,
+      currentCaptionLanguage:
+        meeting.transcription?.languageOptions?.currentCaptionLanguage ||
+        value.currentSpokenLanguage,
+      currentSpokenLanguage:
+        meeting.transcription?.languageOptions?.currentSpokenLanguage ||
+        data.transcripts[0]?.transcript_language_code,
       timestamp: value?.timestamp,
       speaker,
     };
@@ -100,6 +105,7 @@ export const processNewCaptions = ({data, meeting}) => {
         }
       });
       delete transcriptData.interimCaptions[transcriptId];
+      captionData.id = transcriptId;
     }
     transcriptData.captions.push(captionData);
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -905,12 +905,12 @@ describe('plugin-meetings', () => {
 
       describe('#isTranscriptionSupported', () => {
         it('should return false if the feature is not supported for the meeting', () => {
-          meeting.locusInfo.controls = {transcribe: {transcribing: false}};
+          meeting.locusInfo.controls = {transcribe: {caption: false}};
 
           assert.equal(meeting.isTranscriptionSupported(), false);
         });
         it('should return true if webex assitant is enabled', () => {
-          meeting.locusInfo.controls = {transcribe: {transcribing: true}};
+          meeting.locusInfo.controls = {transcribe: {caption: true}};
 
           assert.equal(meeting.isTranscriptionSupported(), true);
         });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/voicea-meeting.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/voicea-meeting.ts
@@ -101,14 +101,7 @@ describe('plugin-meetings', () => {
                     ],
                     transcript_language_code: "en"
                 }
-            ],
-            transcript: {
-                text: "Don't bother me talking I'm just going to get the transcript data that is interim and I needed if I keep talking, I get the interim data",
-                csis: [
-                    1234867712
-                ],
-                transcript_language_code: "en"
-            }
+            ]
         };
     });
 
@@ -160,7 +153,6 @@ describe('plugin-meetings', () => {
             it('should process new final captions correctly', () => {
                 let transcriptData = fakeMeeting.transcription;
                 let transcriptId = fakeVoiceaPayload.transcriptId;
-                delete fakeVoiceaPayload.transcripts;
 
                 // Assuming that processNewCaptions is a pure function that doesn't mutate the input but returns a new state
                 processNewCaptions({
@@ -169,7 +161,7 @@ describe('plugin-meetings', () => {
                 });
 
                 // Check if speaker details are cached if needed
-                const csisKey = fakeVoiceaPayload.transcript.csis[0];
+                const csisKey = fakeVoiceaPayload.transcripts[0].csis[0];
                 const speaker = transcriptData.speakerProxy[csisKey];
                 expect(speaker).to.exist;
 
@@ -178,6 +170,7 @@ describe('plugin-meetings', () => {
 
                 //check if the interim caption is removed
                 const oldInterimCaption = transcriptData.captions.find(caption => caption.id === `${transcriptId}_${speaker.speakerId}`);
+                console.log(oldInterimCaption);
                 expect(oldInterimCaption).to.not.exist;
 
                 // Check the final caption data
@@ -186,8 +179,8 @@ describe('plugin-meetings', () => {
                 expect(newCaption).to.include({
                   id: transcriptId,
                   isFinal: fakeVoiceaPayload.isFinal,
-                  text: fakeVoiceaPayload.transcript.text,
-                  currentSpokenLanguage: fakeVoiceaPayload.transcript.transcript_language_code,
+                  text: fakeVoiceaPayload.transcripts[0].text,
+                  currentSpokenLanguage: fakeVoiceaPayload.transcripts[0].transcript_language_code,
                 });
 
                 // Check the speaker data in the new caption
@@ -197,7 +190,6 @@ describe('plugin-meetings', () => {
             it('should process new interim captions correctly', () => {
                 let transcriptData = fakeMeeting.transcription;
                 let transcriptId = fakeVoiceaPayload.transcriptId;
-                delete fakeVoiceaPayload.transcript;
 
                 transcriptData.captions.splice(transcriptData.length - 1, 1);
                 fakeVoiceaPayload.isFinal = false;
@@ -232,7 +224,6 @@ describe('plugin-meetings', () => {
             it('should process interim captions with an existing one correctly', () => {
                 let transcriptData = fakeMeeting.transcription;
                 let transcriptId = fakeVoiceaPayload.transcriptId;
-                delete fakeVoiceaPayload.transcript;
                 fakeVoiceaPayload.isFinal = false;
 
                 processNewCaptions({


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-533905](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-533905)

## This pull request addresses

As part of this PR: #3620 breaking changes were made to how captions are emitted in the events. This broke the Transcriptions in the plugin-meetings

## by making the following changes

- Change everything to new payload structure
- Add timestamp in new payload for Voicea final captions
- Update voicea and SDK tests in `plugin-meetings`
- We also have refactored a util method,
    - Earlier, we were processing NEW_CAPTIONS in two data formats, `isFinal:true` came with "transcript" object while `isFinal:false` came with "transcripts" array
    - Now, the breaking change has aligned such that we always get only "transcripts" array
    - Therefore, this method now performs all the caption processing on "transcripts" array and only does the needed changes based on "isFinal" boolean. This means that we process `isFinal:false` as an interim caption while `isFinal:true` as final caption thereby removing the interim caption once we receive the final caption for the respective `transcriptId`
- Additionally, we also made changes to emitting spoken and caption languages as follows,
   - Earlier, the processing of spoken language and caption language wasn't accurate and this PR fixes it based on the SDK value of the caption language they had chosen earlier or set it from what the new caption event responds if not chosen via the SDK already

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

1. Ensured all the unit tests passed locally
2. Tested out from the Kitchen Sink app by enabling transcription and seeing if the live captions are generated without any errors
3. Set the Spoken Language to Hindi and spoke in Hindi. This translated the Caption from whatever I spoke in Hindi to English
4. Similarly set the Spoken Language back to English and the Caption language to Hindi. This translated the caption to Hindi from whatever I spoke in English. Verified the translation with Google Translate also

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
