### PR TITLE
feat(meeting-sdk): add-check-meeting-link-in-join

### DIFF
--- a/docs/samples/browser-plugin-meetings/app.js
+++ b/docs/samples/browser-plugin-meetings/app.js
@@ -292,6 +292,8 @@ const meetingsListMsgElm = document.querySelector('#meetings-list-msg');
 const meetingsListElm = document.querySelector('#meetings-list');
 const meetingsAddMediaElm = document.querySelector('#meetings-add-media');
 const meetingsLeaveElm = document.querySelector('#meetings-leave');
+const meetingStartLinkElm = document.querySelector('#meetings-start-link');
+const meetingJoinLinkElm = document.querySelector('#meetings-join-link');
 // captcha elements
 const meetingsJoinCaptchaImgElm = document.querySelector('#meetings-join-captcha');
 const meetingsJoinCaptchaElm = document.querySelector('#meetings-join-captcha-input');
@@ -612,6 +614,8 @@ async function joinMeeting({withMedia, withDevice} = {withMedia: false, withDevi
     resourceId,
     locale: 'en_UK', // audio disclaimer language
     deviceCapabilities: ['SERVER_AUDIO_ANNOUNCEMENT_SUPPORTED'], // audio disclaimer toggle
+    startMeetingLink: meetingStartLinkElm.value,
+    joinMeetingLink: meetingJoinLinkElm.value,
   };
 
   if (meetingsMediaInLobbySupportElm.checked) {

--- a/docs/samples/browser-plugin-meetings/index.html
+++ b/docs/samples/browser-plugin-meetings/index.html
@@ -381,6 +381,8 @@
                 </span>
                 <input id="meetings-join-captcha-input" name="createMeetingCaptcha" placeholder="Captcha" value="" type="hidden">
               </div>
+              <input id="meetings-start-link" placeholder="Start Meeting URL" value="" type="text">
+              <input id="meetings-join-link" placeholder="Join Meeting URL" value="" type="text">
 
               <div class="u-mt">
                 <button id="btn-verify-password" disabled onclick="verifyPassword()" class="btn-code">

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -225,7 +225,8 @@ export const VALID_PMR_LINK =
 export const VALID_PIN = /([0-9]{4,6})/;
 export const UUID_REG =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
+export const VALID_MEETING_LINK_URL =
+  /^https:\/\/[\w.-]+\.webex\.com\/wbxmjs\/joinservice\/sites\/[\w.-]+\/meeting\/download\/\w{32}\?siteurl=[\w.-]+&integrationJoinToken=[\w%]+&displayname=[\w%+.-]+&email=[\w%.-]+&principal=[\w%]+&integrationEndUrl=https%3A%2F%2F[\w.-]+%2Fmc3300%2Fmeetingcenter%2Fmeetingend%2Fmeetingend.do%3Fsiteurl%3D[\w.-]+%26from%3Dmeeting%26backurl%3D$/i;
 // ******************** OBJECTS ********************
 // Please alphabetize, and keep objects organized
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -119,6 +119,7 @@ import {
   MEETING_PERMISSION_TOKEN_REFRESH_REASON,
   ROAP_OFFER_ANSWER_EXCHANGE_TIMEOUT,
   NAMED_MEDIA_GROUP_TYPE_AUDIO,
+  VALID_MEETING_LINK_URL,
 } from '../constants';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import ParameterError from '../common/errors/parameter';
@@ -5145,6 +5146,14 @@ export default class Meeting extends StatelessWebexPlugin {
     // TODO: does this really need to be here?
     if (options.resourceId && this.destination && options.resourceId === this.destination) {
       this.wirelessShare = true;
+    }
+
+    const link = options.startMeetingLink || options.joinMeetingLink;
+    if (link && typeof link === 'string' && !VALID_MEETING_LINK_URL.test(link)) {
+      const invalidLink = options.joinMeetingLink ? 'joinMeetingLink' : 'startMeetingLink';
+      const errorMessage = `Meeting:index#join --> Invalid ${invalidLink} format`;
+
+      return Promise.reject(new Error(errorMessage));
     }
 
     if (options.meetingQuality) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1669,6 +1669,37 @@ describe('plugin-meetings', () => {
             sinon.assert.called(setCorrelationIdSpy);
             assert.equal(meeting.correlationId, '123');
           });
+          it('should join the meeting successfully with a valid joinMeetingLink', async () => {
+            const validLink = `
+              https://example.webex.com/wbxmjs/joinservice/sites/example/meeting/download/1234567890abcdef1234567890abcdef
+              ?siteurl=example
+              &integrationJoinToken=token123
+              &displayname=John+Doe
+              &email=john.doe%40example.com
+              &principal=principal123
+              &integrationEndUrl=https%3A%2F%2Fexample.com%2Fmc3300%2Fmeetingcenter%2Fmeetingend%2Fmeetingend.do%3Fsiteurl%3Dexample%26from%3Dmeeting%26backurl%3D
+            `.replace(/\s+/g, '');
+            const options = { joinMeetingLink: validLink };
+            await meeting.join(options);        
+            assert.calledOnce(MeetingUtil.joinMeeting);
+            assert.calledOnce(meeting.setLocus);
+          });
+        
+          it('should join the meeting successfully with a valid startMeetingLink', async () => {
+            const validLink = `
+              https://example.webex.com/wbxmjs/joinservice/sites/example/meeting/download/1234567890abcdef1234567890abcdef
+              ?siteurl=example
+              &integrationJoinToken=token123
+              &displayname=John+Doe
+              &email=john.doe%40example.com
+              &principal=principal123
+              &integrationEndUrl=https%3A%2F%2Fexample.com%2Fmc3300%2Fmeetingcenter%2Fmeetingend%2Fmeetingend.do%3Fsiteurl%3Dexample%26from%3Dmeeting%26backurl%3D
+            `.replace(/\s+/g, '');
+            const options = { startMeetingLink: validLink };
+            await meeting.join(options);
+            assert.calledOnce(MeetingUtil.joinMeeting);
+            assert.calledOnce(meeting.setLocus);
+          });
         });
 
         describe('failure', () => {
@@ -1749,6 +1780,20 @@ describe('plugin-meetings', () => {
             await meeting.join().catch(() => {
               assert.calledOnce(MeetingUtil.joinMeeting);
             });
+          });
+
+          it('should reject the promise if the joinMeetingLink is invalid', async () => {
+            const invalidLink = 'invalidLink';
+            const options = { joinMeetingLink: invalidLink };
+            await assert.isRejected(meeting.join(options), Error, 'Meeting:index#join --> Invalid joinMeetingLink format');
+            assert.notCalled(MeetingUtil.joinMeeting);
+          });
+        
+          it('should reject the promise if the startMeetingLink is invalid', async () => {
+            const invalidLink = 'invalidLink';
+            const options = { startMeetingLink: invalidLink };
+            await assert.isRejected(meeting.join(options), Error, 'Meeting:index#join --> Invalid startMeetingLink format');
+            assert.notCalled(MeetingUtil.joinMeeting);
           });
         });
         describe('lmm, transcription & permissionTokenRefresh decoupling', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-560435](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-560435) >

## This pull request addresses

* Currently, in the meeting sdk we have no validation or logic for checking the `joinMeetingLink` or `startMeetingLink` a user can pass as per the `JoinOptionsConfig` when joining a meeting.

## by making the following changes

* Code has been added so we now users can enter either a `joinMeetingLink` or `startMeetingLink` string when passing the config before calling `join()`.
* There is a regex check for the URL to ensure it aligns with the required value. This was obtained from [Join a meeting API](https://developer.webex.com/docs/api/v1/meetings/join-a-meeting) and tested across multiple orgs.
* Unit tests have been added and sample app has been updated.
* Documentation will go in another PR, once this is merged.

<!-- You may include screenshots -->

### Vidcasts
* [Join Meeting Success](https://app.vidcast.io/share/7eadb91b-f081-47b3-8570-44039a33d293)
* [Join Meeting Failure](https://app.vidcast.io/share/dfa3ab32-60a3-45cc-81df-d444293b1263)

### GIF of Join Meeting Link Success
![join-meeting-success](https://github.com/user-attachments/assets/0b8fca14-6e28-4eea-b152-a565d4861980)


### GIF of Join Meeting Link Fail
![join-meeting-fail](https://github.com/user-attachments/assets/1b6c7682-ac39-4976-8000-46731c80eca5)


### GIF of Start Meeting Link Success (Only Host)
![start-meeting-success](https://github.com/user-attachments/assets/f8dbaf18-4d96-4034-9706-d90268d3504d)


### GIF of Start Meeting Link Fail (Only Host)
![start-meeting-fail](https://github.com/user-attachments/assets/3f695a88-8175-4ea2-a403-12f33f376d26)



### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
