### PR TITLE
fix(meetings): empty webrtc dumps when user closes the browser early

### DIFF
--- a/packages/@webex/plugin-meetings/src/rtcMetrics/index.ts
+++ b/packages/@webex/plugin-meetings/src/rtcMetrics/index.ts
@@ -34,6 +34,8 @@ export default class RtcMetrics {
 
   connectionId: string;
 
+  initialMetricsSent: boolean;
+
   /**
    * Initialize the interval.
    *
@@ -47,9 +49,7 @@ export default class RtcMetrics {
     this.meetingId = meetingId;
     this.webex = webex;
     this.correlationId = correlationId;
-    this.setNewConnectionId();
-    // Send the first set of metrics at 5 seconds in the case of a user leaving the call shortly after joining.
-    setTimeout(this.sendMetricsInQueue.bind(this), 5 * 1000);
+    this.resetConnection();
   }
 
   /**
@@ -79,6 +79,13 @@ export default class RtcMetrics {
 
       this.metricsQueue.push(data);
 
+      if (!this.initialMetricsSent && data.name === 'stats-report') {
+        // this is the first useful set of data (WCME gives it to us after 5s), send it out immediately
+        // in case the user is unhappy and closes the browser early
+        this.sendMetricsInQueue();
+        this.initialMetricsSent = true;
+      }
+
       try {
         // If a connection fails, send the rest of the metrics in queue and get a new connection id.
         const parsedPayload = parseJsonPayload(data.payload);
@@ -88,7 +95,7 @@ export default class RtcMetrics {
           parsedPayload.value === 'failed'
         ) {
           this.sendMetricsInQueue();
-          this.setNewConnectionId();
+          this.resetConnection();
         }
       } catch (e) {
         console.error(e);
@@ -130,8 +137,9 @@ export default class RtcMetrics {
    *
    * @returns {void}
    */
-  private setNewConnectionId() {
+  private resetConnection() {
     this.connectionId = uuid.v4();
+    this.initialMetricsSent = false;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/rtcMetrics/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/rtcMetrics/index.ts
@@ -120,4 +120,35 @@ describe('RtcMetrics', () => {
     metrics.addMetrics({ name: 'stats-report', payload: [STATS_WITH_IP] });
     assert.calledOnce(anonymizeIpSpy);
   })
+
+  it('should send metrics on first stats-report', () => {
+    assert.callCount(webex.request, 0);
+
+    metrics.addMetrics(FAKE_METRICS_ITEM);
+    assert.callCount(webex.request, 0);
+
+    // first stats-report should trigger a call to webex.request
+    metrics.addMetrics({ name: 'stats-report', payload: [STATS_WITH_IP] });
+    assert.callCount(webex.request, 1);
+  });
+
+  it('should send metrics on first stats-report after a new connection', () => {
+    assert.callCount(webex.request, 0);
+
+    // first stats-report should trigger a call to webex.request
+    metrics.addMetrics({ name: 'stats-report', payload: [STATS_WITH_IP] });
+    assert.callCount(webex.request, 1);
+
+    // subsequent stats-report doesn't trigger it
+    metrics.addMetrics({ name: 'stats-report', payload: [STATS_WITH_IP] });
+    assert.callCount(webex.request, 1);
+
+    // now, simulate a failure - that triggers a new connection and upload of the metrics
+    metrics.addMetrics(FAILURE_METRICS_ITEM);
+    assert.callCount(webex.request, 2);
+
+    // and another stats-report should trigger another upload of the metrics
+    metrics.addMetrics({ name: 'stats-report', payload: [STATS_WITH_IP] });
+    assert.callCount(webex.request, 3);
+  });
 });


### PR DESCRIPTION
# COMPLETES #[SPARK-562098](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-562098)

## This pull request addresses
When investigating join meeting failure cases where ICE connection was successful, but RTP packets seemed to be not getting through I saw a lot of webrtc dumps that were missing the stats, they only contained the log. It's because SDK uploads the dumps 5s after connection creation and WCME also calls getStats() 5s after connection creation, but it's just after the SDK timer, so the metrics that get uploaded don't have the result of the 1st getStats() call.

## by making the following changes
Changed SDK to do the first upload as soon as we get a first stats-report.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests and manual run with the web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
