### PR TITLE
fix(plugin-meetings): trigger transcript connected after llm online

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4954,8 +4954,10 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
-   * This callback is called when LLM comes online
-   * This method in turn will notify the meetings developer that LLM is connected
+   * This is a callback for the LLM event that is triggered when it comes online
+   * This method in turn will trigger an event to the developers that the LLM is connected
+   * @private
+   * @memberof Meeting
    * @returns {null}
    */
   private handleLLMOnline = (): void => {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4954,6 +4954,25 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
+   * This callback is called when LLM comes online
+   * This method in turn will notify the meetings developer that LLM is connected
+   * @returns {null}
+   */
+  private handleLLMOnline = (): void => {
+    // @ts-ignore
+    this.webex.internal.llm.off('online', this.handleLLMOnline);
+    Trigger.trigger(
+      this,
+      {
+        file: 'meeting/index',
+        function: 'handleLLMOnline',
+      },
+      EVENT_TRIGGERS.MEETING_TRANSCRIPTION_CONNECTED,
+      undefined
+    );
+  };
+
+  /**
    * Specify joining via audio (option: pstn), video, screenshare
    * @param {JoinOptions} options A configurable options object for joining a meeting
    * @returns {Promise} the join response
@@ -5172,6 +5191,8 @@ export default class Meeting extends StatelessWebexPlugin {
       .then((join) => {
         // @ts-ignore - config coming from registerPlugin
         if (this.config.enableAutomaticLLM) {
+          // @ts-ignore
+          this.webex.internal.llm.on('online', this.handleLLMOnline);
           this.updateLLMConnection()
             .catch((error) => {
               LoggerProxy.logger.error(
@@ -5188,15 +5209,6 @@ export default class Meeting extends StatelessWebexPlugin {
             .then(() => {
               LoggerProxy.logger.info(
                 'Meeting:index#join --> Transcription Socket Connection Success'
-              );
-              Trigger.trigger(
-                this,
-                {
-                  file: 'meeting/index',
-                  function: 'join',
-                },
-                EVENT_TRIGGERS.MEETING_TRANSCRIPTION_CONNECTED,
-                undefined
               );
             });
         }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1302,6 +1302,31 @@ describe('plugin-meetings', () => {
           );
         });
       });
+
+      describe('#handleLLMOnline', () => {
+        beforeEach(() => {
+          webex.internal.llm.off = sinon.stub();
+        });
+
+        it('turns off llm online, emits transcription connected events', () => {
+          meeting.handleLLMOnline();
+          assert.calledOnceWithExactly(
+            webex.internal.llm.off,
+            'online',
+            meeting.handleLLMOnline
+          );
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {
+              file: 'meeting/index',
+              function: 'handleLLMOnline',
+            },
+            EVENT_TRIGGERS.MEETING_TRANSCRIPTION_CONNECTED
+          );
+        });
+      });
+
       describe('#join', () => {
         let sandbox = null;
         let setCorrelationIdSpy;
@@ -1351,15 +1376,10 @@ describe('plugin-meetings', () => {
             assert.calledOnce(MeetingUtil.joinMeeting);
             assert.calledOnce(meeting.setLocus);
             assert.equal(result, joinMeetingResult);
-
             assert.calledWith(
-              TriggerProxy.trigger,
-              sinon.match.instanceOf(Meeting),
-              {
-                file: 'meeting/index',
-                function: 'join',
-              },
-              EVENT_TRIGGERS.MEETING_TRANSCRIPTION_CONNECTED
+              webex.internal.llm.on,
+              'online',
+              meeting.handleLLMOnline
             );
           });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES AdHoc

## This pull request addresses

So, while joining a meeting using the Web SDK, we check if the `enableAutomaticLLM` is set to true and connect the LLM  websocket and once we do this, we notify the customer through an event `meeting:transcription:connected`

We do this once the `updateLLMConnection` method is resolved. However, this is inaccurate sometimes leading to early emission of the event

## by making the following changes

To avoid such inaccuracy, this change will here-on listen to the 'online' event emitted by the LLM plugin and then trigger the `meeting:transcription:connected` event

### Screenrecording

Here's [link to the sharepoint upload](https://cisco-my.sharepoint.com/:v:/p/kmadavan/EUEyyMAsfDJNhsFgdQwS-nEB1Dheba4JmIeONRGf7MHnRw?nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJPbmVEcml2ZUZvckJ1c2luZXNzIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXciLCJyZWZlcnJhbFZpZXciOiJNeUZpbGVzTGlua0NvcHkifX0&e=IVG4eC).

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- Wrote unit tests for the changes
- Updated the code and tested it by enabling Transcription from the sample app to see if the event is triggered
- Also tried to speak a few words to ensure we receive the transcription payload

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
