### PR TITLE
fix(plugin-presence): set status failed when attempting to set DND

### DIFF
--- a/packages/@webex/internal-plugin-presence/src/presence.js
+++ b/packages/@webex/internal-plugin-presence/src/presence.js
@@ -248,7 +248,7 @@ const Presence = WebexPlugin.extend({
         body: {
           subject: this.webex.internal.device.userId,
           eventType: status,
-          label: this.webex.internal.device.userId,
+          ...(status !== 'dnd' && {label: this.webex.internal.device.userId}),
           ttl,
         },
       })

--- a/packages/@webex/internal-plugin-presence/test/unit/spec/presence.js
+++ b/packages/@webex/internal-plugin-presence/test/unit/spec/presence.js
@@ -79,13 +79,36 @@ describe.skip('plugin-presence', () => {
         };
         sinon.spy(webex, 'request');
 
-        webex.internal.presence.setStatus('dnd');
+        webex.internal.presence.setStatus('active');
 
         assert.calledOnce(webex.request);
 
         const request = webex.request.getCall(0);
 
         assert.equal(request.args[0].body.label, testGuid);
+      });
+
+      it('does not pass a label to the API if the status is DND', () => {
+        const testGuid = 'test-guid';
+
+        webex.internal.device.userId = testGuid;
+
+        webex.request = function (options) {
+          return Promise.resolve({
+            statusCode: 204,
+            body: [],
+            options,
+          });
+        };
+        sinon.spy(webex, 'request');
+
+        webex.internal.presence.setStatus('dnd');
+
+        assert.calledOnce(webex.request);
+
+        const request = webex.request.getCall(0);
+
+        assert.notProperty(request.args[0].body, 'label');
       });
     });
 

--- a/packages/@webex/plugin-presence/src/presence.ts
+++ b/packages/@webex/plugin-presence/src/presence.ts
@@ -252,7 +252,7 @@ const Presence: IPresence = WebexPlugin.extend({
         body: {
           subject: this.webex.internal.device.userId,
           eventType: status,
-          label: this.webex.internal.device.userId,
+          ...(status !== 'dnd' && {label: this.webex.internal.device.userId}),
           ttl,
         },
       })

--- a/packages/@webex/plugin-presence/test/unit/spec/presence.ts
+++ b/packages/@webex/plugin-presence/test/unit/spec/presence.ts
@@ -77,13 +77,36 @@ describe('plugin-presence', () => {
         };
         sinon.spy(webex, 'request');
 
-        webex.presence.setStatus('dnd');
+        webex.presence.setStatus('active');
 
         assert.calledOnce(webex.request);
 
         const request = webex.request.getCall(0);
 
         assert.equal(request.args[0].body.label, testGuid);
+      });
+
+      it('does not pass a label to the API if the status is DND', () => {
+        const testGuid = 'test-guid';
+
+        webex.internal.device.userId = testGuid;
+
+        webex.request = function (options) {
+          return Promise.resolve({
+            statusCode: 204,
+            body: [],
+            options,
+          });
+        };
+        sinon.spy(webex, 'request');
+
+        webex.presence.setStatus('dnd');
+
+        assert.calledOnce(webex.request);
+
+        const request = webex.request.getCall(0);
+
+        assert.notProperty(request.args[0].body, 'label');
       });
     });
 


### PR DESCRIPTION
# COMPLETES [SPARK-573666](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-573666)

## This pull request addresses

https://github.com/webex/webex-js-sdk/pull/3847 introduced a bug whereby DND could no longer be set; as override events such as DND cannot accept a label

## by making the following changes

Only fill the label parameter for non-DND events

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Wrote a unit test for this scenario

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced presence status handling by conditionally including the user label based on the status (e.g., 'dnd').
  
- **Bug Fixes**
	- Improved validation in the `setStatus` method to ensure the label is omitted when the status is 'dnd'.

- **Tests**
	- Updated unit tests for the `setStatus` method to reflect changes in status handling and added tests for label omission when status is 'dnd'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->