### PR TITLE
fix(convo): coerce to 0

### DIFF
--- a/packages/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/@webex/internal-plugin-conversation/src/conversation.js
@@ -68,7 +68,7 @@ const getConvoLimit = (options = {}) => {
   let limit;
 
   if (options.conversationsLimit) {
-    const value = options.conversationsLimit >= 0 ? options.conversationsLimit : 0;
+    const value = Math.max(options.conversationsLimit, 0);
     limit = {
       value,
       name: 'conversationsLimit',

--- a/packages/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/@webex/internal-plugin-conversation/src/conversation.js
@@ -68,8 +68,9 @@ const getConvoLimit = (options = {}) => {
   let limit;
 
   if (options.conversationsLimit) {
+    const value = options.conversationsLimit >= 0 ? options.conversationsLimit : 0;
     limit = {
-      value: options.conversationsLimit,
+      value,
       name: 'conversationsLimit',
     };
   }

--- a/packages/@webex/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/@webex/internal-plugin-conversation/test/integration/spec/get.js
@@ -363,6 +363,15 @@ describe('plugin-conversation', function () {
             assert.include(map(conversations, 'url'), conversation2.url);
           }));
 
+      it('retrieves no conversations', () =>
+        webex.internal.conversation
+          .list({
+            conversationsLimit: -100,
+          })
+          .then((conversations) => {
+            assert.lengthOf(conversations, 0);
+          }));
+
       it('retrieves a paginated set of conversations', () =>
         webex.internal.conversation
           .paginate({


### PR DESCRIPTION
# COMPLETES

## This pull request addresses

I noticed that conversationsLimit is passed as a negative number sometimes from the web client. We should obviously fix this bug, but this fix will help everybody. This currently results in a 400 from convo

## by making the following changes

coerce to 0

![Screenshot 2024-11-19 at 1 54 59 PM](https://github.com/user-attachments/assets/217d3062-31db-4e07-8cdc-5fc66e849cc4)


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

automated

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the conversation limit functionality to prevent negative values from being set, ensuring more reliable behavior.
  
- **Tests**
	- Added a new test case to validate that the conversation list method returns no results when the limit is set to a negative value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->