### PR TITLE
feat(meetings): timeout for cluster discovery request

### DIFF
--- a/packages/@webex/plugin-meetings/src/config.ts
+++ b/packages/@webex/plugin-meetings/src/config.ts
@@ -95,5 +95,6 @@ export default {
     // This only applies to non-multistream meetings
     iceCandidatesGatheringTimeout: undefined,
     backendIpv6NativeSupport: false,
+    reachabilityGetClusterTimeout: 5000,
   },
 };

--- a/packages/@webex/plugin-meetings/src/reachability/request.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/request.ts
@@ -46,6 +46,7 @@ class ReachabilityRequest {
               JCSupport: 1,
               ipver: ipVersion,
             },
+            timeout: this.webex.config.meetings.reachabilityGetClusterTimeout,
           }),
         'internal.get.cluster.time'
       )

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/request.js
@@ -57,18 +57,23 @@ describe('plugin-meetings/reachability', () => {
         }
       }));
 
+      webex.config.meetings.reachabilityGetClusterTimeout = 3000;
+
       const res = await reachabilityRequest.getClusters(IP_VERSION.only_ipv4);
       const requestParams = webex.request.getCall(0).args[0];
 
-      assert.equal(requestParams.method, 'GET');
-      assert.equal(requestParams.resource, `clusters`);
-      assert.equal(requestParams.api, 'calliopeDiscovery');
-      assert.equal(requestParams.shouldRefreshAccessToken, false);
-
-      assert.deepEqual(requestParams.qs, {
-        JCSupport: 1,
-        ipver: 4,
+      assert.deepEqual(requestParams, {
+        method: 'GET',
+        resource: `clusters`,
+        api: 'calliopeDiscovery',
+        shouldRefreshAccessToken: false,
+        qs: {
+          JCSupport: 1,
+          ipver: 4,
+        },
+        timeout: 3000,
       });
+
       assert.deepEqual(res.clusters.clusterId, {udp: "testUDP", isVideoMesh: true})
       assert.deepEqual(res.joinCookie, {anycastEntryPoint: "aws-eu-west-1"})
       assert.calledOnceWithExactly(webex.internal.newMetrics.callDiagnosticLatencies.measureLatency, sinon.match.func, 'internal.get.cluster.time');


### PR DESCRIPTION

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Sometimes the get clusters requests fails. Given we have a timeout of 3 seconds for reachability itself, we should also restrict the time taken to get the servers for reachability.

## by making the following changes

default to 5s timer to get the clusters

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration property for meeting reachability timeout, enhancing the control over request timing.
  
- **Bug Fixes**
  - Updated request handling to include the new timeout parameter for improved request behavior in cluster information retrieval.

- **Tests**
  - Adjusted test cases to validate the new timeout parameter in the request, ensuring accuracy in request parameters and response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->