### PR TITLE
feat: added isWebexMediaBackendUnreachable() API

### DIFF
--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -297,6 +297,63 @@ export default class Reachability {
   }
 
   /**
+   * Returns true only if ALL protocols (UDP, TCP and TLS) have been tested and none
+   * of the media clusters where reachable with any of the protocols. This is done
+   * irrespective of the config, so for example:
+   * if config.meetings.experimental.enableTlsReachability === false,
+   * it will return false, because TLS reachability won't be tested,
+   * so we can't say for sure that media backend is unreachable over TLS.
+   *
+   * @returns {boolean}
+   */
+  async isWebexMediaBackendUnreachable() {
+    let unreachable = false;
+
+    // @ts-ignore
+    const reachabilityData = await this.webex.boundedStorage
+      .get(this.namespace, REACHABILITY.localStorageResult)
+      .catch(() => {});
+
+    if (reachabilityData) {
+      try {
+        const reachabilityResults: ReachabilityResults = JSON.parse(reachabilityData);
+
+        const protocols = {
+          udp: {tested: false, reachable: undefined},
+          tcp: {tested: false, reachable: undefined},
+          xtls: {tested: false, reachable: undefined},
+        };
+
+        Object.values(reachabilityResults).forEach((result) => {
+          Object.keys(protocols).forEach((protocol) => {
+            if (
+              result[protocol]?.result === 'reachable' ||
+              result[protocol]?.result === 'unreachable'
+            ) {
+              protocols[protocol].tested = true;
+
+              // we need at least 1 'reachable' result to mark the whole protocol as reachable
+              if (result[protocol].result === 'reachable') {
+                protocols[protocol].reachable = true;
+              }
+            }
+          });
+        });
+
+        unreachable = Object.values(protocols).every(
+          (protocol) => protocol.tested && !protocol.reachable
+        );
+      } catch (e) {
+        LoggerProxy.logger.error(
+          `Roap:request#attachReachabilityData --> Error in parsing reachability data: ${e}`
+        );
+      }
+    }
+
+    return unreachable;
+  }
+
+  /**
    * Get list of all unreachable clusters
    * @returns {array} Unreachable clusters
    * @private


### PR DESCRIPTION
# COMPLETES #[SPARK-528375](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-528375)

## This pull request addresses
Web app wants to know when we are blocked at the network level so that we can show a UI warning to the user.

## by making the following changes
Added API that web app can call to find out if webex media clusters are completely unreachable. 

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
