### PR TITLE
feat(messaging): only create reaction hmac if doing encryption

### DIFF
--- a/packages/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
+++ b/packages/@webex/internal-plugin-conversation/test/unit/spec/conversation.js
@@ -41,49 +41,27 @@ describe('plugin-conversation', () => {
         const {conversation} = webex.internal;
         const recipientId = 'example-recipient-id';
         const expected = {items: [{id: recipientId, objectType: 'person'}]};
+        conversation.config.includeEncryptionTransforms = true;
         conversation.sendReaction = sinon.stub().returns(Promise.resolve());
         conversation.createReactionHmac = sinon.stub().returns(Promise.resolve('hmac'));
 
         return conversation.addReaction({}, 'example-display-name', {}, recipientId).then(() => {
+          assert.called(conversation.createReactionHmac);
           assert.deepEqual(conversation.sendReaction.args[0][1].recipients, expected);
         });
       });
-    });
 
-    describe('deleteReaction()', () => {
-      it('should add recipients to the payload if provided', () => {
+      it('will not call createReactionHmac if config prohibits', () => {
         const {conversation} = webex.internal;
         const recipientId = 'example-recipient-id';
         const expected = {items: [{id: recipientId, objectType: 'person'}]};
+        conversation.config.includeEncryptionTransforms = false;
         conversation.sendReaction = sinon.stub().returns(Promise.resolve());
-
-        return conversation.deleteReaction({}, 'example-reaction-id', recipientId).then(() => {
-          assert.deepEqual(conversation.sendReaction.args[0][1].recipients, expected);
-        });
-      });
-    });
-
-    describe('prepare()', () => {
-      it('should ammend activity recipients to the returned object', () => {
-        const {conversation} = webex.internal;
-        const activity = {recipients: 'example-recipients'};
-
-        return conversation.prepare(activity).then((results) => {
-          assert.deepEqual(results.recipients, activity.recipients);
-        });
-      });
-    });
-
-    describe('addReaction()', () => {
-      it('should add recipients to the payload if provided', () => {
-        const {conversation} = webex.internal;
-        const recipientId = 'example-recipient-id';
-        const expected = {items: [{id: recipientId, objectType: 'person'}]};
-        conversation.sendReaction = sinon.stub().returns(Promise.resolve());
-        conversation.createReactionHmac = sinon.stub().returns(Promise.resolve('hmac'));
+        conversation.createReactionHmac = sinon.stub();
 
         return conversation.addReaction({}, 'example-display-name', {}, recipientId).then(() => {
           assert.deepEqual(conversation.sendReaction.args[0][1].recipients, expected);
+          assert.notCalled(conversation.createReactionHmac);
         });
       });
     });


### PR DESCRIPTION
## This pull request addresses
there are use cases for the SDK without an encryption key, such as the webcast/recording player widgets. in those cases, the SDK is iframed and the parent page handles encryption/decryption and the JS SDK has no access to encryption keys. generating a reaction hmac requires a key, so in those cases, we should skip hmac generation and let the parent page do it. i refactored addReaction to an async function for maintainability/readability and updated tests. it looks like there was a bad merge at one point in the unit tests and there were duplicate identical tests, so i also removed the duplicated tests

## by making the following changes
there is already a config in the conversation plugin `includeEncryptionTransforms`. if that is true, create the hmac, if not, skip and leave it undefined

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `addReaction` method to support asynchronous operations, improving performance and readability.
	- Introduced a configuration option `includeEncryptionTransforms` that modifies HMAC generation behavior.

- **Bug Fixes**
	- Improved error handling for the `addReaction` method to provide clearer feedback on incorrect usage.

- **Tests**
	- Added new test cases for the `addReaction` method to validate behavior based on the `includeEncryptionTransforms` configuration.
	- Streamlined the test suite by removing redundant tests and consolidating existing ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->