### PR TITLE
fix: send 'client.media-engine.remote-sdp-received' with error when not receiving SDP answer

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
@@ -377,7 +377,7 @@ export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEv
   },
   [MISSING_ROAP_ANSWER_CLIENT_CODE]: {
     errorDescription: ERROR_DESCRIPTIONS.MISSING_ROAP_ANSWER,
-    category: 'signaling',
+    category: 'media',
     fatal: true,
   },
   [DTLS_HANDSHAKE_FAILED_CLIENT_CODE]: {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -9,6 +9,7 @@ import {
   ClientEvent,
   ClientEventLeaveReason,
   CallDiagnosticUtils,
+  CALL_DIAGNOSTIC_CONFIG,
 } from '@webex/internal-plugin-metrics';
 import {ClientEvent as RawClientEvent} from '@webex/event-dictionary-ts';
 
@@ -5764,7 +5765,24 @@ export default class Meeting extends StatelessWebexPlugin {
             {
               logText: `${LOG_HEADER} Roap Offer`,
             }
-          ).catch(() => {
+          ).catch((error) => {
+            // @ts-ignore
+            this.webex.internal.newMetrics.submitClientEvent({
+              name: 'client.media-engine.remote-sdp-received',
+              payload: {
+                canProceed: false,
+                errors: [
+                  // @ts-ignore
+                  this.webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode(
+                    {
+                      clientErrorCode: CALL_DIAGNOSTIC_CONFIG.MISSING_ROAP_ANSWER_CLIENT_CODE,
+                    }
+                  ),
+                ],
+              },
+              options: {meetingId: this.id, rawError: error},
+            });
+
             this.deferSDPAnswer.reject(new Error('failed to send ROAP SDP offer'));
             clearTimeout(this.sdpResponseTimer);
             this.sdpResponseTimer = undefined;
@@ -6438,6 +6456,21 @@ export default class Meeting extends StatelessWebexPlugin {
           ROAP_OFFER_ANSWER_EXCHANGE_TIMEOUT / 1000
         } seconds`
       );
+      // @ts-ignore
+      this.webex.internal.newMetrics.submitClientEvent({
+        name: 'client.media-engine.remote-sdp-received',
+        payload: {
+          canProceed: false,
+          errors: [
+            // @ts-ignore
+            this.webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode({
+              clientErrorCode: CALL_DIAGNOSTIC_CONFIG.MISSING_ROAP_ANSWER_CLIENT_CODE,
+            }),
+          ],
+        },
+        options: {meetingId: this.id, rawError: new Error('Timeout waiting for SDP answer')},
+      });
+
       deferSDPAnswer.reject(new Error('Timed out waiting for REMOTE SDP ANSWER'));
     }, ROAP_OFFER_ANSWER_EXCHANGE_TIMEOUT);
 


### PR DESCRIPTION
# COMPLETES #[SPARK-517225](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-517225)

## This pull request addresses
When we fail to send SDP offer or never receive the answer the calls were incorrectly classified as success in CA

## by making the following changes
It's been agreed with CA team that we should send 'client.media-engine.remote-sdp-received' with an error if we don't receive the answer (that includes also cases where we fail to send the offer as the answer comes in http resposnse to that request).

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manually tested with web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
