### PR TITLE
fix(embedded-interstitial): fixed issue with default device CatalogDetails

### DIFF
--- a/packages/@webex/internal-plugin-device/src/device.js
+++ b/packages/@webex/internal-plugin-device/src/device.js
@@ -409,7 +409,7 @@ const Device = WebexPlugin.extend({
         ...(this.etag ? {'If-None-Match': this.etag} : {}),
       };
 
-      const {includeDetails} = deviceRegistrationOptions;
+      const {includeDetails = CatalogDetails.all} = deviceRegistrationOptions;
 
       return this.request({
         method: 'PUT',

--- a/packages/@webex/internal-plugin-device/test/unit/spec/device.js
+++ b/packages/@webex/internal-plugin-device/test/unit/spec/device.js
@@ -218,6 +218,26 @@ describe('plugin-device', () => {
         assert.deepEqual(requestSpy.args[0][0].headers, {});
       });
 
+      it('calls request with the expected properties when includeDetails is not specified', async () => {
+        setup();
+
+        const registerSpy = sinon.spy(device, 'register');
+        device.setEnergyForecastConfig(false);
+        device.set('registered', true);
+
+        await device.refresh();
+
+        assert.calledWith(requestSpy, {
+          method: 'PUT',
+          uri: 'https://locus-a.wbx2.com/locus/api/v1/devices/88888888-4444-4444-4444-CCCCCCCCCCCC',
+          body: sinon.match.any,
+          headers: {},
+          qs: {includeUpstreamServices: CatalogDetails.all},
+        });
+
+        assert.notCalled(registerSpy);
+      });
+
       it('calls request with the expected properties when includeDetails is specified', async () => {
         setup();
 
@@ -472,6 +492,29 @@ describe('plugin-device', () => {
           body: {},
           headers: {},
           qs: {includeUpstreamServices: CatalogDetails.features},
+        });
+
+        assert.notCalled(refreshSpy);
+      });
+
+      it('calls request with the expected properties when includeDetails is not specified', async () => {
+        setup();
+
+        sinon.stub(device, 'canRegister').callsFake(() => Promise.resolve());
+        const requestSpy = sinon.spy(device, 'request');
+        const refreshSpy = sinon.spy(device, 'refresh');
+
+        device.setEnergyForecastConfig(false);
+
+        await device.register();
+
+        assert.calledWith(requestSpy, {
+          method: 'POST',
+          service: 'wdm',
+          resource: 'devices',
+          body: {},
+          headers: {},
+          qs: {includeUpstreamServices: CatalogDetails.all},
         });
 
         assert.notCalled(refreshSpy);


### PR DESCRIPTION
# COMPLETES 
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-566917

## This pull request addresses

Fixed a bug I introduced in https://github.com/webex/webex-js-sdk/pull/3905.  The default includeDetails for device.refresh() was not working (works correctly on device.register()).

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Added tests to catch the error and manually tested.

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly
