### PR TITLE
fix(plugin-meetings): streamline rtxPackets and rtxBitrate

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -1136,6 +1136,10 @@ export class StatsAnalyzer extends EventsScope {
       this.statsResults[mediaType][sendrecvType].fecPacketsReceived = result.fecPacketsReceived;
       this.statsResults[mediaType][sendrecvType].totalBytesReceived = result.bytesReceived;
       this.statsResults[mediaType][sendrecvType].headerBytesReceived = result.headerBytesReceived;
+      this.statsResults[mediaType][sendrecvType].retransmittedPacketsReceived =
+        result.retransmittedPacketsReceived;
+      this.statsResults[mediaType][sendrecvType].retransmittedBytesReceived =
+        result.retransmittedBytesReceived;
 
       this.statsResults[mediaType][sendrecvType].meanRtpJitter.push(result.jitter);
 

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -998,12 +998,11 @@ export class StatsAnalyzer extends EventsScope {
         result.qualityLimitationReason;
       this.statsResults[mediaType][sendrecvType].qualityLimitationResolutionChanges =
         result.qualityLimitationResolutionChanges;
-      this.statsResults[mediaType][sendrecvType].retransmittedPacketsSent =
+      this.statsResults[mediaType][sendrecvType].totalRtxPacketsSent =
         result.retransmittedPacketsSent;
+      this.statsResults[mediaType][sendrecvType].totalRtxBytesSent = result.retransmittedBytesSent;
       this.statsResults[mediaType][sendrecvType].totalBytesSent = result.bytesSent;
       this.statsResults[mediaType][sendrecvType].headerBytesSent = result.headerBytesSent;
-      this.statsResults[mediaType][sendrecvType].retransmittedBytesSent =
-        result.retransmittedBytesSent;
       this.statsResults[mediaType][sendrecvType].requestedBitrate = result.requestedBitrate;
       this.statsResults[mediaType][sendrecvType].requestedFrameSize = result.requestedFrameSize;
     }
@@ -1136,9 +1135,9 @@ export class StatsAnalyzer extends EventsScope {
       this.statsResults[mediaType][sendrecvType].fecPacketsReceived = result.fecPacketsReceived;
       this.statsResults[mediaType][sendrecvType].totalBytesReceived = result.bytesReceived;
       this.statsResults[mediaType][sendrecvType].headerBytesReceived = result.headerBytesReceived;
-      this.statsResults[mediaType][sendrecvType].retransmittedPacketsReceived =
+      this.statsResults[mediaType][sendrecvType].totalRtxPacketsReceived =
         result.retransmittedPacketsReceived;
-      this.statsResults[mediaType][sendrecvType].retransmittedBytesReceived =
+      this.statsResults[mediaType][sendrecvType].totalRtxBytesReceived =
         result.retransmittedBytesReceived;
 
       this.statsResults[mediaType][sendrecvType].meanRtpJitter.push(result.jitter);

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -244,8 +244,8 @@ export const getVideoReceiverMqa = ({
   const totalPacketsReceived = getTotalValue('totalPacketsReceived');
   const totalBytesReceived = getTotalValue('totalBytesReceived');
 
-  const totalRtxPacketsReceived = getTotalValue('retransmittedPacketsReceived');
-  const totalRtxBytesReceived = getTotalValue('retransmittedBytesReceived');
+  const totalRtxPacketsReceived = getTotalValue('totalRtxPacketsReceived');
+  const totalRtxBytesReceived = getTotalValue('totalRtxBytesReceived');
 
   const meanRemoteJitter = Object.keys(statsResults)
     .filter((mt) => mt.includes(baseMediaType))
@@ -367,8 +367,8 @@ export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, b
   const totalPacketsSent = getTotalValue('totalPacketsSent');
   const totalBytesSent = getTotalValue('totalBytesSent');
   const availableOutgoingBitrate = getTotalValue('availableOutgoingBitrate');
-  const totalRtxPacketsSent = getTotalValue('retransmittedPacketsSent');
-  const totalRtxBytesSent = getTotalValue('retransmittedBytesSent');
+  const totalRtxPacketsSent = getTotalValue('totalRtxPacketsSent');
+  const totalRtxBytesSent = getTotalValue('totalRtxBytesSent');
 
   videoSender.common.common.direction =
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -237,8 +237,8 @@ export const getVideoReceiverMqa = ({
   const lastPacketsLost = getLastTotalValue('totalPacketsLost');
   const lastBytesReceived = getLastTotalValue('totalBytesReceived');
 
-  const lastRtxPacketsReceived = getLastTotalValue('retransmittedPacketsReceived');
-  const lastRtxBytesReceived = getLastTotalValue('retransmittedBytesReceived');
+  const lastRtxPacketsReceived = getLastTotalValue('totalRtxPacketsReceived');
+  const lastRtxBytesReceived = getLastTotalValue('totalRtxBytesReceived');
 
   const packetsLost = getTotalValue('totalPacketsLost');
   const totalPacketsReceived = getTotalValue('totalPacketsReceived');
@@ -360,8 +360,8 @@ export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, b
   const lastPacketsSent = getLastTotalValue('totalPacketsSent');
   const lastBytesSent = getLastTotalValue('totalBytesSent');
   const lastPacketsLostTotal = getLastTotalValue('totalPacketsLostOnReceiver');
-  const lastRtxPacketsSent = getLastTotalValue('retransmittedPacketsSent');
-  const lastRtxBytesSent = getLastTotalValue('retransmittedBytesSent');
+  const lastRtxPacketsSent = getLastTotalValue('totalRtxPacketsSent');
+  const lastRtxBytesSent = getLastTotalValue('totalRtxBytesSent');
 
   const totalPacketsLostOnReceiver = getTotalValue('totalPacketsLostOnReceiver');
   const totalPacketsSent = getTotalValue('totalPacketsSent');

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -237,9 +237,15 @@ export const getVideoReceiverMqa = ({
   const lastPacketsLost = getLastTotalValue('totalPacketsLost');
   const lastBytesReceived = getLastTotalValue('totalBytesReceived');
 
+  const lastRtxPacketsReceived = getLastTotalValue('retransmittedPacketsReceived');
+  const lastRtxBytesReceived = getLastTotalValue('retransmittedBytesReceived');
+
   const packetsLost = getTotalValue('totalPacketsLost');
   const totalPacketsReceived = getTotalValue('totalPacketsReceived');
   const totalBytesReceived = getTotalValue('totalBytesReceived');
+
+  const totalRtxPacketsReceived = getTotalValue('retransmittedPacketsReceived');
+  const totalRtxBytesReceived = getTotalValue('retransmittedBytesReceived');
 
   const meanRemoteJitter = Object.keys(statsResults)
     .filter((mt) => mt.includes(baseMediaType))
@@ -266,9 +272,14 @@ export const getVideoReceiverMqa = ({
 
   // Calculate the outgoing bitrate
   const totalBytesReceivedInaMin = totalBytesReceived - lastBytesReceived;
+  const totalRtxBytesReceivedInaMin = totalRtxBytesReceived - lastRtxBytesReceived;
 
   videoReceiver.common.rtpBitrate = totalBytesReceivedInaMin
     ? (totalBytesReceivedInaMin * 8) / 60
+    : 0;
+  videoReceiver.common.rtxPackets = totalRtxPacketsReceived - lastRtxPacketsReceived;
+  videoReceiver.common.rtxBitrate = totalRtxBytesReceivedInaMin
+    ? (totalRtxBytesReceivedInaMin * 8) / 60
     : 0;
 };
 
@@ -349,11 +360,15 @@ export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, b
   const lastPacketsSent = getLastTotalValue('totalPacketsSent');
   const lastBytesSent = getLastTotalValue('totalBytesSent');
   const lastPacketsLostTotal = getLastTotalValue('totalPacketsLostOnReceiver');
+  const lastRtxPacketsSent = getLastTotalValue('retransmittedPacketsSent');
+  const lastRtxBytesSent = getLastTotalValue('retransmittedBytesSent');
 
   const totalPacketsLostOnReceiver = getTotalValue('totalPacketsLostOnReceiver');
   const totalPacketsSent = getTotalValue('totalPacketsSent');
   const totalBytesSent = getTotalValue('totalBytesSent');
   const availableOutgoingBitrate = getTotalValue('availableOutgoingBitrate');
+  const totalRtxPacketsSent = getTotalValue('retransmittedPacketsSent');
+  const totalRtxBytesSent = getTotalValue('retransmittedBytesSent');
 
   videoSender.common.common.direction =
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
@@ -389,8 +404,11 @@ export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, b
 
   // Calculate the outgoing bitrate
   const totalBytesSentInaMin = totalBytesSent - lastBytesSent;
+  const totalRtxBytesSentInaMin = totalRtxBytesSent - lastRtxBytesSent;
 
   videoSender.common.rtpBitrate = totalBytesSentInaMin ? (totalBytesSentInaMin * 8) / 60 : 0;
+  videoSender.common.rtxPackets = totalRtxPacketsSent - lastRtxPacketsSent;
+  videoSender.common.rtxBitrate = totalRtxBytesSentInaMin ? (totalRtxBytesSentInaMin * 8) / 60 : 0;
 };
 
 export const getVideoSenderStreamMqa = ({

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -135,11 +135,11 @@ describe('plugin-meetings', () => {
         assert.strictEqual(statsAnalyzer.statsResults['video-send'].send.totalPacketsSent, 15000);
         assert.strictEqual(statsAnalyzer.statsResults['video-send'].send.requestedBitrate, 50000);
         assert.strictEqual(
-          statsAnalyzer.statsResults['video-send'].send.retransmittedPacketsSent,
+          statsAnalyzer.statsResults['video-send'].send.totalRtxPacketsSent,
           10
         );
         assert.strictEqual(
-          statsAnalyzer.statsResults['video-send'].send.retransmittedBytesSent,
+          statsAnalyzer.statsResults['video-send'].send.totalRtxBytesSent,
           500
         );
       });
@@ -252,8 +252,8 @@ describe('plugin-meetings', () => {
         assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.totalBytesReceived, 100000);
         assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.requestedBitrate, 50000);
         assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.headerBytesReceived, 10000);
-        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.retransmittedBytesReceived, 500);
-        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.retransmittedPacketsReceived, 10);
+        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.totalRtxBytesReceived, 500);
+        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.totalRtxPacketsReceived, 10);
       });
 
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -64,7 +64,7 @@ describe('plugin-meetings', () => {
         assert(calledSpy.calledOnce);
       });
 
-      it('processOutboundRTPResult should create the correct stats results', () => {
+      it('processOutboundRTPResult should create the correct stats results for audio', () => {
         // establish the `statsResults` object.
         statsAnalyzer.parseGetStatsResult({type: 'none'}, 'audio-send', true);
 
@@ -80,8 +80,6 @@ describe('plugin-meetings', () => {
             nackCount: 1,
             packetsSent: 3600,
             remoteId: 'RTCRemoteInboundRtpAudioStream_123456789',
-            retransmittedBytesSent: 100,
-            retransmittedPacketsSent: 2,
             ssrc: 123456789,
             targetBitrate: 256000,
             timestamp: 1707341489336,
@@ -99,17 +97,54 @@ describe('plugin-meetings', () => {
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.totalNackCount, 1);
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.totalPacketsSent, 3600);
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.requestedBitrate, 10000);
+      });
+
+      it('processOutboundRTPResult should create the correct stats results for video', () => {
+        // establish the `statsResults` object for video.
+        statsAnalyzer.parseGetStatsResult({type: 'none'}, 'video-send', true);
+
+        statsAnalyzer.processOutboundRTPResult(
+          {
+            bytesSent: 250000,
+            codecId: 'RTCCodec_1_Outbound_107',
+            headerBytesSent: 50000,
+            id: 'RTCOutboundRTPVideoStream_987654321',
+            kind: 'video',
+            mediaSourceId: 'RTCVideoSource_3',
+            mediaType: 'video',
+            nackCount: 5,
+            packetsSent: 15000,
+            remoteId: 'RTCRemoteInboundRtpVideoStream_987654321',
+            retransmittedBytesSent: 500,
+            retransmittedPacketsSent: 10,
+            ssrc: 987654321,
+            targetBitrate: 1024000,
+            timestamp: 1707341489336,
+            trackId: 'RTCMediaStreamTrack_sender_3',
+            transportId: 'RTCTransport_0_2',
+            type: 'outbound-rtp',
+            requestedBitrate: 50000,
+          },
+          'video-send',
+          true
+        );
+
+        assert.strictEqual(statsAnalyzer.statsResults['video-send'].send.headerBytesSent, 50000);
+        assert.strictEqual(statsAnalyzer.statsResults['video-send'].send.totalBytesSent, 250000);
+        assert.strictEqual(statsAnalyzer.statsResults['video-send'].send.totalNackCount, 5);
+        assert.strictEqual(statsAnalyzer.statsResults['video-send'].send.totalPacketsSent, 15000);
+        assert.strictEqual(statsAnalyzer.statsResults['video-send'].send.requestedBitrate, 50000);
         assert.strictEqual(
-          statsAnalyzer.statsResults['audio-send'].send.retransmittedPacketsSent,
-          2
+          statsAnalyzer.statsResults['video-send'].send.retransmittedPacketsSent,
+          10
         );
         assert.strictEqual(
-          statsAnalyzer.statsResults['audio-send'].send.retransmittedBytesSent,
-          100
+          statsAnalyzer.statsResults['video-send'].send.retransmittedBytesSent,
+          500
         );
       });
 
-      it('processInboundRTPResult should create the correct stats results', () => {
+      it('processInboundRTPResult should create the correct stats results for audio', () => {
         // establish the `statsResults` object.
         statsAnalyzer.parseGetStatsResult({type: 'none'}, 'audio-recv-1', false);
 
@@ -175,6 +210,52 @@ describe('plugin-meetings', () => {
           200000
         );
       });
+
+      it('processInboundRTPResult should create the correct stats results for video', () => {
+        // establish the `statsResults` object for video.
+        statsAnalyzer.parseGetStatsResult({type: 'none'}, 'video-recv', false);
+
+        statsAnalyzer.processInboundRTPResult(
+          {
+            bytesReceived: 100000,
+            codecId: 'RTCCodec_6_Inbound_107',
+            fecPacketsDiscarded: 2,
+            fecPacketsReceived: 2,
+            headerBytesReceived: 10000,
+            id: 'RTCInboundRTPVideoStream_987654321',
+            jitter: 0.05,
+            jitterBufferDelay: 5000,
+            jitterBufferEmittedCount: 50000,
+            kind: 'video',
+            lastPacketReceivedTimestamp: 1707341488529,
+            mediaType: 'video',
+            packetsDiscarded: 5,
+            packetsLost: 10,
+            packetsReceived: 1500,
+            remoteId: 'RTCRemoteOutboundRTPVideoStream_987654321',
+            ssrc: 987654321,
+            timestamp: 1707341489419,
+            trackId: 'RTCMediaStreamTrack_receiver_3',
+            transportId: 'RTCTransport_0_2',
+            type: 'inbound-rtp',
+            requestedBitrate: 50000,
+            retransmittedBytesReceived: 500,
+            retransmittedPacketsReceived: 10,
+          },
+          'video-recv',
+          false
+        );
+
+        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.totalPacketsReceived, 1500);
+        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.fecPacketsDiscarded, 2);
+        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.fecPacketsReceived, 2);
+        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.totalBytesReceived, 100000);
+        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.requestedBitrate, 50000);
+        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.headerBytesReceived, 10000);
+        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.retransmittedBytesReceived, 500);
+        assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.retransmittedPacketsReceived, 10);
+      });
+
 
       it('parseAudioSource should create the correct stats results', () => {
         // establish the `statsResults` object.


### PR DESCRIPTION
# COMPLETES [SPARK-535389](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-535389)

## This pull request addresses

Incorrect reporting of `rtxPackets` and `rtxBitrate` for video MQEs in `MQEIntervalSessionTransmitVideo` and `MQEIntervalSessionReceiveVideo`.

## by making the following changes

- Updated the reporting of `rtxPackets` to use the WebRTC stat `retransmittedPacketsReceived` for received video and `retransmittedPacketsSent` for transmitted video.
- Updated the reporting of `rtxBitrate` to use the WebRTC stat `retransmittedBytesReceived` for received video and `retransmittedBytesSent` for transmitted video.

### Change Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor


### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly