### PR TITLE
fix(plugin-meetings): fix updateCallStateForMetrics

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1277,7 +1277,7 @@ export default class Meetings extends WebexPlugin {
               return Promise.resolve(createdMeeting);
             });
           }
-          meeting.setCallStateForMetrics(callStateForMetrics);
+          meeting.updateCallStateForMetrics(callStateForMetrics);
 
           // Return the existing meeting.
           return Promise.resolve(meeting);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -813,8 +813,8 @@ describe('plugin-meetings', () => {
           loginType: 'my-login-type',
         };
 
-        it('should call setCallStateForMetrics on any pre-existing meeting', async () => {
-          const fakeMeeting = {setCallStateForMetrics: sinon.mock()};
+        it('should call updateCallStateForMetrics on any pre-existing meeting', async () => {
+          const fakeMeeting = {updateCallStateForMetrics: sinon.mock()};
           webex.meetings.meetingCollection.getByKey = sinon.stub().returns(fakeMeeting);
           await webex.meetings.create(
             test1,
@@ -828,7 +828,7 @@ describe('plugin-meetings', () => {
             undefined,
             sessionCorrelationId
           );
-          assert.calledOnceWithExactly(fakeMeeting.setCallStateForMetrics, {
+          assert.calledOnceWithExactly(fakeMeeting.updateCallStateForMetrics, {
             ...callStateForMetrics,
             correlationId,
             sessionCorrelationId,


### PR DESCRIPTION
## This pull request addresses

The function is not called setCallStateForMetrics, it is called updateCallStateForMetrics

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced metrics management for meetings through updated method for setting call state.
  
- **Bug Fixes**
	- Improved error handling and logging for meeting creation processes.

- **Tests**
	- Updated test suite to reflect changes in method signatures and added new assertions for robust testing of meeting creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->