### PR TITLE
feat(core): mark the services as initFailed if post auth catalog fails to init

### DIFF
--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -1022,9 +1022,10 @@ const Services = WebexPlugin.extend({
           // Validate if the token is authorized.
           if (credentials.canAuthorize) {
             // Attempt to collect the postauth catalog.
-            return this.updateServices().catch(() =>
-              this.logger.warn('services: cannot retrieve postauth catalog')
-            );
+            return this.updateServices().catch(() => {
+              this.initFailed = true;
+              this.logger.warn('services: cannot retrieve postauth catalog');
+            });
           }
 
           // Return a resolved promise for consistent return value.

--- a/packages/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/services.js
@@ -124,6 +124,58 @@ describe('webex-core', () => {
       });
     });
 
+    describe('#initServiceCatalogs', () => {
+      it('does not set initFailed to true when updateServices succeeds', async () => {
+        services.webex.credentials = {
+          getOrgId: sinon.stub().returns('orgId'),
+          canAuthorize: true,
+        };
+
+        services.collectPreauthCatalog = sinon.stub().callsFake(() => {
+          return Promise.resolve();
+        });
+
+        services.updateServices = sinon.stub().callsFake(() => {
+          return Promise.resolve();
+        });
+
+        services.logger.error = sinon.stub();
+
+        await services.initServiceCatalogs();
+
+        assert.isFalse(services.initFailed);
+
+        sinon.assert.calledWith(services.collectPreauthCatalog, {orgId: 'orgId'});
+        sinon.assert.notCalled(services.logger.warn);
+      });
+
+      it('sets initFailed to true when updateServices errors', async () => {
+        const error = new Error('failed');
+
+        services.webex.credentials = {
+          getOrgId: sinon.stub().returns('orgId'),
+          canAuthorize: true,
+        };
+
+        services.collectPreauthCatalog = sinon.stub().callsFake(() => {
+          return Promise.resolve();
+        })
+
+        services.updateServices = sinon.stub().callsFake(() => {
+          return Promise.reject(error);
+        });
+
+        services.logger.error = sinon.stub();
+
+        await services.initServiceCatalogs();
+
+        assert.isTrue(services.initFailed);
+
+        sinon.assert.calledWith(services.collectPreauthCatalog, {orgId: 'orgId'});
+        sinon.assert.calledWith(services.logger.warn, 'services: cannot retrieve postauth catalog');
+      });
+    });
+
     describe('class members', () => {
       describe('#registries', () => {
         it('should be a weakmap', () => {


### PR DESCRIPTION
## This pull request addresses

If the client already has an access token, it will try and init the services. If this fails, we need to notify the app by setting the initFailed flag to true.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
