### PR TITLE
fix(plugin-meetings): firefox <=114 encounters issues with missing ice-ufrag

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -22,7 +22,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/internal-media-core": "2.7.3",
+    "@webex/internal-media-core": "2.7.4",
     "@webex/ts-events": "^1.1.0",
     "@webex/web-media-effects": "2.18.0"
   },

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:*",
-    "@webex/internal-media-core": "2.7.3",
+    "@webex/internal-media-core": "2.7.4",
     "@webex/internal-plugin-conversation": "workspace:*",
     "@webex/internal-plugin-device": "workspace:*",
     "@webex/internal-plugin-llm": "workspace:*",

--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@types/platform": "1.3.4",
-    "@webex/internal-media-core": "2.7.3",
+    "@webex/internal-media-core": "2.7.4",
     "@webex/media-helpers": "workspace:*",
     "async-mutex": "0.4.0",
     "buffer": "6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7400,7 +7400,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.38.1
     "@typescript-eslint/parser": 5.38.1
     "@web/dev-server": 0.4.5
-    "@webex/internal-media-core": 2.7.3
+    "@webex/internal-media-core": 2.7.4
     "@webex/media-helpers": "workspace:*"
     async-mutex: 0.4.0
     buffer: 6.0.3
@@ -7691,19 +7691,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:2.7.3":
-  version: 2.7.3
-  resolution: "@webex/internal-media-core@npm:2.7.3"
+"@webex/internal-media-core@npm:2.7.4":
+  version: 2.7.4
+  resolution: "@webex/internal-media-core@npm:2.7.4"
   dependencies:
     "@babel/runtime": ^7.18.9
     "@webex/ts-sdp": 1.7.0
-    "@webex/web-client-media-engine": 3.22.3
+    "@webex/web-client-media-engine": 3.22.4
     events: ^3.3.0
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
     webrtc-adapter: ^8.1.2
     xstate: ^4.30.6
-  checksum: 1be5011d68f3d18ac8d95e4b8ae699f24b99fd6f1872bd52639e863121a2f21201999d3fcba71aeef94bfabcb7701c629cc4b5b4af1bf16b083d4e4ab2d0cf5d
+  checksum: 0610035ae8dfe3031a0d9004daa0b5f0d155743aa2eaff17c532786de544b77bb64c77a3b65964bf8ff24a1a308525c3256f22814aec73e177ccaad5bec221c9
   languageName: node
   linkType: hard
 
@@ -8471,7 +8471,7 @@ __metadata:
     "@babel/preset-typescript": 7.22.11
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.7.3
+    "@webex/internal-media-core": 2.7.4
     "@webex/jest-config-legacy": "workspace:*"
     "@webex/legacy-tools": "workspace:*"
     "@webex/test-helper-chai": "workspace:*"
@@ -8707,7 +8707,7 @@ __metadata:
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/common": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.7.3
+    "@webex/internal-media-core": 2.7.4
     "@webex/internal-plugin-conversation": "workspace:*"
     "@webex/internal-plugin-device": "workspace:*"
     "@webex/internal-plugin-llm": "workspace:*"
@@ -9419,9 +9419,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:3.22.3":
-  version: 3.22.3
-  resolution: "@webex/web-client-media-engine@npm:3.22.3"
+"@webex/web-client-media-engine@npm:3.22.4":
+  version: 3.22.4
+  resolution: "@webex/web-client-media-engine@npm:3.22.4"
   dependencies:
     "@webex/json-multistream": 2.1.3
     "@webex/rtcstats": ^1.3.2
@@ -9434,7 +9434,7 @@ __metadata:
     js-logger: ^1.6.1
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
-  checksum: 7a6fbea08f38fe8fd7d11f20d585749ea6df7d42692bc97a470eeee48cc4091ddcbe38f3415857d0b3e1450ef87df42cd516d19800cc502bf28e97f51ad53195
+  checksum: 13f24b0411cceaaef046887f6fee8e57be8e12ed07b5382a9a51eb07f56f1ec4eb02bdbb2ed567925690618862a02e831c6775019f9abe559bf7f29c1d3b5fe9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-552205](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-552205)

## This pull request addresses

Last changes to firefox with full-ice supported encountered issues on older versions of firefox <=114.
Those versions expect `ice-ufrag to be present in all m-line sections. Previously it was working correctly, because we were injecting dummy candidates to all lines, and homer was responding with those lines.
With full-ice candidates are injected only to first m-section, which result in having ice-ufrag only in first section in response.

## by making the following changes

Updates internal-media-core to version which ensure that all media sections does have ice candidates.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Tested on firefox 110, 113, 129. Have not found any new issues.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
