### PR TITLE
fix(meetings): webrtc dumps are sometimes empty when users join a meeting via lobby

### DIFF
--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -104,9 +104,7 @@ Media.getDirection = (forceSendRecv: boolean, receive: boolean, send: boolean) =
  *
  * @param {boolean} isMultistream
  * @param {string} debugId string useful for debugging (will appear in media connection logs)
- * @param {object} webex main `webex` object.
  * @param {string} meetingId id for the meeting using this connection
- * @param {string} correlationId id used in requests to correlate to this session
  * @param {Object} options
  * @param {Object} [options.mediaProperties] contains mediaDirection and local tracks:
  *                                 audioTrack, videoTrack, shareVideoTrack, and shareAudioTrack
@@ -120,10 +118,9 @@ Media.getDirection = (forceSendRecv: boolean, receive: boolean, send: boolean) =
 Media.createMediaConnection = (
   isMultistream: boolean,
   debugId: string,
-  webex: object,
   meetingId: string,
-  correlationId: string,
   options: {
+    rtcMetrics?: RtcMetrics;
     mediaProperties: {
       mediaDirection?: {
         receiveAudio: boolean;
@@ -150,6 +147,7 @@ Media.createMediaConnection = (
   }
 ) => {
   const {
+    rtcMetrics,
     mediaProperties,
     remoteQualityLevel,
     enableRtx,
@@ -192,15 +190,13 @@ Media.createMediaConnection = (
       config.bundlePolicy = bundlePolicy;
     }
 
-    const rtcMetrics = new RtcMetrics(webex, meetingId, correlationId);
-
     return new MultistreamRoapMediaConnection(
       config,
       meetingId,
       /* the rtc metrics objects callbacks */
-      (data) => rtcMetrics.addMetrics(data),
-      () => rtcMetrics.closeMetrics(),
-      () => rtcMetrics.sendMetricsInQueue()
+      (data) => rtcMetrics?.addMetrics(data),
+      () => rtcMetrics?.closeMetrics(),
+      () => rtcMetrics?.sendMetricsInQueue()
     );
   }
 

--- a/packages/@webex/plugin-meetings/src/rtcMetrics/index.ts
+++ b/packages/@webex/plugin-meetings/src/rtcMetrics/index.ts
@@ -34,7 +34,7 @@ export default class RtcMetrics {
 
   connectionId: string;
 
-  initialMetricsSent: boolean;
+  shouldSendMetricsOnNextStatsReport: boolean;
 
   /**
    * Initialize the interval.
@@ -65,6 +65,18 @@ export default class RtcMetrics {
   }
 
   /**
+   * Forces sending metrics when we get the next stats-report
+   *
+   * This is useful for cases when something important happens that affects the media connection,
+   * for example when we move from lobby into the meeting.
+   *
+   * @returns {void}
+   */
+  public sendNextMetrics() {
+    this.shouldSendMetricsOnNextStatsReport = true;
+  }
+
+  /**
    * Add metrics items to the metrics queue.
    *
    * @param {object} data - An object with a payload array of metrics items.
@@ -79,11 +91,11 @@ export default class RtcMetrics {
 
       this.metricsQueue.push(data);
 
-      if (!this.initialMetricsSent && data.name === 'stats-report') {
+      if (this.shouldSendMetricsOnNextStatsReport && data.name === 'stats-report') {
         // this is the first useful set of data (WCME gives it to us after 5s), send it out immediately
         // in case the user is unhappy and closes the browser early
         this.sendMetricsInQueue();
-        this.initialMetricsSent = true;
+        this.shouldSendMetricsOnNextStatsReport = false;
       }
 
       try {
@@ -139,7 +151,7 @@ export default class RtcMetrics {
    */
   private resetConnection() {
     this.connectionId = uuid.v4();
-    this.initialMetricsSent = false;
+    this.shouldSendMetricsOnNextStatsReport = true;
   }
 
   /**


### PR DESCRIPTION
# COMPLETES #[SPARK-562381](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-562381)

## This pull request addresses
If a user joins a meeting and ends up in the lobby and later gets admitted to the meeting, it can take up to 30s before we send webrtc dump data after user is admitted to the meeting. If user has any issues, they often close the tab before we send webrtc dump data.

## by making the following changes
Sending webrtc dump data sooner after being admitted. The data is collected every 5s, so it should be good enough if we just send the first batch of data we have after being admitted.


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual test run with the web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
