### PR TITLE
fix(webex-core): fix parsing of u2c hostmap

### DIFF
--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -702,16 +702,20 @@ const Services = WebexPlugin.extend({
 
       const matchingCatalogEntry = serviceHostmap.hostCatalog[host];
 
-      if (!matchingCatalogEntry) {
-        return;
-      }
-
       const formattedHost = {
         name: serviceName,
         defaultUrl: serviceUrl,
         defaultHost: host,
         hosts: [],
       };
+
+      formattedHostmap.push(formattedHost);
+
+      // If the catalog does not have any hosts we will be unable to find the service ID
+      // so can't search for other hosts
+      if (!matchingCatalogEntry || !matchingCatalogEntry[0]) {
+        return;
+      }
 
       const serviceId = extractId(matchingCatalogEntry[0]);
 
@@ -748,7 +752,6 @@ const Services = WebexPlugin.extend({
       });
 
       formattedHost.hosts.push(...otherHosts);
-      formattedHostmap.push(formattedHost);
     });
 
     // update all the service urls in the host catalog

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -1,8 +1,6 @@
-import Url from 'url';
-
 import sha256 from 'crypto-js/sha256';
 
-import {union} from 'lodash';
+import {union, forEach} from 'lodash';
 import WebexPlugin from '../webex-plugin';
 
 import METRICS from './metrics';
@@ -686,59 +684,71 @@ const Services = WebexPlugin.extend({
    */
   _formatReceivedHostmap(serviceHostmap) {
     this._updateHostCatalog(serviceHostmap.hostCatalog);
-    // map the host catalog items to a formatted hostmap
-    const formattedHostmap = Object.keys(serviceHostmap.hostCatalog).reduce((accumulator, key) => {
-      if (serviceHostmap.hostCatalog[key].length === 0) {
-        return accumulator;
+
+    const extractId = (entry) => entry.id.split(':')[3];
+
+    const formattedHostmap = [];
+
+    // for each of the services in the serviceLinks, find the matching host in the catalog
+    Object.keys(serviceHostmap.serviceLinks).forEach((serviceName) => {
+      const serviceUrl = serviceHostmap.serviceLinks[serviceName];
+
+      let host;
+      try {
+        host = new URL(serviceUrl).host;
+      } catch (e) {
+        return;
       }
 
-      const serviceName = serviceHostmap.hostCatalog[key][0].id.split(':')[3];
-      const defaultUrl = serviceHostmap.serviceLinks[serviceName];
+      const matchingCatalogEntry = serviceHostmap.hostCatalog[host];
 
-      let serviceItem = accumulator.find((item) => item.name === serviceName);
-
-      if (!serviceItem) {
-        serviceItem = {
-          name: serviceName,
-          defaultUrl,
-          defaultHost: Url.parse(defaultUrl).hostname,
-          hosts: [],
-        };
-
-        accumulator.push(serviceItem);
+      if (!matchingCatalogEntry) {
+        return;
       }
 
-      serviceItem.hosts.push(
-        // map the default key as a low priority default for cluster matching
-        {
-          host: key,
-          ttl: -1,
-          priority: 10,
-          id: serviceHostmap.hostCatalog[key][0].id,
-          homeCluster: serviceItem.defaultHost === key,
-        },
-        // map the rest of the hosts in their proper locations
-        ...serviceHostmap.hostCatalog[key].map((host) => ({
-          ...host,
-          homeCluster: serviceItem.defaultHost === key,
-        }))
-      );
+      const formattedHost = {
+        name: serviceName,
+        defaultUrl: serviceUrl,
+        defaultHost: host,
+        hosts: [],
+      };
 
-      return accumulator;
-    }, []);
+      const serviceId = extractId(matchingCatalogEntry[0]);
 
-    // append service links that do not exist in the host catalog
-    Object.keys(serviceHostmap.serviceLinks).forEach((key) => {
-      const service = formattedHostmap.find((item) => item.name === key);
+      forEach(matchingCatalogEntry, (entry) => {
+        // The ids for all hosts within a hostCatalog entry should be the same
+        // but for safety, only add host entries that have the same id as the first one
+        if (extractId(entry) === serviceId) {
+          formattedHost.hosts.push({
+            ...entry,
+            homeCluster: true,
+          });
+        }
+      });
 
-      if (!service) {
-        formattedHostmap.push({
-          name: key,
-          defaultUrl: serviceHostmap.serviceLinks[key],
-          defaultHost: Url.parse(serviceHostmap.serviceLinks[key]).hostname,
-          hosts: [],
+      const otherHosts = [];
+
+      // find the services in the host catalog that have the same id
+      // and add them to the otherHosts
+      forEach(serviceHostmap.hostCatalog, (entry) => {
+        // exclude the matching catalog entry as we have already added that
+        if (entry === matchingCatalogEntry) {
+          return;
+        }
+
+        forEach(entry, (entryHost) => {
+          // only add hosts that have the correct id
+          if (extractId(entryHost) === serviceId) {
+            otherHosts.push({
+              ...entryHost,
+              homeCluster: false,
+            });
+          }
         });
-      }
+      });
+
+      formattedHost.hosts.push(...otherHosts);
+      formattedHostmap.push(formattedHost);
     });
 
     // update all the service urls in the host catalog

--- a/packages/@webex/webex-core/test/integration/spec/services/services.js
+++ b/packages/@webex/webex-core/test/integration/spec/services/services.js
@@ -37,11 +37,15 @@ describe('webex-core', () => {
             orgId: process.env.EU_PRIMARY_ORG_ID,
           },
         }),
-      ]).then(([[user], [userEU]]) => {
-        webexUser = user;
-        webexUserEU = userEU;
-      })
-    );
+      ]).then(([[user], [userEU]]) =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            webexUser = user;
+            webexUserEU = userEU;
+            resolve();
+          }, 1000)
+        })
+    ));
 
     beforeEach('create webex instance', () => {
       webex = new WebexCore({credentials: {supertoken: webexUser.token}});

--- a/packages/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/services.js
@@ -302,6 +302,8 @@ describe('webex-core', () => {
             'example-c': 'https://example-c.com/api/v1',
             'example-d': 'https://example-d.com/api/v1',
             'example-e': 'https://example-e.com/api/v1',
+            'example-f': 'https://example-f.com/api/v1',
+            'example-g': 'https://example-g.com/api/v1',
           },
           hostCatalog: {
             'example-a.com': [
@@ -424,6 +426,8 @@ describe('webex-core', () => {
                 id: '0:0:0:different-e-x',
               },
             ],
+            'example-f.com': [
+            ],
           },
           format: 'hostmap',
         };
@@ -478,16 +482,6 @@ describe('webex-core', () => {
           );
 
           assert.isDefined(foundServiceKey);
-        });
-      });
-
-      it('creates a formmated host map containing all received host map host entries', () => {
-        formattedHM = services._formatReceivedHostmap(serviceHostmap);
-
-        formattedHM.forEach((service) => {
-          const foundHosts = serviceHostmap.hostCatalog[service.defaultHost];
-
-          assert.isDefined(foundHosts);
         });
       });
 
@@ -630,6 +624,18 @@ describe('webex-core', () => {
             ],
             name: 'example-e',
           },
+          {
+            defaultHost: 'example-f.com',
+            defaultUrl: 'https://example-f.com/api/v1',
+            hosts: [],
+            name: 'example-f',
+          },
+          {
+            defaultHost: 'example-g.com',
+            defaultUrl: 'https://example-g.com/api/v1',
+            hosts: [],
+            name: 'example-g',
+          }
         ]);
       });
 

--- a/packages/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/services.js
@@ -301,6 +301,7 @@ describe('webex-core', () => {
             'example-b': 'https://example-b.com/api/v1',
             'example-c': 'https://example-c.com/api/v1',
             'example-d': 'https://example-d.com/api/v1',
+            'example-e': 'https://example-e.com/api/v1',
           },
           hostCatalog: {
             'example-a.com': [
@@ -383,6 +384,46 @@ describe('webex-core', () => {
                 id: '0:0:0:example-d-x',
               },
             ],
+            'example-e.com': [
+              {
+                host: 'example-e-1.com',
+                ttl: -1,
+                priority: 5,
+                id: '0:0:0:different-e',
+              },
+              {
+                host: 'example-e-2.com',
+                ttl: -1,
+                priority: 3,
+                id: '0:0:0:different-e',
+              },
+              {
+                host: 'example-e-3.com',
+                ttl: -1,
+                priority: 1,
+                id: '0:0:0:different-e',
+              },
+            ],
+            'example-e-1.com': [
+              {
+                host: 'example-e-4.com',
+                ttl: -1,
+                priority: 5,
+                id: '0:0:0:different-e',
+              },
+              {
+                host: 'example-e-5.com',
+                ttl: -1,
+                priority: 3,
+                id: '0:0:0:different-e',
+              },
+              {
+                host: 'example-e-3.com',
+                ttl: -1,
+                priority: 1,
+                id: '0:0:0:different-e-x',
+              },
+            ],
           },
           format: 'hostmap',
         };
@@ -457,6 +498,139 @@ describe('webex-core', () => {
           serviceHostmap.serviceLinks,
           formattedHM.map((item) => item.name)
         );
+      });
+
+      it('creates the expected formatted host map', () => {
+        formattedHM = services._formatReceivedHostmap(serviceHostmap);
+
+        assert.deepEqual(formattedHM, [
+          {
+            defaultHost: 'example-a.com',
+            defaultUrl: 'https://example-a.com/api/v1',
+            hosts: [
+              {
+                homeCluster: true,
+                host: 'example-a-1.com',
+                id: '0:0:0:example-a',
+                priority: 5,
+                ttl: -1,
+              },
+              {
+                homeCluster: true,
+                host: 'example-a-2.com',
+                id: '0:0:0:example-a',
+                priority: 3,
+                ttl: -1,
+              },
+            ],
+            name: 'example-a',
+          },
+          {
+            defaultHost: 'example-b.com',
+            defaultUrl: 'https://example-b.com/api/v1',
+            hosts: [
+              {
+                homeCluster: true,
+                host: 'example-b-1.com',
+                id: '0:0:0:example-b',
+                priority: 5,
+                ttl: -1,
+              },
+              {
+                homeCluster: true,
+                host: 'example-b-2.com',
+                id: '0:0:0:example-b',
+                priority: 3,
+                ttl: -1,
+              },
+            ],
+            name: 'example-b',
+          },
+          {
+            defaultHost: 'example-c.com',
+            defaultUrl: 'https://example-c.com/api/v1',
+            hosts: [
+              {
+                homeCluster: true,
+                host: 'example-c-1.com',
+                id: '0:0:0:example-c',
+                priority: 5,
+                ttl: -1,
+              },
+              {
+                homeCluster: true,
+                host: 'example-c-2.com',
+                id: '0:0:0:example-c',
+                priority: 3,
+                ttl: -1,
+              },
+            ],
+            name: 'example-c',
+          },
+          {
+            defaultHost: 'example-d.com',
+            defaultUrl: 'https://example-d.com/api/v1',
+            hosts: [
+              {
+                homeCluster: true,
+                host: 'example-c-1.com',
+                id: '0:0:0:example-d',
+                priority: 5,
+                ttl: -1,
+              },
+              {
+                homeCluster: true,
+                host: 'example-c-2.com',
+                id: '0:0:0:example-d',
+                priority: 3,
+                ttl: -1,
+              },
+            ],
+            name: 'example-d',
+          },
+          {
+            defaultHost: 'example-e.com',
+            defaultUrl: 'https://example-e.com/api/v1',
+            hosts: [
+              {
+                homeCluster: true,
+                host: 'example-e-1.com',
+                id: '0:0:0:different-e',
+                priority: 5,
+                ttl: -1,
+              },
+              {
+                homeCluster: true,
+                host: 'example-e-2.com',
+                id: '0:0:0:different-e',
+                priority: 3,
+                ttl: -1,
+              },
+              {
+                homeCluster: true,
+                host: 'example-e-3.com',
+                id: '0:0:0:different-e',
+                priority: 1,
+                ttl: -1,
+              },
+              {
+                homeCluster: false,
+                host: 'example-e-4.com',
+                id: '0:0:0:different-e',
+                priority: 5,
+                ttl: -1,
+              },
+              {
+                homeCluster: false,
+                host: 'example-e-5.com',
+                id: '0:0:0:different-e',
+                priority: 3,
+                ttl: -1,
+              },
+            ],
+            name: 'example-e',
+          },
+        ]);
       });
 
       it('has hostCatalog updated', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [SPARK-540203](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-540203)

## This pull request addresses

There was a fundamental misunderstanding in the previous parsing algorithm. It assumed that the `id` of each service in the host catalog was the same as the service name as referenced by the serviceLinks. This is not the case. The result was that for certain services, no alternative hosts would be identified. The previous version also created a mock version of the primary with a higher priority. I have also removed this.

## by making the following changes

The code does the following:
* Iterates over the serviceLinks. Each key of the service links is the service name.
* Finds the corresponding URL key in the host catalog 
* Extract the ID from the first host under this entry
* Generate the first entries in the hosts for this service. homeCluster is set to true for hosts entered here, as indicated by the serviceLink pointing to this entry.
* Go over the rest of the host catalog and find other entries with the same ID and add hosts

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
