### PR TITLE
feat(meetings): do ip version detection in parallel with reachability

### DIFF
--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -149,6 +149,11 @@ export default class Reachability extends EventsScope {
   public async gatherReachability(): Promise<ReachabilityResults> {
     // Fetch clusters and measure latency
     try {
+      // kick off ip version detection. For now we don't await it, as we're doing it
+      // to gather the timings and send them with our reachability metrics
+      // @ts-ignore
+      this.webex.internal.device.ipNetworkDetector.detect();
+
       const {clusters, joinCookie} = await this.getClusters();
 
       // @ts-ignore
@@ -536,6 +541,16 @@ export default class Reachability extends EventsScope {
         udp: this.getStatistics(results, 'udp', false),
         tcp: this.getStatistics(results, 'tcp', false),
         xtls: this.getStatistics(results, 'xtls', false),
+      },
+      ipver: {
+        // @ts-ignore
+        firstIpV4: this.webex.internal.device.ipNetworkDetector.firstIpV4,
+        // @ts-ignore
+        firstIpV6: this.webex.internal.device.ipNetworkDetector.firstIpV6,
+        // @ts-ignore
+        firstMdns: this.webex.internal.device.ipNetworkDetector.firstMdns,
+        // @ts-ignore
+        totalTime: this.webex.internal.device.ipNetworkDetector.totalTime,
       },
     };
     Metrics.sendBehavioralMetric(


### PR DESCRIPTION
# COMPLETES #[SPARK-562699](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-562699)

## This pull request addresses
Orpheus team wants us to tell them if we are on an ipv4 or ipv6 network (or both) when we call the discovery/v1/clusters API. To know this we would need to gather local ICE candidates before making that call - that can take some time (few hundred milliseconds), so for now we will do this in parallel to making the API call just so that we can measure how long it takes and send the timings with reachability metrics.

## by making the following changes
- starting ip network detection when we do reachability, but not waiting for it to complete
- sending the information about how long it took in reachability metric

This means that now we'll be sending the `ipver` parameter to Locus when we're joining a meeting based on the results of ip network detection done during last reachability check. Previously we've just been always sending ipver=0 which means "we don't know if we're on ipv4 or ipv6 network")

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
