### PR TITLE
fix(sample): fixed jwt token input box error

### DIFF
--- a/docs/samples/calling/index.html
+++ b/docs/samples/calling/index.html
@@ -39,7 +39,7 @@
                   <input id="access-token" name="accessToken" placeholder="Access Token" value="" type="text" style="margin: 1rem 0 0.5rem 0;" required>
 
                   <div id="guest-container" class="hidden">
-                    <input id="jwt-token-for-dest" name="jwtToken" placeholder="JWT token for destination" value="" type="text" style="margin: 0.5rem 0 0.5rem 0;" required>
+                    <input id="jwt-token-for-dest" name="jwtToken" placeholder="JWT token for destination" value="" type="text" style="margin: 0.5rem 0 0.5rem 0;">
                     <button type="button" onclick="generateGuestToken()">Generate Guest Token [Prod only]</button>
                   </div>
                 </div>


### PR DESCRIPTION
# COMPLETES #AD-HOC

## This pull request addresses
In the Kitchen sink app, initialize was failing due to the new input box added for the JWT token as it had both properties: hidden and required. Hence it failed for scenarios where we select service.indicator as calling.

## by making the following changes
Removed the required property from the <input> HTML element 

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
Tried to initialize with calling as well as guest calling.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
