### PR TITLE
feat(internal-plugin-mercury): add mercuryTimeOffset

### DIFF
--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -773,6 +773,41 @@ describe('plugin-mercury', () => {
       });
     });
 
+    describe('#_setTimeOffset', () => {
+      it('sets mercuryTimeOffset based on the difference between wsWriteTimestamp and now', () => {
+        const event = {
+          data: {
+            wsWriteTimestamp: Date.now() - 60000,
+          }          
+        };
+        assert.isUndefined(mercury.mercuryTimeOffset);
+        mercury._setTimeOffset(event);
+        assert.isDefined(mercury.mercuryTimeOffset);
+        assert.isTrue(mercury.mercuryTimeOffset > 0);
+      });
+      it('handles negative offsets', () => {
+        const event = {
+          data: {
+            wsWriteTimestamp: Date.now() + 60000,
+          }          
+        };
+        mercury._setTimeOffset(event);
+        assert.isTrue(mercury.mercuryTimeOffset < 0);
+      });
+      it('handles invalid wsWriteTimestamp', () => {
+        const invalidTimestamps = [null, -1, 'invalid', undefined];
+        invalidTimestamps.forEach(invalidTimestamp => {
+          const event = {
+            data: {
+              wsWriteTimestamp: invalidTimestamp,
+            }          
+          };
+          mercury._setTimeOffset(event);
+          assert.isUndefined(mercury.mercuryTimeOffset);
+        });
+      });
+    });
+    
     describe('#_prepareUrl()', () => {
       beforeEach(() => {
         webex.internal.device.webSocketUrl = 'ws://example.com';


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [CX-17334](https://jira-eng-sjc12.cisco.com/jira/browse/CX-17334)

## This pull request addresses [CX-17334](https://jira-eng-sjc12.cisco.com/jira/browse/CX-17334)

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes we allow clients to know the difference between their system clock, and the time according to Mercury

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

Each message and pong from mercury includes a fiend `wsWriteTimestamp`, the time (millis since epoch) at which the message was written to the websocket. The Webex App already uses this time to check whether the local system clock is correct (and compensate if it's not). This change exposes a value `mercuryTimeOffset` on `mercury`, which is the difference between this timestamp from mercury and `Date.now()`, updated each time we receive a message or pong; which will allow consumers of the SDK to do the same. This has already been successfully tested in the Webex contact center agent desktop client.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Manually tested this in the Webex contact center desktop client (as part of Playtime): https://app.vidcast.io/share/877525a5-2dd7-4069-924f-11071518a973
* Updated unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added time offset tracking mechanism for Mercury plugin
	- Enhanced synchronization capabilities by calculating time offsets during WebSocket communication

- **Tests**
	- Added comprehensive test coverage for new time offset calculation method
	- Verified time offset tracking under various scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->