### PR TITLE
feat(meetings): added support for "early-call-min-clusters" option in Orpheus API

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4771,8 +4771,6 @@ export default class Meeting extends StatelessWebexPlugin {
       if (!joinResponse) {
         // This is the 1st attempt or a retry after join request failed -> we need to do a join with TURN discovery
 
-        // @ts-ignore
-        joinOptions.reachability = await this.webex.meetings.reachability.getReachabilityResults();
         const turnDiscoveryRequest = await this.roap.generateTurnDiscoveryRequestMessage(
           this,
           true

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -2,8 +2,9 @@
 import {defer} from 'lodash';
 import {Defer} from '@webex/common';
 import {WebexPlugin} from '@webex/webex-core';
-import {MEDIA, HTTP_VERBS, ROAP, IP_VERSION} from '../constants';
+import {MEDIA, HTTP_VERBS, ROAP} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
+import {ClientMediaPreferences} from '../reachability/reachability.types';
 
 export type MediaRequestType = 'RoapMessage' | 'LocalMute';
 export type RequestResult = any;
@@ -14,9 +15,8 @@ export type RoapRequest = {
   mediaId: string;
   roapMessage: any;
   reachability: any;
+  clientMediaPreferences: ClientMediaPreferences;
   sequence?: any;
-  joinCookie: any; // any, because this is opaque to the client, we pass whatever object we got from one backend component (Orpheus) to the other (Locus)
-  ipVersion?: IP_VERSION;
 };
 
 export type LocalMuteRequest = {
@@ -202,10 +202,6 @@ export class LocusMediaRequest extends WebexPlugin {
     const body: any = {
       device: this.config.device,
       correlationId: this.config.correlationId,
-      clientMediaPreferences: {
-        preferTranscoding: this.config.preferTranscoding,
-        ipver: request.type === 'RoapMessage' ? request.ipVersion : undefined,
-      },
     };
 
     const localMedias: any = {
@@ -223,7 +219,7 @@ export class LocusMediaRequest extends WebexPlugin {
       case 'RoapMessage':
         localMedias.roapMessage = request.roapMessage;
         localMedias.reachability = request.reachability;
-        body.clientMediaPreferences.joinCookie = request.joinCookie;
+        body.clientMediaPreferences = request.clientMediaPreferences;
 
         // @ts-ignore
         this.webex.internal.newMetrics.submitClientEvent({

--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -26,11 +26,11 @@ import {
   SEND_DTMF_ENDPOINT,
   _SLIDES_,
   ANNOTATION,
-  IP_VERSION,
 } from '../constants';
 import {SendReactionOptions, ToggleReactionsOptions} from './request.type';
 import MeetingUtil from './util';
 import {AnnotationInfo} from '../annotation/annotation.types';
+import {ClientMediaPreferences} from '../reachability/reachability.types';
 
 /**
  * @class MeetingRequest
@@ -128,8 +128,8 @@ export default class MeetingRequest extends StatelessWebexPlugin {
     locale?: string;
     deviceCapabilities?: Array<string>;
     liveAnnotationSupported: boolean;
-    ipVersion?: IP_VERSION;
     alias?: string;
+    clientMediaPreferences: ClientMediaPreferences;
   }) {
     const {
       asResourceOccupant,
@@ -147,20 +147,17 @@ export default class MeetingRequest extends StatelessWebexPlugin {
       moveToResource,
       roapMessage,
       reachability,
-      preferTranscoding,
       breakoutsSupported,
       locale,
       deviceCapabilities = [],
       liveAnnotationSupported,
-      ipVersion,
+      clientMediaPreferences,
       alias,
     } = options;
 
     LoggerProxy.logger.info('Meeting:request#joinMeeting --> Joining a meeting', correlationId);
 
     let url = '';
-
-    const joinCookie = await this.getJoinCookie();
 
     const body: any = {
       asResourceOccupant,
@@ -176,11 +173,7 @@ export default class MeetingRequest extends StatelessWebexPlugin {
       allowMultiDevice: true,
       ensureConversation: ensureConversation || false,
       supportsNativeLobby: 1,
-      clientMediaPreferences: {
-        preferTranscoding: preferTranscoding ?? true,
-        joinCookie,
-        ipver: ipVersion,
-      },
+      clientMediaPreferences,
     };
 
     if (alias) {

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -127,11 +127,26 @@ const MeetingUtil = {
       options: {meetingId: meeting.id},
     });
 
-    const reachability = await webex.meetings.reachability.getReachabilityReportToAttachToRoap();
-    const clientMediaPreferences = await webex.meetings.reachability.getClientMediaPreferences(
-      meeting.isMultistream,
-      MeetingUtil.getIpVersion(webex)
-    );
+    let reachability;
+    let clientMediaPreferences = {
+      // bare minimum fallback value that should allow us to join
+      ipver: IP_VERSION.unknown,
+      joinCookie: undefined,
+      preferTranscoding: !meeting.isMultistream,
+    };
+
+    try {
+      clientMediaPreferences = await webex.meetings.reachability.getClientMediaPreferences(
+        meeting.isMultistream,
+        MeetingUtil.getIpVersion(webex)
+      );
+      reachability = await webex.meetings.reachability.getReachabilityReportToAttachToRoap();
+    } catch (e) {
+      LoggerProxy.logger.error(
+        'Meeting:util#joinMeeting --> Error getting reachability or clientMediaPreferences:',
+        e
+      );
+    }
 
     // eslint-disable-next-line no-warning-comments
     // TODO: check if the meeting is in JOINING state

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -115,7 +115,7 @@ const MeetingUtil = {
     return IP_VERSION.unknown;
   },
 
-  joinMeeting: (meeting, options) => {
+  joinMeeting: async (meeting, options) => {
     if (!meeting) {
       return Promise.reject(new ParameterError('You need a meeting object.'));
     }
@@ -126,6 +126,12 @@ const MeetingUtil = {
       name: 'client.locus.join.request',
       options: {meetingId: meeting.id},
     });
+
+    const reachability = await webex.meetings.reachability.getReachabilityReportToAttachToRoap();
+    const clientMediaPreferences = await webex.meetings.reachability.getClientMediaPreferences(
+      meeting.isMultistream,
+      MeetingUtil.getIpVersion(webex)
+    );
 
     // eslint-disable-next-line no-warning-comments
     // TODO: check if the meeting is in JOINING state
@@ -138,20 +144,19 @@ const MeetingUtil = {
         locusUrl: meeting.locusUrl,
         locusClusterUrl: meeting.meetingInfo?.locusClusterUrl,
         correlationId: meeting.correlationId,
-        reachability: options.reachability,
+        reachability,
         roapMessage: options.roapMessage,
         permissionToken: meeting.permissionToken,
         resourceId: options.resourceId || null,
         moderator: options.moderator,
         pin: options.pin,
         moveToResource: options.moveToResource,
-        preferTranscoding: !meeting.isMultistream,
         asResourceOccupant: options.asResourceOccupant,
         breakoutsSupported: options.breakoutsSupported,
         locale: options.locale,
         deviceCapabilities: options.deviceCapabilities,
         liveAnnotationSupported: options.liveAnnotationSupported,
-        ipVersion: MeetingUtil.getIpVersion(meeting.getWebexObject()),
+        clientMediaPreferences,
       })
       .then((res) => {
         const parsed = MeetingUtil.parseLocusJoin(res);

--- a/packages/@webex/plugin-meetings/src/reachability/clusterReachability.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/clusterReachability.ts
@@ -6,20 +6,7 @@ import {convertStunUrlToTurn, convertStunUrlToTurnTls} from './util';
 import EventsScope from '../common/events/events-scope';
 
 import {CONNECTION_STATE, Enum, ICE_GATHERING_STATE} from '../constants';
-
-// result for a specific transport protocol (like udp or tcp)
-export type TransportResult = {
-  result: 'reachable' | 'unreachable' | 'untested';
-  latencyInMilliseconds?: number; // amount of time it took to get the first ICE candidate
-  clientMediaIPs?: string[];
-};
-
-// reachability result for a specific media cluster
-export type ClusterReachabilityResult = {
-  udp: TransportResult;
-  tcp: TransportResult;
-  xtls: TransportResult;
-};
+import {ClusterReachabilityResult} from './reachability.types';
 
 // data for the Events.resultReady event
 export type ResultEventData = {

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -22,6 +22,7 @@ import {
   ReachabilityResults,
   ReachabilityResultsForBackend,
   TransportResultForBackend,
+  GetClustersTrigger,
 } from './reachability.types';
 import {
   ClientMediaIpsUpdatedEventData,
@@ -96,7 +97,7 @@ export default class Reachability extends EventsScope {
    * @returns {Promise<{clusters: ClusterList, joinCookie: any}>}
    */
   async getClusters(
-    trigger: string,
+    trigger: GetClustersTrigger,
     previousReport?: any,
     isRetry = false
   ): Promise<{

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -9,63 +9,29 @@ import {Defer} from '@webex/common';
 import LoggerProxy from '../common/logs/logger-proxy';
 import MeetingUtil from '../meeting/util';
 
-import {REACHABILITY} from '../constants';
+import {IP_VERSION, REACHABILITY} from '../constants';
 
 import ReachabilityRequest, {ClusterList} from './request';
 import {
+  ClusterReachabilityResult,
+  TransportResult,
+  ClientMediaPreferences,
+  ReachabilityMetrics,
+  ReachabilityReportV0,
+  ReachabilityReportV1,
+  ReachabilityResults,
+  ReachabilityResultsForBackend,
+  TransportResultForBackend,
+} from './reachability.types';
+import {
   ClientMediaIpsUpdatedEventData,
   ClusterReachability,
-  ClusterReachabilityResult,
   Events,
   ResultEventData,
-  TransportResult,
 } from './clusterReachability';
 import EventsScope from '../common/events/events-scope';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import Metrics from '../metrics';
-
-export type ReachabilityMetrics = {
-  reachability_public_udp_success: number;
-  reachability_public_udp_failed: number;
-  reachability_public_tcp_success: number;
-  reachability_public_tcp_failed: number;
-  reachability_public_xtls_success: number;
-  reachability_public_xtls_failed: number;
-  reachability_vmn_udp_success: number;
-  reachability_vmn_udp_failed: number;
-  reachability_vmn_tcp_success: number;
-  reachability_vmn_tcp_failed: number;
-  reachability_vmn_xtls_success: number;
-  reachability_vmn_xtls_failed: number;
-};
-
-/**
- * This is the type that matches what backend expects us to send to them. It is a bit weird, because
- * it uses strings instead of booleans and numbers, but that's what they require.
- */
-export type TransportResultForBackend = {
-  reachable?: 'true' | 'false';
-  latencyInMilliseconds?: string;
-  clientMediaIPs?: string[];
-  untested?: 'true';
-};
-
-export type ReachabilityResultForBackend = {
-  udp: TransportResultForBackend;
-  tcp: TransportResultForBackend;
-  xtls: TransportResultForBackend;
-};
-
-// this is the type that is required by the backend when we send them reachability results
-export type ReachabilityResultsForBackend = Record<string, ReachabilityResultForBackend>;
-
-// this is the type used by Reachability class internally and stored in local storage
-export type ReachabilityResults = Record<
-  string,
-  ClusterReachabilityResult & {
-    isVideoMesh?: boolean;
-  }
->;
 
 // timeouts in seconds
 const DEFAULT_TIMEOUT = 3;
@@ -84,6 +50,9 @@ export default class Reachability extends EventsScope {
     [key: string]: ClusterReachability;
   };
 
+  minRequiredClusters?: number;
+  orpheusApiVersion?: number;
+
   reachabilityDefer?: Defer;
 
   vmnTimer?: ReturnType<typeof setTimeout>;
@@ -92,6 +61,8 @@ export default class Reachability extends EventsScope {
 
   expectedResultsCount = {videoMesh: {udp: 0}, public: {udp: 0, tcp: 0, xtls: 0}};
   resultsCount = {videoMesh: {udp: 0}, public: {udp: 0, tcp: 0, xtls: 0}};
+  startTime = undefined;
+  totalDuration = undefined;
 
   protected lastTrigger?: string;
 
@@ -118,14 +89,35 @@ export default class Reachability extends EventsScope {
 
   /**
    * Fetches the list of media clusters from the backend
+   * @param {string} trigger - explains the reason for starting reachability, used by Orpheus
+   * @param {Object} previousReport - last reachability report
    * @param {boolean} isRetry
    * @private
    * @returns {Promise<{clusters: ClusterList, joinCookie: any}>}
    */
-  async getClusters(isRetry = false): Promise<{clusters: ClusterList; joinCookie: any}> {
+  async getClusters(
+    trigger: string,
+    previousReport?: any,
+    isRetry = false
+  ): Promise<{
+    clusters: ClusterList;
+    joinCookie: any;
+  }> {
     try {
-      const {clusters, joinCookie} = await this.reachabilityRequest.getClusters(
-        MeetingUtil.getIpVersion(this.webex)
+      const {clusters, joinCookie, discoveryOptions} = await this.reachabilityRequest.getClusters(
+        trigger,
+        MeetingUtil.getIpVersion(this.webex),
+        previousReport
+      );
+
+      this.minRequiredClusters = discoveryOptions?.['early-call-min-clusters'];
+      this.orpheusApiVersion = discoveryOptions?.['report-version'];
+
+      // @ts-ignore
+      await this.webex.boundedStorage.put(
+        this.namespace,
+        REACHABILITY.localStorageJoinCookie,
+        JSON.stringify(joinCookie)
       );
 
       return {clusters, joinCookie};
@@ -138,7 +130,7 @@ export default class Reachability extends EventsScope {
         `Reachability:index#getClusters --> Failed with error: ${error}, retrying...`
       );
 
-      return this.getClusters(true);
+      return this.getClusters(trigger, previousReport, true);
     }
   }
 
@@ -159,14 +151,7 @@ export default class Reachability extends EventsScope {
       // @ts-ignore
       this.webex.internal.device.ipNetworkDetector.detect(true);
 
-      const {clusters, joinCookie} = await this.getClusters();
-
-      // @ts-ignore
-      await this.webex.boundedStorage.put(
-        this.namespace,
-        REACHABILITY.localStorageJoinCookie,
-        JSON.stringify(joinCookie)
-      );
+      const {clusters} = await this.getClusters('startup');
 
       this.reachabilityDefer = new Defer();
 
@@ -178,6 +163,98 @@ export default class Reachability extends EventsScope {
       LoggerProxy.logger.error(`Reachability:index#gatherReachability --> Error:`, error);
 
       return {};
+    }
+  }
+
+  /**
+   * Gets the last join cookie we got from Orpheus
+   *
+   * @returns {Promise<Object>} join cookie
+   */
+  async getJoinCookie() {
+    // @ts-ignore
+    const joinCookieRaw = await this.webex.boundedStorage
+      .get(REACHABILITY.namespace, REACHABILITY.localStorageJoinCookie)
+      .catch(() => {});
+
+    let joinCookie;
+
+    if (joinCookieRaw) {
+      try {
+        joinCookie = JSON.parse(joinCookieRaw);
+      } catch (e) {
+        LoggerProxy.logger.error(
+          `MeetingRequest#constructor --> Error in parsing join cookie data: ${e}`
+        );
+      }
+    }
+
+    return joinCookie;
+  }
+
+  /**
+   * Returns the reachability report that needs to be attached to the ROAP messages
+   * that we send to the backend.
+   *
+   * @returns {Promise<Object>}
+   */
+  async getReachabilityReport(): Promise<
+    | {
+        joinCookie: any;
+        reachability?: ReachabilityReportV1;
+      }
+    | {
+        reachability: ReachabilityReportV0;
+      }
+  > {
+    const reachabilityResult = await this.getReachabilityResults();
+    const joinCookie = await this.getJoinCookie();
+
+    // Orpheus API version 0
+    if (!this.orpheusApiVersion) {
+      return {
+        reachability: reachabilityResult,
+      };
+    }
+
+    // Orpheus API version 1
+    return {
+      reachability: {
+        version: 1,
+        result: {
+          usedDiscoveryOptions: {
+            'early-call-min-clusters': this.minRequiredClusters,
+          },
+          metrics: {
+            'total-duration-ms': this.totalDuration,
+          },
+          tests: reachabilityResult,
+        },
+      },
+      joinCookie,
+    };
+  }
+
+  /**
+   * This method is called when we don't succeed in reaching the minimum number of clusters
+   * required by Orpheus. It sends the results to Orpheus and gets a new list that it tries to reach again.
+   * @returns {Promise<ReachabilityResults>} reachability results
+   * @public
+   * @memberof Reachability
+   */
+  public async gatherReachabilityFallback(): Promise<void> {
+    try {
+      const reachabilityReport = await this.getReachabilityReport();
+
+      const {clusters} = await this.getClusters('early-call/no-min-reached', reachabilityReport);
+
+      // stop all previous reachability checks that might still be going on in the background
+      this.abortCurrentChecks();
+
+      // Perform Reachability Check
+      await this.performReachabilityChecks(clusters);
+    } catch (error) {
+      LoggerProxy.logger.error(`Reachability:index#gatherReachabilityFallback --> Error:`, error);
     }
   }
 
@@ -304,7 +381,7 @@ export default class Reachability extends EventsScope {
     } catch (e) {
       // empty storage, that's ok
       LoggerProxy.logger.warn(
-        'Roap:request#attachReachabilityData --> Error parsing reachability data: ',
+        'Reachability:index#getReachabilityResults --> Error parsing reachability data: ',
         e
       );
     }
@@ -336,7 +413,7 @@ export default class Reachability extends EventsScope {
         );
       } catch (e) {
         LoggerProxy.logger.error(
-          `Roap:request#attachReachabilityData --> Error in parsing reachability data: ${e}`
+          `Reachability:index#isAnyPublicClusterReachable --> Error in parsing reachability data: ${e}`
         );
       }
     }
@@ -393,7 +470,7 @@ export default class Reachability extends EventsScope {
         );
       } catch (e) {
         LoggerProxy.logger.error(
-          `Roap:request#attachReachabilityData --> Error in parsing reachability data: ${e}`
+          `Reachability:index#isWebexMediaBackendUnreachable --> Error in parsing reachability data: ${e}`
         );
       }
     }
@@ -425,6 +502,30 @@ export default class Reachability extends EventsScope {
     });
 
     return unreachableList;
+  }
+
+  /**
+   * Gets the number of reachable clusters from last run reachability check
+   * @returns {number} reachable clusters count
+   * @private
+   * @memberof Reachability
+   */
+  private getNumberOfReachableClusters(): number {
+    let count = 0;
+
+    Object.entries(this.clusterReachability).forEach(([key, clusterReachability]) => {
+      const result = clusterReachability.getResult();
+
+      if (
+        result.udp.result === 'reachable' ||
+        result.tcp.result === 'reachable' ||
+        result.xtls.result === 'reachable'
+      ) {
+        count += 1;
+      }
+    });
+
+    return count;
   }
 
   /**
@@ -465,18 +566,27 @@ export default class Reachability extends EventsScope {
 
   /**
    * Resolves the promise returned by gatherReachability() method
+   * @param {boolean} checkMinRequiredClusters - if true, it will check if we have reached the minimum required clusters and do a fallback if needed
    * @returns {void}
    */
-  private resolveReachabilityPromise() {
-    if (this.vmnTimer) {
-      clearTimeout(this.vmnTimer);
-    }
-    if (this.publicCloudTimer) {
-      clearTimeout(this.publicCloudTimer);
-    }
+  private resolveReachabilityPromise(checkMinRequiredClusters = true) {
+    this.totalDuration = performance.now() - this.startTime;
+
+    this.clearTimer('vmnTimer');
+    this.clearTimer('publicCloudTimer');
 
     this.logUnreachableClusters();
     this.reachabilityDefer?.resolve();
+
+    if (checkMinRequiredClusters) {
+      const numReachableClusters = this.getNumberOfReachableClusters();
+      if (this.minRequiredClusters && numReachableClusters < this.minRequiredClusters) {
+        LoggerProxy.logger.log(
+          `Reachability:index#resolveReachabilityPromise --> minRequiredClusters not reached (${numReachableClusters} < ${this.minRequiredClusters}), doing reachability fallback`
+        );
+        this.gatherReachabilityFallback();
+      }
+    }
   }
 
   /**
@@ -591,6 +701,8 @@ export default class Reachability extends EventsScope {
         `Reachability:index#startTimers --> Reachability checks timed out (${DEFAULT_TIMEOUT}s)`
       );
 
+      // check against minimum required clusters, do a new call if we don't have enough
+
       // resolve the promise, so that the client won't be blocked waiting on meetings.register() for too long
       this.resolveReachabilityPromise();
     }, DEFAULT_TIMEOUT * 1000);
@@ -647,6 +759,32 @@ export default class Reachability extends EventsScope {
   }
 
   /**
+   * Clears the timer
+   *
+   * @param {string} timer name of the timer to clear
+   * @returns {void}
+   */
+  private clearTimer(timer: string) {
+    if (this[timer]) {
+      clearTimeout(this[timer]);
+      this[timer] = undefined;
+    }
+  }
+
+  /**
+   * Aborts current checks that are in progress
+   *
+   * @returns {void}
+   */
+  private abortCurrentChecks() {
+    this.clearTimer('vmnTimer');
+    this.clearTimer('publicCloudTimer');
+    this.clearTimer('overallTimer');
+
+    this.abortClusterReachability();
+  }
+
+  /**
    * Performs reachability checks for all clusters
    * @param {ClusterList} clusterList
    * @returns {Promise<void>} promise that's resolved as soon as the checks are started
@@ -656,9 +794,7 @@ export default class Reachability extends EventsScope {
 
     this.clusterReachability = {};
 
-    if (!clusterList || !Object.keys(clusterList).length) {
-      return;
-    }
+    this.startTime = performance.now();
 
     LoggerProxy.logger.log(
       `Reachability:index#performReachabilityChecks --> doing UDP${
@@ -671,7 +807,6 @@ export default class Reachability extends EventsScope {
     );
 
     this.resetResultCounters();
-    this.startTimers();
 
     // sanitize the urls in the clusterList
     Object.keys(clusterList).forEach((key) => {
@@ -721,6 +856,24 @@ export default class Reachability extends EventsScope {
     // save the initialized results (in case we don't get any "resultReady" events at all)
     await this.storeResults(results);
 
+    if (!clusterList || !Object.keys(clusterList).length) {
+      // nothing to do, finish immediately
+      this.resolveReachabilityPromise(false);
+
+      this.emit(
+        {
+          file: 'reachability',
+          function: 'performReachabilityChecks',
+        },
+        'reachability:done',
+        {}
+      );
+
+      return;
+    }
+
+    this.startTimers();
+
     // now start the reachability on all the clusters
     Object.keys(clusterList).forEach((key) => {
       const cluster = clusterList[key];
@@ -753,8 +906,7 @@ export default class Reachability extends EventsScope {
         await this.storeResults(results);
 
         if (areAllResultsReady) {
-          clearTimeout(this.overallTimer);
-          this.overallTimer = undefined;
+          this.clearTimer('overallTimer');
           this.emit(
             {
               file: 'reachability',
@@ -784,5 +936,60 @@ export default class Reachability extends EventsScope {
 
       this.clusterReachability[key].start(); // not awaiting on purpose
     });
+  }
+
+  /**
+   * Returns the clientMediaPreferences object that needs to be sent to the backend
+   * when joining a meeting
+   *
+   * @param {boolean} isMultistream
+   * @param {IP_VERSION} ipver
+   * @returns {Object}
+   */
+  async getClientMediaPreferences(
+    isMultistream: boolean,
+    ipver?: IP_VERSION
+  ): Promise<ClientMediaPreferences> {
+    // if 0 or undefined, we assume version 0 and don't send any reachability in clientMediaPreferences
+    if (!this.orpheusApiVersion) {
+      return {
+        ipver,
+        joinCookie: await this.getJoinCookie(),
+        preferTranscoding: !isMultistream,
+      };
+    }
+
+    // must be version 1
+
+    // for version 1, the reachability report goes into clientMediaPreferences (and it contains joinCookie)
+    const reachabilityReport = (await this.getReachabilityReport()) as {
+      joinCookie: any;
+      reachability?: ReachabilityReportV1;
+    };
+
+    return {
+      ipver,
+      preferTranscoding: !isMultistream,
+      ...reachabilityReport,
+    };
+  }
+
+  /**
+   * Returns the reachability report that needs to be attached to the ROAP messages
+   * that we send to the backend.
+   * It may return undefined, if reachability is not needed to be attached to ROAP messages (that's the case for v1 or Orpheus API)
+   *
+   * @returns {Promise<ReachabilityReportV0>} object that needs to be attached to Roap messages
+   */
+  async getReachabilityReportToAttachToRoap(): Promise<ReachabilityReportV0 | undefined> {
+    // version 0
+    if (!this.orpheusApiVersion) {
+      return this.getReachabilityResults();
+    }
+
+    // version 1
+
+    // for version 1 we don't attach anything to Roap messages, reachability report is sent inside clientMediaPreferences
+    return undefined;
   }
 }

--- a/packages/@webex/plugin-meetings/src/reachability/reachability.types.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/reachability.types.ts
@@ -80,3 +80,6 @@ export interface ClientMediaPreferences {
   preferTranscoding: boolean;
   reachability?: ReachabilityReportV1; // only present when using Orpheus API version 1
 }
+
+/* Orpheus API supports more triggers, but we don't use them yet */
+export type GetClustersTrigger = 'startup' | 'early-call/no-min-reached';

--- a/packages/@webex/plugin-meetings/src/reachability/reachability.types.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/reachability.types.ts
@@ -1,0 +1,82 @@
+import {IP_VERSION} from '../constants';
+
+// result for a specific transport protocol (like udp or tcp)
+export type TransportResult = {
+  result: 'reachable' | 'unreachable' | 'untested';
+  latencyInMilliseconds?: number; // amount of time it took to get the first ICE candidate
+  clientMediaIPs?: string[];
+};
+
+// reachability result for a specific media cluster
+export type ClusterReachabilityResult = {
+  udp: TransportResult;
+  tcp: TransportResult;
+  xtls: TransportResult;
+};
+
+export type ReachabilityMetrics = {
+  reachability_public_udp_success: number;
+  reachability_public_udp_failed: number;
+  reachability_public_tcp_success: number;
+  reachability_public_tcp_failed: number;
+  reachability_public_xtls_success: number;
+  reachability_public_xtls_failed: number;
+  reachability_vmn_udp_success: number;
+  reachability_vmn_udp_failed: number;
+  reachability_vmn_tcp_success: number;
+  reachability_vmn_tcp_failed: number;
+  reachability_vmn_xtls_success: number;
+  reachability_vmn_xtls_failed: number;
+};
+
+/**
+ * This is the type that matches what backend expects us to send to them. It is a bit weird, because
+ * it uses strings instead of booleans and numbers, but that's what they require.
+ */
+export type TransportResultForBackend = {
+  reachable?: 'true' | 'false';
+  latencyInMilliseconds?: string;
+  clientMediaIPs?: string[];
+  untested?: 'true';
+};
+
+export type ReachabilityResultForBackend = {
+  udp: TransportResultForBackend;
+  tcp: TransportResultForBackend;
+  xtls: TransportResultForBackend;
+};
+
+// this is the type that is required by the backend when we send them reachability results
+export type ReachabilityResultsForBackend = Record<string, ReachabilityResultForBackend>;
+
+// this is the type used by Reachability class internally and stored in local storage
+export type ReachabilityResults = Record<
+  string,
+  ClusterReachabilityResult & {
+    isVideoMesh?: boolean;
+  }
+>;
+
+export type ReachabilityReportV0 = ReachabilityResultsForBackend;
+
+export type ReachabilityReportV1 = {
+  version: 1;
+  result: {
+    usedDiscoveryOptions: {
+      'early-call-min-clusters': number;
+      // there are more options, but we don't support them yet
+    };
+    metrics: {
+      'total-duration-ms': number;
+      // there are more metrics, but we don't support them yet
+    };
+    tests: Record<string, ReachabilityResultForBackend>;
+  };
+};
+
+export interface ClientMediaPreferences {
+  ipver: IP_VERSION;
+  joinCookie: any;
+  preferTranscoding: boolean;
+  reachability?: ReachabilityReportV1; // only present when using Orpheus API version 1
+}

--- a/packages/@webex/plugin-meetings/src/reachability/request.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/request.ts
@@ -1,5 +1,6 @@
 import LoggerProxy from '../common/logs/logger-proxy';
 import {HTTP_VERBS, RESOURCE, API, IP_VERSION} from '../constants';
+import {GetClustersTrigger} from './reachability.types';
 
 export interface ClusterNode {
   isVideoMesh: boolean;
@@ -36,7 +37,7 @@ class ReachabilityRequest {
    * @returns {Promise}
    */
   getClusters = (
-    trigger,
+    trigger: GetClustersTrigger,
     ipVersion?: IP_VERSION,
     previousReport?: any
   ): Promise<{

--- a/packages/@webex/plugin-meetings/src/reachability/request.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/request.ts
@@ -30,44 +30,67 @@ class ReachabilityRequest {
   /**
    * Gets the cluster information
    *
+   * @param {string} trigger that's passed to Orpheus
    * @param {IP_VERSION} ipVersion information about current ip network we're on
+   * @param {Object} previousReport last reachability result
    * @returns {Promise}
    */
-  getClusters = (ipVersion?: IP_VERSION): Promise<{clusters: ClusterList; joinCookie: any}> =>
-    this.webex.internal.newMetrics.callDiagnosticLatencies
-      .measureLatency(
-        () =>
-          this.webex.request({
-            method: HTTP_VERBS.GET,
-            shouldRefreshAccessToken: false,
-            api: API.CALLIOPEDISCOVERY,
-            resource: RESOURCE.CLUSTERS,
-            qs: {
-              JCSupport: 1,
-              ipver: ipVersion,
+  getClusters = (
+    trigger,
+    ipVersion?: IP_VERSION,
+    previousReport?: any
+  ): Promise<{
+    clusters: ClusterList;
+    joinCookie: any;
+    discoveryOptions?: Record<string, any>;
+  }> => {
+    // we only measure latency for the initial startup call, not for other triggers
+    const callWrapper =
+      trigger === 'startup'
+        ? this.webex.internal.newMetrics.callDiagnosticLatencies.measureLatency.bind(
+            this.webex.internal.newMetrics.callDiagnosticLatencies
+          )
+        : (func) => func();
+
+    return callWrapper(
+      () =>
+        this.webex.request({
+          method: HTTP_VERBS.POST,
+          shouldRefreshAccessToken: false,
+          api: API.CALLIOPEDISCOVERY,
+          resource: RESOURCE.CLUSTERS,
+          body: {
+            ipver: ipVersion,
+            'supported-options': {
+              'report-version': 1,
+              'early-call-min-clusters': true,
             },
-            timeout: this.webex.config.meetings.reachabilityGetClusterTimeout,
-          }),
-        'internal.get.cluster.time'
-      )
-      .then((res) => {
-        const {clusters, joinCookie} = res.body;
+            'previous-report': previousReport,
+            trigger,
+          },
+          timeout: this.webex.config.meetings.reachabilityGetClusterTimeout,
+        }),
+      'internal.get.cluster.time'
+    ).then((res) => {
+      const {clusters, joinCookie, discoveryOptions} = res.body;
 
-        Object.keys(clusters).forEach((key) => {
-          clusters[key].isVideoMesh = !!res.body.clusterClasses?.hybridMedia?.includes(key);
-        });
-
-        LoggerProxy.logger.log(
-          `Reachability:request#getClusters --> get clusters (ipver=${ipVersion}) successful:${JSON.stringify(
-            clusters
-          )}`
-        );
-
-        return {
-          clusters,
-          joinCookie,
-        };
+      Object.keys(clusters).forEach((key) => {
+        clusters[key].isVideoMesh = !!res.body.clusterClasses?.hybridMedia?.includes(key);
       });
+
+      LoggerProxy.logger.log(
+        `Reachability:request#getClusters --> get clusters (ipver=${ipVersion}) successful:${JSON.stringify(
+          clusters
+        )}`
+      );
+
+      return {
+        clusters,
+        joinCookie,
+        discoveryOptions,
+      };
+    });
+  };
 
   /**
    * gets remote SDP For Clusters

--- a/packages/@webex/plugin-meetings/src/roap/index.ts
+++ b/packages/@webex/plugin-meetings/src/roap/index.ts
@@ -107,7 +107,7 @@ export default class Roap extends StatelessWebexPlugin {
           roapMessage,
           locusSelfUrl: meeting.selfUrl,
           mediaId: options.mediaId,
-          meetingId: meeting.id,
+          isMultistream: meeting.isMultistream,
           locusMediaRequest: meeting.locusMediaRequest,
         })
         .then(() => {
@@ -141,7 +141,7 @@ export default class Roap extends StatelessWebexPlugin {
       roapMessage,
       locusSelfUrl: meeting.selfUrl,
       mediaId: options.mediaId,
-      meetingId: meeting.id,
+      isMultistream: meeting.isMultistream,
       locusMediaRequest: meeting.locusMediaRequest,
     });
   }
@@ -170,7 +170,7 @@ export default class Roap extends StatelessWebexPlugin {
         roapMessage,
         locusSelfUrl: meeting.selfUrl,
         mediaId: options.mediaId,
-        meetingId: meeting.id,
+        isMultistream: meeting.isMultistream,
         locusMediaRequest: meeting.locusMediaRequest,
       })
       .then(() => {
@@ -207,10 +207,9 @@ export default class Roap extends StatelessWebexPlugin {
         roapMessage,
         locusSelfUrl: meeting.selfUrl,
         mediaId: sendEmptyMediaId ? '' : meeting.mediaId,
-        meetingId: meeting.id,
+        isMultistream: meeting.isMultistream,
         preferTranscoding: !meeting.isMultistream,
         locusMediaRequest: meeting.locusMediaRequest,
-        ipVersion: MeetingUtil.getIpVersion(meeting.webex),
       })
       .then(({locus, mediaConnections}) => {
         if (mediaConnections) {

--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -5,6 +5,7 @@ import LoggerProxy from '../common/logs/logger-proxy';
 import {IP_VERSION, REACHABILITY} from '../constants';
 import {LocusMediaRequest} from '../meeting/locusMediaRequest';
 import MeetingUtil from '../meeting/util';
+import {ClientMediaPreferences} from '../reachability/reachability.types';
 
 /**
  * @class RoapRequest
@@ -41,17 +42,28 @@ export default class RoapRequest extends StatelessWebexPlugin {
       return Promise.reject(new Error('sendRoap called when locusMediaRequest is undefined'));
     }
 
-    const reachability =
-      // @ts-ignore
-      await this.webex.meetings.reachability.getReachabilityReportToAttachToRoap();
+    let reachability;
+    let clientMediaPreferences: ClientMediaPreferences = {
+      // bare minimum fallback value that should allow us to join;
+      joinCookie: undefined,
+      ipver: IP_VERSION.unknown,
+      preferTranscoding: !isMultistream,
+    };
 
-    const clientMediaPreferences =
-      // @ts-ignore
-      await this.webex.meetings.reachability.getClientMediaPreferences(
-        isMultistream,
+    try {
+      clientMediaPreferences =
         // @ts-ignore
-        MeetingUtil.getIpVersion(this.webex)
-      );
+        await this.webex.meetings.reachability.getClientMediaPreferences(
+          isMultistream,
+          // @ts-ignore
+          MeetingUtil.getIpVersion(this.webex)
+        );
+      reachability =
+        // @ts-ignore
+        await this.webex.meetings.reachability.getReachabilityReportToAttachToRoap();
+    } catch (error) {
+      LoggerProxy.logger.error('Roap:request#sendRoap --> reachability error:', error);
+    }
 
     LoggerProxy.logger.info(
       `Roap:request#sendRoap --> ${roapMessage.messageType} seq:${roapMessage.seq} ${

--- a/packages/@webex/plugin-meetings/src/roap/request.ts
+++ b/packages/@webex/plugin-meetings/src/roap/request.ts
@@ -4,44 +4,12 @@ import {StatelessWebexPlugin} from '@webex/webex-core';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {IP_VERSION, REACHABILITY} from '../constants';
 import {LocusMediaRequest} from '../meeting/locusMediaRequest';
+import MeetingUtil from '../meeting/util';
 
 /**
  * @class RoapRequest
  */
 export default class RoapRequest extends StatelessWebexPlugin {
-  /**
-   * Returns reachability data.
-   * @param {Object} localSdp
-   * @returns {Object}
-   */
-  async attachReachabilityData(localSdp) {
-    let joinCookie;
-
-    // @ts-ignore
-    const reachabilityResult = await this.webex.meetings.reachability.getReachabilityResults();
-
-    if (reachabilityResult && Object.keys(reachabilityResult).length) {
-      localSdp.reachability = reachabilityResult;
-    }
-
-    // @ts-ignore
-    const joinCookieRaw = await this.webex.boundedStorage
-      .get(REACHABILITY.namespace, REACHABILITY.localStorageJoinCookie)
-      .catch(() => {});
-
-    if (joinCookieRaw) {
-      try {
-        joinCookie = JSON.parse(joinCookieRaw);
-      } catch (e) {
-        LoggerProxy.logger.error(
-          `MeetingRequest#constructor --> Error in parsing join cookie data: ${e}`
-        );
-      }
-    }
-
-    return {localSdp, joinCookie};
-  }
-
   /**
    * Sends a ROAP message
    * @param {Object} options
@@ -50,18 +18,16 @@ export default class RoapRequest extends StatelessWebexPlugin {
    * @param {String} options.mediaId
    * @param {String} options.correlationId
    * @param {String} options.meetingId
-   * @param {IP_VERSION} options.ipVersion only required for offers
    * @returns {Promise} returns the response/failure of the request
    */
   async sendRoap(options: {
     roapMessage: any;
     locusSelfUrl: string;
     mediaId: string;
-    meetingId: string;
-    ipVersion?: IP_VERSION;
+    isMultistream: boolean;
     locusMediaRequest?: LocusMediaRequest;
   }) {
-    const {roapMessage, locusSelfUrl, mediaId, locusMediaRequest, ipVersion} = options;
+    const {roapMessage, locusSelfUrl, isMultistream, mediaId, locusMediaRequest} = options;
 
     if (!mediaId) {
       LoggerProxy.logger.info('Roap:request#sendRoap --> sending empty mediaID');
@@ -74,13 +40,22 @@ export default class RoapRequest extends StatelessWebexPlugin {
 
       return Promise.reject(new Error('sendRoap called when locusMediaRequest is undefined'));
     }
-    const {localSdp: localSdpWithReachabilityData, joinCookie} = await this.attachReachabilityData({
-      roapMessage,
-    });
+
+    const reachability =
+      // @ts-ignore
+      await this.webex.meetings.reachability.getReachabilityReportToAttachToRoap();
+
+    const clientMediaPreferences =
+      // @ts-ignore
+      await this.webex.meetings.reachability.getClientMediaPreferences(
+        isMultistream,
+        // @ts-ignore
+        MeetingUtil.getIpVersion(this.webex)
+      );
 
     LoggerProxy.logger.info(
       `Roap:request#sendRoap --> ${roapMessage.messageType} seq:${roapMessage.seq} ${
-        ipVersion ? `ipver=${ipVersion} ` : ''
+        clientMediaPreferences?.ipver ? `ipver=${clientMediaPreferences?.ipver} ` : ''
       } ${locusSelfUrl}`
     );
 
@@ -88,11 +63,10 @@ export default class RoapRequest extends StatelessWebexPlugin {
       .send({
         type: 'RoapMessage',
         selfUrl: locusSelfUrl,
-        joinCookie,
         mediaId,
         roapMessage,
-        reachability: localSdpWithReachabilityData.reachability,
-        ipVersion,
+        reachability,
+        clientMediaPreferences,
       })
       .then((res) => {
         // always it will be the first mediaConnection Object

--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -408,10 +408,8 @@ export default class TurnDiscovery {
         locusSelfUrl: meeting.selfUrl,
         // @ts-ignore - Fix missing type
         mediaId: isReconnecting ? '' : meeting.mediaId,
-        meetingId: meeting.id,
+        isMultistream: meeting.isMultistream,
         locusMediaRequest: meeting.locusMediaRequest,
-        // @ts-ignore - because of meeting.webex
-        ipVersion: MeetingUtil.getIpVersion(meeting.webex),
       })
       .then(async (response) => {
         const {mediaConnections} = response;
@@ -451,7 +449,7 @@ export default class TurnDiscovery {
       locusSelfUrl: meeting.selfUrl,
       // @ts-ignore - fix type
       mediaId: meeting.mediaId,
-      meetingId: meeting.id,
+      isMultistream: meeting.isMultistream,
       locusMediaRequest: meeting.locusMediaRequest,
     });
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
@@ -34,12 +34,19 @@ describe('LocusMediaRequest.send()', () => {
       'wjfkm.wjfkm.*': {udp:{reachable: true}, tcp:{reachable:false}},
       '1eb65fdf-9643-417f-9974-ad72cae0e10f.59268c12-7a04-4b23-a1a1-4c74be03019a.*': {udp:{reachable: false}, tcp:{reachable:true}},
     },
-    joinCookie: {
-      anycastEntryPoint: 'aws-eu-west-1',
-      clientIpAddress: 'some ip',
-      timeShot: '2023-05-23T08:03:49Z',
-    },
-    ipVersion: IP_VERSION.only_ipv4,
+    clientMediaPreferences: {
+      preferTranscoding: false,
+      joinCookie: {
+        anycastEntryPoint: 'aws-eu-west-1',
+        clientIpAddress: 'some ip',
+        timeShot: '2023-05-23T08:03:49Z',
+      },
+      ipver: IP_VERSION.only_ipv4,
+      reachability: {
+        version: '1',
+        result: 'some fake reachability result',
+      }
+    }
   };
 
   const createExpectedRoapBody = (expectedMessageType, expectedMute:{audioMuted: boolean, videoMuted: boolean}) => {
@@ -53,12 +60,16 @@ describe('LocusMediaRequest.send()', () => {
         }
       ],
       clientMediaPreferences: {
-        preferTranscoding: true,
+        preferTranscoding: false,
         ipver: 4,
         joinCookie: {
           anycastEntryPoint: 'aws-eu-west-1',
           clientIpAddress: 'some ip',
           timeShot: '2023-05-23T08:03:49Z'
+        },
+        reachability: {
+          version: '1',
+          result: 'some fake reachability result',
         }
       }
     };
@@ -87,10 +98,6 @@ describe('LocusMediaRequest.send()', () => {
           localSdp: `{"audioMuted":${expectedMute.audioMuted},"videoMuted":${expectedMute.videoMuted}}`,
         },
       ],
-      clientMediaPreferences: {
-        preferTranscoding: true,
-        ipver: undefined,
-      },
     };
 
     if (sequence) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
@@ -196,6 +196,7 @@ describe('plugin-meetings', () => {
         const permissionToken = 'permission-token';
         const installationId = 'installationId';
         const reachability = 'reachability';
+        const clientMediaPreferences = 'clientMediaPreferences';
 
         await meetingsRequest.joinMeeting({
           locusUrl,
@@ -204,6 +205,7 @@ describe('plugin-meetings', () => {
           roapMessage,
           reachability,
           permissionToken,
+          clientMediaPreferences
         });
         const requestParams = meetingsRequest.request.getCall(0).args[0];
 
@@ -214,6 +216,7 @@ describe('plugin-meetings', () => {
         assert.equal(requestParams.body.device.countryCode, 'US');
         assert.equal(requestParams.body.permissionToken, 'permission-token');
         assert.equal(requestParams.body.device.regionCode, 'WEST-COAST');
+        assert.equal(requestParams.body.clientMediaPreferences, 'clientMediaPreferences');
         assert.include(requestParams.body.device.localIp, '127.0.0');
         assert.deepEqual(requestParams.body.localMedias, [
           {localSdp: '{"roapMessage":"roap-message","reachability":"reachability"}'},
@@ -385,32 +388,6 @@ describe('plugin-meetings', () => {
         const requestParams = meetingsRequest.request.getCall(0).args[0];
 
         assert.deepEqual(requestParams.body.alias, undefined);
-      });
-
-      it('includes joinCookie and ipver correctly', async () => {
-        const locusUrl = 'locusURL';
-        const deviceUrl = 'deviceUrl';
-        const correlationId = 'random-uuid';
-        const roapMessage = 'roap-message';
-        const permissionToken = 'permission-token';
-
-        await meetingsRequest.joinMeeting({
-          locusUrl,
-          deviceUrl,
-          correlationId,
-          roapMessage,
-          permissionToken,
-          ipVersion: IP_VERSION.ipv4_and_ipv6,
-        });
-        const requestParams = meetingsRequest.request.getCall(0).args[0];
-
-        assert.equal(requestParams.method, 'POST');
-        assert.equal(requestParams.uri, `${locusUrl}/participant?alternateRedirect=true`);
-        assert.deepEqual(requestParams.body.clientMediaPreferences, {
-          joinCookie: {anycastEntryPoint: 'aws-eu-west-1'},
-          preferTranscoding: true,
-          ipver: 1,
-        });
       });
     });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -473,6 +473,29 @@ describe('plugin-meetings', () => {
         });
       });
 
+      it('should handle failed reachability report retrieval', async () => {
+        webex.meetings.reachability.getReachabilityReportToAttachToRoap.rejects(
+          new Error('fake error')
+        );
+        await MeetingUtil.joinMeeting(meeting, {});
+        // Verify meeting join still proceeds
+        assert.calledOnce(meeting.meetingRequest.joinMeeting);
+      });
+
+      it('should handle failed clientMediaPreferences retrieval', async () => {
+        webex.meetings.reachability.getClientMediaPreferences.rejects(new Error('fake error'));
+        meeting.isMultistream = true;
+        await MeetingUtil.joinMeeting(meeting, {});
+        // Verify meeting join still proceeds
+        assert.calledOnce(meeting.meetingRequest.joinMeeting);
+        const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
+        assert.deepEqual(parameter.clientMediaPreferences, {
+          preferTranscoding: false,
+          ipver: 0,
+          joinCookie: undefined,
+        });
+      });
+
       it('#Should call meetingRequest.joinMeeting with breakoutsSupported=true when passed in as true', async () => {
         await MeetingUtil.joinMeeting(meeting, {
           breakoutsSupported: true,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -22,6 +22,12 @@ describe('plugin-meetings', () => {
           meetings: Meetings,
         },
       });
+
+      webex.meetings.reachability = {
+        getReachabilityReportToAttachToRoap: sinon.stub().resolves({}),
+        getClientMediaPreferences: sinon.stub().resolves({}),
+      };  
+
       const logger = {
         info: sandbox.stub(),
         log: sandbox.stub(),
@@ -408,17 +414,39 @@ describe('plugin-meetings', () => {
       });
 
       it('#Should call `meetingRequest.joinMeeting', async () => {
+        meeting.isMultistream = true;
+
+        const FAKE_REACHABILITY_REPORT = {
+          id: 'fake reachability report',
+        };
+        const FAKE_CLIENT_MEDIA_PREFERENCES = {
+          id: 'fake client media preferences',
+        };
+  
+        webex.meetings.reachability.getReachabilityReportToAttachToRoap.resolves(FAKE_REACHABILITY_REPORT);
+        webex.meetings.reachability.getClientMediaPreferences.resolves(FAKE_CLIENT_MEDIA_PREFERENCES);
+        
+        sinon
+          .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4')
+          .get(() => true);
+        sinon
+          .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6')
+          .get(() => true);
+          
         await MeetingUtil.joinMeeting(meeting, {
           reachability: 'reachability',
           roapMessage: 'roapMessage',
         });
 
+        assert.calledOnceWithExactly(webex.meetings.reachability.getReachabilityReportToAttachToRoap);
+        assert.calledOnceWithExactly(webex.meetings.reachability.getClientMediaPreferences, meeting.isMultistream, IP_VERSION.ipv4_and_ipv6);
+
         assert.calledOnce(meeting.meetingRequest.joinMeeting);
         const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
 
         assert.equal(parameter.inviteeAddress, 'meetingJoinUrl');
-        assert.equal(parameter.preferTranscoding, true);
-        assert.equal(parameter.reachability, 'reachability');
+        assert.equal(parameter.reachability, FAKE_REACHABILITY_REPORT);
+        assert.equal(parameter.clientMediaPreferences, FAKE_CLIENT_MEDIA_PREFERENCES);
         assert.equal(parameter.roapMessage, 'roapMessage');
 
         assert.calledOnce(meeting.setLocus)
@@ -478,17 +506,6 @@ describe('plugin-meetings', () => {
 
         assert.equal(parameter.locale, 'en_UK');
         assert.deepEqual(parameter.deviceCapabilities, ['TEST']);
-      });
-
-      it('#Should call meetingRequest.joinMeeting with preferTranscoding=false when multistream is enabled', async () => {
-        meeting.isMultistream = true;
-        await MeetingUtil.joinMeeting(meeting, {});
-
-        assert.calledOnce(meeting.meetingRequest.joinMeeting);
-        const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
-
-        assert.equal(parameter.inviteeAddress, 'meetingJoinUrl');
-        assert.equal(parameter.preferTranscoding, false);
       });
 
       it('#Should fallback sipUrl if meetingJoinUrl does not exists', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/request.js
@@ -35,16 +35,11 @@ describe('plugin-meetings/reachability', () => {
   });
 
   describe('#getClusters', () => {
+    let previousReport;
 
     beforeEach(() => {
       sinon.spy(webex.internal.newMetrics.callDiagnosticLatencies, 'measureLatency');
-    });
 
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it('sends a GET request with the correct params', async () => {
       webex.request = sinon.mock().returns(Promise.resolve({
         body: {
           clusterClasses: {
@@ -59,24 +54,65 @@ describe('plugin-meetings/reachability', () => {
 
       webex.config.meetings.reachabilityGetClusterTimeout = 3000;
 
-      const res = await reachabilityRequest.getClusters(IP_VERSION.only_ipv4);
+      previousReport = {
+        id: 'fake previous report',
+      }
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('sends a POST request with the correct params when trigger is "startup"', async () => {
+      const res = await reachabilityRequest.getClusters('startup', IP_VERSION.only_ipv4, previousReport);
       const requestParams = webex.request.getCall(0).args[0];
 
       assert.deepEqual(requestParams, {
-        method: 'GET',
+        method: 'POST',
         resource: `clusters`,
         api: 'calliopeDiscovery',
         shouldRefreshAccessToken: false,
-        qs: {
-          JCSupport: 1,
-          ipver: 4,
-        },
         timeout: 3000,
+        body: {
+          ipver: IP_VERSION.only_ipv4,
+          'supported-options': {
+            'report-version': 1,
+            'early-call-min-clusters': true,
+          },
+          'previous-report': previousReport,
+          trigger: 'startup',
+        },
       });
 
       assert.deepEqual(res.clusters.clusterId, {udp: "testUDP", isVideoMesh: true})
       assert.deepEqual(res.joinCookie, {anycastEntryPoint: "aws-eu-west-1"})
       assert.calledOnceWithExactly(webex.internal.newMetrics.callDiagnosticLatencies.measureLatency, sinon.match.func, 'internal.get.cluster.time');
+    });
+
+    it('sends a POST request with the correct params when trigger is other than "startup"', async () => {
+      const res = await reachabilityRequest.getClusters('other trigger', IP_VERSION.only_ipv4, previousReport);
+      const requestParams = webex.request.getCall(0).args[0];
+
+      assert.deepEqual(requestParams, {
+        method: 'POST',
+        resource: `clusters`,
+        api: 'calliopeDiscovery',
+        shouldRefreshAccessToken: false,
+        timeout: 3000,
+        body: {
+          ipver: IP_VERSION.only_ipv4,
+          'supported-options': {
+            'report-version': 1,
+            'early-call-min-clusters': true,
+          },
+          'previous-report': previousReport,
+          trigger: 'other trigger',
+        },
+      });
+
+      assert.deepEqual(res.clusters.clusterId, {udp: "testUDP", isVideoMesh: true})
+      assert.deepEqual(res.joinCookie, {anycastEntryPoint: "aws-eu-west-1"})
+      assert.notCalled(webex.internal.newMetrics.callDiagnosticLatencies.measureLatency);
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/request.js
@@ -90,7 +90,7 @@ describe('plugin-meetings/reachability', () => {
     });
 
     it('sends a POST request with the correct params when trigger is other than "startup"', async () => {
-      const res = await reachabilityRequest.getClusters('other trigger', IP_VERSION.only_ipv4, previousReport);
+      const res = await reachabilityRequest.getClusters('early-call/no-min-reached', IP_VERSION.only_ipv4, previousReport);
       const requestParams = webex.request.getCall(0).args[0];
 
       assert.deepEqual(requestParams, {
@@ -106,7 +106,7 @@ describe('plugin-meetings/reachability', () => {
             'early-call-min-clusters': true,
           },
           'previous-report': previousReport,
-          trigger: 'other trigger',
+          trigger: 'early-call/no-min-reached',
         },
       });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/index.ts
@@ -161,7 +161,7 @@ describe('Roap', () => {
           roapMessage: expectedRoapMessage,
           locusSelfUrl: meeting.selfUrl,
           mediaId: meeting.mediaId,
-          meetingId: meeting.id,
+          isMultistream: meeting.isMultistream,
           locusMediaRequest: meeting.locusMediaRequest,
         })
       );

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
@@ -82,11 +82,13 @@ describe('plugin-meetings/roap', () => {
     );
   });
 
+  afterEach(() => {
+    sinon.restore();
+  })
+
   describe('sendRoap', () => {
     it('includes clientMediaPreferences and reachability in the request correctly', async () => {
       const locusMediaRequest = {send: sinon.stub().resolves({body: {locus: {}}})};
-
-      const ipVersion = IP_VERSION.unknown;
 
       const FAKE_REACHABILITY_REPORT = {
         id: 'fake reachability report',
@@ -122,6 +124,37 @@ describe('plugin-meetings/roap', () => {
           seq: 'seq',
         },
         reachability: FAKE_REACHABILITY_REPORT,
+      });
+    });
+
+    it('includes default clientMediaPreferences if calls to reachability fail', async () => {
+      const locusMediaRequest = {send: sinon.stub().resolves({body: {locus: {}}})};
+
+      webex.meetings.reachability.getClientMediaPreferences.rejects(new Error('fake error'));
+
+      await roapRequest.sendRoap({
+        locusSelfUrl: locusUrl,
+        mediaId: 'mediaId',
+        roapMessage: {
+          seq: 'seq',
+        },
+        meetingId: 'meeting-id',
+        isMultistream: true,
+        locusMediaRequest,
+      });
+
+      assert.calledOnce(webex.meetings.reachability.getClientMediaPreferences);
+
+      const requestParams = locusMediaRequest.send.getCall(0).args[0];
+      assert.deepEqual(requestParams, {
+        type: 'RoapMessage',
+        selfUrl: locusUrl,
+        clientMediaPreferences: {ipver: 0, joinCookie: undefined, preferTranscoding: false},
+        mediaId: 'mediaId',
+        roapMessage: {
+          seq: 'seq',
+        },
+        reachability: undefined,
       });
     });
   });

--- a/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/roap/request.ts
@@ -4,6 +4,7 @@ import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import Meetings from '@webex/plugin-meetings';
 import RoapRequest from '@webex/plugin-meetings/src/roap/request';
+import MeetingUtil from '@webex/plugin-meetings/src/meeting/util';
 import {IP_VERSION, REACHABILITY} from '@webex/plugin-meetings/src/constants';
 
 describe('plugin-meetings/roap', () => {
@@ -23,6 +24,11 @@ describe('plugin-meetings/roap', () => {
       regionCode: 'WEST-COAST',
     };
 
+    webex.meetings.reachability = {
+      getReachabilityReportToAttachToRoap: sinon.stub().resolves({}),
+      getClientMediaPreferences: sinon.stub().resolves({}),
+    };
+
     webex.internal = {
       services: {
         get: sinon.mock().returns(locusUrl),
@@ -35,6 +41,8 @@ describe('plugin-meetings/roap', () => {
         submitClientEvent: sinon.stub()
       },
     };
+
+    sinon.stub(MeetingUtil, 'getIpVersion').returns(IP_VERSION.ipv4_and_ipv6);
 
     // @ts-ignore
     roapRequest = new RoapRequest({webex});
@@ -74,146 +82,47 @@ describe('plugin-meetings/roap', () => {
     );
   });
 
-  describe('#attachReachabilityData', () => {
-    it('returns the correct reachability data', async () => {
-      const res = await roapRequest.attachReachabilityData({});
+  describe('sendRoap', () => {
+    it('includes clientMediaPreferences and reachability in the request correctly', async () => {
+      const locusMediaRequest = {send: sinon.stub().resolves({body: {locus: {}}})};
 
-      assert.deepEqual(res.localSdp, {
-        reachability: {
-          clusterId: {
-            udp: {
-              reachable: 'true',
-              latencyInMilliseconds: '10',
-            },
-            tcp: {
-              reachable: 'false',
-            },
-            xtls: {
-              untested: 'true',
-            }
-          },
-        },
-      });
-      assert.deepEqual(res.joinCookie, {
-        anycastEntryPoint: 'aws-eu-west-1',
-      });
-    });
+      const ipVersion = IP_VERSION.unknown;
 
-    it('handles the case when reachability data does not exist', async () => {
-      await webex.boundedStorage.del(REACHABILITY.namespace, REACHABILITY.localStorageJoinCookie);
-
-      await webex.boundedStorage.del(REACHABILITY.namespace, REACHABILITY.localStorageResult);
-      const sdp = {
-        some: 'attribute',
+      const FAKE_REACHABILITY_REPORT = {
+        id: 'fake reachability report',
+      };
+      const FAKE_CLIENT_MEDIA_PREFERENCES = {
+        id: 'fake client media preferences',
       };
 
-      const result = await roapRequest.attachReachabilityData(sdp);
-
-      assert.deepEqual(result, {
-        joinCookie: undefined,
-        localSdp: {
-          some: 'attribute',
-        },
-      });
-    });
-  });
-
-  describe('sendRoap', () => {
-    it('includes joinCookie in the request correctly', async () => {
-      const locusMediaRequest = {send: sinon.stub().resolves({body: {locus: {}}})};
-      const ipVersion = IP_VERSION.unknown;
+      webex.meetings.reachability.getReachabilityReportToAttachToRoap.resolves(FAKE_REACHABILITY_REPORT);
+      webex.meetings.reachability.getClientMediaPreferences.resolves(FAKE_CLIENT_MEDIA_PREFERENCES);
 
       await roapRequest.sendRoap({
         locusSelfUrl: locusUrl,
-        ipVersion,
         mediaId: 'mediaId',
         roapMessage: {
           seq: 'seq',
         },
         meetingId: 'meeting-id',
+        isMultistream: true,
         locusMediaRequest,
       });
+
+      assert.calledOnceWithExactly(webex.meetings.reachability.getReachabilityReportToAttachToRoap);
+      assert.calledOnceWithExactly(webex.meetings.reachability.getClientMediaPreferences, true, IP_VERSION.ipv4_and_ipv6);
 
       const requestParams = locusMediaRequest.send.getCall(0).args[0];
       assert.deepEqual(requestParams, {
         type: 'RoapMessage',
         selfUrl: locusUrl,
-        ipVersion,
-        joinCookie: {
-          anycastEntryPoint: 'aws-eu-west-1',
-        },
+        clientMediaPreferences: FAKE_CLIENT_MEDIA_PREFERENCES,
         mediaId: 'mediaId',
         roapMessage: {
           seq: 'seq',
         },
-        reachability: {
-          clusterId: {
-            tcp: {
-              reachable: 'false',
-            },
-            udp: {
-              latencyInMilliseconds: '10',
-              reachable: 'true',
-            },
-            xtls: {
-              untested: 'true',
-            },
-          },
-        },
+        reachability: FAKE_REACHABILITY_REPORT,
       });
-    });
-  });
-
-  it('calls attachReachabilityData when sendRoap', async () => {
-    const locusMediaRequest = { send: sinon.stub().resolves({body: {locus: {}}})};
-
-    const newSdp = {
-      new: 'sdp',
-      reachability: { someResult: 'whatever' }
-    };
-    const ipVersion = IP_VERSION.only_ipv6;
-
-    roapRequest.attachReachabilityData = sinon.stub().returns(
-      Promise.resolve({
-        localSdp: newSdp,
-        joinCookie: {
-          anycastEntryPoint: 'aws-eu-west-1',
-        },
-      })
-    );
-
-    await roapRequest.sendRoap({
-      roapMessage: {
-        seq: 1,
-      },
-      locusSelfUrl: 'locusSelfUrl',
-      ipVersion,
-      mediaId: 'mediaId',
-      meetingId: 'meetingId',
-      preferTranscoding: true,
-      locusMediaRequest
-    });
-
-    const requestParams = locusMediaRequest.send.getCall(0).args[0];
-
-    assert.deepEqual(requestParams, {
-      type: 'RoapMessage',
-      selfUrl: 'locusSelfUrl',
-      ipVersion,
-      joinCookie: {
-        anycastEntryPoint: 'aws-eu-west-1',
-      },
-      mediaId: 'mediaId',
-      roapMessage: {
-        seq: 1,
-      },
-      reachability: { someResult: 'whatever' },
-    });
-
-    assert.calledOnceWithExactly(roapRequest.attachReachabilityData, {
-      roapMessage: {
-        seq: 1,
-      },
     });
   });
 });


### PR DESCRIPTION
# COMPLETES #[SPARK-577185](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-577185)

## This pull request addresses
As parf of IPv6 feature Orpheus has extended their API. Now the /clusters API response may contain a field "early-call-min-clusters" which says the minimum required number of clusters that we should reach. If we fail to reach them, we should call /clusters API again with our results and they will give us a different set of URLs to try (and new value for "early-call-min-clusters"). If we fail to reach minimum number of clusters we should keep calling them.

Each time we call them they also give us updated `joinCookie`, so when we join and pass that cookie, it will allow Orpheus to see the history of all our calls to /clusters API and reachability results sent to them in previous calls.

To use this new API feature we had to move to "version 1" of Orpheus API, which has slightly different format for reachability. Main difference is that in v1 reachability results are inside `clientMediaPreferences` object.

wiki pages for reference:
https://confluence-eng-gpk2.cisco.com/conf/display/CLO/Discovery+Algorithm+Improvements
https://confluence-eng-gpk2.cisco.com/conf/display/CLO/New+Reachability+Format+and+Metrics
https://confluence-eng-gpk2.cisco.com/conf/pages/viewpage.action?pageId=563898338 

## by making the following changes
- added gatherReachabilityFallback() which is called if we don't reach the minimum required number of media clusters. This is done after the existing reachability 3s timeout, but is not blocking the app, so it won't affect JMT.
- created getClientMediaPreferences() and getReachabilityReportToAttachToRoap() in Rechability class, so that now instead of having the logic of populating clientMediaPreferences and reachability in various places, the logic is in the Reachability class and these 2 functions are called from MeetingUtil and Roap modules and values then passed unchanged through the layers all the way to webex.request.

to test this: 
the new Orpheus API is available only in integration environment and you have to ask Rafa from Orpheus team to enable a feature toggle for your user or you can use one of my users.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests and manual testing in integration with Orpheus and web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced media handling with improved error management during meetings.
  - Introduced a fallback mechanism for reachability checks, ensuring retries for cluster availability.
  - Added support for multistream capabilities in ROAP message handling.
  - Updated `joinMeeting` method to include `clientMediaPreferences` for better media management.
  - New methods for resource management during meetings, allowing flexible handling of media connections.

- **Bug Fixes**
  - Improved error handling for media connections and TURN server interactions.
  - Refined logic for managing audio and video streams to prevent invalid state publications.

- **Tests**
  - Expanded test coverage for media connection handling and reachability checks.
  - Updated tests to reflect changes in request structures and parameters, including new reachability methods.
  - Enhanced clarity and organization of test cases for better readability and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->