### PR TITLE
fix(plugin-meetings): do not wait for upload logs before destroying meeting

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1247,10 +1247,9 @@ export default class Meetings extends WebexPlugin {
                       locusId: createdMeeting.locusId,
                       meetingId: createdMeeting.locusInfo?.info?.webExMeetingId,
                       autoupload: true,
-                    }).then(() => this.destroy(createdMeeting, payload.reason));
-                  } else {
-                    this.destroy(createdMeeting, payload.reason);
+                    });
                   }
+                  this.destroy(createdMeeting, payload.reason);
                 });
 
                 createdMeeting.on(EVENTS.REQUEST_UPLOAD_LOGS, (meetingInstance) => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-574076](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-574076)

## This pull request addresses

When leaving a meeting, if the logs fail to upload (for example, if the log upload service is down), the meeting may not be destroyed until much later (up to 23 seconds after leaving the meeting in my tests). If the user rejoins the meeting during that time, it may cause them to get removed from the meeting when the meeting is destroyed.

## by making the following changes

Do not wait for the logs to be uploaded before destroying the meeting.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

1. Manually tested by hardcoding an invalid URL to mimic the log upload service not working. Confirmed that the issue no longer occurs in this scenario.
2. Manually tested by artificially delaying the log upload until 15 seconds after the meeting ends. Logs still upload correctly, even if I rejoin within those 15 seconds.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced meeting log management with automatic log uploads before meeting destruction.
- **Bug Fixes**
	- Improved control flow and clarity in meeting destruction logic.
- **Refactor**
	- Cleaned up code for better readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->