### PR TITLE
fix(plugin-meetings): skip requesting max fs update when width/height are zero

### DIFF
--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -107,10 +107,15 @@ export class RemoteMedia extends EventsScope {
    * to restrict the requested resolution to this size
    * @param width width of the video element
    * @param height height of the video element
+   * @note width/height of 0 will be ignored
    */
   public setSizeHint(width, height) {
     // only base on height for now
     let fs: number;
+
+    if (width === 0 || height === 0) {
+      return;
+    }
 
     if (height < 135) {
       fs = 60;

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -7,7 +7,7 @@ import {RemoteMedia, RemoteMediaEvents} from '@webex/plugin-meetings/src/multist
 import {ReceiveSlotEvents} from '@webex/plugin-meetings/src/multistream/receiveSlot';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
-import { forEach } from 'lodash';
+import {forEach} from 'lodash';
 
 describe('RemoteMedia', () => {
   let remoteMedia;
@@ -227,11 +227,25 @@ describe('RemoteMedia', () => {
   });
 
   describe('setSizeHint()', () => {
-
     it('works if the receive slot is undefined', () => {
       remoteMedia.receiveSlot = undefined;
       remoteMedia.setSizeHint(100, 100);
     });
+
+    forEach(
+      [
+        {width: 0, height: 0},
+        {width: 135, height: 0},
+        {width: 0, height: 240},
+      ],
+      ({width, height}) => {
+        it(`skip updating the max fs when applied ${width}:${height}`, () => {
+          remoteMedia.setSizeHint(width, height);
+
+          assert.notCalled(fakeReceiveSlot.setMaxFs);
+        });
+      }
+    );
 
     forEach(
       [


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-582296](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-582296)

## This pull request addresses

This PR resolves issue of blinking video panels which can occur when during a call remote clients mute/unmute theirs video stream. It also addresses the issue which causes requesting low resolution video, even though higher resolution could be used.

## by making the following changes

Skip sending update of the maxFs, if requested width/height are 0.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested manually on couple of meetings with the webex web application.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `setSizeHint` method to ignore zero width or height inputs, improving media handling.
  
- **Bug Fixes**
	- Updated tests to ensure proper behavior of `setSizeHint()` when dimensions are zero, enhancing reliability.

- **Tests**
	- Expanded test coverage for the `RemoteMedia` class, ensuring accurate functionality of media size hinting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->