### PR TITLE
feat(presence-plugin): pass label to aphelia API whilst setting status

### DIFF
--- a/packages/@webex/internal-plugin-presence/src/presence.js
+++ b/packages/@webex/internal-plugin-presence/src/presence.js
@@ -234,6 +234,7 @@ const Presence = WebexPlugin.extend({
         body: {
           subject: this.webex.internal.device.userId,
           eventType: status,
+		  label: this.webex.internal.device.userId,
           ttl,
         },
       })

--- a/packages/@webex/internal-plugin-presence/src/presence.js
+++ b/packages/@webex/internal-plugin-presence/src/presence.js
@@ -234,7 +234,7 @@ const Presence = WebexPlugin.extend({
         body: {
           subject: this.webex.internal.device.userId,
           eventType: status,
-		  label: this.webex.internal.device.userId,
+          label: this.webex.internal.device.userId,
           ttl,
         },
       })

--- a/packages/@webex/internal-plugin-presence/test/integration/spec/presence.js
+++ b/packages/@webex/internal-plugin-presence/test/integration/spec/presence.js
@@ -206,10 +206,10 @@ describe.skip('plugin-presence', function () {
         spock.webex.internal.presence.setStatus('dnd', 1500).then((statusResponse) => {
           assert.property(statusResponse, 'subject');
           assert.property(statusResponse, 'status');
-		  assert.property(statusResponse, 'label');
+          assert.property(statusResponse, 'label');
           assert.equal(statusResponse.subject, spock.id);
           assert.equal(statusResponse.status, 'dnd');
-		  assert.equal(statusResponse.label, spock.id);
+          assert.equal(statusResponse.label, spock.id);
         }));
     });
   });

--- a/packages/@webex/internal-plugin-presence/test/integration/spec/presence.js
+++ b/packages/@webex/internal-plugin-presence/test/integration/spec/presence.js
@@ -206,8 +206,10 @@ describe.skip('plugin-presence', function () {
         spock.webex.internal.presence.setStatus('dnd', 1500).then((statusResponse) => {
           assert.property(statusResponse, 'subject');
           assert.property(statusResponse, 'status');
+		  assert.property(statusResponse, 'label');
           assert.equal(statusResponse.subject, spock.id);
           assert.equal(statusResponse.status, 'dnd');
+		  assert.equal(statusResponse.label, spock.id);
         }));
     });
   });

--- a/packages/@webex/internal-plugin-presence/test/unit/spec/presence.js
+++ b/packages/@webex/internal-plugin-presence/test/unit/spec/presence.js
@@ -64,6 +64,28 @@ describe.skip('plugin-presence', () => {
     describe('#setStatus()', () => {
       it('requires a status', () =>
         assert.isRejected(webex.internal.presence.setStatus(), /A status is required/));
+      it('passes a label to the API', () => {
+        const testGuid = 'test-guid';
+
+        webex.internal.device.userId = testGuid;
+
+        webex.request = function (options) {
+          return Promise.resolve({
+            statusCode: 204,
+            body: [],
+            options,
+          });
+        };
+        sinon.spy(webex, 'request');
+
+        webex.internal.presence.setStatus('dnd');
+
+        assert.calledOnce(webex.request);
+
+        const request = webex.request.getCall(0);
+
+        assert.equal(request.args[0].body.label, testGuid);
+      });
     });
   });
 });

--- a/packages/@webex/internal-plugin-presence/test/unit/spec/presence.js
+++ b/packages/@webex/internal-plugin-presence/test/unit/spec/presence.js
@@ -64,6 +64,7 @@ describe.skip('plugin-presence', () => {
     describe('#setStatus()', () => {
       it('requires a status', () =>
         assert.isRejected(webex.internal.presence.setStatus(), /A status is required/));
+
       it('passes a label to the API', () => {
         const testGuid = 'test-guid';
 

--- a/packages/@webex/plugin-presence/src/presence.ts
+++ b/packages/@webex/plugin-presence/src/presence.ts
@@ -238,7 +238,7 @@ const Presence: IPresence = WebexPlugin.extend({
         body: {
           subject: this.webex.internal.device.userId,
           eventType: status,
-		  label: this.webex.internal.device.userId,
+          label: this.webex.internal.device.userId,
           ttl,
         },
       })

--- a/packages/@webex/plugin-presence/src/presence.ts
+++ b/packages/@webex/plugin-presence/src/presence.ts
@@ -238,6 +238,7 @@ const Presence: IPresence = WebexPlugin.extend({
         body: {
           subject: this.webex.internal.device.userId,
           eventType: status,
+		  label: this.webex.internal.device.userId,
           ttl,
         },
       })

--- a/packages/@webex/plugin-presence/test/integration/spec/presence.ts
+++ b/packages/@webex/plugin-presence/test/integration/spec/presence.ts
@@ -203,10 +203,10 @@ describe.skip('plugin-presence', function () {
         spock.webex.presence.setStatus('dnd', 1500).then((statusResponse) => {
           assert.property(statusResponse, 'subject');
           assert.property(statusResponse, 'status');
-		  assert.property(statusResponse, 'label');
+          assert.property(statusResponse, 'label');
           assert.equal(statusResponse.subject, spock.id);
           assert.equal(statusResponse.status, 'dnd');
-		  assert.equal(statusResponse.subject, spock.id);
+          assert.equal(statusResponse.subject, spock.id);
         }));
     });
   });

--- a/packages/@webex/plugin-presence/test/integration/spec/presence.ts
+++ b/packages/@webex/plugin-presence/test/integration/spec/presence.ts
@@ -203,8 +203,10 @@ describe.skip('plugin-presence', function () {
         spock.webex.presence.setStatus('dnd', 1500).then((statusResponse) => {
           assert.property(statusResponse, 'subject');
           assert.property(statusResponse, 'status');
+		  assert.property(statusResponse, 'label');
           assert.equal(statusResponse.subject, spock.id);
           assert.equal(statusResponse.status, 'dnd');
+		  assert.equal(statusResponse.subject, spock.id);
         }));
     });
   });

--- a/packages/@webex/plugin-presence/test/unit/spec/presence.ts
+++ b/packages/@webex/plugin-presence/test/unit/spec/presence.ts
@@ -61,6 +61,28 @@ describe('plugin-presence', () => {
     describe('#setStatus()', () => {
       it('requires a status', () =>
         assert.isRejected(webex.presence.setStatus(), /A status is required/));
+      it('passes a label to the API', () => {
+        const testGuid = 'test-guid';
+
+        webex.internal.device.userId = testGuid;
+
+        webex.request = function (options) {
+          return Promise.resolve({
+            statusCode: 204,
+            body: [],
+            options,
+          });
+        };
+        sinon.spy(webex, 'request');
+
+        webex.presence.setStatus('dnd');
+
+        assert.calledOnce(webex.request);
+
+        const request = webex.request.getCall(0);
+
+        assert.equal(request.args[0].body.label, testGuid);
+      });
     });
   });
 });

--- a/packages/@webex/plugin-presence/test/unit/spec/presence.ts
+++ b/packages/@webex/plugin-presence/test/unit/spec/presence.ts
@@ -61,6 +61,7 @@ describe('plugin-presence', () => {
     describe('#setStatus()', () => {
       it('requires a status', () =>
         assert.isRejected(webex.presence.setStatus(), /A status is required/));
+
       it('passes a label to the API', () => {
         const testGuid = 'test-guid';
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [CX-16180](https://jira-eng-sjc12.cisco.com/jira/browse/CX-16180)

## This pull request addresses

Webex user's status is not always being cleared correctly from Agent Desktop after a call ends, as a result of the `label` parameter not being filled in the request to the [Aphelia V1 API](https://backstage.corp.webex.com/catalog/default/api/apheleia-endpoint#/default/post_apheleia_api_v1_events). When the request is made without a `label`, the Aphelia backend is  unable to associate 2 events (the setting and clearing of "on a call" status) that can result in an agent's status getting "stuck" until the TTL expires

## by making the following changes

Filling the `label` parameter in the API request

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Checked request works as intended with Postman
* Added to integration test

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
