### PR TITLE
fix(conversation): pass actorId to addReaction and deleteReaction

### DIFF
--- a/packages/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/@webex/internal-plugin-conversation/src/conversation.js
@@ -303,15 +303,16 @@ const Conversation = WebexPlugin.extend({
   },
 
   /**
-   * delete a reaction
-   * @param {Object} conversation
-   * @param {Object} reactionId,
-   * @param {String} recipientId,
+   * create a reaction
+   * @param {Object} conversation the conversation in which the reaction will be added
+   * @param {Object} reactionId reaction activity to be deleted
+   * @param {Object} actorId id of person object who is reacting
+   * @param {String} recipientId used when reacting to direct IMC messages
    * @returns {Promise<Activity>}
    */
-  deleteReaction(conversation, reactionId, recipientId) {
+  deleteReaction(conversation, reactionId, actorId, recipientId) {
     const deleteReactionPayload = {
-      actor: {objectType: 'person', id: this.webex.internal.device.userId},
+      actor: {objectType: 'person', id: actorId ?? this.webex.internal.device.userId},
       object: {
         id: reactionId,
         objectType: 'activity',
@@ -334,20 +335,21 @@ const Conversation = WebexPlugin.extend({
 
   /**
    * create a reaction
-   * @param {Object} conversation
+   * @param {Object} conversation the conversation in which the reaction will be added
    * @param {Object} displayName must be 'celebrate', 'heart', 'thumbsup', 'smiley', 'haha', 'confused', 'sad'
-   * @param {Object} activity activity object from convo we are reacting to
-   * @param {String} recipientId,
+   * @param {Object} parentActivity activity object from that we are reacting to
+   * @param {Object} actorId id of person object who is reacting
+   * @param {String} recipientId used when reacting to direct IMC messages
    * @returns {Promise<Activity>}
    */
-  async addReaction(conversation, displayName, activity, recipientId) {
+  async addReaction(conversation, displayName, parentActivity, actorId, recipientId) {
     let hmac;
     if (this.config.includeEncryptionTransforms) {
-      hmac = await this.createReactionHmac(displayName, activity);
+      hmac = await this.createReactionHmac(displayName, parentActivity);
     }
 
     const addReactionPayload = {
-      actor: {objectType: 'person', id: this.webex.internal.device.userId},
+      actor: {objectType: 'person', id: actorId ?? this.webex.internal.device.userId},
       target: {
         id: conversation.id,
         objectType: 'conversation',
@@ -356,7 +358,7 @@ const Conversation = WebexPlugin.extend({
       objectType: 'activity',
       parent: {
         type: 'reaction',
-        id: activity.id,
+        id: parentActivity.id,
       },
       object: {
         objectType: 'reaction2',


### PR DESCRIPTION
## This pull request addresses
in messaging widget iframe, i would like to use conversation functions, without depending on webex.internal.device.userId being set (iframe case, no auth/registration of SDK). number of args to reaction functions has changed

## by making the following changes
allow addReaction and deleteReaction to accept an actorId. if present, use it, else fallback to webex.internal.device.userId

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of reactions in conversations by including the actor's ID in the `addReaction` and `deleteReaction` methods.

- **Bug Fixes**
	- Improved unit tests for `addReaction` and `deleteReaction` to ensure correct handling of the `actorId` parameter.

- **Documentation**
	- Updated comments in the methods to clarify the purpose of new parameters. 

- **Tests**
	- Restructured tests to use `async/await` for better readability and added new test cases for `actorId` scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->