### PR TITLE
fix(plugin-meetings): update multistreamEnabled

### DIFF
--- a/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
+++ b/packages/@webex/plugin-meetings/src/mediaQualityMetrics/config.ts
@@ -132,7 +132,7 @@ export const emptyVideoReceive = {
       mariRtxEnabled: false,
       mariQosEnabled: false,
       mariLiteEnabled: false,
-      multistreamEnabled: true, // Not avaliable
+      multistreamEnabled: false,
     },
     dtlsBitrate: 0, // Not avaliable
     dtlsPackets: 0, // Not avaliable
@@ -199,7 +199,7 @@ export const emptyVideoTransmit = {
       mariRtxEnabled: false,
       mariQosEnabled: false,
       mariLiteEnabled: false,
-      multistreamEnabled: false, // Not avaliable
+      multistreamEnabled: false,
     },
     dtlsBitrate: 0, // Not avaliable
     dtlsPackets: 0, // Not avaliable

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6317,12 +6317,13 @@ export default class Meeting extends StatelessWebexPlugin {
     if (this.config.stats.enableStatsAnalyzer) {
       // @ts-ignore - config coming from registerPlugin
       this.networkQualityMonitor = new NetworkQualityMonitor(this.config.stats);
-      this.statsAnalyzer = new StatsAnalyzer(
+      this.statsAnalyzer = new StatsAnalyzer({
         // @ts-ignore - config coming from registerPlugin
-        this.config.stats,
-        (ssrc: number) => this.receiveSlotManager.findReceiveSlotBySsrc(ssrc),
-        this.networkQualityMonitor
-      );
+        config: this.config.stats,
+        receiveSlotCallback: (ssrc: number) => this.receiveSlotManager.findReceiveSlotBySsrc(ssrc),
+        networkQualityMonitor: this.networkQualityMonitor,
+        isMultistream: this.isMultistream,
+      });
       this.setupStatsAnalyzerEventHandlers();
       this.networkQualityMonitor.on(
         EVENT_TRIGGERS.NETWORK_QUALITY,

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -92,22 +92,31 @@ export class StatsAnalyzer extends EventsScope {
   successfulCandidatePair: any;
   localIpAddress: string; // Returns the local IP address for diagnostics. this is the local IP of the interface used for the current media connection a host can have many local Ip Addresses
   receiveSlotCallback: ReceiveSlotCallback;
+  isMultistream: boolean;
 
   /**
    * Creates a new instance of StatsAnalyzer
    * @constructor
    * @public
-   * @param {Object} config SDK Configuration Object
-   * @param {Function} receiveSlotCallback Callback used to access receive slots.
-   * @param {Object} networkQualityMonitor class for assessing network characteristics (jitter, packetLoss, latency)
-   * @param {Object} statsResults Default properties for stats
+   * @param {Object} config - SDK Configuration Object
+   * @param {Function} receiveSlotCallback - Callback used to access receive slots.
+   * @param {Object} networkQualityMonitor - Class for assessing network characteristics (jitter, packetLoss, latency)
+   * @param {Object} statsResults - Default properties for stats
+   * @param {boolean | undefined} isMultistream - Param indicating if the media connection is multistream or not
    */
-  constructor(
-    config: any,
-    receiveSlotCallback: ReceiveSlotCallback = () => undefined,
-    networkQualityMonitor: object = {},
-    statsResults: object = defaultStats
-  ) {
+  constructor({
+    config,
+    receiveSlotCallback = () => undefined,
+    networkQualityMonitor = {},
+    statsResults = defaultStats,
+    isMultistream = false,
+  }: {
+    config: any;
+    receiveSlotCallback: ReceiveSlotCallback;
+    networkQualityMonitor: any;
+    statsResults?: any;
+    isMultistream?: boolean;
+  }) {
     super();
     this.statsStarted = false;
     this.statsResults = statsResults;
@@ -121,6 +130,7 @@ export class StatsAnalyzer extends EventsScope {
     this.receiveSlotCallback = receiveSlotCallback;
     this.successfulCandidatePair = {};
     this.localIpAddress = '';
+    this.isMultistream = isMultistream;
   }
 
   /**
@@ -188,6 +198,13 @@ export class StatsAnalyzer extends EventsScope {
         this.lastMqaDataSent[mediaType].recv = {};
       }
     });
+
+    if (this.isMultistream) {
+      emptyAudioTransmit.common.common.multistreamEnabled = true;
+      emptyAudioReceive.common.common.multistreamEnabled = true;
+      emptyVideoTransmit.common.common.multistreamEnabled = true;
+      emptyVideoReceive.common.common.multistreamEnabled = true;
+    }
 
     // Create stats the first level, totals for senders and receivers
     const audioSender = cloneDeep(emptyAudioTransmit);

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -209,26 +209,12 @@ export class StatsAnalyzer extends EventsScope {
     const videoReceiver = cloneDeep(emptyVideoReceive);
     const videoShareReceiver = cloneDeep(emptyVideoReceive);
 
-    if (this.isMultistream) {
-      [
-        audioSender,
-        audioShareSender,
-        audioReceiver,
-        audioShareReceiver,
-        videoSender,
-        videoShareSender,
-        videoReceiver,
-        videoShareReceiver,
-      ].forEach((mediaType) => {
-        mediaType.common.common.multistreamEnabled = true;
-      });
-    }
-
     getAudioSenderMqa({
       audioSender,
       statsResults: this.statsResults,
       lastMqaDataSent: this.lastMqaDataSent,
       baseMediaType: 'audio-send',
+      isMultistream: this.isMultistream,
     });
     newMqa.audioTransmit.push(audioSender);
 
@@ -237,6 +223,7 @@ export class StatsAnalyzer extends EventsScope {
       statsResults: this.statsResults,
       lastMqaDataSent: this.lastMqaDataSent,
       baseMediaType: 'audio-share-send',
+      isMultistream: this.isMultistream,
     });
     newMqa.audioTransmit.push(audioShareSender);
 
@@ -245,6 +232,7 @@ export class StatsAnalyzer extends EventsScope {
       statsResults: this.statsResults,
       lastMqaDataSent: this.lastMqaDataSent,
       baseMediaType: 'audio-recv',
+      isMultistream: this.isMultistream,
     });
     newMqa.audioReceive.push(audioReceiver);
 
@@ -253,6 +241,7 @@ export class StatsAnalyzer extends EventsScope {
       statsResults: this.statsResults,
       lastMqaDataSent: this.lastMqaDataSent,
       baseMediaType: 'audio-share-recv',
+      isMultistream: this.isMultistream,
     });
     newMqa.audioReceive.push(audioShareReceiver);
 
@@ -261,6 +250,7 @@ export class StatsAnalyzer extends EventsScope {
       statsResults: this.statsResults,
       lastMqaDataSent: this.lastMqaDataSent,
       baseMediaType: 'video-send',
+      isMultistream: this.isMultistream,
     });
     newMqa.videoTransmit.push(videoSender);
 
@@ -269,6 +259,7 @@ export class StatsAnalyzer extends EventsScope {
       statsResults: this.statsResults,
       lastMqaDataSent: this.lastMqaDataSent,
       baseMediaType: 'video-share-send',
+      isMultistream: this.isMultistream,
     });
     newMqa.videoTransmit.push(videoShareSender);
 
@@ -277,6 +268,7 @@ export class StatsAnalyzer extends EventsScope {
       statsResults: this.statsResults,
       lastMqaDataSent: this.lastMqaDataSent,
       baseMediaType: 'video-recv',
+      isMultistream: this.isMultistream,
     });
     newMqa.videoReceive.push(videoReceiver);
 
@@ -285,6 +277,7 @@ export class StatsAnalyzer extends EventsScope {
       statsResults: this.statsResults,
       lastMqaDataSent: this.lastMqaDataSent,
       baseMediaType: 'video-share-recv',
+      isMultistream: this.isMultistream,
     });
     newMqa.videoReceive.push(videoShareReceiver);
 

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -199,13 +199,6 @@ export class StatsAnalyzer extends EventsScope {
       }
     });
 
-    if (this.isMultistream) {
-      emptyAudioTransmit.common.common.multistreamEnabled = true;
-      emptyAudioReceive.common.common.multistreamEnabled = true;
-      emptyVideoTransmit.common.common.multistreamEnabled = true;
-      emptyVideoReceive.common.common.multistreamEnabled = true;
-    }
-
     // Create stats the first level, totals for senders and receivers
     const audioSender = cloneDeep(emptyAudioTransmit);
     const audioShareSender = cloneDeep(emptyAudioTransmit);
@@ -215,6 +208,21 @@ export class StatsAnalyzer extends EventsScope {
     const videoShareSender = cloneDeep(emptyVideoTransmit);
     const videoReceiver = cloneDeep(emptyVideoReceive);
     const videoShareReceiver = cloneDeep(emptyVideoReceive);
+
+    if (this.isMultistream) {
+      [
+        audioSender,
+        audioShareSender,
+        audioReceiver,
+        audioShareReceiver,
+        videoSender,
+        videoShareSender,
+        videoReceiver,
+        videoShareReceiver,
+      ].forEach((mediaType) => {
+        mediaType.common.common.multistreamEnabled = true;
+      });
+    }
 
     getAudioSenderMqa({
       audioSender,

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -28,6 +28,7 @@ export const getAudioReceiverMqa = ({
   statsResults,
   lastMqaDataSent,
   baseMediaType,
+  isMultistream,
 }) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
@@ -52,6 +53,7 @@ export const getAudioReceiverMqa = ({
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
       ?.direction || 'inactive';
   audioReceiver.common.common.isMain = !baseMediaType.includes('-share');
+  audioReceiver.common.common.multistreamEnabled = isMultistream;
   audioReceiver.common.transportType = statsResults.connectionType.local.transport;
 
   // add rtpPacket info inside common as also for call analyzer
@@ -127,7 +129,13 @@ export const getAudioReceiverStreamMqa = ({
     ((statsResults[mediaType][sendrecvType].totalBytesReceived - lastBytesReceived) * 8) / 60 || 0;
 };
 
-export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, baseMediaType}) => {
+export const getAudioSenderMqa = ({
+  audioSender,
+  statsResults,
+  lastMqaDataSent,
+  baseMediaType,
+  isMultistream,
+}) => {
   const sendrecvType = STATS.SEND_DIRECTION;
 
   const getLastTotalValue = (value: string) =>
@@ -152,6 +160,7 @@ export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, b
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
       ?.direction || 'inactive';
   audioSender.common.common.isMain = !baseMediaType.includes('-share');
+  audioSender.common.common.multistreamEnabled = isMultistream;
   audioSender.common.transportType = statsResults.connectionType.local.transport;
 
   audioSender.common.maxRemoteJitter = max(meanRemoteJitter) * 1000 || 0;
@@ -225,6 +234,7 @@ export const getVideoReceiverMqa = ({
   statsResults,
   lastMqaDataSent,
   baseMediaType,
+  isMultistream,
 }) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
@@ -254,6 +264,7 @@ export const getVideoReceiverMqa = ({
   videoReceiver.common.common.direction =
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
       ?.direction || 'inactive';
+  videoReceiver.common.common.multistreamEnabled = isMultistream;
   videoReceiver.common.common.isMain = !baseMediaType.includes('-share');
   videoReceiver.common.transportType = statsResults.connectionType.local.transport;
 
@@ -357,7 +368,13 @@ export const getVideoReceiverStreamMqa = ({
         MQA_INTERVAL);
 };
 
-export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, baseMediaType}) => {
+export const getVideoSenderMqa = ({
+  videoSender,
+  statsResults,
+  lastMqaDataSent,
+  baseMediaType,
+  isMultistream,
+}) => {
   const sendrecvType = STATS.SEND_DIRECTION;
 
   const getLastTotalValue = (value: string) =>
@@ -381,6 +398,7 @@ export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, b
   videoSender.common.common.direction =
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
       ?.direction || 'inactive';
+  videoSender.common.common.multistreamEnabled = isMultistream;
   videoSender.common.common.isMain = !baseMediaType.includes('-share');
   videoSender.common.transportType = statsResults.connectionType.local.transport;
 

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -28,7 +28,6 @@ export const getAudioReceiverMqa = ({
   statsResults,
   lastMqaDataSent,
   baseMediaType,
-  // isMultistream,
 }) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
@@ -53,7 +52,6 @@ export const getAudioReceiverMqa = ({
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
       ?.direction || 'inactive';
   audioReceiver.common.common.isMain = !baseMediaType.includes('-share');
-  // audioReceiver.common.common.multistreamEnabled = isMultistream;
   audioReceiver.common.transportType = statsResults.connectionType.local.transport;
 
   // add rtpPacket info inside common as also for call analyzer
@@ -79,7 +77,6 @@ export const getAudioReceiverStreamMqa = ({
   statsResults,
   lastMqaDataSent,
   mediaType,
-  // isMultistream,
 }) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
@@ -128,17 +125,9 @@ export const getAudioReceiverStreamMqa = ({
     statsResults[mediaType][sendrecvType].concealedSamples - lastConcealedSamples || 0;
   audioReceiverStream.common.receivedBitrate =
     ((statsResults[mediaType][sendrecvType].totalBytesReceived - lastBytesReceived) * 8) / 60 || 0;
-
-  // audioReceiverStream.common.common.multistreamEnabled = isMultistream;
 };
 
-export const getAudioSenderMqa = ({
-  audioSender,
-  statsResults,
-  lastMqaDataSent,
-  baseMediaType,
-  // isMultistream,
-}) => {
+export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, baseMediaType}) => {
   const sendrecvType = STATS.SEND_DIRECTION;
 
   const getLastTotalValue = (value: string) =>
@@ -195,7 +184,6 @@ export const getAudioSenderMqa = ({
     getTotalValueFromBaseType(lastMqaDataSent, sendrecvType, baseMediaType, 'totalBytesSent');
 
   audioSender.common.rtpBitrate = totalBytesSentInaMin ? (totalBytesSentInaMin * 8) / 60 : 0;
-  // audioSender.common.common.multistreamEnabled = isMultistream;
 };
 
 export const getAudioSenderStreamMqa = ({
@@ -237,7 +225,6 @@ export const getVideoReceiverMqa = ({
   statsResults,
   lastMqaDataSent,
   baseMediaType,
-  // isMultistream,
 }) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
@@ -267,7 +254,6 @@ export const getVideoReceiverMqa = ({
   videoReceiver.common.common.direction =
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
       ?.direction || 'inactive';
-  // videoReceiver.common.common.multistreamEnabled = isMultistream;
   videoReceiver.common.common.isMain = !baseMediaType.includes('-share');
   videoReceiver.common.transportType = statsResults.connectionType.local.transport;
 
@@ -395,7 +381,6 @@ export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, b
   videoSender.common.common.direction =
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
       ?.direction || 'inactive';
-  // videoSender.common.common.multistreamEnabled = isMultistream;
   videoSender.common.common.isMain = !baseMediaType.includes('-share');
   videoSender.common.transportType = statsResults.connectionType.local.transport;
 

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -28,6 +28,7 @@ export const getAudioReceiverMqa = ({
   statsResults,
   lastMqaDataSent,
   baseMediaType,
+  // isMultistream,
 }) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
@@ -52,6 +53,7 @@ export const getAudioReceiverMqa = ({
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
       ?.direction || 'inactive';
   audioReceiver.common.common.isMain = !baseMediaType.includes('-share');
+  // audioReceiver.common.common.multistreamEnabled = isMultistream;
   audioReceiver.common.transportType = statsResults.connectionType.local.transport;
 
   // add rtpPacket info inside common as also for call analyzer
@@ -77,6 +79,7 @@ export const getAudioReceiverStreamMqa = ({
   statsResults,
   lastMqaDataSent,
   mediaType,
+  // isMultistream,
 }) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
@@ -125,9 +128,17 @@ export const getAudioReceiverStreamMqa = ({
     statsResults[mediaType][sendrecvType].concealedSamples - lastConcealedSamples || 0;
   audioReceiverStream.common.receivedBitrate =
     ((statsResults[mediaType][sendrecvType].totalBytesReceived - lastBytesReceived) * 8) / 60 || 0;
+
+  // audioReceiverStream.common.common.multistreamEnabled = isMultistream;
 };
 
-export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, baseMediaType}) => {
+export const getAudioSenderMqa = ({
+  audioSender,
+  statsResults,
+  lastMqaDataSent,
+  baseMediaType,
+  // isMultistream,
+}) => {
   const sendrecvType = STATS.SEND_DIRECTION;
 
   const getLastTotalValue = (value: string) =>
@@ -166,8 +177,8 @@ export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, b
     baseMediaType,
     'availableOutgoingBitrate'
   );
-  // Calculate based on how much packets lost of received compated to how to the client sent
 
+  // Calculate based on how much packets lost of received compated to how to the client sent
   const totalPacketsLostForaMin = totalPacketsLostOnReceiver - lastPacketsLostTotal;
   audioSender.common.remoteLossRate =
     totalPacketsSent - lastPacketsSent > 0
@@ -184,6 +195,7 @@ export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, b
     getTotalValueFromBaseType(lastMqaDataSent, sendrecvType, baseMediaType, 'totalBytesSent');
 
   audioSender.common.rtpBitrate = totalBytesSentInaMin ? (totalBytesSentInaMin * 8) / 60 : 0;
+  // audioSender.common.common.multistreamEnabled = isMultistream;
 };
 
 export const getAudioSenderStreamMqa = ({
@@ -225,6 +237,7 @@ export const getVideoReceiverMqa = ({
   statsResults,
   lastMqaDataSent,
   baseMediaType,
+  // isMultistream,
 }) => {
   const sendrecvType = STATS.RECEIVE_DIRECTION;
 
@@ -254,6 +267,7 @@ export const getVideoReceiverMqa = ({
   videoReceiver.common.common.direction =
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
       ?.direction || 'inactive';
+  // videoReceiver.common.common.multistreamEnabled = isMultistream;
   videoReceiver.common.common.isMain = !baseMediaType.includes('-share');
   videoReceiver.common.transportType = statsResults.connectionType.local.transport;
 
@@ -381,6 +395,7 @@ export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, b
   videoSender.common.common.direction =
     statsResults[Object.keys(statsResults).find((mediaType) => mediaType.includes(baseMediaType))]
       ?.direction || 'inactive';
+  // videoSender.common.common.multistreamEnabled = isMultistream;
   videoSender.common.common.isMain = !baseMediaType.includes('-share');
   videoSender.common.transportType = statsResults.connectionType.local.transport;
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -16,7 +16,15 @@ const {assert} = chai;
 chai.use(chaiAsPromised);
 sinon.assert.expose(chai.assert, {prefix: ''});
 
-describe('plugin-meetings', () => {
+const startStatsAnalyzer = async ({statsAnalyzer, mediaStatus, lastEmittedEvents = {}, pc}) => {
+  statsAnalyzer.updateMediaStatus(mediaStatus);
+  statsAnalyzer.startAnalyzer(pc);
+  statsAnalyzer.lastEmittedStartStopEvent = lastEmittedEvents;
+
+  await testUtils.flushPromises();
+};
+
+describe.only('plugin-meetings', () => {
   describe('StatsAnalyzer', () => {
     describe('parseStatsResult', () => {
       const sandbox = sinon.createSandbox();
@@ -29,10 +37,12 @@ describe('plugin-meetings', () => {
         const networkQualityMonitor = new NetworkQualityMonitor(initialConfig);
 
         statsAnalyzer = new StatsAnalyzer(
-          initialConfig,
-          () => ({}),
-          networkQualityMonitor,
-          defaultStats
+          {
+            config: initialConfig,
+            receiveSlotCallback: () => ({}),
+            networkQualityMonitor,
+            statsResults: defaultStats,
+          },
         );
       });
 
@@ -89,7 +99,7 @@ describe('plugin-meetings', () => {
             requestedBitrate: 10000,
           },
           'audio-send',
-          true
+          true,
         );
 
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.headerBytesSent, 25000);
@@ -126,7 +136,7 @@ describe('plugin-meetings', () => {
             requestedBitrate: 50000,
           },
           'video-send',
-          true
+          true,
         );
 
         assert.strictEqual(statsAnalyzer.statsResults['video-send'].send.headerBytesSent, 50000);
@@ -136,11 +146,11 @@ describe('plugin-meetings', () => {
         assert.strictEqual(statsAnalyzer.statsResults['video-send'].send.requestedBitrate, 50000);
         assert.strictEqual(
           statsAnalyzer.statsResults['video-send'].send.totalRtxPacketsSent,
-          10
+          10,
         );
         assert.strictEqual(
           statsAnalyzer.statsResults['video-send'].send.totalRtxBytesSent,
-          500
+          500,
         );
       });
 
@@ -183,12 +193,12 @@ describe('plugin-meetings', () => {
             requestedBitrate: 10000,
           },
           'audio-recv-1',
-          false
+          false,
         );
 
         assert.strictEqual(
           statsAnalyzer.statsResults['audio-recv-1'].recv.totalPacketsReceived,
-          12
+          12,
         );
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.fecPacketsDiscarded, 1);
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.fecPacketsReceived, 1);
@@ -196,18 +206,18 @@ describe('plugin-meetings', () => {
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.requestedBitrate, 10000);
         assert.strictEqual(
           statsAnalyzer.statsResults['audio-recv-1'].recv.headerBytesReceived,
-          250
+          250,
         );
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.audioLevel, 0);
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.totalAudioEnergy, 133);
         assert.strictEqual(
           statsAnalyzer.statsResults['audio-recv-1'].recv.totalSamplesReceived,
-          300000
+          300000,
         );
         assert.strictEqual(statsAnalyzer.statsResults['audio-recv-1'].recv.totalSamplesDecoded, 0);
         assert.strictEqual(
           statsAnalyzer.statsResults['audio-recv-1'].recv.concealedSamples,
-          200000
+          200000,
         );
       });
 
@@ -243,7 +253,7 @@ describe('plugin-meetings', () => {
             retransmittedPacketsReceived: 10,
           },
           'video-recv',
-          false
+          false,
         );
 
         assert.strictEqual(statsAnalyzer.statsResults['video-recv'].recv.totalPacketsReceived, 1500);
@@ -275,7 +285,7 @@ describe('plugin-meetings', () => {
             type: 'media-source',
           },
           'audio-send',
-          true
+          true,
         );
 
         assert.strictEqual(statsAnalyzer.statsResults['audio-send'].send.audioLevel, 0.03);
@@ -322,15 +332,17 @@ describe('plugin-meetings', () => {
         const networkQualityMonitor = new NetworkQualityMonitor(initialConfig);
 
         statsAnalyzer = new StatsAnalyzer(
-          initialConfig,
-          () => ({}),
-          networkQualityMonitor,
-          defaultStats
+          {
+            config: initialConfig,
+            receiveSlotCallback: () => ({}),
+            networkQualityMonitor,
+            statsResults: defaultStats,
+          },
         );
 
         sandBoxSpy = sandbox.spy(
           statsAnalyzer.networkQualityMonitor,
-          'determineUplinkNetworkQuality'
+          'determineUplinkNetworkQuality',
         );
       });
 
@@ -347,7 +359,7 @@ describe('plugin-meetings', () => {
             mediaType: 'video-send-1',
             remoteRtpResults: statusResult,
             statsAnalyzerCurrentStats: statsAnalyzer.statsResults,
-          })
+          }),
         );
       });
     });
@@ -379,6 +391,24 @@ describe('plugin-meetings', () => {
           local: {},
           remote: {},
         };
+      };
+
+      const registerStatsAnalyzerEvents = (statsAnalyzer) => {
+        statsAnalyzer.on(EVENTS.LOCAL_MEDIA_STARTED, (data) => {
+          receivedEventsData.local.started = data;
+        });
+        statsAnalyzer.on(EVENTS.LOCAL_MEDIA_STOPPED, (data) => {
+          receivedEventsData.local.stopped = data;
+        });
+        statsAnalyzer.on(EVENTS.REMOTE_MEDIA_STARTED, (data) => {
+          receivedEventsData.remote.started = data;
+        });
+        statsAnalyzer.on(EVENTS.REMOTE_MEDIA_STOPPED, (data) => {
+          receivedEventsData.remote.stopped = data;
+        });
+        statsAnalyzer.on(EVENTS.MEDIA_QUALITY, ({data}) => {
+          mqeData = data;
+        });
       };
 
       before(() => {
@@ -635,23 +665,11 @@ describe('plugin-meetings', () => {
 
         networkQualityMonitor = new NetworkQualityMonitor(initialConfig);
 
-        statsAnalyzer = new StatsAnalyzer(initialConfig, () => receiveSlot, networkQualityMonitor);
+        statsAnalyzer = new StatsAnalyzer({
+          config: initialConfig, receiveSlotCallback: () => receiveSlot, networkQualityMonitor,
+        });
 
-        statsAnalyzer.on(EVENTS.LOCAL_MEDIA_STARTED, (data) => {
-          receivedEventsData.local.started = data;
-        });
-        statsAnalyzer.on(EVENTS.LOCAL_MEDIA_STOPPED, (data) => {
-          receivedEventsData.local.stopped = data;
-        });
-        statsAnalyzer.on(EVENTS.REMOTE_MEDIA_STARTED, (data) => {
-          receivedEventsData.remote.started = data;
-        });
-        statsAnalyzer.on(EVENTS.REMOTE_MEDIA_STOPPED, (data) => {
-          receivedEventsData.remote.stopped = data;
-        });
-        statsAnalyzer.on(EVENTS.MEDIA_QUALITY, ({data}) => {
-          mqeData = data;
-        });
+        registerStatsAnalyzerEvents(statsAnalyzer);
       });
 
       afterEach(() => {
@@ -659,20 +677,12 @@ describe('plugin-meetings', () => {
         clock.restore();
       });
 
-      const startStatsAnalyzer = async (mediaStatus, lastEmittedEvents) => {
-        statsAnalyzer.updateMediaStatus(mediaStatus);
-        statsAnalyzer.startAnalyzer(pc);
-        statsAnalyzer.lastEmittedStartStopEvent = lastEmittedEvents || {};
-
-        await testUtils.flushPromises();
-      };
-
       const mergeProperties = (
         target,
         properties,
         keyValue = 'fake-candidate-id',
         matchKey = 'type',
-        matchValue = 'local-candidate'
+        matchValue = 'local-candidate',
       ) => {
         for (let key in target) {
           if (target.hasOwnProperty(key)) {
@@ -717,7 +727,15 @@ describe('plugin-meetings', () => {
       };
 
       it('emits LOCAL_MEDIA_STARTED and LOCAL_MEDIA_STOPPED events for audio', async () => {
-        await startStatsAnalyzer({expected: {sendAudio: true}});
+        await startStatsAnalyzer({
+          statsAnalyzer,
+          pc,
+          mediaStatus: {
+            expected: {
+              sendAudio: true,
+            },
+          },
+        });
 
         // check that we haven't received any events yet
         checkReceivedEvent({expected: {}});
@@ -737,7 +755,7 @@ describe('plugin-meetings', () => {
       });
 
       it('emits LOCAL_MEDIA_STARTED and LOCAL_MEDIA_STOPPED events for video', async () => {
-        await startStatsAnalyzer({expected: {sendVideo: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {sendVideo: true}}});
 
         // check that we haven't received any events yet
         checkReceivedEvent({expected: {}});
@@ -757,7 +775,7 @@ describe('plugin-meetings', () => {
       });
 
       it('emits LOCAL_MEDIA_STARTED and LOCAL_MEDIA_STOPPED events for share', async () => {
-        await startStatsAnalyzer({expected: {sendShare: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {sendShare: true}}});
 
         // check that we haven't received any events yet
         checkReceivedEvent({expected: {}});
@@ -777,7 +795,7 @@ describe('plugin-meetings', () => {
       });
 
       it('emits REMOTE_MEDIA_STARTED and REMOTE_MEDIA_STOPPED events for audio', async () => {
-        await startStatsAnalyzer({expected: {receiveAudio: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveAudio: true}}});
 
         // check that we haven't received any events yet
         checkReceivedEvent({expected: {}});
@@ -797,7 +815,7 @@ describe('plugin-meetings', () => {
       });
 
       it('emits REMOTE_MEDIA_STARTED and REMOTE_MEDIA_STOPPED events for video', async () => {
-        await startStatsAnalyzer({expected: {receiveVideo: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
         // check that we haven't received any events yet
         checkReceivedEvent({expected: {}});
@@ -817,7 +835,7 @@ describe('plugin-meetings', () => {
       });
 
       it('emits REMOTE_MEDIA_STARTED and REMOTE_MEDIA_STOPPED events for share', async () => {
-        await startStatsAnalyzer({expected: {receiveShare: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveShare: true}}});
 
         // check that we haven't received any events yet
         checkReceivedEvent({expected: {}});
@@ -837,7 +855,7 @@ describe('plugin-meetings', () => {
       });
 
       it('emits the correct MEDIA_QUALITY events', async () => {
-        await startStatsAnalyzer({expected: {receiveVideo: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
         await progressTime();
 
@@ -846,7 +864,7 @@ describe('plugin-meetings', () => {
       });
 
       it('emits the correct transportType in MEDIA_QUALITY events', async () => {
-        await startStatsAnalyzer({expected: {receiveVideo: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
         await progressTime();
 
@@ -860,7 +878,7 @@ describe('plugin-meetings', () => {
         fakeStats.audio.receivers[0].report[4].relayProtocol = 'tls';
         fakeStats.video.receivers[0].report[4].relayProtocol = 'tls';
 
-        await startStatsAnalyzer({expected: {receiveVideo: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
         await progressTime();
 
@@ -869,19 +887,19 @@ describe('plugin-meetings', () => {
       });
 
       it('emits the correct peripherals in MEDIA_QUALITY events', async () => {
-        await startStatsAnalyzer({expected: {receiveVideo: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
         await progressTime();
 
         assert.strictEqual(
           mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.MICROPHONE)
             .information,
-          'fake-microphone'
+          'fake-microphone',
         );
         assert.strictEqual(
           mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.CAMERA)
             .information,
-          'fake-camera'
+          'fake-camera',
         );
       });
 
@@ -889,19 +907,19 @@ describe('plugin-meetings', () => {
         fakeStats.audio.senders[0].localTrackLabel = undefined;
         fakeStats.video.senders[0].localTrackLabel = undefined;
 
-        await startStatsAnalyzer({expected: {receiveVideo: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
         await progressTime();
 
         assert.strictEqual(
           mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.MICROPHONE)
             .information,
-          _UNKNOWN_
+          _UNKNOWN_,
         );
         assert.strictEqual(
           mqeData.intervalMetadata.peripherals.find((val) => val.name === MEDIA_DEVICES.CAMERA)
             .information,
-          _UNKNOWN_
+          _UNKNOWN_,
         );
       });
 
@@ -928,7 +946,7 @@ describe('plugin-meetings', () => {
 
       describe('RTP packets count in stats analyzer', () => {
         beforeEach(async () => {
-          await startStatsAnalyzer();
+          await startStatsAnalyzer({pc, statsAnalyzer});
         });
 
         it('should report zero RTP packets for all streams at the start of the stats analyzer', async () => {
@@ -969,8 +987,8 @@ describe('plugin-meetings', () => {
 
       describe('FEC packet reporting in stats analyzer', () => {
         beforeEach(async () => {
-          await startStatsAnalyzer();
-        })
+          await startStatsAnalyzer({pc, statsAnalyzer});
+        });
 
         it('should initially report zero FEC packets at the start of the stats analyzer', async () => {
           assert.strictEqual(mqeData.audioReceive[0].common.fecPackets, 0);
@@ -994,8 +1012,8 @@ describe('plugin-meetings', () => {
 
       describe('packet loss metrics reporting in stats analyzer', () => {
         beforeEach(async () => {
-          await startStatsAnalyzer();
-        })
+          await startStatsAnalyzer({pc, statsAnalyzer});
+        });
 
         it('should report zero packet loss for both audio and video at the start of the stats analyzer', async () => {
           assert.strictEqual(mqeData.audioReceive[0].common.mediaHopByHopLost, 0);
@@ -1018,7 +1036,7 @@ describe('plugin-meetings', () => {
 
       describe('remote loss rate reporting in stats analyzer', () => {
         beforeEach(async () => {
-          await startStatsAnalyzer();
+          await startStatsAnalyzer({pc, statsAnalyzer});
         });
 
         it('should report a zero remote loss rate for both audio and video at the start', async () => {
@@ -1049,7 +1067,7 @@ describe('plugin-meetings', () => {
 
 
       it('has the correct localIpAddress set when the candidateType is host', async () => {
-        await startStatsAnalyzer();
+        await startStatsAnalyzer({pc, statsAnalyzer});
 
         await progressTime();
         assert.strictEqual(statsAnalyzer.getLocalIpAddress(), '');
@@ -1059,7 +1077,7 @@ describe('plugin-meetings', () => {
       });
 
       it('has the correct localIpAddress set when the candidateType is prflx and relayProtocol is set', async () => {
-        await startStatsAnalyzer();
+        await startStatsAnalyzer({pc, statsAnalyzer});
 
         await progressTime();
         assert.strictEqual(statsAnalyzer.getLocalIpAddress(), '');
@@ -1073,7 +1091,7 @@ describe('plugin-meetings', () => {
       });
 
       it('has the correct localIpAddress set when the candidateType is prflx and relayProtocol is not set', async () => {
-        await startStatsAnalyzer();
+        await startStatsAnalyzer({pc, statsAnalyzer});
 
         await progressTime();
         assert.strictEqual(statsAnalyzer.getLocalIpAddress(), '');
@@ -1087,7 +1105,7 @@ describe('plugin-meetings', () => {
       });
 
       it('has no localIpAddress set when the candidateType is invalid', async () => {
-        await startStatsAnalyzer();
+        await startStatsAnalyzer({pc, statsAnalyzer});
 
         await progressTime();
         assert.strictEqual(statsAnalyzer.getLocalIpAddress(), '');
@@ -1098,8 +1116,10 @@ describe('plugin-meetings', () => {
 
       it('logs a message when audio send packets do not increase', async () => {
         await startStatsAnalyzer(
-          {expected: {sendAudio: true}},
-          {audio: {local: EVENTS.LOCAL_MEDIA_STARTED}}
+          {
+            statsAnalyzer, pc, mediaStatus: {expected: {sendAudio: true}},
+            lastEmittedEvents: {audio: {local: EVENTS.LOCAL_MEDIA_STARTED}},
+          },
         );
 
         // don't increase the packets when time progresses.
@@ -1107,15 +1127,17 @@ describe('plugin-meetings', () => {
 
         assert(
           loggerSpy.calledWith(
-            'StatsAnalyzer:index#compareLastStatsResult --> No audio RTP packets sent'
-          )
+            'StatsAnalyzer:index#compareLastStatsResult --> No audio RTP packets sent',
+          ),
         );
       });
 
       it('does not log a message when audio send packets increase', async () => {
-        await startStatsAnalyzer(
-          {expected: {sendAudio: true}},
-          {audio: {local: EVENTS.LOCAL_MEDIA_STOPPED}}
+        await startStatsAnalyzer({
+            statsAnalyzer, pc,
+            mediaStatus: {expected: {sendAudio: true}},
+            lastEmittedEvents: {audio: {local: EVENTS.LOCAL_MEDIA_STOPPED}},
+          },
         );
 
         fakeStats.audio.senders[0].report[0].packetsSent += 5;
@@ -1123,15 +1145,16 @@ describe('plugin-meetings', () => {
 
         assert(
           loggerSpy.neverCalledWith(
-            'StatsAnalyzer:index#compareLastStatsResult --> No audio RTP packets sent'
-          )
+            'StatsAnalyzer:index#compareLastStatsResult --> No audio RTP packets sent',
+          ),
         );
       });
 
       it('logs a message when video send packets do not increase', async () => {
-        await startStatsAnalyzer(
-          {expected: {sendVideo: true}},
-          {video: {local: EVENTS.LOCAL_MEDIA_STARTED}}
+        await startStatsAnalyzer({
+            statsAnalyzer, pc, mediaStatus: {expected: {sendVideo: true}},
+            lastEmittedEvents: {video: {local: EVENTS.LOCAL_MEDIA_STARTED}},
+          },
         );
 
         // don't increase the packets when time progresses.
@@ -1139,31 +1162,42 @@ describe('plugin-meetings', () => {
 
         assert(
           loggerSpy.calledWith(
-            'StatsAnalyzer:index#compareLastStatsResult --> No video RTP packets sent'
-          )
+            'StatsAnalyzer:index#compareLastStatsResult --> No video RTP packets sent',
+          ),
         );
       });
 
       it('does not log a message when video send packets increase', async () => {
         await startStatsAnalyzer(
-          {expected: {sendVideo: true}},
-          {video: {local: EVENTS.LOCAL_MEDIA_STOPPED}}
-        );
+          {
+            statsAnalyzer, pc,
+            mediaStatus: {
+              expected: {
+                sendVideo: true,
+              },
+            },
+            lastEmittedEvents: {
+              video: {
+                local: EVENTS.LOCAL_MEDIA_STOPPED,
+              },
+            },
+          });
 
         fakeStats.video.senders[0].report[0].packetsSent += 5;
         await progressTime();
 
         assert(
           loggerSpy.neverCalledWith(
-            'StatsAnalyzer:index#compareLastStatsResult --> No video RTP packets sent'
-          )
+            'StatsAnalyzer:index#compareLastStatsResult --> No video RTP packets sent',
+          ),
         );
       });
 
       it('logs a message when share send packets do not increase', async () => {
-        await startStatsAnalyzer(
-          {expected: {sendShare: true}},
-          {share: {local: EVENTS.LOCAL_MEDIA_STARTED}}
+        await startStatsAnalyzer({
+            pc, mediaStatus: {expected: {sendShare: true}},
+            lastEmittedEvents: {share: {local: EVENTS.LOCAL_MEDIA_STARTED}}, statsAnalyzer,
+          },
         );
 
         // don't increase the packets when time progresses.
@@ -1171,15 +1205,16 @@ describe('plugin-meetings', () => {
 
         assert(
           loggerSpy.calledWith(
-            'StatsAnalyzer:index#compareLastStatsResult --> No share RTP packets sent'
-          )
+            'StatsAnalyzer:index#compareLastStatsResult --> No share RTP packets sent',
+          ),
         );
       });
 
       it('does not log a message when share send packets increase', async () => {
-        await startStatsAnalyzer(
-          {expected: {sendShare: true}},
-          {share: {local: EVENTS.LOCAL_MEDIA_STOPPED}}
+        await startStatsAnalyzer({
+            pc, statsAnalyzer, mediaStatus: {expected: {sendShare: true}},
+            lastEmittedEvents: {share: {local: EVENTS.LOCAL_MEDIA_STOPPED}},
+          },
         );
 
         fakeStats.share.senders[0].report[0].packetsSent += 5;
@@ -1187,8 +1222,8 @@ describe('plugin-meetings', () => {
 
         assert(
           loggerSpy.neverCalledWith(
-            'StatsAnalyzer:index#compareLastStatsResult --> No share RTP packets sent'
-          )
+            'StatsAnalyzer:index#compareLastStatsResult --> No share RTP packets sent',
+          ),
         );
       });
 
@@ -1201,7 +1236,7 @@ describe('plugin-meetings', () => {
               id: '4',
             };
 
-            await startStatsAnalyzer();
+            await startStatsAnalyzer({pc, statsAnalyzer});
 
             // don't increase the packets when time progresses.
             await progressTime();
@@ -1209,10 +1244,10 @@ describe('plugin-meetings', () => {
             assert.neverCalledWith(
               loggerSpy,
               'StatsAnalyzer:index#processInboundRTPResult --> No packets received for receive slot id: "4" and csi: 2. Total packets received on slot: ',
-              0
+              0,
             );
           });
-        }
+        },
       );
 
       it(`logs a message if no packets are sent`, async () => {
@@ -1221,7 +1256,7 @@ describe('plugin-meetings', () => {
           csi: 2,
           id: '4',
         };
-        await startStatsAnalyzer();
+        await startStatsAnalyzer({pc, statsAnalyzer});
 
         // don't increase the packets when time progresses.
         await progressTime();
@@ -1229,52 +1264,52 @@ describe('plugin-meetings', () => {
         assert.calledWith(
           loggerSpy,
           'StatsAnalyzer:index#processInboundRTPResult --> No packets received for mediaType: video-recv-0, receive slot id: "4" and csi: 2. Total packets received on slot: ',
-          0
+          0,
         );
 
         assert.calledWith(
           loggerSpy,
           'StatsAnalyzer:index#processInboundRTPResult --> No frames received for mediaType: video-recv-0,  receive slot id: "4" and csi: 2. Total frames received on slot: ',
-          0
+          0,
         );
 
         assert.calledWith(
           loggerSpy,
           'StatsAnalyzer:index#processInboundRTPResult --> No frames decoded for mediaType: video-recv-0,  receive slot id: "4" and csi: 2. Total frames decoded on slot: ',
-          0
+          0,
         );
 
         assert.calledWith(
           loggerSpy,
           'StatsAnalyzer:index#processInboundRTPResult --> No packets received for mediaType: audio-recv-0, receive slot id: "4" and csi: 2. Total packets received on slot: ',
-          0
+          0,
         );
 
         assert.calledWith(
           loggerSpy,
           'StatsAnalyzer:index#processInboundRTPResult --> No packets received for mediaType: video-share-recv-0, receive slot id: "4" and csi: 2. Total packets received on slot: ',
-          0
+          0,
         );
 
         assert.calledWith(
           loggerSpy,
           'StatsAnalyzer:index#processInboundRTPResult --> No frames received for mediaType: video-share-recv-0,  receive slot id: "4" and csi: 2. Total frames received on slot: ',
-          0
+          0,
         );
         assert.calledWith(
           loggerSpy,
           'StatsAnalyzer:index#processInboundRTPResult --> No frames decoded for mediaType: video-share-recv-0,  receive slot id: "4" and csi: 2. Total frames decoded on slot: ',
-          0
+          0,
         );
         assert.calledWith(
           loggerSpy,
           'StatsAnalyzer:index#processInboundRTPResult --> No packets received for mediaType: audio-share-recv-0, receive slot id: "4" and csi: 2. Total packets received on slot: ',
-          0
+          0,
         );
       });
 
       it(`does not log a message if receiveSlot is undefined`, async () => {
-        await startStatsAnalyzer();
+        await startStatsAnalyzer({pc, statsAnalyzer});
 
         // don't increase the packets when time progresses.
         await progressTime();
@@ -1282,12 +1317,12 @@ describe('plugin-meetings', () => {
         assert.neverCalledWith(
           loggerSpy,
           'StatsAnalyzer:index#processInboundRTPResult --> No packets received for receive slot "". Total packets received on slot: ',
-          0
+          0,
         );
       });
 
       it('has the correct number of senders and receivers (2)', async () => {
-        await startStatsAnalyzer({expected: {receiveVideo: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
         await progressTime();
 
@@ -1298,7 +1333,7 @@ describe('plugin-meetings', () => {
       });
 
       it('has one stream per sender/reciever', async () => {
-        await startStatsAnalyzer({expected: {receiveVideo: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
         await progressTime();
 
@@ -1558,7 +1593,7 @@ describe('plugin-meetings', () => {
           },
         });
 
-        await startStatsAnalyzer({expected: {receiveVideo: true}});
+        await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
         await progressTime();
 
@@ -1662,7 +1697,7 @@ describe('plugin-meetings', () => {
         ]);
       });
 
-      describe('stream count for simulcast', async() => {
+      describe('stream count for simulcast', async () => {
         it('has three streams for video senders for simulcast', async () => {
           pc.getTransceiverStats = sinon.stub().resolves({
             audio: {
@@ -1729,7 +1764,15 @@ describe('plugin-meetings', () => {
             },
           });
 
-          await startStatsAnalyzer({expected: {receiveVideo: true}});
+          await startStatsAnalyzer({
+            pc,
+            statsAnalyzer,
+            mediaStatus: {
+              expected: {
+                receiveVideo: true,
+              },
+            },
+          });
 
           await progressTime();
 
@@ -1744,7 +1787,7 @@ describe('plugin-meetings', () => {
                 rtpPackets: 0,
                 ssci: 0,
                 transmittedBitrate: 0.13333333333333333,
-                transmittedFrameRate: 0
+                transmittedFrameRate: 0,
               },
               h264CodecProfile: 'BP',
               isAvatar: false,
@@ -1844,7 +1887,7 @@ describe('plugin-meetings', () => {
               transmittedKeyFramesUnknown: 0,
               transmittedWidth: 0,
               requestedBitrate: 0,
-            }
+            },
           ]);
         });
       });
@@ -1917,9 +1960,9 @@ describe('plugin-meetings', () => {
       });
 
       describe('window and screen size emission', async () => {
-        beforeEach(async() => {
+        beforeEach(async () => {
           await startStatsAnalyzer();
-        })
+        });
 
         it('should record the screen size from window.screen properties', async () => {
           sinon.stub(window.screen, 'width').get(() => 1280);
@@ -1928,7 +1971,7 @@ describe('plugin-meetings', () => {
           assert.strictEqual(mqeData.intervalMetadata.screenWidth, 1280);
           assert.strictEqual(mqeData.intervalMetadata.screenHeight, 720);
           assert.strictEqual(mqeData.intervalMetadata.screenResolution, 3600);
-        })
+        });
 
         it('should record the initial app window size from window properties', async () => {
           sinon.stub(window, 'innerWidth').get(() => 720);
@@ -1944,8 +1987,68 @@ describe('plugin-meetings', () => {
           assert.strictEqual(mqeData.intervalMetadata.appWindowWidth, 1080);
           assert.strictEqual(mqeData.intervalMetadata.appWindowHeight, 720);
           assert.strictEqual(mqeData.intervalMetadata.appWindowSize, 3038);
-        })
-      })
-    })
+        });
+      });
+      describe('multistreamEnabled', async () => {
+        it('sends false value if StatsAnalyzer initialized with default value for isMultistream', async () => {
+          await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
+
+          await progressTime();
+
+          for (const data of [
+            mqeData.audioTransmit,
+            mqeData.audioReceive,
+            mqeData.videoTransmit,
+            mqeData.videoReceive,
+          ]) {
+            assert.strictEqual(data[0].common.common.multistreamEnabled, false);
+          }
+        });
+
+        it('sends true value if StatsAnalyzer initialized with multistream', async () => {
+          statsAnalyzer = new StatsAnalyzer({
+            config: initialConfig,
+            receiveSlotCallback: () => receiveSlot,
+            networkQualityMonitor,
+            isMultistream: true,
+          });
+          registerStatsAnalyzerEvents(statsAnalyzer);
+          await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
+
+          await progressTime();
+
+          for (const data of [
+            mqeData.audioTransmit,
+            mqeData.audioReceive,
+            mqeData.videoTransmit,
+            mqeData.videoReceive,
+          ]) {
+            assert.strictEqual(data[0].common.common.multistreamEnabled, true);
+          }
+        });
+
+        it('sends false value if StatsAnalyzer initialized with false', async () => {
+          statsAnalyzer = new StatsAnalyzer({
+            config: initialConfig,
+            receiveSlotCallback: () => receiveSlot,
+            networkQualityMonitor,
+            isMultistream: false,
+          });
+          registerStatsAnalyzerEvents(statsAnalyzer);
+          await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: false}}});
+
+          await progressTime();
+
+          for (const data of [
+            mqeData.audioTransmit,
+            mqeData.audioReceive,
+            mqeData.videoTransmit,
+            mqeData.videoReceive,
+          ]) {
+            assert.strictEqual(data[0].common.common.multistreamEnabled, false);
+          }
+        });
+      });
+    });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -1990,7 +1990,7 @@ describe('plugin-meetings', () => {
       });
 
       describe('sends multistreamEnabled', async () => {
-        it('false value if StatsAnalyzer initialized with default value for isMultistream', async () => {
+        it('false if StatsAnalyzer initialized with default value for isMultistream', async () => {
           await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
           await progressTime();
@@ -2005,7 +2005,7 @@ describe('plugin-meetings', () => {
           }
         });
 
-        it('false value if StatsAnalyzer initialized with false', async () => {
+        it('false if StatsAnalyzer initialized with false', async () => {
           statsAnalyzer = new StatsAnalyzer({
             config: initialConfig,
             receiveSlotCallback: () => receiveSlot,
@@ -2027,7 +2027,7 @@ describe('plugin-meetings', () => {
           }
         });
 
-        it('true value if StatsAnalyzer initialized with multistream', async () => {
+        it('true if StatsAnalyzer initialized with multistream', async () => {
           statsAnalyzer = new StatsAnalyzer({
             config: initialConfig,
             receiveSlotCallback: () => receiveSlot,

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -1065,7 +1065,6 @@ describe('plugin-meetings', () => {
         });
       });
 
-
       it('has the correct localIpAddress set when the candidateType is host', async () => {
         await startStatsAnalyzer({pc, statsAnalyzer});
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -1989,8 +1989,8 @@ describe('plugin-meetings', () => {
         });
       });
 
-      describe('multistreamEnabled', async () => {
-        it('sends false value if StatsAnalyzer initialized with default value for isMultistream', async () => {
+      describe('sends multistreamEnabled', async () => {
+        it('false value if StatsAnalyzer initialized with default value for isMultistream', async () => {
           await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
 
           await progressTime();
@@ -2005,29 +2005,7 @@ describe('plugin-meetings', () => {
           }
         });
 
-        it('sends true value if StatsAnalyzer initialized with multistream', async () => {
-          statsAnalyzer = new StatsAnalyzer({
-            config: initialConfig,
-            receiveSlotCallback: () => receiveSlot,
-            networkQualityMonitor,
-            isMultistream: true,
-          });
-          registerStatsAnalyzerEvents(statsAnalyzer);
-          await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
-
-          await progressTime();
-
-          for (const data of [
-            mqeData.audioTransmit,
-            mqeData.audioReceive,
-            mqeData.videoTransmit,
-            mqeData.videoReceive,
-          ]) {
-            assert.strictEqual(data[0].common.common.multistreamEnabled, true);
-          }
-        });
-
-        it('sends false value if StatsAnalyzer initialized with false', async () => {
+        it('false value if StatsAnalyzer initialized with false', async () => {
           statsAnalyzer = new StatsAnalyzer({
             config: initialConfig,
             receiveSlotCallback: () => receiveSlot,
@@ -2046,6 +2024,28 @@ describe('plugin-meetings', () => {
             mqeData.videoReceive,
           ]) {
             assert.strictEqual(data[0].common.common.multistreamEnabled, false);
+          }
+        });
+
+        it('true value if StatsAnalyzer initialized with multistream', async () => {
+          statsAnalyzer = new StatsAnalyzer({
+            config: initialConfig,
+            receiveSlotCallback: () => receiveSlot,
+            networkQualityMonitor,
+            isMultistream: true,
+          });
+          registerStatsAnalyzerEvents(statsAnalyzer);
+          await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});
+
+          await progressTime();
+
+          for (const data of [
+            mqeData.audioTransmit,
+            mqeData.audioReceive,
+            mqeData.videoTransmit,
+            mqeData.videoReceive,
+          ]) {
+            assert.strictEqual(data[0].common.common.multistreamEnabled, true);
           }
         });
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -24,7 +24,7 @@ const startStatsAnalyzer = async ({statsAnalyzer, mediaStatus, lastEmittedEvents
   await testUtils.flushPromises();
 };
 
-describe.only('plugin-meetings', () => {
+describe('plugin-meetings', () => {
   describe('StatsAnalyzer', () => {
     describe('parseStatsResult', () => {
       const sandbox = sinon.createSandbox();
@@ -1989,6 +1989,7 @@ describe.only('plugin-meetings', () => {
           assert.strictEqual(mqeData.intervalMetadata.appWindowSize, 3038);
         });
       });
+
       describe('multistreamEnabled', async () => {
         it('sends false value if StatsAnalyzer initialized with default value for isMultistream', async () => {
           await startStatsAnalyzer({pc, statsAnalyzer, mediaStatus: {expected: {receiveVideo: true}}});

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -925,7 +925,7 @@ describe('plugin-meetings', () => {
 
       describe('frame rate reporting in stats analyzer', () => {
         beforeEach(async () => {
-          await startStatsAnalyzer();
+          await startStatsAnalyzer({pc, statsAnalyzer});
         });
 
         it('should report a zero frame rate for both transmitted and received video at the start', async () => {
@@ -1892,7 +1892,7 @@ describe('plugin-meetings', () => {
       });
       describe('active speaker status emission', async () => {
         beforeEach(async () => {
-          await startStatsAnalyzer();
+          await startStatsAnalyzer({pc, statsAnalyzer});
           performance.timeOrigin = 1;
         });
 
@@ -1927,7 +1927,7 @@ describe('plugin-meetings', () => {
 
         beforeEach(async () => {
           performance.timeOrigin = 0;
-          await startStatsAnalyzer();
+          await startStatsAnalyzer({pc, statsAnalyzer});
         });
 
         it('should send a stream if it is requested', async () => {
@@ -1960,7 +1960,7 @@ describe('plugin-meetings', () => {
 
       describe('window and screen size emission', async () => {
         beforeEach(async () => {
-          await startStatsAnalyzer();
+          await startStatsAnalyzer({pc, statsAnalyzer});
         });
 
         it('should record the screen size from window.screen properties', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [WEBEX-389398](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-389398)

## This pull request addresses

Currently, `multistreamEnabled` has the wrong value for MQE. It should be `true` for **multistream** and `false` for **transcoded** meetings

## by making the following changes

Fix value for MQE `multistreamEnabled`, add tests

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- [x] automated tests for plugin-meetings
- [x] SDK test meeting correctly [sends MQE](https://gist.github.com/antsukanova/367800e16040da8360dbd8abf658eb55) in automated diagnostics

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
