### PR TITLE
feat(webex-core): hostmap interceptor

### DIFF
--- a/packages/@webex/webex-core/src/index.js
+++ b/packages/@webex/webex-core/src/index.js
@@ -25,6 +25,7 @@ export {
   Services,
   ServiceHost,
   ServiceUrl,
+  HostMapInterceptor,
 } from './lib/services';
 
 export {

--- a/packages/@webex/webex-core/src/lib/services/index.js
+++ b/packages/@webex/webex-core/src/lib/services/index.js
@@ -18,6 +18,7 @@ registerInternalPlugin('services', Services, {
 export {constants};
 export {default as ServiceInterceptor} from './interceptors/service';
 export {default as ServerErrorInterceptor} from './interceptors/server-error';
+export {default as HostMapInterceptor} from './interceptors/hostmap';
 export {default as Services} from './services';
 export {default as ServiceCatalog} from './service-catalog';
 export {default as ServiceRegistry} from './service-registry';

--- a/packages/@webex/webex-core/src/lib/services/interceptors/hostmap.js
+++ b/packages/@webex/webex-core/src/lib/services/interceptors/hostmap.js
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) 2015-2024 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {Interceptor} from '@webex/http-core';
+
+/**
+ * This interceptor replaces the host in the request uri with the host from the hostmap
+ * It will attempt to do this for every request, but not all URIs will be in the hostmap
+ * URIs with hosts that are not in the hostmap will be left unchanged
+ */
+export default class HostMapInterceptor extends Interceptor {
+  /**
+   * @returns {HostMapInterceptor}
+   */
+  static create() {
+    return new HostMapInterceptor({webex: this});
+  }
+
+  /**
+   * @see Interceptor#onRequest
+   * @param {Object} options
+   * @returns {Object}
+   */
+  onRequest(options) {
+    if (options.uri) {
+      try {
+        options.uri = this.webex.internal.services.replaceHostFromHostmap(options.uri);
+      } catch (error) {
+        /* empty */
+      }
+    }
+
+    return options;
+  }
+}

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -676,6 +676,33 @@ const Services = WebexPlugin.extend({
   },
 
   /**
+   * Looks up the hostname in the host catalog
+   * and replaces it with the first host if it finds it
+   * @param {string} uri
+   * @returns {string} uri with the host replaced
+   */
+  replaceHostFromHostmap(uri) {
+    const url = new URL(uri);
+    const hostCatalog = this._hostCatalog;
+
+    if (!hostCatalog) {
+      return uri;
+    }
+
+    const host = hostCatalog[url.host];
+
+    if (host && host[0]) {
+      const newHost = host[0].host;
+
+      url.host = newHost;
+
+      return url.toString();
+    }
+
+    return uri;
+  },
+
+  /**
    * @private
    * Organize a received hostmap from a service
    * catalog endpoint.

--- a/packages/@webex/webex-core/src/webex-core.js
+++ b/packages/@webex/webex-core/src/webex-core.js
@@ -31,6 +31,7 @@ import WebexUserAgentInterceptor from './interceptors/webex-user-agent';
 import RateLimitInterceptor from './interceptors/rate-limit';
 import EmbargoInterceptor from './interceptors/embargo';
 import DefaultOptionsInterceptor from './interceptors/default-options';
+import HostMapInterceptor from './lib/services/interceptors/hostmap';
 import config from './config';
 import {makeWebexStore} from './lib/storage';
 import mixinWebexCorePlugins from './lib/webex-core-plugin-mixin';
@@ -71,6 +72,7 @@ const interceptors = {
   NetworkTimingInterceptor: NetworkTimingInterceptor.create,
   EmbargoInterceptor: EmbargoInterceptor.create,
   DefaultOptionsInterceptor: DefaultOptionsInterceptor.create,
+  HostMapInterceptor: HostMapInterceptor.create,
 };
 
 const preInterceptors = [

--- a/packages/@webex/webex-core/test/unit/spec/services/interceptors/hostmap.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/interceptors/hostmap.js
@@ -1,0 +1,79 @@
+/*!
+ * Copyright (c) 2015-2024 Cisco Systems, Inc. See LICENSE file.
+ */
+
+/* eslint-disable camelcase */
+
+import sinon from 'sinon';
+import {assert} from '@webex/test-helper-chai';
+import MockWebex from '@webex/test-helper-mock-webex';
+import {HostMapInterceptor, config, Credentials} from '@webex/webex-core';
+import {cloneDeep} from 'lodash';
+
+describe('webex-core', () => {
+  describe('Interceptors', () => {
+    describe('HostMapInterceptor', () => {
+      let interceptor, webex;
+
+      beforeEach(() => {
+        webex = new MockWebex({
+          children: {
+            credentials: Credentials,
+          },
+          config: cloneDeep(config),
+          request: sinon.spy(),
+        });
+
+        webex.internal.services = {
+          replaceHostFromHostmap: sinon.stub().returns('http://replaceduri.com'),
+        }
+
+        interceptor = Reflect.apply(HostMapInterceptor.create, webex, []);
+      });
+
+      describe('#onRequest', () => {
+        it('calls replaceHostFromHostmap if options.uri is defined', () => {
+          const options = {
+            uri: 'http://example.com',
+          };
+
+          interceptor.onRequest(options);
+
+          sinon.assert.calledWith(
+            webex.internal.services.replaceHostFromHostmap,
+            'http://example.com'
+          );
+
+          assert.equal(options.uri, 'http://replaceduri.com');
+        });
+
+        it('does not call replaceHostFromHostmap if options.uri is not defined', () => {
+          const options = {};
+
+          interceptor.onRequest(options);
+
+          sinon.assert.notCalled(webex.internal.services.replaceHostFromHostmap);
+
+          assert.isUndefined(options.uri);
+        });
+
+        it('does not modify options.uri if replaceHostFromHostmap throws an error', () => {
+          const options = {
+            uri: 'http://example.com',
+          };
+
+          webex.internal.services.replaceHostFromHostmap.throws(new Error('replaceHostFromHostmap error'));
+
+          interceptor.onRequest(options);
+
+          sinon.assert.calledWith(
+            webex.internal.services.replaceHostFromHostmap,
+            'http://example.com'
+          );
+
+          assert.equal(options.uri, 'http://example.com');
+        });
+      });
+    });
+  });
+});

--- a/packages/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/services.js
@@ -290,6 +290,61 @@ describe('webex-core', () => {
       });
     });
 
+    describe('replaceHostFromHostmap', () => {
+      it('returns the same uri if the hostmap is not set', () => {
+        services._hostCatalog = null;
+
+        const uri = 'http://example.com';
+
+        assert.equal(services.replaceHostFromHostmap(uri), uri);
+      });
+
+      it('returns the same uri if the hostmap does not contain the host', () => {
+        services._hostCatalog = {
+          'not-example.com': [
+            {
+              host: 'example-1.com',
+              ttl: -1,
+              priority: 5,
+              id: '0:0:0:example',
+            },
+          ],
+        };
+
+        const uri = 'http://example.com';
+
+        assert.equal(services.replaceHostFromHostmap(uri), uri);
+      });
+
+      it('returns the original uri if the hostmap has no hosts for the host', () => {
+
+        services._hostCatalog = {
+          'example.com': [],
+        };
+
+        const uri = 'http://example.com';
+
+        assert.equal(services.replaceHostFromHostmap(uri), uri);
+      });
+
+      it('returns the replaces the host in the uri with the host from the hostmap', () => {
+        services._hostCatalog = {
+          'example.com': [
+            {
+              host: 'example-1.com',
+              ttl: -1,
+              priority: 5,
+              id: '0:0:0:example',
+            },
+          ],
+        };
+
+        const uri = 'http://example.com/somepath';
+
+        assert.equal(services.replaceHostFromHostmap(uri), 'http://example-1.com/somepath');
+      });
+    });
+
     describe('#_formatReceivedHostmap()', () => {
       let serviceHostmap;
       let formattedHM;


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

The hostmap from u2c maps the logical name of the service (these are actually FQDNs) to the hosts. Until recently, the first host listed for each logical name was the same as the logical name. Going forward this will not be the case. Services will continue to use logical names i.e. conversations/locus and the client needs to replace these with the correct host.

Existing methods in webex-core/services do not handle this (e.g. getServiceFromUrl)

## by making the following changes

I've created a new method replaceHostFromHostmap which looks up the host in the hostmap and replaces it in a supplied URI. I've used this new method in an interceptor, so it will automatically happen for each request.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
