### PR TITLE
fix(internal-plugin-metrics): remove exports.getBuildType error

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -198,16 +198,9 @@ export const isBrowserMediaErrorName = (errorName: any) => {
  * @returns
  */
 export const getBuildType = (
-  webex,
   webClientDomain,
   markAsTestEvent = false
 ): Event['origin']['buildType'] => {
-  webex.logger.log(
-    `CallDiagnosticMetricsUtil: getBuildType is called`,
-    webClientDomain,
-    markAsTestEvent
-  );
-
   // used temporary to test pre join in production without creating noise data, SPARK-468456
   if (markAsTestEvent) {
     return 'test';
@@ -233,7 +226,6 @@ export const getBuildType = (
 export const prepareDiagnosticMetricItem = (webex: any, item: any) => {
   const origin: Partial<Event['origin']> = {
     buildType: getBuildType(
-      webex,
       item.eventPayload?.event?.eventData?.webClientDomain,
       item.eventPayload?.event?.eventData?.markAsTestEvent
     ),

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -198,9 +198,16 @@ export const isBrowserMediaErrorName = (errorName: any) => {
  * @returns
  */
 export const getBuildType = (
+  webex,
   webClientDomain,
   markAsTestEvent = false
 ): Event['origin']['buildType'] => {
+  webex.logger.log(
+    `CallDiagnosticMetricsUtil: getBuildType is called`,
+    webClientDomain,
+    markAsTestEvent
+  );
+
   // used temporary to test pre join in production without creating noise data, SPARK-468456
   if (markAsTestEvent) {
     return 'test';
@@ -225,7 +232,8 @@ export const getBuildType = (
  */
 export const prepareDiagnosticMetricItem = (webex: any, item: any) => {
   const origin: Partial<Event['origin']> = {
-    buildType: exports.getBuildType(
+    buildType: getBuildType(
+      webex,
       item.eventPayload?.event?.eventData?.webClientDomain,
       item.eventPayload?.event?.eventData?.markAsTestEvent
     ),
@@ -314,7 +322,6 @@ export const prepareDiagnosticMetricItem = (webex: any, item: any) => {
 
   item.eventPayload.origin = Object.assign(origin, item.eventPayload.origin);
 
-  // @ts-ignore
   webex.logger.log(
     `CallDiagnosticLatencies,prepareDiagnosticMetricItem: ${JSON.stringify({
       latencies: Object.fromEntries(cdl.latencyTimestamps),

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -234,14 +234,8 @@ describe('internal-plugin-metrics', () => {
   });
 
   describe('getBuildType', () => {
-    let webex;
     beforeEach(() => {
       process.env.NODE_ENV = 'production';
-      webex = {
-        logger: {
-          log: () => undefined
-        }
-      }
     });
 
     [


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-535057](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-535057)

## This pull request addresses

Removal of the non-blocking `exports.getBuildType` error that appears in the logs which was annoying

## by making the following changes

As per [this ticket](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-470747), the `exports` was added to the `getBuildType` call so that it can be stubbed and tested in the unit tests. To address this, I've changed the getBuildType code to show a log that this method was called and then test `webex.logger.log` instead of `getBuildType`

The aim was to know if this method was called with the right attributes and that is accomplished

**Logs before and after**

| Before | After |
| --- | --- |
| [webex.github.io-1719717587011.log](https://github.com/user-attachments/files/16043036/webex.github.io-1719717587011.log) | [pr-3671.d3m3l2kee0btzx.amplifyapp.com-1719717796375.log](https://github.com/user-attachments/files/16043035/pr-3671.d3m3l2kee0btzx.amplifyapp.com-1719717796375.log) |

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

I opened the sample app locally and tried joining a meeting and by this time, I already saw several logs for getBuildType being called and no errors that appeared earlier

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
