### PR TITLE
fix(plugin-meetings): update MQE for MARI related metrics

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1122,6 +1122,8 @@ export const MQA_STATS = {
         direction: 'sendrecv', // TODO: parse from SDP and save globally
         isMain: false, // always true for share sender
         mariFecEnabled: false, // unavailable
+        mariRtxEnabled: false, // unavailable
+        mariLiteEnabled: false, // unavailable
         mariQosEnabled: false, // unavailable
         multistreamEnabled: false, // unavailable
       },
@@ -1134,7 +1136,6 @@ export const MQA_STATS = {
       queueDelay: 0, // unavailable
       remoteJitter: 0, // unavailable
       remoteLossRate: 0,
-      remoteReceiveRate: 0, // unavailable
       roundTripTime: 0,
       rtcpBitrate: 0, // unavailable
       rtcpPackets: 0, // unavailable

--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -189,10 +189,10 @@ export const emptyVideoTransmit = {
     common: {
       direction: 'inactive',
       isMain: true,
-      mariFecEnabled: false, // Not avaliable
-      mariRtxEnabled: false, // Not avaliable
-      mariQosEnabled: false, // Not avaliable
-      mariLiteEnabled: false, // Not avaliable
+      mariFecEnabled: false,
+      mariRtxEnabled: false,
+      mariQosEnabled: false,
+      mariLiteEnabled: false,
       multistreamEnabled: false, // Not avaliable
     },
     dtlsBitrate: 0, // Not avaliable

--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -21,7 +21,9 @@ export const emptyAudioReceive = {
       direction: 'inactive',
       isMain: true,
       mariFecEnabled: false,
+      mariRtxEnabled: false,
       mariQosEnabled: false,
+      mariLiteEnabled: false,
       multistreamEnabled: false,
     },
     dtlsBitrate: 0,
@@ -75,7 +77,9 @@ export const emptyAudioTransmit = {
       direction: 'inactive',
       isMain: true,
       mariFecEnabled: false,
+      mariRtxEnabled: false,
       mariQosEnabled: false,
+      mariLiteEnabled: false,
       multistreamEnabled: false,
     },
     dtlsBitrate: 0,
@@ -86,7 +90,6 @@ export const emptyAudioTransmit = {
     queueDelay: 0,
     remoteJitter: 0,
     remoteLossRate: 0,
-    remoteReceiveRate: 0,
     roundTripTime: 0,
     rtcpBitrate: 0,
     rtcpPackets: 0,
@@ -119,8 +122,10 @@ export const emptyVideoReceive = {
     common: {
       direction: 'inactive',
       isMain: true, // Not avaliable
-      mariFecEnabled: true, // Not avaliable
-      mariQosEnabled: true, // Not avaliable
+      mariFecEnabled: false,
+      mariRtxEnabled: false,
+      mariQosEnabled: false,
+      mariLiteEnabled: false,
       multistreamEnabled: true, // Not avaliable
     },
     dtlsBitrate: 0, // Not avaliable
@@ -185,7 +190,9 @@ export const emptyVideoTransmit = {
       direction: 'inactive',
       isMain: true,
       mariFecEnabled: false, // Not avaliable
+      mariRtxEnabled: false, // Not avaliable
       mariQosEnabled: false, // Not avaliable
+      mariLiteEnabled: false, // Not avaliable
       multistreamEnabled: false, // Not avaliable
     },
     dtlsBitrate: 0, // Not avaliable
@@ -193,10 +200,9 @@ export const emptyVideoTransmit = {
     fecBitrate: 0, // Not avaliable
     fecPackets: 0, // TODO: check inbound-rtp// Not avaliable
     maxBitrate: 0, // Currently hardcoded
-    queueDelay: 0, // outboundRtp.totalPacketSentDelay  // TODO: check if totalInterFrameDelay/ packetSentDelay/ jitterBufferDalay
+    queueDelay: 0,
     remoteJitter: 0, // remoteInboundRtp.jitter
     remoteLossRate: 0, // comparedResults.lossRate
-    remoteReceiveRate: 0, // compareResults.packetsLost
     roundTripTime: 0, // compareResults.roundTripTime
     rtcpBitrate: 0, // Dont have access to it
     rtcpPackets: 0, // Dont have access to rtcp


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [WEBEX-389680](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-389680)

## This pull request addresses

Currently, there were a couple of MARI-related metrics with incorrect values. The purpose of this PR is to update metrics for the Web client.

## by making the following changes

Add `mariRtxEnabled`, `mariLiteEnabled`, remove `remoteReceiveRate`

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- [x] automated tests for plugin-meetings
- [x] SDK test meeting correctly [sends MQE](https://gist.github.com/antsukanova/6158a7399f8e07760e0aa68ed58c3412) in automated diagnostics

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
