### PR TITLE
fix(calling): switching off stream listeners to avoid having multiple listeners

### DIFF
--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -37,25 +37,6 @@ const defaultServiceIndicator = ServiceIndicator.CALLING;
 const activeUrl = 'FakeActiveUrl';
 const mockLineId = 'e4e8ee2a-a154-4e52-8f11-ef4cde2dce72';
 
-// class MockMediaStream {
-//   private track;
-
-//   constructor(track: any) {
-//     this.track = track;
-//   }
-// }
-
-// globalThis.MediaStream = MockMediaStream;
-
-// // eslint-disable-next-line @typescript-eslint/no-unused-vars
-// jest.spyOn(window, 'MediaStream').mockImplementation((tracks: MediaStreamTrack[]) => {
-//   return {} as MediaStream;
-// });
-
-// // Object.defineProperty(window, 'MediaStream', {
-// //   writable: true,
-// // });
-
 describe('Call Tests', () => {
   const deviceId = '55dfb53f-bed2-36da-8e85-cee7f02aa68e';
   const dest = {
@@ -530,6 +511,11 @@ describe('Call Tests', () => {
     await waitForMsecs(50);
 
     /* Checks for switching off the listeners on call disconnect */
+    expect(offStreamSpy).toBeCalledTimes(2);
+    expect(offStreamSpy).toBeCalledWith(
+      MediaSDK.LocalStreamEventNames.OutputTrackChange,
+      expect.any(Function)
+    );
     expect(offStreamSpy).toBeCalledWith(
       MediaSDK.LocalStreamEventNames.EffectAdded,
       expect.any(Function)

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -2467,6 +2467,10 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     );
   };
 
+  private updateTrack = (audioTrack: MediaStreamTrack) => {
+    this.mediaConnection.updateLocalTracks({audio: audioTrack});
+  };
+
   private registerEffectListener = (addedEffect: TrackEffect) => {
     if (this.localAudioStream) {
       const effect = this.localAudioStream.getEffectByKind(NOISE_REDUCTION_EFFECT);
@@ -2488,13 +2492,12 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       }
 
       this.localAudioStream.off(LocalStreamEventNames.EffectAdded, this.registerEffectListener);
+      this.localAudioStream.off(LocalStreamEventNames.OutputTrackChange, this.updateTrack);
     }
   }
 
   private registerListeners(localAudioStream: LocalMicrophoneStream) {
-    localAudioStream.on(LocalStreamEventNames.OutputTrackChange, (audioTrack: MediaStreamTrack) => {
-      this.mediaConnection.updateLocalTracks({audio: audioTrack});
-    });
+    localAudioStream.on(LocalStreamEventNames.OutputTrackChange, this.updateTrack);
 
     localAudioStream.on(LocalStreamEventNames.EffectAdded, this.registerEffectListener);
 


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-511584 

## This pull request addresses
While updating the local track, a DOM exception error was encountered complaining for the peer connection to be closed. Hence enabling BNR fails after the first call. This happens because the old listener is used for the OutputTrackChange event on the localAudioStream, which uses the previous media connection, which is closed while updating the local track.

index.js:6603 Uncaught (in promise) DOMException: The peer connection is closed.
    at https://localhost:8000/samples/calling.min.js:2:3712596
    at Array.forEach (<anonymous>)
    at r.value (https://localhost:8000/samples/calling.min.js:2:3712231)
    at r.value (https://localhost:8000/samples/calling.min.js:2:3713170)
    at r.value (https://localhost:8000/samples/calling.min.js:2:3847575)
    at Je.<anonymous> (https://localhost:8000/samples/calling.min.js:2:3976135)
    at Ne.emit (https://localhost:8000/samples/calling.min.js:2:3059270)
    at Xe.emit (https://localhost:8000/samples/calling.min.js:2:3061589)
    at r.changeOutputTrack (https://localhost:8000/samples/calling.min.js:2:3064449)
    at NoiseReductionEffect.t (https://localhost:8000/samples/calling.min.js:2:3065066)

Steps to reproduce:

1. Initiate a call, enable BNR then disable BNR followed by call disconnect. Everything works fine till this point.
2. Initiated 2nd call and enabled BNR, updating local track fails and it complains of peer connection being closed.

## by making the following changes
Switching off the localAudioStream listener for the OutputTrackChange event fixes this issue.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

1. Initiate a call, enable BNR then disable BNR followed by call disconnect. Everything works fine till this point.
2. Initiated 2nd call and enabled BNR, enabling BNR works smoothly and no error is observed.

[DOM_Exception_Fix.log](https://github.com/user-attachments/files/15895528/DOM_Exception_Fix.log)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
