### PR TITLE
fix(meetings): added reachability trigger to metrics

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -765,7 +765,7 @@ export default class Meetings extends WebexPlugin {
     return Promise.all([
       this.fetchUserPreferredWebexSite(),
       this.getGeoHint(),
-      this.startReachability().catch((error) => {
+      this.startReachability('registration').catch((error) => {
         LoggerProxy.logger.error(`Meetings:index#register --> GDM error, ${error.message}`);
       }),
       // @ts-ignore
@@ -967,12 +967,13 @@ export default class Meetings extends WebexPlugin {
 
   /**
    * initializes and starts gathering reachability for Meetings
+   * @param {string} trigger - explains the reason for starting reachability
    * @returns {Promise}
    * @public
    * @memberof Meetings
    */
-  startReachability() {
-    return this.getReachability().gatherReachability();
+  startReachability(trigger = 'client') {
+    return this.getReachability().gatherReachability(trigger);
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -93,6 +93,8 @@ export default class Reachability extends EventsScope {
   expectedResultsCount = {videoMesh: {udp: 0}, public: {udp: 0, tcp: 0, xtls: 0}};
   resultsCount = {videoMesh: {udp: 0}, public: {udp: 0, tcp: 0, xtls: 0}};
 
+  protected lastTrigger?: string;
+
   /**
    * Creates an instance of Reachability.
    * @param {object} webex
@@ -142,13 +144,16 @@ export default class Reachability extends EventsScope {
 
   /**
    * Gets a list of media clusters from the backend and performs reachability checks on all the clusters
+   * @param {string} trigger - explains the reason for starting reachability
    * @returns {Promise<ReachabilityResults>} reachability results
    * @public
    * @memberof Reachability
    */
-  public async gatherReachability(): Promise<ReachabilityResults> {
+  public async gatherReachability(trigger: string): Promise<ReachabilityResults> {
     // Fetch clusters and measure latency
     try {
+      this.lastTrigger = trigger;
+
       // kick off ip version detection. For now we don't await it, as we're doing it
       // to gather the timings and send them with our reachability metrics
       // @ts-ignore
@@ -552,6 +557,7 @@ export default class Reachability extends EventsScope {
         // @ts-ignore
         totalTime: this.webex.internal.device.ipNetworkDetector.totalTime,
       },
+      trigger: this.lastTrigger,
     };
     Metrics.sendBehavioralMetric(
       BEHAVIORAL_METRICS.REACHABILITY_COMPLETED,

--- a/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
@@ -342,7 +342,7 @@ export default class ReconnectionManager {
       }
 
       try {
-        await this.webex.meetings.startReachability();
+        await this.webex.meetings.startReachability('reconnection');
       } catch (err) {
         LoggerProxy.logger.info(
           'ReconnectionManager:index#reconnect --> Reachability failed, continuing with reconnection attempt, err: ',


### PR DESCRIPTION
# COMPLETES #[SPARK-562699](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-562699)

## This pull request addresses
We've recently added information about timings for IP network version checks to "js_sdk_reachability_completed" metric, but reachability is triggered from various places, one of them being reconnection. We want to know the timings just from reachability that's called during webex.meetings.register() and not from reconnection.

## by making the following changes
added reachability trigger information to the "js_sdk_reachability_completed" metric

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
