### PR TITLE
fix(mercury): add client timestamp

### DIFF
--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -185,6 +185,8 @@ const Mercury = WebexPlugin.extend({
           webSocketUrl.query.multipleConnections = true;
         }
 
+        webSocketUrl.query.clientTimestamp = Date.now();
+
         return url.format(webSocketUrl);
       });
   },
@@ -211,7 +213,6 @@ const Mercury = WebexPlugin.extend({
         attemptWSUrl = webSocketUrl;
 
         let options = {
-          clientTimestamp: Date.now(),
           forceCloseDelay: this.config.forceCloseDelay,
           pingInterval: this.config.pingInterval,
           pongTimeout: this.config.pongTimeout,

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -211,6 +211,7 @@ const Mercury = WebexPlugin.extend({
         attemptWSUrl = webSocketUrl;
 
         let options = {
+          clientTimestamp: Date.now(),
           forceCloseDelay: this.config.forceCloseDelay,
           pingInterval: this.config.pingInterval,
           pongTimeout: this.config.pongTimeout,

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -435,8 +435,6 @@ describe('plugin-mercury', () => {
 
       describe('when webSocketUrl is provided', () => {
         it('connects to Mercury with provided url', () => {
-          const clientTimestamp = Date.now();
-          sinon.useFakeTimers(clientTimestamp);
           const webSocketUrl = 'ws://providedurl.com';
           const promise = mercury.connect(webSocketUrl);
 
@@ -449,8 +447,8 @@ describe('plugin-mercury', () => {
             assert.isFalse(mercury.connecting, 'Mercury is not connecting');
             assert.calledWith(
               Socket.prototype.open,
-              sinon.match(/ws:\/\/providedurl.com/),
-              sinon.match.has('clientTimestamp', clientTimestamp + 1) // process.nextTick(() => mockWebSocket.open()); the mock websocket has a clock.tick of 1
+              sinon.match(/ws:\/\/providedurl.com.*clientTimestamp[=]\d+/),
+              sinon.match.any
             );
           });
         });
@@ -785,16 +783,16 @@ describe('plugin-mercury', () => {
       it('uses provided webSocketUrl', () =>
         webex.internal.mercury
           ._prepareUrl('ws://provided.com')
-          .then((wsUrl) => assert.match(wsUrl, /provided.com/)));
+          .then((wsUrl) => assert.match(wsUrl, /.*provided.com.*/)));
       it('requests text-mode WebSockets', () =>
         webex.internal.mercury
           ._prepareUrl()
-          .then((wsUrl) => assert.match(wsUrl, /outboundWireFormat=text/)));
+          .then((wsUrl) => assert.match(wsUrl, /.*outboundWireFormat=text.*/)));
 
       it('requests the buffer state message', () =>
         webex.internal.mercury
           ._prepareUrl()
-          .then((wsUrl) => assert.match(wsUrl, /bufferStates=true/)));
+          .then((wsUrl) => assert.match(wsUrl, /.*bufferStates=true.*/)));
 
       it('does not add conditional properties', () =>
         webex.internal.mercury._prepareUrl().then((wsUrl) => {

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -435,6 +435,8 @@ describe('plugin-mercury', () => {
 
       describe('when webSocketUrl is provided', () => {
         it('connects to Mercury with provided url', () => {
+          const clientTimestamp = Date.now();
+          sinon.useFakeTimers(clientTimestamp);
           const webSocketUrl = 'ws://providedurl.com';
           const promise = mercury.connect(webSocketUrl);
 
@@ -448,7 +450,7 @@ describe('plugin-mercury', () => {
             assert.calledWith(
               Socket.prototype.open,
               sinon.match(/ws:\/\/providedurl.com/),
-              sinon.match.has('clientTimestamp', clock.now + 2) // 2 for 2 ticks
+              sinon.match.has('clientTimestamp', clientTimestamp + 1) // process.nextTick(() => mockWebSocket.open()); the mock websocket has a clock.tick of 1
             );
           });
         });

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -448,7 +448,7 @@ describe('plugin-mercury', () => {
             assert.calledWith(
               Socket.prototype.open,
               sinon.match(/ws:\/\/providedurl.com/),
-              sinon.match.any
+              sinon.match.has('clientTimestamp', clock.now + 2) // 2 for 2 ticks
             );
           });
         });


### PR DESCRIPTION
# COMPLETES

## This pull request addresses
Clients have an issue with potentially ending up in an infinite reconnect loop. adding clientTimestamp to the socket allows mercury to throw away old mercury web sockets in the case of a thundering herd and limiting the potential for a 429 from mercury

## by making the following changes

Adding client timestamp to the socket open request

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Automated unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced connection management with improved error handling and logging.
	- Introduced a new `clientTimestamp` property for better connection attempt tracking.

- **Deprecations**
	- Deprecated `listen` and `stopListening` methods; users should now use `connect` and `disconnect`.

- **Bug Fixes**
	- Improved handling of connection errors and retries, ensuring robust connection behavior.

- **Tests**
	- Expanded test coverage for connection handling, error scenarios, and logout processes, including new tests for the `connect()` method and handling of provided URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->