### PR TITLE
fix(plugin-authorization): use orgId if emailhash unavailable

### DIFF
--- a/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
@@ -103,10 +103,12 @@ const Authorization = WebexPlugin.extend({
     this._verifySecurityToken(location.query);
     this._cleanUrl(location);
 
+    const orgId = code.split('_')[2];
+
     // Wait until nextTick in case `credentials` hasn't initialized yet
     process.nextTick(() => {
       this.webex.internal.services
-        .collectPreauthCatalog(emailhash ? {emailhash}: undefined)
+        .collectPreauthCatalog(emailhash ? {emailhash}: {orgId})
         .catch(() => Promise.resolve())
         .then(() => this.requestAuthorizationCodeGrant({code, codeVerifier}))
         .catch((error) => {


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

Using the by proximity u2c catalog during auth can result in sending the code to the wrong cluster

< DESCRIBE THE CONTEXT OF THE ISSUE >

Use the orgId, contained in the code, when emailhash is not provided

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
