### PR TITLE
fix(bo): can't receive broadcast in some cases

### DIFF
--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -56,6 +56,8 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
 
   private locusUrl?: string;
 
+  private datachannelUrl?: string;
+
   /**
    * Register to the websocket
    * @param {string} llmSocketUrl
@@ -86,6 +88,7 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
     this.register(datachannelUrl).then(() => {
       if (!locusUrl || !datachannelUrl) return undefined;
       this.locusUrl = locusUrl;
+      this.datachannelUrl = datachannelUrl;
       this.connect(this.webSocketUrl);
     });
 
@@ -106,6 +109,12 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
    * @returns {string} locus Url
    */
   public getLocusUrl = (): string => this.locusUrl;
+
+  /**
+   * Get data channel URL for the connection
+   * @returns {string} data channel Url
+   */
+  public getDatachannelUrl = (): string => this.datachannelUrl;
 
   /**
    * Disconnects websocket connection

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -123,6 +123,7 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   public disconnectLLM = (): Promise<void> =>
     this.disconnect().then(() => {
       this.locusUrl = undefined;
+      this.datachannelUrl = undefined;
       this.binding = undefined;
       this.webSocketUrl = undefined;
     });

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -88,12 +88,26 @@ describe('plugin-llm', () => {
       });
     });
 
+    describe('#getDatachannelUrl', () => {
+      it('gets dataChannel Url', async () => {
+        llmService.register = sinon.stub().resolves({
+          body: {
+            binding: 'binding',
+            webSocketUrl: 'url',
+          },
+        });
+        await llmService.registerAndConnect(locusUrl, datachannelUrl);
+        assert.equal(llmService.getDatachannelUrl(), datachannelUrl);
+      });
+    });
+
     describe('#disconnect', () => {
       it('disconnects mercury', async () => {
         await llmService.disconnect();
         sinon.assert.calledOnce(llmService.disconnect);
         assert.equal(llmService.isConnected(), false);
         assert.equal(llmService.getLocusUrl(), undefined);
+        assert.equal(llmService.getDatachannelUrl(), undefined);
         assert.equal(llmService.getBinding(), undefined);
       });
     });

--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -148,7 +148,6 @@ const Breakouts = WebexPlugin.extend({
       this.triggerReturnToMainEvent(breakout);
     });
     this.listenToCurrentSessionTypeChange();
-    // this.listenToBroadcastMessages();
     this.listenToBreakoutRosters();
     this.listenToBreakoutHelp();
     // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -148,7 +148,6 @@ const Breakouts = WebexPlugin.extend({
       this.triggerReturnToMainEvent(breakout);
     });
     this.listenToCurrentSessionTypeChange();
-    this.hasSubscribedToMessage = false;
     // this.listenToBroadcastMessages();
     this.listenToBreakoutRosters();
     this.listenToBreakoutHelp();
@@ -162,7 +161,7 @@ const Breakouts = WebexPlugin.extend({
    */
   cleanUp() {
     this.stopListening();
-    this.hasSubscribedToMessage = false;
+    this.hasSubscribedToMessage = undefined;
   },
 
   /**

--- a/packages/@webex/plugin-meetings/src/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/src/breakouts/index.ts
@@ -148,7 +148,8 @@ const Breakouts = WebexPlugin.extend({
       this.triggerReturnToMainEvent(breakout);
     });
     this.listenToCurrentSessionTypeChange();
-    this.listenToBroadcastMessages();
+    this.hasSubscribedToMessage = false;
+    // this.listenToBroadcastMessages();
     this.listenToBreakoutRosters();
     this.listenToBreakoutHelp();
     // @ts-ignore
@@ -161,6 +162,7 @@ const Breakouts = WebexPlugin.extend({
    */
   cleanUp() {
     this.stopListening();
+    this.hasSubscribedToMessage = false;
   },
 
   /**
@@ -170,6 +172,7 @@ const Breakouts = WebexPlugin.extend({
    */
   locusUrlUpdate(locusUrl) {
     this.set('locusUrl', locusUrl);
+    this.listenToBroadcastMessages();
     const {isInMainSession, mainLocusUrl} = this;
     if (isInMainSession || !mainLocusUrl) {
       this.set('mainLocusUrl', locusUrl);
@@ -255,6 +258,10 @@ const Breakouts = WebexPlugin.extend({
    * @returns {void}
    */
   listenToBroadcastMessages() {
+    if (!this.webex.internal.llm.isConnected() || this.hasSubscribedToMessage) {
+      return;
+    }
+
     this.listenTo(this.webex.internal.llm, 'event:breakout.message', (event) => {
       const {
         data: {senderUserId, sentTime, message},
@@ -270,6 +277,7 @@ const Breakouts = WebexPlugin.extend({
         sessionId: this.currentBreakoutSession.sessionId,
       });
     });
+    this.hasSubscribedToMessage = true;
   },
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5234,7 +5234,11 @@ export default class Meeting extends StatelessWebexPlugin {
     // @ts-ignore - Fix type
     if (this.webex.internal.llm.isConnected()) {
       // @ts-ignore - Fix type
-      if (url === this.webex.internal.llm.getLocusUrl() && isJoined) {
+      if (
+        url === this.webex.internal.llm.getLocusUrl() &&
+        datachannelUrl === this.webex.internal.llm.getDatachannelUrl() &&
+        isJoined
+      ) {
         return undefined;
       }
       // @ts-ignore - Fix type

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5233,9 +5233,10 @@ export default class Meeting extends StatelessWebexPlugin {
 
     // @ts-ignore - Fix type
     if (this.webex.internal.llm.isConnected()) {
-      // @ts-ignore - Fix type
       if (
+        // @ts-ignore - Fix type
         url === this.webex.internal.llm.getLocusUrl() &&
+        // @ts-ignore - Fix type
         datachannelUrl === this.webex.internal.llm.getDatachannelUrl() &&
         isJoined
       ) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/breakouts/index.ts
@@ -87,6 +87,7 @@ describe('plugin-meetings', () => {
       // @ts-ignore
       webex = new MockWebex({});
       webex.internal.llm.on = sinon.stub();
+      webex.internal.llm.isConnected = sinon.stub();
       webex.internal.mercury.on = sinon.stub();
       breakouts = new Breakouts({}, {parent: webex});
       breakouts.groupId = 'groupId';

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -6275,7 +6275,7 @@ describe('plugin-meetings', () => {
             },
             'SELF_OBSERVING'
           );
-          
+
 
           // Verify that the event handler behaves as expected
           expect(meeting.statsAnalyzer.stopAnalyzer.calledOnce).to.be.true;
@@ -9781,6 +9781,7 @@ describe('plugin-meetings', () => {
         beforeEach(() => {
           webex.internal.llm.isConnected = sinon.stub().returns(false);
           webex.internal.llm.getLocusUrl = sinon.stub();
+          webex.internal.llm.getDatachannelUrl = sinon.stub();
           webex.internal.llm.registerAndConnect = sinon
             .stub()
             .returns(Promise.resolve('something'));
@@ -9808,6 +9809,7 @@ describe('plugin-meetings', () => {
           meeting.joinedWith = {state: 'JOINED'};
           webex.internal.llm.isConnected.returns(true);
           webex.internal.llm.getLocusUrl.returns('a url');
+          webex.internal.llm.getDatachannelUrl.returns('a datachannel url');
 
           meeting.locusInfo = {url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
 
@@ -9844,6 +9846,7 @@ describe('plugin-meetings', () => {
           meeting.joinedWith = {state: 'JOINED'};
           webex.internal.llm.isConnected.returns(true);
           webex.internal.llm.getLocusUrl.returns('a url');
+          webex.internal.llm.getDatachannelUrl.returns('a datachannel url');
 
           meeting.locusInfo = {url: 'a different url', info: {datachannelUrl: 'a datachannel url'}};
 
@@ -9854,6 +9857,36 @@ describe('plugin-meetings', () => {
             webex.internal.llm.registerAndConnect,
             'a different url',
             'a datachannel url'
+          );
+          assert.equal(result, 'something');
+          assert.calledWithExactly(
+            meeting.webex.internal.llm.off,
+            'event:relay.event',
+            meeting.processRelayEvent
+          );
+          assert.calledTwice(meeting.webex.internal.llm.off);
+          assert.calledOnceWithExactly(
+            meeting.webex.internal.llm.on,
+            'event:relay.event',
+            meeting.processRelayEvent
+          );
+        });
+
+        it('disconnects if first if the data channel url has changed', async () => {
+          meeting.joinedWith = {state: 'JOINED'};
+          webex.internal.llm.isConnected.returns(true);
+          webex.internal.llm.getLocusUrl.returns('a url');
+          webex.internal.llm.getDatachannelUrl.returns('a datachannel url');
+
+          meeting.locusInfo = {url: 'a url', info: {datachannelUrl: 'a different datachannel url'}};
+
+          const result = await meeting.updateLLMConnection();
+
+          assert.calledWith(webex.internal.llm.disconnectLLM);
+          assert.calledWith(
+            webex.internal.llm.registerAndConnect,
+            'a url',
+            'a different datachannel url'
           );
           assert.equal(result, 'something');
           assert.calledWithExactly(


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-541046
## This pull request addresses

There were two issues in previous implementation:
1. SDK subscribe breakout message right after join meeting but before client register and connect to LLM successfully, so subscription will fail.
2. When dataChannelUrl changed will trigger updateLLMConnection, but updateLLMConnection doesn't check whether dataChannelUrl changed, and do nothing if locus Url is same. But in fact we need reconnect LLM if dataChannelUrl changed.

## by making the following changes

1. SDK subscribe breakout message only when join a breakout when LLM should be connected successfully.
2. updateLLMConnection do reconnect if dataChannelUrl changed.






![13_16_20](https://github.com/webex/webex-js-sdk/assets/121160648/f00c9db6-8565-406b-b335-3bdd248e71d9)

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
