### PR TITLE
fix(plugin-meetings): clientSignallingProtocol stat

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -455,6 +455,9 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
         },
         intervals: payload.intervals,
         callingServiceType: 'LOCUS',
+        meetingJoinInfo: {
+          clientSignallingProtocol: 'WebRTC',
+        },
         sourceMetadata: {
           applicationSoftwareType: CLIENT_NAME,
           // @ts-ignore

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -1454,6 +1454,9 @@ describe('internal-plugin-metrics', () => {
             eventData: {webClientDomain: 'whatever'},
             intervals: [{}],
             callingServiceType: 'LOCUS',
+            meetingJoinInfo: {
+              clientSignallingProtocol: 'WebRTC',
+            },
             sourceMetadata: {
               applicationSoftwareType: 'webex-js-sdk',
               applicationSoftwareVersion: 'webex-version',
@@ -1490,6 +1493,9 @@ describe('internal-plugin-metrics', () => {
               eventData: {webClientDomain: 'whatever'},
               intervals: [{}],
               callingServiceType: 'LOCUS',
+              meetingJoinInfo: {
+                clientSignallingProtocol: 'WebRTC',
+              },
               sourceMetadata: {
                 applicationSoftwareType: 'webex-js-sdk',
                 applicationSoftwareVersion: 'webex-version',
@@ -1524,6 +1530,9 @@ describe('internal-plugin-metrics', () => {
             eventData: {webClientDomain: 'whatever'},
             intervals: [{}],
             callingServiceType: 'LOCUS',
+            meetingJoinInfo: {
+              clientSignallingProtocol: 'WebRTC',
+            },
             sourceMetadata: {
               applicationSoftwareType: 'webex-js-sdk',
               applicationSoftwareVersion: 'webex-version',


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [WEBEX-396966](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-396966)

## This pull request addresses

Missing `clientSignallingProtocol` stat in media quality event

## by making the following changes

Fill `clientSignallingProtocol` at `meetingJoinInfo.clientSignallingProtocol` with value `WebRTC`

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- [x] Unit tests
- [ ] Stat correctly shows on automateddiagnostic (with test-app)
- [ ] No validation errors on [grafana](https://wapgrafana-staging.webex.com/a/cisco-pinot-app/discover?dataSource=Pinot+PROD%28Internal%29&table=media_analytics_ops_metrics&timeStamp=ingestTimestamp&sortOrder=ingestTimestamp%2Cdesc&filters=%7B"filter"%3A%5B%7B"selectedColumn"%3A"intervalMetadata_subClientType"%2C"selectedColumnValues"%3A%5B"WEB_APP"%5D%2C"selectedOperation"%3A"in"%2C"selectedDataType"%3A"STRING"%2C"selectedJson"%3A""%2C"isFilterShow"%3Atrue%7D%2C%7B"selectedColumn"%3A"eventName"%2C"selectedColumnValues"%3A%5B"client.mediaquality.event"%5D%2C"selectedOperation"%3A"in"%2C"selectedDataType"%3A"STRING"%2C"selectedJson"%3A""%2C"isFilterShow"%3Atrue%7D%5D%7D&columns=%5B"errors.errorInfo.error"%5D)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
