### PR TITLE
fix: end meeting for all getCurUserType type issue

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -155,6 +155,9 @@ export type BasicMeetingInformation = {
   };
   meetingInfo: any;
   sessionCorrelationId: string;
+  roles: string[];
+  getCurUserType: () => string | null;
+  callStateForMetrics: CallStateForMetrics;
 };
 
 /**
@@ -1143,6 +1146,9 @@ export default class Meetings extends WebexPlugin {
           sessionId: meeting.locusInfo?.fullState?.sessionId,
         },
       },
+      roles: meeting.roles,
+      callStateForMetrics: meeting.callStateForMetrics,
+      getCurUserType: meeting.getCurUserType,
     });
     this.meetingCollection.delete(meeting.id);
     Trigger.trigger(

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -131,9 +131,9 @@ describe('plugin-meetings', () => {
         logger,
         people: {
           _getMe: sinon.stub().resolves({
-            type: 'validuser', 
+            type: 'validuser',
           }),
-        }
+        },
       });
 
       startReachabilityStub = sinon.stub(webex.meetings, 'startReachability').resolves();
@@ -1985,6 +1985,8 @@ describe('plugin-meetings', () => {
             const meetingIds = {
               meetingId: meeting.id,
               correlationId: meeting.correlationId,
+              roles: meeting.roles,
+              callStateForMetrics: meeting.callStateForMetrics,
             };
 
             webex.meetings.destroy(meeting, test1);
@@ -2021,6 +2023,8 @@ describe('plugin-meetings', () => {
 
             assert.equal(deletedMeetingInfo.id, meetingIds.meetingId);
             assert.equal(deletedMeetingInfo.correlationId, meetingIds.correlationId);
+            assert.equal(deletedMeetingInfo.roles, meetingIds.roles);
+            assert.equal(deletedMeetingInfo.callStateForMetrics, meetingIds.callStateForMetrics);
           });
         });
 
@@ -2092,7 +2096,7 @@ describe('plugin-meetings', () => {
           );
         });
 
-        const setup = ({me = { type: 'validuser'}, user} = {}) => {
+        const setup = ({me = {type: 'validuser'}, user} = {}) => {
           loggerProxySpy = sinon.spy(LoggerProxy.logger, 'error');
           assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), []);
 
@@ -2113,9 +2117,9 @@ describe('plugin-meetings', () => {
 
         it('should not call request.getMeetingPreferences if user is a guest', async () => {
           setup({me: {type: 'appuser'}});
-      
+
           await webex.meetings.fetchUserPreferredWebexSite();
-      
+
           assert.equal(webex.meetings.preferredWebexSite, '');
           assert.deepEqual(webex.internal.services._getCatalog().getAllowedDomains(), []);
           assert.notCalled(webex.internal.services.getMeetingPreferences);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [CSCwn60262](https://bst.cisco.com/bugsearch/bug/CSCwn60262)

## This pull request addresses

fixing Console error when we call meeting.EndMeetingForAll()

## by making the following changes

Added below properties and function to BasicMeetingInformation type so that they will be accessible after ending the meeting as well.

roles: string[];
 getCurUserType: () => string | null;
 callStateForMetrics: CallStateForMetrics;

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

 Joined meeting as host in sample app and called endMeetingForAll() => there were no errors observed.


### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced meeting data structure to retain user roles and type information after a meeting is deleted.
	- Added new properties for improved meeting state management.

- **Bug Fixes**
	- Improved handling of user scenarios in meeting functionality tests, including guest users and incomplete data.

- **Tests**
	- Refined test cases and added new assertions to ensure accurate validation of meeting functionalities and metrics handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->