### PR TITLE
fix: don't send CA events when we do Locus /media API calls for mute/unmute and improve when we send them for Roap messages

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6705,6 +6705,7 @@ export default class Meeting extends StatelessWebexPlugin {
     this.locusMediaRequest = new LocusMediaRequest(
       {
         correlationId: this.correlationId,
+        meetingId: this.id,
         device: {
           url: this.deviceUrl,
           // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -88,6 +88,7 @@ export type Config = {
     regionCode?: string;
   };
   correlationId: string;
+  meetingId: string;
   preferTranscoding: boolean;
 };
 
@@ -223,6 +224,14 @@ export class LocusMediaRequest extends WebexPlugin {
         localMedias.roapMessage = request.roapMessage;
         localMedias.reachability = request.reachability;
         body.clientMediaPreferences.joinCookie = request.joinCookie;
+
+        // @ts-ignore
+        this.webex.internal.newMetrics.submitClientEvent({
+          name: 'client.locus.media.request',
+          options: {
+            meetingId: this.config.meetingId,
+          },
+        });
         break;
     }
 
@@ -256,6 +265,16 @@ export class LocusMediaRequest extends WebexPlugin {
           this.confluenceState = 'created';
         }
 
+        if (request.type === 'RoapMessage') {
+          // @ts-ignore
+          this.webex.internal.newMetrics.submitClientEvent({
+            name: 'client.locus.media.response',
+            options: {
+              meetingId: this.config.meetingId,
+            },
+          });
+        }
+
         return result;
       })
       .catch((e) => {
@@ -265,6 +284,18 @@ export class LocusMediaRequest extends WebexPlugin {
         ) {
           this.confluenceState = 'not created';
         }
+
+        if (request.type === 'RoapMessage') {
+          // @ts-ignore
+          this.webex.internal.newMetrics.submitClientEvent({
+            name: 'client.locus.media.response',
+            options: {
+              meetingId: this.config.meetingId,
+              rawError: e,
+            },
+          });
+        }
+
         throw e;
       });
   }

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -47,7 +47,6 @@ const MeetingUtil = {
   },
 
   remoteUpdateAudioVideo: (meeting, audioMuted?: boolean, videoMuted?: boolean) => {
-    const webex = meeting.getWebexObject();
     if (!meeting) {
       return Promise.reject(new ParameterError('You need a meeting object.'));
     }
@@ -60,12 +59,6 @@ const MeetingUtil = {
       );
     }
 
-    // @ts-ignore
-    webex.internal.newMetrics.submitClientEvent({
-      name: 'client.locus.media.request',
-      options: {meetingId: meeting.id},
-    });
-
     return meeting.locusMediaRequest
       .send({
         type: 'LocalMute',
@@ -77,15 +70,7 @@ const MeetingUtil = {
           videoMuted,
         },
       })
-      .then((response) => {
-        // @ts-ignore
-        webex.internal.newMetrics.submitClientEvent({
-          name: 'client.locus.media.response',
-          options: {meetingId: meeting.id},
-        });
-
-        return response?.body?.locus;
-      });
+      .then((response) => response?.body?.locus);
   },
 
   hasOwner: (info) => info && info.owner,

--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -61,7 +61,7 @@ export default class RoapRequest extends StatelessWebexPlugin {
     ipVersion?: IP_VERSION;
     locusMediaRequest?: LocusMediaRequest;
   }) {
-    const {roapMessage, locusSelfUrl, mediaId, meetingId, locusMediaRequest, ipVersion} = options;
+    const {roapMessage, locusSelfUrl, mediaId, locusMediaRequest, ipVersion} = options;
 
     if (!mediaId) {
       LoggerProxy.logger.info('Roap:request#sendRoap --> sending empty mediaID');
@@ -82,14 +82,6 @@ export default class RoapRequest extends StatelessWebexPlugin {
       `Roap:request#sendRoap --> ${locusSelfUrl} \n ${roapMessage.messageType} \n seq:${roapMessage.seq}`
     );
 
-    // @ts-ignore
-    this.webex.internal.newMetrics.submitClientEvent({
-      name: 'client.locus.media.request',
-      options: {
-        meetingId,
-      },
-    });
-
     return locusMediaRequest
       .send({
         type: 'RoapMessage',
@@ -101,13 +93,6 @@ export default class RoapRequest extends StatelessWebexPlugin {
         ipVersion,
       })
       .then((res) => {
-        // @ts-ignore
-        this.webex.internal.newMetrics.submitClientEvent({
-          name: 'client.locus.media.response',
-          options: {
-            meetingId,
-          },
-        });
         // always it will be the first mediaConnection Object
         const mediaConnections =
           res.body.mediaConnections &&
@@ -131,14 +116,6 @@ export default class RoapRequest extends StatelessWebexPlugin {
         };
       })
       .catch((err) => {
-        // @ts-ignore
-        this.webex.internal.newMetrics.submitClientEvent({
-          name: 'client.locus.media.response',
-          options: {
-            meetingId,
-            rawError: err,
-          },
-        });
         LoggerProxy.logger.error(`Roap:request#sendRoap --> Error:`, err);
         LoggerProxy.logger.error(
           `Roap:request#sendRoapRequest --> roapMessage that caused error:${JSON.stringify(

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -370,16 +370,6 @@ describe('plugin-meetings', () => {
           sequence: {},
           type: 'LocalMute',
         });
-
-        assert.calledWith(webex.internal.newMetrics.submitClientEvent, {
-          name: 'client.locus.media.request',
-          options: {meetingId: meeting.id},
-        });
-
-        assert.calledWith(webex.internal.newMetrics.submitClientEvent, {
-          name: 'client.locus.media.response',
-          options: {meetingId: meeting.id},
-        });
       });
     });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
@@ -133,20 +133,6 @@ describe('plugin-meetings/roap', () => {
         locusMediaRequest,
       });
 
-      assert.calledWith(webex.internal.newMetrics.submitClientEvent, {
-        name: 'client.locus.media.request',
-        options: {
-          meetingId: 'meeting-id',
-        },
-      });
-
-      assert.calledWith(webex.internal.newMetrics.submitClientEvent, {
-        name: 'client.locus.media.response',
-        options: {
-          meetingId: 'meeting-id',
-        },
-      });
-
       const requestParams = locusMediaRequest.send.getCall(0).args[0];
       assert.deepEqual(requestParams, {
         type: 'RoapMessage',
@@ -174,29 +160,6 @@ describe('plugin-meetings/roap', () => {
           },
         },
       });
-    });
-
-    it('sends correct client event when fails', async () => {
-      const locusMediaRequest = {send: sinon.stub().rejects({code: 300, message: 'error'})};
-      try {
-        await roapRequest.sendRoap({
-          locusSelfUrl: locusUrl,
-          mediaId: 'mediaId',
-          roapMessage: {
-            seq: 'seq',
-          },
-          meetingId: 'meeting-id',
-          locusMediaRequest,
-        });
-      } catch (err) {
-        assert.calledWith(webex.internal.newMetrics.submitClientEvent, {
-          name: 'client.locus.media.response',
-          options: {
-            meetingId: 'meeting-id',
-            rawError: {code: 300, message: 'error'},
-          },
-        });
-      }
     });
   });
 


### PR DESCRIPTION
# COMPLETES #[SPARK-529334](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-529334)

## This pull request addresses
We were sending CA event "client.locus.media.request" and "client.locus.media.response" every time we do Locus /media API call. These calls are made when we want to send Roap messages, but also when we mute/unmute. CA is not interested in the mute/unmute ones and in some meetings users generate a lot of them.

## by making the following changes
It's been agreed with CA team that we will only send the "client.locus.media.request" and "client.locus.media.response" events for Roap messages, not for mute/unmute operations.

Also I've noticed that for Roap messages we were sending the "client.locus.media.request" event too early, when it still might be queued inside LocusMediaRequest, so in some extreme edge cases when the LocusMediaRequest is stuck, we might send the CA event and never actually do the Locus reuqest, so I've moved the code for sending the CA events from roap/request.ts to LocusMediaRequest.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests + manual test with the web app - confirmed that CA didn't receive the events and that it still marked the call as success (correlationId=b92f8b1c-cbd1-45dd-9f62-96b716710960)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
