### PR TITLE
fix(plugin-meetings): deprecate remoteLossRate for maxRemoteLossRate

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -169,7 +169,7 @@ export const getAudioSenderMqa = ({audioSender, statsResults, lastMqaDataSent, b
   // Calculate based on how much packets lost of received compated to how to the client sent
 
   const totalPacketsLostForaMin = totalPacketsLostOnReceiver - lastPacketsLostTotal;
-  audioSender.common.remoteLossRate =
+  audioSender.common.maxRemoteLossRate =
     totalPacketsSent - lastPacketsSent > 0
       ? (totalPacketsLostForaMin * 100) / (totalPacketsSent - lastPacketsSent)
       : 0; // This is the packets sent with in last min
@@ -401,7 +401,7 @@ export const getVideoSenderMqa = ({videoSender, statsResults, lastMqaDataSent, b
   // Calculate based on how much packets lost of received compated to how to the client sent
   const totalPacketsLostForaMin = totalPacketsLostOnReceiver - lastPacketsLostTotal;
 
-  videoSender.common.remoteLossRate =
+  videoSender.common.maxRemoteLossRate =
     totalPacketsSent - lastPacketsSent > 0
       ? (totalPacketsLostForaMin * 100) / (totalPacketsSent - lastPacketsSent)
       : 0; // This is the packets sent with in last min || 0;


### PR DESCRIPTION
<!--
Hey there,
Thank you for taking the time to improve our code! 🙂
Please let us know why this change is necessary and what testing you have performed. 
This ensures our reviewers understand the impact of your change. 

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [WEBEX-379505](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-379505)

## This pull request addresses

The deprecation of the `remoteLossRate` property in MQE and its replacement with `maxRemoteLossRate`.

## by making the following changes

- Removed the `remoteLossRate` property from relevant MQE data structures and interfaces.
- Added the `maxRemoteLossRate` property where applicable.
- Updated all references and calculations to use `maxRemoteLossRate` instead of `remoteLossRate`.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Unit tests were updated and run to ensure that the new property is being used and the old property is no longer referenced.
- Manual testing was conducted in a development environment to ensure that the changes did not negatively impact the user experience or data reporting.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
