### PR TITLE
feat: add `upgradeChannel` metric

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -237,7 +237,7 @@ export const prepareDiagnosticMetricItem = (webex: any, item: any) => {
     item.eventPayload?.event?.eventData?.markAsTestEvent
   );
 
-  // Set upgradeChannel to 'gold' if buildType is 'prod', otherwise undefined
+  // Set upgradeChannel to 'gold' if buildType is 'prod', otherwise to the buildType value
   const upgradeChannel = buildType === 'prod' ? 'gold' : buildType;
 
   const origin: Partial<Event['origin']> = {

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -238,7 +238,7 @@ export const prepareDiagnosticMetricItem = (webex: any, item: any) => {
   );
 
   // Set upgradeChannel to 'gold' if buildType is 'prod', otherwise undefined
-  const upgradeChannel = buildType === 'prod' ? 'gold' : undefined;
+  const upgradeChannel = buildType === 'prod' ? 'gold' : buildType;
 
   const origin: Partial<Event['origin']> = {
     buildType,

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -231,13 +231,19 @@ export const getBuildType = (
  * @returns {Object} prepared item
  */
 export const prepareDiagnosticMetricItem = (webex: any, item: any) => {
+  const buildType = getBuildType(
+    webex,
+    item.eventPayload?.event?.eventData?.webClientDomain,
+    item.eventPayload?.event?.eventData?.markAsTestEvent
+  );
+
+  // Set upgradeChannel to 'gold' if buildType is 'prod', otherwise undefined
+  const upgradeChannel = buildType === 'prod' ? 'gold' : undefined;
+
   const origin: Partial<Event['origin']> = {
-    buildType: getBuildType(
-      webex,
-      item.eventPayload?.event?.eventData?.webClientDomain,
-      item.eventPayload?.event?.eventData?.markAsTestEvent
-    ),
+    buildType,
     networkType: 'unknown',
+    upgradeChannel,
   };
 
   // check event names and append latencies?

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -441,7 +441,7 @@ describe('plugin-metrics', () => {
         // item also gets assigned a delay property but the key is a Symbol and haven't been able to test that..
         assert.deepEqual(calls.args[0].eventPayload, {
           event: 'my.event',
-          origin: {buildType: 'test', networkType: 'unknown'},
+          origin: {buildType: 'test', networkType: 'unknown', upgradeChannel: 'test'},
         });
 
         assert.deepEqual(calls.args[0].type, ['diagnostic-event']);
@@ -455,6 +455,7 @@ describe('plugin-metrics', () => {
           origin: {
             buildType: 'test',
             networkType: 'unknown',
+            upgradeChannel: 'test',
           },
         });
         assert.deepEqual(prepareDiagnosticMetricItemCalls[0].args[1].type, ['diagnostic-event']);

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -2314,6 +2314,7 @@ describe('internal-plugin-metrics', () => {
                     environment: 'meeting_evn',
                     name: 'endpoint',
                     networkType: 'unknown',
+                    upgradeChannel: 'test',
                     userAgent,
                   },
                   originTime: {

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -446,7 +446,7 @@ describe('internal-plugin-metrics', () => {
       assert.deepEqual(item.eventPayload.origin.buildType, 'prod');
     });
 
-    it('sets the upgradeChannel value correctly', () => {
+    it('sets the upgradeChannel as "gold" when the buildType is "prod"', () => {
       const item: any = {
         eventPayload: {
           event: {
@@ -464,14 +464,14 @@ describe('internal-plugin-metrics', () => {
       assert.deepEqual(item.eventPayload.origin.upgradeChannel, 'gold');
     });
 
-    it('sets the upgradeChannel value correctly', () => {
+    it('sets the upgradeChannel as buildType value if it is not "prod"' , () => {
       const item: any = {
         eventPayload: {
           event: {
             name: 'client.exit.app',
             eventData: {
               markAsTestEvent: true,
-              webClientDomain: 'https://web.webex.com',
+              webClientDomain: 'https://test.webex.com',
             },
           },
         },
@@ -479,10 +479,10 @@ describe('internal-plugin-metrics', () => {
       };
 
       prepareDiagnosticMetricItem(webex, item);
+      assert.deepEqual(item.eventPayload.origin.buildType, 'test')
       assert.deepEqual(item.eventPayload.origin.upgradeChannel, 'test');
     });
   });
-
 
   describe('setMetricTimings', () => {
     let webex: any;

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -460,13 +460,22 @@ describe('internal-plugin-metrics', () => {
         type: ['diagnostic-event'],
       };
 
+      delete item.eventPayload.origin.buildType;
+      item.eventPayload.origin.buildType = 'prod';
+
+      delete item.eventPayload.origin.upgradeChannel;
       prepareDiagnosticMetricItem(webex, item);
       assert.deepEqual(item.eventPayload.origin.upgradeChannel, 'gold');
 
-      delete item.eventPayload.origin.upgradeChannel;
-      item.eventPayload.event.eventData.markAsTestEvent = true;
-      prepareDiagnosticMetricItem(webex, item);
-      assert.deepEqual(item.eventPayload.origin.upgradeChannel, undefined);
+      const otherBuildTypes = ["debug", "test" ,"tap", "analyzer-test"];
+      otherBuildTypes.forEach((buildType) => {
+        delete item.eventPayload.origin.buildType;
+        item.eventPayload.origin.buildType = buildType;
+
+        delete item.eventPayload.origin.upgradeChannel;
+        prepareDiagnosticMetricItem(webex, item);
+        assert.deepEqual(item.eventPayload.origin.upgradeChannel, buildType)
+      });
     });
   });
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -275,7 +275,7 @@ describe('internal-plugin-metrics', () => {
     let webex: any;
 
     const check = (eventName: string, expectedEvent: any, expectedUpgradeChannel: string) => {
-      const eventPayload = { event: { name: eventName } };
+      const eventPayload = {event: {name: eventName}};
       const item = prepareDiagnosticMetricItem(webex, {
         eventPayload,
         type: ['diagnostic-event'],
@@ -288,19 +288,19 @@ describe('internal-plugin-metrics', () => {
             networkType: 'unknown',
             upgradeChannel: expectedUpgradeChannel
           },
-          event: { name: eventName, ...expectedEvent },
+          event: {name: eventName, ...expectedEvent},
         },
         type: ['diagnostic-event'],
       });
     };
 
     beforeEach(async () => {
-      webex = { internal: { newMetrics: {} } };
+      webex = {internal: {newMetrics: {}}};
       webex.internal.newMetrics.callDiagnosticLatencies = new CallDiagnosticLatencies(
         {},
-        { parent: webex }
+        {parent: webex}
       );
-      webex.logger = new Logger({}, { parent: webex });
+      webex.logger = new Logger({}, {parent: webex});
     });
 
     beforeEach(() => {

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -461,6 +461,7 @@ describe('internal-plugin-metrics', () => {
       };
 
       prepareDiagnosticMetricItem(webex, item);
+      assert.deepEqual(item.eventPayload.origin.buildType, 'prod');
       assert.deepEqual(item.eventPayload.origin.upgradeChannel, 'gold');
     });
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../../src/call-diagnostic/config';
 import Logger from '@webex/plugin-logger';
 
-let {
+const {
   clearEmptyKeysRecursively,
   extractVersionMetadata,
   getBuildType,
@@ -274,7 +274,7 @@ describe('internal-plugin-metrics', () => {
   describe('prepareDiagnosticMetricItem', () => {
     let webex: any;
 
-    const check = (eventName: string, expectedEvent: any, expectedUpgradeChannel: string | undefined) => {
+    const check = (eventName: string, expectedEvent: any, expectedUpgradeChannel: string) => {
       const eventPayload = { event: { name: eventName } };
       const item = prepareDiagnosticMetricItem(webex, {
         eventPayload,
@@ -460,22 +460,26 @@ describe('internal-plugin-metrics', () => {
         type: ['diagnostic-event'],
       };
 
-      delete item.eventPayload.origin.buildType;
-      item.eventPayload.origin.buildType = 'prod';
-
-      delete item.eventPayload.origin.upgradeChannel;
       prepareDiagnosticMetricItem(webex, item);
       assert.deepEqual(item.eventPayload.origin.upgradeChannel, 'gold');
+    });
 
-      const otherBuildTypes = ["debug", "test" ,"tap", "analyzer-test"];
-      otherBuildTypes.forEach((buildType) => {
-        delete item.eventPayload.origin.buildType;
-        item.eventPayload.origin.buildType = buildType;
+    it('sets the upgradeChannel value correctly', () => {
+      const item: any = {
+        eventPayload: {
+          event: {
+            name: 'client.exit.app',
+            eventData: {
+              markAsTestEvent: true,
+              webClientDomain: 'https://web.webex.com',
+            },
+          },
+        },
+        type: ['diagnostic-event'],
+      };
 
-        delete item.eventPayload.origin.upgradeChannel;
-        prepareDiagnosticMetricItem(webex, item);
-        assert.deepEqual(item.eventPayload.origin.upgradeChannel, buildType)
-      });
+      prepareDiagnosticMetricItem(webex, item);
+      assert.deepEqual(item.eventPayload.origin.upgradeChannel, 'test');
     });
   });
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -422,7 +422,7 @@ describe('internal-plugin-metrics', () => {
       });
     });
 
-    it('getBuildType returns correct value', () => {
+    it('sets buildType and upgradeChannel correctly', () => {
       const item: any = {
         eventPayload: {
           event: {
@@ -439,49 +439,14 @@ describe('internal-plugin-metrics', () => {
       // just submit any event
       prepareDiagnosticMetricItem(webex, item);
       assert.deepEqual(item.eventPayload.origin.buildType, 'test');
+      assert.deepEqual(item.eventPayload.origin.upgradeChannel, 'test');
 
       delete item.eventPayload.origin.buildType;
+      delete item.eventPayload.origin.upgradeChannel;
       item.eventPayload.event.eventData.markAsTestEvent = false;
       prepareDiagnosticMetricItem(webex, item);
       assert.deepEqual(item.eventPayload.origin.buildType, 'prod');
-    });
-
-    it('sets the upgradeChannel as "gold" when the buildType is "prod"', () => {
-      const item: any = {
-        eventPayload: {
-          event: {
-            name: 'client.exit.app',
-            eventData: {
-              markAsTestEvent: false,
-              webClientDomain: 'https://web.webex.com',
-            },
-          },
-        },
-        type: ['diagnostic-event'],
-      };
-
-      prepareDiagnosticMetricItem(webex, item);
-      assert.deepEqual(item.eventPayload.origin.buildType, 'prod');
       assert.deepEqual(item.eventPayload.origin.upgradeChannel, 'gold');
-    });
-
-    it('sets the upgradeChannel as buildType value if it is not "prod"' , () => {
-      const item: any = {
-        eventPayload: {
-          event: {
-            name: 'client.exit.app',
-            eventData: {
-              markAsTestEvent: true,
-              webClientDomain: 'https://test.webex.com',
-            },
-          },
-        },
-        type: ['diagnostic-event'],
-      };
-
-      prepareDiagnosticMetricItem(webex, item);
-      assert.deepEqual(item.eventPayload.origin.buildType, 'test')
-      assert.deepEqual(item.eventPayload.origin.upgradeChannel, 'test');
     });
   });
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/prelogin-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/prelogin-metrics-batcher.ts
@@ -82,6 +82,7 @@ describe('internal-plugin-metrics', () => {
                   origin: {
                     buildType: 'test',
                     networkType: 'unknown',
+                    upgradeChannel: 'test',
                   },
                   originTime: {
                     sent: dateAfterBatcherWait.toISOString(),
@@ -211,7 +212,7 @@ describe('internal-plugin-metrics', () => {
         // item also gets assigned a delay property but the key is a Symbol and haven't been able to test that..
         assert.deepEqual(calls.args[0].eventPayload, {
           event: 'my.event',
-          origin: {buildType: 'test', networkType: 'unknown'},
+          origin: {buildType: 'test', networkType: 'unknown', upgradeChannel: 'test'},
         });
 
         assert.deepEqual(calls.args[0].type, ['diagnostic-event']);
@@ -225,6 +226,7 @@ describe('internal-plugin-metrics', () => {
           origin: {
             buildType: 'test',
             networkType: 'unknown',
+            upgradeChannel: 'test',
           },
         });
         assert.deepEqual(prepareDiagnosticMetricItemCalls[0].args[1].type, ['diagnostic-event']);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [`WEBEX-402267`](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-402267)

## This pull request addresses
... the update to the diagnostic event, ensuring that the `upgradeChannel` field is populated with the value `"gold"` for `buildType` set to `"prod"` (already populated in SDK). For other options, the string value remains the same as in `buildType.`


## by making the following changes

- Populate the `upgradeChannel` field with the value `"gold"` for buildType set to `"prod"`.
- Ensure that for other `buildType` options, the `upgradeChannel` string value remains the same as in `buildType`.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

- Updated the unit test to reflect the changes.
- Manual testing with the sample app:
![Screenshot 2024-10-07 at 11 00 09 AM](https://github.com/user-attachments/assets/34d29f50-b3d2-413b-8e36-b58b417234bb)

![Screenshot 2024-10-07 at 11 02 29 AM](https://github.com/user-attachments/assets/25629486-e536-4410-b8e3-1ea4b6f06634)
- MQR are generated with the new property: 
![Screenshot 2024-10-07 at 11 22 54 AM](https://github.com/user-attachments/assets/b10cb3e1-0244-47f6-b461-939bbcf49425)


### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request
- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly
