### PR TITLE
fix(plugin-meetings): prevent fetchMeetingInfo service call for one2one meeting. 

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -14,7 +14,7 @@ export const ANSWER = 'answer';
 export const CALL = 'call';
 export const CORRELATION_ID = 'correlationId';
 export const MEETINGNUMBER = 'meetingNumber';
-export const CONVERSATION_URL = 'conversationUrl';
+export const CONVERSATION_URL_KEY = 'conversationUrl';
 export const CALENDAR = 'calendar';
 export const CALENDAR_EVENTS_API = 'calendarEvents';
 export const CMR_MEETINGS = 'cmrmeetings';
@@ -64,7 +64,7 @@ export const READY = 'ready';
 
 export const SEND_DTMF_ENDPOINT = 'sendDtmf';
 export const SENDRECV = 'sendrecv';
-export const SIP_URI = 'sipUri';
+export const SIP_URI_KEY = 'sipUri';
 export const SHARE = 'share';
 
 export const TYPE = 'type';
@@ -81,7 +81,6 @@ export const _ACTIVE_ = 'ACTIVE';
 export const _CALL_ = 'CALL';
 export const _CREATED_ = 'CREATED';
 export const _CONFLICT_ = 'CONFLICT';
-export const _CONVERSATION_URL_ = 'CONVERSATION_URL';
 
 export const _ERROR_ = 'ERROR';
 
@@ -97,22 +96,17 @@ export const _ID_ = 'id';
 export const _JOIN_ = 'JOIN';
 export const _JOINED_ = 'JOINED';
 
-export const _LOCUS_ID_ = 'LOCUS_ID';
 export const _LEFT_ = 'LEFT';
 export const _MOVED_ = 'MOVED';
 export const _ON_HOLD_LOBBY_ = 'ON_HOLD_LOBBY';
-export const _MEETING_LINK_ = 'MEETING_LINK';
-export const _MEETING_UUID_ = 'MEETING_UUID';
 export const _MEETING_ = 'MEETING';
 export const _MEETING_CENTER_ = 'MEETING_CENTER';
-export const _MEETING_ID_ = 'MEETING_ID';
 
 export const _NOT_IN_MEETING_ = 'NOT_IN_MEETING';
 export const _NONE_ = 'NONE';
 
 export const _OBSERVE_ = 'OBSERVE';
 
-export const _PERSONAL_ROOM_ = 'PERSONAL_ROOM';
 export const _PEOPLE_ = hydraTypes.PEOPLE;
 
 export const _REQUESTED_ = 'REQUESTED';
@@ -122,7 +116,6 @@ export const _REMOVE_ = 'REMOVE';
 export const _ROOM_ = hydraTypes.ROOM;
 
 export const _SIP_BRIDGE_ = 'SIP_BRIDGE';
-export const _SIP_URI_ = 'SIP_URI';
 export const _SEND_RECEIVE_ = 'SENDRECV';
 export const _SEND_ONLY_ = 'SENDONLY';
 export const _INACTIVE_ = 'INACTIVE';
@@ -135,8 +128,6 @@ export const _UNKNOWN_ = 'UNKNOWN';
 export const _WEBEX_MEETING_ = 'WEBEX_MEETING';
 export const _WAIT_ = 'WAIT';
 export const _MOVE_MEDIA_ = 'MOVE_MEDIA';
-
-export const _ONE_2_ONE_MEEETING_ = 'ONE_2_ONE_MEETING';
 
 // *********** PARTICIPANT DELTAS ***********
 export const PARTICIPANT_DELTAS = {
@@ -1333,3 +1324,24 @@ export const MEETING_PERMISSION_TOKEN_REFRESH_REASON = 'ttl-join';
 
 // constant for named media group type
 export const NAMED_MEDIA_GROUP_TYPE_AUDIO = 1;
+
+export enum MeetingType {
+  CONVERSATION_URL = 'CONVERSATION_URL',
+  MEETING_LINK = 'MEETING_LINK',
+  SIP_URI = 'SIP_URI',
+  PERSONAL_ROOM = 'PERSONAL_ROOM',
+  ONE_ON_ONE_CALL = 'ONE_ON_ONE_CALL',
+  LOCUS_ID = 'LOCUS_ID',
+  MEETING_ID = 'MEETING_ID',
+  MEETING_UUID = 'MEETING_UUID',
+}
+
+// TODO: remove this after the meeting type is fully migrated to MeetingType
+export const _CONVERSATION_URL_ = 'CONVERSATION_URL';
+export const _MEETING_LINK_ = 'MEETING_LINK';
+export const _SIP_URI_ = 'SIP_URI';
+export const _PERSONAL_ROOM_ = 'PERSONAL_ROOM';
+export const _ONE_ON_ONE_CALL_ = 'ONE_ON_ONE_CALL';
+export const _LOCUS_ID_ = 'LOCUS_ID';
+export const _MEETING_ID_ = 'MEETING_ID';
+export const _MEETING_UUID_ = 'MEETING_UUID';

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -12,9 +12,6 @@ export const ALIAS = 'alias';
 export const ANSWER = 'answer';
 
 export const CALL = 'call';
-export const CORRELATION_ID = 'correlationId';
-export const MEETINGNUMBER = 'meetingNumber';
-export const CONVERSATION_URL_KEY = 'conversationUrl';
 export const CALENDAR = 'calendar';
 export const CALENDAR_EVENTS_API = 'calendarEvents';
 export const CMR_MEETINGS = 'cmrmeetings';
@@ -40,7 +37,6 @@ export const LEAVE = 'leave';
 export const LIVE = 'live';
 export const LOCAL = 'local';
 export const LOCI = 'loci';
-export const LOCUS_URL = 'locusUrl';
 export const END = 'end';
 
 export const MAX_RANDOM_DELAY_FOR_MEETING_INFO = 3 * 60 * 1000;
@@ -64,7 +60,6 @@ export const READY = 'ready';
 
 export const SEND_DTMF_ENDPOINT = 'sendDtmf';
 export const SENDRECV = 'sendrecv';
-export const SIP_URI_KEY = 'sipUri';
 export const SHARE = 'share';
 
 export const TYPE = 'type';
@@ -1325,13 +1320,15 @@ export const MEETING_PERMISSION_TOKEN_REFRESH_REASON = 'ttl-join';
 // constant for named media group type
 export const NAMED_MEDIA_GROUP_TYPE_AUDIO = 1;
 
-export enum DestinationType {
-  CONVERSATION_URL = 'CONVERSATION_URL',
-  MEETING_LINK = 'MEETING_LINK',
-  SIP_URI = 'SIP_URI',
-  PERSONAL_ROOM = 'PERSONAL_ROOM',
-  ONE_ON_ONE_CALL = 'ONE_ON_ONE_CALL',
-  LOCUS_ID = 'LOCUS_ID',
-  MEETING_ID = 'MEETING_ID',
-  MEETING_UUID = 'MEETING_UUID',
-}
+export const DESTINATION_TYPE = {
+  CONVERSATION_URL: 'CONVERSATION_URL',
+  MEETING_LINK: 'MEETING_LINK',
+  SIP_URI: 'SIP_URI',
+  PERSONAL_ROOM: 'PERSONAL_ROOM',
+  ONE_ON_ONE_CALL: 'ONE_ON_ONE_CALL',
+  LOCUS_ID: 'LOCUS_ID',
+  MEETING_ID: 'MEETING_ID',
+  MEETING_UUID: 'MEETING_UUID',
+} as const;
+
+export type DESTINATION_TYPE = Enum<typeof DESTINATION_TYPE>;

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1325,7 +1325,7 @@ export const MEETING_PERMISSION_TOKEN_REFRESH_REASON = 'ttl-join';
 // constant for named media group type
 export const NAMED_MEDIA_GROUP_TYPE_AUDIO = 1;
 
-export enum MeetingType {
+export enum DestinationType {
   CONVERSATION_URL = 'CONVERSATION_URL',
   MEETING_LINK = 'MEETING_LINK',
   SIP_URI = 'SIP_URI',
@@ -1335,13 +1335,3 @@ export enum MeetingType {
   MEETING_ID = 'MEETING_ID',
   MEETING_UUID = 'MEETING_UUID',
 }
-
-// TODO: remove this after the meeting type is fully migrated to MeetingType
-export const _CONVERSATION_URL_ = 'CONVERSATION_URL';
-export const _MEETING_LINK_ = 'MEETING_LINK';
-export const _SIP_URI_ = 'SIP_URI';
-export const _PERSONAL_ROOM_ = 'PERSONAL_ROOM';
-export const _ONE_ON_ONE_CALL_ = 'ONE_ON_ONE_CALL';
-export const _LOCUS_ID_ = 'LOCUS_ID';
-export const _MEETING_ID_ = 'MEETING_ID';
-export const _MEETING_UUID_ = 'MEETING_UUID';

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -12,6 +12,9 @@ export const ALIAS = 'alias';
 export const ANSWER = 'answer';
 
 export const CALL = 'call';
+export const CORRELATION_ID = 'correlationId';
+export const MEETINGNUMBER = 'meetingNumber';
+export const CONVERSATION_URL = 'conversationUrl';
 export const CALENDAR = 'calendar';
 export const CALENDAR_EVENTS_API = 'calendarEvents';
 export const CMR_MEETINGS = 'cmrmeetings';
@@ -37,6 +40,7 @@ export const LEAVE = 'leave';
 export const LIVE = 'live';
 export const LOCAL = 'local';
 export const LOCI = 'loci';
+export const LOCUS_URL = 'locusUrl';
 export const END = 'end';
 
 export const MAX_RANDOM_DELAY_FOR_MEETING_INFO = 3 * 60 * 1000;
@@ -60,6 +64,7 @@ export const READY = 'ready';
 
 export const SEND_DTMF_ENDPOINT = 'sendDtmf';
 export const SENDRECV = 'sendrecv';
+export const SIP_URI = 'sipUri';
 export const SHARE = 'share';
 
 export const TYPE = 'type';
@@ -76,6 +81,7 @@ export const _ACTIVE_ = 'ACTIVE';
 export const _CALL_ = 'CALL';
 export const _CREATED_ = 'CREATED';
 export const _CONFLICT_ = 'CONFLICT';
+export const _CONVERSATION_URL_ = 'CONVERSATION_URL';
 
 export const _ERROR_ = 'ERROR';
 
@@ -91,17 +97,22 @@ export const _ID_ = 'id';
 export const _JOIN_ = 'JOIN';
 export const _JOINED_ = 'JOINED';
 
+export const _LOCUS_ID_ = 'LOCUS_ID';
 export const _LEFT_ = 'LEFT';
 export const _MOVED_ = 'MOVED';
 export const _ON_HOLD_LOBBY_ = 'ON_HOLD_LOBBY';
+export const _MEETING_LINK_ = 'MEETING_LINK';
+export const _MEETING_UUID_ = 'MEETING_UUID';
 export const _MEETING_ = 'MEETING';
 export const _MEETING_CENTER_ = 'MEETING_CENTER';
+export const _MEETING_ID_ = 'MEETING_ID';
 
 export const _NOT_IN_MEETING_ = 'NOT_IN_MEETING';
 export const _NONE_ = 'NONE';
 
 export const _OBSERVE_ = 'OBSERVE';
 
+export const _PERSONAL_ROOM_ = 'PERSONAL_ROOM';
 export const _PEOPLE_ = hydraTypes.PEOPLE;
 
 export const _REQUESTED_ = 'REQUESTED';
@@ -111,6 +122,7 @@ export const _REMOVE_ = 'REMOVE';
 export const _ROOM_ = hydraTypes.ROOM;
 
 export const _SIP_BRIDGE_ = 'SIP_BRIDGE';
+export const _SIP_URI_ = 'SIP_URI';
 export const _SEND_RECEIVE_ = 'SENDRECV';
 export const _SEND_ONLY_ = 'SENDONLY';
 export const _INACTIVE_ = 'INACTIVE';

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -136,6 +136,8 @@ export const _WEBEX_MEETING_ = 'WEBEX_MEETING';
 export const _WAIT_ = 'WAIT';
 export const _MOVE_MEDIA_ = 'MOVE_MEDIA';
 
+export const _ONE_2_ONE_MEEETING_ = 'ONE_2_ONE_MEETING';
+
 // *********** PARTICIPANT DELTAS ***********
 export const PARTICIPANT_DELTAS = {
   TARGETS: {

--- a/packages/@webex/plugin-meetings/src/meeting-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/index.ts
@@ -157,7 +157,7 @@ export default class MeetingInfo {
   /**
    * Fetches meeting info from the server
    * @param {String} destination one of many different types of destinations to look up info for
-   * @param {String} [type] to match up with the destination value
+   * @param {DestinationType} [type] to match up with the destination value
    * @param {String} [password] meeting password
    * @param {Object} [captchaInfo] captcha code and id
    * @param {String} [installedOrgID]
@@ -170,7 +170,7 @@ export default class MeetingInfo {
    */
   public fetchMeetingInfo(
     destination: string,
-    type: string = null,
+    type: DestinationType = null,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     password: string = null,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/@webex/plugin-meetings/src/meeting-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/index.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
  */
 
-import {_MEETING_LINK_, _SIP_URI_, _PERSONAL_ROOM_} from '../constants';
+import {DestinationType} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
 
 import MeetingInfoCollection from './collection';
@@ -186,7 +186,7 @@ export default class MeetingInfo {
     extraParams: object = {},
     options: {meetingId?: string; sendCAevents?: boolean} = {}
   ) {
-    if (type === _PERSONAL_ROOM_ && !destination) {
+    if (type === DestinationType.PERSONAL_ROOM && !destination) {
       destination = this.webex.internal.device.userId;
     }
 
@@ -195,10 +195,13 @@ export default class MeetingInfo {
         // fetch meeting info
         this.requestFetchInfo({...infoOptions, ...options}).catch((error) => {
           // if it failed the first time as meeting link
-          if (infoOptions.type === _MEETING_LINK_) {
+          if (infoOptions.type === DestinationType.MEETING_LINK) {
             // convert the meeting link to sip URI and retry
             return this.requestFetchInfo({
-              ...this.fetchInfoOptions(MeetingInfoUtil.convertLinkToSip(destination), _SIP_URI_),
+              ...this.fetchInfoOptions(
+                MeetingInfoUtil.convertLinkToSip(destination),
+                DestinationType.SIP_URI
+              ),
               ...options,
             });
           }

--- a/packages/@webex/plugin-meetings/src/meeting-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/index.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
  */
 
-import {DestinationType} from '../constants';
+import {DESTINATION_TYPE} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
 
 import MeetingInfoCollection from './collection';
@@ -157,7 +157,7 @@ export default class MeetingInfo {
   /**
    * Fetches meeting info from the server
    * @param {String} destination one of many different types of destinations to look up info for
-   * @param {DestinationType} [type] to match up with the destination value
+   * @param {DESTINATION_TYPE} [type] to match up with the destination value
    * @param {String} [password] meeting password
    * @param {Object} [captchaInfo] captcha code and id
    * @param {String} [installedOrgID]
@@ -170,7 +170,7 @@ export default class MeetingInfo {
    */
   public fetchMeetingInfo(
     destination: string,
-    type: DestinationType = null,
+    type: DESTINATION_TYPE = null,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     password: string = null,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -186,7 +186,7 @@ export default class MeetingInfo {
     extraParams: object = {},
     options: {meetingId?: string; sendCAevents?: boolean} = {}
   ) {
-    if (type === DestinationType.PERSONAL_ROOM && !destination) {
+    if (type === DESTINATION_TYPE.PERSONAL_ROOM && !destination) {
       destination = this.webex.internal.device.userId;
     }
 
@@ -195,12 +195,12 @@ export default class MeetingInfo {
         // fetch meeting info
         this.requestFetchInfo({...infoOptions, ...options}).catch((error) => {
           // if it failed the first time as meeting link
-          if (infoOptions.type === DestinationType.MEETING_LINK) {
+          if (infoOptions.type === DESTINATION_TYPE.MEETING_LINK) {
             // convert the meeting link to sip URI and retry
             return this.requestFetchInfo({
               ...this.fetchInfoOptions(
                 MeetingInfoUtil.convertLinkToSip(destination),
-                DestinationType.SIP_URI
+                DESTINATION_TYPE.SIP_URI
               ),
               ...options,
             });

--- a/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
@@ -249,7 +249,7 @@ export default class MeetingInfoV2 {
   /**
    * Fetches meeting info from the server
    * @param {String} destination one of many different types of destinations to look up info for
-   * @param {String} [type] to match up with the destination value
+   * @param {DestinationType} [type] to match up with the destination value
    * @param {String} password
    * @param {Object} captchaInfo
    * @param {String} captchaInfo.code
@@ -264,7 +264,7 @@ export default class MeetingInfoV2 {
    */
   async fetchMeetingInfo(
     destination: string,
-    type: string = null,
+    type: DestinationType = null,
     password: string = null,
     captchaInfo: {
       code: string;

--- a/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
@@ -1,7 +1,7 @@
 import lodash from 'lodash';
 import {
   HTTP_VERBS,
-  _CONVERSATION_URL_,
+  DestinationType,
   WBXAPPAPI_SERVICE,
   DEFAULT_MEETING_INFO_REQUEST_BODY,
 } from '../constants';
@@ -284,7 +284,7 @@ export default class MeetingInfoV2 {
     });
 
     if (
-      destinationType.type === _CONVERSATION_URL_ &&
+      destinationType.type === DestinationType.CONVERSATION_URL &&
       this.webex.config.meetings.experimental.enableAdhocMeetings &&
       this.webex.meetings.preferredWebexSite
     ) {

--- a/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
@@ -1,7 +1,7 @@
 import lodash from 'lodash';
 import {
   HTTP_VERBS,
-  DestinationType,
+  DESTINATION_TYPE,
   WBXAPPAPI_SERVICE,
   DEFAULT_MEETING_INFO_REQUEST_BODY,
 } from '../constants';
@@ -249,7 +249,7 @@ export default class MeetingInfoV2 {
   /**
    * Fetches meeting info from the server
    * @param {String} destination one of many different types of destinations to look up info for
-   * @param {DestinationType} [type] to match up with the destination value
+   * @param {DESTINATION_TYPE} [type] to match up with the destination value
    * @param {String} password
    * @param {Object} captchaInfo
    * @param {String} captchaInfo.code
@@ -264,7 +264,7 @@ export default class MeetingInfoV2 {
    */
   async fetchMeetingInfo(
     destination: string,
-    type: DestinationType = null,
+    type: DESTINATION_TYPE = null,
     password: string = null,
     captchaInfo: {
       code: string;
@@ -284,7 +284,7 @@ export default class MeetingInfoV2 {
     });
 
     if (
-      destinationType.type === DestinationType.CONVERSATION_URL &&
+      destinationType.type === DESTINATION_TYPE.CONVERSATION_URL &&
       this.webex.config.meetings.experimental.enableAdhocMeetings &&
       this.webex.meetings.preferredWebexSite
     ) {

--- a/packages/@webex/plugin-meetings/src/meeting-info/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/util.ts
@@ -8,7 +8,7 @@ import ParameterError from '../common/errors/parameter';
 import LoggerProxy from '../common/logs/logger-proxy';
 
 import {
-  DestinationType,
+  DESTINATION_TYPE,
   _PEOPLE_,
   _ROOM_,
   HTTP_VERBS,
@@ -32,10 +32,10 @@ import {
  * @class MeetingInfoUtil
  */
 export default class MeetingInfoUtil {
-  static extractDestination(destination, type: DestinationType) {
+  static extractDestination(destination, type: DESTINATION_TYPE) {
     let dest = destination;
 
-    if (type === DestinationType.LOCUS_ID) {
+    if (type === DESTINATION_TYPE.LOCUS_ID) {
       if (!(destination && destination.url)) {
         throw new ParameterError(
           'You cannot create a meeting by locus without a locus.url defined'
@@ -195,19 +195,19 @@ export default class MeetingInfoUtil {
         'Meeting-info:util#generateOptions --> WARN, use of Meeting Link is deprecated, please use a SIP URI instead'
       );
 
-      options.type = DestinationType.MEETING_LINK;
+      options.type = DESTINATION_TYPE.MEETING_LINK;
       options.destination = destination;
     } else if (this.isSipUri(destination)) {
-      options.type = DestinationType.SIP_URI;
+      options.type = DESTINATION_TYPE.SIP_URI;
       options.destination = destination;
     } else if (this.isPhoneNumber(destination)) {
-      options.type = DestinationType.SIP_URI;
+      options.type = DESTINATION_TYPE.SIP_URI;
       options.destination = destination;
     } else if (this.isConversationUrl(destination, webex)) {
-      options.type = DestinationType.CONVERSATION_URL;
+      options.type = DESTINATION_TYPE.CONVERSATION_URL;
       options.destination = destination;
     } else if (hydraId.people) {
-      options.type = DestinationType.SIP_URI;
+      options.type = DESTINATION_TYPE.SIP_URI;
 
       return this.getSipUriFromHydraPersonId(hydraId.destination, webex).then((res) => {
         options.destination = res;
@@ -220,7 +220,7 @@ export default class MeetingInfoUtil {
         return Promise.resolve(options);
       });
     } else if (hydraId.room) {
-      options.type = DestinationType.CONVERSATION_URL;
+      options.type = DESTINATION_TYPE.CONVERSATION_URL;
       try {
         await webex.internal.services.waitForCatalog('postauth');
 
@@ -249,33 +249,33 @@ export default class MeetingInfoUtil {
 
   /**
    * Helper function to build up a correct locus url depending on the value passed
-   * @param {DestinationType} type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
+   * @param {DESTINATION_TYPE} type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
    * @param {Object} value ?? value.value
    * @returns {Object} returns an object with {resource, method}
    */
-  static getResourceUrl(type: DestinationType, value: any) {
+  static getResourceUrl(type: DESTINATION_TYPE, value: any) {
     let resource = `/${LOCI}/${MEETINGINFO}`;
     let method = HTTP_VERBS.GET;
     let uri = null;
 
     switch (type) {
-      case DestinationType.SIP_URI:
-      case DestinationType.PERSONAL_ROOM:
-      case DestinationType.MEETING_ID:
+      case DESTINATION_TYPE.SIP_URI:
+      case DESTINATION_TYPE.PERSONAL_ROOM:
+      case DESTINATION_TYPE.MEETING_ID:
         resource = `/${LOCI}/${MEETINGINFO}/${encodeURIComponent(
           value
         )}?${TYPE}=${type}&${USE_URI_LOOKUP_FALSE}`;
         break;
-      case DestinationType.CONVERSATION_URL:
+      case DESTINATION_TYPE.CONVERSATION_URL:
         method = HTTP_VERBS.PUT;
         break;
-      case DestinationType.LOCUS_ID:
+      case DESTINATION_TYPE.LOCUS_ID:
         uri = `${value}/${MEETINGINFO}`;
         method = HTTP_VERBS.PUT;
         break;
-      case DestinationType.MEETING_LINK:
+      case DESTINATION_TYPE.MEETING_LINK:
         resource = `$/${LOCI}/${MEETINGINFO}/${btoa(value)}?${TYPE}=${
-          DestinationType.MEETING_LINK
+          DESTINATION_TYPE.MEETING_LINK
         }&${USE_URI_LOOKUP_FALSE}`;
         break;
       default:
@@ -288,7 +288,7 @@ export default class MeetingInfoUtil {
     };
   }
 
-  static getRequestParams(resourceOptions, type: DestinationType, value, api) {
+  static getRequestParams(resourceOptions, type: DESTINATION_TYPE, value, api) {
     let requestParams: any = {
       method: resourceOptions.method,
       api,
@@ -298,14 +298,14 @@ export default class MeetingInfoUtil {
     if (resourceOptions.method === HTTP_VERBS.GET) {
       // for handling URL redirections
       requestParams.resource = requestParams.resource.concat(`&${ALTERNATE_REDIRECT_TRUE}`);
-    } else if (type !== DestinationType.LOCUS_ID) {
+    } else if (type !== DESTINATION_TYPE.LOCUS_ID) {
       // locus id check is a PUT not sure why
       requestParams.resource = requestParams.resource.concat(`?${ALTERNATE_REDIRECT_TRUE}`);
       requestParams.body = {
         value,
         lookupType: type,
       };
-    } else if (type === DestinationType.LOCUS_ID) {
+    } else if (type === DESTINATION_TYPE.LOCUS_ID) {
       requestParams = {
         method: resourceOptions.method,
         uri: resourceOptions.uri,

--- a/packages/@webex/plugin-meetings/src/meeting-info/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/util.ts
@@ -32,7 +32,7 @@ import {
  * @class MeetingInfoUtil
  */
 export default class MeetingInfoUtil {
-  static extractDestination(destination, type) {
+  static extractDestination(destination, type: DestinationType) {
     let dest = destination;
 
     if (type === DestinationType.LOCUS_ID) {
@@ -249,11 +249,11 @@ export default class MeetingInfoUtil {
 
   /**
    * Helper function to build up a correct locus url depending on the value passed
-   * @param {String} type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
+   * @param {DestinationType} type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
    * @param {Object} value ?? value.value
    * @returns {Object} returns an object with {resource, method}
    */
-  static getResourceUrl(type: string, value: any) {
+  static getResourceUrl(type: DestinationType, value: any) {
     let resource = `/${LOCI}/${MEETINGINFO}`;
     let method = HTTP_VERBS.GET;
     let uri = null;
@@ -288,7 +288,7 @@ export default class MeetingInfoUtil {
     };
   }
 
-  static getRequestParams(resourceOptions, type, value, api) {
+  static getRequestParams(resourceOptions, type: DestinationType, value, api) {
     let requestParams: any = {
       method: resourceOptions.method,
       api,

--- a/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
@@ -220,12 +220,12 @@ export default class MeetingInfoUtil {
   /**
    * Helper function to build up a correct locus url depending on the value passed
    * @param {Object} options type and value to fetch meeting info
-   * @param {String} options.type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
+   * @param {DestinationType} options.type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
    * @param {String} options.installedOrgID org ID of user's machine
    * @param {Object} options.destination ?? value.value
    * @returns {Object} returns an object with {resource, method}
    */
-  static getRequestBody(options: {type: string; destination: object} | any) {
+  static getRequestBody(options: {type: DestinationType; destination: object} | any) {
     const {type, destination, password, captchaInfo, installedOrgID, locusId, extraParams} =
       options;
     const body: any = {

--- a/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
@@ -4,7 +4,7 @@ import url from 'url';
 import {deconstructHydraId} from '@webex/common';
 
 import {
-  DestinationType,
+  DESTINATION_TYPE,
   _PEOPLE_,
   _ROOM_,
   DIALER_REGEX,
@@ -138,7 +138,7 @@ export default class MeetingInfoUtil {
     const {type, webex} = from;
     let {destination} = from;
 
-    if (type === DestinationType.PERSONAL_ROOM) {
+    if (type === DESTINATION_TYPE.PERSONAL_ROOM) {
       // this case checks if your type is personal room
       if (!destination) {
         // if we are not getting anything in desination we fetch org and user ids from webex instance
@@ -179,19 +179,19 @@ export default class MeetingInfoUtil {
         'Meeting-info:util#generateOptions --> WARN, use of Meeting Link is deprecated, please use a SIP URI instead'
       );
 
-      options.type = DestinationType.MEETING_LINK;
+      options.type = DESTINATION_TYPE.MEETING_LINK;
       options.destination = destination;
     } else if (this.isSipUri(destination)) {
-      options.type = DestinationType.SIP_URI;
+      options.type = DESTINATION_TYPE.SIP_URI;
       options.destination = destination;
     } else if (this.isPhoneNumber(destination)) {
-      options.type = DestinationType.SIP_URI;
+      options.type = DESTINATION_TYPE.SIP_URI;
       options.destination = destination;
     } else if (this.isConversationUrl(destination, webex)) {
-      options.type = DestinationType.CONVERSATION_URL;
+      options.type = DESTINATION_TYPE.CONVERSATION_URL;
       options.destination = destination;
     } else if (hydraId && hydraId.people) {
-      options.type = DestinationType.SIP_URI;
+      options.type = DESTINATION_TYPE.SIP_URI;
 
       return this.getSipUriFromHydraPersonId(hydraId && hydraId.destination, webex).then((res) => {
         options.destination = res;
@@ -220,12 +220,12 @@ export default class MeetingInfoUtil {
   /**
    * Helper function to build up a correct locus url depending on the value passed
    * @param {Object} options type and value to fetch meeting info
-   * @param {DestinationType} options.type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
+   * @param {DESTINATION_TYPE} options.type One of [SIP_URI, PERSONAL_ROOM, MEETING_ID, CONVERSATION_URL, LOCUS_ID, MEETING_LINK]
    * @param {String} options.installedOrgID org ID of user's machine
    * @param {Object} options.destination ?? value.value
    * @returns {Object} returns an object with {resource, method}
    */
-  static getRequestBody(options: {type: DestinationType; destination: object} | any) {
+  static getRequestBody(options: {type: DESTINATION_TYPE; destination: object} | any) {
     const {type, destination, password, captchaInfo, installedOrgID, locusId, extraParams} =
       options;
     const body: any = {
@@ -234,20 +234,20 @@ export default class MeetingInfoUtil {
     };
 
     switch (type) {
-      case DestinationType.SIP_URI:
+      case DESTINATION_TYPE.SIP_URI:
         body.sipUrl = destination;
         break;
-      case DestinationType.PERSONAL_ROOM:
+      case DESTINATION_TYPE.PERSONAL_ROOM:
         body.userId = destination.userId;
         body.orgId = destination.orgId;
         break;
-      case DestinationType.MEETING_ID:
+      case DESTINATION_TYPE.MEETING_ID:
         body.meetingKey = destination;
         break;
-      case DestinationType.CONVERSATION_URL:
+      case DESTINATION_TYPE.CONVERSATION_URL:
         body.conversationUrl = destination;
         break;
-      case DestinationType.LOCUS_ID:
+      case DESTINATION_TYPE.LOCUS_ID:
         // use meetingID for the completer meeting info for the already started meeting
         if (destination.info?.webExMeetingId) {
           body.meetingKey = destination.info.webExMeetingId;
@@ -255,10 +255,10 @@ export default class MeetingInfoUtil {
           body.sipUrl = destination.info.sipUri;
         }
         break;
-      case DestinationType.MEETING_LINK:
+      case DESTINATION_TYPE.MEETING_LINK:
         body.meetingUrl = destination;
         break;
-      case DestinationType.MEETING_UUID: {
+      case DESTINATION_TYPE.MEETING_UUID: {
         body.meetingUUID = destination;
         break;
       }
@@ -311,10 +311,10 @@ export default class MeetingInfoUtil {
     let preferredWebexSite = null;
 
     switch (type) {
-      case DestinationType.SIP_URI:
+      case DESTINATION_TYPE.SIP_URI:
         preferredWebexSite = this.getWebexSite(destination);
         break;
-      case DestinationType.LOCUS_ID:
+      case DESTINATION_TYPE.LOCUS_ID:
         preferredWebexSite = destination.info?.webExSite;
         break;
       default:

--- a/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
@@ -4,15 +4,9 @@ import url from 'url';
 import {deconstructHydraId} from '@webex/common';
 
 import {
-  _SIP_URI_,
-  _PERSONAL_ROOM_,
-  _MEETING_ID_,
-  _CONVERSATION_URL_,
-  _LOCUS_ID_,
-  _MEETING_LINK_,
+  DestinationType,
   _PEOPLE_,
   _ROOM_,
-  _MEETING_UUID_,
   DIALER_REGEX,
   WEBEX_DOT_COM,
   CONVERSATION_SERVICE,
@@ -144,7 +138,7 @@ export default class MeetingInfoUtil {
     const {type, webex} = from;
     let {destination} = from;
 
-    if (type === _PERSONAL_ROOM_) {
+    if (type === DestinationType.PERSONAL_ROOM) {
       // this case checks if your type is personal room
       if (!destination) {
         // if we are not getting anything in desination we fetch org and user ids from webex instance
@@ -185,19 +179,19 @@ export default class MeetingInfoUtil {
         'Meeting-info:util#generateOptions --> WARN, use of Meeting Link is deprecated, please use a SIP URI instead'
       );
 
-      options.type = _MEETING_LINK_;
+      options.type = DestinationType.MEETING_LINK;
       options.destination = destination;
     } else if (this.isSipUri(destination)) {
-      options.type = _SIP_URI_;
+      options.type = DestinationType.SIP_URI;
       options.destination = destination;
     } else if (this.isPhoneNumber(destination)) {
-      options.type = _SIP_URI_;
+      options.type = DestinationType.SIP_URI;
       options.destination = destination;
     } else if (this.isConversationUrl(destination, webex)) {
-      options.type = _CONVERSATION_URL_;
+      options.type = DestinationType.CONVERSATION_URL;
       options.destination = destination;
     } else if (hydraId && hydraId.people) {
-      options.type = _SIP_URI_;
+      options.type = DestinationType.SIP_URI;
 
       return this.getSipUriFromHydraPersonId(hydraId && hydraId.destination, webex).then((res) => {
         options.destination = res;
@@ -240,20 +234,20 @@ export default class MeetingInfoUtil {
     };
 
     switch (type) {
-      case _SIP_URI_:
+      case DestinationType.SIP_URI:
         body.sipUrl = destination;
         break;
-      case _PERSONAL_ROOM_:
+      case DestinationType.PERSONAL_ROOM:
         body.userId = destination.userId;
         body.orgId = destination.orgId;
         break;
-      case _MEETING_ID_:
+      case DestinationType.MEETING_ID:
         body.meetingKey = destination;
         break;
-      case _CONVERSATION_URL_:
+      case DestinationType.CONVERSATION_URL:
         body.conversationUrl = destination;
         break;
-      case _LOCUS_ID_:
+      case DestinationType.LOCUS_ID:
         // use meetingID for the completer meeting info for the already started meeting
         if (destination.info?.webExMeetingId) {
           body.meetingKey = destination.info.webExMeetingId;
@@ -261,10 +255,10 @@ export default class MeetingInfoUtil {
           body.sipUrl = destination.info.sipUri;
         }
         break;
-      case _MEETING_LINK_:
+      case DestinationType.MEETING_LINK:
         body.meetingUrl = destination;
         break;
-      case _MEETING_UUID_: {
+      case DestinationType.MEETING_UUID: {
         body.meetingUUID = destination;
         break;
       }
@@ -317,10 +311,10 @@ export default class MeetingInfoUtil {
     let preferredWebexSite = null;
 
     switch (type) {
-      case _SIP_URI_:
+      case DestinationType.SIP_URI:
         preferredWebexSite = this.getWebexSite(destination);
         break;
-      case _LOCUS_ID_:
+      case DestinationType.LOCUS_ID:
         preferredWebexSite = destination.info?.webExSite;
         break;
       default:

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -79,7 +79,7 @@ import {Reactions, SkinTones} from '../reactions/reactions';
 import PasswordError from '../common/errors/password-error';
 import CaptchaError from '../common/errors/captcha-error';
 import {
-  DestinationType,
+  DESTINATION_TYPE,
   _INCOMING_,
   _JOIN_,
   AUDIO,
@@ -526,7 +526,7 @@ export default class Meeting extends StatelessWebexPlugin {
   conversationUrl: string;
   callStateForMetrics: CallStateForMetrics;
   destination: string;
-  destinationType: DestinationType;
+  destinationType: DESTINATION_TYPE;
   deviceUrl: string;
   hostId: string;
   id: string;
@@ -1738,7 +1738,7 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     const isStartingSpaceInstantV2Meeting =
-      this.destinationType === DestinationType.CONVERSATION_URL &&
+      this.destinationType === DESTINATION_TYPE.CONVERSATION_URL &&
       // @ts-ignore - config coming from registerPlugin
       this.config.experimental.enableAdhocMeetings &&
       // @ts-ignore
@@ -1748,7 +1748,7 @@ export default class Meeting extends StatelessWebexPlugin {
       ? this.meetingInfo.meetingJoinUrl
       : this.destination;
     const destinationType = isStartingSpaceInstantV2Meeting
-      ? DestinationType.MEETING_LINK
+      ? DESTINATION_TYPE.MEETING_LINK
       : this.destinationType;
 
     const permissionTokenExpiryInfo = this.getPermissionTokenExpiryInfo();

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -79,10 +79,9 @@ import {Reactions, SkinTones} from '../reactions/reactions';
 import PasswordError from '../common/errors/password-error';
 import CaptchaError from '../common/errors/captcha-error';
 import {
-  _CONVERSATION_URL_,
+  DestinationType,
   _INCOMING_,
   _JOIN_,
-  _MEETING_LINK_,
   AUDIO,
   CONTENT,
   DISPLAY_HINTS,
@@ -1739,7 +1738,7 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     const isStartingSpaceInstantV2Meeting =
-      this.destinationType === _CONVERSATION_URL_ &&
+      this.destinationType === DestinationType.CONVERSATION_URL &&
       // @ts-ignore - config coming from registerPlugin
       this.config.experimental.enableAdhocMeetings &&
       // @ts-ignore
@@ -1748,7 +1747,9 @@ export default class Meeting extends StatelessWebexPlugin {
     const destination = isStartingSpaceInstantV2Meeting
       ? this.meetingInfo.meetingJoinUrl
       : this.destination;
-    const destinationType = isStartingSpaceInstantV2Meeting ? _MEETING_LINK_ : this.destinationType;
+    const destinationType = isStartingSpaceInstantV2Meeting
+      ? DestinationType.MEETING_LINK
+      : this.destinationType;
 
     const permissionTokenExpiryInfo = this.getPermissionTokenExpiryInfo();
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -526,7 +526,7 @@ export default class Meeting extends StatelessWebexPlugin {
   conversationUrl: string;
   callStateForMetrics: CallStateForMetrics;
   destination: string;
-  destinationType: string;
+  destinationType: DestinationType;
   deviceUrl: string;
   hostId: string;
   id: string;

--- a/packages/@webex/plugin-meetings/src/meetings/collection.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/collection.ts
@@ -1,18 +1,7 @@
 import {find} from 'lodash';
-import {Enum} from '../constants';
 
 import Collection from '../common/collection';
-
-export const MEETING_KEY = {
-  CONVERSATION_URL: 'conversationUrl',
-  SIP_URI: 'sipUri',
-  LOCUS_URL: 'locusUrl',
-  MEETINGNUMBER: 'meetingNumber',
-  CORRELATION_ID: 'correlationId',
-} as const;
-
-export type MEETING_KEY = Enum<typeof MEETING_KEY>;
-
+import {MEETING_KEY} from './meetings.types';
 /**
  * @export
  * @class MeetingCollection

--- a/packages/@webex/plugin-meetings/src/meetings/collection.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/collection.ts
@@ -1,6 +1,17 @@
 import {find} from 'lodash';
+import {Enum} from '../constants';
 
 import Collection from '../common/collection';
+
+export const MEETING_KEY = {
+  CONVERSATION_URL: 'conversationUrl',
+  SIP_URI: 'sipUri',
+  LOCUS_URL: 'locusUrl',
+  MEETINGNUMBER: 'meetingNumber',
+  CORRELATION_ID: 'correlationId',
+} as const;
+
+export type MEETING_KEY = Enum<typeof MEETING_KEY>;
 
 /**
  * @export
@@ -26,13 +37,13 @@ export default class MeetingCollection extends Collection {
 
   /**
    * get a specific meeting searching for key
-   * @param {String} key
+   * @param {MEETING_KEY} key
    * @param {Any} value
    * @returns {Meeting} if found, else returns null
    * @public
    * @memberof MeetingCollection
    */
-  public getByKey(key: string, value: any) {
+  public getByKey(key: MEETING_KEY, value: any) {
     if (key && value) {
       // @ts-ignore
       return find(this.meetings, (meeting) => meeting[key] === value);

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -47,6 +47,7 @@ import {
   _MOVED_,
   _ON_HOLD_LOBBY_,
   _WAIT_,
+  _ONE_2_ONE_MEEETING_,
 } from '../constants';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import MeetingInfo from '../meeting-info';
@@ -1084,7 +1085,6 @@ export default class Meetings extends WebexPlugin {
    * @param {CallStateForMetrics} callStateForMetrics - information about call state for metrics
    * @param {Object} [meetingInfo] - Pre-fetched complete meeting info
    * @param {String} [meetingLookupUrl] - meeting info prefetch url
-   * @param {Boolean} [isOne2OneMeeting] - whether the meeting is a 1:1 meeting
    * @returns {Promise<Meeting>} A new Meeting.
    * @public
    * @memberof Meetings
@@ -1098,8 +1098,7 @@ export default class Meetings extends WebexPlugin {
     failOnMissingMeetingInfo = false,
     callStateForMetrics: CallStateForMetrics = undefined,
     meetingInfo = undefined,
-    meetingLookupUrl = undefined,
-    isOne2OneMeeting = false
+    meetingLookupUrl = undefined
   ) {
     // TODO: type should be from a dictionary
 
@@ -1160,8 +1159,7 @@ export default class Meetings extends WebexPlugin {
               callStateForMetrics,
               failOnMissingMeetingInfo,
               meetingInfo,
-              meetingLookupUrl,
-              isOne2OneMeeting
+              meetingLookupUrl
             ).then((createdMeeting: any) => {
               // If the meeting was successfully created.
               if (createdMeeting && createdMeeting.on) {
@@ -1228,7 +1226,6 @@ export default class Meetings extends WebexPlugin {
    * @param {Boolean} failOnMissingMeetingInfo - whether to throw an error if meeting info fails to fetch (for calls that are not 1:1 or content share)
    * @param {Object} [meetingInfo] - Pre-fetched complete meeting info
    * @param {String} [meetingLookupUrl] - meeting info prefetch url
-   * @param {Boolean} [isOne2OneMeeting] - whether the meeting is a 1:1 meeting
    * @returns {Promise} a new meeting instance complete with meeting info and destination
    * @private
    * @memberof Meetings
@@ -1241,8 +1238,7 @@ export default class Meetings extends WebexPlugin {
     callStateForMetrics: CallStateForMetrics = undefined,
     failOnMissingMeetingInfo = false,
     meetingInfo = undefined,
-    meetingLookupUrl = undefined,
-    isOne2OneMeeting = false
+    meetingLookupUrl = undefined
   ) {
     const meeting = new Meeting(
       {
@@ -1295,7 +1291,7 @@ export default class Meetings extends WebexPlugin {
 
       if (meetingInfo) {
         meeting.injectMeetingInfo(meetingInfo, meetingInfoOptions, meetingLookupUrl);
-      } else if (!isOne2OneMeeting) {
+      } else if (type !== _ONE_2_ONE_MEEETING_) {
         // ignore fetchMeetingInfo for 1:1 meetings
         if (enableUnifiedMeetings && !isMeetingActive && useRandomDelayForInfo && waitingTime > 0) {
           meeting.fetchMeetingInfoTimeoutId = setTimeout(

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1078,7 +1078,7 @@ export default class Meetings extends WebexPlugin {
    * When meeting info passed it should be complete, e.g.: fetched after password or captcha provided
    *
    * @param {string} destination - sipURL, phonenumber, or locus object}
-   * @param {string} [type] - the optional specified type, such as locusId
+   * @param {string | MeetingType} [type] - the optional specified type, such as locusId
    * @param {Boolean} useRandomDelayForInfo - whether a random delay should be added to fetching meeting info
    * @param {Object} infoExtraParams extra parameters to be provided when fetching meeting info
    * @param {string} correlationId - the optional specified correlationId (callStateForMetrics.correlationId can be provided instead)

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -51,10 +51,10 @@ import Reachability from '../reachability';
 import Request from './request';
 import PasswordError from '../common/errors/password-error';
 import CaptchaError from '../common/errors/captcha-error';
-import MeetingCollection, {MEETING_KEY} from './collection';
+import MeetingCollection from './collection';
+import {MEETING_KEY, INoiseReductionEffect, IVirtualBackgroundEffect} from './meetings.types';
 import MeetingsUtil from './util';
 import PermissionError from '../common/errors/permission';
-import {INoiseReductionEffect, IVirtualBackgroundEffect} from './meetings.types';
 import {SpaceIDDeprecatedError} from '../common/errors/webex-errors';
 import NoMeetingInfoError from '../common/errors/no-meeting-info';
 

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1223,7 +1223,7 @@ export default class Meetings extends WebexPlugin {
    * When meeting info passed it should be complete, e.g.: fetched after password or captcha provided
    *
    * @param {String} destination see create()
-   * @param {String} type see create()
+   * @param {DestinationType} type see create()
    * @param {Boolean} useRandomDelayForInfo whether a random delay should be added to fetching meeting info
    * @param {Object} infoExtraParams extra parameters to be provided when fetching meeting info
    * @param {CallStateForMetrics} callStateForMetrics - information about call state for metrics
@@ -1236,7 +1236,7 @@ export default class Meetings extends WebexPlugin {
    */
   private async createMeeting(
     destination: any,
-    type: string = null,
+    type: DestinationType = null,
     useRandomDelayForInfo = false,
     infoExtraParams = {},
     callStateForMetrics: CallStateForMetrics = undefined,

--- a/packages/@webex/plugin-meetings/src/meetings/meetings.types.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/meetings.types.ts
@@ -2,6 +2,7 @@ import type {
   NoiseReductionEffectOptions,
   VirtualBackgroundEffectOptions,
 } from '@webex/media-helpers';
+import {Enum} from '../constants';
 
 type INoiseReductionEffect = Omit<
   NoiseReductionEffectOptions,
@@ -10,3 +11,13 @@ type INoiseReductionEffect = Omit<
 type IVirtualBackgroundEffect = Omit<VirtualBackgroundEffectOptions, 'authToken'>;
 
 export type {INoiseReductionEffect, IVirtualBackgroundEffect};
+
+export const MEETING_KEY = {
+  CONVERSATION_URL: 'conversationUrl',
+  SIP_URI: 'sipUri',
+  LOCUS_URL: 'locusUrl',
+  MEETINGNUMBER: 'meetingNumber',
+  CORRELATION_ID: 'correlationId',
+} as const;
+
+export type MEETING_KEY = Enum<typeof MEETING_KEY>;

--- a/packages/@webex/plugin-meetings/src/meetings/util.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/util.ts
@@ -39,7 +39,7 @@ import Metrics from '../metrics';
 
 const MeetingsUtil: any = {};
 
-MeetingsUtil.getMeetingAddedType = (type) =>
+MeetingsUtil.getMeetingAddedType = (type: DestinationType) =>
   type === DestinationType.LOCUS_ID ? _INCOMING_ : _CREATED_;
 
 MeetingsUtil.handleRoapMercury = (envelope, meetingCollection) => {

--- a/packages/@webex/plugin-meetings/src/meetings/util.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/util.ts
@@ -17,7 +17,7 @@ import LoggerProxy from '../common/logs/logger-proxy';
 import Trigger from '../common/events/trigger-proxy';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import Metrics from '../metrics';
-import {MEETING_KEY} from './collection';
+import {MEETING_KEY} from './meetings.types';
 
 /**
  * Meetings Media Codec Missing Event

--- a/packages/@webex/plugin-meetings/src/meetings/util.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/util.ts
@@ -5,7 +5,7 @@ import {
   _INCOMING_,
   _JOINED_,
   _LEFT_,
-  _LOCUS_ID_,
+  DestinationType,
   _MOVED_,
   BREAKOUTS,
   CORRELATION_ID,
@@ -39,7 +39,8 @@ import Metrics from '../metrics';
 
 const MeetingsUtil: any = {};
 
-MeetingsUtil.getMeetingAddedType = (type) => (type === _LOCUS_ID_ ? _INCOMING_ : _CREATED_);
+MeetingsUtil.getMeetingAddedType = (type) =>
+  type === DestinationType.LOCUS_ID ? _INCOMING_ : _CREATED_;
 
 MeetingsUtil.handleRoapMercury = (envelope, meetingCollection) => {
   const {data} = envelope;

--- a/packages/@webex/plugin-meetings/src/meetings/util.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/util.ts
@@ -5,10 +5,9 @@ import {
   _INCOMING_,
   _JOINED_,
   _LEFT_,
-  DestinationType,
+  DESTINATION_TYPE,
   _MOVED_,
   BREAKOUTS,
-  CORRELATION_ID,
   EVENT_TRIGGERS,
   LOCUS,
   LOCUSEVENT,
@@ -18,6 +17,7 @@ import LoggerProxy from '../common/logs/logger-proxy';
 import Trigger from '../common/events/trigger-proxy';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import Metrics from '../metrics';
+import {MEETING_KEY} from './collection';
 
 /**
  * Meetings Media Codec Missing Event
@@ -39,15 +39,15 @@ import Metrics from '../metrics';
 
 const MeetingsUtil: any = {};
 
-MeetingsUtil.getMeetingAddedType = (type: DestinationType) =>
-  type === DestinationType.LOCUS_ID ? _INCOMING_ : _CREATED_;
+MeetingsUtil.getMeetingAddedType = (type: DESTINATION_TYPE) =>
+  type === DESTINATION_TYPE.LOCUS_ID ? _INCOMING_ : _CREATED_;
 
 MeetingsUtil.handleRoapMercury = (envelope, meetingCollection) => {
   const {data} = envelope;
   const {eventType} = data;
 
   if (eventType === LOCUSEVENT.MESSAGE_ROAP) {
-    const meeting = meetingCollection.getByKey(CORRELATION_ID, data.correlationId);
+    const meeting = meetingCollection.getByKey(MEETING_KEY.CORRELATION_ID, data.correlationId);
 
     if (meeting) {
       const {seq, messageType, tieBreaker, errorType, errorCause} = data.message;

--- a/packages/@webex/plugin-meetings/src/personal-meeting-room/index.ts
+++ b/packages/@webex/plugin-meetings/src/personal-meeting-room/index.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
-import {MEETINGS, _PERSONAL_ROOM_} from '../constants';
+import {MEETINGS, DestinationType} from '../constants';
 import ParameterError from '../common/errors/parameter';
 
 import PersonalMeetingRoomRequest from './request';
@@ -141,7 +141,7 @@ export default class PersonalMeetingRoom extends StatelessWebexPlugin {
    */
   public get() {
     const options = {
-      type: _PERSONAL_ROOM_,
+      type: DestinationType.PERSONAL_ROOM,
     };
 
     return this.meetingInfo.fetchMeetingInfo(options).then((pmr) => {

--- a/packages/@webex/plugin-meetings/src/personal-meeting-room/index.ts
+++ b/packages/@webex/plugin-meetings/src/personal-meeting-room/index.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import {StatelessWebexPlugin} from '@webex/webex-core';
 
-import {MEETINGS, DestinationType} from '../constants';
+import {MEETINGS, DESTINATION_TYPE} from '../constants';
 import ParameterError from '../common/errors/parameter';
 
 import PersonalMeetingRoomRequest from './request';
@@ -141,7 +141,7 @@ export default class PersonalMeetingRoom extends StatelessWebexPlugin {
    */
   public get() {
     const options = {
-      type: DestinationType.PERSONAL_ROOM,
+      type: DESTINATION_TYPE.PERSONAL_ROOM,
     };
 
     return this.meetingInfo.fetchMeetingInfo(options).then((pmr) => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/index.js
@@ -1,7 +1,7 @@
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
 import MockWebex from '@webex/test-helper-mock-webex';
-import {DestinationType} from '@webex/plugin-meetings/src/constants';
+import {DESTINATION_TYPE} from '@webex/plugin-meetings/src/constants';
 
 import MeetingInfo from '@webex/plugin-meetings/src/meeting-info/index';
 import MeetingInfoUtil from '@webex/plugin-meetings/src/meeting-info/util';
@@ -34,7 +34,7 @@ describe('plugin-meetings', () => {
           .resolves({type: 'MEETING_ID', destination: '123456'});
         sinon.stub(MeetingInfoRequest.prototype, 'fetchMeetingInfo').returns(Promise.resolve(confIdStrProp ? bodyConfIdStr : body));
 
-        await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, null, null, null, null, null, {
+        await meetingInfo.fetchMeetingInfo('1234323', DESTINATION_TYPE.MEETING_ID, null, null, null, null, null, {
           meetingId,
           sendCAevents,
         });
@@ -113,7 +113,7 @@ describe('plugin-meetings', () => {
         try {
           await meetingInfo.fetchMeetingInfo(
             '1234323',
-            DestinationType.MEETING_ID,
+            DESTINATION_TYPE.MEETING_ID,
             null,
             null,
             null,
@@ -196,7 +196,7 @@ describe('plugin-meetings', () => {
         try {
           await meetingInfo.fetchMeetingInfo(
             '1234323',
-            DestinationType.MEETING_ID,
+            DESTINATION_TYPE.MEETING_ID,
             null,
             null,
             null,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/index.js
@@ -1,7 +1,7 @@
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
 import MockWebex from '@webex/test-helper-mock-webex';
-import {_MEETING_ID_} from '@webex/plugin-meetings/src/constants';
+import {DestinationType} from '@webex/plugin-meetings/src/constants';
 
 import MeetingInfo from '@webex/plugin-meetings/src/meeting-info/index';
 import MeetingInfoUtil from '@webex/plugin-meetings/src/meeting-info/util';
@@ -34,7 +34,7 @@ describe('plugin-meetings', () => {
           .resolves({type: 'MEETING_ID', destination: '123456'});
         sinon.stub(MeetingInfoRequest.prototype, 'fetchMeetingInfo').returns(Promise.resolve(confIdStrProp ? bodyConfIdStr : body));
 
-        await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, null, null, null, null, null, {
+        await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, null, null, null, null, null, {
           meetingId,
           sendCAevents,
         });
@@ -113,7 +113,7 @@ describe('plugin-meetings', () => {
         try {
           await meetingInfo.fetchMeetingInfo(
             '1234323',
-            _MEETING_ID_,
+            DestinationType.MEETING_ID,
             null,
             null,
             null,
@@ -196,7 +196,7 @@ describe('plugin-meetings', () => {
         try {
           await meetingInfo.fetchMeetingInfo(
             '1234323',
-            _MEETING_ID_,
+            DestinationType.MEETING_ID,
             null,
             null,
             null,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -8,7 +8,7 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import Device from '@webex/internal-plugin-device';
 import Mercury from '@webex/internal-plugin-mercury';
 import {
-  DestinationType,
+  DESTINATION_TYPE,
   WBXAPPAPI_SERVICE,
 } from '@webex/plugin-meetings/src/constants';
 
@@ -104,7 +104,7 @@ describe('plugin-meetings', () => {
         webex.request.resolves(requestResponse);
 
         const result = await meetingInfo.fetchMeetingInfo({
-          type: DestinationType.MEETING_ID,
+          type: DESTINATION_TYPE.MEETING_ID,
           destination: '1234323',
         });
 
@@ -131,7 +131,7 @@ describe('plugin-meetings', () => {
         webex.request.resolves(requestResponse);
 
         const result = await meetingInfo.fetchMeetingInfo({
-          type: DestinationType.PERSONAL_ROOM,
+          type: DESTINATION_TYPE.PERSONAL_ROOM,
         });
 
         assert.calledWith(webex.request, {
@@ -152,21 +152,21 @@ describe('plugin-meetings', () => {
 
         sinon
           .stub(MeetingInfoUtil, 'getDestinationType')
-          .returns(Promise.resolve({type: DestinationType.SIP_URI, destination: 'example@something.webex.com'}));
+          .returns(Promise.resolve({type: DESTINATION_TYPE.SIP_URI, destination: 'example@something.webex.com'}));
         sinon.stub(MeetingInfoUtil, 'getRequestBody').returns(Promise.resolve(body));
         sinon.stub(MeetingInfoUtil, 'getDirectMeetingInfoURI').returns('https://example.com');
         webex.request.resolves(requestResponse);
 
-        const result = await meetingInfo.fetchMeetingInfo('example@something.webex.com', DestinationType.SIP_URI);
+        const result = await meetingInfo.fetchMeetingInfo('example@something.webex.com', DESTINATION_TYPE.SIP_URI);
 
         assert.calledWith(MeetingInfoUtil.getDestinationType, {
           destination: 'example@something.webex.com',
-          type: DestinationType.SIP_URI,
+          type: DESTINATION_TYPE.SIP_URI,
           webex,
         });
         assert.calledWith(MeetingInfoUtil.getDirectMeetingInfoURI, {
           destination: 'example@something.webex.com',
-          type: DestinationType.SIP_URI,
+          type: DESTINATION_TYPE.SIP_URI,
         });
         assert.calledWith(webex.request, {
           method: 'POST',
@@ -185,7 +185,7 @@ describe('plugin-meetings', () => {
 
         webex.request.resolves(requestResponse);
 
-        const result = await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, 'abc', {
+        const result = await meetingInfo.fetchMeetingInfo('1234323', DESTINATION_TYPE.MEETING_ID, 'abc', {
           id: '999',
           code: 'aabbcc11',
         });
@@ -217,7 +217,7 @@ describe('plugin-meetings', () => {
 
         webex.request.resolves(requestResponse);
 
-        const result = await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, null, null, installedOrgID);
+        const result = await meetingInfo.fetchMeetingInfo('1234323', DESTINATION_TYPE.MEETING_ID, null, null, installedOrgID);
 
         assert.calledWith(webex.request, {
           method: 'POST',
@@ -244,7 +244,7 @@ describe('plugin-meetings', () => {
 
         webex.request.resolves(requestResponse);
 
-        const result = await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, null, null, null, locusId);
+        const result = await meetingInfo.fetchMeetingInfo('1234323', DESTINATION_TYPE.MEETING_ID, null, null, null, locusId);
 
         assert.calledWith(webex.request, {
           method: 'POST',
@@ -271,7 +271,7 @@ describe('plugin-meetings', () => {
 
         webex.request.resolves(requestResponse);
 
-        const result = await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, null, null, null, null, extraParams);
+        const result = await meetingInfo.fetchMeetingInfo('1234323', DESTINATION_TYPE.MEETING_ID, null, null, null, null, extraParams);
 
         assert.calledWith(webex.request, {
           method: 'POST',
@@ -294,7 +294,7 @@ describe('plugin-meetings', () => {
 
       it('create adhoc meeting when conversationUrl passed with enableAdhocMeetings toggle', async () => {
         sinon.stub(meetingInfo, 'createAdhocSpaceMeeting').returns(Promise.resolve());
-        await meetingInfo.fetchMeetingInfo('conversationUrl', DestinationType.CONVERSATION_URL);
+        await meetingInfo.fetchMeetingInfo('conversationUrl', DESTINATION_TYPE.CONVERSATION_URL);
 
         assert.calledWith(meetingInfo.createAdhocSpaceMeeting, 'conversationUrl');
         assert.notCalled(webex.request);
@@ -308,7 +308,7 @@ describe('plugin-meetings', () => {
 
         await meetingInfo.fetchMeetingInfo(
           'conversationUrl',
-          DestinationType.CONVERSATION_URL,
+          DESTINATION_TYPE.CONVERSATION_URL,
           null,
           null,
           installedOrgID
@@ -328,7 +328,7 @@ describe('plugin-meetings', () => {
         webex.config.meetings.experimental.enableAdhocMeetings = false;
         sinon.stub(meetingInfo, 'createAdhocSpaceMeeting').returns(Promise.resolve());
 
-        await meetingInfo.fetchMeetingInfo('conversationUrl', DestinationType.CONVERSATION_URL);
+        await meetingInfo.fetchMeetingInfo('conversationUrl', DESTINATION_TYPE.CONVERSATION_URL);
 
         assert.notCalled(meetingInfo.createAdhocSpaceMeeting);
         assert.called(webex.request);
@@ -339,7 +339,7 @@ describe('plugin-meetings', () => {
         sinon.stub(meetingInfo, 'createAdhocSpaceMeeting').returns(Promise.resolve());
         webex.meetings.preferredWebexSite = undefined;
 
-        await meetingInfo.fetchMeetingInfo('conversationUrl', DestinationType.CONVERSATION_URL);
+        await meetingInfo.fetchMeetingInfo('conversationUrl', DESTINATION_TYPE.CONVERSATION_URL);
 
         assert.notCalled(meetingInfo.createAdhocSpaceMeeting);
         assert.called(webex.request);
@@ -402,7 +402,7 @@ describe('plugin-meetings', () => {
             try {
               await meetingInfo.fetchMeetingInfo(
                 '1234323',
-                DestinationType.MEETING_ID,
+                DESTINATION_TYPE.MEETING_ID,
                 'abc',
                 {
                   id: '999',
@@ -489,7 +489,7 @@ describe('plugin-meetings', () => {
     
             const result = await meetingInfo.fetchMeetingInfo(
               '1234323',
-              DestinationType.MEETING_ID,
+              DESTINATION_TYPE.MEETING_ID,
               null,
               null,
               null,
@@ -562,7 +562,7 @@ describe('plugin-meetings', () => {
 
         const result = await meetingInfo.fetchMeetingInfo(
           '1234323',
-          DestinationType.MEETING_ID,
+          DESTINATION_TYPE.MEETING_ID,
           null,
           null,
           null,
@@ -638,7 +638,7 @@ describe('plugin-meetings', () => {
             try {
               await meetingInfo.fetchMeetingInfo(
                 '1234323',
-                DestinationType.MEETING_ID,
+                DESTINATION_TYPE.MEETING_ID,
                 'abc',
                 {
                   id: '999',
@@ -666,7 +666,7 @@ describe('plugin-meetings', () => {
           .rejects({statusCode: 403, body: {code: 403000, data: {meetingInfo: FAKE_MEETING_INFO}}});
 
         try {
-          await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, 'abc', {
+          await meetingInfo.fetchMeetingInfo('1234323', DESTINATION_TYPE.MEETING_ID, 'abc', {
             id: '999',
             code: 'aabbcc11',
           });
@@ -693,7 +693,7 @@ describe('plugin-meetings', () => {
             },
           });
           try {
-            await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, 'abc', {
+            await meetingInfo.fetchMeetingInfo('1234323', DESTINATION_TYPE.MEETING_ID, 'abc', {
               id: '999',
               code: 'aabbcc11',
             });
@@ -735,13 +735,13 @@ describe('plugin-meetings', () => {
 
         sinon
           .stub(MeetingInfoUtil, 'getDestinationType')
-          .returns(Promise.resolve({type: DestinationType.LOCUS_ID, destination: '123456'}));
+          .returns(Promise.resolve({type: DESTINATION_TYPE.LOCUS_ID, destination: '123456'}));
         sinon.stub(MeetingInfoUtil, 'getRequestBody').returns(Promise.resolve(body));
         webex.request.resolves(requestResponse);
 
         try {
           await meetingInfo.fetchMeetingInfo({
-            type: DestinationType.LOCUS_ID,
+            type: DESTINATION_TYPE.LOCUS_ID,
           });
           assert.fail('fetchMeetingInfo should have thrown, but has not done that');
         } catch (err) {
@@ -750,7 +750,7 @@ describe('plugin-meetings', () => {
             BEHAVIORAL_METRICS.FETCH_MEETING_INFO_V1_FAILURE,
             {
               reason: 'Not enough information to fetch meeting info',
-              destinationType: DestinationType.LOCUS_ID,
+              destinationType: DESTINATION_TYPE.LOCUS_ID,
               webExMeetingId: undefined,
               sipUri: undefined,
             }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -8,12 +8,8 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import Device from '@webex/internal-plugin-device';
 import Mercury from '@webex/internal-plugin-mercury';
 import {
-  _MEETING_ID_,
-  _PERSONAL_ROOM_,
-  _CONVERSATION_URL_,
-  _SIP_URI_,
+  DestinationType,
   WBXAPPAPI_SERVICE,
-  _LOCUS_ID_,
 } from '@webex/plugin-meetings/src/constants';
 
 import Meetings from '@webex/plugin-meetings/src/meetings';
@@ -108,7 +104,7 @@ describe('plugin-meetings', () => {
         webex.request.resolves(requestResponse);
 
         const result = await meetingInfo.fetchMeetingInfo({
-          type: _MEETING_ID_,
+          type: DestinationType.MEETING_ID,
           destination: '1234323',
         });
 
@@ -135,7 +131,7 @@ describe('plugin-meetings', () => {
         webex.request.resolves(requestResponse);
 
         const result = await meetingInfo.fetchMeetingInfo({
-          type: _PERSONAL_ROOM_,
+          type: DestinationType.PERSONAL_ROOM,
         });
 
         assert.calledWith(webex.request, {
@@ -156,21 +152,21 @@ describe('plugin-meetings', () => {
 
         sinon
           .stub(MeetingInfoUtil, 'getDestinationType')
-          .returns(Promise.resolve({type: _SIP_URI_, destination: 'example@something.webex.com'}));
+          .returns(Promise.resolve({type: DestinationType.SIP_URI, destination: 'example@something.webex.com'}));
         sinon.stub(MeetingInfoUtil, 'getRequestBody').returns(Promise.resolve(body));
         sinon.stub(MeetingInfoUtil, 'getDirectMeetingInfoURI').returns('https://example.com');
         webex.request.resolves(requestResponse);
 
-        const result = await meetingInfo.fetchMeetingInfo('example@something.webex.com', _SIP_URI_);
+        const result = await meetingInfo.fetchMeetingInfo('example@something.webex.com', DestinationType.SIP_URI);
 
         assert.calledWith(MeetingInfoUtil.getDestinationType, {
           destination: 'example@something.webex.com',
-          type: _SIP_URI_,
+          type: DestinationType.SIP_URI,
           webex,
         });
         assert.calledWith(MeetingInfoUtil.getDirectMeetingInfoURI, {
           destination: 'example@something.webex.com',
-          type: _SIP_URI_,
+          type: DestinationType.SIP_URI,
         });
         assert.calledWith(webex.request, {
           method: 'POST',
@@ -189,7 +185,7 @@ describe('plugin-meetings', () => {
 
         webex.request.resolves(requestResponse);
 
-        const result = await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, 'abc', {
+        const result = await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, 'abc', {
           id: '999',
           code: 'aabbcc11',
         });
@@ -221,7 +217,7 @@ describe('plugin-meetings', () => {
 
         webex.request.resolves(requestResponse);
 
-        const result = await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, null, null, installedOrgID);
+        const result = await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, null, null, installedOrgID);
 
         assert.calledWith(webex.request, {
           method: 'POST',
@@ -248,7 +244,7 @@ describe('plugin-meetings', () => {
 
         webex.request.resolves(requestResponse);
 
-        const result = await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, null, null, null, locusId);
+        const result = await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, null, null, null, locusId);
 
         assert.calledWith(webex.request, {
           method: 'POST',
@@ -275,7 +271,7 @@ describe('plugin-meetings', () => {
 
         webex.request.resolves(requestResponse);
 
-        const result = await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, null, null, null, null, extraParams);
+        const result = await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, null, null, null, null, extraParams);
 
         assert.calledWith(webex.request, {
           method: 'POST',
@@ -298,7 +294,7 @@ describe('plugin-meetings', () => {
 
       it('create adhoc meeting when conversationUrl passed with enableAdhocMeetings toggle', async () => {
         sinon.stub(meetingInfo, 'createAdhocSpaceMeeting').returns(Promise.resolve());
-        await meetingInfo.fetchMeetingInfo('conversationUrl', _CONVERSATION_URL_);
+        await meetingInfo.fetchMeetingInfo('conversationUrl', DestinationType.CONVERSATION_URL);
 
         assert.calledWith(meetingInfo.createAdhocSpaceMeeting, 'conversationUrl');
         assert.notCalled(webex.request);
@@ -312,7 +308,7 @@ describe('plugin-meetings', () => {
 
         await meetingInfo.fetchMeetingInfo(
           'conversationUrl',
-          _CONVERSATION_URL_,
+          DestinationType.CONVERSATION_URL,
           null,
           null,
           installedOrgID
@@ -332,7 +328,7 @@ describe('plugin-meetings', () => {
         webex.config.meetings.experimental.enableAdhocMeetings = false;
         sinon.stub(meetingInfo, 'createAdhocSpaceMeeting').returns(Promise.resolve());
 
-        await meetingInfo.fetchMeetingInfo('conversationUrl', _CONVERSATION_URL_);
+        await meetingInfo.fetchMeetingInfo('conversationUrl', DestinationType.CONVERSATION_URL);
 
         assert.notCalled(meetingInfo.createAdhocSpaceMeeting);
         assert.called(webex.request);
@@ -343,7 +339,7 @@ describe('plugin-meetings', () => {
         sinon.stub(meetingInfo, 'createAdhocSpaceMeeting').returns(Promise.resolve());
         webex.meetings.preferredWebexSite = undefined;
 
-        await meetingInfo.fetchMeetingInfo('conversationUrl', _CONVERSATION_URL_);
+        await meetingInfo.fetchMeetingInfo('conversationUrl', DestinationType.CONVERSATION_URL);
 
         assert.notCalled(meetingInfo.createAdhocSpaceMeeting);
         assert.called(webex.request);
@@ -406,7 +402,7 @@ describe('plugin-meetings', () => {
             try {
               await meetingInfo.fetchMeetingInfo(
                 '1234323',
-                _MEETING_ID_,
+                DestinationType.MEETING_ID,
                 'abc',
                 {
                   id: '999',
@@ -493,7 +489,7 @@ describe('plugin-meetings', () => {
     
             const result = await meetingInfo.fetchMeetingInfo(
               '1234323',
-              _MEETING_ID_,
+              DestinationType.MEETING_ID,
               null,
               null,
               null,
@@ -566,7 +562,7 @@ describe('plugin-meetings', () => {
 
         const result = await meetingInfo.fetchMeetingInfo(
           '1234323',
-          _MEETING_ID_,
+          DestinationType.MEETING_ID,
           null,
           null,
           null,
@@ -642,7 +638,7 @@ describe('plugin-meetings', () => {
             try {
               await meetingInfo.fetchMeetingInfo(
                 '1234323',
-                _MEETING_ID_,
+                DestinationType.MEETING_ID,
                 'abc',
                 {
                   id: '999',
@@ -670,7 +666,7 @@ describe('plugin-meetings', () => {
           .rejects({statusCode: 403, body: {code: 403000, data: {meetingInfo: FAKE_MEETING_INFO}}});
 
         try {
-          await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, 'abc', {
+          await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, 'abc', {
             id: '999',
             code: 'aabbcc11',
           });
@@ -697,7 +693,7 @@ describe('plugin-meetings', () => {
             },
           });
           try {
-            await meetingInfo.fetchMeetingInfo('1234323', _MEETING_ID_, 'abc', {
+            await meetingInfo.fetchMeetingInfo('1234323', DestinationType.MEETING_ID, 'abc', {
               id: '999',
               code: 'aabbcc11',
             });
@@ -739,13 +735,13 @@ describe('plugin-meetings', () => {
 
         sinon
           .stub(MeetingInfoUtil, 'getDestinationType')
-          .returns(Promise.resolve({type: _LOCUS_ID_, destination: '123456'}));
+          .returns(Promise.resolve({type: DestinationType.LOCUS_ID, destination: '123456'}));
         sinon.stub(MeetingInfoUtil, 'getRequestBody').returns(Promise.resolve(body));
         webex.request.resolves(requestResponse);
 
         try {
           await meetingInfo.fetchMeetingInfo({
-            type: _LOCUS_ID_,
+            type: DestinationType.LOCUS_ID,
           });
           assert.fail('fetchMeetingInfo should have thrown, but has not done that');
         } catch (err) {
@@ -754,7 +750,7 @@ describe('plugin-meetings', () => {
             BEHAVIORAL_METRICS.FETCH_MEETING_INFO_V1_FAILURE,
             {
               reason: 'Not enough information to fetch meeting info',
-              destinationType: _LOCUS_ID_,
+              destinationType: DestinationType.LOCUS_ID,
               webExMeetingId: undefined,
               sipUri: undefined,
             }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/request.js
@@ -8,7 +8,7 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import Device from '@webex/internal-plugin-device';
 import Mercury from '@webex/internal-plugin-mercury';
 import Meetings from '@webex/plugin-meetings/src/meetings';
-import {DestinationType} from '@webex/plugin-meetings/src/constants';
+import {DESTINATION_TYPE} from '@webex/plugin-meetings/src/constants';
 
 import MeetingInfoRequest from '../../../../src/meeting-info/request';
 
@@ -53,7 +53,7 @@ describe('plugin-meetings', () => {
 
       it('Should call request with valid parameter', () => {
         meetingInfoRequest.fetchMeetingInfo({
-          type: DestinationType.LOCUS_ID,
+          type: DESTINATION_TYPE.LOCUS_ID,
           destination: 'locus_url',
         });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/request.js
@@ -8,7 +8,7 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import Device from '@webex/internal-plugin-device';
 import Mercury from '@webex/internal-plugin-mercury';
 import Meetings from '@webex/plugin-meetings/src/meetings';
-import {_LOCUS_ID_} from '@webex/plugin-meetings/src/constants';
+import {DestinationType} from '@webex/plugin-meetings/src/constants';
 
 import MeetingInfoRequest from '../../../../src/meeting-info/request';
 
@@ -53,7 +53,7 @@ describe('plugin-meetings', () => {
 
       it('Should call request with valid parameter', () => {
         meetingInfoRequest.fetchMeetingInfo({
-          type: _LOCUS_ID_,
+          type: DestinationType.LOCUS_ID,
           destination: 'locus_url',
         });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
@@ -4,7 +4,7 @@
 
 import {assert, expect} from '@webex/test-helper-chai';
 import sinon from 'sinon';
-import {DestinationType} from '@webex/plugin-meetings/src/constants';
+import {DESTINATION_TYPE} from '@webex/plugin-meetings/src/constants';
 import MeetingInfoUtil from '@webex/plugin-meetings/src/meeting-info/utilv2';
 import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
@@ -31,11 +31,11 @@ describe('plugin-meetings', () => {
     describe('#getDestinationType', () => {
       it('For destination with type', async () => {
         const res = await MeetingInfoUtil.getDestinationType({
-          type: DestinationType.MEETING_ID,
+          type: DESTINATION_TYPE.MEETING_ID,
           destination: '1234323',
         });
 
-        assert.equal(res.type, DestinationType.MEETING_ID);
+        assert.equal(res.type, DESTINATION_TYPE.MEETING_ID);
         assert.equal(res.destination, '1234323');
       });
 
@@ -44,7 +44,7 @@ describe('plugin-meetings', () => {
           destination: 'https://cisco.webex.com/meet/arungane',
         });
 
-        assert.equal(res.type, DestinationType.MEETING_LINK);
+        assert.equal(res.type, DESTINATION_TYPE.MEETING_LINK);
         assert.equal(res.destination, 'https://cisco.webex.com/meet/arungane');
       });
 
@@ -53,7 +53,7 @@ describe('plugin-meetings', () => {
           destination: 'testing@webex.com',
         });
 
-        assert.equal(res.type, DestinationType.SIP_URI);
+        assert.equal(res.type, DESTINATION_TYPE.SIP_URI);
         assert.equal(res.destination, 'testing@webex.com');
       });
 
@@ -62,7 +62,7 @@ describe('plugin-meetings', () => {
           destination: '+14252086070',
         });
 
-        assert.equal(res.type, DestinationType.SIP_URI);
+        assert.equal(res.type, DESTINATION_TYPE.SIP_URI);
         assert.equal(res.destination, '+14252086070');
       });
 
@@ -72,7 +72,7 @@ describe('plugin-meetings', () => {
           destination: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49280',
         });
 
-        assert.equal(res.type, DestinationType.CONVERSATION_URL);
+        assert.equal(res.type, DESTINATION_TYPE.CONVERSATION_URL);
         assert.equal(
           res.destination,
           'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49280'
@@ -96,7 +96,7 @@ describe('plugin-meetings', () => {
 
         it('should return a userID and orgID without passing a destination', async () => {
           const res = await MeetingInfoUtil.getDestinationType({
-            type: DestinationType.PERSONAL_ROOM,
+            type: DESTINATION_TYPE.PERSONAL_ROOM,
             webex: {
               internal: {
                 device: {
@@ -113,7 +113,7 @@ describe('plugin-meetings', () => {
 
         it('should return a userID and orgID when passing an email', async () => {
           const res = await MeetingInfoUtil.getDestinationType({
-            type: DestinationType.PERSONAL_ROOM,
+            type: DESTINATION_TYPE.PERSONAL_ROOM,
             destination: 'amritesi@cisco.com',
             webex: {
               people: {list: sinon.stub().returns(mockedList)},
@@ -127,7 +127,7 @@ describe('plugin-meetings', () => {
 
         it('should return a userID and orgID when passing an id', async () => {
           const res = await MeetingInfoUtil.getDestinationType({
-            type: DestinationType.PERSONAL_ROOM,
+            type: DESTINATION_TYPE.PERSONAL_ROOM,
             destination: '01824b9b-adef-4b10-b5c1-8a2fe2fb7c0e',
             webex: {
               people: {list: sinon.stub().returns(mockedList)},
@@ -143,9 +143,9 @@ describe('plugin-meetings', () => {
 
     describe('#getRequestBody', () => {
 
-      it('for DestinationType.PERSONAL_ROOM', () => {
+      it('for DESTINATION_TYPE.PERSONAL_ROOM', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: DestinationType.PERSONAL_ROOM,
+          type: DESTINATION_TYPE.PERSONAL_ROOM,
           destination: {
             userId: '01824b9b-adef-4b10-b5c1-8a2fe2fb7c0e',
             orgId: '1eb65fdf-9643-417f-9974-ad72cae0e10f',
@@ -156,54 +156,54 @@ describe('plugin-meetings', () => {
         assert.equal(res.userId, '01824b9b-adef-4b10-b5c1-8a2fe2fb7c0e');
       });
 
-      it('for DestinationType.MEETING_ID', () => {
+      it('for DESTINATION_TYPE.MEETING_ID', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: DestinationType.MEETING_ID,
+          type: DESTINATION_TYPE.MEETING_ID,
           destination: '1234323',
         });
 
         assert.equal(res.meetingKey, '1234323');
       });
 
-      it('for DestinationType.MEETING_LINK', () => {
+      it('for DESTINATION_TYPE.MEETING_LINK', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: DestinationType.MEETING_LINK,
+          type: DESTINATION_TYPE.MEETING_LINK,
           destination: 'https://cisco.webex.com/meet/arungane',
         });
 
         assert.equal(res.meetingUrl, 'https://cisco.webex.com/meet/arungane');
       });
 
-      it('for DestinationType.SIP_URI', () => {
+      it('for DESTINATION_TYPE.SIP_URI', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: DestinationType.SIP_URI,
+          type: DESTINATION_TYPE.SIP_URI,
           destination: 'testing@webex.com',
         });
 
         assert.equal(res.sipUrl, 'testing@webex.com');
       });
 
-      it('for DestinationType.MEETING_UUID', () => {
+      it('for DESTINATION_TYPE.MEETING_UUID', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: DestinationType.MEETING_UUID,
+          type: DESTINATION_TYPE.MEETING_UUID,
           destination: 'xsddsdsdsdssdsdsdsdsd',
         });
 
         assert.equal(res.meetingUUID, 'xsddsdsdsdssdsdsdsdsd');
       });
 
-      it('for DestinationType.LOCUS_ID', () => {
+      it('for DESTINATION_TYPE.LOCUS_ID', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: DestinationType.LOCUS_ID,
+          type: DESTINATION_TYPE.LOCUS_ID,
           destination: {info: {webExMeetingId: '123456'}},
         });
 
         assert.equal(res.meetingKey, '123456');
       });
 
-      it('for DestinationType.CONVERSATION_URL', () => {
+      it('for DESTINATION_TYPE.CONVERSATION_URL', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: DestinationType.CONVERSATION_URL,
+          type: DESTINATION_TYPE.CONVERSATION_URL,
           destination: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49280',
         });
 
@@ -217,7 +217,7 @@ describe('plugin-meetings', () => {
         const extraParams = {mtid: 'm9fe0afd8c435e892afcce9ea25b97046', joinTXId: 'TSmrX61wNF'}
 
         const res = MeetingInfoUtil.getRequestBody({
-          type: DestinationType.CONVERSATION_URL,
+          type: DESTINATION_TYPE.CONVERSATION_URL,
           destination: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49281',
           extraParams,
         });
@@ -256,20 +256,20 @@ describe('plugin-meetings', () => {
     });
 
     describe('#getDirectMeetingInfoURI', () => {
-      it('for DestinationType.SIP_URI', () => {
+      it('for DESTINATION_TYPE.SIP_URI', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: DestinationType.SIP_URI,
+            type: DESTINATION_TYPE.SIP_URI,
             destination: 'testing@convergedats.webex.com',
           }),
           'https://convergedats.webex.com/wbxappapi/v1/meetingInfo'
         );
       });
 
-      it('for DestinationType.LOCUS_ID with webExSite', () => {
+      it('for DESTINATION_TYPE.LOCUS_ID with webExSite', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: DestinationType.LOCUS_ID,
+            type: DESTINATION_TYPE.LOCUS_ID,
             destination: {
               info: {
                 webExMeetingId: '123456',
@@ -282,10 +282,10 @@ describe('plugin-meetings', () => {
       });
 
       // null means fall back to default meeting info URI
-      it('for DestinationType.PERSONAL_ROOM', () => {
+      it('for DESTINATION_TYPE.PERSONAL_ROOM', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: DestinationType.PERSONAL_ROOM,
+            type: DESTINATION_TYPE.PERSONAL_ROOM,
             destination: {
               userId: '01824b9b-adef-4b10-b5c1-8a2fe2fb7c0e',
               orgId: '1eb65fdf-9643-417f-9974-ad72cae0e10f',
@@ -295,50 +295,50 @@ describe('plugin-meetings', () => {
         );
       });
 
-      it('for DestinationType.MEETING_ID', () => {
+      it('for DESTINATION_TYPE.MEETING_ID', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: DestinationType.MEETING_ID,
+            type: DESTINATION_TYPE.MEETING_ID,
             destination: '1234323',
           }),
           null
         );
       });
 
-      it('for DestinationType.MEETING_UUID', () => {
+      it('for DESTINATION_TYPE.MEETING_UUID', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: DestinationType.MEETING_UUID,
+            type: DESTINATION_TYPE.MEETING_UUID,
             destination: 'xsddsdsdsdssdsdsdsdsd',
           }),
           null
         );
       });
 
-      it('for DestinationType.LOCUS_ID with sipUri with excepted domain', () => {
+      it('for DESTINATION_TYPE.LOCUS_ID with sipUri with excepted domain', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: DestinationType.LOCUS_ID,
+            type: DESTINATION_TYPE.LOCUS_ID,
             destination: {info: {webExMeetingId: '123456', sipUri: 'testing@meetup.webex.com'}},
           }),
           null
         );
       });
 
-      it('for DestinationType.CONVERSATION_URL', () => {
+      it('for DESTINATION_TYPE.CONVERSATION_URL', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: DestinationType.CONVERSATION_URL,
+            type: DESTINATION_TYPE.CONVERSATION_URL,
             destination: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49280',
           }),
           null
         );
       });
 
-      it('for DestinationType.SIP_URI with an email address', () => {
+      it('for DESTINATION_TYPE.SIP_URI with an email address', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: DestinationType.SIP_URI,
+            type: DESTINATION_TYPE.SIP_URI,
             destination: 'testing@email.com',
           }),
           null

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/utilv2.js
@@ -4,15 +4,7 @@
 
 import {assert, expect} from '@webex/test-helper-chai';
 import sinon from 'sinon';
-import {
-  _MEETING_ID_,
-  _SIP_URI_,
-  _CONVERSATION_URL_,
-  _MEETING_LINK_,
-  _PERSONAL_ROOM_,
-  _LOCUS_ID_,
-  _MEETING_UUID_,
-} from '@webex/plugin-meetings/src/constants';
+import {DestinationType} from '@webex/plugin-meetings/src/constants';
 import MeetingInfoUtil from '@webex/plugin-meetings/src/meeting-info/utilv2';
 import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
@@ -39,11 +31,11 @@ describe('plugin-meetings', () => {
     describe('#getDestinationType', () => {
       it('For destination with type', async () => {
         const res = await MeetingInfoUtil.getDestinationType({
-          type: _MEETING_ID_,
+          type: DestinationType.MEETING_ID,
           destination: '1234323',
         });
 
-        assert.equal(res.type, _MEETING_ID_);
+        assert.equal(res.type, DestinationType.MEETING_ID);
         assert.equal(res.destination, '1234323');
       });
 
@@ -52,7 +44,7 @@ describe('plugin-meetings', () => {
           destination: 'https://cisco.webex.com/meet/arungane',
         });
 
-        assert.equal(res.type, _MEETING_LINK_);
+        assert.equal(res.type, DestinationType.MEETING_LINK);
         assert.equal(res.destination, 'https://cisco.webex.com/meet/arungane');
       });
 
@@ -61,7 +53,7 @@ describe('plugin-meetings', () => {
           destination: 'testing@webex.com',
         });
 
-        assert.equal(res.type, _SIP_URI_);
+        assert.equal(res.type, DestinationType.SIP_URI);
         assert.equal(res.destination, 'testing@webex.com');
       });
 
@@ -70,7 +62,7 @@ describe('plugin-meetings', () => {
           destination: '+14252086070',
         });
 
-        assert.equal(res.type, _SIP_URI_);
+        assert.equal(res.type, DestinationType.SIP_URI);
         assert.equal(res.destination, '+14252086070');
       });
 
@@ -80,7 +72,7 @@ describe('plugin-meetings', () => {
           destination: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49280',
         });
 
-        assert.equal(res.type, _CONVERSATION_URL_);
+        assert.equal(res.type, DestinationType.CONVERSATION_URL);
         assert.equal(
           res.destination,
           'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49280'
@@ -104,7 +96,7 @@ describe('plugin-meetings', () => {
 
         it('should return a userID and orgID without passing a destination', async () => {
           const res = await MeetingInfoUtil.getDestinationType({
-            type: _PERSONAL_ROOM_,
+            type: DestinationType.PERSONAL_ROOM,
             webex: {
               internal: {
                 device: {
@@ -121,7 +113,7 @@ describe('plugin-meetings', () => {
 
         it('should return a userID and orgID when passing an email', async () => {
           const res = await MeetingInfoUtil.getDestinationType({
-            type: _PERSONAL_ROOM_,
+            type: DestinationType.PERSONAL_ROOM,
             destination: 'amritesi@cisco.com',
             webex: {
               people: {list: sinon.stub().returns(mockedList)},
@@ -135,7 +127,7 @@ describe('plugin-meetings', () => {
 
         it('should return a userID and orgID when passing an id', async () => {
           const res = await MeetingInfoUtil.getDestinationType({
-            type: _PERSONAL_ROOM_,
+            type: DestinationType.PERSONAL_ROOM,
             destination: '01824b9b-adef-4b10-b5c1-8a2fe2fb7c0e',
             webex: {
               people: {list: sinon.stub().returns(mockedList)},
@@ -151,9 +143,9 @@ describe('plugin-meetings', () => {
 
     describe('#getRequestBody', () => {
 
-      it('for _PERSONAL_ROOM_', () => {
+      it('for DestinationType.PERSONAL_ROOM', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: _PERSONAL_ROOM_,
+          type: DestinationType.PERSONAL_ROOM,
           destination: {
             userId: '01824b9b-adef-4b10-b5c1-8a2fe2fb7c0e',
             orgId: '1eb65fdf-9643-417f-9974-ad72cae0e10f',
@@ -164,54 +156,54 @@ describe('plugin-meetings', () => {
         assert.equal(res.userId, '01824b9b-adef-4b10-b5c1-8a2fe2fb7c0e');
       });
 
-      it('for _MEETING_ID_', () => {
+      it('for DestinationType.MEETING_ID', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: _MEETING_ID_,
+          type: DestinationType.MEETING_ID,
           destination: '1234323',
         });
 
         assert.equal(res.meetingKey, '1234323');
       });
 
-      it('for _MEETING_LINK_', () => {
+      it('for DestinationType.MEETING_LINK', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: _MEETING_LINK_,
+          type: DestinationType.MEETING_LINK,
           destination: 'https://cisco.webex.com/meet/arungane',
         });
 
         assert.equal(res.meetingUrl, 'https://cisco.webex.com/meet/arungane');
       });
 
-      it('for _SIP_URI_', () => {
+      it('for DestinationType.SIP_URI', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: _SIP_URI_,
+          type: DestinationType.SIP_URI,
           destination: 'testing@webex.com',
         });
 
         assert.equal(res.sipUrl, 'testing@webex.com');
       });
 
-      it('for _MEETING_UUID_', () => {
+      it('for DestinationType.MEETING_UUID', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: _MEETING_UUID_,
+          type: DestinationType.MEETING_UUID,
           destination: 'xsddsdsdsdssdsdsdsdsd',
         });
 
         assert.equal(res.meetingUUID, 'xsddsdsdsdssdsdsdsdsd');
       });
 
-      it('for _LOCUS_ID_', () => {
+      it('for DestinationType.LOCUS_ID', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: _LOCUS_ID_,
+          type: DestinationType.LOCUS_ID,
           destination: {info: {webExMeetingId: '123456'}},
         });
 
         assert.equal(res.meetingKey, '123456');
       });
 
-      it('for _CONVERSATION_URL_', () => {
+      it('for DestinationType.CONVERSATION_URL', () => {
         const res = MeetingInfoUtil.getRequestBody({
-          type: _CONVERSATION_URL_,
+          type: DestinationType.CONVERSATION_URL,
           destination: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49280',
         });
 
@@ -225,7 +217,7 @@ describe('plugin-meetings', () => {
         const extraParams = {mtid: 'm9fe0afd8c435e892afcce9ea25b97046', joinTXId: 'TSmrX61wNF'}
 
         const res = MeetingInfoUtil.getRequestBody({
-          type: _CONVERSATION_URL_,
+          type: DestinationType.CONVERSATION_URL,
           destination: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49281',
           extraParams,
         });
@@ -264,20 +256,20 @@ describe('plugin-meetings', () => {
     });
 
     describe('#getDirectMeetingInfoURI', () => {
-      it('for _SIP_URI_', () => {
+      it('for DestinationType.SIP_URI', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: _SIP_URI_,
+            type: DestinationType.SIP_URI,
             destination: 'testing@convergedats.webex.com',
           }),
           'https://convergedats.webex.com/wbxappapi/v1/meetingInfo'
         );
       });
 
-      it('for _LOCUS_ID_ with webExSite', () => {
+      it('for DestinationType.LOCUS_ID with webExSite', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: _LOCUS_ID_,
+            type: DestinationType.LOCUS_ID,
             destination: {
               info: {
                 webExMeetingId: '123456',
@@ -290,10 +282,10 @@ describe('plugin-meetings', () => {
       });
 
       // null means fall back to default meeting info URI
-      it('for _PERSONAL_ROOM_', () => {
+      it('for DestinationType.PERSONAL_ROOM', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: _PERSONAL_ROOM_,
+            type: DestinationType.PERSONAL_ROOM,
             destination: {
               userId: '01824b9b-adef-4b10-b5c1-8a2fe2fb7c0e',
               orgId: '1eb65fdf-9643-417f-9974-ad72cae0e10f',
@@ -303,50 +295,50 @@ describe('plugin-meetings', () => {
         );
       });
 
-      it('for _MEETING_ID_', () => {
+      it('for DestinationType.MEETING_ID', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: _MEETING_ID_,
+            type: DestinationType.MEETING_ID,
             destination: '1234323',
           }),
           null
         );
       });
 
-      it('for _MEETING_UUID_', () => {
+      it('for DestinationType.MEETING_UUID', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: _MEETING_UUID_,
+            type: DestinationType.MEETING_UUID,
             destination: 'xsddsdsdsdssdsdsdsdsd',
           }),
           null
         );
       });
 
-      it('for _LOCUS_ID_ with sipUri with excepted domain', () => {
+      it('for DestinationType.LOCUS_ID with sipUri with excepted domain', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: _LOCUS_ID_,
+            type: DestinationType.LOCUS_ID,
             destination: {info: {webExMeetingId: '123456', sipUri: 'testing@meetup.webex.com'}},
           }),
           null
         );
       });
 
-      it('for _CONVERSATION_URL_', () => {
+      it('for DestinationType.CONVERSATION_URL', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: _CONVERSATION_URL_,
+            type: DestinationType.CONVERSATION_URL,
             destination: 'https://conv-a.wbx2.com/conversation/api/v1/conversations/bfb49280',
           }),
           null
         );
       });
 
-      it('for _SIP_URI_ with an email address', () => {
+      it('for DestinationType.SIP_URI with an email address', () => {
         assert.equal(
           MeetingInfoUtil.getDirectMeetingInfoURI({
-            type: _SIP_URI_,
+            type: DestinationType.SIP_URI,
             destination: 'testing@email.com',
           }),
           null

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -21,8 +21,7 @@ import {
   PASSWORD_STATUS,
   EVENTS,
   EVENT_TRIGGERS,
-  _SIP_URI_,
-  _MEETING_ID_,
+  DestinationType,
   MEETING_REMOVED_REASON,
   LOCUSINFO,
   ICE_AND_DTLS_CONNECTION_TIMEOUT,
@@ -279,7 +278,7 @@ describe('plugin-meetings', () => {
         deviceUrl: uuid3,
         locus: {url: url1},
         destination: testDestination,
-        destinationType: _MEETING_ID_,
+        destinationType: DestinationType.MEETING_ID,
         correlationId,
         selfId: uuid1,
       },
@@ -347,7 +346,7 @@ describe('plugin-meetings', () => {
           assert.equal(meeting.requiredCaptcha, null);
           assert.equal(meeting.meetingInfoFailureReason, undefined);
           assert.equal(meeting.destination, testDestination);
-          assert.equal(meeting.destinationType, _MEETING_ID_);
+          assert.equal(meeting.destinationType, DestinationType.MEETING_ID);
           assert.instanceOf(meeting.breakouts, Breakouts);
           assert.instanceOf(meeting.simultaneousInterpretation, SimultaneousInterpretation);
           assert.instanceOf(meeting.webinar, Webinar);
@@ -367,7 +366,7 @@ describe('plugin-meetings', () => {
               deviceUrl: uuid3,
               locus: {url: url1},
               destination: testDestination,
-              destinationType: _MEETING_ID_,
+              destinationType: DestinationType.MEETING_ID,
             },
             {
               parent: webex,
@@ -385,7 +384,7 @@ describe('plugin-meetings', () => {
               deviceUrl: uuid3,
               locus: {url: url1},
               destination: testDestination,
-              destinationType: _MEETING_ID_,
+              destinationType: DestinationType.MEETING_ID,
               callStateForMetrics: {
                 correlationId: uuid4,
                 joinTrigger: 'fake-join-trigger',
@@ -426,7 +425,7 @@ describe('plugin-meetings', () => {
                 deviceUrl: uuid3,
                 locus: {url: url1},
                 destination: testDestination,
-                destinationType: _MEETING_ID_,
+                destinationType: DestinationType.MEETING_ID,
               },
               {
                 parent: webex,
@@ -502,7 +501,7 @@ describe('plugin-meetings', () => {
                 deviceUrl: uuid3,
                 locus: {url: url1},
                 destination: testDestination,
-                destinationType: _MEETING_ID_,
+                destinationType: DestinationType.MEETING_ID,
               },
               {
                 parent: webex,
@@ -5199,7 +5198,7 @@ describe('plugin-meetings', () => {
 
       describe('#fetchMeetingInfo', () => {
         const FAKE_DESTINATION = 'something@somecompany.com';
-        const FAKE_TYPE = _SIP_URI_;
+        const FAKE_TYPE = DestinationType.SIP_URI;
         const FAKE_TIMEOUT_FETCHMEETINGINFO_ID = '123456';
         const FAKE_PASSWORD = '123abc';
         const FAKE_CAPTCHA_CODE = 'a1b2c3XYZ';
@@ -5634,7 +5633,7 @@ describe('plugin-meetings', () => {
         const FAKE_PASSWORD = '123456';
         const FAKE_CAPTCHA_CODE = '654321';
         const FAKE_DESTINATION = 'something@somecompany.com';
-        const FAKE_TYPE = _SIP_URI_;
+        const FAKE_TYPE = DestinationType.SIP_URI;
         const FAKE_INSTALLED_ORG_ID = '123456';
         const FAKE_MEETING_INFO_LOOKUP_URL = 'meetingLookupUrl';
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -21,7 +21,7 @@ import {
   PASSWORD_STATUS,
   EVENTS,
   EVENT_TRIGGERS,
-  DestinationType,
+  DESTINATION_TYPE,
   MEETING_REMOVED_REASON,
   LOCUSINFO,
   ICE_AND_DTLS_CONNECTION_TIMEOUT,
@@ -278,7 +278,7 @@ describe('plugin-meetings', () => {
         deviceUrl: uuid3,
         locus: {url: url1},
         destination: testDestination,
-        destinationType: DestinationType.MEETING_ID,
+        destinationType: DESTINATION_TYPE.MEETING_ID,
         correlationId,
         selfId: uuid1,
       },
@@ -346,7 +346,7 @@ describe('plugin-meetings', () => {
           assert.equal(meeting.requiredCaptcha, null);
           assert.equal(meeting.meetingInfoFailureReason, undefined);
           assert.equal(meeting.destination, testDestination);
-          assert.equal(meeting.destinationType, DestinationType.MEETING_ID);
+          assert.equal(meeting.destinationType, DESTINATION_TYPE.MEETING_ID);
           assert.instanceOf(meeting.breakouts, Breakouts);
           assert.instanceOf(meeting.simultaneousInterpretation, SimultaneousInterpretation);
           assert.instanceOf(meeting.webinar, Webinar);
@@ -366,7 +366,7 @@ describe('plugin-meetings', () => {
               deviceUrl: uuid3,
               locus: {url: url1},
               destination: testDestination,
-              destinationType: DestinationType.MEETING_ID,
+              destinationType: DESTINATION_TYPE.MEETING_ID,
             },
             {
               parent: webex,
@@ -384,7 +384,7 @@ describe('plugin-meetings', () => {
               deviceUrl: uuid3,
               locus: {url: url1},
               destination: testDestination,
-              destinationType: DestinationType.MEETING_ID,
+              destinationType: DESTINATION_TYPE.MEETING_ID,
               callStateForMetrics: {
                 correlationId: uuid4,
                 joinTrigger: 'fake-join-trigger',
@@ -425,7 +425,7 @@ describe('plugin-meetings', () => {
                 deviceUrl: uuid3,
                 locus: {url: url1},
                 destination: testDestination,
-                destinationType: DestinationType.MEETING_ID,
+                destinationType: DESTINATION_TYPE.MEETING_ID,
               },
               {
                 parent: webex,
@@ -501,7 +501,7 @@ describe('plugin-meetings', () => {
                 deviceUrl: uuid3,
                 locus: {url: url1},
                 destination: testDestination,
-                destinationType: DestinationType.MEETING_ID,
+                destinationType: DESTINATION_TYPE.MEETING_ID,
               },
               {
                 parent: webex,
@@ -5198,7 +5198,7 @@ describe('plugin-meetings', () => {
 
       describe('#fetchMeetingInfo', () => {
         const FAKE_DESTINATION = 'something@somecompany.com';
-        const FAKE_TYPE = DestinationType.SIP_URI;
+        const FAKE_TYPE = DESTINATION_TYPE.SIP_URI;
         const FAKE_TIMEOUT_FETCHMEETINGINFO_ID = '123456';
         const FAKE_PASSWORD = '123abc';
         const FAKE_CAPTCHA_CODE = 'a1b2c3XYZ';
@@ -5633,7 +5633,7 @@ describe('plugin-meetings', () => {
         const FAKE_PASSWORD = '123456';
         const FAKE_CAPTCHA_CODE = '654321';
         const FAKE_DESTINATION = 'something@somecompany.com';
-        const FAKE_TYPE = DestinationType.SIP_URI;
+        const FAKE_TYPE = DESTINATION_TYPE.SIP_URI;
         const FAKE_INSTALLED_ORG_ID = '123456';
         const FAKE_MEETING_INFO_LOOKUP_URL = 'meetingLookupUrl';
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -35,6 +35,7 @@ import {
   ROAP,
   LOCUSINFO,
   EVENT_TRIGGERS,
+  _ONE_2_ONE_MEEETING_,
 } from '../../../../src/constants';
 import CaptchaError from '@webex/plugin-meetings/src/common/errors/captcha-error';
 import {forEach} from 'lodash';
@@ -1265,10 +1266,9 @@ describe('plugin-meetings', () => {
             extraParams = {},
             expectedMeetingData = {},
             sendCAevents = false,
-            injectMeetingInfo = false,
-            isOne2OneMeeting = false
+            injectMeetingInfo = false
           ) => {
-            if (isOne2OneMeeting) {
+            if (type === _ONE_2_ONE_MEEETING_) {
               assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
             } else if (injectMeetingInfo) {
               assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
@@ -1361,9 +1361,9 @@ describe('plugin-meetings', () => {
             );
           });
 
-          it('creates the meeting avoiding meeting info fetch by passing one2OneMeeting true', async () => {
+          it('creates the meeting avoiding meeting info fetch by passing type as _ONE_2_ONE_MEEETING_', async () => {
 
-            const meeting = await webex.meetings.createMeeting('test destination', 'test type', false, {}, undefined, false, undefined, undefined, true);
+            const meeting = await webex.meetings.createMeeting('test destination', _ONE_2_ONE_MEEETING_);
 
             const expectedMeetingData = {
               permissionToken:
@@ -1375,11 +1375,9 @@ describe('plugin-meetings', () => {
             checkCreateWithoutDelay(
               meeting,
               'test destination',
-              'test type',
+              _ONE_2_ONE_MEEETING_,
               {},
-              expectedMeetingData,
-              false,
-              true,
+              expectedMeetingData
             );
           });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1793,12 +1793,6 @@ describe('plugin-meetings', () => {
               'createMeeting should eventually resolve to a Meeting Object'
             );
 
-            assert.instanceOf(
-              meeting,
-              Meeting,
-              'createMeeting should eventually resolve to a Meeting Object'
-            );
-
             assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
           });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -35,7 +35,7 @@ import {
   ROAP,
   LOCUSINFO,
   EVENT_TRIGGERS,
-  DestinationType,
+  DESTINATION_TYPE,
 } from '../../../../src/constants';
 import CaptchaError from '@webex/plugin-meetings/src/common/errors/captcha-error';
 import {forEach} from 'lodash';
@@ -1784,8 +1784,8 @@ describe('plugin-meetings', () => {
             checkCreateMeetingWithNoMeetingInfo(true, true);
           });
 
-          it('creates the meeting avoiding meeting info fetch by passing type as DestinationType.ONE_ON_ONE_CALL', async () => {
-            const meeting = await webex.meetings.createMeeting('test destination', DestinationType.ONE_ON_ONE_CALL);
+          it('creates the meeting avoiding meeting info fetch by passing type as DESTINATION_TYPE.ONE_ON_ONE_CALL', async () => {
+            const meeting = await webex.meetings.createMeeting('test destination', DESTINATION_TYPE.ONE_ON_ONE_CALL);
 
             assert.instanceOf(
               meeting,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -35,7 +35,7 @@ import {
   ROAP,
   LOCUSINFO,
   EVENT_TRIGGERS,
-  _ONE_ON_ONE_CALL_,
+  DestinationType,
 } from '../../../../src/constants';
 import CaptchaError from '@webex/plugin-meetings/src/common/errors/captcha-error';
 import {forEach} from 'lodash';
@@ -1784,8 +1784,8 @@ describe('plugin-meetings', () => {
             checkCreateMeetingWithNoMeetingInfo(true, true);
           });
 
-          it('creates the meeting avoiding meeting info fetch by passing type as _ONE_ON_ONE_CALL_', async () => {
-            const meeting = await webex.meetings.createMeeting('test destination', _ONE_ON_ONE_CALL_);
+          it('creates the meeting avoiding meeting info fetch by passing type as DestinationType.ONE_ON_ONE_CALL', async () => {
+            const meeting = await webex.meetings.createMeeting('test destination', DestinationType.ONE_ON_ONE_CALL);
 
             assert.instanceOf(
               meeting,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1265,9 +1265,12 @@ describe('plugin-meetings', () => {
             extraParams = {},
             expectedMeetingData = {},
             sendCAevents = false,
-            injectMeetingInfo = false
+            injectMeetingInfo = false,
+            isOne2OneMeeting = false
           ) => {
-            if (injectMeetingInfo) {
+            if (isOne2OneMeeting) {
+              assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
+            } else if (injectMeetingInfo) {
               assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
             } else {
               assert.calledOnce(webex.meetings.meetingInfo.fetchMeetingInfo);
@@ -1355,6 +1358,28 @@ describe('plugin-meetings', () => {
               'test type',
               {},
               expectedMeetingData
+            );
+          });
+
+          it('creates the meeting avoiding meeting info fetch by passing one2OneMeeting true', async () => {
+
+            const meeting = await webex.meetings.createMeeting('test destination', 'test type', false, {}, undefined, false, undefined, undefined, true);
+
+            const expectedMeetingData = {
+              permissionToken:
+                'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxMjM0NTYiLCJwZXJtaXNzaW9uIjp7InVzZXJQb2xpY2llcyI6eyJhIjp0cnVlfX19.wkTk0Hp8sUlq2wi2nP4-Ym4Xb7aEUHzyXA1kzk6f0V0',
+              meetingJoinUrl: 'meetingJoinUrl',
+              correlationId: meeting.id,
+            };
+
+            checkCreateWithoutDelay(
+              meeting,
+              'test destination',
+              'test type',
+              {},
+              expectedMeetingData,
+              false,
+              true,
             );
           });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1268,9 +1268,7 @@ describe('plugin-meetings', () => {
             sendCAevents = false,
             injectMeetingInfo = false
           ) => {
-            if (type === _ONE_2_ONE_MEEETING_) {
-              assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
-            } else if (injectMeetingInfo) {
+            if (injectMeetingInfo) {
               assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
             } else {
               assert.calledOnce(webex.meetings.meetingInfo.fetchMeetingInfo);
@@ -1356,26 +1354,6 @@ describe('plugin-meetings', () => {
               meeting,
               'test destination',
               'test type',
-              {},
-              expectedMeetingData
-            );
-          });
-
-          it('creates the meeting avoiding meeting info fetch by passing type as _ONE_2_ONE_MEEETING_', async () => {
-
-            const meeting = await webex.meetings.createMeeting('test destination', _ONE_2_ONE_MEEETING_);
-
-            const expectedMeetingData = {
-              permissionToken:
-                'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxMjM0NTYiLCJwZXJtaXNzaW9uIjp7InVzZXJQb2xpY2llcyI6eyJhIjp0cnVlfX19.wkTk0Hp8sUlq2wi2nP4-Ym4Xb7aEUHzyXA1kzk6f0V0',
-              meetingJoinUrl: 'meetingJoinUrl',
-              correlationId: meeting.id,
-            };
-
-            checkCreateWithoutDelay(
-              meeting,
-              'test destination',
-              _ONE_2_ONE_MEEETING_,
               {},
               expectedMeetingData
             );
@@ -1607,7 +1585,7 @@ describe('plugin-meetings', () => {
             );
             checkCreateWithoutDelay(meeting, FAKE_LOCUS_MEETING, 'test type');
           });
-
+          
           it('creates the meeting from a successful meeting info fetch that has no random delay because meeting start time is in the past', async () => {
             const FAKE_LOCUS_MEETING = {
               conversationUrl: 'locusConvURL',
@@ -1805,6 +1783,30 @@ describe('plugin-meetings', () => {
           it('creates the meeting from a rejected meeting info fetch and destroys it if failOnMissingMeetingInfo', async () => {
             checkCreateMeetingWithNoMeetingInfo(true, true);
           });
+
+          const checkCreateMeetingWithOne2OneType = async () => {
+            try {
+              const meeting = await webex.meetings.createMeeting(
+                'test destination',
+                _ONE_2_ONE_MEEETING_
+              );
+
+              assert.instanceOf(
+                meeting,
+                Meeting,
+                'createMeeting should eventually resolve to a Meeting Object'
+              );
+              assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
+              assert.calledThrice(TriggerProxy.trigger);
+            } catch (err) {
+              assert.instanceOf(err, NoMeetingInfoError);
+            }
+          };
+
+          it('creates the meeting avoiding meeting info fetch by passing type as _ONE_2_ONE_MEEETING_', async () => {
+            checkCreateMeetingWithOne2OneType();
+          });
+
         });
 
         describe('rejected MeetingInfo.#fetchMeetingInfo - does not log for known Error types', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -35,7 +35,7 @@ import {
   ROAP,
   LOCUSINFO,
   EVENT_TRIGGERS,
-  _ONE_2_ONE_MEEETING_,
+  _ONE_ON_ONE_CALL_,
 } from '../../../../src/constants';
 import CaptchaError from '@webex/plugin-meetings/src/common/errors/captcha-error';
 import {forEach} from 'lodash';
@@ -1784,8 +1784,8 @@ describe('plugin-meetings', () => {
             checkCreateMeetingWithNoMeetingInfo(true, true);
           });
 
-          it('creates the meeting avoiding meeting info fetch by passing type as _ONE_2_ONE_MEEETING_', async () => {
-            const meeting = await webex.meetings.createMeeting('test destination', _ONE_2_ONE_MEEETING_);
+          it('creates the meeting avoiding meeting info fetch by passing type as _ONE_ON_ONE_CALL_', async () => {
+            const meeting = await webex.meetings.createMeeting('test destination', _ONE_ON_ONE_CALL_);
 
             assert.instanceOf(
               meeting,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1585,7 +1585,7 @@ describe('plugin-meetings', () => {
             );
             checkCreateWithoutDelay(meeting, FAKE_LOCUS_MEETING, 'test type');
           });
-          
+
           it('creates the meeting from a successful meeting info fetch that has no random delay because meeting start time is in the past', async () => {
             const FAKE_LOCUS_MEETING = {
               conversationUrl: 'locusConvURL',
@@ -1784,27 +1784,22 @@ describe('plugin-meetings', () => {
             checkCreateMeetingWithNoMeetingInfo(true, true);
           });
 
-          const checkCreateMeetingWithOne2OneType = async () => {
-            try {
-              const meeting = await webex.meetings.createMeeting(
-                'test destination',
-                _ONE_2_ONE_MEEETING_
-              );
-
-              assert.instanceOf(
-                meeting,
-                Meeting,
-                'createMeeting should eventually resolve to a Meeting Object'
-              );
-              assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
-              assert.calledThrice(TriggerProxy.trigger);
-            } catch (err) {
-              assert.instanceOf(err, NoMeetingInfoError);
-            }
-          };
-
           it('creates the meeting avoiding meeting info fetch by passing type as _ONE_2_ONE_MEEETING_', async () => {
-            checkCreateMeetingWithOne2OneType();
+            const meeting = await webex.meetings.createMeeting('test destination', _ONE_2_ONE_MEEETING_);
+
+            assert.instanceOf(
+              meeting,
+              Meeting,
+              'createMeeting should eventually resolve to a Meeting Object'
+            );
+
+            assert.instanceOf(
+              meeting,
+              Meeting,
+              'createMeeting should eventually resolve to a Meeting Object'
+            );
+
+            assert.notCalled(webex.meetings.meetingInfo.fetchMeetingInfo);
           });
 
         });

--- a/packages/@webex/plugin-meetings/test/unit/spec/personal-meeting-room/personal-meeting-room.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/personal-meeting-room/personal-meeting-room.js
@@ -5,7 +5,7 @@
 import 'jsdom-global/register';
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
-import {_PERSONAL_ROOM_} from '@webex/plugin-meetings/src/constants';
+import {DestinationType} from '@webex/plugin-meetings/src/constants';
 import PersonalMeetingRoom from '@webex/plugin-meetings/src/personal-meeting-room';
 
 describe('personal-meeting-room', () => {
@@ -23,7 +23,7 @@ describe('personal-meeting-room', () => {
     it('returns personal meeting room info', async () => {
       await pmr.get();
       assert.calledOnce(meetingInfo.fetchMeetingInfo);
-      assert.calledWith(meetingInfo.fetchMeetingInfo, {type: _PERSONAL_ROOM_});
+      assert.calledWith(meetingInfo.fetchMeetingInfo, {type: DestinationType.PERSONAL_ROOM});
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/personal-meeting-room/personal-meeting-room.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/personal-meeting-room/personal-meeting-room.js
@@ -5,7 +5,7 @@
 import 'jsdom-global/register';
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
-import {DestinationType} from '@webex/plugin-meetings/src/constants';
+import {DESTINATION_TYPE} from '@webex/plugin-meetings/src/constants';
 import PersonalMeetingRoom from '@webex/plugin-meetings/src/personal-meeting-room';
 
 describe('personal-meeting-room', () => {
@@ -23,7 +23,7 @@ describe('personal-meeting-room', () => {
     it('returns personal meeting room info', async () => {
       await pmr.get();
       assert.calledOnce(meetingInfo.fetchMeetingInfo);
-      assert.calledWith(meetingInfo.fetchMeetingInfo, {type: DestinationType.PERSONAL_ROOM});
+      assert.calledWith(meetingInfo.fetchMeetingInfo, {type: DESTINATION_TYPE.PERSONAL_ROOM});
     });
   });
 });


### PR DESCRIPTION
1-1 calls cause fetchmeeting request to be sent to wbxappapi that always fails

# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-274559

## This pull request addresses
create meeting API

## by making the following changes

Added new type to create meeting api to state its a one2one meeting so by using that type to skip fetchmeeting api

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >
MANUAL Testing done by passing ONE_ON_ONE_CALL in WWC and added below network logs
[withFix.txt](https://github.com/user-attachments/files/16487469/withFix.txt)
[withoutFix.txt](https://github.com/user-attachments/files/16487470/withoutFix.txt)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
