### PR TITLE
fix(internal-plugin-mercury): missing maxRetries property in mercury plugin config

### DIFF
--- a/packages/@webex/internal-plugin-mercury/README.md
+++ b/packages/@webex/internal-plugin-mercury/README.md
@@ -55,14 +55,12 @@ webex.init({
 
 ### Retries
 
-
 The default behaviour is for Mercury to continue to try to connect with an exponential back-off. This behavior can be adjusted with the following config params:
 
-- `maxRetries` - the number of times it will retry before error. Default: 0
+- `maxRetries` - the number of times it will retry before error. Default: 5
 - `initialConnectionMaxRetries` - the number of times it will retry before error on the first connection. Once a connection has been established, any further connection attempts will use `maxRetries`. Default: 0
 - `backoffTimeMax` - The maximum time between connection attempts in ms. Default: 32000
 - `backoffTimeReset` - The time before the first retry in ms. Default: 1000
-
 
 ## Maintainers
 

--- a/packages/@webex/internal-plugin-mercury/src/config.js
+++ b/packages/@webex/internal-plugin-mercury/src/config.js
@@ -36,5 +36,11 @@ export default {
      * @type {String}
      */
     beforeLogoutOptionsCloseReason: process.env.MERCURY_LOGOUT_REASON || 'done (forced)',
+
+    /**
+     * Maximum number of retries to attempt before giving up
+     * @type {Number}
+     */
+    maxRetries: process.env.MERCURY_MAX_RETRIES || 5,
   },
 };


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-548638](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-548638)

## This pull request addresses

This PR addresses the issue that manifests itself as an infinite loop of reconnection. It occurs if during the meeting reconnection, JS-SDK  is getting stuck on the mercury socket reconnection.

## by making the following changes

Add missing configuration which specifies how many reconnection attempts we can do before giving up, otherwise we will try to connect infinitly.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested with JS-SDK sample app, disconnecting client in various ways to identify if everytime, meeting will give up reconnections after 5 times.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the connection retry logic in the Mercury plugin, now allowing up to 5 retries before failing.
	- Introduced a new configuration option for managing connection retries with a default value of 5.

- **Documentation**
	- Revised the README to reflect the changes in configuration options related to connection retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->