### PR TITLE
fix(meetings): ca event validation failures

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -49,7 +49,7 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
   private getMeeting() {
     if (this.meetingId) {
       // @ts-ignore
-      return this.webex.meetings.meetingCollection.get(this.meetingId);
+      return this.webex.meetings.getBasicMeetingInformation(this.meetingId);
     }
 
     return undefined;

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -139,7 +139,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
   getIsConvergedArchitectureEnabled({meetingId}: {meetingId?: string}): boolean {
     if (meetingId) {
       // @ts-ignore
-      const meeting = this.webex.meetings.meetingCollection.get(meetingId);
+      const meeting = this.webex.meetings.getBasicMeetingInformation(meetingId);
 
       return meeting?.meetingInfo?.enableConvergedArchitecture;
     }
@@ -245,7 +245,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
 
       if (meetingId) {
         // @ts-ignore
-        const meeting = this.webex.meetings.meetingCollection.get(meetingId);
+        const meeting = this.webex.meetings.getBasicMeetingInformation(meetingId);
         if (meeting?.environment) {
           origin.environment = meeting.environment;
         }
@@ -430,7 +430,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
     // events that will most likely happen in join phase
     if (meetingId) {
       // @ts-ignore
-      const meeting = this.webex.meetings.meetingCollection.get(meetingId);
+      const meeting = this.webex.meetings.getBasicMeetingInformation(meetingId);
 
       if (!meeting) {
         console.warn(
@@ -667,7 +667,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
     } = options;
 
     // @ts-ignore
-    const meeting = this.webex.meetings.meetingCollection.get(meetingId);
+    const meeting = this.webex.meetings.getBasicMeetingInformation(meetingId);
 
     if (!meeting) {
       console.warn(

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -12,12 +12,10 @@ describe('internal-plugin-metrics', () => {
       sinon.useFakeTimers(now.getTime());
       const webex = {
         meetings: {
-          meetingCollection: {
-            get: (id: string) => {
-              if (id === 'meeting-id') {
-                return {id: 'meeting-id', allowMediaInLobby: true};
-              }
-            },
+          getBasicMeetingInformation: (id: string) => {
+            if (id === 'meeting-id') {
+              return {id: 'meeting-id', allowMediaInLobby: true};
+            }
           },
         },
       };

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -42,9 +42,6 @@ describe('internal-plugin-metrics', () => {
       },
       meetingInfo: {},
       getCurUserType: () => 'host',
-      statsAnalyzer: {
-        getLocalIpAddress: () => '192.168.1.90',
-      },
     };
 
     const fakeMeeting2 = {
@@ -96,8 +93,19 @@ describe('internal-plugin-metrics', () => {
               clientName: 'Cantina',
             },
           },
+          getBasicMeetingInformation: (id) => fakeMeetings[id],
           meetingCollection: {
-            get: (id) => fakeMeetings[id],
+            get: (meetingId) => {
+              return {
+                statsAnalyzer: {
+                  getLocalIpAddress: () => {
+                    if (meetingId) {
+                      return '192.168.1.90';
+                    }
+                  },
+                }
+              }
+            },
           },
           geoHintInfo: {
             clientAddress: '1.3.4.5',
@@ -1714,7 +1722,8 @@ describe('internal-plugin-metrics', () => {
       });
 
       it('should send behavioral event if meetingId provided but meeting is undefined', () => {
-        webex.meetings.meetingCollection.get = sinon.stub().returns(undefined);
+        webex.meetings.getBasicMeetingInformation = sinon.stub().returns(undefined);
+
         cd.submitClientEvent({name: 'client.alert.displayed', options: {meetingId: 'meetingId'}});
         assert.calledWith(
           webex.internal.metrics.submitClientMetrics,
@@ -1918,7 +1927,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       it('should send behavioral event if meeting is undefined', () => {
-        webex.meetings.meetingCollection.get = sinon.stub().returns(undefined);
+        webex.meetings.getBasicMeetingInformation = sinon.stub().returns(undefined);
         cd.submitMQE({
           name: 'client.mediaquality.event',
           payload: {

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
@@ -11,9 +11,6 @@ describe('internal-plugin-metrics', () => {
       newMetrics: NewMetrics,
     },
     meetings: {
-      meetingCollection: {
-        get: sinon.stub(),
-      },
     },
     request: sinon.stub().resolves({}),
     logger: {

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1,5 +1,5 @@
 /* eslint no-shadow: ["error", { "allow": ["eventType"] }] */
-import {union} from 'lodash';
+import {cloneDeep, union} from 'lodash';
 import '@webex/internal-plugin-mercury';
 import '@webex/internal-plugin-conversation';
 import '@webex/internal-plugin-metrics';
@@ -134,6 +134,21 @@ class MediaLogger {
  */
 
 /**
+ * Object containing only the most basic information about a meeting.
+ * This is the information that is kept even after the meeting is deleted from the MeetingCollection
+ */
+export type BasicMeetingInformation = {
+  allowMediaInLobby: boolean;
+  correlationId: string;
+  environment: string;
+  id: string;
+  locusUrl: string;
+  locusInfo: any; // it's only a very small subset of the locus info, see what's populated in the destroy() method
+  meetingInfo: any;
+  sessionCorrelationId: string;
+};
+
+/**
  * Maintain a cache of meetings and sync with services.
  * @class
  */
@@ -141,6 +156,7 @@ export default class Meetings extends WebexPlugin {
   loggerRequest: any;
   media: any;
   meetingCollection: any;
+  deletedMeetings: Map<string, BasicMeetingInformation>;
   personalMeetingRoom: any;
   preferredWebexSite: any;
   reachability: Reachability;
@@ -191,6 +207,8 @@ export default class Meetings extends WebexPlugin {
     // @ts-ignore
     this.loggerRequest = new LoggerRequest({webex: this.webex});
     this.meetingCollection = new MeetingCollection();
+    this.deletedMeetings = new Map();
+
     /**
      * The PersonalMeetingRoom object to interact with server
      * @instance
@@ -1043,6 +1061,17 @@ export default class Meetings extends WebexPlugin {
   }
 
   /**
+   * Returns basic information about a meeting that exists or
+   * used to exist in the MeetingCollection
+   *
+   * @param {string} meetingId
+   * @returns {BasicMeetingInformation|undefined}
+   */
+  public getBasicMeetingInformation(meetingId: string): BasicMeetingInformation {
+    return this.meetingCollection.get(meetingId) || this.deletedMeetings.get(meetingId);
+  }
+
+  /**
    * @param {Meeting} meeting
    * @param {Object} reason
    * @param {String} type
@@ -1052,6 +1081,25 @@ export default class Meetings extends WebexPlugin {
    */
   private destroy(meeting: Meeting, reason: object) {
     MeetingUtil.cleanUp(meeting);
+    // keep some basic info about the deleted meeting forever
+    this.deletedMeetings.set(meeting.id, {
+      id: meeting.id,
+      allowMediaInLobby: meeting.allowMediaInLobby,
+      correlationId: meeting.correlationId,
+      sessionCorrelationId: meeting.sessionCorrelationId,
+      environment: meeting.environment,
+      locusUrl: meeting.locusUrl,
+      meetingInfo: cloneDeep(meeting.meetingInfo),
+      locusInfo: {
+        // locusInfo can be quite big, so keep just the minimal info
+        sequence: meeting.locusInfo?.sequence,
+        url: meeting.locusInfo?.url,
+        fullState: {
+          lastActive: meeting.locusInfo?.fullState?.lastActive,
+          sessionId: meeting.locusInfo?.fullState?.sessionId,
+        },
+      },
+    });
     this.meetingCollection.delete(meeting.id);
     Trigger.trigger(
       this,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -196,6 +196,43 @@ describe('plugin-meetings', () => {
       assert.calledOnce(MeetingsUtil.checkH264Support);
     });
 
+    describe('#getBasicMeetingInformation', () => {
+      beforeEach(() => {
+        sinon.stub(MeetingUtil, 'cleanUp');
+      });
+
+      it('returns correct meeting information', async () => {
+        const meeting = await webex.meetings.createMeeting('test', 'test');
+
+        const meetingIds = {
+          meetingId: meeting.id,
+          correlationId: meeting.correlationId,
+        };
+
+        // before meeting is destroyed - it should return information from the meetingCollection
+        assert.equal(
+          webex.meetings.getBasicMeetingInformation(meetingIds.meetingId).id,
+          meetingIds.meetingId
+        );
+        assert.equal(
+          webex.meetings.getBasicMeetingInformation(meetingIds.meetingId).correlationId,
+          meetingIds.correlationId
+        );
+
+        webex.meetings.destroy(meeting, test1);
+
+        // and it should still return the information after the meeting is destroyed
+        assert.equal(
+          webex.meetings.getBasicMeetingInformation(meetingIds.meetingId).id,
+          meetingIds.meetingId
+        );
+        assert.equal(
+          webex.meetings.getBasicMeetingInformation(meetingIds.meetingId).correlationId,
+          meetingIds.correlationId
+        );
+      });
+    });
+
     describe('#startReachability', () => {
       let gatherReachabilitySpy;
       let fakeResult = {id: 'fake-result'};
@@ -1904,17 +1941,23 @@ describe('plugin-meetings', () => {
           assert.exists(webex.meetings.destroy);
         });
         describe('correctly established meeting', () => {
+          let deleteSpy;
           beforeEach(() => {
-            webex.meetings.meetingCollection.delete = sinon.stub().returns(true);
+            deleteSpy = sinon.spy(webex.meetings.meetingCollection, 'delete');
           });
 
-          it('tests the destroy removal from the collection', async () => {
+          it('tests the destroy removal from the collection and storing basic info in deletedMeetings', async () => {
             const meeting = await webex.meetings.createMeeting('test', 'test');
+
+            const meetingIds = {
+              meetingId: meeting.id,
+              correlationId: meeting.correlationId,
+            };
 
             webex.meetings.destroy(meeting, test1);
 
-            assert.calledOnce(webex.meetings.meetingCollection.delete);
-            assert.calledWith(webex.meetings.meetingCollection.delete, meeting.id);
+            assert.calledOnce(deleteSpy);
+            assert.calledWith(deleteSpy, meeting.id);
             assert.calledWith(
               TriggerProxy.trigger,
               sinon.match.instanceOf(Meetings),
@@ -1928,6 +1971,23 @@ describe('plugin-meetings', () => {
                 reason: test1,
               }
             );
+
+            // check that the meeting is stored in deletedMeetings and removed from meetingCollection
+            assert.equal(webex.meetings.deletedMeetings.get(meeting.id).id, meetingIds.meetingId);
+            assert.equal(
+              webex.meetings.deletedMeetings.get(meeting.id).correlationId,
+              meetingIds.correlationId
+            );
+
+            assert.equal(webex.meetings.meetingCollection.get(meeting.id), undefined);
+
+            // and that getBasicMeetingInformation() still returns the meeting info
+            const deletedMeetingInfo = webex.meetings.getBasicMeetingInformation(
+              meetingIds.meetingId
+            );
+
+            assert.equal(deletedMeetingInfo.id, meetingIds.meetingId);
+            assert.equal(deletedMeetingInfo.correlationId, meetingIds.correlationId);
           });
         });
 


### PR DESCRIPTION
# COMPLETES #[SPARK-570490](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-570490)

## This pull request addresses
CA event validation failures, because of missing fields like correlationId, etc.

## by making the following changes
When meetings are deleted and removed from webex.meetings.meetingCollection, copy the bare minimum information about them like correlationId, locusUrl, etc to another collection `deletedMeetings` so that the information can be retrieved later by metrics plugin or anyone else that needs it.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
