### PR TITLE
feat(cc-sdk): added-device-type-for-agent-config

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -130,14 +130,15 @@ function register() {
         });
         const loginVoiceOptions = agentProfile.loginVoiceOptions;
         agentLogin.innerHTML = '<option value="" selected>Choose Agent Login ...</option>'; // Clear previously selected option on agentLogin.
-        dialNumber.value = '';
-        dialNumber.disabled = true;
+        dialNumber.value = agentProfile.defaultDn ? agentProfile.defaultDn : '';
+        dialNumber.disabled = agentProfile.defaultDn ? false : true;
         if(loginVoiceOptions.length > 0) agentLoginButton.disabled = false;
         loginVoiceOptions.forEach((voiceOptions)=> {
           const option = document.createElement('option');
           option.text = voiceOptions;
           option.value = voiceOptions;
           agentLogin.add(option);
+          option.selected = agentProfile.isAgentLoggedIn && voiceOptions === agentProfile.deviceType;
         });
 
         if (agentProfile.isAgentLoggedIn) {

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -208,6 +208,7 @@ function logoutAgent() {
 
     setTimeout(() => {
       logoutAgentElm.classList.add('hidden');
+      agentLogin.selectedIndex = 0;
     }, 1000);
   }
   ).catch((error) => {

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -334,14 +334,8 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     switch (deviceType) {
       case LoginOption.BROWSER:
         await this.webCallingService.registerWebCallingLine();
-        this.agentConfig.deviceType = LoginOption.BROWSER;
         break;
-      case LoginOption.AGENT_DN:
-        this.agentConfig.deviceType = LoginOption.AGENT_DN;
-        this.agentConfig.defaultDn = dn;
-        break;
-      case LoginOption.EXTENSION:
-        this.agentConfig.deviceType = LoginOption.EXTENSION;
+      case (LoginOption.AGENT_DN, LoginOption.EXTENSION):
         this.agentConfig.defaultDn = dn;
         break;
       default:
@@ -351,5 +345,6 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         });
         throw new Error(`Unsupported device type: ${deviceType}`);
     }
+    this.agentConfig.deviceType = deviceType as LoginOption;
   }
 }

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -335,7 +335,8 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       case LoginOption.BROWSER:
         await this.webCallingService.registerWebCallingLine();
         break;
-      case (LoginOption.AGENT_DN, LoginOption.EXTENSION):
+      case LoginOption.AGENT_DN:
+      case LoginOption.EXTENSION:
         this.agentConfig.defaultDn = dn;
         break;
       default:

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -295,7 +295,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   private async silentRelogin(): Promise<void> {
     try {
       const reLoginResponse = await this.services.agent.reload();
-      const {auxCodeId, agentId, lastStateChangeReason} = reLoginResponse.data;
+      const {auxCodeId, agentId, lastStateChangeReason, deviceType, dn} = reLoginResponse.data;
 
       if (lastStateChangeReason === 'agent-wss-disconnect') {
         LoggerProxy.info(
@@ -310,7 +310,8 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         };
         await this.setAgentState(stateChangeData);
       }
-      // Updating isAgentLoggedIn as true to indicate to the end user
+
+      await this.handleDeviceType(deviceType, dn);
       this.agentConfig.isAgentLoggedIn = true;
     } catch (error) {
       const {reason, error: detailedError} = getErrorDetails(error, 'silentReLogin', CC_FILE);
@@ -323,6 +324,32 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         return;
       }
       throw detailedError;
+    }
+  }
+
+  /**
+   * Handles the device type specific logic
+   */
+  private async handleDeviceType(deviceType: string, dn: string): Promise<void> {
+    switch (deviceType) {
+      case LoginOption.BROWSER:
+        await this.webCallingService.registerWebCallingLine();
+        this.agentConfig.deviceType = LoginOption.BROWSER;
+        break;
+      case LoginOption.AGENT_DN:
+        this.agentConfig.deviceType = LoginOption.AGENT_DN;
+        this.agentConfig.defaultDn = dn;
+        break;
+      case LoginOption.EXTENSION:
+        this.agentConfig.deviceType = LoginOption.EXTENSION;
+        this.agentConfig.defaultDn = dn;
+        break;
+      default:
+        LoggerProxy.error(`Unsupported device type: ${deviceType}`, {
+          module: CC_FILE,
+          method: this.handleDeviceType.name,
+        });
+        throw new Error(`Unsupported device type: ${deviceType}`);
     }
   }
 }

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -311,7 +311,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         await this.setAgentState(stateChangeData);
       }
 
-      await this.handleDeviceType(deviceType, dn);
+      await this.handleDeviceType(deviceType as LoginOption, dn);
       this.agentConfig.isAgentLoggedIn = true;
     } catch (error) {
       const {reason, error: detailedError} = getErrorDetails(error, 'silentReLogin', CC_FILE);
@@ -330,7 +330,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   /**
    * Handles the device type specific logic
    */
-  private async handleDeviceType(deviceType: string, dn: string): Promise<void> {
+  private async handleDeviceType(deviceType: LoginOption, dn: string): Promise<void> {
     switch (deviceType) {
       case LoginOption.BROWSER:
         await this.webCallingService.registerWebCallingLine();
@@ -345,6 +345,6 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         });
         throw new Error(`Unsupported device type: ${deviceType}`);
     }
-    this.agentConfig.deviceType = deviceType as LoginOption;
+    this.agentConfig.deviceType = deviceType;
   }
 }

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -183,6 +183,8 @@ describe('webex.cc', () => {
         data: {
           auxCodeId: 'auxCodeId',
           agentId: 'agentId',
+          deviceType: LoginOption.EXTENSION,
+          dn: '12345',
         },
       });
       const configSpy = jest
@@ -667,6 +669,8 @@ describe('webex.cc', () => {
           auxCodeId: 'auxCodeId',
           agentId: 'agentId',
           lastStateChangeReason: 'agent-wss-disconnect',
+          deviceType: LoginOption.BROWSER,
+          dn: '12345',
         },
       };
 
@@ -695,6 +699,7 @@ describe('webex.cc', () => {
         agentId: 'agentId',
       });
       expect(webex.cc.agentConfig.isAgentLoggedIn).toBe(true);
+      expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.BROWSER);
     });
 
     it('should handle AGENT_NOT_FOUND error silently', async () => {
@@ -713,6 +718,39 @@ describe('webex.cc', () => {
         'Agent not found during re-login, handling silently',
         {module: CC_FILE, method: 'silentRelogin'}
       );
+    });
+  
+    it('should handle errors during silent relogin', async () => {
+      const error = new Error('Error while performing silentReLogin');
+      jest.spyOn(webex.cc.services.agent, 'reload').mockRejectedValue(error);
+  
+      await expect(webex.cc['silentRelogin']()).rejects.toThrow(error);
+    });
+  
+    it('should update agentConfig with deviceType during silent relogin', async () => {
+      const mockReLoginResponse = {
+        data: {
+          auxCodeId: 'auxCodeId',
+          agentId: 'agentId',
+          lastStateChangeReason: 'agent-wss-disconnect',
+          deviceType: LoginOption.EXTENSION,
+          dn: '12345',
+        },
+      };
+  
+      // Mock the agentConfig
+      webex.cc.agentConfig = {
+        agentId: 'agentId',
+        agentProfileID: 'test-agent-profile-id',
+        isAgentLoggedIn: false,
+      } as Profile;
+  
+      jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue(mockReLoginResponse);
+  
+      await webex.cc['silentRelogin']();
+  
+      expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.EXTENSION);
+      expect(webex.cc.agentConfig.defaultDn).toBe('12345');
     });
   });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -727,7 +727,7 @@ describe('webex.cc', () => {
       await expect(webex.cc['silentRelogin']()).rejects.toThrow(error);
     });
   
-    it('should update agentConfig with deviceType during silent relogin', async () => {
+    it('should update agentConfig with deviceType during silent relogin for EXTENSION', async () => {
       const mockReLoginResponse = {
         data: {
           auxCodeId: 'auxCodeId',
@@ -751,6 +751,33 @@ describe('webex.cc', () => {
   
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.EXTENSION);
       expect(webex.cc.agentConfig.defaultDn).toBe('12345');
+    });
+
+    it('should update agentConfig with deviceType during silent relogin for AGENT_DN', async () => {
+      const mockReLoginResponse = {
+        data: {
+          auxCodeId: 'auxCodeId',
+          agentId: 'agentId',
+          lastStateChangeReason: 'agent-wss-disconnect',
+          deviceType: LoginOption.AGENT_DN,
+          dn: '67890',
+          subStatus: 'subStatusValue',
+        },
+      };
+  
+      // Mock the agentConfig
+      webex.cc.agentConfig = {
+        agentId: 'agentId',
+        agentProfileID: 'test-agent-profile-id',
+        isAgentLoggedIn: false,
+      } as Profile;
+  
+      jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue(mockReLoginResponse);
+  
+      await webex.cc['silentRelogin']();
+  
+      expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.AGENT_DN);
+      expect(webex.cc.agentConfig.defaultDn).toBe('67890');
     });
   });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-586282](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-586282) >

## This pull request addresses

* Currently, as a part of the CC SDK, we are only updating the agent config `isAgentLoggedIn` flag.
* As a result, whenever we are doing a relogin or a register (ie say, we reload the webpage), we only get the login state and not the device type the user has logged in with.
* Further, we were not calling the mobius re-registration on browser relogin (this would cause problems later on).

## by making the following changes

* We now obtain the device type object from the response data of the `reLogin` method.
* Using this, we populate the config data.
* We also check for `BROWSER` device type and if it is present, we initiate a re-registration of `WebexCallingService`, ie create the lines again and send request to mobius,

### Vidcast showing EXTENSION device type
https://app.vidcast.io/share/c9ae1f0e-53fc-4c85-ae5b-395cb5b163d3


### Vidcast showing BROWSER device type
https://app.vidcast.io/share/b5142b97-df0a-46cc-a814-9ab2554d6243


### Vidcast showing internet disconnect flow (same behaviour as before, not broken anything)
https://app.vidcast.io/share/3201f886-2536-4021-a366-6d65fee7bd93


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested the device type of EXTENSION and reloaded the page to see if relogin worked
* Tested the [device type of BROWSER](https://app.vidcast.io/share/b5142b97-df0a-46cc-a814-9ab2554d6243) and reloaded the page to see if relogin worked and mobius registration has happened
* Tested the device type of AGENT_DN and reloaded the page to see if dial number shows up
* Tested the scenario when we get disconnected and we need to [relogin](https://app.vidcast.io/share/3201f886-2536-4021-a366-6d65fee7bd93). Observed that everything was working fine including agent status setting up.
* Tested the scenario when relogin fails (ie agent is not logged in) and ensures it works correctly

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
