### PR TITLE
fix(plugin-meetings): transcription:started event for every participant

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -56,6 +56,7 @@ const currentMeetingInfoStatus = document.getElementById('current-meeting-info-s
 
 const enableLLM = document.getElementById('meetings-enable-llm');
 const enableTranscript = document.getElementById('meetings-enable-transcription');
+const spokenLangNote = document.getElementById('only-host-spoken-language');
 
 // Store and Grab `access-token` from localstorage
 if (localStorage.getItem('date') > new Date().getTime()) {
@@ -1120,9 +1121,14 @@ function setTranscriptEvents() {
 
     meeting.on('meeting:receiveTranscription:started', (payload) => {
       fillLanguageDropDowns(voiceaCaptionLanguage,payload.captionLanguages);
-      fillLanguageDropDowns(voiceaSpokenLanguage,payload.spokenLanguages);
-      voiceaSpokenLanguage.disabled = false;
-      voiceaSpokenLanguageBtn.disabled = false;
+      if(typeof payload.spokenLanguages !== "undefined" && meeting.getCurUserType() === "host"){
+        fillLanguageDropDowns(voiceaSpokenLanguage,payload.spokenLanguages);
+        voiceaSpokenLanguage.disabled = false;
+        voiceaSpokenLanguageBtn.disabled = false;
+      }
+      else {
+        spokenLangNote.classList.remove("hidden");
+      }
       voiceaCaptionLanguage.disabled = false;
       voiceaCaptionLanguageBtn.disabled = false;
     });

--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -853,7 +853,7 @@
                   onclick="toggleTranscription()" class="btn-code" data-enabled="false">Start Transcription</button>
                 <br>
                 Caption Language: <select id="voicea-caption-language" style="display: inline;" disabled></select><button id="voicea-caption-language-btn" onclick="setCaptionLanguage()" disabled>meeting.setCaptionLanguage()</button><br/>
-                Spoken Language: <select id="voicea-spoken-language" style="display: inline;" disabled></select><button id="voicea-spoken-language-btn"  onclick="setSpokenLanguage()" disabled>meeting.setSpokenLanguage()</button>
+                Spoken Language: <select id="voicea-spoken-language" style="display: inline;" disabled></select><button id="voicea-spoken-language-btn"  onclick="setSpokenLanguage()" disabled>meeting.setSpokenLanguage()</button> <p id="only-host-spoken-language" class="hidden">Only Meeting Host can Set Spoken Language</p>
                 <br>
               </div>
               <textarea id="gc-transcription-content"

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -645,6 +645,10 @@ export default class Meeting extends StatelessWebexPlugin {
         })}event#${EVENT_TRIGGERS.MEETING_STARTED_RECEIVING_TRANSCRIPTION}`
       );
 
+      if (this.getCurUserType() !== 'host') {
+        delete payload.spokenLanguages;
+      }
+
       // @ts-ignore
       this.trigger(EVENT_TRIGGERS.MEETING_STARTED_RECEIVING_TRANSCRIPTION, payload);
     },
@@ -4831,6 +4835,14 @@ export default class Meeting extends StatelessWebexPlugin {
         reject(new Error('Webex Assistant is not enabled/supported'));
       }
 
+      if (this.getCurUserType() !== 'host') {
+        LoggerProxy.logger.error(
+          'Meeting:index#setSpokenLanguage --> Only host can set spoken language'
+        );
+
+        reject(new Error('Only host can set spoken language'));
+      }
+
       try {
         const voiceaListenerLanguageUpdate = (payload) => {
           // @ts-ignore
@@ -4884,10 +4896,8 @@ export default class Meeting extends StatelessWebexPlugin {
           this.setUpVoiceaListeners();
         }
 
-        if (this.getCurUserType() === 'host') {
-          // @ts-ignore
-          await this.webex.internal.voicea.turnOnCaptions(options?.spokenLanguage);
-        }
+        // @ts-ignore
+        await this.webex.internal.voicea.turnOnCaptions(options?.spokenLanguage);
       } catch (error) {
         LoggerProxy.logger.error(`Meeting:index#startTranscription --> ${error}`);
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.RECEIVE_TRANSCRIPTION_FAILURE, {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1016,6 +1016,7 @@ describe('plugin-meetings', () => {
           assert.equal(webex.internal.voicea.on.callCount, 4);
           assert.equal(meeting.areVoiceaEventsSetup, true);
           assert.equal(webex.internal.voicea.listenToEvents.callCount, 1);
+          assert.calledOnce(webex.internal.voicea.turnOnCaptions);
         });
 
         it("should throw error if request doesn't work", async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1005,7 +1005,7 @@ describe('plugin-meetings', () => {
           assert.calledTwice(webex.internal.voicea.turnOnCaptions);
         });
 
-        it('should listen to events and not turnOnCaptions if the user is not a host', async () => {
+        it('should listen to events and turnOnCaptions for all users', async () => {
           meeting.joinedWith = {
             state: 'JOINED',
           };

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1010,14 +1010,12 @@ describe('plugin-meetings', () => {
             state: 'JOINED',
           };
           meeting.areVoiceaEventsSetup = false;
-          meeting.roles = ['COHOST'];
 
           await meeting.startTranscription();
 
           assert.equal(webex.internal.voicea.on.callCount, 4);
           assert.equal(meeting.areVoiceaEventsSetup, true);
           assert.equal(webex.internal.voicea.listenToEvents.callCount, 1);
-          assert.notCalled(webex.internal.voicea.turnOnCaptions);
         });
 
         it("should throw error if request doesn't work", async () => {
@@ -1134,6 +1132,7 @@ describe('plugin-meetings', () => {
           webex.internal.voicea.on = sinon.stub();
           webex.internal.voicea.off = sinon.stub();
           webex.internal.voicea.setSpokenLanguage = sinon.stub();
+          meeting.roles = ['MODERATOR'];
         });
 
         afterEach(() => {
@@ -1146,6 +1145,16 @@ describe('plugin-meetings', () => {
 
           meeting.setSpokenLanguage('fr').catch((error) => {
             assert.equal(error.message, 'Webex Assistant is not enabled/supported');
+            done();
+          });
+        });
+
+        it('should reject if current user is not a host', (done) => {
+          meeting.isTranscriptionSupported.returns(true);
+          meeting.roles = ['COHOST'];
+
+          meeting.setSpokenLanguage('fr').catch((error) => {
+            assert.equal(error.message, 'Only host can set spoken language');
             done();
           });
         });


### PR DESCRIPTION

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-542912](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-542912)

## This pull request addresses

When a meeting host has joined and started transcription already and a non-host participant joins the meeting, the `meeting:receiveTranscription:started` event is not triggered. We had the condition because:
1. A non-host participant cannot `toggleTranscribing` and now, a participant can `turnOnCaptions` even if they're not host. 
2. A non-host participant would receive captions even without having to request Voicea to `turnOnCaptions`

## by making the following changes

Now, we are removing the host condition because:
1. `turnOnCaptions` is allowed by locus for non-host participants also
2. The original issue of `meeting:receiveTranscription:started` event not triggered is because Voicea doesn't think it has to trigger that event unless we `turnOnCaptions`

Additionally, in this PR we also restrict `setSpokenLanguage` to be called only by a host participant at the SDK level itself instead of an earlier API reject approach. This is just to cut-down an unwanted API call. We already updated this restriction in the documentation [here](https://developer.webex.com/docs/sdks/webex-meetings-sdk-web-advanced-meeting-controls#transcription).

Supporting Screenshot:
<img width="741" alt="Screenshot 2024-08-18 at 6 08 51 AM" src="https://github.com/user-attachments/assets/f2bc7032-e351-4ea9-be80-b4210a2f5207">


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Manually tested the following,
1. `meeting.startTranscription()` call triggers `meeting:receiveTranscription:started` event for both host and non-host participant (including a guest issuer participant)
2. `meeting.setSpokenLanguage()` rejects if the current user is not a `host`
3. `meeting.setCaptionLanguage()` sends the translated language

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
