### PR TITLE
fix(internal-plugin-metrics): restricted region wdm error marked as expected

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
@@ -129,7 +129,7 @@ export const ERROR_DESCRIPTIONS = {
   ICE_AND_REACHABILITY_FAILED: 'ICEAndReachabilityFailed',
   SDP_OFFER_CREATION_ERROR: 'SdpOfferCreationError',
   SDP_OFFER_CREATION_ERROR_MISSING_CODEC: 'SdpOfferCreationErrorMissingCodec',
-  WDM_RESTRICTED_REGION: 'WdmRegionRestricted',
+  WDM_RESTRICTED_REGION: 'WdmRestrictedRegion',
 };
 
 export const SERVICE_ERROR_CODES_TO_CLIENT_ERROR_CODES_MAP = {

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
@@ -129,6 +129,7 @@ export const ERROR_DESCRIPTIONS = {
   ICE_AND_REACHABILITY_FAILED: 'ICEAndReachabilityFailed',
   SDP_OFFER_CREATION_ERROR: 'SdpOfferCreationError',
   SDP_OFFER_CREATION_ERROR_MISSING_CODEC: 'SdpOfferCreationErrorMissingCodec',
+  WDM_RESTRICTED_REGION: 'WdmRegionRestricted',
 };
 
 export const SERVICE_ERROR_CODES_TO_CLIENT_ERROR_CODES_MAP = {
@@ -288,6 +289,12 @@ export const SERVICE_ERROR_CODES_TO_CLIENT_ERROR_CODES_MAP = {
   100005: 4103, // Depracated because of an issue in the UCF Clients
   // If both email-hash and domain-hash are null or undefined.
   100004: 4103,
+
+  // ---- WDM ----
+  // WDM_BLOCKED_ACCESS_BY_COUNTRY_CODE_BANNED_COUNTRY_ERROR_CODE
+  4404002: 13000,
+  // WDM_BLOCKED_ACCESS_BY_COUNTRY_CODE_RESTRICTED_COUNTRY_ERROR_CODE
+  4404003: 13000,
 };
 
 export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEventError>> = {
@@ -684,6 +691,11 @@ export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEv
   },
   12003: {
     errorDescription: ERROR_DESCRIPTIONS.USER_NOT_INVITED_TO_JOIN,
+    category: 'expected',
+    fatal: true,
+  },
+  13000: {
+    errorDescription: ERROR_DESCRIPTIONS.WDM_RESTRICTED_REGION,
     category: 'expected',
     fatal: true,
   },

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -2195,7 +2195,7 @@ describe('internal-plugin-metrics', () => {
         });
         assert.deepEqual(res, {
           category: 'expected',
-          errorDescription: 'WdmRegionRestricted',
+          errorDescription: 'WdmRestrictedRegion',
           fatal: true,
           name: 'other',
           shownToUser: false,
@@ -2212,7 +2212,7 @@ describe('internal-plugin-metrics', () => {
         });
         assert.deepEqual(res, {
           category: 'expected',
-          errorDescription: 'WdmRegionRestricted',
+          errorDescription: 'WdmRestrictedRegion',
           fatal: true,
           name: 'other',
           shownToUser: false,

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -2188,6 +2188,40 @@ describe('internal-plugin-metrics', () => {
         });
       });
 
+      it('should generate event error payload correctly for wdm error 4404002', () => {
+        const res = cd.generateClientEventErrorPayload({
+          body: {errorCode: 4404002},
+          message: 'Operation denied due to region restriction',
+        });
+        assert.deepEqual(res, {
+          category: 'expected',
+          errorDescription: 'WdmRegionRestricted',
+          fatal: true,
+          name: 'other',
+          shownToUser: false,
+          serviceErrorCode: 4404002,
+          errorCode: 13000,
+          rawErrorMessage: 'Operation denied due to region restriction',
+        });
+      });
+
+      it('should generate event error payload correctly for wdm error 4404003', () => {
+        const res = cd.generateClientEventErrorPayload({
+          body: {errorCode: 4404003},
+          message: 'Operation denied due to region restriction',
+        });
+        assert.deepEqual(res, {
+          category: 'expected',
+          errorDescription: 'WdmRegionRestricted',
+          fatal: true,
+          name: 'other',
+          shownToUser: false,
+          serviceErrorCode: 4404003,
+          errorCode: 13000,
+          rawErrorMessage: 'Operation denied due to region restriction',
+        });
+      });
+
       describe('httpStatusCode', () => {
         it('should include httpStatusCode for browser media errors', () => {
           const res = cd.generateClientEventErrorPayload({


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-568724](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-568724)

## This pull request addresses

When a user is accessing webex from a restricted region WDM is sending an error which gets marked as a client.login.failure result in CA.

These are expected failures and we should be marking them as expected.

## by making the following changes

I've added the WDM errors with codes 4404002 and 4404003 as an expected error when generating the error object for CA events.

The errors from WDM were taken from [here](https://sqbu-github.cisco.com/WebExSquared/wdm/blob/2405875ef0201358322f8fc31cd3f5ba04459284/server/src/main/java/com/cisco/wx2/wdm/server/WDMUtils.java)

Dashboard to see the current CA failures due to this error: https://wapgrafana-staging.webex.com/d/bacea9f0-52cc-42b3-b4f5-82e9985d4e0a/operation-denied-due-to-region-restriction?orgId=1&from=now-30d&to=now

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Unit tests have been added

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
