### PR TITLE
feat(voicea-highlight): added-highlights

### DIFF
--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -851,6 +851,8 @@
               <div class="btn-group u-mb">
                 <button id="gc-toggle-transcription" type="button"
                   onclick="toggleTranscription()" class="btn-code" data-enabled="false">Start Transcription</button>
+                <button id="gc-toggle-highlights" type="button"
+                  onclick="toggleHighlights()" class="btn-code" data-enabled="false">Show Highlights</button>
                 <br>
                 Caption Language: <select id="voicea-caption-language" style="display: inline;" disabled></select><button id="voicea-caption-language-btn" onclick="setCaptionLanguage()" disabled>meeting.setCaptionLanguage()</button><br/>
                 Spoken Language: <select id="voicea-spoken-language" style="display: inline;" disabled></select><button id="voicea-spoken-language-btn"  onclick="setSpokenLanguage()" disabled>meeting.setSpokenLanguage()</button> <p id="only-host-spoken-language" class="hidden">Only Meeting Host can Set Spoken Language</p>
@@ -858,6 +860,8 @@
               </div>
               <textarea id="gc-transcription-content"
                 disabled="">Transcription Content: Webex Assistant must be enabled, check the console!</textarea>
+              <textarea id="gc-highlights-content"
+                disabled="">Highlighting: Webex Assistant must be enabled, check the console!</textarea>
             </div>
           </fieldset>
         </div>

--- a/packages/@webex/internal-plugin-voicea/src/index.ts
+++ b/packages/@webex/internal-plugin-voicea/src/index.ts
@@ -1,10 +1,11 @@
 import * as WebexCore from '@webex/webex-core';
 
 import VoiceaChannel from './voicea';
-import type {MeetingTranscriptPayload} from './voicea.types';
+import type {MeetingTranscriptPayload, MeetingHighlightPayload} from './voicea.types';
 
 WebexCore.registerInternalPlugin('voicea', VoiceaChannel, {});
 
 export {default} from './voicea';
 export {type MeetingTranscriptPayload};
+export {type MeetingHighlightPayload};
 export {EVENT_TRIGGERS, TURN_ON_CAPTION_STATUS} from './constants';

--- a/packages/@webex/internal-plugin-voicea/src/voicea.types.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.types.ts
@@ -103,6 +103,15 @@ type MeetingTranscriptPayload = {
   transcripts: Array<MeetingTranscripts>;
 };
 
+type MeetingHighlightPayload = {
+  csis: string;
+  highlightId: string;
+  text: string;
+  highlightLabel: string;
+  highlightSource: string;
+  timestamp?: string;
+};
+
 export type {
   AnnouncementPayload,
   CaptionLanguageResponse,
@@ -111,4 +120,5 @@ export type {
   Highlight,
   IVoiceaChannel,
   MeetingTranscriptPayload,
+  MeetingHighlightPayload,
 };

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -365,6 +365,7 @@ export const EVENT_TRIGGERS = {
   MEETING_STOPPED_RECEIVING_TRANSCRIPTION: 'meeting:receiveTranscription:stopped',
   MEETING_MANUAL_CAPTION_UPDATED: 'meeting:manualCaptionControl:updated',
   MEETING_CAPTION_RECEIVED: 'meeting:caption-received',
+  MEETING_HIGHLIGHT_CREATED: 'meeting:highlight-created',
 };
 
 export const EVENT_TYPES = {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-509136](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-509136) >

## This pull request addresses

* Added transcription highlighting to the meeting sdk.
* **NOTE** - This only works for orgs which have webex ai assistant toggle turned off (new one)

## by making the following changes

* Added code to talk to locus on the old webex assistant so as to enable highlighting.
* Emmitting a highlight event from meeting sdk with the required object.
* Added code changes to the sample app to utilise this.
* Added unit tests.

<!-- You may include screenshots -->

### Screenshot of highlights object
![Screenshot 2024-09-04 at 11 21 16 AM](https://github.com/user-attachments/assets/cf984ad5-a256-4d29-83d9-fb891dec1ed3)


### Screenshot of Sample App
![Screenshot 2024-09-04 at 11 23 34 AM](https://github.com/user-attachments/assets/48cd3294-d12e-4f40-a684-3fcc014ea085)


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
