### PR TITLE
fix: added config for backend ipv6 native support

### DIFF
--- a/packages/@webex/plugin-meetings/src/config.ts
+++ b/packages/@webex/plugin-meetings/src/config.ts
@@ -94,5 +94,6 @@ export default {
     },
     // This only applies to non-multistream meetings
     iceCandidatesGatheringTimeout: undefined,
+    backendIpv6NativeSupport: false,
   },
 };

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -89,8 +89,12 @@ const MeetingUtil = {
   getIpVersion(webex: any): IP_VERSION | undefined {
     const {supportsIpV4, supportsIpV6} = webex.internal.device.ipNetworkDetector;
 
-    if (BrowserDetection().isBrowser('firefox')) {
-      // our ipv6 solution relies on FQDN ICE candidates, but Firefox doesn't support them,
+    if (
+      !webex.config.meetings.backendIpv6NativeSupport &&
+      BrowserDetection().isBrowser('firefox')
+    ) {
+      // when backend doesn't support native ipv6,
+      // then our NAT64/DNS64 based solution relies on FQDN ICE candidates, but Firefox doesn't support them,
       // see https://bugzilla.mozilla.org/show_bug.cgi?id=1713128
       // so for Firefox we don't want the backend to activate the "ipv6 feature"
       return undefined;

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -763,6 +763,25 @@ export default class Meetings extends WebexPlugin {
   }
 
   /**
+   * API to toggle backend ipv6 native support config, needs to be called before webex.meetings.register()
+   *
+   * @param {Boolean} newValue
+   * @private
+   * @memberof Meetings
+   * @returns {undefined}
+   */
+  private _toggleIpv6BackendNativeSupport(newValue: boolean) {
+    if (typeof newValue !== 'boolean') {
+      return;
+    }
+    // @ts-ignore
+    if (this.config.backendIpv6NativeSupport !== newValue) {
+      // @ts-ignore
+      this.config.backendIpv6NativeSupport = newValue;
+    }
+  }
+
+  /**
    * Explicitly sets up the meetings plugin by registering
    * the device, connecting to mercury, and listening for locus events.
    *

--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -79,7 +79,9 @@ export default class RoapRequest extends StatelessWebexPlugin {
     });
 
     LoggerProxy.logger.info(
-      `Roap:request#sendRoap --> ${locusSelfUrl} \n ${roapMessage.messageType} \n seq:${roapMessage.seq}`
+      `Roap:request#sendRoap --> ${roapMessage.messageType} seq:${roapMessage.seq} ${
+        ipVersion ? `ipver=${ipVersion} ` : ''
+      } ${locusSelfUrl}`
     );
 
     return locusMediaRequest

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -1013,7 +1013,7 @@ describe('plugin-meetings', () => {
           assert.equal(MeetingUtil.getIpVersion(webex), expectedOutput);
         });
 
-        it(`returns undefined when supportsIpV4=${supportsIpV4} and supportsIpV6=${supportsIpV6} and browser is firefox`, () => {
+        it(`returns ${expectedOutput} when supportsIpV4=${supportsIpV4} and supportsIpV6=${supportsIpV6} for Firefox if config is enabled`, () => {
           sinon
             .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4')
             .get(() => supportsIpV4);
@@ -1021,6 +1021,21 @@ describe('plugin-meetings', () => {
             .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6')
             .get(() => supportsIpV6);
 
+          webex.config.meetings.backendIpv6NativeSupport = true;
+          isBrowserStub.callsFake((name) => name === 'firefox');
+
+          assert.equal(MeetingUtil.getIpVersion(webex), expectedOutput);
+        });
+
+        it(`returns undefined when supportsIpV4=${supportsIpV4} and supportsIpV6=${supportsIpV6}, config disabled and browser is firefox`, () => {
+          sinon
+            .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4')
+            .get(() => supportsIpV4);
+          sinon
+            .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6')
+            .get(() => supportsIpV6);
+
+          webex.config.meetings.backendIpv6NativeSupport = false;
           isBrowserStub.callsFake((name) => name === 'firefox');
 
           assert.equal(MeetingUtil.getIpVersion(webex), undefined);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -345,6 +345,22 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#_toggleIpv6BackendNativeSupport', () => {
+      it('should have _toggleIpv6BackendNativeSupport', () => {
+        assert.equal(typeof webex.meetings._toggleIpv6BackendNativeSupport, 'function');
+      });
+
+      describe('success', () => {
+        it('should update meetings config accordingly', () => {
+          webex.meetings._toggleIpv6BackendNativeSupport(true);
+          assert.equal(webex.meetings.config.backendIpv6NativeSupport, true);
+
+          webex.meetings._toggleIpv6BackendNativeSupport(false);
+          assert.equal(webex.meetings.config.backendIpv6NativeSupport, false);
+        });
+      });
+    });
+
     describe('Public API Contracts', () => {
       describe('#register', () => {
         it('emits an event and resolves when register succeeds', async () => {


### PR DESCRIPTION
# COMPLETES #[SPARK-561233](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-561233)

## This pull request addresses
added config option for backend ipv6 native support - it's required because we need to have a different behavior on Firefox:
- send ipver=undefined if backend supports ipv6 natively
- send correct ipver value if backed does not support ipv6 natively

Config will be controlled by the web app via a feature toggle.

Corresponding web app changes: 
https://sqbu-github.cisco.com/WebExSquared/webex-web-client/pull/6919

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual testing with web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new configuration option for backend IPv6 support.
  - Added a private method to toggle the backend's IPv6 native support in the meetings class.

- **Improvements**
  - Enhanced logic for determining IP version based on backend support.
  - Updated logging clarity in the RoapRequest class.

- **Tests**
  - Added unit tests for the new IPv6 toggle method to ensure proper functionality.
  - Expanded tests for the getIpVersion method to cover various scenarios related to backend IPv6 support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->