### PR TITLE
fix: incorrect icePhase when joinWithMedia() fails on 1st attempt

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1459,7 +1459,10 @@ export default class Meeting extends StatelessWebexPlugin {
     this.turnServerUsed = false;
 
     /**
-     * Contains information used during the addMedia() operation
+     * Contains information used during the addMedia() operation:
+     * retriedWithTurnServer - whether retry was done using TURN Discovery
+     * icePhaseCallback - callback for determining the value for icePhase when sending failure event to CA
+     *
      * @instance
      * @type {Object}
      * @private

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -155,7 +155,7 @@ import PermissionError from '../common/errors/permission';
 import {LocusMediaRequest} from './locusMediaRequest';
 import {ConnectionStateHandler, ConnectionStateEvent} from './connectionStateHandler';
 
-// default callback so we don't call an undefined function, but it practice it should never be used
+// default callback so we don't call an undefined function, but in practice it should never be used
 const DEFAULT_ICE_PHASE_CALLBACK = () => 'JOIN_MEETING_FINAL';
 
 const logRequest = (request: any, {logText = ''}) => {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -155,6 +155,9 @@ import PermissionError from '../common/errors/permission';
 import {LocusMediaRequest} from './locusMediaRequest';
 import {ConnectionStateHandler, ConnectionStateEvent} from './connectionStateHandler';
 
+// default callback so we don't call an undefined function, but it practice it should never be used
+const DEFAULT_ICE_PHASE_CALLBACK = () => 'JOIN_MEETING_FINAL';
+
 const logRequest = (request: any, {logText = ''}) => {
   LoggerProxy.logger.info(`${logText} - sending request`);
 
@@ -679,7 +682,11 @@ export default class Meeting extends StatelessWebexPlugin {
     },
   };
 
-  private retriedWithTurnServer: boolean;
+  private addMediaData: {
+    retriedWithTurnServer: boolean;
+    icePhaseCallback: () => string;
+  };
+
   private sendSlotManager: SendSlotManager = new SendSlotManager(LoggerProxy);
   private deferSDPAnswer?: Defer; // used for waiting for a response
   private sdpResponseTimer?: ReturnType<typeof setTimeout>;
@@ -1452,13 +1459,16 @@ export default class Meeting extends StatelessWebexPlugin {
     this.turnServerUsed = false;
 
     /**
-     * Whether retry was done using TURN Discovery.
+     * Contains information used during the addMedia() operation
      * @instance
-     * @type {boolean}
+     * @type {Object}
      * @private
      * @memberof Meeting
      */
-    this.retriedWithTurnServer = false;
+    this.addMediaData = {
+      retriedWithTurnServer: false,
+      icePhaseCallback: DEFAULT_ICE_PHASE_CALLBACK,
+    };
 
     /**
      * Whether or not the media connection has ever successfully connected.
@@ -4627,7 +4637,14 @@ export default class Meeting extends StatelessWebexPlugin {
         joined = true;
       }
 
-      const mediaResponse = await this.addMedia(mediaOptions, turnServerInfo, forceTurnDiscovery);
+      const mediaResponse = await this.addMediaInternal(
+        () => {
+          return this.joinWithMediaRetryInfo.isRetry ? 'JOIN_MEETING_FINAL' : 'JOIN_MEETING_RETRY';
+        },
+        turnServerInfo,
+        forceTurnDiscovery,
+        mediaOptions
+      );
 
       this.joinWithMediaRetryInfo = {isRetry: false, prevJoinResponse: undefined};
 
@@ -6382,7 +6399,7 @@ export default class Meeting extends StatelessWebexPlugin {
           name: 'client.ice.end',
           payload: {
             canProceed: !this.turnServerUsed, // If we haven't done turn tls retry yet we will proceed with join attempt
-            icePhase: this.turnServerUsed ? 'JOIN_MEETING_FINAL' : 'JOIN_MEETING_RETRY',
+            icePhase: this.addMediaData.icePhaseCallback(),
             errors: [
               // @ts-ignore
               this.webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode(
@@ -6549,7 +6566,7 @@ export default class Meeting extends StatelessWebexPlugin {
     remoteMediaManagerConfig?: RemoteMediaManagerConfiguration,
     bundlePolicy?: BundlePolicy
   ): Promise<void> {
-    this.retriedWithTurnServer = true;
+    this.addMediaData.retriedWithTurnServer = true;
     const LOG_HEADER = 'Meeting:index#addMedia():retryWithForcedTurnDiscovery -->';
 
     await this.cleanUpBeforeRetryWithTurnServer();
@@ -6644,7 +6661,7 @@ export default class Meeting extends StatelessWebexPlugin {
         correlation_id: this.correlationId,
         latency: cdl.getTurnDiscoveryTime(),
         turnServerUsed: this.turnServerUsed,
-        retriedWithTurnServer: this.retriedWithTurnServer,
+        retriedWithTurnServer: this.addMediaData.retriedWithTurnServer,
       });
     }
 
@@ -6824,18 +6841,39 @@ export default class Meeting extends StatelessWebexPlugin {
    * Creates a media connection to the server. Media connection is required for sending or receiving any audio/video.
    *
    * @param {AddMediaOptions} options
-   * @param {TurnServerInfo} turnServerInfo - TURN server information (used only internally by the SDK)
-   * @param {boolean} forceTurnDiscovery - if true, TURN discovery will be done (used only internally by the SDK)
    * @returns {Promise<void>}
    * @public
    * @memberof Meeting
    */
-  async addMedia(
-    options: AddMediaOptions = {},
-    turnServerInfo: TurnServerInfo = undefined,
-    forceTurnDiscovery = false
+  addMedia(options: AddMediaOptions = {}): Promise<void> {
+    return this.addMediaInternal(
+      () => (this.turnServerUsed ? 'JOIN_MEETING_FINAL' : 'JOIN_MEETING_RETRY'),
+      undefined,
+      false,
+      options
+    );
+  }
+
+  /**
+   * Internal version of addMedia() with some more arguments for finer control of its behavior
+   *
+   * @param {Function} icePhaseCallback - callback to determine the icePhase for CA "client.ice.end" failure events
+   * @param {TurnServerInfo} turnServerInfo - TURN server information
+   * @param {boolean} forceTurnDiscovery - if true, TURN discovery will be done
+   * @param {AddMediaOptions} options - same as options of the public addMedia() method
+   * @returns {Promise<void>}
+   * @protected
+   * @memberof Meeting
+   */
+  protected async addMediaInternal(
+    icePhaseCallback: () => string,
+    turnServerInfo: TurnServerInfo,
+    forceTurnDiscovery,
+    options: AddMediaOptions = {}
   ): Promise<void> {
-    this.retriedWithTurnServer = false;
+    this.addMediaData.retriedWithTurnServer = false;
+    this.addMediaData.icePhaseCallback = icePhaseCallback;
+
     this.hasMediaConnectionConnectedAtLeastOnce = false;
     const LOG_HEADER = 'Meeting:index#addMedia -->';
     LoggerProxy.logger.info(
@@ -6946,7 +6984,7 @@ export default class Meeting extends StatelessWebexPlugin {
         selectedCandidatePairChanges,
         numTransports,
         isMultistream: this.isMultistream,
-        retriedWithTurnServer: this.retriedWithTurnServer,
+        retriedWithTurnServer: this.addMediaData.retriedWithTurnServer,
         isJoinWithMediaRetry: this.joinWithMediaRetryInfo.isRetry,
         ...reachabilityStats,
       });
@@ -6984,7 +7022,7 @@ export default class Meeting extends StatelessWebexPlugin {
         numTransports,
         turnDiscoverySkippedReason: this.turnDiscoverySkippedReason,
         turnServerUsed: this.turnServerUsed,
-        retriedWithTurnServer: this.retriedWithTurnServer,
+        retriedWithTurnServer: this.addMediaData.retriedWithTurnServer,
         isMultistream: this.isMultistream,
         isJoinWithMediaRetry: this.joinWithMediaRetryInfo.isRetry,
         signalingState:
@@ -7024,6 +7062,8 @@ export default class Meeting extends StatelessWebexPlugin {
       }
 
       throw error;
+    } finally {
+      this.addMediaData.icePhaseCallback = DEFAULT_ICE_PHASE_CALLBACK;
     }
   }
 


### PR DESCRIPTION
# COMPLETES #[SPARK-554031](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-554031)

## This pull request addresses
When joinWithMedia() fails to establish media connection, but succeeds on the retry, Call Analyzer still marks the join with mediaOutcome=failed

## by making the following changes
Introduced a callback for determining the value of icePhase sent on failure. The callback has different logic when addMedia() is called from joinWithMedia(), because joinWithMedia() knows that it will do a retry as opposed to the public addMedia() method, which also has its own retry logic, but it's different - it only does a retry if TURN server is not used on 1st attempt.

There was also another property called `retriedWithTurnServer` that was purely used by addMedia() internally so I've created a `addMediaData` object inside `Meeting` to store all "addMedia" related things in it.

I've also split the public addMedia() method into a protected addMediaInternal() and public addMedia(). This allows us to easily add more parameters to addMediaInternal() for internal SDK use without impacting the public API of addMedia().

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests and tested manually with web app - simulated failure on 1st attempt and success on retry, confirmed CA marked it as success

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
