### PR TITLE
fix: joinWithMedia() retries don't work correctly in some cases

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -501,6 +501,7 @@ export default class LocusInfo extends EventsScope {
       // When we dont add MEDIA for condition 2. The state of bob='IDLE'
 
       if (this.fullState && this.fullState.state === LOCUS.STATE.INACTIVE) {
+        console.log('marcin: isMeetingActive: 1st case CALL_INACTIVE');
         // TODO: update the meeting state
         LoggerProxy.logger.warn(
           'Locus-info:index#isMeetingActive --> Call Ended, locus state is inactive.'
@@ -532,6 +533,7 @@ export default class LocusInfo extends EventsScope {
           this.parsedLocus.self.state === MEETING_STATE.STATES.NOTIFIED ||
           this.parsedLocus.self.state === MEETING_STATE.STATES.JOINED)
       ) {
+        console.log('marcin: isMeetingActive: 2nd case PARTNER_LEFT');
         // @ts-ignore
         this.webex.internal.newMetrics.submitClientEvent({
           name: 'client.call.remote-ended',
@@ -559,6 +561,7 @@ export default class LocusInfo extends EventsScope {
           partner.state === MEETING_STATE.STATES.NOTIFIED ||
           partner.state === MEETING_STATE.STATES.IDLE) // Happens when user just joins and adds no Media
       ) {
+        console.log('marcin: isMeetingActive: last case SELF_LEFT');
         // @ts-ignore
         this.webex.internal.newMetrics.submitClientEvent({
           name: 'client.call.remote-ended',

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -165,8 +165,8 @@ Media.createMediaConnection = (
   if (turnServerInfo?.url) {
     iceServers.push({
       urls: turnServerInfo.url,
-      username: turnServerInfo.username || '',
-      credential: turnServerInfo.password || '',
+      username: turnServerInfo.username || '', // 'marcin-test', //
+      credential: turnServerInfo.password || '', // 'marcin-test', //
     });
   }
 

--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -377,6 +377,7 @@ export default class TurnDiscovery {
     meeting: Meeting,
     isReconnecting: boolean
   ): Promise<TurnDiscoveryResult> {
+    console.log('marcin: sendRoapTurnDiscoveryRequest');
     if (this.defer) {
       LoggerProxy.logger.warn(
         'Roap:turnDiscovery#sendRoapTurnDiscoveryRequest --> already in progress'


### PR DESCRIPTION
# COMPLETES #[SPARK-XXX](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-XXX)

## This pull request addresses
When media connection fails on 1st attempt, `joinWithMedia()` does a retry, but it always fails: server rejects our new SDP offer, because of wrong `seq` value

## by making the following changes
Changed `joinWithMedia()` so that we do a new turn discovery with empty mediaId before calling addMedia() again. Empty mediaId triggers the backend to create a new confluence (it's like a brand new connection) so seq starts from 0 again.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
