### PR TITLE
fix: Moderated unmute mode not working when web client is remotely muted

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
@@ -441,6 +441,11 @@ SelfUtils.mutedByOthersChanged = (oldSelf, changedSelf) => {
     return false;
   }
 
+  // there is no need to trigger user update if no one muted user
+  if (changedSelf.selfIdentity === changedSelf.modifiedBy) {
+    return false;
+  }
+
   return (
     changedSelf.remoteMuted !== null &&
     (oldSelf.remoteMuted !== changedSelf.remoteMuted ||

--- a/packages/@webex/plugin-meetings/src/meeting/muteState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/muteState.ts
@@ -379,12 +379,7 @@ export class MuteState {
     }
     if (muted !== undefined) {
       this.state.server.remoteMute = muted;
-
-      // We never want to unmute the local stream from a server remote mute update.
-      // Moderated unmute is handled by a different function.
-      if (muted) {
-        this.muteLocalStream(meeting, muted, 'remotelyMuted');
-      }
+      this.muteLocalStream(meeting, muted, 'remotelyMuted');
     }
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
@@ -435,37 +435,49 @@ describe('plugin-meetings', () => {
   });
 
   describe('mutedByOthersChanged', () => {
-    it('throws an error if changedSelf is not provided', function() {
-      assert.throws(() => SelfUtils.mutedByOthersChanged({}, null), 'New self must be defined to determine if self was muted by others.');
+    it('throws an error if changedSelf is not provided', function () {
+      assert.throws(
+        () => SelfUtils.mutedByOthersChanged({}, null),
+        'New self must be defined to determine if self was muted by others.'
+      );
     });
 
-    it('return false when oldSelf is not defined', function() {
-      assert.equal(SelfUtils.mutedByOthersChanged(null, { remoteMuted: false }), false);
+    it('return false when oldSelf is not defined', function () {
+      assert.equal(SelfUtils.mutedByOthersChanged(null, {remoteMuted: false}), false);
     });
 
-    it('should return true when remoteMuted is true on entry', function() {
-      assert.equal(SelfUtils.mutedByOthersChanged(null, { remoteMuted: true }), true);
+    it('should return true when remoteMuted is true on entry', function () {
+      assert.equal(SelfUtils.mutedByOthersChanged(null, {remoteMuted: true}), true);
     });
 
-    it('should return false when selfIdentity and modifiedBy are the same', function() {
-      assert.equal(SelfUtils.mutedByOthersChanged(
-        { remoteMuted: false },
-        { remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user1' }
-      ), false);
+    it('should return false when selfIdentity and modifiedBy are the same', function () {
+      assert.equal(
+        SelfUtils.mutedByOthersChanged(
+          {remoteMuted: false},
+          {remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user1'}
+        ),
+        false
+      );
     });
 
-    it('should return true when remoteMuted values are different', function() {
-      assert.equal(SelfUtils.mutedByOthersChanged(
-        { remoteMuted: false },
-        { remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user2' }
-      ), true);
+    it('should return true when remoteMuted values are different', function () {
+      assert.equal(
+        SelfUtils.mutedByOthersChanged(
+          {remoteMuted: false},
+          {remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user2'}
+        ),
+        true
+      );
     });
 
-    it('should return true when remoteMuted is true and unmuteAllowed has changed', function() {
-      assert.equal(SelfUtils.mutedByOthersChanged(
-        { remoteMuted: true, unmuteAllowed: false },
-        { remoteMuted: true, unmuteAllowed: true, selfIdentity: 'user1', modifiedBy: 'user2' }
-      ), true);
+    it('should return true when remoteMuted is true and unmuteAllowed has changed', function () {
+      assert.equal(
+        SelfUtils.mutedByOthersChanged(
+          {remoteMuted: true, unmuteAllowed: false},
+          {remoteMuted: true, unmuteAllowed: true, selfIdentity: 'user1', modifiedBy: 'user2'}
+        ),
+        true
+      );
     });
   });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
@@ -435,39 +435,37 @@ describe('plugin-meetings', () => {
   });
 
   describe('mutedByOthersChanged', () => {
-    it('throws an error if changedSelf is not provided', function () {
-      assert.throws(
-        () => SelfUtils.mutedByOthersChanged({}, null),
-        'New self must be defined to determine if self was muted by others.'
-      );
+    it('throws an error if changedSelf is not provided', function() {
+      assert.throws(() => SelfUtils.mutedByOthersChanged({}, null), 'New self must be defined to determine if self was muted by others.');
     });
 
-    it('return false when oldSelf is not defined', function () {
-      assert.equal(SelfUtils.mutedByOthersChanged(null, {remoteMuted: false}), false);
+    it('return false when oldSelf is not defined', function() {
+      assert.equal(SelfUtils.mutedByOthersChanged(null, { remoteMuted: false }), false);
     });
 
-    it('should return true when remoteMuted is true on entry', function () {
-      assert.equal(SelfUtils.mutedByOthersChanged(null, {remoteMuted: true}), true);
+    it('should return true when remoteMuted is true on entry', function() {
+      assert.equal(SelfUtils.mutedByOthersChanged(null, { remoteMuted: true }), true);
     });
 
-    it('should return true when remoteMuted values are different', function () {
-      assert.equal(
-        SelfUtils.mutedByOthersChanged(
-          {remoteMuted: false},
-          {remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user2'}
-        ),
-        true
-      );
+    it('should return false when selfIdentity and modifiedBy are the same', function() {
+      assert.equal(SelfUtils.mutedByOthersChanged(
+        { remoteMuted: false },
+        { remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user1' }
+      ), false);
     });
 
-    it('should return true when remoteMuted is true and unmuteAllowed has changed', function () {
-      assert.equal(
-        SelfUtils.mutedByOthersChanged(
-          {remoteMuted: true, unmuteAllowed: false},
-          {remoteMuted: true, unmuteAllowed: true, selfIdentity: 'user1', modifiedBy: 'user2'}
-        ),
-        true
-      );
+    it('should return true when remoteMuted values are different', function() {
+      assert.equal(SelfUtils.mutedByOthersChanged(
+        { remoteMuted: false },
+        { remoteMuted: true, selfIdentity: 'user1', modifiedBy: 'user2' }
+      ), true);
+    });
+
+    it('should return true when remoteMuted is true and unmuteAllowed has changed', function() {
+      assert.equal(SelfUtils.mutedByOthersChanged(
+        { remoteMuted: true, unmuteAllowed: false },
+        { remoteMuted: true, unmuteAllowed: true, selfIdentity: 'user1', modifiedBy: 'user2' }
+      ), true);
     });
   });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
@@ -113,30 +113,6 @@ describe('plugin-meetings', () => {
       assert.isTrue(audio.isRemotelyMuted());
     });
 
-    it('does not locally unmute on a server unmute', async () => {
-      const setServerMutedSpy = meeting.mediaProperties.audioStream.setServerMuted;
-
-      // simulate remote mute
-      audio.handleServerRemoteMuteUpdate(meeting, true, true);
-
-      assert.isTrue(audio.isRemotelyMuted());
-      assert.isTrue(audio.isLocallyMuted());
-
-      // mutes local
-      assert.calledOnceWithExactly(setServerMutedSpy, true, 'remotelyMuted');
-
-      setServerMutedSpy.resetHistory();
-
-      // simulate remote unmute
-      audio.handleServerRemoteMuteUpdate(meeting, false, true);
-
-      assert.isFalse(audio.isRemotelyMuted());
-      assert.isTrue(audio.isLocallyMuted());
-
-      // does not unmute local
-      assert.notCalled(setServerMutedSpy);
-    });
-
     it('does local audio unmute if localAudioUnmuteRequired is received', async () => {
       // first we need to have the local stream user muted
       meeting.mediaProperties.audioStream.userMuted = true;


### PR DESCRIPTION
This is a revert of a [PR from a few months ago](https://github.com/webex/webex-js-sdk/pull/3797), because the root cause has been fixed in Locus now (see [WEBEX-410234](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-410234) ), so we can now again rely on the `metadata.modifiedBy` to ignore Locus DTO updates caused by our own actions. 

3 separate scenarios described in these jiras should be working correctly now:
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-555818
https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-382445
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-583170

EDIT: during testing a new Locus issue was found: https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-415530 - this has now also been fixed

I've tested the scenario for host:
- locally muting and unmuting with toggling the "allow participants to unmute themselves" while host is unmuted and while host is muted

and for guest:
- locally muting, locally unmuting
- locally muting, remote unmuting
- remote muting, local unmute
- above scenarios again but toggling the "allow participants to unmute themselves" checkbox in muted and unmuted state
- quickly muting/unmuting
- quickly unmuting/muting after being remotely muted