### PR TITLE
feat(consolidated-interstitial): joinFlowVersion from meeting.callStateForMetrics

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -718,8 +718,9 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       webexSubServiceType: this.getSubServiceType(meeting),
     };
 
-    if (options.joinFlowVersion) {
-      clientEventObject.joinFlowVersion = options.joinFlowVersion;
+    const joinFlowVersion = options.joinFlowVersion ?? meeting.callStateForMetrics?.joinFlowVersion;
+    if (joinFlowVersion) {
+      clientEventObject.joinFlowVersion = joinFlowVersion;
     }
 
     return clientEventObject;


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-576382

## This pull request addresses

Pull new joinFlowVersion from meeting.callStateForMetrics when it does not exist on options.

This is a small follow-up to [my previous PR](https://github.com/webex/webex-js-sdk/pull/3991).

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Updated unit tests and tested with modified cantina.

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in determining the `joinFlowVersion` for client events, allowing it to derive from the meeting's state if not provided.
  
- **Bug Fixes**
	- Streamlined error handling in the client event error payload generation.

- **Tests**
	- Expanded test cases to validate the inclusion and priority of `joinFlowVersion` in client event submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->