### PR TITLE
fix: add ice candidates gathering timeout for roap media connection

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1328,3 +1328,5 @@ export const DESTINATION_TYPE = {
 } as const;
 
 export type DESTINATION_TYPE = Enum<typeof DESTINATION_TYPE>;
+
+export const ICE_CANDIDATES_TIMEOUT = 5000;

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -17,7 +17,7 @@ import {
 } from '@webex/media-helpers';
 import {RtcMetrics} from '@webex/internal-plugin-metrics';
 import LoggerProxy from '../common/logs/logger-proxy';
-import {MEDIA_TRACK_CONSTRAINT} from '../constants';
+import {ICE_CANDIDATES_TIMEOUT, MEDIA_TRACK_CONSTRAINT} from '../constants';
 import Config from '../config';
 import StaticConfig from '../common/config';
 import BrowserDetection from '../common/browser-detection';
@@ -210,6 +210,7 @@ Media.createMediaConnection = (
   return new RoapMediaConnection(
     {
       iceServers,
+      iceCandidatesTimeout: ICE_CANDIDATES_TIMEOUT,
       skipInactiveTransceivers: false,
       requireH264: true,
       sdpMunging: {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-576423](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-576423)

## This pull request addresses

Long waiting time for ICE Candidates gathering for customers which are using transcoded meetings.

## by making the following changes

Add a timeout for RoapMediaConnection, which is responsible for transcoded meeting session setup.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
