### PR TITLE
fix(plugin-meetings): send metrics on gathered ice candidates count

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
@@ -399,7 +399,7 @@ export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEv
   },
   [ICE_AND_REACHABILITY_FAILED_CLIENT_CODE]: {
     errorDescription: ERROR_DESCRIPTIONS.ICE_AND_REACHABILITY_FAILED,
-    category: 'network',
+    category: 'expected',
     fatal: true,
   },
   2050: {

--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -22,7 +22,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/internal-media-core": "2.7.4",
+    "@webex/internal-media-core": "2.8.0",
     "@webex/ts-events": "^1.1.0",
     "@webex/web-media-effects": "2.18.0"
   },

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@webex/common": "workspace:*",
-    "@webex/internal-media-core": "2.7.4",
+    "@webex/internal-media-core": "2.8.0",
     "@webex/internal-plugin-conversation": "workspace:*",
     "@webex/internal-plugin-device": "workspace:*",
     "@webex/internal-plugin-llm": "workspace:*",

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -694,6 +694,7 @@ export default class Meeting extends StatelessWebexPlugin {
   private joinWithMediaRetryInfo?: {isRetry: boolean; prevJoinResponse?: any};
   private connectionStateHandler?: ConnectionStateHandler;
   private iceCandidateErrors: Map<string, number>;
+  private iceCandidatesCount: number;
 
   /**
    * @param {Object} attrs
@@ -1508,6 +1509,15 @@ export default class Meeting extends StatelessWebexPlugin {
      * @memberof Meeting
      */
     this.iceCandidateErrors = new Map();
+
+    /**
+     * Gathered ICE Candidates count
+     * @instance
+     * @type {number}
+     * @private
+     * @memberof Meeting
+     */
+    this.iceCandidatesCount = 0;
   }
 
   /**
@@ -6119,6 +6129,13 @@ export default class Meeting extends StatelessWebexPlugin {
 
       this.iceCandidateErrors.set(error, count + 1);
     });
+
+    this.iceCandidatesCount = 0;
+    this.mediaProperties.webrtcMediaConnection.on(Event.ICE_CANDIDATE, (event) => {
+      if (event.candidate) {
+        this.iceCandidatesCount += 1;
+      }
+    });
   };
 
   /**
@@ -6990,6 +7007,7 @@ export default class Meeting extends StatelessWebexPlugin {
         retriedWithTurnServer: this.addMediaData.retriedWithTurnServer,
         isJoinWithMediaRetry: this.joinWithMediaRetryInfo.isRetry,
         ...reachabilityStats,
+        iceCandidatesCount: this.iceCandidatesCount,
       });
       // @ts-ignore
       this.webex.internal.newMetrics.submitClientEvent({
@@ -7045,6 +7063,7 @@ export default class Meeting extends StatelessWebexPlugin {
           'unknown',
         ...reachabilityMetrics,
         ...iceCandidateErrors,
+        iceCandidatesCount: this.iceCandidatesCount,
       });
 
       await this.cleanUpOnAddMediaFailure();

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -3419,7 +3419,7 @@ describe('plugin-meetings', () => {
               unreachable: true,
               expectedErrorPayload: {
                 errorDescription: ERROR_DESCRIPTIONS.ICE_AND_REACHABILITY_FAILED,
-                category: 'network',
+                category: 'expected',
               },
             },
           ].forEach(({clientErrorCode, expectedErrorPayload, unreachable}) => {

--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@types/platform": "1.3.4",
-    "@webex/internal-media-core": "2.7.4",
+    "@webex/internal-media-core": "2.8.0",
     "@webex/media-helpers": "workspace:*",
     "async-mutex": "0.4.0",
     "buffer": "6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7400,7 +7400,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.38.1
     "@typescript-eslint/parser": 5.38.1
     "@web/dev-server": 0.4.5
-    "@webex/internal-media-core": 2.7.4
+    "@webex/internal-media-core": 2.8.0
     "@webex/media-helpers": "workspace:*"
     async-mutex: 0.4.0
     buffer: 6.0.3
@@ -7691,19 +7691,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:2.7.4":
-  version: 2.7.4
-  resolution: "@webex/internal-media-core@npm:2.7.4"
+"@webex/internal-media-core@npm:2.8.0":
+  version: 2.8.0
+  resolution: "@webex/internal-media-core@npm:2.8.0"
   dependencies:
     "@babel/runtime": ^7.18.9
     "@webex/ts-sdp": 1.7.0
-    "@webex/web-client-media-engine": 3.22.4
+    "@webex/web-client-media-engine": 3.23.1
     events: ^3.3.0
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
     webrtc-adapter: ^8.1.2
     xstate: ^4.30.6
-  checksum: 0610035ae8dfe3031a0d9004daa0b5f0d155743aa2eaff17c532786de544b77bb64c77a3b65964bf8ff24a1a308525c3256f22814aec73e177ccaad5bec221c9
+  checksum: a27ddbd484404dc99b627879df10ff97212fddb3bf94829aa41408d719436b33d6bce824b2a33a30a5dd83eabc9c3d70cbb4fe086fc00d5c1aca5da918503e3d
   languageName: node
   linkType: hard
 
@@ -8471,7 +8471,7 @@ __metadata:
     "@babel/preset-typescript": 7.22.11
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.7.4
+    "@webex/internal-media-core": 2.8.0
     "@webex/jest-config-legacy": "workspace:*"
     "@webex/legacy-tools": "workspace:*"
     "@webex/test-helper-chai": "workspace:*"
@@ -8707,7 +8707,7 @@ __metadata:
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/common": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.7.4
+    "@webex/internal-media-core": 2.8.0
     "@webex/internal-plugin-conversation": "workspace:*"
     "@webex/internal-plugin-device": "workspace:*"
     "@webex/internal-plugin-llm": "workspace:*"
@@ -9419,9 +9419,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:3.22.4":
-  version: 3.22.4
-  resolution: "@webex/web-client-media-engine@npm:3.22.4"
+"@webex/web-client-media-engine@npm:3.23.1":
+  version: 3.23.1
+  resolution: "@webex/web-client-media-engine@npm:3.23.1"
   dependencies:
     "@webex/json-multistream": 2.1.3
     "@webex/rtcstats": ^1.3.2
@@ -9434,7 +9434,7 @@ __metadata:
     js-logger: ^1.6.1
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
-  checksum: 13f24b0411cceaaef046887f6fee8e57be8e12ed07b5382a9a51eb07f56f1ec4eb02bdbb2ed567925690618862a02e831c6775019f9abe559bf7f29c1d3b5fe9
+  checksum: e1a502725ac0ad588891e4ec0e73ffa5242d44fc612161a4c09d9f5f3a31734f22be28c8bf41838d3ae779e5f5689933f0b8deeb325c755499d3648d6e8035a5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-556235](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-556235)

## This pull request addresses

We are rolling out Full-ICE support for Firefox. Currently we have low limitation on number of ICE Candidates. We will gather metrics to understand how many ICE Candidates we need, to adjust correctly new maximum number of ICE Candidates. To ensure none of them will be skipped.

## by making the following changes

This PR introduce changes which will result on submitting metrics on ICE Candidates.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Tested with JS-SDK Sample app Chrome 127, Firefox 113, 129

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
