### PR TITLE
fix(plugin-meetings): framerate multiplied by 100

### DIFF
--- a/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
+++ b/packages/@webex/plugin-meetings/src/statsAnalyzer/mqaUtil.ts
@@ -343,10 +343,10 @@ export const getVideoReceiverStreamMqa = ({
     statsResults[mediaType][sendrecvType].framesDecoded - lastFramesDecoded;
 
   videoReceiverStream.common.receivedFrameRate = Math.round(
-    totalFrameReceivedInaMin ? totalFrameReceivedInaMin / 60 : 0
+    totalFrameReceivedInaMin ? (totalFrameReceivedInaMin * 100) / 60 : 0
   );
   videoReceiverStream.common.renderedFrameRate = Math.round(
-    totalFrameDecodedInaMin ? totalFrameDecodedInaMin / 60 : 0
+    totalFrameDecodedInaMin ? (totalFrameDecodedInaMin * 100) / 60 : 0
   );
 
   videoReceiverStream.common.framesDropped =
@@ -479,7 +479,7 @@ export const getVideoSenderStreamMqa = ({
     statsResults[mediaType][sendrecvType].framesSent - (lastFramesSent || 0);
 
   videoSenderStream.common.transmittedFrameRate = Math.round(
-    totalFrameSentInaMin ? totalFrameSentInaMin / 60 : 0
+    totalFrameSentInaMin ? (totalFrameSentInaMin * 100) / 60 : 0
   );
   videoSenderStream.transmittedHeight = statsResults[mediaType][sendrecvType].height || 0;
   videoSenderStream.transmittedWidth = statsResults[mediaType][sendrecvType].width || 0;

--- a/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/stats-analyzer/index.js
@@ -941,8 +941,8 @@ describe('plugin-meetings', () => {
           await progressTime(MQA_INTERVAL);
 
           // 300 frames in 60 seconds = 5 frames per second
-          assert.strictEqual(mqeData.videoTransmit[0].streams[0].common.transmittedFrameRate, 5);
-          assert.strictEqual(mqeData.videoReceive[0].streams[0].common.receivedFrameRate, 5);
+          assert.strictEqual(mqeData.videoTransmit[0].streams[0].common.transmittedFrameRate, 500);
+          assert.strictEqual(mqeData.videoReceive[0].streams[0].common.receivedFrameRate, 500);
         });
       });
 
@@ -1925,7 +1925,7 @@ describe('plugin-meetings', () => {
                 rtpPackets: 0,
                 ssci: 0,
                 transmittedBitrate: 133.33333333333334,
-                transmittedFrameRate: 0,
+                transmittedFrameRate: 2,
               },
               h264CodecProfile: 'BP',
               isAvatar: false,


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [WEBEX-396717](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-396717)

## This pull request addresses

The frame rate of metrics that is from CLP automateddiagnostics for WEB APP is not unified with Webex APP. The frame rate of the Webex APP is multiple 100, but the WEB APP is not. 

## by making the following changes

Multiply frame related stats by 100

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- samples app correctly sends stats multiplied by 100
- unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
