### PR TITLE
fix(calling): failover immediately after 4 keepalive failures for cc flow

### DIFF
--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -732,7 +732,7 @@ describe('Registration Tests', () => {
       expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
       expect(reg.keepaliveTimer).not.toBe(timer);
 
-      webex.request.mockRejectedValueOnce(failurePayload).mockResolvedValue(successPayload);
+      webex.request.mockResolvedValue(successPayload);
 
       jest.advanceTimersByTime(REG_TRY_BACKUP_TIMER_VAL_FOR_CC_IN_SEC * SEC_TO_MSEC_MFACTOR);
       await flushPromises();


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-569580](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-569580) >

## This pull request addresses

Failover to secondary mobius server immediately after 4 keep alive failure for contact center flow.

Here we have introduced a new variable/flag to check we need to failover immediately or not. That flag gets set only when the flow is contact centre and keepalive is failing. It gets reset back when the immediate failover logic runs.

## by making the following changes

Able to failover to backup mobius server immediately after 4 keepalive failure.

**Note**: Please check the [HAR](https://jira-eng-gpk2.cisco.com/jira/secure/attachment/1324962/failover-after-keepalive-public-repo.har) file attached on the JIRA.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested on the samples page by blocking the primary server domain and after 4 keepalive failure registration switched to secondary server.

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
