### PR TITLE
fix(authorization): set supertoken after authorization success

### DIFF
--- a/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
@@ -434,6 +434,7 @@ const Authorization = WebexPlugin.extend({
             eventType: 'authorizationSuccess',
             data: res.body,
           });
+          this.webex.credentials.set({supertoken: res.body});
           this.cancelQRCodePolling();
         })
         .catch((res) => {

--- a/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
@@ -599,6 +599,7 @@ describe('plugin-authorization-browser-first-party', () => {
 
         webex.request.onFirstCall().resolves({statusCode: 200, body: {access_token: 'token'}});
         const emitSpy = sinon.spy(webex.authorization.eventEmitter, 'emit');
+        const credentialsSetSpy = sinon.spy(webex.credentials, 'set');
         sinon.spy(webex.authorization, 'cancelQRCodePolling');
 
         webex.authorization._startQRCodePolling(options);
@@ -617,6 +618,7 @@ describe('plugin-authorization-browser-first-party', () => {
         );
 
         assert.calledOnce(webex.authorization.cancelQRCodePolling);
+        assert.calledOnce(credentialsSetSpy);
         assert.calledTwice(emitSpy);
         assert.equal(emitSpy.getCall(0).args[1].eventType, 'authorizationSuccess');
         assert.equal(emitSpy.getCall(1).args[1].eventType, 'pollingCanceled');
@@ -708,7 +710,8 @@ describe('plugin-authorization-browser-first-party', () => {
         webex.request.onSecondCall().resolves({statusCode: 200, body: {access_token: 'token'}});
         sinon.spy(webex.authorization, 'cancelQRCodePolling');
         const emitSpy = sinon.spy(webex.authorization.eventEmitter, 'emit');
-
+        const credentialsSetSpy = sinon.spy(webex.credentials, 'set');
+        
         webex.authorization._startQRCodePolling(options);
         await clock.tickAsync(4000);
 
@@ -720,6 +723,7 @@ describe('plugin-authorization-browser-first-party', () => {
 
         assert.calledTwice(webex.request);
         assert.calledOnce(webex.authorization.cancelQRCodePolling);
+        assert.calledOnce(credentialsSetSpy);
         assert.calledTwice(emitSpy);
         assert.equal(emitSpy.getCall(0).args[1].eventType, 'authorizationSuccess');
         assert.equal(emitSpy.getCall(1).args[1].eventType, 'pollingCanceled');


### PR DESCRIPTION
# COMPLETES #[SPARK-591039](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-591039)

## This pull request addresses
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-591039

## by making the following changes

After the user is authorized successfully, a super token needs to be set so that the user can complete the QR code joining process

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced QR code login process with improved token management and error handling.
	- Added checks to ensure valid authorization codes are provided before proceeding with token requests.
  
- **Bug Fixes**
	- Improved handling of simultaneous polling requests for QR code login.

- **Tests**
	- Expanded test coverage for authorization processes, including error handling and state management.
	- Introduced new assertions and spies to monitor credential management during authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->