### PR TITLE
fix: reachability metrics sending nested metricFields

### DIFF
--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -514,7 +514,10 @@ export default class Reachability extends EventsScope {
         xtls: this.getStatistics(results, 'xtls', false),
       },
     };
-    Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.REACHABILITY_COMPLETED, stats);
+    Metrics.sendBehavioralMetric(
+      BEHAVIORAL_METRICS.REACHABILITY_COMPLETED,
+      Metrics.prepareMetricFields(stats)
+    );
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/metrics/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/metrics/index.js
@@ -58,4 +58,114 @@ describe('Meeting metrics', () => {
       });
     });
   });
+
+  describe('prepareMetricFields', () => {
+    it('handles empty objects correctly', () => {
+      const result = metrics.prepareMetricFields({});
+
+      assert.deepEqual(result, {});
+    });
+
+    it('handles literal values correctly', () => {
+      assert.deepEqual(metrics.prepareMetricFields('any string'), {value: 'any string'});
+      assert.deepEqual(metrics.prepareMetricFields(999), {value: 999});
+      assert.deepEqual(metrics.prepareMetricFields(null), {value: null});
+      assert.deepEqual(metrics.prepareMetricFields(true), {value: true});
+      assert.deepEqual(metrics.prepareMetricFields(false), {value: false});
+    });
+
+    it('handles simple objects correctly', () => {
+      const result = metrics.prepareMetricFields({
+        someStringProp: 'some string',
+        numberProp: 100,
+        booleanPropFalse: false,
+        booleanPropTrue: true,
+      });
+
+      assert.deepEqual(result, {
+        someStringProp: 'some string',
+        numberProp: 100,
+        booleanPropFalse: false,
+        booleanPropTrue: true,
+      });
+    });
+
+    it('handles nested objects correctly', () => {
+      const result = metrics.prepareMetricFields({
+        someStringProp: 'some string',
+        nestedObject: {
+          stringProp: 'another string',
+          numberProp: 1234,
+          deepObject: {
+            oneMoreString: 'deep nested string',
+            someBoolean: true,
+            oneMoreNumber: 10,
+          },
+        },
+      });
+
+      assert.deepEqual(result, {
+        someStringProp: 'some string',
+        nestedObject_stringProp: 'another string',
+        nestedObject_numberProp: 1234,
+        nestedObject_deepObject_oneMoreString: 'deep nested string',
+        nestedObject_deepObject_someBoolean: true,
+        nestedObject_deepObject_oneMoreNumber: 10,
+      });
+    });
+
+    it('handles arrays correctly', () => {
+      const result = metrics.prepareMetricFields(['a string', 10, true, false, {id: 'object id'}]);
+
+      assert.deepEqual(result, {
+        0: 'a string',
+        1: 10,
+        2: true,
+        3: false,
+        '4_id': 'object id',
+      });
+    });
+
+    it('handles arrays nested in objects correctly', () => {
+      const result = metrics.prepareMetricFields({
+        something: 10,
+        anObject: {
+          someArray: ['a string', 10, true, false, {id: 'object id'}],
+        },
+      });
+
+      assert.deepEqual(result, {
+        something: 10,
+        anObject_someArray_0: 'a string',
+        anObject_someArray_1: 10,
+        anObject_someArray_2: true,
+        anObject_someArray_3: false,
+        anObject_someArray_4_id: 'object id',
+      });
+    });
+
+    it('handles arrays nested in arrays correctly', () => {
+      const result = metrics.prepareMetricFields({
+        something: 10,
+        topLevelArray: [
+          [1, 2, 'three', {prop1: '1st prop of object 1', prop2: '2nd prop of object 1'}],
+          [10, 20, 'thirty', {prop1: '1st prop of object 2', prop2: '2nd prop of object 2'}],
+        ],
+      });
+
+      assert.deepEqual(result, {
+        something: 10,
+        topLevelArray_0_0: 1,
+        topLevelArray_0_1: 2,
+        topLevelArray_0_2: 'three',
+        topLevelArray_0_3_prop1: '1st prop of object 1',
+        topLevelArray_0_3_prop2: '2nd prop of object 1',
+        topLevelArray_1_0: 10,
+        topLevelArray_1_1: 20,
+        topLevelArray_1_2: 'thirty',
+        topLevelArray_1_3_prop1: '1st prop of object 2',
+        topLevelArray_1_3_prop2: '2nd prop of object 2',
+      });
+    });
+  });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/metrics/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/metrics/index.js
@@ -167,5 +167,21 @@ describe('Meeting metrics', () => {
         topLevelArray_1_3_prop2: '2nd prop of object 2',
       });
     });
+
+    it('prepends the prefix', () => {
+      const result = metrics.prepareMetricFields({
+        someStringProp: 'a string',
+        numberProp: 111,
+        booleanPropFalse: false,
+        booleanPropTrue: true,
+      }, 'testPrefix');
+
+      assert.deepEqual(result, {
+        testPrefix_someStringProp: 'a string',
+        testPrefix_numberProp: 111,
+        testPrefix_booleanPropFalse: false,
+        testPrefix_booleanPropTrue: true,
+      });
+    })
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -575,12 +575,18 @@ describe('gatherReachability', () => {
         },
       },
       expectedMetrics: {
-        vmn: {udp: {min: -1, max: -1, average: -1}},
-        public: {
-          udp: {min: 22, max: 22, average: 22},
-          tcp: {min: 11, max: 11, average: 11},
-          xtls: {min: 33, max: 33, average: 33},
-        },
+        vmn_udp_min: -1,
+        vmn_udp_max: -1,
+        vmn_udp_average: -1,
+        public_udp_min: 22,
+        public_udp_max: 22,
+        public_udp_average: 22,
+        public_tcp_min: 11,
+        public_tcp_max: 11,
+        public_tcp_average: 11,
+        public_xtls_min: 33,
+        public_xtls_max: 33,
+        public_xtls_average: 33,
       },
     },
     // ========================================================================
@@ -657,12 +663,18 @@ describe('gatherReachability', () => {
         },
       },
       expectedMetrics: {
-        vmn: {udp: {min: -1, max: -1, average: -1}},
-        public: {
-          udp: {min: 13, max: 13, average: 13},
-          tcp: {min: 53, max: 53, average: 53},
-          xtls: {min: 113, max: 113, average: 113},
-        },
+        vmn_udp_min: -1,
+        vmn_udp_max: -1,
+        vmn_udp_average: -1,
+        public_udp_min: 13,
+        public_udp_max: 13,
+        public_udp_average: 13,
+        public_tcp_min: 53,
+        public_tcp_max: 53,
+        public_tcp_average: 53,
+        public_xtls_min: 113,
+        public_xtls_max: 113,
+        public_xtls_average: 113,
       },
     },
     // ========================================================================
@@ -788,12 +800,18 @@ describe('gatherReachability', () => {
         },
       },
       expectedMetrics: {
-        vmn: {udp: {min: -1, max: -1, average: -1}},
-        public: {
-          udp: {min: 10, max: 30, average: 20},
-          tcp: {min: 100, max: 120, average: 110},
-          xtls: {min: 200, max: 240, average: 220},
-        },
+        vmn_udp_min: -1,
+        vmn_udp_max: -1,
+        vmn_udp_average: -1,
+        public_udp_min: 10,
+        public_udp_max: 30,
+        public_udp_average: 20,
+        public_tcp_min: 100,
+        public_tcp_max: 120,
+        public_tcp_average: 110,
+        public_xtls_min: 200,
+        public_xtls_max: 240,
+        public_xtls_average: 220,
       },
     },
     // ========================================================================
@@ -831,12 +849,18 @@ describe('gatherReachability', () => {
         },
       },
       expectedMetrics: {
-        vmn: {udp: {min: -1, max: -1, average: -1}},
-        public: {
-          udp: {min: -1, max: -1, average: -1},
-          tcp: {min: -1, max: -1, average: -1},
-          xtls: {min: -1, max: -1, average: -1},
-        },
+        vmn_udp_min: -1,
+        vmn_udp_max: -1,
+        vmn_udp_average: -1,
+        public_udp_min: -1,
+        public_udp_max: -1,
+        public_udp_average: -1,
+        public_tcp_min: -1,
+        public_tcp_max: -1,
+        public_tcp_average: -1,
+        public_xtls_min: -1,
+        public_xtls_max: -1,
+        public_xtls_average: -1,
       },
     },
     // ========================================================================
@@ -913,12 +937,18 @@ describe('gatherReachability', () => {
         },
       },
       expectedMetrics: {
-        vmn: {udp: {min: -1, max: -1, average: -1}},
-        public: {
-          udp: {min: 10, max: 10, average: 10},
-          tcp: {min: 100, max: 100, average: 100},
-          xtls: {min: 200, max: 200, average: 200},
-        },
+        vmn_udp_min: -1,
+        vmn_udp_max: -1,
+        vmn_udp_average: -1,
+        public_udp_min: 10,
+        public_udp_max: 10,
+        public_udp_average: 10,
+        public_tcp_min: 100,
+        public_tcp_max: 100,
+        public_tcp_average: 100,
+        public_xtls_min: 200,
+        public_xtls_max: 200,
+        public_xtls_average: 200,
       },
     },
     // ========================================================================
@@ -975,12 +1005,18 @@ describe('gatherReachability', () => {
         },
       },
       expectedMetrics: {
-        vmn: {udp: {min: 100, max: 300, average: 200}},
-        public: {
-          udp: {min: -1, max: -1, average: -1},
-          tcp: {min: -1, max: -1, average: -1},
-          xtls: {min: -1, max: -1, average: -1},
-        },
+        vmn_udp_min: 100,
+        vmn_udp_max: 300,
+        vmn_udp_average: 200,
+        public_udp_min: -1,
+        public_udp_max: -1,
+        public_udp_average: -1,
+        public_tcp_min: -1,
+        public_tcp_max: -1,
+        public_tcp_average: -1,
+        public_xtls_min: -1,
+        public_xtls_max: -1,
+        public_xtls_average: -1,
       },
     },
   ].forEach(
@@ -2003,9 +2039,11 @@ describe('sendMetric', () => {
     // setup stub for getStatistics to return values that show what parameters it was called with,
     // this way we can verify that the correct results of calls to getStatistics are placed
     // in correct data fields when sendBehavioralMetric() is called
-    sinon.stub(reachability, 'getStatistics').callsFake((results, protocol, isVideoMesh) => {
-      return {results, protocol, isVideoMesh};
-    });
+    const getStatisticsStub = sinon
+      .stub(reachability, 'getStatistics')
+      .callsFake((results, protocol, isVideoMesh) => {
+        return {result: 'fake', protocol, isVideoMesh};
+      });
 
     // setup fake clusterReachability results
     reachability.setFakeClusterReachability({
@@ -2041,31 +2079,26 @@ describe('sendMetric', () => {
       },
     ];
 
+    // check that getStatistics is called 4 times and each time with all the results
+    assert.callCount(getStatisticsStub, 4);
+    assert.alwaysCalledWith(getStatisticsStub, expectedResults, sinon.match.any, sinon.match.any);
+
     assert.calledWith(Metrics.sendBehavioralMetric, 'js_sdk_reachability_completed', {
-      vmn: {
-        udp: {
-          results: expectedResults,
-          protocol: 'udp',
-          isVideoMesh: true,
-        },
-      },
-      public: {
-        udp: {
-          results: expectedResults,
-          protocol: 'udp',
-          isVideoMesh: false,
-        },
-        tcp: {
-          results: expectedResults,
-          protocol: 'tcp',
-          isVideoMesh: false,
-        },
-        xtls: {
-          results: expectedResults,
-          protocol: 'xtls',
-          isVideoMesh: false,
-        },
-      },
+      vmn_udp_result: 'fake',
+      vmn_udp_protocol: 'udp',
+      vmn_udp_isVideoMesh: true,
+
+      public_udp_result: 'fake',
+      public_udp_protocol: 'udp',
+      public_udp_isVideoMesh: false,
+
+      public_tcp_result: 'fake',
+      public_tcp_protocol: 'tcp',
+      public_tcp_isVideoMesh: false,
+
+      public_xtls_result: 'fake',
+      public_xtls_protocol: 'xtls',
+      public_xtls_isVideoMesh: false,
     });
   });
 });


### PR DESCRIPTION
# COMPLETES #[SPARK-540198](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-540198)

## This pull request addresses
Recently added reachability metrics are sending an object with nested objects inside it as metricsFields, Amplitude doesn't like that, we need to flatten the object.

## by making the following changes
Added a helper method for flattening the objects for Amplitude metrics and using it in reachability.

Original PR where the reachability metric was introduced:
https://github.com/webex/webex-js-sdk/pull/3696


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
