### PR TITLE
fix(meetings): handle getMe error due to insufficient privileges

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1089,7 +1089,9 @@ export default class Meetings extends WebexPlugin {
         return Promise.resolve();
       })
       .catch(() => {
-        LoggerProxy.logger.error('Failed to retrieve user information. No preferredWebexSite will be set');
+        LoggerProxy.logger.error(
+          'Failed to retrieve user information. No preferredWebexSite will be set'
+        );
       });
   }
 

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1044,48 +1044,53 @@ export default class Meetings extends WebexPlugin {
    */
   fetchUserPreferredWebexSite() {
     // @ts-ignore
-    return this.webex.people._getMe().then((me) => {
-      const isGuestUser = me.type === 'appuser';
-      if (!isGuestUser) {
-        return this.request.getMeetingPreferences().then((res) => {
-          if (res) {
-            const preferredWebexSite = MeetingsUtil.parseDefaultSiteFromMeetingPreferences(res);
-            this.preferredWebexSite = preferredWebexSite;
-            // @ts-ignore
-            this.webex.internal.services._getCatalog().addAllowedDomains([preferredWebexSite]);
-          }
+    return this.webex.people
+      ._getMe()
+      .then((me) => {
+        const isGuestUser = me.type === 'appuser';
+        if (!isGuestUser) {
+          return this.request.getMeetingPreferences().then((res) => {
+            if (res) {
+              const preferredWebexSite = MeetingsUtil.parseDefaultSiteFromMeetingPreferences(res);
+              this.preferredWebexSite = preferredWebexSite;
+              // @ts-ignore
+              this.webex.internal.services._getCatalog().addAllowedDomains([preferredWebexSite]);
+            }
 
-          // fall back to getting the preferred site from the user information
-          if (!this.preferredWebexSite) {
-            // @ts-ignore
-            return this.webex.internal.user
-              .get()
-              .then((user) => {
-                const preferredWebexSite =
-                  user?.userPreferences?.userPreferencesItems?.preferredWebExSite;
-                if (preferredWebexSite) {
-                  this.preferredWebexSite = preferredWebexSite;
-                  // @ts-ignore
-                  this.webex.internal.services
-                    ._getCatalog()
-                    .addAllowedDomains([preferredWebexSite]);
-                } else {
-                  throw new Error('site not found');
-                }
-              })
-              .catch(() => {
-                LoggerProxy.logger.error(
-                  'Failed to fetch preferred site from user - no site will be set'
-                );
-              });
-          }
+            // fall back to getting the preferred site from the user information
+            if (!this.preferredWebexSite) {
+              // @ts-ignore
+              return this.webex.internal.user
+                .get()
+                .then((user) => {
+                  const preferredWebexSite =
+                    user?.userPreferences?.userPreferencesItems?.preferredWebExSite;
+                  if (preferredWebexSite) {
+                    this.preferredWebexSite = preferredWebexSite;
+                    // @ts-ignore
+                    this.webex.internal.services
+                      ._getCatalog()
+                      .addAllowedDomains([preferredWebexSite]);
+                  } else {
+                    throw new Error('site not found');
+                  }
+                })
+                .catch(() => {
+                  LoggerProxy.logger.error(
+                    'Failed to fetch preferred site from user - no site will be set'
+                  );
+                });
+            }
 
-          return Promise.resolve();
-        });
-      }
+            return Promise.resolve();
+          });
+        }
 
-      return Promise.resolve();
-    });
+        return Promise.resolve();
+      })
+      .catch(() => {
+        LoggerProxy.logger.error('Failed to retrieve user information. No site will be set');
+      });
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1089,7 +1089,7 @@ export default class Meetings extends WebexPlugin {
         return Promise.resolve();
       })
       .catch(() => {
-        LoggerProxy.logger.error('Failed to retrieve user information. No site will be set');
+        LoggerProxy.logger.error('Failed to retrieve user information. No preferredWebexSite will be set');
       });
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -2077,6 +2077,21 @@ describe('plugin-meetings', () => {
           ]);
         });
 
+        it('should handle failure to get user information if scopes are insufficient', async () => {
+          loggerProxySpy = sinon.spy(LoggerProxy.logger, 'error');
+          Object.assign(webex.people, {
+            _getMe: sinon.stub().returns(Promise.reject()),
+          });
+
+          await webex.meetings.fetchUserPreferredWebexSite();
+
+          assert.equal(webex.meetings.preferredWebexSite, '');
+          assert.calledOnceWithExactly(
+            loggerProxySpy,
+            'Failed to retrieve user information. No site will be set'
+          );
+        });
+
         const setup = ({me = { type: 'validuser'}, user} = {}) => {
           loggerProxySpy = sinon.spy(LoggerProxy.logger, 'error');
           assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), []);
@@ -2093,7 +2108,7 @@ describe('plugin-meetings', () => {
 
           Object.assign(webex.people, {
             _getMe: sinon.stub().returns(Promise.resolve(me)),
-        });
+          });
         };
 
         it('should not call request.getMeetingPreferences if user is a guest', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -2088,7 +2088,7 @@ describe('plugin-meetings', () => {
           assert.equal(webex.meetings.preferredWebexSite, '');
           assert.calledOnceWithExactly(
             loggerProxySpy,
-            'Failed to retrieve user information. No site will be set'
+            'Failed to retrieve user information. No preferredWebexSite will be set'
           );
         });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # ADHOC

## This pull request addresses

a blocker to join meetings when the `spark:people_read` scope is missing from an access token. The issue was found on the Control Hub while they were joining meetings.
This issue is being caused by #3908 which doesn't handle a failure while calling the `getMe()` function. Due to this, the entire `webex.meetings.register()` function stops executing and a developer cannot proceed with registration and joining a meeting.
Due to this, any developers who upgrade to v3.6.0 and don't have the `spark:people_read` scope will get blocked from joining meetings.

Error:
```
logger.js:396 wx-js-sdk Meetings:index#register --> ERROR, Unable to register, The server understood the request, but refused to fulfill it because the access token is missing required scopes or the user is missing required roles or licenses.
undefined https://hydra-a.wbx2.com/v1/people/me
```

## by making the following changes

Added a catch to ensure the registration doesn't get blocked due to the failure to get user information.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

1. Created an integration with only limited scopes "spark:calls_write", "spark:telephony_config_write", "spark:kms", "spark:webrtc_calling", "spark:calls_read", "spark:xsi", "spark:telephony_config_read"
2. Generated an access token from the integration above.
3. Tried to use this access token to register and join a meeting in the kitchen sink without the fix. Registration failed. Please see the console logs attached.
4. Used the access token after adding the fix initialize webex in the kitchen sink page and join a meeting.
5. Was able to join the meeting successfully with audio and video
6. Added UT to ensure we are testing the catch block

[Logs.zip](https://github.com/user-attachments/files/17934797/Logs.zip)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for scenarios where user information retrieval fails, ensuring a fallback mechanism is in place.
	- Enhanced logging for better visibility when preferred Webex site cannot be set.

- **Tests**
	- Added new test cases to verify error handling when user information retrieval fails.
	- Updated test setup to ensure robust coverage of new error handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->