### PR TITLE
fix(meetings): webex.internal.device doesn't know when user is in a meeting

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5232,6 +5232,9 @@ export default class Meeting extends StatelessWebexPlugin {
         this.meetingFiniteStateMachine.join();
         this.setupLocusMediaRequest();
 
+        // @ts-ignore
+        this.webex.internal.device.meetingStarted();
+
         LoggerProxy.logger.log('Meeting:index#join --> Success');
 
         Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.JOIN_SUCCESS, {

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -170,6 +170,8 @@ const MeetingUtil = {
   },
 
   cleanUp: (meeting) => {
+    meeting.getWebexObject().internal.device.meetingEnded();
+
     meeting.breakouts.cleanUp();
     meeting.simultaneousInterpretation.cleanUp();
     meeting.locusMediaRequest = undefined;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1605,6 +1605,7 @@ describe('plugin-meetings', () => {
             const result = await join;
 
             assert.calledOnce(MeetingUtil.joinMeeting);
+            assert.calledOnce(webex.internal.device.meetingStarted);
             assert.calledOnce(meeting.setLocus);
             assert.equal(result, joinMeetingResult);
             assert.calledWith(webex.internal.llm.on, 'online', meeting.handleLLMOnline);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -71,6 +71,7 @@ describe('plugin-meetings', () => {
         assert.calledOnce(meeting.updateLLMConnection);
         assert.calledOnce(meeting.breakouts.cleanUp);
         assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
+        assert.calledOnce(webex.internal.device.meetingEnded);
       });
 
       it('do clean up on meeting object with LLM disabled', async () => {
@@ -87,6 +88,7 @@ describe('plugin-meetings', () => {
         assert.notCalled(meeting.updateLLMConnection);
         assert.calledOnce(meeting.breakouts.cleanUp);
         assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
+        assert.calledOnce(webex.internal.device.meetingEnded);
       });
 
       it('do clean up on meeting object with no config', async () => {
@@ -102,6 +104,7 @@ describe('plugin-meetings', () => {
         assert.notCalled(meeting.updateLLMConnection);
         assert.calledOnce(meeting.breakouts.cleanUp);
         assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
+        assert.calledOnce(webex.internal.device.meetingEnded);
       });
     });
 

--- a/packages/@webex/test-helper-mock-webex/src/index.js
+++ b/packages/@webex/test-helper-mock-webex/src/index.js
@@ -268,6 +268,8 @@ function makeWebex(options) {
           get: sinon.stub(),
         },
       },
+      meetingEnded: sinon.stub(),
+      meetingStarted: sinon.stub(),
       registered: true,
       register: sinon.stub().returns(Promise.resolve()),
       ipNetworkDetector: {


### PR DESCRIPTION
# COMPLETES #[SPARK-564815](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-564815)

## This pull request addresses
Raised from a customer BEMS case:
When users have configured inactivity timeout in control hub for example for 30 mins, when they join a meeting, after 30 min they get logged out by the SDK and web app doesn't update the UI, so they remain in the meeting but cannot do any operations like mute/unmute/start recording (they just fail) and also Mercury connection is dropped, so they won't get any updates about the meeting.

## by making the following changes
Internal device plugin has the inactivity timer and it relies on meetingStarted/meetingEnded methods to be called when a user joins or leaves (or gets dropped from) a meeting to avoid being logged out while in a meeting. These methods were not being called from anywhere, so I've added calls to them in plugin-meetings.

This solution is not ideal as it won't work correctly if user joins more than one meeting in parallel, but AFAIK none of the SDK clients do that, so for now it's fine. A bigger refactor of internal device plugin would be needed to fix this more properly.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
