### PR TITLE
fix: don't retry if we're missing h264 codec

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4647,7 +4647,16 @@ export default class Meeting extends StatelessWebexPlugin {
         }
       );
 
-      if (!isRetry) {
+      // if this was the first attempt, let's do a retry
+      let shouldRetry = !isRetry;
+
+      if (CallDiagnosticUtils.isSdpOfferCreationError(error)) {
+        // errors related to offer creation (for example missing H264 codec) will happen again no matter how many times we try,
+        // so there is no point doing a retry
+        shouldRetry = false;
+      }
+
+      if (shouldRetry) {
         LoggerProxy.logger.warn('Meeting:index#joinWithMedia --> retrying call to joinWithMedia');
         this.joinWithMediaRetryInfo.isRetry = true;
         this.joinWithMediaRetryInfo.prevJoinResponse = joinResponse;


### PR DESCRIPTION
# COMPLETES #[SPARK-547931](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-547931)

## This pull request addresses
When we're missing H264 codec, we will fail to add media, but joinWithMedia() will still do a 2nd attempt - this is unnecessary. Also, for any other case where we fail to create the offer, there is no point retrying.

## by making the following changes
Don't do retries when we fail to create the SDP offer (that's what happens when the codec is missing).

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual test with webapp

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
