### PR TITLE
feat(webex-core): expose tracking id

### DIFF
--- a/packages/@webex/webex-core/src/index.js
+++ b/packages/@webex/webex-core/src/index.js
@@ -53,6 +53,7 @@ export {default as RequestLoggerInterceptor} from './interceptors/request-logger
 export {default as RequestTimingInterceptor} from './interceptors/request-timing';
 export {default as UserAgentInterceptor} from './interceptors/user-agent';
 export {default as WebexTrackingIdInterceptor} from './interceptors/webex-tracking-id';
+export {sequenceNumbers as webexTrackingIdSequenceNumbers} from './interceptors/webex-tracking-id';
 export {default as WebexUserAgentInterceptor} from './interceptors/webex-user-agent';
 export {default as RateLimitInterceptor} from './interceptors/rate-limit';
 export {default as EmbargoInterceptor} from './interceptors/embargo';

--- a/packages/@webex/webex-core/src/interceptors/webex-tracking-id.js
+++ b/packages/@webex/webex-core/src/interceptors/webex-tracking-id.js
@@ -4,7 +4,7 @@
 
 import {Interceptor} from '@webex/http-core';
 
-const sequenceNumbers = new WeakMap();
+export const sequenceNumbers = new Map();
 
 /**
  * @class

--- a/packages/@webex/webex-core/src/webex-core.js
+++ b/packages/@webex/webex-core/src/webex-core.js
@@ -204,7 +204,6 @@ const WebexCore = AmpState.extend({
       type: 'any',
     },
     sessionId: {
-      setOnce: true,
       type: 'string',
     },
   },


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Currently the tracking id is fixed at the point of initialization of the sdk. In order to use the same trackingid for the same web session, it is necessary to make a few small changes to expose both the id itself and the sequence number.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
