### PR TITLE
fix(voicemail): added /v2.0/ check for BWRKS xsiendipoint

### DIFF
--- a/packages/calling/src/common/Utils.test.ts
+++ b/packages/calling/src/common/Utils.test.ts
@@ -1373,3 +1373,84 @@ describe('Get endpoint by CALLING_BACKEND tests', () => {
     expect(await getVgActionEndpoint(webex, CALLING_BACKEND.WXC)).toBeInstanceOf(Error);
   });
 });
+
+describe('Get XSI Action Endpoint tests', () => {
+  const mockWebex: any = {
+    request: jest.fn(),
+    internal: {
+      services: {
+        _serviceUrls: {
+          wdm: 'https://fake-webex-url.com',
+        },
+      },
+    },
+  };
+
+  const loggerContext = {
+    file: 'testFile',
+    method: 'testMethod',
+  };
+
+  it('should return xsiEndpoint for BWRKS backend when URL ends with /v2.0', async () => {
+    const mockResponse = {
+      body: {
+        devices: [
+          {
+            settings: {
+              broadworksXsiActionsUrl: 'https://fake-broadworks-url.com/v2.0',
+            },
+          },
+        ],
+      },
+    };
+
+    mockWebex.request.mockResolvedValue(mockResponse);
+
+    const xsiEndpoint = await getXsiActionEndpoint(mockWebex, loggerContext, CALLING_BACKEND.BWRKS);
+
+    expect(mockWebex.request).toHaveBeenCalledTimes(1);
+    expect(xsiEndpoint).toBe('https://fake-broadworks-url.com');
+  });
+
+  it('should return xsiEndpoint for BWRKS backend when URL ends with /v2.0/', async () => {
+    const mockResponse = {
+      body: {
+        devices: [
+          {
+            settings: {
+              broadworksXsiActionsUrl: 'https://fake-broadworks-url.com/v2.0/',
+            },
+          },
+        ],
+      },
+    };
+
+    mockWebex.request.mockResolvedValue(mockResponse);
+
+    const xsiEndpoint = await getXsiActionEndpoint(mockWebex, loggerContext, CALLING_BACKEND.BWRKS);
+
+    expect(mockWebex.request).toHaveBeenCalledTimes(1);
+    expect(xsiEndpoint).toBe('https://fake-broadworks-url.com');
+  });
+
+  it('should return xsiEndpoint for BWRKS backend when URL does not end with any version', async () => {
+    const mockResponse = {
+      body: {
+        devices: [
+          {
+            settings: {
+              broadworksXsiActionsUrl: 'https://fake-broadworks-url.com',
+            },
+          },
+        ],
+      },
+    };
+
+    mockWebex.request.mockResolvedValue(mockResponse);
+
+    const xsiEndpoint = await getXsiActionEndpoint(mockWebex, loggerContext, CALLING_BACKEND.BWRKS);
+
+    expect(mockWebex.request).toHaveBeenCalledTimes(1);
+    expect(xsiEndpoint).toBe('https://fake-broadworks-url.com');
+  });
+});

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -119,6 +119,7 @@ import {
   SCIM_USER_FILTER,
   WEBEX_API_PROD,
   WEBEX_API_BTS,
+  BW_XSI_ENDPOINT_VERSION_WITH_SLASH,
 } from './constants';
 import {Model, WebexSDK} from '../SDKConnector/types';
 import SDKConnector from '../SDKConnector';
@@ -1110,8 +1111,13 @@ export async function getXsiActionEndpoint(
 
         let xsiEndpoint = response[DEVICES][0][SETTINGS][BW_XSI_URL];
 
-        if (response[DEVICES][0][SETTINGS][BW_XSI_URL].endsWith(BW_XSI_ENDPOINT_VERSION)) {
-          xsiEndpoint = response[DEVICES][0][SETTINGS][BW_XSI_URL].slice(0, -5);
+        const xsiUrl = response[DEVICES][0][SETTINGS][BW_XSI_URL];
+
+        // Check if it ends with specific version and slice accordingly
+        if (xsiUrl.endsWith(BW_XSI_ENDPOINT_VERSION)) {
+          xsiEndpoint = xsiUrl.slice(0, -5); // Remove 'v2.0'
+        } else if (xsiUrl.endsWith(BW_XSI_ENDPOINT_VERSION_WITH_SLASH)) {
+          xsiEndpoint = xsiUrl.slice(0, -6); // Remove 'v2.0/'
         }
 
         return xsiEndpoint;

--- a/packages/calling/src/common/constants.ts
+++ b/packages/calling/src/common/constants.ts
@@ -38,6 +38,7 @@ export const ENTITLEMENT_STANDARD = 'bc-sp-standard';
 export const NATIVE_SIP_CALL_TO_UCM = 'NATIVE_SIP_CALL_TO_UCM';
 export const NATIVE_WEBEX_TEAMS_CALLING = 'NATIVE_WEBEX_TEAMS_CALLING';
 export const BW_XSI_ENDPOINT_VERSION = 'v2.0';
+export const BW_XSI_ENDPOINT_VERSION_WITH_SLASH = 'v2.0/';
 export const BW_XSI_URL = 'broadworksXsiActionsUrl';
 export const WEBEX_CALLING_CONNECTOR_FILE = 'WxCallBackendConnector';
 export const UCM_CONNECTOR_FILE = 'UcmBackendConnector';


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-568088

## This pull request addresses
The BroadWorks API was failing due to an issue where the v2.0 version string was appearing twice in the endpoint URL. This was happening because some customers were configuring the XSI endpoint in the Partner Hub with /v2.0/ instead of the expected /v2.0. As a result, this duplication was causing the API calls to fail.

We have added an additional check inside the getXsiActionEndpoint function to handle this scenario:

If the xsiEndpoint contains /v2.0/, we slice it to remove the trailing / and avoid duplicating the version string in the URL.
This ensures that the URL is correctly formatted and prevents further issues with BroadWorks API calls.
This fix now accounts for both /v2.0 and /v2.0/, providing more flexibility in the endpoint configuration while resolving the API issue.

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

Before fix
<img width="1144" alt="Screenshot 2024-10-10 at 11 45 24 AM" src="https://github.com/user-attachments/assets/f1757801-9451-4291-b9f6-0cd77fc38e9a">

After fix
<img width="1160" alt="Screenshot 2024-10-10 at 11 47 49 AM" src="https://github.com/user-attachments/assets/89ce743a-f9d3-4db2-81b7-1193966fdb7b">


<img width="1178" alt="Screenshot 2024-10-10 at 12 12 08 PM" src="https://github.com/user-attachments/assets/442d6e13-1cf7-44d0-918b-263fda0d38d2">


<img width="1041" alt="Screenshot 2024-10-10 at 4 52 27 PM" src="https://github.com/user-attachments/assets/b4a72372-7e49-49a8-99b5-80ccde7ad3e7">


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

We conducted thorough testing to ensure the changes work correctly in both scenarios where the XSI endpoint URL includes /v2.0 and /v2.0/. The following tests were performed:

Manual Tests:

Scenario 1: XSI Endpoint with /v2.0:
Verified that the BroadWorks API successfully processes requests when the XSI endpoint URL is configured with /v2.0.
Checked that the API responds correctly and the issue with the double versioning in the URL does not occur.

Scenario 2: XSI Endpoint with /v2.0/:
Verified that the API works when the XSI endpoint URL is configured with /v2.0/ (extra slash).
Ensured that the additional logic we implemented slices the trailing slash and properly processes the request.

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
