### PR TITLE
fix: more logs for publishing/unpublishing streams and sharing

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -2739,6 +2739,9 @@ export default class Meeting extends StatelessWebexPlugin {
         newShareStatus = SHARE_STATUS.NO_SHARE;
       }
 
+      LoggerProxy.logger.info(
+        `Meeting:index#setUpLocusInfoMediaInactiveListener --> this.shareStatus=${this.shareStatus} newShareStatus=${newShareStatus}`
+      );
       if (newShareStatus !== this.shareStatus) {
         const oldShareStatus = this.shareStatus;
 
@@ -8182,6 +8185,9 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {undefined}
    */
   private handleShareAudioStreamEnded = async () => {
+    LoggerProxy.logger.info(
+      `Meeting:index#handleShareAudioStreamEnded --> audio share stream ended`
+    );
     // current share audio stream has ended, but there might be an active
     // share video stream. we only leave from wireless share if share has
     // completely ended, which means no share audio or video streams active
@@ -8224,6 +8230,9 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {undefined}
    */
   private handleShareVideoStreamEnded = async () => {
+    LoggerProxy.logger.info(
+      `Meeting:index#handleShareVideoStreamEnded --> video share stream ended`
+    );
     // current share video stream has ended, but there might be an active
     // share audio stream. we only leave from wireless share if share has
     // completely ended, which means no share audio or video streams active
@@ -8712,6 +8721,9 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {Promise}
    */
   async publishStreams(streams: LocalStreams): Promise<void> {
+    LoggerProxy.logger.info(
+      `Meeting:index#publishStreams --> called with: ${JSON.stringify(streams)}`
+    );
     this.checkMediaConnection();
     if (
       !streams.microphone &&
@@ -8793,6 +8805,9 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {Promise}
    */
   async unpublishStreams(streams: LocalStream[]): Promise<void> {
+    LoggerProxy.logger.info(
+      `Meeting:index#unpublishStreams --> called with: ${JSON.stringify(streams)}`
+    );
     this.checkMediaConnection();
 
     const promises = [];


### PR DESCRIPTION
## This pull request addresses
BEMS case about share failure and we have no idea what's going on, because there are almost no useful logs in the area of publishing/unpublishing streams and share floor changes

## by making the following changes
added some logs

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

manually checked the logs when running with web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging for media stream management, providing better visibility into the status of audio and video streams during meetings.
	- Improved handling of stream lifecycle events, ensuring the application reacts appropriately when share streams end.

- **Bug Fixes**
	- Updated methods to ensure only active streams are processed, preventing issues related to ended streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->