### PR TITLE
fix: during adding xtls reachability logging unreachable xtls clusters were missed

### DIFF
--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -314,6 +314,9 @@ export default class Reachability {
       if (result.tcp.result === 'unreachable') {
         unreachableList.push({name: key, protocol: 'tcp'});
       }
+      if (result.xtls.result === 'unreachable') {
+        unreachableList.push({name: key, protocol: 'xtls'});
+      }
     });
 
     return unreachableList;


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-535587](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-535587)

## This pull request addresses

This PR adds missing functionality of logging unreachable xTLS clusters.

## by making the following changes

After this change all unreachable xTLS clusters will be logged at the end of reachability check.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Tested with JS-SDK sample app.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
