### PR TITLE
fix(plugin-meeting): remove sdp-transform dependency as it is unnecessary

### DIFF
--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -85,7 +85,6 @@
     "javascript-state-machine": "^3.1.0",
     "jwt-decode": "3.1.2",
     "lodash": "^4.17.21",
-    "sdp-transform": "^2.12.0",
     "uuid": "^3.3.2",
     "webrtc-adapter": "^8.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8744,7 +8744,6 @@ __metadata:
     jwt-decode: 3.1.2
     lodash: ^4.17.21
     prettier: ^2.7.1
-    sdp-transform: ^2.12.0
     sinon: ^9.2.4
     typed-emitter: ^2.1.0
     typescript: ^4.7.4
@@ -28669,15 +28668,6 @@ __metadata:
     ajv-formats: ^2.1.1
     ajv-keywords: ^5.1.0
   checksum: 26a0463d47683258106e6652e9aeb0823bf0b85843039e068b57da1892f7ae6b6b1094d48e9ed5ba5cbe9f7166469d880858b9d91abe8bd249421eb813850cde
-  languageName: node
-  linkType: hard
-
-"sdp-transform@npm:^2.12.0":
-  version: 2.14.1
-  resolution: "sdp-transform@npm:2.14.1"
-  bin:
-    sdp-verify: checker.js
-  checksum: 8b3179786db1a0f1ebfdacb1ac0dfe2833e63e8c64b638884cec212455061d53beaa8d9c8bf76fdbd5f844b7885f3892adec27e87734cfbc2b3e5c65e18a489b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [CSC-1459](https://jira-eng-sjc12.cisco.com/jira/browse/CSC-1459)

## This pull request addresses

a security issue reported on the `sdp-transform` library with respect to IP exposure. Taking a look at the code, it looks like we aren't even using this NPM package in the code.

## by making the following changes

Removed the `sdp-transform` dependency from plugin-meetings

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Joined a multi-stream meeting with video and audio enabled. Tested BNR and it was fine as well.
Changed layouts in the samples page and didn't observe any problems.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
