### PR TITLE
fix: locus DTOs not handled if an earlier one causes an error

### DIFF
--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -391,10 +391,12 @@ const Mercury = WebexPlugin.extend({
     try {
       this.trigger(...args);
     } catch (error) {
-      this.logger.error(`${this.namespace}: error occurred in event handler`, {
+      this.logger.error(
+        `${this.namespace}: error occurred in event handler:`,
         error,
-        arguments: args,
-      });
+        ' with args: ',
+        args
+      );
     }
   },
 

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -706,10 +706,13 @@ describe('plugin-mercury', () => {
         sinon.stub(mercury.logger, 'error');
 
         return Promise.resolve(mercury._emit('break', event)).then((res) => {
-          assert.calledWith(mercury.logger.error, 'Mercury: error occurred in event handler', {
+          assert.calledWith(
+            mercury.logger.error,
+            'Mercury: error occurred in event handler:',
             error,
-            arguments: ['break', event],
-          });
+            ' with args: ',
+            ['break', event]
+          );
           return res;
         });
       });

--- a/packages/@webex/plugin-meetings/src/locus-info/parser.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/parser.ts
@@ -771,7 +771,14 @@ export default class Parser {
         )}, Action: ${lociComparison}`
       );
 
-      this.onDeltaAction(lociComparison, newLoci);
+      try {
+        this.onDeltaAction(lociComparison, newLoci);
+      } catch (error) {
+        LoggerProxy.logger.error(
+          'Locus-info:parser#processDeltaEvent --> Error in onDeltaAction',
+          error
+        );
+      }
     }
 
     this.nextEvent();

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -1807,6 +1807,35 @@ describe('plugin-meetings', () => {
         assert.calledWith(locusInfo.applyLocusDeltaData, action, parsedLoci, fakeMeeting);
       });
 
+      it('catches errors thrown by onDeltaAction and is able to process next Locus delta', () => {
+        const fakeLocusDelta = {
+          sequence: {
+            rangeStart: 0,
+            rangeEnd: 0,
+          },
+        };
+        locusInfo.locusParser.workingCopy = {
+          sequence: {
+            rangeStart: 0,
+            rangeEnd: 0,
+          },
+        };
+        const testMeeting = {locusInfo: {onDeltaLocus: sinon.stub()}};
+
+        locusParser.onDeltaAction = sandbox
+          .stub()
+          .onCall(0)
+          .callsFake(() => {
+            throw new Error('fake error');
+          });
+
+        // simulate first locus delta coming - it will trigger an error thrown by onDeltaAction
+        locusInfo.handleLocusDelta(fakeLocusDelta, testMeeting);
+
+        // simulate a second locus delta coming - it should be processed without errors
+        locusInfo.handleLocusDelta(fakeLocusDelta, testMeeting);
+      });
+
       it('applyLocusDeltaData handles USE_INCOMING action correctly', () => {
         const {USE_INCOMING} = LocusDeltaParser.loci;
         const meeting = {


### PR DESCRIPTION
# COMPLETES #[SPARK-559101](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-559101)

## This pull request addresses
When an error is thrown while processing some Locus DTO, SDK gets stuck and will not process any further updates from Locus.

## by making the following changes
Catching the error in the right place, so that the LocusInfo parser state is updated and doesn't get stuck on "WORKING" preventing any further locus DTOs from being processed.

Also fixed an error log in mercury, because it was not really showing the error that was caught - intead it would show: `error={}`

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual test with web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the Mercury connection and event processing, improving overall robustness.
	- Added a new test case to verify error resilience in Locus delta event processing.

- **Bug Fixes**
	- Improved logging clarity for connection and disconnection processes, aiding in debugging.

- **Documentation**
	- Deprecated methods `listen()` and `stopListening()` in favor of `connect()` and `disconnect()`, respectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->