### PR TITLE
feat(byods-sdk): added-storage-adapter

### DIFF
--- a/packages/byods/src/byods/index.ts
+++ b/packages/byods/src/byods/index.ts
@@ -37,9 +37,14 @@ export default class BYODS {
    * @example
    * const sdk = new BYODS({ clientId: 'your-client-id', clientSecret: 'your-client-secret' });
    */
-  constructor({clientId, clientSecret}: SDKConfig) {
-    this.config = {clientId, clientSecret};
-    this.tokenManager = new TokenManager(clientId, clientSecret);
+  constructor({clientId, clientSecret, tokenStorageAdapter}: SDKConfig) {
+    this.config = {clientId, clientSecret, tokenStorageAdapter};
+    this.tokenManager = new TokenManager(
+      clientId,
+      clientSecret,
+      PRODUCTION_BASE_URL,
+      tokenStorageAdapter
+    );
 
     /**
      * The environment variable `process.env.BYODS_ENVIRONMENT` determines the environment in which the SDK operates.

--- a/packages/byods/src/token-storage-adapter/inMemoryTokenStorage.ts
+++ b/packages/byods/src/token-storage-adapter/inMemoryTokenStorage.ts
@@ -1,0 +1,46 @@
+import {OrgServiceAppAuthorization} from '../types';
+import {TokenStorageAdapter} from './types';
+
+/**
+ * An in-memory adapter for storing, listing and retrieving service app authorization tokens.
+ *
+ * @public
+ */
+export class InMemoryTokenStorageAdapter implements TokenStorageAdapter {
+  /**
+   * The local memory cache for the tokens.
+   */
+  private storage: {[orgId: string]: OrgServiceAppAuthorization} = {};
+
+  /**
+   * Method to set the token for an organization.
+   * @param orgId Organization ID
+   * @param token Respective token
+   * @example
+   * storageAdapter.setToken('org-id', token);
+   */
+  setToken(orgId: string, token: OrgServiceAppAuthorization): void {
+    this.storage[orgId] = token;
+  }
+
+  /**
+   * Method to extract a token based on the organization id.
+   * @param orgId Organization ID
+   * @returns {OrgServiceAppAuthorization} The token object for the organization
+   * @example
+   * const token = storageAdapter.getToken('org-id');
+   */
+  getToken(orgId: string): OrgServiceAppAuthorization | undefined {
+    return this.storage[orgId];
+  }
+
+  /**
+   * Method which returns the list of all tokens stored in the InMemoryTokenStorageAdapter.
+   * @returns {OrgServiceAppAuthorization[]} List of
+   * @example
+   * const tokens = storageAdapter.listTokens();
+   */
+  listTokens(): OrgServiceAppAuthorization[] {
+    return Object.values(this.storage);
+  }
+}

--- a/packages/byods/src/token-storage-adapter/types.ts
+++ b/packages/byods/src/token-storage-adapter/types.ts
@@ -1,0 +1,28 @@
+import {OrgServiceAppAuthorization} from '../types';
+
+/**
+ * Represents a adapter for storing and retrieving service app authorization tokens.
+ *
+ * @public
+ */
+export interface TokenStorageAdapter {
+  /**
+   * Method to set the token for an organization.
+   * @param orgId Organization ID
+   * @param token Respective token
+   */
+  setToken(orgId: string, token: OrgServiceAppAuthorization): void;
+
+  /**
+   * Method to extract a token id based on the organization id.
+   * @param orgId Organization
+   * @returns {OrgServiceAppAuthorization} The token object for the organization
+   */
+  getToken(orgId: string): OrgServiceAppAuthorization | undefined;
+
+  /**
+   * Method which returns the list of all tokens stored in the TokenStorageAdapter.
+   * @returns {OrgServiceAppAuthorization[]} List of tokens
+   */
+  listTokens(): OrgServiceAppAuthorization[];
+}

--- a/packages/byods/src/types.ts
+++ b/packages/byods/src/types.ts
@@ -1,3 +1,5 @@
+import {TokenStorageAdapter} from 'token-storage-adapter/types';
+
 /**
  * Configuration options for the SDK.
  *
@@ -13,6 +15,11 @@ export interface SDKConfig {
    * The client secret of the service app.
    */
   clientSecret: string;
+
+  /**
+   * The token storage adapter passed by the client
+   */
+  tokenStorageAdapter?: TokenStorageAdapter;
 }
 
 /**
@@ -89,16 +96,4 @@ export interface OrgServiceAppAuthorization {
    * The token details.
    */
   serviceAppToken: ServiceAppToken;
-}
-
-/**
- * Represents a map of service app authorizations to the orgId.
- *
- * @public
- */
-export interface ServiceAppAuthorizationMap {
-  /**
-   * The organization ID mapped to its authorization details.
-   */
-  [orgId: string]: OrgServiceAppAuthorization;
 }

--- a/packages/byods/test/unit/spec/token-storage-adapter/index.ts
+++ b/packages/byods/test/unit/spec/token-storage-adapter/index.ts
@@ -1,0 +1,55 @@
+import {InMemoryTokenStorageAdapter} from '../../../../src/token-storage-adapter/inMemoryTokenStorage';;
+import {OrgServiceAppAuthorization} from '../../../../src/types';;
+
+describe('InMemoryTokenStorageAdapter', () => {
+  let tokenStorage: InMemoryTokenStorageAdapter;
+  const orgId = 'org-123';
+  const token: OrgServiceAppAuthorization = {
+    orgId,
+    serviceAppToken: {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: new Date(Date.now() + 3600 * 1000),
+      refreshAccessTokenExpiresAt: new Date(Date.now() + 7200 * 1000),
+    },
+  };
+
+  beforeEach(() => {
+    tokenStorage = new InMemoryTokenStorageAdapter();
+  });
+
+  test('should store a token', () => {
+    tokenStorage.setToken(orgId, token);
+    expect(tokenStorage.getToken(orgId)).toEqual(token);
+  });
+
+  test('should retrieve a token', () => {
+    tokenStorage.setToken(orgId, token);
+    const retrievedToken = tokenStorage.getToken(orgId);
+    expect(retrievedToken).toEqual(token);
+  });
+
+  test('should return undefined for a non-existent token', () => {
+    const retrievedToken = tokenStorage.getToken('non-existent-org');
+    expect(retrievedToken).toBeUndefined();
+  });
+
+  test('should list all stored tokens', () => {
+    const dummyOrgId = 'org-456';
+    const dummyToken: OrgServiceAppAuthorization = {
+      orgId: dummyOrgId,
+      serviceAppToken: {
+        accessToken: 'another-access-token',
+        refreshToken: 'another-refresh-token',
+        expiresAt: new Date(Date.now() + 3600 * 1000),
+        refreshAccessTokenExpiresAt: new Date(Date.now() + 7200 * 1000),
+      },
+    };
+
+    tokenStorage.setToken(orgId, token);
+    tokenStorage.setToken(dummyOrgId, dummyToken);
+
+    const tokens = tokenStorage.listTokens();
+    expect(tokens).toContain(token);
+    expect(tokens).toContain(dummyToken);});
+});


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-563139](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-563139) >

## This pull request addresses

* Creation of an interface known as `StorageAdapter` which allows users to implement their own interfaces for storing tokens.

## by making the following changes

* Interface for base `StorageAdapter` has been added.
* It has also been implemented as an InMemoryAdapter which has a cache which stores the org id and tokens with methods to set and get them.
* Unit tests have been added and BYODS config has a new field.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
