### PR TITLE
fix(moveToLobby): need handle main locus info when move to lobby from breakout

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -100,7 +100,7 @@ export const _JOINED_ = 'JOINED';
 export const _LOCUS_ID_ = 'LOCUS_ID';
 export const _LEFT_ = 'LEFT';
 export const _MOVED_ = 'MOVED';
-
+export const _ON_HOLD_LOBBY_ = 'ON_HOLD_LOBBY';
 export const _MEETING_LINK_ = 'MEETING_LINK';
 export const _MEETING_UUID_ = 'MEETING_UUID';
 export const _MEETING_ = 'MEETING';

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -45,6 +45,8 @@ import {
   MEETINGNUMBER,
   _JOINED_,
   _MOVED_,
+  _ON_HOLD_LOBBY_,
+  _WAIT_,
 } from '../constants';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import MeetingInfo from '../meeting-info';
@@ -340,6 +342,9 @@ export default class Meetings extends WebexPlugin {
     if (newLocus) {
       const isNewLocusAsBreakout = MeetingsUtil.isBreakoutLocusDTO(newLocus);
       const isSelfMoved = newLocus?.self?.state === _LEFT_ && newLocus?.self?.reason === _MOVED_;
+      const isSelfMovedToLobby =
+        newLocus?.self?.devices[0]?.intent?.reason === _ON_HOLD_LOBBY_ &&
+        newLocus?.self?.devices[0]?.intent?.type === _WAIT_;
       if (!meeting) {
         if (isNewLocusAsBreakout) {
           LoggerProxy.logger.log(
@@ -352,7 +357,7 @@ export default class Meetings extends WebexPlugin {
         return this.isNeedHandleMainLocus(meeting, newLocus);
       }
       if (!isNewLocusAsBreakout) {
-        return this.isNeedHandleMainLocus(meeting, newLocus);
+        return isSelfMovedToLobby || this.isNeedHandleMainLocus(meeting, newLocus);
       }
 
       return !isSelfMoved;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1011,6 +1011,7 @@ describe('plugin-meetings', () => {
                   callBackInfo: {
                     callbackAddress: uri1,
                   },
+                  devices: [],
                 },
                 info: {
                   webExMeetingId,
@@ -1038,6 +1039,7 @@ describe('plugin-meetings', () => {
                 callBackInfo: {
                   callbackAddress: uri1,
                 },
+                devices: [],
               },
               info: {
                 webExMeetingId,
@@ -1052,6 +1054,7 @@ describe('plugin-meetings', () => {
                   callBackInfo: {
                     callbackAddress: uri1,
                   },
+                  devices: [],
                 },
                 info: {
                   webExMeetingId,
@@ -1074,6 +1077,7 @@ describe('plugin-meetings', () => {
                 callBackInfo: {
                   callbackAddress: uri1,
                 },
+                devices: [],
               },
               info: {
                 webExMeetingId,
@@ -1091,6 +1095,7 @@ describe('plugin-meetings', () => {
                   callBackInfo: {
                     callbackAddress: uri1,
                   },
+                  devices: [],
                 },
                 info: {
                   webExMeetingId,
@@ -1121,6 +1126,7 @@ describe('plugin-meetings', () => {
                   callBackInfo: {
                     callbackAddress: uri1,
                   },
+                  devices: [],
                 },
                 info: {
                   webExMeetingId,
@@ -1143,6 +1149,7 @@ describe('plugin-meetings', () => {
                 callBackInfo: {
                   callbackAddress: uri1,
                 },
+                devices: [],
               },
               info: {
                 webExMeetingId,
@@ -1157,6 +1164,7 @@ describe('plugin-meetings', () => {
                 callbackInfo: {
                   callbackAddress: uri1,
                 },
+                devices: [],
               },
               info: {
                 isUnifiedSpaceMeeting,
@@ -2299,6 +2307,7 @@ describe('plugin-meetings', () => {
           sessionType: 'BREAKOUT',
         };
         newLocus.self.state = 'JOINED';
+        newLocus.self.devices = [];
         newLocus.fullState = {
           active: true,
         };
@@ -2315,7 +2324,7 @@ describe('plugin-meetings', () => {
           sessionType: 'MAIN',
         };
         newLocus.self.state = 'JOINED';
-
+        newLocus.self.devices = [];
         LoggerProxy.logger.log = sinon.stub();
         const result = webex.meetings.isNeedHandleLocusDTO(meeting, newLocus);
         assert.equal(result, true);
@@ -2330,10 +2339,25 @@ describe('plugin-meetings', () => {
         };
         newLocus.self.state = 'LEFT';
         newLocus.self.reason = 'MOVED';
-
+        newLocus.self.devices = [];
         LoggerProxy.logger.log = sinon.stub();
         const result = webex.meetings.isNeedHandleLocusDTO(meeting, newLocus);
         assert.equal(result, false);
+      });
+      it('moved to lobby, return true', () => {
+        newLocus.controls.breakout = {
+          sessionType: 'MAIN',
+        };
+        newLocus.self.state = 'JOINED';
+        newLocus.self.devices = [{
+          intent: {
+            reason: 'ON_HOLD_LOBBY',
+            type: 'WAIT',
+          }
+        }];
+        LoggerProxy.logger.log = sinon.stub();
+        const result = webex.meetings.isNeedHandleLocusDTO(meeting, newLocus);
+        assert.equal(result, true);
       });
     });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

When host move a web client to lobby in a breakout, the web client UI state should be right.

## by making the following changes

Need handle main session locus info in the case.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
