### PR TITLE
fix: lobby entry/exit metrics

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3249,6 +3249,9 @@ export default class Meeting extends StatelessWebexPlugin {
           options: {meetingId: this.id},
         });
       }
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.GUEST_ENTERED_LOBBY, {
+        correlation_id: this.correlationId,
+      });
       this.updateLLMConnection();
     });
     this.locusInfo.on(LOCUSINFO.EVENTS.SELF_ADMITTED_GUEST, async (payload) => {
@@ -3271,6 +3274,9 @@ export default class Meeting extends StatelessWebexPlugin {
         this.webex.internal.newMetrics.submitClientEvent({
           name: 'client.lobby.exited',
           options: {meetingId: this.id},
+        });
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.GUEST_EXITED_LOBBY, {
+          correlation_id: this.correlationId,
         });
       }
       this.rtcMetrics?.sendNextMetrics();

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -71,6 +71,8 @@ const BEHAVIORAL_METRICS = {
   TURN_DISCOVERY_REQUIRES_OK: 'js_sdk_turn_discovery_requires_ok',
   REACHABILITY_COMPLETED: 'js_sdk_reachability_completed',
   WEBINAR_REGISTRATION_ERROR: 'js_sdk_webinar_registration_error',
+  GUEST_ENTERED_LOBBY: 'js_sdk_guest_entered_lobby',
+  GUEST_EXITED_LOBBY: 'js_sdk_guest_exited_lobby',
 };
 
 export {BEHAVIORAL_METRICS as default};

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -8629,6 +8629,13 @@ describe('plugin-meetings', () => {
             {payload: test1}
           );
           assert.calledOnce(meeting.updateLLMConnection);
+          assert.calledOnceWithExactly(
+            Metrics.sendBehavioralMetric,
+            BEHAVIORAL_METRICS.GUEST_ENTERED_LOBBY,
+            {
+              correlation_id: meeting.correlationId,
+            }
+          );
           done();
         });
         it('listens to the self admitted guest event', (done) => {
@@ -8650,6 +8657,13 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.updateLLMConnection);
           assert.calledOnceWithExactly(meeting.rtcMetrics.sendNextMetrics);
 
+          assert.calledOnceWithExactly(
+            Metrics.sendBehavioralMetric,
+            BEHAVIORAL_METRICS.GUEST_EXITED_LOBBY,
+            {
+              correlation_id: meeting.correlationId,
+            }
+          );
           done();
         });
 


### PR DESCRIPTION
## This pull request addresses

We have no indication of entering/exiting lobby in SDK's behavioral metrics (we also don't have it in the web app)

## by making the following changes

Added metrics for entr/exit of lobby

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced guest admission and lobby management with new metrics for guest entry and exit.
	- Added methods for managing screen sharing and improved media management.
	- Introduced new event listeners for better responsiveness during meetings.

- **Bug Fixes**
	- Improved error handling for media connection failures and transcription.

- **Chores**
	- Updated constants for behavioral metrics related to guest interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->