### PR TITLE
fix(mercury): fix logout mercury delete

### DIFF
--- a/packages/@webex/internal-plugin-mercury/src/config.js
+++ b/packages/@webex/internal-plugin-mercury/src/config.js
@@ -30,5 +30,11 @@ export default {
      * @type {[type]}
      */
     forceCloseDelay: process.env.MERCURY_FORCE_CLOSE_DELAY || 2000,
+    /**
+     * When logging out, use default reason which can trigger a reconnect,
+     * or set to something else, like `done (permanent)` to prevent reconnect
+     * @type {String}
+     */
+    beforeLogoutOptionsCloseReason: process.env.MERCURY_LOGOUT_REASON || 'done (forced)',
   },
 };

--- a/packages/@webex/internal-plugin-mercury/src/index.js
+++ b/packages/@webex/internal-plugin-mercury/src/index.js
@@ -14,7 +14,7 @@ import config from './config';
 registerInternalPlugin('mercury', Mercury, {
   config,
   onBeforeLogout() {
-    return this.disconnect();
+    return this.logout();
   },
 });
 

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -122,8 +122,15 @@ export default class Socket extends EventEmitter {
       }
 
       options = options || {};
-      if (options.code && options.code !== 1000 && (options.code < 3000 || options.code > 4999)) {
-        reject(new Error('`options.code` must be 1000 or between 3000 and 4999 (inclusive)'));
+      if (
+        options.code &&
+        options.code !== 1000 &&
+        options.code !== 1050 &&
+        (options.code < 3000 || options.code > 4999)
+      ) {
+        reject(
+          new Error('`options.code` must be 1000 or 1050 or between 3000 and 4999 (inclusive)')
+        );
 
         return;
       }
@@ -137,10 +144,14 @@ export default class Socket extends EventEmitter {
         try {
           this.logger.info(`socket,${this._domain}: no close event received, forcing closure`);
           resolve(
-            this.onclose({
-              code: 1000,
-              reason: 'Done (forced)',
-            })
+            this.onclose(
+              options.code === 1050
+                ? {code: 1050, reason: options.reason}
+                : {
+                    code: 1000,
+                    reason: 'Done (forced)',
+                  }
+            )
           );
         } catch (error) {
           this.logger.warn(`socket,${this._domain}: force-close failed`, error);

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
@@ -452,7 +452,7 @@ describe('plugin-mercury', () => {
         Promise.all([
           assert.isRejected(
             socket.close({code: 1001}),
-            /`options.code` must be 1000 or between 3000 and 4999 \(inclusive\)/
+            /`options.code` must be 1000 or 1050 or between 3000 and 4999 \(inclusive\)/
           ),
           socket.close({code: 1000}),
         ]));
@@ -464,6 +464,14 @@ describe('plugin-mercury', () => {
             reason: 'Custom Normal',
           })
           .then(() => assert.calledWith(mockWebSocket.close, 3001, 'Custom Normal')));
+
+      it('accepts the logout reason', () =>
+            socket
+              .close({
+                code: 1050,
+                reason: 'done (permanent)',
+              })
+              .then(() => assert.calledWith(mockWebSocket.close, 1050, 'done (permanent)')));
 
       it('can safely be called called multiple times', () => {
         const p1 = socket.close();
@@ -500,6 +508,84 @@ describe('plugin-mercury', () => {
           mockWebSocket.removeAllListeners('close');
 
           const promise = socket.close();
+
+          clock.tick(mockoptions.forceCloseDelay);
+
+          return promise.then(() => {
+            assert.called(spy);
+            assert.calledWith(spy, {
+              code: 1000,
+              reason: 'Done (forced)',
+            });
+          });
+        });
+      });
+
+      it('signals closure if no close frame is received within the specified window, but uses the initial options as 1050 if specified by options call', () => {
+        const socket = new Socket();
+        const promise = socket.open('ws://example.com', mockoptions);
+
+        mockWebSocket.readyState = 1;
+        mockWebSocket.emit('open');
+        mockWebSocket.emit('message', {
+          data: JSON.stringify({
+            id: uuid.v4(),
+            data: {
+              eventType: 'mercury.buffer_state',
+            },
+          }),
+        });
+
+        return promise.then(() => {
+          const spy = sinon.spy();
+
+          socket.on('close', spy);
+          mockWebSocket.close = () =>
+            new Promise(() => {
+              /* eslint no-inline-comments: [0] */
+            });
+          mockWebSocket.removeAllListeners('close');
+
+          const promise = socket.close({code: 1050, reason: 'done (permanent)'});
+
+          clock.tick(mockoptions.forceCloseDelay);
+
+          return promise.then(() => {
+            assert.called(spy);
+            assert.calledWith(spy, {
+              code: 1050,
+              reason: 'done (permanent)',
+            });
+          });
+        });
+      });
+
+      it('signals closure if no close frame is received within the specified window, and uses default options as 1000 if the code is not 1050', () => {
+        const socket = new Socket();
+        const promise = socket.open('ws://example.com', mockoptions);
+
+        mockWebSocket.readyState = 1;
+        mockWebSocket.emit('open');
+        mockWebSocket.emit('message', {
+          data: JSON.stringify({
+            id: uuid.v4(),
+            data: {
+              eventType: 'mercury.buffer_state',
+            },
+          }),
+        });
+
+        return promise.then(() => {
+          const spy = sinon.spy();
+
+          socket.on('close', spy);
+          mockWebSocket.close = () =>
+            new Promise(() => {
+              /* eslint no-inline-comments: [0] */
+            });
+          mockWebSocket.removeAllListeners('close');
+
+          const promise = socket.close({code: 1000, reason: 'test'});
 
           clock.tick(mockoptions.forceCloseDelay);
 
@@ -617,6 +703,26 @@ describe('plugin-mercury', () => {
             });
           }
         );
+      });
+
+      describe('when it receives close code 1050', () => {
+        it(`emits code 1050 for code 1050`, () => {
+          const code = 1050;
+          const reason = 'done (permanent)';
+          const spy = sinon.spy();
+
+          socket.on('close', spy);
+
+          mockWebSocket.emit('close', {
+            code,
+            reason,
+          });
+          assert.called(spy);
+          assert.calledWith(spy, {
+            code,
+            reason,
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## This pull request addresses

webexteams://im?space=0f339300-7b90-11ef-a299-e5869c69951d
BEMS01793489

On logout, we are not properly deleting the registered device. This PR addresses this issue, whilst keeping backwards compatibility.

## by making the following changes
A new config option, `beforeLogoutOptionsCloseReason` is provided which defaults to the existing reason -> `done (forced)`.

A new logout function, used on logout which proxies into disconnect, using the provided reason code by consumer. if it is undefined, or already one of the existing reasons, it skips this flow, and uses the same disconnect as before (via proxy). If it is a new reason, i.e., `done (permanent)` this will get passed through all the way to the socket.close function. The socket close function, even with done (forced) was previously calling a reconnect, which caused the same device registration to get put right back into the array. For backwards compatibility reasons, we will leave this flow intact. For the web client, we will set this config value to force mercury plugin from calling reconnect using the existing code defined in `case 1000` and adding a new `logout` code -> `1050`. 

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

I was able to reproduce the customer issue. Then, after making my changes, I was able to ensure, manually, that the customer issue no longer occurs, using the WDM GET API for device registrations. I also added complete unit testing.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
