### PR TITLE
fix(plugin-meetings): init locusInfo before join.response event

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -318,7 +318,6 @@ const MeetingUtil = {
     return MeetingUtil.joinMeeting(meeting, options).catch((err) => {
       // joining a claimed PMR that is not my own, scenario B
       if (MeetingUtil.isPinOrGuest(err)) {
-        // @ts-ignore
         webex.internal.newMetrics.submitClientEvent({
           name: 'client.pin.prompt',
           options: {

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -150,7 +150,9 @@ const MeetingUtil = {
         ipVersion: MeetingUtil.getIpVersion(meeting.getWebexObject()),
       })
       .then((res) => {
-        // @ts-ignore
+        const parsed = MeetingUtil.parseLocusJoin(res);
+
+        meeting.locusInfo.initialSetup(parsed.locus);
         webex.internal.newMetrics.submitClientEvent({
           name: 'client.locus.join.response',
           payload: {
@@ -161,11 +163,11 @@ const MeetingUtil = {
           },
           options: {
             meetingId: meeting.id,
-            mediaConnections: res.body.mediaConnections,
+            mediaConnections: parsed.mediaConnections,
           },
         });
 
-        return MeetingUtil.parseLocusJoin(res);
+        return parsed;
       });
   },
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1641,7 +1641,6 @@ describe('plugin-meetings', () => {
 
             assert.calledOnce(MeetingUtil.joinMeeting);
             assert.calledOnce(webex.internal.device.meetingStarted);
-            assert.calledOnce(meeting.setLocus);
             assert.equal(result, joinMeetingResult);
             assert.calledWith(webex.internal.llm.on, 'online', meeting.handleLLMOnline);
           });
@@ -3789,10 +3788,14 @@ describe('plugin-meetings', () => {
             // that's being tested in these tests)
             meeting.webex.meetings.registered = true;
             meeting.webex.internal.device.config = {};
-            sinon.stub(MeetingUtil, 'joinMeeting').resolves({
-              id: 'fake locus from mocked join request',
-              locusUrl: 'fake locus url',
-              mediaId: 'fake media id',
+            sinon.stub(MeetingUtil, 'joinMeeting').callsFake(async (meeting) => {
+              const result = {
+                id: 'fake locus from mocked join request',
+                locusUrl: 'fake locus url',
+                mediaId: 'fake media id',
+              };
+              meeting.setLocus(result)
+              return result;
             });
             await meeting.join({enableMultistream: isMultistream});
           });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -3788,15 +3788,16 @@ describe('plugin-meetings', () => {
             // that's being tested in these tests)
             meeting.webex.meetings.registered = true;
             meeting.webex.internal.device.config = {};
-            sinon.stub(MeetingUtil, 'joinMeeting').callsFake(async (meeting) => {
-              const result = {
-                id: 'fake locus from mocked join request',
-                locusUrl: 'fake locus url',
-                mediaId: 'fake media id',
-              };
-              meeting.setLocus(result)
-              return result;
-            });
+            sinon.stub(MeetingUtil, 'parseLocusJoin').returns({
+              id: 'fake locus from mocked join request',
+              locusUrl: 'fake locus url',
+              mediaId: 'fake media id',
+            })
+            sinon.stub(meeting.meetingRequest, 'joinMeeting').resolves({
+              headers: {
+                trackingid: 'fake tracking id',
+              }
+            })
             await meeting.join({enableMultistream: isMultistream});
           });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -9,7 +9,6 @@ import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
 import {SELF_POLICY, IP_VERSION} from '@webex/plugin-meetings/src/constants';
 import MockWebex from '@webex/test-helper-mock-webex';
 import * as BrowserDetectionModule from '@webex/plugin-meetings/src/common/browser-detection';
-import LocusInfo from "../../../../src/locus-info";
 
 describe('plugin-meetings', () => {
   let webex;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -400,12 +400,10 @@ describe('plugin-meetings', () => {
           locusUrl: 'locusUrl',
           meetingRequest: {
             joinMeeting: sinon.stub().returns(
-              Promise.resolve(joinMeetingResponse))
+              Promise.resolve(joinMeetingResponse)),
           },
           getWebexObject: sinon.stub().returns(webex),
-          locusInfo: {
-            initialSetup: sinon.stub(),
-          },
+          setLocus: sinon.stub(),
         };
       });
 
@@ -423,9 +421,9 @@ describe('plugin-meetings', () => {
         assert.equal(parameter.reachability, 'reachability');
         assert.equal(parameter.roapMessage, 'roapMessage');
 
-        assert.calledOnce(meeting.locusInfo.initialSetup)
-        const initialSetupParameter = meeting.locusInfo.initialSetup.getCall(0).args[0];
-        assert.deepEqual(initialSetupParameter, joinMeetingResponse.body.locus)
+        assert.calledOnce(meeting.setLocus)
+        const setLocusParameter = meeting.setLocus.getCall(0).args[0];
+        assert.deepEqual(setLocusParameter, MeetingUtil.parseLocusJoin(joinMeetingResponse))
 
         assert.calledWith(webex.internal.newMetrics.submitClientEvent, {
           name: 'client.locus.join.request',

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -391,8 +391,8 @@ describe('plugin-meetings', () => {
         headers: {
           trackingid: 'trackingId',
         },
-      }
-      let meeting
+      };
+      let meeting;
 
       beforeEach(() => {
         meeting = {
@@ -406,8 +406,8 @@ describe('plugin-meetings', () => {
           locusInfo: {
             initialSetup: sinon.stub(),
           },
-        }
-      })
+        };
+      });
 
       it('#Should call `meetingRequest.joinMeeting', async () => {
         await MeetingUtil.joinMeeting(meeting, {
@@ -494,8 +494,8 @@ describe('plugin-meetings', () => {
       });
 
       it('#Should fallback sipUrl if meetingJoinUrl does not exists', async () => {
-        delete meeting.meetingJoinUrl
-        meeting.sipUri = 'sipUri'
+        delete meeting.meetingJoinUrl;
+        meeting.sipUri = 'sipUri';
         await MeetingUtil.joinMeeting(meeting, {});
 
         assert.calledOnce(meeting.meetingRequest.joinMeeting);
@@ -505,8 +505,8 @@ describe('plugin-meetings', () => {
       });
 
       it('#Should fallback to meetingNumber if meetingJoinUrl/sipUrl  does not exists', async () => {
-        delete meeting.meetingJoinUrl
-        meeting.meetingNumber = 'meetingNumber'
+        delete meeting.meetingJoinUrl;
+        meeting.meetingNumber = 'meetingNumber';
         await MeetingUtil.joinMeeting(meeting, {});
 
         assert.calledOnce(meeting.meetingRequest.joinMeeting);
@@ -519,7 +519,7 @@ describe('plugin-meetings', () => {
       it('should pass in the locusClusterUrl from meetingInfo', async () => {
         meeting.meetingInfo = {
           locusClusterUrl: 'locusClusterUrl',
-        }
+        };
         await MeetingUtil.joinMeeting(meeting, {});
 
         assert.calledOnce(meeting.meetingRequest.joinMeeting);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -9,6 +9,7 @@ import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
 import {SELF_POLICY, IP_VERSION} from '@webex/plugin-meetings/src/constants';
 import MockWebex from '@webex/test-helper-mock-webex';
 import * as BrowserDetectionModule from '@webex/plugin-meetings/src/common/browser-detection';
+import LocusInfo from "../../../../src/locus-info";
 
 describe('plugin-meetings', () => {
   let webex;
@@ -378,24 +379,38 @@ describe('plugin-meetings', () => {
     });
 
     describe('joinMeeting', () => {
-      it('#Should call `meetingRequest.joinMeeting', async () => {
-        const meeting = {
+      const joinMeetingResponse = {
+        body: {
+          mediaConnections: [],
+          locus: {
+            url: 'differentLocusUrl',
+            self: {
+              id: 'selfId',
+            },
+          },
+        },
+        headers: {
+          trackingid: 'trackingId',
+        },
+      }
+      let meeting
+
+      beforeEach(() => {
+        meeting = {
           meetingJoinUrl: 'meetingJoinUrl',
           locusUrl: 'locusUrl',
           meetingRequest: {
             joinMeeting: sinon.stub().returns(
-              Promise.resolve({
-                body: {mediaConnections: 'mediaConnections'},
-                headers: {
-                  trackingid: 'trackingId',
-                },
-              })
-            ),
+              Promise.resolve(joinMeetingResponse))
           },
           getWebexObject: sinon.stub().returns(webex),
-        };
+          locusInfo: {
+            initialSetup: sinon.stub(),
+          },
+        }
+      })
 
-        const parseLocusJoinSpy = sinon.stub(MeetingUtil, 'parseLocusJoin');
+      it('#Should call `meetingRequest.joinMeeting', async () => {
         await MeetingUtil.joinMeeting(meeting, {
           reachability: 'reachability',
           roapMessage: 'roapMessage',
@@ -408,6 +423,10 @@ describe('plugin-meetings', () => {
         assert.equal(parameter.preferTranscoding, true);
         assert.equal(parameter.reachability, 'reachability');
         assert.equal(parameter.roapMessage, 'roapMessage');
+
+        assert.calledOnce(meeting.locusInfo.initialSetup)
+        const initialSetupParameter = meeting.locusInfo.initialSetup.getCall(0).args[0];
+        assert.deepEqual(initialSetupParameter, joinMeetingResponse.body.locus)
 
         assert.calledWith(webex.internal.newMetrics.submitClientEvent, {
           name: 'client.locus.join.request',
@@ -424,21 +443,12 @@ describe('plugin-meetings', () => {
           },
           options: {
             meetingId: meeting.id,
-            mediaConnections: 'mediaConnections',
+            mediaConnections: [],
           },
         });
-        parseLocusJoinSpy.restore();
       });
 
       it('#Should call meetingRequest.joinMeeting with breakoutsSupported=true when passed in as true', async () => {
-        const meeting = {
-          meetingRequest: {
-            joinMeeting: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
-          },
-          getWebexObject: sinon.stub().returns(webex),
-        };
-
-        const parseLocusJoinSpy = sinon.stub(MeetingUtil, 'parseLocusJoin');
         await MeetingUtil.joinMeeting(meeting, {
           breakoutsSupported: true,
         });
@@ -447,18 +457,9 @@ describe('plugin-meetings', () => {
         const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
 
         assert.equal(parameter.breakoutsSupported, true);
-        parseLocusJoinSpy.restore();
       });
 
       it('#Should call meetingRequest.joinMeeting with liveAnnotationSupported=true when passed in as true', async () => {
-        const meeting = {
-          meetingRequest: {
-            joinMeeting: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
-          },
-          getWebexObject: sinon.stub().returns(webex),
-        };
-
-        const parseLocusJoinSpy = sinon.stub(MeetingUtil, 'parseLocusJoin');
         await MeetingUtil.joinMeeting(meeting, {
           liveAnnotationSupported: true,
         });
@@ -467,18 +468,9 @@ describe('plugin-meetings', () => {
         const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
 
         assert.equal(parameter.liveAnnotationSupported, true);
-        parseLocusJoinSpy.restore();
       });
 
       it('#Should call meetingRequest.joinMeeting with locale=en_UK, deviceCapabilities=["TEST"] when they are passed in as those values', async () => {
-        const meeting = {
-          meetingRequest: {
-            joinMeeting: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
-          },
-          getWebexObject: sinon.stub().returns(webex),
-        };
-
-        const parseLocusJoinSpy = sinon.stub(MeetingUtil, 'parseLocusJoin');
         await MeetingUtil.joinMeeting(meeting, {
           locale: 'en_UK',
           deviceCapabilities: ['TEST'],
@@ -489,21 +481,10 @@ describe('plugin-meetings', () => {
 
         assert.equal(parameter.locale, 'en_UK');
         assert.deepEqual(parameter.deviceCapabilities, ['TEST']);
-        parseLocusJoinSpy.restore();
       });
 
       it('#Should call meetingRequest.joinMeeting with preferTranscoding=false when multistream is enabled', async () => {
-        const meeting = {
-          isMultistream: true,
-          meetingJoinUrl: 'meetingJoinUrl',
-          locusUrl: 'locusUrl',
-          meetingRequest: {
-            joinMeeting: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
-          },
-          getWebexObject: sinon.stub().returns(webex),
-        };
-
-        const parseLocusJoinSpy = sinon.stub(MeetingUtil, 'parseLocusJoin');
+        meeting.isMultistream = true;
         await MeetingUtil.joinMeeting(meeting, {});
 
         assert.calledOnce(meeting.meetingRequest.joinMeeting);
@@ -511,40 +492,22 @@ describe('plugin-meetings', () => {
 
         assert.equal(parameter.inviteeAddress, 'meetingJoinUrl');
         assert.equal(parameter.preferTranscoding, false);
-        parseLocusJoinSpy.restore();
       });
 
       it('#Should fallback sipUrl if meetingJoinUrl does not exists', async () => {
-        const meeting = {
-          sipUri: 'sipUri',
-          locusUrl: 'locusUrl',
-          meetingRequest: {
-            joinMeeting: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
-          },
-          getWebexObject: sinon.stub().returns(webex),
-        };
-
-        const parseLocusJoinSpy = sinon.stub(MeetingUtil, 'parseLocusJoin');
+        delete meeting.meetingJoinUrl
+        meeting.sipUri = 'sipUri'
         await MeetingUtil.joinMeeting(meeting, {});
 
         assert.calledOnce(meeting.meetingRequest.joinMeeting);
         const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
 
         assert.equal(parameter.inviteeAddress, 'sipUri');
-        parseLocusJoinSpy.restore();
       });
 
       it('#Should fallback to meetingNumber if meetingJoinUrl/sipUrl  does not exists', async () => {
-        const meeting = {
-          meetingNumber: 'meetingNumber',
-          locusUrl: 'locusUrl',
-          meetingRequest: {
-            joinMeeting: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
-          },
-          getWebexObject: sinon.stub().returns(webex),
-        };
-
-        const parseLocusJoinSpy = sinon.stub(MeetingUtil, 'parseLocusJoin');
+        delete meeting.meetingJoinUrl
+        meeting.meetingNumber = 'meetingNumber'
         await MeetingUtil.joinMeeting(meeting, {});
 
         assert.calledOnce(meeting.meetingRequest.joinMeeting);
@@ -552,28 +515,18 @@ describe('plugin-meetings', () => {
 
         assert.isUndefined(parameter.inviteeAddress);
         assert.equal(parameter.meetingNumber, 'meetingNumber');
-        parseLocusJoinSpy.restore();
       });
 
       it('should pass in the locusClusterUrl from meetingInfo', async () => {
-        const meeting = {
-          meetingInfo: {
-            locusClusterUrl: 'locusClusterUrl',
-          },
-          meetingRequest: {
-            joinMeeting: sinon.stub().returns(Promise.resolve({body: {}, headers: {}})),
-          },
-          getWebexObject: sinon.stub().returns(webex),
-        };
-
-        const parseLocusJoinSpy = sinon.stub(MeetingUtil, 'parseLocusJoin');
+        meeting.meetingInfo = {
+          locusClusterUrl: 'locusClusterUrl',
+        }
         await MeetingUtil.joinMeeting(meeting, {});
 
         assert.calledOnce(meeting.meetingRequest.joinMeeting);
         const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
 
         assert.equal(parameter.locusClusterUrl, 'locusClusterUrl');
-        parseLocusJoinSpy.restore();
       });
     });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -492,7 +492,7 @@ describe('plugin-meetings', () => {
       });
 
       it('#Should fallback sipUrl if meetingJoinUrl does not exists', async () => {
-        delete meeting.meetingJoinUrl;
+        meeting.meetingJoinUrl = undefined;
         meeting.sipUri = 'sipUri';
         await MeetingUtil.joinMeeting(meeting, {});
 
@@ -503,7 +503,7 @@ describe('plugin-meetings', () => {
       });
 
       it('#Should fallback to meetingNumber if meetingJoinUrl/sipUrl  does not exists', async () => {
-        delete meeting.meetingJoinUrl;
+        meeting.meetingJoinUrl = undefined;
         meeting.meetingNumber = 'meetingNumber';
         await MeetingUtil.joinMeeting(meeting, {});
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-570035](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-570035)

## This pull request addresses

Missing locusInfo in `event.identifiers` in first `client.locus.join.response` event

## by making the following changes

Initial setup of locusInfo **before** first `client.locus.join.response` event

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [x] Automated tests
- [x] Scenario:
  1. Schedule meeting from native client
  2. Join a meeting from native client
  3. Copy the meeting url from native client
  4. In sample app paste the url to "Destination" (above "Sync Meetings")
  5. In sample app click "Create Meeting"
  6. Join with media after choosing this meeting from list
  7. `client.locus.join.response` now has property `identifiers.locusUrl`(with id) and `identifiers.locusId` filled

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced methods for managing screen sharing and whiteboard functionalities.
  - Enhanced media management capabilities, including support for various media types.

- **Bug Fixes**
  - Improved error handling in meeting lifecycle methods to ensure appropriate logging and responses.

- **Refactor**
  - Streamlined the `joinMeeting` and `joinMeetingOptions` methods for better readability and efficiency.
  - Refined event handling and metrics submission processes for improved tracking and analysis.

- **Tests**
  - Updated test cases to reflect changes in response structures and ensure proper validation of new functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->