### PR TITLE
fix: circular dependency b/w feature and mercury

### DIFF
--- a/packages/@webex/internal-plugin-feature/package.json
+++ b/packages/@webex/internal-plugin-feature/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "@webex/internal-plugin-device": "workspace:*",
-    "@webex/internal-plugin-mercury": "workspace:*",
     "@webex/webex-core": "workspace:*",
     "lodash": "^4.17.21"
   }

--- a/packages/@webex/internal-plugin-feature/src/feature.js
+++ b/packages/@webex/internal-plugin-feature/src/feature.js
@@ -47,7 +47,7 @@ const Feature = WebexCore.WebexPlugin.extend({
    * @param {Object} envelope
    * @returns {undefined}
    */
-  handleFeatureUpdate(envelope) {
+  updateFeature(envelope) {
     if (envelope && envelope.data) {
       const feature = envelope.data.featureToggle;
       const keyType = feature.type.toLowerCase();
@@ -56,21 +56,6 @@ const Feature = WebexCore.WebexPlugin.extend({
         this.webex.internal.device.features[keyType].add([feature], {merge: true});
       }
     }
-  },
-
-  /**
-   * Register to listen for incoming feature events
-   * @instance
-   * @returns {undefined}
-   */
-  listen() {
-    if (this.mercury) {
-      this.listenTo(this.mercury, 'event:featureToggle_update', this.handleFeatureUpdate);
-      this.isListeningToMercury = true;
-
-      return;
-    }
-    this.isListeningToMercury = false;
   },
 
   /**
@@ -142,13 +127,6 @@ const Feature = WebexCore.WebexPlugin.extend({
       'change:internal.device.features.user',
       this.trigger.bind(this, 'change:user')
     );
-  },
-
-  setMercury(mercury) {
-    this.mercury = mercury;
-    if (typeof this.isListeningToMercury !== 'undefined' && !this.isListeningToMercury) {
-      this.listen();
-    }
   },
 });
 

--- a/packages/@webex/internal-plugin-feature/src/feature.js
+++ b/packages/@webex/internal-plugin-feature/src/feature.js
@@ -43,6 +43,11 @@ const Feature = WebexCore.WebexPlugin.extend({
 
   /**
    * Handles a feature toggle update from the server.
+   * When one of these legacy feature gets updated, this event handler be triggered
+   *     * group-message-notifications
+   *     * mention-notifications
+   *     * thread-notifications,
+   * This handler is being listened from mercury connection success method for the event "event:featureToggle_update"
    * @param {Object} envelope
    * @returns {undefined}
    */

--- a/packages/@webex/internal-plugin-feature/src/feature.js
+++ b/packages/@webex/internal-plugin-feature/src/feature.js
@@ -8,6 +8,7 @@ import * as WebexCore from '@webex/webex-core';
 
 const Feature = WebexCore.WebexPlugin.extend({
   namespace: 'Feature',
+  isListeningToMercury: undefined,
 
   /**
    * Returns the value of the requested feature toggle.
@@ -63,11 +64,13 @@ const Feature = WebexCore.WebexPlugin.extend({
    * @returns {undefined}
    */
   listen() {
-    this.listenTo(
-      this.webex.internal.mercury,
-      'event:featureToggle_update',
-      this.handleFeatureUpdate
-    );
+    if (this.mercury) {
+      this.listenTo(this.mercury, 'event:featureToggle_update', this.handleFeatureUpdate);
+      this.isListeningToMercury = true;
+
+      return;
+    }
+    this.isListeningToMercury = false;
   },
 
   /**
@@ -139,6 +142,13 @@ const Feature = WebexCore.WebexPlugin.extend({
       'change:internal.device.features.user',
       this.trigger.bind(this, 'change:user')
     );
+  },
+
+  setMercury(mercury) {
+    this.mercury = mercury;
+    if (typeof this.isListeningToMercury !== 'undefined' && !this.isListeningToMercury) {
+      this.listen();
+    }
   },
 });
 

--- a/packages/@webex/internal-plugin-feature/src/feature.js
+++ b/packages/@webex/internal-plugin-feature/src/feature.js
@@ -8,7 +8,6 @@ import * as WebexCore from '@webex/webex-core';
 
 const Feature = WebexCore.WebexPlugin.extend({
   namespace: 'Feature',
-  isListeningToMercury: undefined,
 
   /**
    * Returns the value of the requested feature toggle.

--- a/packages/@webex/internal-plugin-feature/src/feature.js
+++ b/packages/@webex/internal-plugin-feature/src/feature.js
@@ -48,12 +48,11 @@ const Feature = WebexCore.WebexPlugin.extend({
    *     * mention-notifications
    *     * thread-notifications,
    * This handler is being listened from mercury connection success method for the event "event:featureToggle_update"
-   * @param {Object} envelope
+   * @param {Object} feature
    * @returns {undefined}
    */
-  updateFeature(envelope) {
-    if (envelope && envelope.data) {
-      const feature = envelope.data.featureToggle;
+  updateFeature(feature) {
+    if (feature) {
       const keyType = feature.type.toLowerCase();
 
       if (keyType === 'user' || keyType === 'developer') {

--- a/packages/@webex/internal-plugin-feature/src/index.js
+++ b/packages/@webex/internal-plugin-feature/src/index.js
@@ -1,7 +1,6 @@
 /*!
  * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
  */
-import '@webex/internal-plugin-mercury';
 
 import {registerInternalPlugin} from '@webex/webex-core';
 

--- a/packages/@webex/internal-plugin-feature/test/unit/spec/feature.js
+++ b/packages/@webex/internal-plugin-feature/test/unit/spec/feature.js
@@ -102,20 +102,16 @@ describe('plugin-feature', () => {
       it('updates the feature toggle', () => {
         const key = 'featureName';
         const keyType = 'user';
-        const envelope = {
-          data: {
-            featureToggle: {
-              key,
-              mutable: true,
-              type: 'USER',
-              val: 'true',
-              value: true,
-            },
-          },
+        const feature = {
+          key,
+          mutable: true,
+          type: 'USER',
+          val: 'true',
+          value: true,
         };
 
         sinon.spy(webex.internal.device.features[keyType], 'add');
-        webex.internal.feature.updateFeature(envelope);
+        webex.internal.feature.updateFeature(feature);
         assert.called(webex.internal.device.features[keyType].add);
       });
     });

--- a/packages/@webex/internal-plugin-feature/test/unit/spec/feature.js
+++ b/packages/@webex/internal-plugin-feature/test/unit/spec/feature.js
@@ -120,6 +120,37 @@ describe('plugin-feature', () => {
       });
     });
 
+    describe('#listen & #setFeature', () => {
+      beforeEach(() => {
+        webex.internal.mercury.on = sinon.stub();
+        // webex.internal.feature.setFeature()
+      });
+
+      afterEach(() => {
+        webex.internal.feature.mercury = null;
+        webex.internal.feature.isListeningToMercury = undefined;
+      })
+
+      it('listens to mercury if mercury object is available', () => {
+        assert.equal(webex.internal.feature.isListeningToMercury, undefined);
+        webex.internal.feature.setMercury(webex.internal.mercury);
+        assert.equal(webex.internal.feature.isListeningToMercury, undefined);
+        webex.internal.feature.listen();
+        assert.equal(webex.internal.feature.isListeningToMercury, true);
+        assert.calledOnce(webex.internal.mercury.on);
+      });
+
+      it('listens to mercury after mercury object is available', () => {
+        assert.equal(webex.internal.feature.isListeningToMercury, undefined);
+        webex.internal.feature.listen();
+        assert.notCalled(webex.internal.mercury.on);
+        assert.equal(webex.internal.feature.isListeningToMercury, false);
+        webex.internal.feature.setMercury(webex.internal.mercury);
+        assert.equal(webex.internal.feature.isListeningToMercury, true);
+        assert.calledOnce(webex.internal.mercury.on);
+      });
+    })
+
     describe('when a feature is changed', () => {
       ['developer', 'entitlement', 'user'].forEach((keyType) => {
         it(`emits \`change:${keyType}\` on ${keyType} feature change`, () => {

--- a/packages/@webex/internal-plugin-feature/test/unit/spec/feature.js
+++ b/packages/@webex/internal-plugin-feature/test/unit/spec/feature.js
@@ -65,6 +65,39 @@ describe('plugin-feature', () => {
       });
     });
 
+    describe('#setFeature()', () => {
+      beforeEach(() => {
+        webex.request = sinon.stub().returns(
+          Promise.resolve({
+            body: {},
+            statusCode: 200,
+          })
+        );
+      });
+      afterEach(() => {
+        webex.request.resetHistory();
+      });
+      it('does not allow entitlement keyType to be set', () =>
+        assert.isRejected(
+          webex.internal.feature.setFeature('entitlement', 'featureName', true),
+          /Only `developer` and `user` feature toggles can be set./
+        ));
+
+      ['developer', 'user'].forEach((keyType) => {
+        it(`sets a value for a ${keyType} feature toggle`, () => {
+          sinon.spy(webex.internal.device.features[keyType], 'add');
+
+          return webex.internal.feature.setFeature(keyType, 'featureName', true).then(() => {
+            assert.called(webex.internal.device.features[keyType].add);
+            assert.equal(
+              webex.request.getCall(0).args[0].resource,
+              `features/users/${webex.internal.device.userId}/${keyType}`
+            );
+          });
+        });
+      });
+    });
+
     describe('#updateFeature', () => {
       it('updates the feature toggle', () => {
         const key = 'featureName';

--- a/packages/@webex/internal-plugin-feature/test/unit/spec/feature.js
+++ b/packages/@webex/internal-plugin-feature/test/unit/spec/feature.js
@@ -65,40 +65,7 @@ describe('plugin-feature', () => {
       });
     });
 
-    describe('#setFeature()', () => {
-      beforeEach(() => {
-        webex.request = sinon.stub().returns(
-          Promise.resolve({
-            body: {},
-            statusCode: 200,
-          })
-        );
-      });
-      afterEach(() => {
-        webex.request.resetHistory();
-      });
-      it('does not allow entitlement keyType to be set', () =>
-        assert.isRejected(
-          webex.internal.feature.setFeature('entitlement', 'featureName', true),
-          /Only `developer` and `user` feature toggles can be set./
-        ));
-
-      ['developer', 'user'].forEach((keyType) => {
-        it(`sets a value for a ${keyType} feature toggle`, () => {
-          sinon.spy(webex.internal.device.features[keyType], 'add');
-
-          return webex.internal.feature.setFeature(keyType, 'featureName', true).then(() => {
-            assert.called(webex.internal.device.features[keyType].add);
-            assert.equal(
-              webex.request.getCall(0).args[0].resource,
-              `features/users/${webex.internal.device.userId}/${keyType}`
-            );
-          });
-        });
-      });
-    });
-
-    describe('#handleFeatureUpdate', () => {
+    describe('#updateFeature', () => {
       it('updates the feature toggle', () => {
         const key = 'featureName';
         const keyType = 'user';
@@ -115,41 +82,10 @@ describe('plugin-feature', () => {
         };
 
         sinon.spy(webex.internal.device.features[keyType], 'add');
-        webex.internal.feature.handleFeatureUpdate(envelope);
+        webex.internal.feature.updateFeature(envelope);
         assert.called(webex.internal.device.features[keyType].add);
       });
     });
-
-    describe('#listen & #setFeature', () => {
-      beforeEach(() => {
-        webex.internal.mercury.on = sinon.stub();
-        // webex.internal.feature.setFeature()
-      });
-
-      afterEach(() => {
-        webex.internal.feature.mercury = null;
-        webex.internal.feature.isListeningToMercury = undefined;
-      })
-
-      it('listens to mercury if mercury object is available', () => {
-        assert.equal(webex.internal.feature.isListeningToMercury, undefined);
-        webex.internal.feature.setMercury(webex.internal.mercury);
-        assert.equal(webex.internal.feature.isListeningToMercury, undefined);
-        webex.internal.feature.listen();
-        assert.equal(webex.internal.feature.isListeningToMercury, true);
-        assert.calledOnce(webex.internal.mercury.on);
-      });
-
-      it('listens to mercury after mercury object is available', () => {
-        assert.equal(webex.internal.feature.isListeningToMercury, undefined);
-        webex.internal.feature.listen();
-        assert.notCalled(webex.internal.mercury.on);
-        assert.equal(webex.internal.feature.isListeningToMercury, false);
-        webex.internal.feature.setMercury(webex.internal.mercury);
-        assert.equal(webex.internal.feature.isListeningToMercury, true);
-        assert.calledOnce(webex.internal.mercury.on);
-      });
-    })
 
     describe('when a feature is changed', () => {
       ['developer', 'entitlement', 'user'].forEach((keyType) => {

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -312,6 +312,7 @@ const Mercury = WebexPlugin.extend({
         this.connected = true;
         this.hasEverConnected = true;
         this._emit('online');
+        this.webex.internal.feature.setMercury(this);
 
         return resolve();
       };

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -312,7 +312,7 @@ const Mercury = WebexPlugin.extend({
         this.connected = true;
         this.hasEverConnected = true;
         this._emit('online');
-        this.webex.internal.feature.setMercury(this);
+        this.on('event:featureToggle_update', this.webex.internal.feature.updateFeature);
 
         return resolve();
       };

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -52,6 +52,20 @@ const Mercury = WebexPlugin.extend({
     },
   },
 
+  initialize() {
+    /*
+      When one of these legacy feature gets updated, this event would be triggered
+        * group-message-notifications
+        * mention-notifications
+        * thread-notifications
+    */
+    this.on('event:featureToggle_update', (envelope) => {
+      if (envelope && envelope.data) {
+        this.webex.internal.feature.updateFeature(envelope.data.featureToggle);
+      }
+    });
+  },
+
   /**
    * Get the last error.
    * @returns {any} The last error.
@@ -312,17 +326,6 @@ const Mercury = WebexPlugin.extend({
         this.connected = true;
         this.hasEverConnected = true;
         this._emit('online');
-        /*
-          When one of these legacy feature gets updated, this event would be triggered
-                * group-message-notifications
-                * mention-notifications
-                * thread-notifications,
-        */
-        this.on('event:featureToggle_update', (envelope) => {
-          if (envelope && envelope.data) {
-            this.webex.internal.feature.updateFeature(envelope.data.featureToggle);
-          }
-        });
 
         return resolve();
       };

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -318,7 +318,11 @@ const Mercury = WebexPlugin.extend({
                 * mention-notifications
                 * thread-notifications,
         */
-        this.on('event:featureToggle_update', this.webex.internal.feature.updateFeature);
+        this.on('event:featureToggle_update', (envelope) => {
+          if (envelope && envelope.data) {
+            this.webex.internal.feature.updateFeature(envelope.data.featureToggle);
+          }
+        });
 
         return resolve();
       };

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -312,6 +312,12 @@ const Mercury = WebexPlugin.extend({
         this.connected = true;
         this.hasEverConnected = true;
         this._emit('online');
+        /*
+          When one of these legacy feature gets updated, this event would be triggered
+                * group-message-notifications
+                * mention-notifications
+                * thread-notifications,
+        */
         this.on('event:featureToggle_update', this.webex.internal.feature.updateFeature);
 
         return resolve();

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -138,8 +138,9 @@ describe('plugin-mercury', () => {
       });
 
       it('connects to Mercury using default url', () => {
-        webex.internal.feature.setMercury = sinon.stub();
+        webex.internal.feature.updateFeature = sinon.stub();
         const promise = mercury.connect();
+        const updatedFeature = {};
 
         assert.isFalse(mercury.connected, 'Mercury is not connected');
         assert.isTrue(mercury.connecting, 'Mercury is connecting');
@@ -149,8 +150,9 @@ describe('plugin-mercury', () => {
           assert.isTrue(mercury.connected, 'Mercury is connected');
           assert.isFalse(mercury.connecting, 'Mercury is not connecting');
           assert.calledWith(socketOpenStub, sinon.match(/ws:\/\/example.com/), sinon.match.any);
-          assert.calledOnce(webex.internal.feature.setMercury);
-          assert.calledWith(webex.internal.feature.setMercury, mercury);
+          mercury._emit('event:featureToggle_update', updatedFeature)
+          assert.calledOnce(webex.internal.feature.updateFeature);
+          assert.calledWith(webex.internal.feature.updateFeature, updatedFeature);
         });
       });
 

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -161,6 +161,17 @@ describe('plugin-mercury', () => {
         });
       });
 
+      it('connects to Mercury but does not call updateFeature', () => {
+        webex.internal.feature.updateFeature = sinon.stub();
+        const promise = mercury.connect();
+        const envelope = {};
+
+        return promise.then(() => {
+          mercury._emit('event:featureToggle_update', envelope);
+          assert.notCalled(webex.internal.feature.updateFeature);
+        });
+      });
+
       describe('when `maxRetries` is set', () => {
 
         const check = () => {

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -138,6 +138,7 @@ describe('plugin-mercury', () => {
       });
 
       it('connects to Mercury using default url', () => {
+        webex.internal.feature.setMercury = sinon.stub();
         const promise = mercury.connect();
 
         assert.isFalse(mercury.connected, 'Mercury is not connected');
@@ -148,6 +149,8 @@ describe('plugin-mercury', () => {
           assert.isTrue(mercury.connected, 'Mercury is connected');
           assert.isFalse(mercury.connecting, 'Mercury is not connecting');
           assert.calledWith(socketOpenStub, sinon.match(/ws:\/\/example.com/), sinon.match.any);
+          assert.calledOnce(webex.internal.feature.setMercury);
+          assert.calledWith(webex.internal.feature.setMercury, mercury);
         });
       });
 

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -158,6 +158,7 @@ describe('plugin-mercury', () => {
           assert.calledWith(socketOpenStub, sinon.match(/ws:\/\/example.com/), sinon.match.any);
           mercury._emit('event:featureToggle_update', envelope);
           assert.calledOnceWithExactly(webex.internal.feature.updateFeature, envelope.data.featureToggle);
+          sinon.restore();
         });
       });
 
@@ -169,6 +170,7 @@ describe('plugin-mercury', () => {
         return promise.then(() => {
           mercury._emit('event:featureToggle_update', envelope);
           assert.notCalled(webex.internal.feature.updateFeature);
+          sinon.restore();
         });
       });
 

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -150,9 +150,8 @@ describe('plugin-mercury', () => {
           assert.isTrue(mercury.connected, 'Mercury is connected');
           assert.isFalse(mercury.connecting, 'Mercury is not connecting');
           assert.calledWith(socketOpenStub, sinon.match(/ws:\/\/example.com/), sinon.match.any);
-          mercury._emit('event:featureToggle_update', updatedFeature)
-          assert.calledOnce(webex.internal.feature.updateFeature);
-          assert.calledWith(webex.internal.feature.updateFeature, updatedFeature);
+          mercury._emit('event:featureToggle_update', updatedFeature);
+          assert.calledOnceWithExactly(webex.internal.feature.updateFeature, updatedFeature);
         });
       });
 

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -140,7 +140,13 @@ describe('plugin-mercury', () => {
       it('connects to Mercury using default url', () => {
         webex.internal.feature.updateFeature = sinon.stub();
         const promise = mercury.connect();
-        const updatedFeature = {};
+        const envelope = {
+          data: {
+            featureToggle: {
+              'feature-name': true
+            }
+          }
+        };
 
         assert.isFalse(mercury.connected, 'Mercury is not connected');
         assert.isTrue(mercury.connecting, 'Mercury is connecting');
@@ -150,8 +156,8 @@ describe('plugin-mercury', () => {
           assert.isTrue(mercury.connected, 'Mercury is connected');
           assert.isFalse(mercury.connecting, 'Mercury is not connecting');
           assert.calledWith(socketOpenStub, sinon.match(/ws:\/\/example.com/), sinon.match.any);
-          mercury._emit('event:featureToggle_update', updatedFeature);
-          assert.calledOnceWithExactly(webex.internal.feature.updateFeature, updatedFeature);
+          mercury._emit('event:featureToggle_update', envelope);
+          assert.calledOnceWithExactly(webex.internal.feature.updateFeature, envelope.data.featureToggle);
         });
       });
 

--- a/packages/@webex/test-helper-mock-webex/src/index.js
+++ b/packages/@webex/test-helper-mock-webex/src/index.js
@@ -282,7 +282,6 @@ function makeWebex(options) {
     feature: {
       setFeature: sinon.stub().returns(Promise.resolve(false)),
       getFeature: sinon.stub().returns(Promise.resolve(false)),
-      setMercury: sinon.stub(),
     },
     encryption: {},
     metrics: {

--- a/packages/@webex/test-helper-mock-webex/src/index.js
+++ b/packages/@webex/test-helper-mock-webex/src/index.js
@@ -282,6 +282,7 @@ function makeWebex(options) {
     feature: {
       setFeature: sinon.stub().returns(Promise.resolve(false)),
       getFeature: sinon.stub().returns(Promise.resolve(false)),
+      setMercury: sinon.stub(),
     },
     encryption: {},
     metrics: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,7 +177,7 @@ module.exports = (env = {NODE_ENV: process.env.NODE_ENV || 'production'}) => ({
       // exclude detection of files based on a RegExp
       exclude: /a\.js|node_modules/,
       // add errors to webpack instead of warnings
-      failOnError: false,
+      failOnError: true,
       // allow import cycles that include an asyncronous import,
       // e.g. via import(/* webpackMode: "weak" */ './file.js')
       allowAsyncCycles: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7379,7 +7379,6 @@ __metadata:
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
     "@webex/internal-plugin-device": "workspace:*"
-    "@webex/internal-plugin-mercury": "workspace:*"
     "@webex/jest-config-legacy": "workspace:*"
     "@webex/legacy-tools": "workspace:*"
     "@webex/test-helper-chai": "workspace:*"


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-515520](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-515520)

## This pull request addresses

The final circular dependency that is left out. This PR cuts off the circular dependency between `internal-plugin-mercury` and `internal-plugin-feature` 

## by making the following changes

- Remove the `internal-plugin-mercury` dependency from `internal-plugin-feature`
- On successful connect of `webex.mercury.connect` event, the mercury object listens to the `event_featureToggle`
- Whenever this event is called, the handler checks if it has a legitimate envelope and identifies the feature and sends it to feature plugin by calling `webex.internal.feature.updateFeature`
- This `webex.internal.feature.updateFeature` is the method that is modified from earlier `handleFeatureUpdate` call back listener


<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
