### PR TITLE
fix(samples): dummy commit to rebuild samples

### DIFF
--- a/packages/calling/src/CallingClient/CallingClient.test.ts
+++ b/packages/calling/src/CallingClient/CallingClient.test.ts
@@ -211,7 +211,7 @@ describe('CallingClient Tests', () => {
       try {
         callingClient = await createClient(webex, {serviceData: serviceDataObj});
       } catch (e) {
-        expect(e.message).toEqual('Invalid service domain .');
+        expect(e.message).toEqual('Invalid service domain.');
       }
       expect.assertions(1);
     });

--- a/packages/calling/src/CallingClient/CallingClient.test.ts
+++ b/packages/calling/src/CallingClient/CallingClient.test.ts
@@ -211,7 +211,7 @@ describe('CallingClient Tests', () => {
       try {
         callingClient = await createClient(webex, {serviceData: serviceDataObj});
       } catch (e) {
-        expect(e.message).toEqual('Invalid service domain.');
+        expect(e.message).toEqual('Invalid service domain .');
       }
       expect.assertions(1);
     });

--- a/packages/calling/src/CallingClient/CallingClient.test.ts
+++ b/packages/calling/src/CallingClient/CallingClient.test.ts
@@ -218,7 +218,7 @@ describe('CallingClient Tests', () => {
 
     /**
      * Input sdk config to callingClient with serviceData carrying valid value for indicator
-     * 'contactcenter', and a valid domain type string for domain field in it.
+     * 'contactcenter' , and a valid domain type string for domain field in it.
      *
      * Execution should proceed properly and createRegistration should be called with same serviceData.
      *


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #Adhoc

## This pull request addresses
Due to adding new a new feature branch for contact center the samples were overwritten with wxcc code which broke the samples app. This is a dummy PR to rebuild the samples from next branch

## by making the following changes

A rebuild will be triggered moving the samples to its previous state



### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the error message assertion in the test suite for the `ContactCenter` service to ensure accurate validation of error messages.

- **Tests**
	- Updated the expected error message format in the test cases for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->