### PR TITLE
fix(audio-mute): fix sometimes out-of-sync remote audio mute

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
@@ -428,11 +428,6 @@ SelfUtils.mutedByOthersChanged = (oldSelf, changedSelf) => {
     return false;
   }
 
-  // there is no need to trigger user update if no one muted user
-  if (changedSelf.selfIdentity === changedSelf.modifiedBy) {
-    return false;
-  }
-
   return (
     changedSelf.remoteMuted !== null &&
     (oldSelf.remoteMuted !== changedSelf.remoteMuted ||

--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -379,7 +379,11 @@ export class MuteState {
     }
     if (muted !== undefined) {
       this.state.server.remoteMute = muted;
-      this.muteLocalStream(meeting, muted, 'remotelyMuted');
+
+      // never want to unmute the local stream from a server remote mute update
+      if (muted) {
+        this.muteLocalStream(meeting, muted, 'remotelyMuted');
+      }
     }
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -380,7 +380,8 @@ export class MuteState {
     if (muted !== undefined) {
       this.state.server.remoteMute = muted;
 
-      // never want to unmute the local stream from a server remote mute update
+      // We never want to unmute the local stream from a server remote mute update.
+      // Moderated unmute is handled by a different function.
       if (muted) {
         this.muteLocalStream(meeting, muted, 'remotelyMuted');
       }

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
@@ -322,171 +322,171 @@ describe('plugin-meetings', () => {
         assert.equal(updates.isSharingBlockedChanged, false);
       });
     });
+  });
 
-    describe('isJoined', () => {
-      it(' returns true if state is joined', () => {
-        assert.deepEqual(SelfUtils.isJoined(self), true);
-      });
-
-      it(' returns true if state is not joined', () => {
-        const customSelf = {...self, state: 'NOT_JOINED'};
-
-        assert.deepEqual(SelfUtils.isJoined(customSelf), false);
-      });
-
-      it(' returns true if state is empty', () => {
-        const customSelf = {...self};
-
-        delete customSelf.state;
-
-        assert.deepEqual(SelfUtils.isJoined(customSelf), false);
-      });
+  describe('isJoined', () => {
+    it(' returns true if state is joined', () => {
+      assert.deepEqual(SelfUtils.isJoined(self), true);
     });
 
-    describe('mutedByOthersChanged', () => {
-      it('throws an error if changedSelf is not provided', function () {
-        assert.throws(
-          () => SelfUtils.mutedByOthersChanged({}, null),
-          'New self must be defined to determine if self was muted by others.'
-        );
-      });
+    it(' returns true if state is not joined', () => {
+      const customSelf = {...self, state: 'NOT_JOINED'};
 
-      it('return false when oldSelf is not defined', function () {
-        assert.equal(SelfUtils.mutedByOthersChanged(null, {remoteMuted: false}), false);
-      });
-
-      it('should return true when remoteMuted is true on entry', function () {
-        assert.equal(SelfUtils.mutedByOthersChanged(null, {remoteMuted: true}), true);
-      });
-
-      it('should return true when remoteMuted values are different', function () {
-        assert.equal(
-          SelfUtils.mutedByOthersChanged(
-            {remoteMuted: false},
-            {remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user2'}
-          ),
-          true
-        );
-      });
-
-      it('should return true when remoteMuted is true and unmuteAllowed has changed', function () {
-        assert.equal(
-          SelfUtils.mutedByOthersChanged(
-            {remoteMuted: true, unmuteAllowed: false},
-            {remoteMuted: true, unmuteAllowed: true, selfIdentity: 'user1', modifiedBy: 'user2'}
-          ),
-          true
-        );
-      });
+      assert.deepEqual(SelfUtils.isJoined(customSelf), false);
     });
 
-    describe('videoMutedByOthersChanged', () => {
-      it('returns true if changed', () => {
-        assert.equal(
-          SelfUtils.videoMutedByOthersChanged({remoteVideoMuted: true}, {remoteVideoMuted: false}),
-          true
-        );
-      });
+    it(' returns true if state is empty', () => {
+      const customSelf = {...self};
 
-      it('returns true if changed from undefined', () => {
-        assert.equal(SelfUtils.videoMutedByOthersChanged({}, {remoteVideoMuted: false}), true);
-      });
+      delete customSelf.state;
 
-      it('returns false if not changed', () => {
-        assert.equal(
-          SelfUtils.videoMutedByOthersChanged({remoteVideoMuted: false}, {remoteVideoMuted: false}),
-          false
-        );
-      });
+      assert.deepEqual(SelfUtils.isJoined(customSelf), false);
+    });
+  });
+
+  describe('mutedByOthersChanged', () => {
+    it('throws an error if changedSelf is not provided', function () {
+      assert.throws(
+        () => SelfUtils.mutedByOthersChanged({}, null),
+        'New self must be defined to determine if self was muted by others.'
+      );
     });
 
-    describe('getReplacedBreakoutMoveId', () => {
-      const deviceId = 'https://wdm-a.wbx2.com/wdm/api/v1/devices/20eabde3-4254-48da-9a24';
-      const breakoutMoveId = 'e5caeb2c-ffcc-4e06-a08a-1122e7710398';
-      const clonedSelf = cloneDeep(self);
-
-      it('get breakoutMoveId works', () => {
-        assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(self, deviceId), breakoutMoveId);
-      });
-
-      it('replaces is empty', () => {
-        clonedSelf.devices[0].replaces = undefined;
-        assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(clonedSelf, deviceId), null);
-      });
-
-      it('no self or self.devices is not array', () => {
-        assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(undefined, deviceId), null);
-
-        clonedSelf.devices = {
-          url: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/20eabde3-4254-48da-9a24',
-          deviceType: 'WEB',
-          mediaSessionsExternal: false,
-          replaces: [
-            {
-              breakoutMoveId: 'e5caeb2c-ffcc-4e06-a08a-1122e7710398',
-              lastActive: '2023-05-04T07:14:32.068Z',
-              locusUrl:
-                'https://locus-alpha-apdx.prod.meetapi.webex.com/locus/api/v1/loci/495061ca-7b3c-3b77-85ff-4e1bd58600d1',
-              replacedAt: '2023-05-04T07:16:04.905Z',
-              sessionId: 'be3147d4-c318-86d8-7611-8d24beaaca8d',
-            },
-          ],
-          state: 'JOINED',
-        };
-        assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(clonedSelf, deviceId), null);
-      });
+    it('return false when oldSelf is not defined', function () {
+      assert.equal(SelfUtils.mutedByOthersChanged(null, {remoteMuted: false}), false);
     });
 
-    describe('isRolesChanged', () => {
-      it('should return false if new self is null', () => {
-        const parsedSelf = SelfUtils.parse(self);
-
-        assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, null), false);
-      });
-
-      it('should return true if self roles has changed', () => {
-        const parsedSelf = SelfUtils.parse(self);
-        const clonedSelf = cloneDeep(parsedSelf);
-
-        clonedSelf.roles = ['COHOST'];
-
-        assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, clonedSelf), true);
-      });
-
-      it('should return false if self roles has not changed', () => {
-        const parsedSelf = SelfUtils.parse(self);
-        const clonedSelf = cloneDeep(parsedSelf);
-
-        clonedSelf.roles = ['PRESENTER'];
-
-        assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, clonedSelf), false);
-      });
+    it('should return true when remoteMuted is true on entry', function () {
+      assert.equal(SelfUtils.mutedByOthersChanged(null, {remoteMuted: true}), true);
     });
 
-    describe('interpretationChanged', () => {
-      it('should return false if new self is null', () => {
-        const parsedSelf = SelfUtils.parse(self);
+    it('should return true when remoteMuted values are different', function () {
+      assert.equal(
+        SelfUtils.mutedByOthersChanged(
+          {remoteMuted: false},
+          {remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user2'}
+        ),
+        true
+      );
+    });
 
-        assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, null), false);
-      });
+    it('should return true when remoteMuted is true and unmuteAllowed has changed', function () {
+      assert.equal(
+        SelfUtils.mutedByOthersChanged(
+          {remoteMuted: true, unmuteAllowed: false},
+          {remoteMuted: true, unmuteAllowed: true, selfIdentity: 'user1', modifiedBy: 'user2'}
+        ),
+        true
+      );
+    });
+  });
 
-      it('should return true if interpretation info has changed', () => {
-        const parsedSelf = SelfUtils.parse(self);
-        const clonedSelf = cloneDeep(parsedSelf);
+  describe('videoMutedByOthersChanged', () => {
+    it('returns true if changed', () => {
+      assert.equal(
+        SelfUtils.videoMutedByOthersChanged({remoteVideoMuted: true}, {remoteVideoMuted: false}),
+        true
+      );
+    });
 
-        clonedSelf.interpretation.sourceLanguage = 'ja';
+    it('returns true if changed from undefined', () => {
+      assert.equal(SelfUtils.videoMutedByOthersChanged({}, {remoteVideoMuted: false}), true);
+    });
 
-        assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, clonedSelf), true);
-      });
+    it('returns false if not changed', () => {
+      assert.equal(
+        SelfUtils.videoMutedByOthersChanged({remoteVideoMuted: false}, {remoteVideoMuted: false}),
+        false
+      );
+    });
+  });
 
-      it('should return false if interpretation info  has not changed', () => {
-        const parsedSelf = SelfUtils.parse(self);
-        const clonedSelf = cloneDeep(parsedSelf);
+  describe('getReplacedBreakoutMoveId', () => {
+    const deviceId = 'https://wdm-a.wbx2.com/wdm/api/v1/devices/20eabde3-4254-48da-9a24';
+    const breakoutMoveId = 'e5caeb2c-ffcc-4e06-a08a-1122e7710398';
+    const clonedSelf = cloneDeep(self);
 
-        clonedSelf.interpretation.sourceLanguage = 'en';
+    it('get breakoutMoveId works', () => {
+      assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(self, deviceId), breakoutMoveId);
+    });
 
-        assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, clonedSelf), false);
-      });
+    it('replaces is empty', () => {
+      clonedSelf.devices[0].replaces = undefined;
+      assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(clonedSelf, deviceId), null);
+    });
+
+    it('no self or self.devices is not array', () => {
+      assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(undefined, deviceId), null);
+
+      clonedSelf.devices = {
+        url: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/20eabde3-4254-48da-9a24',
+        deviceType: 'WEB',
+        mediaSessionsExternal: false,
+        replaces: [
+          {
+            breakoutMoveId: 'e5caeb2c-ffcc-4e06-a08a-1122e7710398',
+            lastActive: '2023-05-04T07:14:32.068Z',
+            locusUrl:
+              'https://locus-alpha-apdx.prod.meetapi.webex.com/locus/api/v1/loci/495061ca-7b3c-3b77-85ff-4e1bd58600d1',
+            replacedAt: '2023-05-04T07:16:04.905Z',
+            sessionId: 'be3147d4-c318-86d8-7611-8d24beaaca8d',
+          },
+        ],
+        state: 'JOINED',
+      };
+      assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(clonedSelf, deviceId), null);
+    });
+  });
+
+  describe('isRolesChanged', () => {
+    it('should return false if new self is null', () => {
+      const parsedSelf = SelfUtils.parse(self);
+
+      assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, null), false);
+    });
+
+    it('should return true if self roles has changed', () => {
+      const parsedSelf = SelfUtils.parse(self);
+      const clonedSelf = cloneDeep(parsedSelf);
+
+      clonedSelf.roles = ['COHOST'];
+
+      assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, clonedSelf), true);
+    });
+
+    it('should return false if self roles has not changed', () => {
+      const parsedSelf = SelfUtils.parse(self);
+      const clonedSelf = cloneDeep(parsedSelf);
+
+      clonedSelf.roles = ['PRESENTER'];
+
+      assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, clonedSelf), false);
+    });
+  });
+
+  describe('interpretationChanged', () => {
+    it('should return false if new self is null', () => {
+      const parsedSelf = SelfUtils.parse(self);
+
+      assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, null), false);
+    });
+
+    it('should return true if interpretation info has changed', () => {
+      const parsedSelf = SelfUtils.parse(self);
+      const clonedSelf = cloneDeep(parsedSelf);
+
+      clonedSelf.interpretation.sourceLanguage = 'ja';
+
+      assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, clonedSelf), true);
+    });
+
+    it('should return false if interpretation info  has not changed', () => {
+      const parsedSelf = SelfUtils.parse(self);
+      const clonedSelf = cloneDeep(parsedSelf);
+
+      clonedSelf.interpretation.sourceLanguage = 'en';
+
+      assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, clonedSelf), false);
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
@@ -322,169 +322,171 @@ describe('plugin-meetings', () => {
         assert.equal(updates.isSharingBlockedChanged, false);
       });
     });
-  });
 
-  describe('isJoined', () => {
-    it(' returns true if state is joined', () => {
-      assert.deepEqual(SelfUtils.isJoined(self), true);
+    describe('isJoined', () => {
+      it(' returns true if state is joined', () => {
+        assert.deepEqual(SelfUtils.isJoined(self), true);
+      });
+
+      it(' returns true if state is not joined', () => {
+        const customSelf = {...self, state: 'NOT_JOINED'};
+
+        assert.deepEqual(SelfUtils.isJoined(customSelf), false);
+      });
+
+      it(' returns true if state is empty', () => {
+        const customSelf = {...self};
+
+        delete customSelf.state;
+
+        assert.deepEqual(SelfUtils.isJoined(customSelf), false);
+      });
     });
 
-    it(' returns true if state is not joined', () => {
-      const customSelf = {...self, state: 'NOT_JOINED'};
+    describe('mutedByOthersChanged', () => {
+      it('throws an error if changedSelf is not provided', function () {
+        assert.throws(
+          () => SelfUtils.mutedByOthersChanged({}, null),
+          'New self must be defined to determine if self was muted by others.'
+        );
+      });
 
-      assert.deepEqual(SelfUtils.isJoined(customSelf), false);
+      it('return false when oldSelf is not defined', function () {
+        assert.equal(SelfUtils.mutedByOthersChanged(null, {remoteMuted: false}), false);
+      });
+
+      it('should return true when remoteMuted is true on entry', function () {
+        assert.equal(SelfUtils.mutedByOthersChanged(null, {remoteMuted: true}), true);
+      });
+
+      it('should return true when remoteMuted values are different', function () {
+        assert.equal(
+          SelfUtils.mutedByOthersChanged(
+            {remoteMuted: false},
+            {remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user2'}
+          ),
+          true
+        );
+      });
+
+      it('should return true when remoteMuted is true and unmuteAllowed has changed', function () {
+        assert.equal(
+          SelfUtils.mutedByOthersChanged(
+            {remoteMuted: true, unmuteAllowed: false},
+            {remoteMuted: true, unmuteAllowed: true, selfIdentity: 'user1', modifiedBy: 'user2'}
+          ),
+          true
+        );
+      });
     });
 
-    it(' returns true if state is empty', () => {
-      const customSelf = {...self};
+    describe('videoMutedByOthersChanged', () => {
+      it('returns true if changed', () => {
+        assert.equal(
+          SelfUtils.videoMutedByOthersChanged({remoteVideoMuted: true}, {remoteVideoMuted: false}),
+          true
+        );
+      });
 
-      delete customSelf.state;
+      it('returns true if changed from undefined', () => {
+        assert.equal(SelfUtils.videoMutedByOthersChanged({}, {remoteVideoMuted: false}), true);
+      });
 
-      assert.deepEqual(SelfUtils.isJoined(customSelf), false);
-    });
-  });
-
-  describe('mutedByOthersChanged', () => {
-    it('throws an error if changedSelf is not provided', function() {
-      assert.throws(() => SelfUtils.mutedByOthersChanged({}, null), 'New self must be defined to determine if self was muted by others.');
-    });
-
-    it('return false when oldSelf is not defined', function() {
-      assert.equal(SelfUtils.mutedByOthersChanged(null, { remoteMuted: false }), false);
-    });
-
-    it('should return true when remoteMuted is true on entry', function() {
-      assert.equal(SelfUtils.mutedByOthersChanged(null, { remoteMuted: true }), true);
+      it('returns false if not changed', () => {
+        assert.equal(
+          SelfUtils.videoMutedByOthersChanged({remoteVideoMuted: false}, {remoteVideoMuted: false}),
+          false
+        );
+      });
     });
 
-    it('should return false when selfIdentity and modifiedBy are the same', function() {
-      assert.equal(SelfUtils.mutedByOthersChanged(
-        { remoteMuted: false },
-        { remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user1' }
-      ), false);
+    describe('getReplacedBreakoutMoveId', () => {
+      const deviceId = 'https://wdm-a.wbx2.com/wdm/api/v1/devices/20eabde3-4254-48da-9a24';
+      const breakoutMoveId = 'e5caeb2c-ffcc-4e06-a08a-1122e7710398';
+      const clonedSelf = cloneDeep(self);
+
+      it('get breakoutMoveId works', () => {
+        assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(self, deviceId), breakoutMoveId);
+      });
+
+      it('replaces is empty', () => {
+        clonedSelf.devices[0].replaces = undefined;
+        assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(clonedSelf, deviceId), null);
+      });
+
+      it('no self or self.devices is not array', () => {
+        assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(undefined, deviceId), null);
+
+        clonedSelf.devices = {
+          url: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/20eabde3-4254-48da-9a24',
+          deviceType: 'WEB',
+          mediaSessionsExternal: false,
+          replaces: [
+            {
+              breakoutMoveId: 'e5caeb2c-ffcc-4e06-a08a-1122e7710398',
+              lastActive: '2023-05-04T07:14:32.068Z',
+              locusUrl:
+                'https://locus-alpha-apdx.prod.meetapi.webex.com/locus/api/v1/loci/495061ca-7b3c-3b77-85ff-4e1bd58600d1',
+              replacedAt: '2023-05-04T07:16:04.905Z',
+              sessionId: 'be3147d4-c318-86d8-7611-8d24beaaca8d',
+            },
+          ],
+          state: 'JOINED',
+        };
+        assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(clonedSelf, deviceId), null);
+      });
     });
 
-    it('should return true when remoteMuted values are different', function() {
-      assert.equal(SelfUtils.mutedByOthersChanged(
-        { remoteMuted: false },
-        { remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user2' }
-      ), true);
+    describe('isRolesChanged', () => {
+      it('should return false if new self is null', () => {
+        const parsedSelf = SelfUtils.parse(self);
+
+        assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, null), false);
+      });
+
+      it('should return true if self roles has changed', () => {
+        const parsedSelf = SelfUtils.parse(self);
+        const clonedSelf = cloneDeep(parsedSelf);
+
+        clonedSelf.roles = ['COHOST'];
+
+        assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, clonedSelf), true);
+      });
+
+      it('should return false if self roles has not changed', () => {
+        const parsedSelf = SelfUtils.parse(self);
+        const clonedSelf = cloneDeep(parsedSelf);
+
+        clonedSelf.roles = ['PRESENTER'];
+
+        assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, clonedSelf), false);
+      });
     });
 
-    it('should return true when remoteMuted is true and unmuteAllowed has changed', function() {
-      assert.equal(SelfUtils.mutedByOthersChanged(
-        { remoteMuted: true, unmuteAllowed: false },
-        { remoteMuted: true, unmuteAllowed: true, selfIdentity: 'user1', modifiedBy: 'user2' }
-      ), true);
-    });
-  });
+    describe('interpretationChanged', () => {
+      it('should return false if new self is null', () => {
+        const parsedSelf = SelfUtils.parse(self);
 
-  describe('videoMutedByOthersChanged', () => {
-    it('returns true if changed', () => {
-      assert.equal(
-        SelfUtils.videoMutedByOthersChanged({remoteVideoMuted: true}, {remoteVideoMuted: false}),
-        true
-      );
-    });
+        assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, null), false);
+      });
 
-    it('returns true if changed from undefined', () => {
-      assert.equal(SelfUtils.videoMutedByOthersChanged({}, {remoteVideoMuted: false}), true);
-    });
+      it('should return true if interpretation info has changed', () => {
+        const parsedSelf = SelfUtils.parse(self);
+        const clonedSelf = cloneDeep(parsedSelf);
 
-    it('returns false if not changed', () => {
-      assert.equal(
-        SelfUtils.videoMutedByOthersChanged({remoteVideoMuted: false}, {remoteVideoMuted: false}),
-        false
-      );
-    });
-  });
+        clonedSelf.interpretation.sourceLanguage = 'ja';
 
-  describe('getReplacedBreakoutMoveId', () => {
-    const deviceId = 'https://wdm-a.wbx2.com/wdm/api/v1/devices/20eabde3-4254-48da-9a24';
-    const breakoutMoveId = 'e5caeb2c-ffcc-4e06-a08a-1122e7710398';
-    const clonedSelf = cloneDeep(self);
+        assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, clonedSelf), true);
+      });
 
-    it('get breakoutMoveId works', () => {
-      assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(self, deviceId), breakoutMoveId);
-    });
+      it('should return false if interpretation info  has not changed', () => {
+        const parsedSelf = SelfUtils.parse(self);
+        const clonedSelf = cloneDeep(parsedSelf);
 
-    it('replaces is empty', () => {
-      clonedSelf.devices[0].replaces = undefined;
-      assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(clonedSelf, deviceId), null);
-    });
+        clonedSelf.interpretation.sourceLanguage = 'en';
 
-    it('no self or self.devices is not array', () => {
-      assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(undefined, deviceId), null);
-
-      clonedSelf.devices = {
-        url: 'https://wdm-a.wbx2.com/wdm/api/v1/devices/20eabde3-4254-48da-9a24',
-        deviceType: 'WEB',
-        mediaSessionsExternal: false,
-        replaces: [
-          {
-            breakoutMoveId: 'e5caeb2c-ffcc-4e06-a08a-1122e7710398',
-            lastActive: '2023-05-04T07:14:32.068Z',
-            locusUrl:
-              'https://locus-alpha-apdx.prod.meetapi.webex.com/locus/api/v1/loci/495061ca-7b3c-3b77-85ff-4e1bd58600d1',
-            replacedAt: '2023-05-04T07:16:04.905Z',
-            sessionId: 'be3147d4-c318-86d8-7611-8d24beaaca8d',
-          },
-        ],
-        state: 'JOINED',
-      };
-      assert.deepEqual(SelfUtils.getReplacedBreakoutMoveId(clonedSelf, deviceId), null);
-    });
-  });
-
-  describe('isRolesChanged', () => {
-    it('should return false if new self is null', () => {
-      const parsedSelf = SelfUtils.parse(self);
-
-      assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, null), false);
-    });
-
-    it('should return true if self roles has changed', () => {
-      const parsedSelf = SelfUtils.parse(self);
-      const clonedSelf = cloneDeep(parsedSelf);
-
-      clonedSelf.roles = ['COHOST'];
-
-      assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, clonedSelf), true);
-    });
-
-    it('should return false if self roles has not changed', () => {
-      const parsedSelf = SelfUtils.parse(self);
-      const clonedSelf = cloneDeep(parsedSelf);
-
-      clonedSelf.roles = ['PRESENTER'];
-
-      assert.deepEqual(SelfUtils.isRolesChanged(parsedSelf, clonedSelf), false);
-    });
-  });
-
-  describe('interpretationChanged', () => {
-    it('should return false if new self is null', () => {
-      const parsedSelf = SelfUtils.parse(self);
-
-      assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, null), false);
-    });
-
-    it('should return true if interpretation info has changed', () => {
-      const parsedSelf = SelfUtils.parse(self);
-      const clonedSelf = cloneDeep(parsedSelf);
-
-      clonedSelf.interpretation.sourceLanguage = 'ja';
-
-      assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, clonedSelf), true);
-    });
-
-    it('should return false if interpretation info  has not changed', () => {
-      const parsedSelf = SelfUtils.parse(self);
-      const clonedSelf = cloneDeep(parsedSelf);
-
-      clonedSelf.interpretation.sourceLanguage = 'en';
-
-      assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, clonedSelf), false);
+        assert.deepEqual(SelfUtils.interpretationChanged(parsedSelf, clonedSelf), false);
+      });
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
@@ -113,6 +113,30 @@ describe('plugin-meetings', () => {
       assert.isTrue(audio.isRemotelyMuted());
     });
 
+    it('does not locally unmute on a server unmute', async () => {
+      const setServerMutedSpy = meeting.mediaProperties.audioStream.setServerMuted;
+
+      // simulate remote mute
+      audio.handleServerRemoteMuteUpdate(meeting, true, true);
+
+      assert.isTrue(audio.isRemotelyMuted());
+      assert.isTrue(audio.isLocallyMuted());
+
+      // mutes local
+      assert.calledOnceWithExactly(setServerMutedSpy, true, 'remotelyMuted');
+
+      setServerMutedSpy.resetHistory();
+
+      // simulate remote unmute
+      audio.handleServerRemoteMuteUpdate(meeting, false, true);
+
+      assert.isFalse(audio.isRemotelyMuted());
+      assert.isTrue(audio.isLocallyMuted());
+
+      // does not unmute local
+      assert.notCalled(setServerMutedSpy);
+    });
+
     it('does local audio unmute if localAudioUnmuteRequired is received', async () => {
       // first we need to have the local stream user muted
       meeting.mediaProperties.audioStream.userMuted = true;


### PR DESCRIPTION
# COMPLETES

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-555818

## This pull request addresses

Fixes a BEMS case defect where remote audio mute can get out of sync with local audio mute.

BEMS space: webexteams://im?space=c4706ce0-56e0-11ef-81df-a39e6dd40a42

Steps to recreate bug:

1. start a meeting as host, unmuted
2. uncheck "allow participants to unmute"
3. mute 
4. unmute
5. mute (problem: sdk's representation of server remote audio is still unmuted)
6. unmute (because sdk thinks remote is already unmuted, we do not try to change it)

The server remote audio is still muted (notice the muted icon in the participant list)
With the fix, the server remote audio is unmuted as expected.

## by making the following changes

First, I needed to revert a [fix from months ago](https://github.com/webex/webex-js-sdk/pull/3621). This fix was causing the locus diff update from step 5 to be skipped because the modifiedBy value was the same as the local user.  We did *not* skip the update in step 3 because modifiedBy was undefined.  I met with Rajesh Kadikar about this and he indicated that the modifiedBy should contain the current user in this scenario, and that we should not be skipping locus updates, even it they were modified by the current user.

Second, I needed to find a new way to fix what was reverted. I added console.logs in various places in the flow and found that if you unmute and mute quickly, `_LocalMicrophoneStream.setUserMuted(true)` happens before we receive the locus diff from the unmute.  When the locus diff eventually comes in, `handleServerRemoteMuteUpdate()` unmutes the local stream to match the remote mute state, which should not be done.  So I added an `if` around the local stream update to only execute it when muting, not unmuting.

While testing this PR, I found a few problems around host mute/unmute (unrelated to this change) and opened these Jiras:

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-559101
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-559095

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Manually tested the scenario in the BEMS Jira (SPARK-555818).
Manually tested the scenario in [a related BEMS Jira](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-556880).
Manually tested the scenario from [the reverted PR/Jira](https://github.com/webex/webex-js-sdk/pull/3621).
Manually tested host unmuting a user when in a moderated meeting.

Updated unit tests.

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly
