### PR TITLE
feat: update participant stepped away status

### DIFF
--- a/packages/@webex/plugin-meetings/src/members/index.ts
+++ b/packages/@webex/plugin-meetings/src/members/index.ts
@@ -330,13 +330,14 @@ export default class Members extends StatelessWebexPlugin {
    * @private
    * @memberof Members
    */
-  locusParticipantsUpdate(payload: {participants: any[]; isReplace?: boolean}) {
+  locusParticipantsUpdate(payload: {participants: object; isReplace?: boolean}) {
     if (payload) {
       if (payload.isReplace) {
         this.clearMembers();
       }
       const delta = this.handleLocusInfoUpdatedParticipants(payload);
       const full = this.handleMembersUpdate(delta); // SDK should propagate the full list for both delta and non delta updates
+      const participantsArray = Object.values(payload.participants);
 
       this.receiveSlotManager?.updateMemberIds();
 
@@ -354,7 +355,7 @@ export default class Members extends StatelessWebexPlugin {
         }
       );
 
-      payload.participants.forEach((participant) => {
+      participantsArray.forEach((participant) => {
         if (participant.controls?.brb?.enabled) {
           Trigger.trigger(
             this,

--- a/packages/@webex/plugin-meetings/src/members/index.ts
+++ b/packages/@webex/plugin-meetings/src/members/index.ts
@@ -322,15 +322,15 @@ export default class Members extends StatelessWebexPlugin {
   }
 
   /**
-   * when new participant updates come in, both delta and full participants, update them in members collection
-   * delta object in the event will have {updated, added} and full will be the full membersCollection
+   * When new participant updates come in, both delta and full participants, update them in members collection.
+   * Delta object in the event will have {updated, added} and full will be the full membersCollection.
    * @param {Object} payload
    * @param {Object} payload.participants
    * @returns {undefined}
    * @private
    * @memberof Members
    */
-  locusParticipantsUpdate(payload: {participants: object; isReplace?: boolean}) {
+  locusParticipantsUpdate(payload: {participants: any[]; isReplace?: boolean}) {
     if (payload) {
       if (payload.isReplace) {
         this.clearMembers();
@@ -353,6 +353,20 @@ export default class Members extends StatelessWebexPlugin {
           isReplace: !!payload.isReplace,
         }
       );
+
+      payload.participants.forEach((participant) => {
+        if (participant.controls?.brb?.enabled) {
+          Trigger.trigger(
+            this,
+            {
+              file: 'members',
+              function: 'locusParticipantsUpdate',
+            },
+            'participant:stepped_away',
+            participant
+          );
+        }
+      });
     }
   }
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-559646](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-559646)

## This pull request addresses

... the need for the the SDK to listen to Locus participant updates so that it would tell the web client if a user whose video we are not currently requesting has stepped away, and forward this information to the web client so that the participant list, for example, can be updated to show that the user has stepped away.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
