### PR TITLE
fix(plugin-meetings): add to peer connection bare turn tcp server

### DIFF
--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -163,6 +163,19 @@ Media.createMediaConnection = (
   // we might not have any TURN server if TURN discovery failed or wasn't done or
   // we might get an empty TURN url if we land on a video mesh node
   if (turnServerInfo?.url) {
+    if (!isBrowser('firefox')) {
+      let bareTurnServer = turnServerInfo.url;
+      bareTurnServer = bareTurnServer.replace('turns', 'turn');
+      bareTurnServer = bareTurnServer.replace('443', '5004');
+
+      iceServers.push({
+        urls: bareTurnServer,
+        username: turnServerInfo.username || '',
+        credential: turnServerInfo.password || '',
+      });
+    }
+
+    // TURN-TLS server
     iceServers.push({
       urls: turnServerInfo.url,
       username: turnServerInfo.username || '',

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -165,7 +165,7 @@ Media.createMediaConnection = (
   if (turnServerInfo?.url) {
     if (!isBrowser('firefox')) {
       let bareTurnServer = turnServerInfo.url;
-      bareTurnServer = bareTurnServer.replace('turns', 'turn');
+      bareTurnServer = bareTurnServer.replace('turns:', 'turn:');
       bareTurnServer = bareTurnServer.replace('443', '5004');
 
       iceServers.push({

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
@@ -16,39 +16,39 @@ describe('createMediaConnection', () => {
     id: 'roap media connection',
   };
   const fakeTrack = {
-    id: 'any fake track'
-  }
+    id: 'any fake track',
+  };
   const fakeAudioStream = {
     outputStream: {
       getTracks: () => {
         return [fakeTrack];
-      }
-    }
+      },
+    },
   };
   const fakeVideoStream = {
     outputStream: {
       getTracks: () => {
         return [fakeTrack];
-      }
-    }
+      },
+    },
   };
   const fakeShareVideoStream = {
     outputStream: {
       getTracks: () => {
         return [fakeTrack];
-      }
-    }
+      },
+    },
   };
   const fakeShareAudioStream = {
     outputStream: {
       getTracks: () => {
         return [fakeTrack];
-      }
-    }
+      },
+    },
   };
   afterEach(() => {
     sinon.restore();
-    clock.uninstall()
+    clock.uninstall();
   });
 
   it('creates a RoapMediaConnection when multistream is disabled', () => {
@@ -80,7 +80,7 @@ describe('createMediaConnection', () => {
       enableRtx: ENABLE_RTX,
       enableExtmap: ENABLE_EXTMAP,
       turnServerInfo: {
-        url: 'turn server url',
+        url: 'turns:turn-server-url:443?transport=tcp',
         username: 'turn username',
         password: 'turn password',
       },
@@ -91,7 +91,12 @@ describe('createMediaConnection', () => {
       {
         iceServers: [
           {
-            urls: 'turn server url',
+            urls: 'turn:turn-server-url:5004?transport=tcp',
+            username: 'turn username',
+            credential: 'turn password',
+          },
+          {
+            urls: 'turns:turn-server-url:443?transport=tcp',
             username: 'turn username',
             credential: 'turn password',
           },
@@ -146,7 +151,7 @@ describe('createMediaConnection', () => {
         },
       },
       turnServerInfo: {
-        url: 'turn server url',
+        url: 'turns:turn-server-url:443?transport=tcp',
         username: 'turn username',
         password: 'turn password',
       },
@@ -158,7 +163,12 @@ describe('createMediaConnection', () => {
       {
         iceServers: [
           {
-            urls: 'turn server url',
+            urls: 'turn:turn-server-url:5004?transport=tcp',
+            username: 'turn username',
+            credential: 'turn password',
+          },
+          {
+            urls: 'turns:turn-server-url:443?transport=tcp',
             username: 'turn username',
             credential: 'turn password',
           },
@@ -171,7 +181,10 @@ describe('createMediaConnection', () => {
 
   [
     {testCase: 'turnServerInfo is undefined', turnServerInfo: undefined},
-    {testCase: 'turnServerInfo.url is empty string', turnServerInfo: {url: '', username: 'turn username', password: 'turn password'}},
+    {
+      testCase: 'turnServerInfo.url is empty string',
+      turnServerInfo: {url: '', username: 'turn username', password: 'turn password'},
+    },
   ].forEach(({testCase, turnServerInfo}) => {
     it(`passes empty ICE servers array to MultistreamRoapMediaConnection if ${testCase} (multistream enabled)`, () => {
       const multistreamRoapMediaConnectionConstructorStub = sinon
@@ -198,7 +211,7 @@ describe('createMediaConnection', () => {
           iceServers: [],
         },
         'meeting id'
-        );
+      );
     });
   });
 
@@ -232,7 +245,10 @@ describe('createMediaConnection', () => {
 
   [
     {testCase: 'turnServerInfo is undefined', turnServerInfo: undefined},
-    {testCase: 'turnServerInfo.url is empty string', turnServerInfo: {url: '', username: 'turn username', password: 'turn password'}},
+    {
+      testCase: 'turnServerInfo.url is empty string',
+      turnServerInfo: {url: '', username: 'turn username', password: 'turn password'},
+    },
   ].forEach(({testCase, turnServerInfo}) => {
     it(`passes empty ICE servers array to RoapMediaConnection if ${testCase} (multistream disabled)`, () => {
       const roapMediaConnectionConstructorStub = sinon

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -625,7 +625,9 @@ describe('plugin-meetings', () => {
 
         beforeEach(() => {
           meeting.join = sinon.stub().returns(Promise.resolve(fakeJoinResult));
-          addMediaInternalStub = sinon.stub(meeting, 'addMediaInternal').returns(Promise.resolve(test4));
+          addMediaInternalStub = sinon
+            .stub(meeting, 'addMediaInternal')
+            .returns(Promise.resolve(test4));
 
           webex.meetings.reachability.getReachabilityResults.resolves(fakeReachabilityResults);
 
@@ -656,12 +658,21 @@ describe('plugin-meetings', () => {
             meeting,
             fakeJoinResult
           );
-          assert.calledOnceWithExactly(meeting.addMediaInternal, sinon.match.any, fakeTurnServerInfo, false, mediaOptions);
+          assert.calledOnceWithExactly(
+            meeting.addMediaInternal,
+            sinon.match.any,
+            fakeTurnServerInfo,
+            false,
+            mediaOptions
+          );
 
           assert.deepEqual(result, {join: fakeJoinResult, media: test4});
 
           // resets joinWithMediaRetryInfo
-          assert.deepEqual(meeting.joinWithMediaRetryInfo, {isRetry: false, prevJoinResponse: undefined});
+          assert.deepEqual(meeting.joinWithMediaRetryInfo, {
+            isRetry: false,
+            prevJoinResponse: undefined,
+          });
         });
 
         it("should not call handleTurnDiscoveryHttpResponse if we don't send a TURN discovery request with join", async () => {
@@ -681,7 +692,13 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(generateTurnDiscoveryRequestMessageStub, meeting, true);
           assert.notCalled(handleTurnDiscoveryHttpResponseStub);
           assert.notCalled(abortTurnDiscoveryStub);
-          assert.calledOnceWithExactly(meeting.addMediaInternal, sinon.match.any, undefined, false, mediaOptions);
+          assert.calledOnceWithExactly(
+            meeting.addMediaInternal,
+            sinon.match.any,
+            undefined,
+            false,
+            mediaOptions
+          );
 
           assert.deepEqual(result, {join: fakeJoinResult, media: test4});
           assert.equal(meeting.turnServerUsed, false);
@@ -711,7 +728,13 @@ describe('plugin-meetings', () => {
             fakeJoinResult
           );
           assert.calledOnceWithExactly(abortTurnDiscoveryStub);
-          assert.calledOnceWithExactly(meeting.addMediaInternal, sinon.match.any, undefined, false, mediaOptions);
+          assert.calledOnceWithExactly(
+            meeting.addMediaInternal,
+            sinon.match.any,
+            undefined,
+            false,
+            mediaOptions
+          );
 
           assert.deepEqual(result, {join: fakeJoinResult, media: test4});
         });
@@ -758,12 +781,20 @@ describe('plugin-meetings', () => {
           );
 
           // resets joinWithMediaRetryInfo
-          assert.deepEqual(meeting.joinWithMediaRetryInfo, {isRetry: false, prevJoinResponse: undefined});
+          assert.deepEqual(meeting.joinWithMediaRetryInfo, {
+            isRetry: false,
+            prevJoinResponse: undefined,
+          });
         });
 
         it('should resolve if join() fails the first time but succeeds the second time', async () => {
           const error = new Error('fake');
-          meeting.join = sinon.stub().onFirstCall().returns(Promise.reject(error)).onSecondCall().returns(Promise.resolve(fakeJoinResult));
+          meeting.join = sinon
+            .stub()
+            .onFirstCall()
+            .returns(Promise.reject(error))
+            .onSecondCall()
+            .returns(Promise.resolve(fakeJoinResult));
           const leaveStub = sinon.stub(meeting, 'leave').resolves();
 
           const result = await meeting.joinWithMedia({
@@ -795,7 +826,10 @@ describe('plugin-meetings', () => {
           assert.deepEqual(result, {join: fakeJoinResult, media: test4});
 
           // resets joinWithMediaRetryInfo
-          assert.deepEqual(meeting.joinWithMediaRetryInfo, {isRetry: false, prevJoinResponse: undefined});
+          assert.deepEqual(meeting.joinWithMediaRetryInfo, {
+            isRetry: false,
+            prevJoinResponse: undefined,
+          });
         });
 
         it('should fail if called with allowMediaInLobby:false', async () => {
@@ -827,7 +861,6 @@ describe('plugin-meetings', () => {
             resourceId: 'some resource',
             reason: 'joinWithMedia failure',
           });
-
 
           // Behavioral metric is sent on both calls of joinWithMedia
           assert.calledTwice(Metrics.sendBehavioralMetric);
@@ -1068,12 +1101,15 @@ describe('plugin-meetings', () => {
           const addMediaError = new Error('fake addMedia error');
           addMediaError.name = 'SdpOfferCreationError';
 
-          meeting.addMediaInternal.rejects(addMediaError)
+          meeting.addMediaInternal.rejects(addMediaError);
 
-          await assert.isRejected(meeting.joinWithMedia({
-            joinOptions,
-            mediaOptions,
-          }), addMediaError);
+          await assert.isRejected(
+            meeting.joinWithMedia({
+              joinOptions,
+              mediaOptions,
+            }),
+            addMediaError
+          );
 
           // check that only 1 attempt was done
           assert.calledOnce(meeting.join);
@@ -1339,10 +1375,7 @@ describe('plugin-meetings', () => {
 
         it('should trigger meeting:caption-received event', () => {
           meeting.voiceaListenerCallbacks[VOICEAEVENTS.NEW_CAPTION]({});
-          assert.calledWith(
-            meeting.trigger,
-            EVENT_TRIGGERS.MEETING_CAPTION_RECEIVED
-          );
+          assert.calledWith(meeting.trigger, EVENT_TRIGGERS.MEETING_CAPTION_RECEIVED);
         });
 
         it('should trigger meeting:receiveTranscription:started event', () => {
@@ -1355,10 +1388,7 @@ describe('plugin-meetings', () => {
 
         it('should trigger meeting:caption-received event', () => {
           meeting.voiceaListenerCallbacks[VOICEAEVENTS.NEW_CAPTION]({});
-          assert.calledWith(
-            meeting.trigger,
-            EVENT_TRIGGERS.MEETING_CAPTION_RECEIVED
-          );
+          assert.calledWith(meeting.trigger, EVENT_TRIGGERS.MEETING_CAPTION_RECEIVED);
         });
       });
 
@@ -1513,11 +1543,7 @@ describe('plugin-meetings', () => {
 
         it('turns off llm online, emits transcription connected events', () => {
           meeting.handleLLMOnline();
-          assert.calledOnceWithExactly(
-            webex.internal.llm.off,
-            'online',
-            meeting.handleLLMOnline
-          );
+          assert.calledOnceWithExactly(webex.internal.llm.off, 'online', meeting.handleLLMOnline);
           assert.calledWith(
             TriggerProxy.trigger,
             sinon.match.instanceOf(Meeting),
@@ -1579,11 +1605,7 @@ describe('plugin-meetings', () => {
             assert.calledOnce(MeetingUtil.joinMeeting);
             assert.calledOnce(meeting.setLocus);
             assert.equal(result, joinMeetingResult);
-            assert.calledWith(
-              webex.internal.llm.on,
-              'online',
-              meeting.handleLLMOnline
-            );
+            assert.calledWith(webex.internal.llm.on, 'online', meeting.handleLLMOnline);
           });
 
           [true, false].forEach((enableMultistream) => {
@@ -1906,7 +1928,9 @@ describe('plugin-meetings', () => {
           };
           meeting.mediaProperties.setMediaDirection = sinon.stub().returns(true);
           meeting.mediaProperties.waitForMediaConnectionConnected = sinon.stub().resolves();
-          meeting.mediaProperties.getCurrentConnectionInfo = sinon.stub().resolves({connectionType: 'udp', selectedCandidatePairChanges: 2, numTransports: 1});
+          meeting.mediaProperties.getCurrentConnectionInfo = sinon
+            .stub()
+            .resolves({connectionType: 'udp', selectedCandidatePairChanges: 2, numTransports: 1});
           meeting.audio = muteStateStub;
           meeting.video = muteStateStub;
           sinon.stub(Media, 'createMediaConnection').returns(fakeMediaConnection);
@@ -1920,7 +1944,12 @@ describe('plugin-meetings', () => {
           // normally the first Roap message we send is creating confluence, so mock LocusMediaRequest.isConfluenceCreated()
           // to return false the first time it's called and true the 2nd time, to simulate how it would happen for real
           meeting.locusMediaRequest = {
-            isConfluenceCreated: sinon.stub().onFirstCall().returns(false).onSecondCall().returns(true)
+            isConfluenceCreated: sinon
+              .stub()
+              .onFirstCall()
+              .returns(false)
+              .onSecondCall()
+              .returns(true),
           };
         });
 
@@ -2485,7 +2514,6 @@ describe('plugin-meetings', () => {
         it('should reject if waitForMediaConnectionConnected() rejects after turn server retry', async () => {
           const FAKE_ERROR = {fatal: true};
           const getErrorPayloadForClientErrorCodeStub =
-
             (webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode =
               sinon.stub().returns(FAKE_ERROR));
           webex.meetings.reachability = {
@@ -2690,9 +2718,16 @@ describe('plugin-meetings', () => {
         it('should resolve if waitForMediaConnectionConnected() rejects the first time but resolves the second time', async () => {
           const FAKE_ERROR = {fatal: true};
           webex.meetings.reachability = {
-            isWebexMediaBackendUnreachable: sinon.stub().onCall(0).rejects().onCall(1).resolves(true).onCall(2).resolves(false),
+            isWebexMediaBackendUnreachable: sinon
+              .stub()
+              .onCall(0)
+              .rejects()
+              .onCall(1)
+              .resolves(true)
+              .onCall(2)
+              .resolves(false),
             getReachabilityMetrics: sinon.stub().resolves({}),
-          }
+          };
           const getErrorPayloadForClientErrorCodeStub =
             (webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode =
               sinon.stub().returns(FAKE_ERROR));
@@ -3445,9 +3480,9 @@ describe('plugin-meetings', () => {
                 .returns(clientErrorCode);
 
               meeting.meetingState = 'ACTIVE';
-              meeting.mediaProperties.waitForMediaConnectionConnected.rejects(
-                {iceConnected: false}
-              );
+              meeting.mediaProperties.waitForMediaConnectionConnected.rejects({
+                iceConnected: false,
+              });
 
               let errorThrown = false;
 
@@ -3562,12 +3597,18 @@ describe('plugin-meetings', () => {
             meeting.meetingState = 'ACTIVE';
             meeting.selfUrl = 'selfUrl';
             meeting.mediaProperties.waitForMediaConnectionConnected = sinon.stub().resolves();
-            meeting.mediaProperties.getCurrentConnectionInfo = sinon.stub().resolves({connectionType: 'udp', selectedCandidatePairChanges: 2, numTransports: 1});
+            meeting.mediaProperties.getCurrentConnectionInfo = sinon
+              .stub()
+              .resolves({connectionType: 'udp', selectedCandidatePairChanges: 2, numTransports: 1});
             meeting.setMercuryListener = sinon.stub();
             meeting.locusInfo.onFullLocus = sinon.stub();
             meeting.webex.meetings.geoHintInfo = {regionCode: 'EU', countryCode: 'UK'};
             meeting.roap.doTurnDiscovery = sinon.stub().resolves({
-              turnServerInfo: {url: 'turn-url', username: 'turn user', password: 'turn password'},
+              turnServerInfo: {
+                url: 'turns:turn-server-url:443?transport=tcp',
+                username: 'turn user',
+                password: 'turn password',
+              },
               turnDiscoverySkippedReason: 'reachability',
             });
             meeting.deferSDPAnswer = new Defer();
@@ -3580,7 +3621,18 @@ describe('plugin-meetings', () => {
             // setup things that are expected to be the same across all the tests and are actually irrelevant for these tests
             expectedDebugId = `MC-${meeting.id.substring(0, 4)}`;
             expectedMediaConnectionConfig = {
-              iceServers: [{urls: 'turn-url', username: 'turn user', credential: 'turn password'}],
+              iceServers: [
+                {
+                  urls: 'turn:turn-server-url:5004?transport=tcp',
+                  username: 'turn user',
+                  credential: 'turn password',
+                },
+                {
+                  urls: 'turns:turn-server-url:443?transport=tcp',
+                  username: 'turn user',
+                  credential: 'turn password',
+                },
+              ],
               skipInactiveTransceivers: false,
               requireH264: true,
               sdpMunging: {
@@ -3665,13 +3717,11 @@ describe('plugin-meetings', () => {
             // that's being tested in these tests)
             meeting.webex.meetings.registered = true;
             meeting.webex.internal.device.config = {};
-            sinon
-              .stub(MeetingUtil, 'joinMeeting')
-              .resolves({
-                id: 'fake locus from mocked join request',
-                locusUrl: 'fake locus url',
-                mediaId: 'fake media id',
-              });
+            sinon.stub(MeetingUtil, 'joinMeeting').resolves({
+              id: 'fake locus from mocked join request',
+              locusUrl: 'fake locus url',
+              mediaId: 'fake media id',
+            });
             await meeting.join({enableMultistream: isMultistream});
           });
 
@@ -3701,7 +3751,8 @@ describe('plugin-meetings', () => {
 
             for (let idx = 0; idx < roapMediaConnectionToCheck.on.callCount; idx += 1) {
               if (
-                roapMediaConnectionToCheck.on.getCall(idx).args[0] === MediaConnectionEventNames.ROAP_MESSAGE_TO_SEND
+                roapMediaConnectionToCheck.on.getCall(idx).args[0] ===
+                MediaConnectionEventNames.ROAP_MESSAGE_TO_SEND
               ) {
                 return roapMediaConnectionToCheck.on.getCall(idx).args[1];
               }
@@ -4148,13 +4199,13 @@ describe('plugin-meetings', () => {
             await meeting.addMedia({
               localStreams: {microphone: fakeMicrophoneStream},
               audioEnabled: false,
-              videoEnabled: false
+              videoEnabled: false,
             });
             await simulateRoapOffer();
             await simulateRoapOk();
 
             assert.notCalled(handleDeviceLoggingSpy);
-          })
+          });
 
           it('addMedia() works correctly when media is disabled with no streams to publish', async () => {
             await meeting.addMedia({audioEnabled: false});
@@ -6589,14 +6640,14 @@ describe('plugin-meetings', () => {
         beforeEach(() => {
           sandbox = sinon.createSandbox();
           meeting.statsAnalyzer = {
-            stopAnalyzer: sinon.stub().returns(Promise.resolve())
+            stopAnalyzer: sinon.stub().returns(Promise.resolve()),
           };
 
           meeting.reconnectionManager = {
-            cleanUp: sinon.stub()
+            cleanUp: sinon.stub(),
           };
 
-          meeting.cleanupLocalStreams=sinon.stub();
+          meeting.cleanupLocalStreams = sinon.stub();
           meeting.closeRemoteStreams = sinon.stub().returns(Promise.resolve());
           meeting.closePeerConnections = sinon.stub().returns(Promise.resolve());
           meeting.unsetRemoteStreams = sinon.stub();
@@ -6678,7 +6729,6 @@ describe('plugin-meetings', () => {
             'SELF_OBSERVING'
           );
 
-
           // Verify that the event handler behaves as expected
           expect(meeting.statsAnalyzer.stopAnalyzer.calledOnce).to.be.true;
           expect(meeting.closeRemoteStreams.calledOnce).to.be.true;
@@ -6690,11 +6740,13 @@ describe('plugin-meetings', () => {
           expect(meeting.unsetPeerConnections.calledOnce).to.be.true;
           expect(meeting.reconnectionManager.cleanUp.calledOnce).to.be.true;
           expect(meeting.mediaProperties.setMediaDirection.calledOnce).to.be.true;
-          expect(meeting.addMedia.calledOnceWithExactly({
-            audioEnabled: false,
-            videoEnabled: false,
-            shareVideoEnabled: true
-          })).to.be.true;
+          expect(
+            meeting.addMedia.calledOnceWithExactly({
+              audioEnabled: false,
+              videoEnabled: false,
+              shareVideoEnabled: true,
+            })
+          ).to.be.true;
           await testUtils.flushPromises();
           assert.equal(meeting.isMoveToInProgress, false);
         });
@@ -7482,9 +7534,11 @@ describe('plugin-meetings', () => {
           getTracks: () => [{id: 'track', addEventListener: sinon.stub()}],
         };
         const simulateConnectionStateChange = (newState) => {
-          meeting.mediaProperties.webrtcMediaConnection.getConnectionState = sinon.stub().returns(newState);
+          meeting.mediaProperties.webrtcMediaConnection.getConnectionState = sinon
+            .stub()
+            .returns(newState);
           eventListeners[MediaConnectionEventNames.PEER_CONNECTION_STATE_CHANGED]();
-        }
+        };
 
         beforeEach(() => {
           eventListeners = {};
@@ -7506,7 +7560,9 @@ describe('plugin-meetings', () => {
           assert.isFunction(eventListeners[MediaConnectionEventNames.ROAP_FAILURE]);
           assert.isFunction(eventListeners[MediaConnectionEventNames.ROAP_MESSAGE_TO_SEND]);
           assert.isFunction(eventListeners[MediaConnectionEventNames.REMOTE_TRACK_ADDED]);
-          assert.isFunction(eventListeners[MediaConnectionEventNames.PEER_CONNECTION_STATE_CHANGED]);
+          assert.isFunction(
+            eventListeners[MediaConnectionEventNames.PEER_CONNECTION_STATE_CHANGED]
+          );
           assert.isFunction(eventListeners[MediaConnectionEventNames.ICE_CONNECTION_STATE_CHANGED]);
           assert.isFunction(eventListeners[MediaConnectionEventNames.ICE_CANDIDATE]);
           assert.isFunction(eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]);
@@ -7569,28 +7625,44 @@ describe('plugin-meetings', () => {
           });
 
           it('should not collect skipped ice candidates error', () => {
-            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]({error: { errorCode: 600, errorText: 'Address not associated with the desired network interface.' }});
+            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]({
+              error: {
+                errorCode: 600,
+                errorText: 'Address not associated with the desired network interface.',
+              },
+            });
 
             assert.equal(meeting.iceCandidateErrors.size, 0);
           });
 
           it('should collect valid ice candidates error', () => {
-            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]({error: { errorCode: 701, errorText: '' }});
+            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]({
+              error: {errorCode: 701, errorText: ''},
+            });
 
             assert.equal(meeting.iceCandidateErrors.size, 1);
             assert.equal(meeting.iceCandidateErrors.has('701_'), true);
           });
 
           it('should increment counter if same valid ice candidates error collected', () => {
-            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]({error: { errorCode: 701, errorText: '' }});
+            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]({
+              error: {errorCode: 701, errorText: ''},
+            });
 
-            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]({error: { errorCode: 701, errorText: 'STUN host lookup received error.' }});
-            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]({error: { errorCode: 701, errorText: 'STUN host lookup received error.' }});
+            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]({
+              error: {errorCode: 701, errorText: 'STUN host lookup received error.'},
+            });
+            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE_ERROR]({
+              error: {errorCode: 701, errorText: 'STUN host lookup received error.'},
+            });
 
             assert.equal(meeting.iceCandidateErrors.size, 2);
             assert.equal(meeting.iceCandidateErrors.has('701_'), true);
             assert.equal(meeting.iceCandidateErrors.get('701_'), 1);
-            assert.equal(meeting.iceCandidateErrors.has('701_stun_host_lookup_received_error'), true);
+            assert.equal(
+              meeting.iceCandidateErrors.has('701_stun_host_lookup_received_error'),
+              true
+            );
             assert.equal(meeting.iceCandidateErrors.get('701_stun_host_lookup_received_error'), 2);
           });
         });
@@ -8263,8 +8335,12 @@ describe('plugin-meetings', () => {
           });
 
           it('registers for audio and video source count changed', () => {
-            assert.isFunction(eventListeners[MediaConnectionEventNames.VIDEO_SOURCES_COUNT_CHANGED]);
-            assert.isFunction(eventListeners[MediaConnectionEventNames.AUDIO_SOURCES_COUNT_CHANGED]);
+            assert.isFunction(
+              eventListeners[MediaConnectionEventNames.VIDEO_SOURCES_COUNT_CHANGED]
+            );
+            assert.isFunction(
+              eventListeners[MediaConnectionEventNames.AUDIO_SOURCES_COUNT_CHANGED]
+            );
           });
 
           it('forwards the VIDEO_SOURCES_COUNT_CHANGED event as "media:remoteVideoSourceCountChanged"', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-559031](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-559031)

## This pull request addresses

Sometimes TURN-TCP reachability completes succesfully, but then media fails to connect over TCP. Adding TURN-TCP to peer connection configuration, to verify if it will help in this scenario.

## by making the following changes

Modifying discovered TURN-TLS to work as bare TURN-TCP server.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

Tested with sample app(Chrome,Edge,Firefox) and blocked UDP to force connections over TCP.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
