### PR TITLE
fix(config): enable inactivity enforcement

### DIFF
--- a/packages/@webex/internal-plugin-device/src/config.js
+++ b/packages/@webex/internal-plugin-device/src/config.js
@@ -38,7 +38,7 @@ export default {
      *
      * @type {boolean}
      */
-    enableInactivityEnforcement: false,
+    enableInactivityEnforcement: true,
 
     /**
      * When true, the device registration will include a ttl value of


### PR DESCRIPTION
Control Hub offers an inactivity timeout for organizations.  It currently doesn't work on the web because of an SDK config value.  Making this true allows the web client to honor the Control Hub setting.

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-527321
## This pull request addresses

See above.

## by making the following changes

Sets the config value to true
<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
