### PR TITLE
fix: cannot unmute web client in moderated unmute mode when unmuteAllowed is false

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3104,7 +3104,7 @@ export default class Meeting extends StatelessWebexPlugin {
   private setUpLocusInfoSelfListener() {
     this.locusInfo.on(LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUIRED, (payload) => {
       if (this.audio) {
-        this.audio.handleServerLocalUnmuteRequired(this);
+        this.audio.handleServerLocalUnmuteRequired(this, payload.unmuteAllowed);
         Trigger.trigger(
           this,
           {

--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -394,21 +394,25 @@ export class MuteState {
    * @public
    * @memberof MuteState
    * @param {Object} [meeting] the meeting object
+   * @param {Boolean} [unmuteAllowed] whether the user is allowed to unmute self
    * @returns {undefined}
    */
-  public handleServerLocalUnmuteRequired(meeting?: any) {
+  public handleServerLocalUnmuteRequired(meeting: any, unmuteAllowed: boolean) {
     if (!this.state.client.enabled) {
       LoggerProxy.logger.warn(
         `Meeting:muteState#handleServerLocalUnmuteRequired --> ${this.type}: localAudioUnmuteRequired received while ${this.type} is disabled -> local unmute will not result in ${this.type} being sent`
       );
     } else {
       LoggerProxy.logger.info(
-        `Meeting:muteState#handleServerLocalUnmuteRequired --> ${this.type}: localAudioUnmuteRequired received -> doing local unmute`
+        `Meeting:muteState#handleServerLocalUnmuteRequired --> ${this.type}: localAudioUnmuteRequired received -> doing local unmute (unmuteAllowed=${unmuteAllowed})`
       );
     }
 
     // todo: I'm seeing "you can now unmute yourself " popup  when this happens - but same thing happens on web.w.c so we can ignore for now
     this.state.server.remoteMute = false;
+    this.state.server.unmuteAllowed = unmuteAllowed;
+
+    this.applyUnmuteAllowedToStream(meeting);
 
     // change user mute state to false, but keep localMute true if overall mute state is still true
     this.muteLocalStream(meeting, false, 'localUnmuteRequired');

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -12200,6 +12200,43 @@ describe('plugin-meetings', () => {
           await testEmit(false);
         });
       });
+
+      describe('LOCAL_UNMUTE_REQUIRED locus event', () => {
+        const testEmit = async (unmuteAllowed) => {
+          meeting.audio = {
+            handleServerLocalUnmuteRequired: sinon.stub(),
+          }
+          await meeting.locusInfo.emitScoped(
+            {},
+            LOCUSINFO.EVENTS.LOCAL_UNMUTE_REQUIRED,
+            {
+              unmuteAllowed,
+            }
+          );
+
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {
+              file: 'meeting/index',
+              function: 'setUpLocusInfoSelfListener',
+            },
+            EVENT_TRIGGERS.MEETING_SELF_UNMUTED_BY_OTHERS,
+            {
+              payload: {
+                unmuteAllowed,
+              },
+            }
+          );
+          assert.calledOnceWithExactly(meeting.audio.handleServerLocalUnmuteRequired, meeting, unmuteAllowed)
+        };
+
+        [true, false].forEach((unmuteAllowed) => {
+          it(`emits the expected event and calls handleServerLocalUnmuteRequired() when unmuteAllowed=${unmuteAllowed}`, async () => {
+            await testEmit(unmuteAllowed);
+          });
+        });
+      });
     });
   });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
@@ -151,7 +151,7 @@ describe('plugin-meetings', () => {
       meeting.mediaProperties.audioStream.setServerMuted = sinon.stub().callsFake((muted) => {
         meeting.mediaProperties.audioStream.userMuted = muted;
       });
-      audio.handleServerLocalUnmuteRequired(meeting);
+      audio.handleServerLocalUnmuteRequired(meeting, true);
 
       await testUtils.flushPromises();
 
@@ -161,6 +161,8 @@ describe('plugin-meetings', () => {
         false,
         'localUnmuteRequired'
       );
+      // and unmuteAllowed was updated
+      assert.calledWith(meeting.mediaProperties.audioStream.setUnmuteAllowed, true);
 
       // and local unmute was sent to server
       assert.calledOnce(MeetingUtil.remoteUpdateAudioVideo);
@@ -184,7 +186,7 @@ describe('plugin-meetings', () => {
       meeting.mediaProperties.audioStream.setServerMuted = sinon.stub().callsFake((muted) => {
         meeting.mediaProperties.audioStream.userMuted = muted;
       });
-      audio.handleServerLocalUnmuteRequired(meeting);
+      audio.handleServerLocalUnmuteRequired(meeting, true);
 
       await testUtils.flushPromises();
 
@@ -215,7 +217,7 @@ describe('plugin-meetings', () => {
       meeting.mediaProperties.videoStream.setServerMuted = sinon.stub().callsFake((muted) => {
         meeting.mediaProperties.videoStream.userMuted = muted;
       });
-      video.handleServerLocalUnmuteRequired(meeting);
+      video.handleServerLocalUnmuteRequired(meeting, true);
 
       await testUtils.flushPromises();
 
@@ -225,6 +227,8 @@ describe('plugin-meetings', () => {
         false,
         'localUnmuteRequired'
       );
+      // and unmuteAllowed was updated
+      assert.calledWith(meeting.mediaProperties.videoStream.setUnmuteAllowed, true);
 
       // and local unmute was sent to server
       assert.calledOnce(MeetingUtil.remoteUpdateAudioVideo);
@@ -248,7 +252,7 @@ describe('plugin-meetings', () => {
       meeting.mediaProperties.videoStream.setServerMuted = sinon.stub().callsFake((muted) => {
         meeting.mediaProperties.videoStream.userMuted = muted;
       });
-      video.handleServerLocalUnmuteRequired(meeting);
+      video.handleServerLocalUnmuteRequired(meeting, true);
 
       await testUtils.flushPromises();
 


### PR DESCRIPTION
# COMPLETES #[SPARK-480563](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-480563)

## This pull request addresses
When user is not allowed to unmute himself/herself, then when we receive unmute required from Locus and SDK calls setUserMuted(false), it fails because of the `unmuteAllowed` check.

## by making the following changes
When Locus sends unmute required, they also send unmuteAllowed=true in the same update, so we need to make sure we process it and update unmuteAllowed when we handle unmute required in handleServerLocalUnmuteRequired()

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual test with web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of unmute requests, allowing users to be informed if they are permitted to unmute themselves during meetings.
	- New event handler for `LOCAL_UNMUTE_REQUIRED` event that triggers appropriate actions based on user permissions.

- **Bug Fixes**
	- Improved logic for managing audio and video mute states in response to server commands.

- **Tests**
	- Added tests to verify the correct behavior of the new unmute event handler and ensure the mute state reflects user permissions accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->