### PR TITLE
feat(cc-sdk): added-custom-logger

### DIFF
--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -71,7 +71,10 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       return await this.connectWebsocket();
     } catch (error) {
-      this.$webex.logger.error(`file: ${CC_FILE}: Error during register: ${error}`);
+      LoggerProxy.error(`Error during register: ${error}`, {
+        module: CC_FILE,
+        method: this.register.name,
+      });
 
       throw error;
     }
@@ -91,7 +94,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         data: {agentProfileId: this.agentConfig.agentProfileID, ...data},
       });
     } catch (error) {
-      const {error: detailedError} = getErrorDetails(error, 'getBuddyAgents');
+      const {error: detailedError} = getErrorDetails(error, 'getBuddyAgents', CC_FILE);
       throw detailedError;
     }
   }
@@ -112,7 +115,10 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           const agentId = data.agentId;
           const orgId = this.$webex.credentials.getOrgId();
           this.agentConfig = await this.services.config.getAgentConfig(orgId, agentId);
-          this.$webex.logger.log(`file: ${CC_FILE}: agent config is fetched successfully`);
+          LoggerProxy.log(`agent config is fetched successfully`, {
+            module: CC_FILE,
+            method: this.connectWebsocket.name,
+          });
           if (this.$config && this.$config.allowAutomatedRelogin) {
             await this.silentRelogin();
           }
@@ -123,7 +129,10 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           throw error;
         });
     } catch (error) {
-      this.$webex.logger.error(`file: ${CC_FILE}: Error during register: ${error}`);
+      LoggerProxy.error(`Error during register: ${error}`, {
+        module: CC_FILE,
+        method: this.connectWebsocket.name,
+      });
 
       throw error;
     }
@@ -162,7 +171,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       return loginResponse;
     } catch (error) {
-      const {error: detailedError} = getErrorDetails(error, 'stationLogin');
+      const {error: detailedError} = getErrorDetails(error, 'stationLogin', CC_FILE);
       throw detailedError;
     }
   }
@@ -186,7 +195,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       return logoutResponse;
     } catch (error) {
-      const {error: detailedError} = getErrorDetails(error, 'stationLogout');
+      const {error: detailedError} = getErrorDetails(error, 'stationLogout', CC_FILE);
       throw detailedError;
     }
   }
@@ -201,7 +210,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       return reLoginResponse;
     } catch (error) {
-      const {error: detailedError} = getErrorDetails(error, 'stationReLogin');
+      const {error: detailedError} = getErrorDetails(error, 'stationReLogin', CC_FILE);
       throw detailedError;
     }
   }
@@ -227,11 +236,14 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         data: {...data, agentId: data.agentId || this.agentConfig.agentId},
       });
 
-      this.$webex.logger.log(`file: ${CC_FILE}: SET AGENT STATUS API SUCCESS`);
+      LoggerProxy.log(`SET AGENT STATUS API SUCCESS`, {
+        module: CC_FILE,
+        method: this.setAgentState.name,
+      });
 
       return agentStatusResponse;
     } catch (error) {
-      const {error: detailedError} = getErrorDetails(error, 'setAgentState');
+      const {error: detailedError} = getErrorDetails(error, 'setAgentState', CC_FILE);
       throw detailedError;
     }
   }
@@ -261,11 +273,15 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   private async handleConnectionLost(msg: ConnectionLostDetails): Promise<void> {
     if (msg.isConnectionLost) {
       // TODO: Emit an event saying connection is lost
-      this.$webex.logger.info('event=handleConnectionLost | Connection lost');
+      LoggerProxy.info('event=handleConnectionLost | Connection lost', {
+        module: CC_FILE,
+        method: this.handleConnectionLost.name,
+      });
     } else if (msg.isSocketReconnected) {
       // TODO: Emit an event saying connection is re-estabilished
-      this.$webex.logger.info(
-        'event=handleConnectionReconnect | Connection reconnected attempting to request silent relogin'
+      LoggerProxy.info(
+        'event=handleConnectionReconnect | Connection reconnected attempting to request silent relogin',
+        {module: CC_FILE, method: this.handleConnectionLost.name}
       );
       if (this.$config && this.$config.allowAutomatedRelogin) {
         await this.silentRelogin();
@@ -282,8 +298,9 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       const {auxCodeId, agentId, lastStateChangeReason} = reLoginResponse.data;
 
       if (lastStateChangeReason === 'agent-wss-disconnect') {
-        this.$webex.logger.info(
-          'event=requestAutoStateChange | Requesting state change to available on socket reconnect'
+        LoggerProxy.info(
+          'event=requestAutoStateChange | Requesting state change to available on socket reconnect',
+          {module: CC_FILE, method: this.silentRelogin.name}
         );
         const stateChangeData: StateChange = {
           state: AGENT_STATE_AVAILABLE,
@@ -296,9 +313,12 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       // Updating isAgentLoggedIn as true to indicate to the end user
       this.agentConfig.isAgentLoggedIn = true;
     } catch (error) {
-      const {reason, error: detailedError} = getErrorDetails(error, 'silentReLogin');
+      const {reason, error: detailedError} = getErrorDetails(error, 'silentReLogin', CC_FILE);
       if (reason === 'AGENT_NOT_FOUND') {
-        this.$webex.logger.info('Agent not found during re-login, handling silently');
+        LoggerProxy.info('Agent not found during re-login, handling silently', {
+          module: CC_FILE,
+          method: this.silentRelogin.name,
+        });
 
         return;
       }

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -101,7 +101,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
   /**
    * This is used for connecting the websocket and fetching the agent profile.
-   * @returns Promise<IAgentProfile>
+   * @returns Promise<Profile>
    * @throws Error
    * @private
    */

--- a/packages/@webex/plugin-cc/src/constants.ts
+++ b/packages/@webex/plugin-cc/src/constants.ts
@@ -1,5 +1,12 @@
 export const EVENT = 'event';
 export const READY = 'ready';
-export const CC_FILE = 'cc';
 export const TIMEOUT_DURATION = 20000; // 20 seconds timeout duration for webrtc registration
 export const EMPTY_STRING = '';
+// FILE NAMES
+export const LOG_PREFIX = 'PLUGIN_CC';
+export const WEB_CALLING_SERVICE_FILE = 'WebCallingService';
+export const CONFIG_FILE_NAME = 'config-index';
+export const CC_FILE = 'cc';
+export const CONNECTION_SERVICE_FILE = 'connection-service';
+export const WEB_SOCKET_MANAGER_FILE = 'WebSocketManager';
+export const AQM_REQS_FILE = 'aqm-reqs';

--- a/packages/@webex/plugin-cc/src/logger-proxy.ts
+++ b/packages/@webex/plugin-cc/src/logger-proxy.ts
@@ -1,9 +1,48 @@
-import {Logger} from './types';
+import {Logger, LogContext, LOGGING_LEVEL} from './types';
+import {LOG_PREFIX} from './constants';
 
 export default class LoggerProxy {
   public static logger: Logger;
 
   public static initialize(logger: Logger): void {
     LoggerProxy.logger = logger;
+  }
+
+  public static log(message: string, context: LogContext = {}): void {
+    if (LoggerProxy.logger) {
+      LoggerProxy.logger.log(LoggerProxy.format(LOGGING_LEVEL.log, message, context));
+    }
+  }
+
+  public static info(message: string, context: LogContext = {}): void {
+    if (LoggerProxy.logger) {
+      LoggerProxy.logger.info(LoggerProxy.format(LOGGING_LEVEL.info, message, context));
+    }
+  }
+
+  public static warn(message: string, context: LogContext = {}): void {
+    if (LoggerProxy.logger) {
+      LoggerProxy.logger.warn(LoggerProxy.format(LOGGING_LEVEL.warn, message, context));
+    }
+  }
+
+  public static trace(message: string, context: LogContext = {}): void {
+    if (LoggerProxy.logger) {
+      LoggerProxy.logger.trace(LoggerProxy.format(LOGGING_LEVEL.trace, message, context));
+    }
+  }
+
+  public static error(message: string, context: LogContext = {}): void {
+    if (LoggerProxy.logger) {
+      LoggerProxy.logger.error(LoggerProxy.format(LOGGING_LEVEL.error, message, context));
+    }
+  }
+
+  private static format(level: LOGGING_LEVEL, message: string, context: LogContext): string {
+    const timestamp = new Date().toISOString();
+    const moduleName = context.module || 'unknown';
+    const methodName = context.method || 'unknown';
+
+    return `${timestamp} ${LOG_PREFIX} - [${level}]: module:${moduleName} - method:${methodName} - ${message}`;
   }
 }

--- a/packages/@webex/plugin-cc/src/services/WebCallingService.ts
+++ b/packages/@webex/plugin-cc/src/services/WebCallingService.ts
@@ -26,7 +26,7 @@ export default class WebCallingService {
     this.line = Object.values(this.callingClient.getLines())[0];
 
     this.line.on(LINE_EVENTS.UNREGISTERED, () => {
-      LoggerProxy.log(`WxCC-SDK: Desktop un registered successfully`, {
+      LoggerProxy.log(`WxCC-SDK: Desktop unregistered successfully`, {
         module: WEB_CALLING_SERVICE_FILE,
         method: this.registerWebCallingLine.name,
       });

--- a/packages/@webex/plugin-cc/src/services/WebCallingService.ts
+++ b/packages/@webex/plugin-cc/src/services/WebCallingService.ts
@@ -7,7 +7,8 @@ import {
   CallingClientConfig,
 } from '@webex/calling';
 import {WebexSDK} from '../types';
-import {TIMEOUT_DURATION} from '../constants';
+import {TIMEOUT_DURATION, WEB_CALLING_SERVICE_FILE} from '../constants';
+import LoggerProxy from '../logger-proxy';
 
 export default class WebCallingService {
   private callingClient: ICallingClient;
@@ -25,7 +26,10 @@ export default class WebCallingService {
     this.line = Object.values(this.callingClient.getLines())[0];
 
     this.line.on(LINE_EVENTS.UNREGISTERED, () => {
-      this.webex.logger.log(`WxCC-SDK: Desktop un registered successfully`);
+      LoggerProxy.log(`WxCC-SDK: Desktop un registered successfully`, {
+        module: WEB_CALLING_SERVICE_FILE,
+        method: this.registerWebCallingLine.name,
+      });
     });
 
     // Start listening for incoming calls
@@ -48,8 +52,9 @@ export default class WebCallingService {
 
       this.line.on(LINE_EVENTS.REGISTERED, (deviceInfo: ILine) => {
         clearTimeout(timeout);
-        this.webex.logger.log(
-          `WxCC-SDK: Desktop registered successfully, mobiusDeviceId: ${deviceInfo.mobiusDeviceId}`
+        LoggerProxy.log(
+          `WxCC-SDK: Desktop registered successfully, mobiusDeviceId: ${deviceInfo.mobiusDeviceId}`,
+          {module: WEB_CALLING_SERVICE_FILE, method: this.registerWebCallingLine.name}
         );
         resolve();
       });

--- a/packages/@webex/plugin-cc/src/services/config/index.ts
+++ b/packages/@webex/plugin-cc/src/services/config/index.ts
@@ -16,6 +16,7 @@ import {
 } from './types';
 import HttpRequest from '../core/HttpRequest';
 import {WCC_API_GATEWAY} from '../constants';
+import {CONFIG_FILE_NAME} from '../../constants';
 import {parseAgentConfigs} from './Util';
 import {
   DEFAULT_AUXCODE_ATTRIBUTES,
@@ -55,7 +56,7 @@ export default class AgentConfigService {
       );
 
       const userConfigData = await userConfigPromise;
-      LoggerProxy.logger.info('Fetched user data');
+      LoggerProxy.info('Fetched user data', {module: CONFIG_FILE_NAME, method: 'getAgentConfig'});
 
       const agentProfilePromise = this.getDesktopProfileById(orgId, userConfigData.agentProfileId);
 
@@ -92,7 +93,10 @@ export default class AgentConfigService {
         auxCodesPromise,
       ]);
 
-      LoggerProxy.logger.info('Fetched all required data');
+      LoggerProxy.info('Fetched all required data', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
 
       const response = parseAgentConfigs({
         userData: userConfigData,
@@ -106,12 +110,22 @@ export default class AgentConfigService {
         urlMapping: urlMappingData,
       });
 
-      LoggerProxy.logger.info('Parsing completed for agent-config');
-      LoggerProxy.logger.info('Fetched configuration data successfully');
+      // replace CONFIG_FILE_NAME with CONFIG_FILE_NAME
+      LoggerProxy.info('Parsing completed for agent-config', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
+      LoggerProxy.info('Fetched configuration data successfully', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
 
       return response;
     } catch (error) {
-      LoggerProxy.logger.error(`getAgentConfig call failed with ${error}`);
+      LoggerProxy.error(`getAgentConfig call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
       throw error;
     }
   }
@@ -135,11 +149,17 @@ export default class AgentConfigService {
         throw new Error(`API call failed with ${response.statusCode}`);
       }
 
-      LoggerProxy.logger.log('getUserUsingCI api success.');
+      LoggerProxy.log('getUserUsingCI api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getUserUsingCI',
+      });
 
       return Promise.resolve(response.body);
     } catch (error) {
-      LoggerProxy.logger.error(`getUserUsingCI API call failed with ${error}`);
+      LoggerProxy.error(`getUserUsingCI API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getUserUsingCI',
+      });
       throw error;
     }
   }
@@ -166,11 +186,17 @@ export default class AgentConfigService {
         throw new Error(`API call failed with ${response.statusCode}`);
       }
 
-      LoggerProxy.logger.log('getDesktopProfileById api success.');
+      LoggerProxy.log('getDesktopProfileById api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getDesktopProfileById',
+      });
 
       return Promise.resolve(response.body);
     } catch (error) {
-      LoggerProxy.logger.error(`getDesktopProfileById API call failed with ${error}`);
+      LoggerProxy.error(`getDesktopProfileById API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getDesktopProfileById',
+      });
       throw error;
     }
   }
@@ -203,11 +229,17 @@ export default class AgentConfigService {
         throw new Error(`API call failed with ${response.statusCode}`);
       }
 
-      LoggerProxy.logger.log('getListOfTeams api success.');
+      LoggerProxy.log('getListOfTeams api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfTeams',
+      });
 
       return Promise.resolve(response.body);
     } catch (error) {
-      LoggerProxy.logger.error(`getListOfTeams API call failed with ${error}`);
+      LoggerProxy.error(`getListOfTeams API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfTeams',
+      });
       throw error;
     }
   }
@@ -244,7 +276,10 @@ export default class AgentConfigService {
 
       return allTeams;
     } catch (error) {
-      LoggerProxy.logger.error(`getAllTeams API call failed with ${error}`);
+      LoggerProxy.error(`getAllTeams API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getAllTeams',
+      });
       throw error;
     }
   }
@@ -256,7 +291,7 @@ export default class AgentConfigService {
    * @param {number} pageSize
    * @param {string[]} filter
    * @param {string[]} attributes
-   * @returns {Promise<ListAuxCodesResponse
+   * @returns {Promise<ListAuxCodesResponse>}
    */
   public async getListOfAuxCodes(
     orgId: string,
@@ -277,11 +312,17 @@ export default class AgentConfigService {
         throw new Error(`API call failed with ${response.statusCode}`);
       }
 
-      LoggerProxy.logger.log('getListOfAuxCodes api success.');
+      LoggerProxy.log('getListOfAuxCodes api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfAuxCodes',
+      });
 
       return Promise.resolve(response.body);
     } catch (error) {
-      LoggerProxy.logger.error(`getListOfAuxCodes API call failed with ${error}`);
+      LoggerProxy.error(`getListOfAuxCodes API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfAuxCodes',
+      });
       throw error;
     }
   }
@@ -321,7 +362,10 @@ export default class AgentConfigService {
 
       return allAuxCodes;
     } catch (error) {
-      LoggerProxy.logger.error(`getAllAuxCodes API call failed with ${error}`);
+      LoggerProxy.error(`getAllAuxCodes API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getAllAuxCodes',
+      });
       throw error;
     }
   }
@@ -344,11 +388,14 @@ export default class AgentConfigService {
         throw new Error(`API call failed with ${response.statusCode}`);
       }
 
-      LoggerProxy.logger.log('getOrgInfo api success.');
+      LoggerProxy.log('getOrgInfo api success.', {module: CONFIG_FILE_NAME, method: 'getOrgInfo'});
 
       return Promise.resolve(response.body);
     } catch (error) {
-      LoggerProxy.logger.error(`getOrgInfo API call failed with ${error}`);
+      LoggerProxy.error(`getOrgInfo API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getOrgInfo',
+      });
       throw error;
     }
   }
@@ -371,11 +418,17 @@ export default class AgentConfigService {
         throw new Error(`API call failed with ${response.statusCode}`);
       }
 
-      LoggerProxy.logger.log('getOrganizationSetting api success.');
+      LoggerProxy.log('getOrganizationSetting api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getOrganizationSetting',
+      });
 
       return Promise.resolve(response.body.data[0]);
     } catch (error) {
-      LoggerProxy.logger.error(`getOrganizationSetting API call failed with ${error}`);
+      LoggerProxy.error(`getOrganizationSetting API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getOrganizationSetting',
+      });
       throw error;
     }
   }
@@ -398,11 +451,17 @@ export default class AgentConfigService {
         throw new Error(`API call failed with ${response.statusCode}`);
       }
 
-      LoggerProxy.logger.log('getTenantData api success.');
+      LoggerProxy.log('getTenantData api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getTenantData',
+      });
 
       return Promise.resolve(response.body.data[0]);
     } catch (error) {
-      LoggerProxy.logger.error(`getTenantData API call failed with ${error}`);
+      LoggerProxy.error(`getTenantData API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getTenantData',
+      });
       throw error;
     }
   }
@@ -425,11 +484,17 @@ export default class AgentConfigService {
         throw new Error(`API call failed with ${response.statusCode}`);
       }
 
-      LoggerProxy.logger.log('getURLMapping api success.');
+      LoggerProxy.log('getURLMapping api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getURLMapping',
+      });
 
       return Promise.resolve(response.body.data);
     } catch (error) {
-      LoggerProxy.logger.error(`getURLMapping API call failed with ${error}`);
+      LoggerProxy.error(`getURLMapping API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getURLMapping',
+      });
       throw error;
     }
   }
@@ -452,11 +517,17 @@ export default class AgentConfigService {
         throw new Error(`API call failed with ${response.statusCode}`);
       }
 
-      LoggerProxy.logger.log('getDialPlanData api success.');
+      LoggerProxy.log('getDialPlanData api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getDialPlanData',
+      });
 
       return Promise.resolve(response.body);
     } catch (error) {
-      LoggerProxy.logger.error(`getDialPlanData API call failed with ${error}`);
+      LoggerProxy.error(`getDialPlanData API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getDialPlanData',
+      });
       throw error;
     }
   }

--- a/packages/@webex/plugin-cc/src/services/core/Utils.ts
+++ b/packages/@webex/plugin-cc/src/services/core/Utils.ts
@@ -10,13 +10,13 @@ const getCommonErrorDetails = (errObj: WebexRequestPayload) => {
   };
 };
 
-export const getErrorDetails = (error: any, methodName: string) => {
+export const getErrorDetails = (error: any, methodName: string, moduleName: string) => {
   const failure = error.details as Failure;
   const reason = failure?.data?.reason ?? `Error while performing ${methodName}`;
-  // We don't want to log silentReLogin errors
-  if (methodName !== 'silentReLogin') {
-    LoggerProxy.logger.error(`${methodName} failed with trackingId: ${failure?.trackingId}`);
-  }
+  LoggerProxy.error(`${methodName} failed with trackingId: ${failure?.trackingId}`, {
+    module: moduleName,
+    method: methodName,
+  });
 
   return {
     error: new Error(reason ?? `Error while performing ${methodName}`),

--- a/packages/@webex/plugin-cc/src/services/core/WebSocket/connection-service.ts
+++ b/packages/@webex/plugin-cc/src/services/core/WebSocket/connection-service.ts
@@ -7,6 +7,7 @@ import {
   WS_DISCONNECT_ALLOWED,
   CONNECTIVITY_CHECK_INTERVAL,
 } from '../constants';
+import {CONNECTION_SERVICE_FILE} from '../../../constants';
 import {SubscribeRequest} from '../../../types';
 
 export class ConnectionService extends EventEmitter {
@@ -52,6 +53,10 @@ export class ConnectionService extends EventEmitter {
       isKeepAlive: this.isKeepAlive,
     };
     this.webSocketManager.handleConnectionLost(event);
+    LoggerProxy.log(`Dispatching connection lost event`, {
+      module: CONNECTION_SERVICE_FILE,
+      method: this.dispatchConnectionEvent.name,
+    });
     this.emit('connectionLost', event);
   }
 
@@ -112,7 +117,10 @@ export class ConnectionService extends EventEmitter {
   };
 
   private handleSocketClose = async (): Promise<void> => {
-    LoggerProxy.logger.info(`event=socketConnectionRetry | Trying to reconnect to notifs socket`);
+    LoggerProxy.info(`event=socketConnectionRetry | Trying to reconnect to websocket`, {
+      module: CONNECTION_SERVICE_FILE,
+      method: this.handleSocketClose.name,
+    });
     const onlineStatus = navigator.onLine;
     if (onlineStatus) {
       await this.webSocketManager.initWebSocket({body: this.subscribeRequest});

--- a/packages/@webex/plugin-cc/src/services/core/aqm-reqs.ts
+++ b/packages/@webex/plugin-cc/src/services/core/aqm-reqs.ts
@@ -5,6 +5,7 @@ import HttpRequest from './HttpRequest';
 import LoggerProxy from '../../logger-proxy';
 import {CbRes, Conf, ConfEmpty, Pending, Req, Res, ResEmpty} from './types';
 import {TIMEOUT_REQ} from './constants';
+import {AQM_REQS_FILE} from '../../constants';
 import {WebSocketManager} from './WebSocket/WebSocketManager';
 
 export default class AqmReqs {
@@ -94,9 +95,15 @@ export default class AqmReqs {
             clear();
             const notifFail = c.notifFail!;
             if ('errId' in notifFail) {
-              LoggerProxy.logger.log(`Routing request failed: ${msg}`);
+              LoggerProxy.log(`Routing request failed: ${msg}`, {
+                module: AQM_REQS_FILE,
+                method: this.createPromise.name,
+              });
               const eerr = new Err.Details(notifFail.errId, msg as any);
-              LoggerProxy.logger.log(`Routing request failed: ${eerr}`);
+              LoggerProxy.log(`Routing request failed: ${eerr}`, {
+                module: AQM_REQS_FILE,
+                method: this.createPromise.name,
+              });
               reject(eerr);
             } else {
               reject(notifFail.err(msg as any));
@@ -147,7 +154,10 @@ export default class AqmReqs {
             if (response?.headers) {
               response.headers.Authorization = '*';
             }
-            LoggerProxy.logger.error(`Routing request timeout${keySuccess}${response!}${c.url}`);
+            LoggerProxy.error(`Routing request timeout${keySuccess}${response!}${c.url}`, {
+              module: AQM_REQS_FILE,
+              method: this.createPromise.name,
+            });
             reject(
               new Err.Details('Service.aqm.reqs.Timeout', {
                 key: keySuccess,
@@ -205,19 +215,28 @@ export default class AqmReqs {
   private readonly onMessage = (msg: any) => {
     const event = JSON.parse(msg);
     if (event.type === 'Welcome') {
-      LoggerProxy.logger.info(`Welcome message from Notifs Websocket`);
+      LoggerProxy.info(`Welcome message from Notifs Websocket`, {
+        module: AQM_REQS_FILE,
+        method: this.onMessage.name,
+      });
 
       return;
     }
 
     if (event.keepalive === 'true') {
-      LoggerProxy.logger.info(`Keepalive from web socket`);
+      LoggerProxy.info(`Keepalive from web socket`, {
+        module: AQM_REQS_FILE,
+        method: this.onMessage.name,
+      });
 
       return;
     }
 
     if (event.type === 'AgentReloginFailed') {
-      LoggerProxy.logger.info('Silently handling the agent relogin fail');
+      LoggerProxy.info('Silently handling the agent relogin fail', {
+        module: AQM_REQS_FILE,
+        method: this.onMessage.name,
+      });
     }
 
     let isHandled = false;
@@ -244,9 +263,10 @@ export default class AqmReqs {
     // TODO:  add event emitter for unhandled events to replicate event.listen or .on
 
     if (!isHandled) {
-      LoggerProxy.logger.info(
-        `event=missingEventHandler | [AqmReqs] missing routing message handler`
-      );
+      LoggerProxy.info(`event=missingEventHandler | [AqmReqs] missing routing message handler`, {
+        module: AQM_REQS_FILE,
+        method: this.onMessage.name,
+      });
     }
   };
 }

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -58,6 +58,9 @@ export interface CCPluginConfig {
   callingClientConfig: CallingClientConfig;
 }
 
+/**
+ * Logging related types
+ */
 export type Logger = {
   log: (payload: string) => void;
   error: (payload: string) => void;
@@ -66,6 +69,19 @@ export type Logger = {
   trace: (payload: string) => void;
   debug: (payload: string) => void;
 };
+
+export interface LogContext {
+  module?: string;
+  method?: string;
+}
+
+export enum LOGGING_LEVEL {
+  error = 'ERROR',
+  warn = 'WARN',
+  log = 'LOG',
+  info = 'INFO',
+  trace = 'TRACE',
+}
 
 export interface WebexSDK {
   version: string;

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -15,19 +15,19 @@ import {AGENT, WEB_RTC_PREFIX} from '../../../src/services/constants';
 import Services from '../../../src/services';
 import config from '../../../src/config';
 import LoggerProxy from '../../../src/logger-proxy';
+import {CC_FILE} from '../../../src/constants';
 
 // Mock the Worker API
 import '../../../__mocks__/workerMock';
 import {Profile} from '../../../src/services/config/types';
-import mock from 'webdriverio/build/commands/browser/mock';
+import {Logger} from '@webex/calling';
 
 jest.mock('../../../src/logger-proxy', () => ({
   __esModule: true,
   default: {
-    logger: {
-      log: jest.fn(),
-      error: jest.fn(),
-    },
+    log: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
     initialize: jest.fn(),
   },
 }));
@@ -187,7 +187,9 @@ describe('webex.cc', () => {
           agentId: 'agentId',
         },
       });
-      const configSpy = jest.spyOn(webex.cc.services.config, 'getAgentConfig').mockResolvedValue(mockAgentProfile);
+      const configSpy = jest
+        .spyOn(webex.cc.services.config, 'getAgentConfig')
+        .mockResolvedValue(mockAgentProfile);
       mockWebSocketManager.initWebSocket.mockResolvedValue({
         agentId: 'agent123',
       });
@@ -204,9 +206,10 @@ describe('webex.cc', () => {
         },
       });
       expect(configSpy).toHaveBeenCalled();
-      expect(webex.logger.log).toHaveBeenCalledWith(
-        'file: cc: agent config is fetched successfully'
-      );
+      expect(LoggerProxy.log).toHaveBeenCalledWith('agent config is fetched successfully', {
+        module: CC_FILE,
+        method: 'mockConstructor',
+      });
       expect(reloadSpy).toHaveBeenCalled();
       expect(result).toEqual(mockAgentProfile);
     });
@@ -291,8 +294,9 @@ describe('webex.cc', () => {
         },
       });
       expect(configSpy).toHaveBeenCalled();
-      expect(webex.logger.log).toHaveBeenCalledWith(
-        'file: cc: agent config is fetched successfully'
+      expect(LoggerProxy.log).toHaveBeenCalledWith(
+        'agent config is fetched successfully',
+        {module: CC_FILE, method: 'mockConstructor'}
       );
       expect(reloadSpy).not.toHaveBeenCalled();
       expect(result).toEqual(mockAgentProfile);
@@ -304,9 +308,10 @@ describe('webex.cc', () => {
 
       await expect(webex.cc.register()).rejects.toThrow('Error while performing register');
 
-      expect(webex.logger.error).toHaveBeenCalledWith(
-        `file: cc: Error during register: ${mockError}`
-      );
+      expect(LoggerProxy.error).toHaveBeenCalledWith(`Error during register: ${mockError}`, {
+        module: CC_FILE,
+        method: 'register',
+      });
     });
   });
 
@@ -399,8 +404,9 @@ describe('webex.cc', () => {
 
       await expect(webex.cc.stationLogin(options)).rejects.toThrow(error.details.data.reason);
 
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        `stationLogin failed with trackingId: ${error.details.trackingId}`
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        `stationLogin failed with trackingId: ${error.details.trackingId}`,
+        {module: CC_FILE, method: 'stationLogin'}
       );
     });
   });
@@ -435,8 +441,9 @@ describe('webex.cc', () => {
 
       await expect(webex.cc.stationLogout(data)).rejects.toThrow(error.details.data.reason);
 
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        `stationLogout failed with trackingId: ${error.details.trackingId}`
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        `stationLogout failed with trackingId: ${error.details.trackingId}`,
+        {module: CC_FILE, method: 'stationLogout'}
       );
     });
   });
@@ -469,8 +476,9 @@ describe('webex.cc', () => {
 
       await expect(webex.cc.stationReLogin()).rejects.toThrow(error.details.data.reason);
 
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        `stationReLogin failed with trackingId: ${error.details.trackingId}`
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        `stationReLogin failed with trackingId: ${error.details.trackingId}`,
+        {module: CC_FILE, method: 'stationReLogin'}
       );
     });
   });
@@ -492,7 +500,10 @@ describe('webex.cc', () => {
 
       expect(setAgentStatusMock).toHaveBeenCalledWith({data: expectedPayload});
       expect(result).toEqual(expectedPayload);
-      expect(webex.logger.log).toHaveBeenCalledWith('file: cc: SET AGENT STATUS API SUCCESS');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('SET AGENT STATUS API SUCCESS', {
+        module: CC_FILE,
+        method: 'setAgentState',
+      });
     });
 
     it('should set agent status successfully when status is Meeting', async () => {
@@ -511,7 +522,10 @@ describe('webex.cc', () => {
 
       expect(setAgentStatusMock).toHaveBeenCalledWith({data: expectedPayload});
       expect(result).toEqual(expectedPayload);
-      expect(webex.logger.log).toHaveBeenCalledWith('file: cc: SET AGENT STATUS API SUCCESS');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('SET AGENT STATUS API SUCCESS', {
+        module: CC_FILE,
+        method: 'setAgentState',
+      });
     });
 
     it('should handle error during setAgentStatus when status is Meeting', async () => {
@@ -535,8 +549,9 @@ describe('webex.cc', () => {
       await expect(webex.cc.setAgentState(expectedPayload)).rejects.toThrow(
         error.details.data.reason
       );
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        `setAgentState failed with trackingId: ${error.details.trackingId}`
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        `setAgentState failed with trackingId: ${error.details.trackingId}`,
+        {module: CC_FILE, method: 'setAgentState'}
       );
     });
 
@@ -560,8 +575,9 @@ describe('webex.cc', () => {
       await expect(webex.cc.setAgentState(invalidPayload)).rejects.toThrow(
         error.details.data.reason
       );
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        `setAgentState failed with trackingId: ${error.details.trackingId}`
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        `setAgentState failed with trackingId: ${error.details.trackingId}`,
+        {module: CC_FILE, method: 'setAgentState'}
       );
     });
   });
@@ -639,12 +655,13 @@ describe('webex.cc', () => {
       jest.spyOn(webex.cc.services.agent, 'buddyAgents').mockRejectedValue(error);
 
       await expect(webex.cc.getBuddyAgents(data)).rejects.toThrow(error.details.data.reason);
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        `getBuddyAgents failed with trackingId: ${error.details.trackingId}`
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        `getBuddyAgents failed with trackingId: ${error.details.trackingId}`,
+        {module: CC_FILE, method: 'getBuddyAgents'}
       );
     });
   });
-  
+
   describe('silentRelogin', () => {
     it('should perform silent relogin and set agent state to available', async () => {
       const mockReLoginResponse = {
@@ -661,14 +678,17 @@ describe('webex.cc', () => {
         agentProfileID: 'test-agent-profile-id',
         isAgentLoggedIn: false,
       } as Profile;
-  
-      const setAgentStateSpy = jest.spyOn(webex.cc, 'setAgentState').mockResolvedValue({} as SetStateResponse);
+
+      const setAgentStateSpy = jest
+        .spyOn(webex.cc, 'setAgentState')
+        .mockResolvedValue({} as SetStateResponse);
       jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue(mockReLoginResponse);
-  
+
       await webex.cc['silentRelogin']();
-  
-      expect(webex.logger.info).toHaveBeenCalledWith(
-        'event=requestAutoStateChange | Requesting state change to available on socket reconnect'
+
+      expect(LoggerProxy.info).toHaveBeenCalledWith(
+        'event=requestAutoStateChange | Requesting state change to available on socket reconnect',
+        {module: CC_FILE, method: 'silentRelogin'}
       );
       expect(setAgentStateSpy).toHaveBeenCalledWith({
         state: 'Available',
@@ -678,7 +698,7 @@ describe('webex.cc', () => {
       });
       expect(webex.cc.agentConfig.isAgentLoggedIn).toBe(true);
     });
-  
+
     it('should handle AGENT_NOT_FOUND error silently', async () => {
       const error = {
         details: {
@@ -688,10 +708,13 @@ describe('webex.cc', () => {
           },
         },
       };
-  
+
       jest.spyOn(webex.cc.services.agent, 'reload').mockRejectedValue(error);
       await webex.cc['silentRelogin']();
-      expect(webex.logger.info).toHaveBeenCalledWith('Agent not found during re-login, handling silently');
+      expect(LoggerProxy.info).toHaveBeenCalledWith(
+        'Agent not found during re-login, handling silently',
+        {module: CC_FILE, method: 'silentRelogin'}
+      );
     });
   });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -10,7 +10,6 @@ import ContactCenter from '../../../src/cc';
 import MockWebex from '@webex/test-helper-mock-webex';
 import {StationLoginSuccess} from '../../../src/services/agent/types';
 import {SetStateResponse} from '../../../src/types';
-import {IAgentProfile} from '../../../src/types';
 import {AGENT, WEB_RTC_PREFIX} from '../../../src/services/constants';
 import Services from '../../../src/services';
 import config from '../../../src/config';
@@ -20,7 +19,6 @@ import {CC_FILE} from '../../../src/constants';
 // Mock the Worker API
 import '../../../__mocks__/workerMock';
 import {Profile} from '../../../src/services/config/types';
-import {Logger} from '@webex/calling';
 
 jest.mock('../../../src/logger-proxy', () => ({
   __esModule: true,

--- a/packages/@webex/plugin-cc/test/unit/spec/services/WebCallingService.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/WebCallingService.ts
@@ -10,7 +10,19 @@ import {
 } from '@webex/calling';
 import {WebexSDK} from '../../../../src/types';
 import config from '../../../../src/config';
+import LoggerProxy from '../../../../src/logger-proxy';
+import {WEB_CALLING_SERVICE_FILE} from '../../../../src/constants';
 jest.mock('@webex/calling');
+
+jest.mock('../../../../src/logger-proxy', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    initialize: jest.fn(),
+  },
+}));
 
 describe('WebCallingService', () => {
   let webex: WebexSDK;
@@ -74,8 +86,9 @@ describe('WebCallingService', () => {
       expect(createClient).toHaveBeenCalledWith(webex, config.cc.callingClientConfig);
       expect(lineOnSpy).toHaveBeenCalledWith(LINE_EVENTS.REGISTERED, expect.any(Function));
       expect(line.register).toHaveBeenCalled();
-      expect(webex.logger.log).toHaveBeenCalledWith(
-        `WxCC-SDK: Desktop registered successfully, mobiusDeviceId: ${deviceInfo.mobiusDeviceId}`
+      expect(LoggerProxy.log).toHaveBeenCalledWith(
+        `WxCC-SDK: Desktop registered successfully, mobiusDeviceId: ${deviceInfo.mobiusDeviceId}`,
+        {"method": "registerWebCallingLine", "module": WEB_CALLING_SERVICE_FILE}
       );
     }, 20000); // Increased timeout to 20 seconds
 

--- a/packages/@webex/plugin-cc/test/unit/spec/services/config/index.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/config/index.ts
@@ -2,9 +2,20 @@ import {WebexSDK} from '../../../../../src/types';
 import AgentConfigService from '../../../../../src/services/config';
 import HttpRequest from '../../../../../src/services/core/HttpRequest';
 import {WCC_API_GATEWAY} from '../../../../../src/services/constants';
+import {CONFIG_FILE_NAME} from '../../../../../src/constants';
 import MockWebex from '@webex/test-helper-mock-webex';
 import LoggerProxy from '../../../../../src/logger-proxy';
 import * as util from '../../../../../src/services/config/Util';
+
+jest.mock('../../../../../src/logger-proxy', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    initialize: jest.fn(),
+  },
+}));
 
 describe('AgentConfigService', () => {
   let agentConfigService: AgentConfigService;
@@ -23,7 +34,6 @@ describe('AgentConfigService', () => {
       },
     });
 
-    LoggerProxy.logger = webex.logger;
     mockHttpRequest = HttpRequest.getInstance({webex});
     mockHttpRequest.request = jest.fn();
 
@@ -56,7 +66,10 @@ describe('AgentConfigService', () => {
         method: 'GET',
       });
       expect(result).toEqual(mockResponse.body);
-      expect(LoggerProxy.logger.log).toHaveBeenCalledWith('getUserUsingCI api success.');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getUserUsingCI api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getUserUsingCI',
+      });
     });
 
     it('should throw an error if the API call fails', async () => {
@@ -106,7 +119,10 @@ describe('AgentConfigService', () => {
         method: 'GET',
       });
       expect(result).toEqual(mockResponse.body);
-      expect(LoggerProxy.logger.log).toHaveBeenCalledWith('getDesktopProfileById api success.');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getDesktopProfileById api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getDesktopProfileById',
+      });
     });
 
     it('should throw an error if the API call fails', async () => {
@@ -164,7 +180,10 @@ describe('AgentConfigService', () => {
         method: 'GET',
       });
       expect(result).toEqual(mockResponse.body);
-      expect(LoggerProxy.logger.log).toHaveBeenCalledWith('getListOfTeams api success.');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getListOfTeams api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfTeams',
+      });
     });
 
     it('should throw an error if the API call fails', async () => {
@@ -240,7 +259,10 @@ describe('AgentConfigService', () => {
         method: 'GET',
       });
       expect(result).toEqual(mockResponse.body);
-      expect(LoggerProxy.logger.log).toHaveBeenCalledWith('getListOfAuxCodes api success.');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getListOfAuxCodes api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfAuxCodes',
+      });
     });
 
     it('should throw an error if the API call fails', async () => {
@@ -284,7 +306,10 @@ describe('AgentConfigService', () => {
 
       const result = await agentConfigService.getOrgInfo(mockOrgId);
       expect(result).toEqual(mockResponse.body);
-      expect(LoggerProxy.logger.log).toHaveBeenCalledWith('getOrgInfo api success.');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getOrgInfo api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getOrgInfo',
+      });
     });
 
     it('should throw an error if API call returns non-200 status code', async () => {
@@ -294,8 +319,9 @@ describe('AgentConfigService', () => {
       await expect(agentConfigService.getOrgInfo(mockOrgId)).rejects.toThrow(
         'API call failed with 500'
       );
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getOrgInfo API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getOrgInfo API call failed with Error: API call failed with 500',
+        {module: CONFIG_FILE_NAME, method: 'getOrgInfo'}
       );
     });
 
@@ -304,8 +330,9 @@ describe('AgentConfigService', () => {
       mockHttpRequest.request.mockRejectedValue(networkError);
 
       await expect(agentConfigService.getOrgInfo(mockOrgId)).rejects.toThrow('Network Error');
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getOrgInfo API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getOrgInfo API call failed with Error: Network Error',
+        {module: CONFIG_FILE_NAME, method: 'getOrgInfo'}
       );
     });
 
@@ -314,8 +341,9 @@ describe('AgentConfigService', () => {
       mockHttpRequest.request.mockRejectedValue(timeoutError);
 
       await expect(agentConfigService.getOrgInfo(mockOrgId)).rejects.toThrow('Timeout Error');
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getOrgInfo API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getOrgInfo API call failed with Error: Timeout Error',
+        {module: CONFIG_FILE_NAME, method: 'getOrgInfo'}
       );
     });
   });
@@ -327,7 +355,10 @@ describe('AgentConfigService', () => {
 
       const result = await agentConfigService.getOrganizationSetting();
       expect(result).toEqual(mockResponse.body.data[0]);
-      expect(LoggerProxy.logger.log).toHaveBeenCalledWith('getOrganizationSetting api success.');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getOrganizationSetting api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getOrganizationSetting',
+      });
     });
 
     it('should throw an error if API call returns non-200 status code', async () => {
@@ -337,8 +368,9 @@ describe('AgentConfigService', () => {
       await expect(agentConfigService.getOrganizationSetting(mockOrgId)).rejects.toThrow(
         'API call failed with 500'
       );
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getOrganizationSetting API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getOrganizationSetting API call failed with Error: API call failed with 500',
+        {module: CONFIG_FILE_NAME, method: 'getOrganizationSetting'}
       );
     });
 
@@ -349,8 +381,9 @@ describe('AgentConfigService', () => {
       await expect(agentConfigService.getOrganizationSetting(mockOrgId)).rejects.toThrow(
         'Network Error'
       );
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getOrganizationSetting API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getOrganizationSetting API call failed with Error: Network Error',
+        {module: CONFIG_FILE_NAME, method: 'getOrganizationSetting'}
       );
     });
 
@@ -361,8 +394,9 @@ describe('AgentConfigService', () => {
       await expect(agentConfigService.getOrganizationSetting(mockOrgId)).rejects.toThrow(
         'Timeout Error'
       );
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getOrganizationSetting API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getOrganizationSetting API call failed with Error: Timeout Error',
+        {module: CONFIG_FILE_NAME, method: 'getOrganizationSetting'}
       );
     });
   });
@@ -374,7 +408,10 @@ describe('AgentConfigService', () => {
 
       const result = await agentConfigService.getTenantData(mockOrgId);
       expect(result).toEqual(mockResponse.body.data[0]);
-      expect(LoggerProxy.logger.log).toHaveBeenCalledWith('getTenantData api success.');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getTenantData api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getTenantData',
+      });
     });
 
     it('should throw an error if API call returns non-200 status code', async () => {
@@ -384,8 +421,9 @@ describe('AgentConfigService', () => {
       await expect(agentConfigService.getTenantData(mockOrgId)).rejects.toThrow(
         'API call failed with 500'
       );
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getTenantData API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getTenantData API call failed with Error: API call failed with 500',
+        {module: CONFIG_FILE_NAME, method: 'getTenantData'}
       );
     });
 
@@ -394,8 +432,9 @@ describe('AgentConfigService', () => {
       mockHttpRequest.request.mockRejectedValue(networkError);
 
       await expect(agentConfigService.getTenantData(mockOrgId)).rejects.toThrow('Network Error');
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getTenantData API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getTenantData API call failed with Error: Network Error',
+        {module: CONFIG_FILE_NAME, method: 'getTenantData'}
       );
     });
   });
@@ -407,7 +446,10 @@ describe('AgentConfigService', () => {
 
       const result = await agentConfigService.getURLMapping(mockOrgId);
       expect(result).toEqual(mockResponse.body.data);
-      expect(LoggerProxy.logger.log).toHaveBeenCalledWith('getURLMapping api success.');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getURLMapping api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getURLMapping',
+      });
     });
 
     it('should throw an error if API call returns non-200 status code', async () => {
@@ -417,8 +459,9 @@ describe('AgentConfigService', () => {
       await expect(agentConfigService.getURLMapping(mockOrgId)).rejects.toThrow(
         'API call failed with 500'
       );
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getURLMapping API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getURLMapping API call failed with Error: API call failed with 500',
+        {module: CONFIG_FILE_NAME, method: 'getURLMapping'}
       );
     });
 
@@ -427,8 +470,9 @@ describe('AgentConfigService', () => {
       mockHttpRequest.request.mockRejectedValue(networkError);
 
       await expect(agentConfigService.getURLMapping(mockOrgId)).rejects.toThrow('Network Error');
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getURLMapping API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getURLMapping API call failed with Error: Network Error',
+        {module: CONFIG_FILE_NAME, method: 'getURLMapping'}
       );
     });
   });
@@ -440,7 +484,10 @@ describe('AgentConfigService', () => {
 
       const result = await agentConfigService.getDialPlanData(mockOrgId);
       expect(result).toEqual(mockResponse.body);
-      expect(LoggerProxy.logger.log).toHaveBeenCalledWith('getDialPlanData api success.');
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getDialPlanData api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getDialPlanData',
+      });
     });
 
     it('should throw an error if API call returns non-200 status code', async () => {
@@ -450,8 +497,9 @@ describe('AgentConfigService', () => {
       await expect(agentConfigService.getDialPlanData(mockOrgId)).rejects.toThrow(
         'API call failed with 500'
       );
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getDialPlanData API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getDialPlanData API call failed with Error: API call failed with 500',
+        {module: CONFIG_FILE_NAME, method: 'getDialPlanData'}
       );
     });
 
@@ -460,8 +508,9 @@ describe('AgentConfigService', () => {
       mockHttpRequest.request.mockRejectedValue(networkError);
 
       await expect(agentConfigService.getDialPlanData(mockOrgId)).rejects.toThrow('Network Error');
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getDialPlanData API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getDialPlanData API call failed with Error: Network Error',
+        {module: CONFIG_FILE_NAME, method: 'getDialPlanData'}
       );
     });
   });
@@ -496,12 +545,21 @@ describe('AgentConfigService', () => {
         ...mockResponseOther.body.data,
       ]);
 
-      expect(LoggerProxy.logger.log).toHaveBeenCalledTimes(3);
+      expect(LoggerProxy.log).toHaveBeenCalledTimes(3);
 
       // Verify that each call was made with the expected message
-      expect(LoggerProxy.logger.log).toHaveBeenNthCalledWith(1, 'getListOfTeams api success.');
-      expect(LoggerProxy.logger.log).toHaveBeenNthCalledWith(2, 'getListOfTeams api success.');
-      expect(LoggerProxy.logger.log).toHaveBeenNthCalledWith(3, 'getListOfTeams api success.');
+      expect(LoggerProxy.log).toHaveBeenNthCalledWith(1, 'getListOfTeams api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfTeams',
+      });
+      expect(LoggerProxy.log).toHaveBeenNthCalledWith(2, 'getListOfTeams api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfTeams',
+      });
+      expect(LoggerProxy.log).toHaveBeenNthCalledWith(3, 'getListOfTeams api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfTeams',
+      });
     });
 
     it('should throw an error if API call returns non-200 status code', async () => {
@@ -515,8 +573,9 @@ describe('AgentConfigService', () => {
       await expect(
         agentConfigService.getAllTeams(mockOrgId, pageSize, filter, attributes)
       ).rejects.toThrow('API call failed with 500');
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getListOfTeams API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getListOfTeams API call failed with Error: API call failed with 500',
+        {module: CONFIG_FILE_NAME, method: 'getListOfTeams'}
       );
     });
   });
@@ -556,12 +615,21 @@ describe('AgentConfigService', () => {
         ...mockResponseOther.body.data,
       ]);
 
-      expect(LoggerProxy.logger.log).toHaveBeenCalledTimes(3);
+      expect(LoggerProxy.log).toHaveBeenCalledTimes(3);
 
       // Verify that each call was made with the expected message
-      expect(LoggerProxy.logger.log).toHaveBeenNthCalledWith(1, 'getListOfAuxCodes api success.');
-      expect(LoggerProxy.logger.log).toHaveBeenNthCalledWith(2, 'getListOfAuxCodes api success.');
-      expect(LoggerProxy.logger.log).toHaveBeenNthCalledWith(3, 'getListOfAuxCodes api success.');
+      expect(LoggerProxy.log).toHaveBeenNthCalledWith(1, 'getListOfAuxCodes api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfAuxCodes',
+      });
+      expect(LoggerProxy.log).toHaveBeenNthCalledWith(2, 'getListOfAuxCodes api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfAuxCodes',
+      });
+      expect(LoggerProxy.log).toHaveBeenNthCalledWith(3, 'getListOfAuxCodes api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getListOfAuxCodes',
+      });
     });
 
     it('should throw an error if API call returns non-200 status code', async () => {
@@ -575,8 +643,12 @@ describe('AgentConfigService', () => {
       await expect(
         agentConfigService.getAllAuxCodes(mockOrgId, pageSize, filter, attributes)
       ).rejects.toThrow('API call failed with 500');
-      expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('getListOfAuxCodes API call failed with')
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getListOfAuxCodes API call failed with Error: API call failed with 500',
+        {
+          module: CONFIG_FILE_NAME,
+          method: 'getListOfAuxCodes',
+        }
       );
     });
   });
@@ -677,12 +749,22 @@ describe('AgentConfigService', () => {
 
       const result = await agentConfigService.getAgentConfig(mockOrgId, mockAgentId);
 
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith('Fetched user data');
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith('Fetched all required data');
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith('Parsing completed for agent-config');
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith(
-        'Fetched configuration data successfully'
-      );
+      expect(LoggerProxy.info).toHaveBeenCalledWith('Fetched user data', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
+      expect(LoggerProxy.info).toHaveBeenCalledWith('Fetched all required data', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
+      expect(LoggerProxy.info).toHaveBeenCalledWith('Parsing completed for agent-config', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
+      expect(LoggerProxy.info).toHaveBeenCalledWith('Fetched configuration data successfully', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
       expect(parseAgentConfigsSpy).toHaveBeenCalledTimes(1);
 
       expect(parseAgentConfigsSpy).toHaveBeenCalledWith({
@@ -796,12 +878,22 @@ describe('AgentConfigService', () => {
 
       const result = await agentConfigService.getAgentConfig(mockOrgId, mockAgentId);
 
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith('Fetched user data');
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith('Fetched all required data');
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith('Parsing completed for agent-config');
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith(
-        'Fetched configuration data successfully'
-      );
+      expect(LoggerProxy.info).toHaveBeenCalledWith('Fetched user data', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
+      expect(LoggerProxy.info).toHaveBeenCalledWith('Fetched all required data', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
+      expect(LoggerProxy.info).toHaveBeenCalledWith('Parsing completed for agent-config', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
+      expect(LoggerProxy.info).toHaveBeenCalledWith('Fetched configuration data successfully', {
+        module: CONFIG_FILE_NAME,
+        method: 'getAgentConfig',
+      });
       expect(parseAgentConfigsSpy).toHaveBeenCalledTimes(1);
 
       expect(parseAgentConfigsSpy).toHaveBeenCalledWith({

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/WebSocket/WebSocketManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/WebSocket/WebSocketManager.ts
@@ -2,17 +2,16 @@
 import { WebSocketManager } from '../../../../../../src/services/core/WebSocket/WebSocketManager';
 import { WebexSDK, SubscribeRequest } from '../../../../../../src/types';
 import { SUBSCRIBE_API, WCC_API_GATEWAY } from '../../../../../../src/services/constants';
+import { WEB_SOCKET_MANAGER_FILE } from '../../../../../../src/constants';
 import LoggerProxy from '../../../../../../src/logger-proxy';
 
 jest.mock('../../../../../../src/services/core/HttpRequest');
 jest.mock('../../../../../../src/logger-proxy', () => ({
   __esModule: true,
   default: {
-    logger: {
-      log: jest.fn(),
-      error: jest.fn(),
-      info: jest.fn(),
-    },
+    log: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
     initialize: jest.fn(),
   },
 }));
@@ -201,11 +200,13 @@ describe('WebSocketManager', () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(mockWorker.postMessage).toHaveBeenCalledWith({ type: 'terminate' });
-    expect(LoggerProxy.logger.info).toHaveBeenCalledWith(
-      '[WebSocketStatus] | desktop online status is false'
+    expect(LoggerProxy.info).toHaveBeenCalledWith(
+      '[WebSocketStatus] | desktop online status is false',
+      { module: WEB_SOCKET_MANAGER_FILE, method: 'webSocketOnCloseHandler' }
     );
-    expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-      '[WebSocketStatus] | event=webSocketClose | WebSocket connection closed REASON: network issue'
+    expect(LoggerProxy.error).toHaveBeenCalledWith(
+      '[WebSocketStatus] | event=webSocketClose | WebSocket connection closed REASON: network issue',
+      { module: WEB_SOCKET_MANAGER_FILE, method: 'webSocketOnCloseHandler' }
     );
 
     // Restore navigator.onLine to true
@@ -231,8 +232,9 @@ describe('WebSocketManager', () => {
     const errorEvent = new Event('error');
     MockWebSocket.inst.onerror(errorEvent);
 
-    expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-      '[WebSocketStatus] | event=socketConnectionFailed | WebSocket connection failed [object Event]'
+    expect(LoggerProxy.error).toHaveBeenCalledWith(
+      '[WebSocketStatus] | event=socketConnectionFailed | WebSocket connection failed [object Event]',
+      { module: WEB_SOCKET_MANAGER_FILE, method: 'connect' }
     );
   });
 
@@ -253,8 +255,9 @@ describe('WebSocketManager', () => {
     MockWebSocket.inst.onmessage(messageEvent);
 
     expect(MockWebSocket.inst.close).toHaveBeenCalled();
-    expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-      '[WebSocketStatus] | event=agentMultiLogin | WebSocket connection closed by agent multiLogin'
+    expect(LoggerProxy.error).toHaveBeenCalledWith(
+      '[WebSocketStatus] | event=agentMultiLogin | WebSocket connection closed by agent multiLogin',
+      { module: WEB_SOCKET_MANAGER_FILE, method: 'connect' }
     );
   });
 
@@ -306,8 +309,9 @@ describe('WebSocketManager', () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(mockWorker.postMessage).toHaveBeenCalledWith({ type: 'terminate' });
-    expect(LoggerProxy.logger.error).toHaveBeenCalledWith(
-      '[WebSocketStatus] | event=webSocketClose | WebSocket connection closed REASON: WebSocket auto close timed out. Forcefully closed websocket.'
+    expect(LoggerProxy.error).toHaveBeenCalledWith(
+      '[WebSocketStatus] | event=webSocketClose | WebSocket connection closed REASON: WebSocket auto close timed out. Forcefully closed websocket.',
+      { module: WEB_SOCKET_MANAGER_FILE, method: 'webSocketOnCloseHandler' }
     );
   });
 
@@ -335,8 +339,9 @@ describe('WebSocketManager', () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(mockWorker.postMessage).toHaveBeenCalledWith({ type: 'terminate' });
-    expect(LoggerProxy.logger.error).not.toHaveBeenCalledWith(
-      '[WebSocketStatus] | event=webSocketClose | WebSocket connection closed REASON: no reconnect'
+    expect(LoggerProxy.error).not.toHaveBeenCalledWith(
+      '[WebSocketStatus] | event=webSocketClose | WebSocket connection closed REASON: no reconnect',
+      { module: WEB_SOCKET_MANAGER_FILE, method: 'webSocketOnCloseHandler' }
     );
   });
 
@@ -365,8 +370,9 @@ describe('WebSocketManager', () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(mockWorker.postMessage).toHaveBeenCalledWith({ type: 'terminate' });
-    expect(LoggerProxy.logger.error).not.toHaveBeenCalledWith(
-      '[WebSocketStatus] | event=webSocketClose | WebSocket connection closed REASON: clean close'
+    expect(LoggerProxy.error).not.toHaveBeenCalledWith(
+      '[WebSocketStatus] | event=webSocketClose | WebSocket connection closed REASON: clean close',
+      { module: WEB_SOCKET_MANAGER_FILE, method: 'webSocketOnCloseHandler' }
     );
   });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/WebSocket/connection-service.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/WebSocket/connection-service.ts
@@ -3,16 +3,15 @@ import {WebSocketManager} from '../../../../../../src/services/core/WebSocket/We
 import {SubscribeRequest} from '../../../../../../src/types';
 import LoggerProxy from '../../../../../../src/logger-proxy';
 import {CONNECTIVITY_CHECK_INTERVAL} from '../../../../../../src/services/core/constants';
+import { CONNECTION_SERVICE_FILE } from '../../../../../../src/constants';
 
 jest.mock('../../../../../../src/services/core/WebSocket/WebSocketManager');
 jest.mock('../../../../../../src/logger-proxy', () => ({
   __esModule: true,
   default: {
-    logger: {
-      log: jest.fn(),
-      error: jest.fn(),
-      info: jest.fn(),
-    },
+    log: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
     initialize: jest.fn(),
   },
 }));
@@ -106,8 +105,9 @@ describe('ConnectionService', () => {
     });
 
     await connectionService['handleSocketClose']();
-    expect(LoggerProxy.logger.info).toHaveBeenCalledWith(
-      'event=socketConnectionRetry | Trying to reconnect to notifs socket'
+    expect(LoggerProxy.info).toHaveBeenCalledWith(
+      'event=socketConnectionRetry | Trying to reconnect to websocket',
+      {module: CONNECTION_SERVICE_FILE, method: 'handleSocketClose'}
     );
     expect(mockWebSocketManager.initWebSocket).toHaveBeenCalledWith({body: mockSubscribeRequest});
   });
@@ -163,8 +163,9 @@ describe('ConnectionService', () => {
       });
 
       await connectionService['handleSocketClose']();
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith(
-        'event=socketConnectionRetry | Trying to reconnect to notifs socket'
+      expect(LoggerProxy.info).toHaveBeenCalledWith(
+        'event=socketConnectionRetry | Trying to reconnect to websocket',
+        {module: CONNECTION_SERVICE_FILE, method: 'handleSocketClose'}
       );
     });
 

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/aqm-reqs.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/aqm-reqs.ts
@@ -3,16 +3,15 @@ import HttpRequest from '../../../../../src/services/core/HttpRequest';
 import { WebSocketManager } from '../../../../../src/services/core/WebSocket/WebSocketManager';
 import LoggerProxy from '../../../../../src/logger-proxy';
 import { IHttpResponse } from '../../../../../src/types';
+import {AQM_REQS_FILE} from '../../../../../src/constants';
 
 jest.mock('../../../../../src/services/core/HttpRequest');
 jest.mock('../../../../../src/logger-proxy', () => ({
   __esModule: true,
   default: {
-    logger: {
-      log: jest.fn(),
+    log: jest.fn(),
       error: jest.fn(),
       info: jest.fn(),
-    },
     initialize: jest.fn(),
   },
 }));
@@ -371,7 +370,7 @@ describe('AqmReqs', () => {
         })
       );
     
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith('Welcome message from Notifs Websocket');
+      expect(LoggerProxy.info).toHaveBeenCalledWith("Welcome message from Notifs Websocket", {"method": "onMessage", "module": AQM_REQS_FILE});
     
       // Keep-alive events
       webSocketManagerInstance.emit(
@@ -382,7 +381,7 @@ describe('AqmReqs', () => {
         })
       );
     
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith('Keepalive from web socket');
+      expect(LoggerProxy.info).toHaveBeenCalledWith('Keepalive from web socket', {"method": "onMessage", "module": AQM_REQS_FILE});
     
       // Unhandled event
       webSocketManagerInstance.emit(
@@ -393,8 +392,8 @@ describe('AqmReqs', () => {
         })
       );
     
-      expect(LoggerProxy.logger.info).toHaveBeenCalledWith(
-        'event=missingEventHandler | [AqmReqs] missing routing message handler'
+      expect(LoggerProxy.info).toHaveBeenCalledWith(
+        'event=missingEventHandler | [AqmReqs] missing routing message handler', {"method": "onMessage", "module": AQM_REQS_FILE}
       );
     });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-580611](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-580611)>

## This pull request addresses

* Addition of a custom logging file which enables easy to use logging for the cc-sdk.
* Changed few logs to be more descriptive.


## by making the following changes

* Adding a customised `LoggerProxy` which is able to take in an input message, module name and method name and render it as an appropriate log.

## Log Screenshots

### Before
<img width="1920" alt="Screenshot 2024-11-25 at 8 48 56 AM (2)" src="https://github.com/user-attachments/assets/e1a8d89e-0d49-4752-bfe7-2d1ea23b013d">



### After
![Screenshot 2024-11-22 at 11 12 02 AM](https://github.com/user-attachments/assets/4e852b7f-84f6-4edf-9830-d7ecafc964c8)


![Screenshot 2024-11-22 at 11 13 14 AM](https://github.com/user-attachments/assets/45520f18-f51b-4f38-a758-5b90fe2b40bb)



## Error Screenshots

### Before
<img width="1920" alt="Screenshot 2024-11-25 at 8 48 43 AM (2)" src="https://github.com/user-attachments/assets/b50f80e6-be52-461b-811f-828878afe561">



### After
![Screenshot 2024-11-22 at 11 12 12 AM](https://github.com/user-attachments/assets/c425f187-538e-489f-a614-9286fee43835)


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested to see if logs were coming for `info` and `log`.
* Tested to check that logs were coming for `error` and `warn`.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
