### PR TITLE
feat: add share video encoder implementation to share video mute event

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -7897,6 +7897,7 @@ export default class Meeting extends StatelessWebexPlugin {
     Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_SHARE_VIDEO_MUTE_STATE_CHANGE, {
       correlationId: this.correlationId,
       muted,
+      encoderImplementation: this.statsAnalyzer.shareVideoEncoderImplementation,
     });
   };
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -7897,7 +7897,7 @@ export default class Meeting extends StatelessWebexPlugin {
     Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_SHARE_VIDEO_MUTE_STATE_CHANGE, {
       correlationId: this.correlationId,
       muted,
-      encoderImplementation: this.statsAnalyzer.shareVideoEncoderImplementation,
+      encoderImplementation: this.statsAnalyzer?.shareVideoEncoderImplementation,
     });
   };
 

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -91,6 +91,7 @@ export class StatsAnalyzer extends EventsScope {
   statsStarted: any;
   successfulCandidatePair: any;
   localIpAddress: string; // Returns the local IP address for diagnostics. this is the local IP of the interface used for the current media connection a host can have many local Ip Addresses
+  shareVideoEncoderImplementation?: string;
   receiveSlotCallback: ReceiveSlotCallback;
   isMultistream: boolean;
 
@@ -613,6 +614,8 @@ export class StatsAnalyzer extends EventsScope {
           this.statsResults[newType].direction = statsItem.currentDirection;
           this.statsResults[newType].trackLabel = statsItem.localTrackLabel;
           this.statsResults[newType].csi = statsItem.csi;
+        } else if (type === 'video-share-send' && result.type === 'outbound-rtp') {
+          this.shareVideoEncoderImplementation = result.encoderImplementation;
         } else {
           this.parseGetStatsResult(result, type, isSender);
         }

--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/index.ts
@@ -616,6 +616,7 @@ export class StatsAnalyzer extends EventsScope {
           this.statsResults[newType].csi = statsItem.csi;
         } else if (type === 'video-share-send' && result.type === 'outbound-rtp') {
           this.shareVideoEncoderImplementation = result.encoderImplementation;
+          this.parseGetStatsResult(result, type, isSender);
         } else {
           this.parseGetStatsResult(result, type, isSender);
         }

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -579,6 +579,7 @@ describe('plugin-meetings', () => {
                     packetsSent: 0,
                     isRequested: true,
                     lastRequestedUpdateTimestamp: 0,
+                    encoderImplementation: 'fake-encoder',
                   },
                   {
                     type: 'remote-inbound-rtp',
@@ -1150,6 +1151,13 @@ describe('plugin-meetings', () => {
         mergeProperties(fakeStats, {candidateType: 'invalid'});
         await progressTime();
         assert.strictEqual(statsAnalyzer.getLocalIpAddress(), '');
+      });
+
+      it('has the correct share video encoder implementation as provided by the stats', async () => {
+        await startStatsAnalyzer({pc, statsAnalyzer});
+
+        await progressTime();
+        assert.strictEqual(statsAnalyzer.shareVideoEncoderImplementation, 'fake-encoder');
       });
 
       it('logs a message when audio send packets do not increase', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-542195](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-542195)

## This pull request addresses

Being able to determine whether a hardware or a software encoder is being used when share video gets muted.

## by making the following changes

Including the share video encoder implementation in the SDK event that is emitted whenever the share video mute state changes.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
