### PR TITLE
feat(calling): add rtcMetrics in the call

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
+++ b/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
@@ -242,3 +242,19 @@ export type PreComputedLatencies =
   | 'internal.call.init.join.req'
   | 'internal.other.app.api.time'
   | 'internal.api.fetch.intelligence.models';
+
+export interface IdType {
+  meetingId?: string;
+  callId?: string;
+}
+
+export interface IMetricsAttributes {
+  type: string;
+  version: string;
+  userId: string;
+  correlationId: string;
+  connectionId: string;
+  data: any[];
+  meetingId?: string;
+  callId?: string;
+}

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6376,7 +6376,7 @@ export default class Meeting extends StatelessWebexPlugin {
   private async createMediaConnection(turnServerInfo, bundlePolicy?: BundlePolicy) {
     this.rtcMetrics = this.isMultistream
       ? // @ts-ignore
-        new RtcMetrics(this.webex, this.id, this.correlationId)
+        new RtcMetrics(this.webex, {meetingId: this.id}, this.correlationId)
       : undefined;
 
     const mc = Media.createMediaConnection(

--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -346,7 +346,10 @@ describe('Call Tests', () => {
     expect(mockInternalMediaCoreModule.RoapMediaConnection).toBeCalledOnceWith(
       roapMediaConnectionConfig,
       roapMediaConnectionOptions,
-      expect.any(String)
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
     );
     expect(call['mediaStateMachine'].state.value).toBe('S_SEND_ROAP_OFFER');
 
@@ -400,7 +403,10 @@ describe('Call Tests', () => {
     expect(mockInternalMediaCoreModule.RoapMediaConnection).toBeCalledOnceWith(
       roapMediaConnectionConfig,
       roapMediaConnectionOptions,
-      expect.any(String)
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
     );
     expect(call['callStateMachine'].state.value).toBe('S_IDLE');
     expect(warnSpy).toBeCalledOnceWith(`Call cannot be answered because the state is : S_IDLE`, {
@@ -454,7 +460,10 @@ describe('Call Tests', () => {
     expect(mockInternalMediaCoreModule.RoapMediaConnection).toBeCalledOnceWith(
       roapMediaConnectionConfig,
       roapMediaConnectionOptions,
-      expect.any(String)
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
     );
     expect(call['mediaStateMachine'].state.value).toBe('S_SEND_ROAP_OFFER');
 

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -7,8 +7,14 @@ import {
 import {createMachine, interpret} from 'xstate';
 import {v4 as uuid} from 'uuid';
 import {EffectEvent, TrackEffect} from '@webex/web-media-effects';
+import {RtcMetrics} from '@webex/internal-plugin-metrics';
+import ExtendedError from '../../Errors/catalog/ExtendedError';
 import {ERROR_LAYER, ERROR_TYPE, ErrorContext} from '../../Errors/types';
-import {handleCallErrors, parseMediaQualityStatistics} from '../../common/Utils';
+import {
+  handleCallErrors,
+  parseMediaQualityStatistics,
+  serviceErrorCodeHandler,
+} from '../../common/Utils';
 import {
   ALLOWED_SERVICES,
   CallDetails,
@@ -158,6 +164,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
 
   private localAudioStream?: LocalMicrophoneStream;
 
+  private rtcMetrics: RtcMetrics;
+
   /**
    * Getter to check if the call is muted or not.
    *
@@ -243,6 +251,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     });
     this.remoteRoapMessage = null;
     this.disconnectReason = {code: DisconnectCode.NORMAL, cause: DisconnectCause.NORMAL};
+
+    this.rtcMetrics = new RtcMetrics(this.webex, {callId: this.callId}, this.correlationId);
 
     const callMachine = createMachine(
       {
@@ -1927,6 +1937,33 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     }
   }
 
+  /**
+   * Media failed, so collect a stats report from webrtc
+   * send a webrtc telemetry dump to the configured server using the internal media core check metrics configured callback
+   * @param {String} callFrom - the function calling this function, optional.
+   * @returns {Promise<void>}
+   */
+  private forceSendStatsReport = async ({callFrom}: {callFrom?: string}) => {
+    const loggerContext = {
+      file: CALL_FILE,
+      method: this.forceSendStatsReport.name,
+    };
+
+    try {
+      await this.mediaConnection.forceRtcMetricsSend();
+      log.info(`Successfully uploaded available webrtc telemetry statistics`, loggerContext);
+      log.info(`callFrom: ${callFrom}`, loggerContext);
+    } catch (error) {
+      const errorInfo = error as WebexRequestPayload;
+      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      const errorLog = new Error(
+        `Failed to upload webrtc telemetry statistics. ${errorStatus}`
+      ) as ExtendedError;
+
+      log.error(errorLog, loggerContext);
+    }
+  };
+
   /* istanbul ignore next */
   /**
    * Initialize Media Connection.
@@ -1955,7 +1992,10 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
           screenShareVideo: 'inactive',
         },
       },
-      debugId || `WebexCallSDK-${this.correlationId}`
+      debugId || `WebexCallSDK-${this.correlationId}`,
+      (data) => this.rtcMetrics.addMetrics(data),
+      () => this.rtcMetrics.closeMetrics(),
+      () => this.rtcMetrics.sendMetricsInQueue()
     );
 
     this.mediaConnection = mediaConnection;
@@ -1999,6 +2039,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
    */
   public setCallId = (callId: CallId) => {
     this.callId = callId;
+    this.rtcMetrics.updateCallId(callId);
+
     log.info(`Setting callId : ${this.callId} for correlationId: ${this.correlationId}`, {
       file: CALL_FILE,
       method: this.setCallId.name,


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-529191](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-529191) >

## This pull request addresses

Adds RtcMetrics to the Calling package.

## by making the following changes

Calling SDK is now able to send the RTC Metrics.

**Screenshot**
<img width="1372" alt="Calling-RtcMetrics" src="https://github.com/user-attachments/assets/48f89599-3a68-4358-a0c6-14ff9a31af3e">

**Note**: Please check the JIRA for [HAR](https://jira-eng-gpk2.cisco.com/jira/secure/attachment/1324588/calling-rtc-metrics.har) file.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested both Calling and Meeting stats being sent and attached the HAR files on the JIRA.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
