### PR TITLE
fix: missed xtls reachability accounting in isAnyPublicClusterReachable

### DIFF
--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -284,7 +284,9 @@ export default class Reachability {
         reachable = Object.values(reachabilityResults).some(
           (result) =>
             !result.isVideoMesh &&
-            (result.udp?.result === 'reachable' || result.tcp?.result === 'reachable')
+            (result.udp?.result === 'reachable' ||
+              result.tcp?.result === 'reachable' ||
+              result.xtls?.result === 'reachable')
         );
       } catch (e) {
         LoggerProxy.logger.error(

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -40,28 +40,59 @@ describe('isAnyPublicClusterReachable', () => {
 
   it('returns true when udp is reachable', async () => {
     await checkIsClusterReachable(
-      {x: {udp: {result: 'reachable'}, tcp: {result: 'unreachable'}}},
+      {
+        x: {
+          udp: {result: 'reachable'},
+          tcp: {result: 'unreachable'},
+          xtls: {result: 'unreachable'},
+        },
+      },
       true
     );
   });
 
   it('returns true when tcp is reachable', async () => {
     await checkIsClusterReachable(
-      {x: {udp: {result: 'unreachable'}, tcp: {result: 'reachable'}}},
+      {
+        x: {
+          udp: {result: 'unreachable'},
+          tcp: {result: 'reachable'},
+          xtls: {result: 'unreachable'},
+        },
+      },
       true
     );
   });
 
-  it('returns true when both tcp and udp are reachable', async () => {
+  it('returns true when xtls is reachable', async () => {
     await checkIsClusterReachable(
-      {x: {udp: {result: 'reachable'}, tcp: {result: 'reachable'}}},
+      {
+        x: {
+          udp: {result: 'unreachable'},
+          tcp: {result: 'unreachable'},
+          xtls: {result: 'reachable'},
+        },
+      },
       true
     );
   });
 
-  it('returns false when both tcp and udp are unreachable', async () => {
+  it('returns true when udp, tcp and xtls are reachable', async () => {
     await checkIsClusterReachable(
-      {x: {udp: {result: 'unreachable'}, tcp: {result: 'unreachable'}}},
+      {x: {udp: {result: 'reachable'}, tcp: {result: 'reachable'}, xtls: {result: 'reachable'}}},
+      true
+    );
+  });
+
+  it('returns false when udp, tcp and xtls are unreachable', async () => {
+    await checkIsClusterReachable(
+      {
+        x: {
+          udp: {result: 'unreachable'},
+          tcp: {result: 'unreachable'},
+          xtls: {result: 'unreachable'},
+        },
+      },
       false
     );
   });
@@ -81,11 +112,13 @@ describe('isAnyPublicClusterReachable', () => {
           x: {
             udp: {result: 'reachable'},
             tcp: {result: 'reachable'},
+            xtls: {result: 'reachable'},
             isVideoMesh: true,
           },
           y: {
             udp: {result: 'unreachable'},
             tcp: {result: 'reachable'},
+            xtls: {result: 'unreachable'},
             isVideoMesh: true,
           },
         },
@@ -99,16 +132,19 @@ describe('isAnyPublicClusterReachable', () => {
           x: {
             udp: {result: 'unreachable'},
             tcp: {result: 'reachable'},
+            xtls: {result: 'unreachable'},
             isVideoMesh: true,
           },
           y: {
             udp: {result: 'reachable'},
             tcp: {result: 'unreachable'},
+            xtls: {result: 'unreachable'},
             isVideoMesh: true,
           },
           publicOne: {
             udp: {result: 'unreachable'},
             tcp: {result: 'unreachable'},
+            xtls: {result: 'unreachable'},
             isVideoMesh: false,
           },
         },
@@ -122,16 +158,19 @@ describe('isAnyPublicClusterReachable', () => {
           x: {
             udp: {result: 'reachable'},
             tcp: {result: 'reachable'},
+            xtls: {result: 'reachable'},
             isVideoMesh: true,
           },
           y: {
             udp: {result: 'unreachable'},
             tcp: {result: 'reachable'},
+            xtls: {result: 'unreachable'},
             isVideoMesh: true,
           },
           publicOne: {
             udp: {result: 'unreachable'},
             tcp: {result: 'reachable'},
+            xtls: {result: 'unreachable'},
             isVideoMesh: false,
           },
         },


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-535587](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-535587)

## This pull request addresses

This PR adds missing taking into account if we should do turn discovery based on reachability results. Now it's not particularly used, since we do turn discovery always.

## by making the following changes

Will calculate need of turn discovery with xTLS Servers (TurnTLS)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Tested on JS-SDK Plugin Meeting App

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
