### PR TITLE
feat(plugin-meetings): set up the listeners before triggering ice gathering

### DIFF
--- a/packages/@webex/plugin-meetings/src/reachability/clusterReachability.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/clusterReachability.ts
@@ -357,11 +357,14 @@ export class ClusterReachability extends EventsScope {
 
       this.startTimestamp = performance.now();
 
+      // Set up the state change listeners before triggering the ICE gathering
+      const gatherIceCandidatePromise = this.gatherIceCandidates();
+
       // not awaiting the next call on purpose, because we're not sending the offer anywhere and there won't be any answer
       // we just need to make this call to trigger the ICE gathering process
       this.pc.setLocalDescription(offer);
 
-      await this.gatherIceCandidates();
+      await gatherIceCandidatePromise;
     } catch (error) {
       LoggerProxy.logger.warn(`Reachability:ClusterReachability#start --> Error: `, error);
     }


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

There is the potential for a race condition in reachability. If the state changes on the peer connection before the listener is added then maybe miss the change and get the incorrect reachability result.

## by making the following changes

Add the listeners before setting the local description.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the asynchronous flow for gathering ICE candidates in the reachability process.

- **Tests**
	- Enhanced test cases to monitor the order of method calls related to ICE candidate gathering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->