### PR TITLE
fix(plugin-meetings):  Windows/Chrome still asks for camera permissions even when not selecting videoEnabled and shareVideoEnabled

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6512,12 +6512,21 @@ export default class Meeting extends StatelessWebexPlugin {
    *
    * @private
    * @static
+   * @param {boolean} isAudioEnabled
+   * @param {boolean} isVideoEnabled
    * @returns {Promise<void>}
    */
-  private static async handleDeviceLogging(): Promise<void> {
+  private static async handleDeviceLogging(
+    isAudioEnabled = false,
+    isVideoEnabled = false
+  ): Promise<void> {
     try {
-      const devices = await getDevices();
+      const deviceKind =
+        (isVideoEnabled && Media.DeviceKind.VIDEO_INPUT) ||
+        (isAudioEnabled && Media.DeviceKind.AUDIO_INPUT) ||
+        undefined;
 
+      const devices = await getDevices(deviceKind);
       MeetingUtil.handleDeviceLogging(devices);
     } catch {
       // getDevices may fail if we don't have browser permissions, that's ok, we still can have a media connection
@@ -7010,7 +7019,7 @@ export default class Meeting extends StatelessWebexPlugin {
       );
 
       if (audioEnabled || videoEnabled) {
-        await Meeting.handleDeviceLogging();
+        await Meeting.handleDeviceLogging(audioEnabled, videoEnabled);
       } else {
         LoggerProxy.logger.info(`${LOG_HEADER} device logging not required`);
       }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -4054,6 +4054,8 @@ describe('plugin-meetings', () => {
             assert.calledTwice(locusMediaRequestStub);
 
             assert.calledOnce(handleDeviceLoggingSpy);
+            assert.calledWith(handleDeviceLoggingSpy, true);
+
           });
 
           it('addMedia() works correctly when media is enabled with streams to publish and stream is user muted', async () => {
@@ -4090,6 +4092,8 @@ describe('plugin-meetings', () => {
             // and that these were the only /media requests that were sent
             assert.calledTwice(locusMediaRequestStub);
             assert.calledOnce(handleDeviceLoggingSpy);
+            assert.calledWith(handleDeviceLoggingSpy, true);
+
           });
 
           it('addMedia() works correctly when media is enabled with tracks to publish and track is ended', async () => {
@@ -4196,6 +4200,8 @@ describe('plugin-meetings', () => {
             // and that these were the only /media requests that were sent
             assert.calledTwice(locusMediaRequestStub);
             assert.calledOnce(handleDeviceLoggingSpy);
+            assert.calledWith(handleDeviceLoggingSpy, false);
+
           });
 
           it('handleDeviceLogging not called when media is disabled', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-539683](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-539683) >

## This pull request addresses

This pull request addresses the issue with a kitchen sink app. When the user tries to disable the videoEnabled checkbox and sharVideoEnabled checkbox, the sample app still asks for camera access. This pull request resolves this problem with the following changes:
## by making the following changes
Changes have been made in the plugin-meetings where previously getDevices() was being called without considering the user's usage. Now, getDevices is being called with parameters based on the user's requests.


https://github.com/user-attachments/assets/011647bd-81ac-4433-b1d0-6be72c12909e






### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested
Tested this Pull request by 
1) uncheck the _**videoEnabled**_ and _**shareVideoEnabled**_ checkbox and click on _**joinWithMedia()**_ button ----> ask for microphone permission
2) uncheck the _**audioEnabled**_ and **_shareAudioEnabled_** checkbox and click on _**joinWithMedia()**_ button -----> ask for camera permission
3) checked both checkboxes ----> ask for the both permissions
4) Checked with the **_**mid-meeting**_** 

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
