### PR TITLE
fix(webex-core): include number of sections in user token error

### DIFF
--- a/packages/@webex/webex-core/src/lib/credentials/credentials.js
+++ b/packages/@webex/webex-core/src/lib/credentials/credentials.js
@@ -203,7 +203,9 @@ const Credentials = WebexPlugin.extend({
 
     // Validate that the provided token has the proper amount of sections.
     if (fields.length !== 3) {
-      throw new Error('the provided token is not a valid format');
+      throw new Error(
+        `the provided token is not a valid format, token has ${fields.length} sections`
+      );
     }
 
     // Return the token section that contains the OrgId.

--- a/packages/@webex/webex-core/test/unit/spec/credentials/credentials.js
+++ b/packages/@webex/webex-core/test/unit/spec/credentials/credentials.js
@@ -368,7 +368,7 @@ describe('webex-core', () => {
       });
 
       it('should throw when provided an invalid token', () =>
-        expect(() => credentials.extractOrgIdFromUserToken()).toThrow('the provided token is not a valid format'));
+        expect(() => credentials.extractOrgIdFromUserToken()).toThrow('the provided token is not a valid format, token has 1 sections'));
 
       it('should throw when no token is provided', () =>
         expect(() => credentials.extractOrgIdFromUserToken()).toThrow());


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-571125](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-571125)

## This pull request addresses

We are seeing the "the provided token is not a valid format" error in CA results but we want to see how many sections the provided token has for debug purposes.

We believe if the current failures say it is 1 the token is coming through as undefined, but if it is in 2 sections it may be a service account token.

## by making the following changes

state the number of sections in the error message

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Unit test changed

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
