### PR TITLE
fix: update internal media core version

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -22,7 +22,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/internal-media-core": "2.5.2",
+    "@webex/internal-media-core": "2.5.3",
     "@webex/ts-events": "^1.1.0",
     "@webex/web-media-effects": "2.18.0"
   },

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:*",
-    "@webex/internal-media-core": "2.5.2",
+    "@webex/internal-media-core": "2.5.3",
     "@webex/internal-plugin-conversation": "workspace:*",
     "@webex/internal-plugin-device": "workspace:*",
     "@webex/internal-plugin-llm": "workspace:*",

--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@types/platform": "1.3.4",
-    "@webex/internal-media-core": "2.5.2",
+    "@webex/internal-media-core": "2.5.3",
     "@webex/media-helpers": "workspace:*",
     "async-mutex": "0.4.0",
     "buffer": "6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6830,7 +6830,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.38.1
     "@typescript-eslint/parser": 5.38.1
     "@web/dev-server": 0.1.30
-    "@webex/internal-media-core": 2.5.2
+    "@webex/internal-media-core": 2.5.3
     "@webex/media-helpers": "workspace:*"
     async-mutex: 0.4.0
     buffer: 6.0.3
@@ -7121,19 +7121,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:2.5.2":
-  version: 2.5.2
-  resolution: "@webex/internal-media-core@npm:2.5.2"
+"@webex/internal-media-core@npm:2.5.3":
+  version: 2.5.3
+  resolution: "@webex/internal-media-core@npm:2.5.3"
   dependencies:
     "@babel/runtime": ^7.18.9
     "@webex/ts-sdp": 1.6.0
-    "@webex/web-client-media-engine": 3.20.3
+    "@webex/web-client-media-engine": 3.20.4
     events: ^3.3.0
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
     webrtc-adapter: ^8.1.2
     xstate: ^4.30.6
-  checksum: e68b6ccb279a39e7f8ac00351fc6a3c39d67cc42ffa17089231de690eca43590228a826d11dd7ffcb7e72cd868747b31050605ca82e1ad361d358e3d43ece71f
+  checksum: 058bbd5ffa62cf6552fc30e81224561daab0c0cc5dee0aaed8b4d43757b6ef7f6f2e2d8cdbcb6d5943579a9aa891e34bd924a6efde6f8e68df4d2650e38dbf97
   languageName: node
   linkType: hard
 
@@ -7901,7 +7901,7 @@ __metadata:
     "@babel/preset-typescript": 7.22.11
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.5.2
+    "@webex/internal-media-core": 2.5.3
     "@webex/jest-config-legacy": "workspace:*"
     "@webex/legacy-tools": "workspace:*"
     "@webex/test-helper-chai": "workspace:*"
@@ -8137,7 +8137,7 @@ __metadata:
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/common": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.5.2
+    "@webex/internal-media-core": 2.5.3
     "@webex/internal-plugin-conversation": "workspace:*"
     "@webex/internal-plugin-device": "workspace:*"
     "@webex/internal-plugin-llm": "workspace:*"
@@ -8429,13 +8429,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/rtcstats@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "@webex/rtcstats@npm:1.3.1"
+"@webex/rtcstats@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "@webex/rtcstats@npm:1.3.2"
   dependencies:
     "@types/node": ^20.14.1
     uuid: ^8.3.2
-  checksum: c144ee5423b2429c4a400f37bb0b5fef22b3dd929d4005019da42960fdc87413ff893bd2e42c733973b440f4c483e43a1c02f9a550900fd2e55b67061a347159
+  checksum: dab5bbd1310e549e0e60dce4f7f5e67cbc8729ded894581ff196af189e9884fdb89ac7ef19f9a125ddefd1a9d57d228a34c9a9f4cfb792d939d07d11c0cfc604
   languageName: node
   linkType: hard
 
@@ -8849,12 +8849,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:3.20.3":
-  version: 3.20.3
-  resolution: "@webex/web-client-media-engine@npm:3.20.3"
+"@webex/web-client-media-engine@npm:3.20.4":
+  version: 3.20.4
+  resolution: "@webex/web-client-media-engine@npm:3.20.4"
   dependencies:
     "@webex/json-multistream": 2.1.3
-    "@webex/rtcstats": ^1.3.1
+    "@webex/rtcstats": ^1.3.2
     "@webex/ts-events": ^1.0.1
     "@webex/ts-sdp": 1.6.0
     "@webex/web-capabilities": ^1.3.0
@@ -8864,7 +8864,7 @@ __metadata:
     js-logger: ^1.6.1
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
-  checksum: 929d0b6c890d35ea145cbf8cc31ceebebd3e02ea960ef43e716f4cdc1d406669d72d299c4fc7f9a6e4d4acf76eeb525bbb546bfe54b121a99d8668b4e02971d2
+  checksum: 1cf164b99b2a627884085589310028a40f28efa4965aa93af85950f533bf2e1c5f37f1b39f275a6533a2b2901f462c728f73b250c06d82e478df12314632cb02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [WEBEX-390724](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-390724)

## This pull request addresses

the problem where `rtcstats` is causing join failures on Firefox versions around 107/108 due to the following error: TypeError: _this.sctp.addEventListener is not a function.
 
`rtcstats` fix: https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-390724 

WCME version update: https://sqbu-github.cisco.com/CPaaS/web-client-media-engine/pull/389
Media Core version update: https://sqbu-github.cisco.com/WebExSquared/webrtc-media-core/pull/232

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly
