### PR TITLE
feat(webinar): add webcast API

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -383,6 +383,13 @@ export const EVENT_TYPES = {
   ERROR: 'error',
 };
 
+export const HEADERS = {
+  CONTENT_TYPE: 'Content-Type',
+  CONTENT_TYPE_VALUE: {
+    APPLICATION_JSON: 'application/json',
+  },
+};
+
 // Handles the reason when meeting gets destroyed
 // host removed you from the meeting
 // You are the host and you left the meeting

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -1,9 +1,10 @@
 /*!
  * Copyright (c) 2015-2023 Cisco Systems, Inc. See LICENSE file.
  */
-import {WebexPlugin} from '@webex/webex-core';
+import {WebexPlugin, config} from '@webex/webex-core';
+import uuid from 'uuid';
 import {get} from 'lodash';
-import {HTTP_VERBS, MEETINGS, SELF_ROLES} from '../constants';
+import {HEADERS, HTTP_VERBS, MEETINGS, SELF_ROLES} from '../constants';
 
 import WebinarCollection from './collection';
 import LoggerProxy from '../common/logs/logger-proxy';
@@ -102,6 +103,141 @@ const Webinar = WebexPlugin.extend({
    */
   updatePracticeSessionStatus(payload) {
     this.set('practiceSessionEnabled', payload.enabled);
+  },
+
+  /**
+   * start webcast mode for webinar
+   * @param {object} meeting
+   * @param {object} layout
+   * @returns {Promise}
+   */
+  async startWebcast(meeting, layout) {
+    return this.request({
+      method: HTTP_VERBS.PUT,
+      uri: `${this.webcastInstanceUrl}/streaming`,
+      headers: {
+        authorization: await this.webex.credentials.getUserToken(),
+        trackingId: `${config.trackingIdPrefix}_${uuid.v4().toString()}`,
+        [HEADERS.CONTENT_TYPE]: HEADERS.CONTENT_TYPE_VALUE.APPLICATION_JSON,
+      },
+      body: {
+        action: 'start',
+        meetingInfo: {
+          locusId: meeting.locusId,
+          correlationId: meeting.correlationId,
+        },
+        layout,
+      },
+    }).catch((error) => {
+      LoggerProxy.logger.error('Meeting:webinar#startWebcast failed', error);
+      throw error;
+    });
+  },
+
+  /**
+   * stop webcast mode for webinar
+   * @returns {Promise}
+   */
+  async stopWebcast() {
+    return this.request({
+      method: HTTP_VERBS.PUT,
+      uri: `${this.webcastInstanceUrl}/streaming`,
+      headers: {
+        authorization: await this.webex.credentials.getUserToken(),
+        trackingId: `${config.trackingIdPrefix}_${uuid.v4().toString()}`,
+        [HEADERS.CONTENT_TYPE]: HEADERS.CONTENT_TYPE_VALUE.APPLICATION_JSON,
+      },
+      body: {
+        action: 'stop',
+      },
+    }).catch((error) => {
+      LoggerProxy.logger.error('Meeting:webinar#stopWebcast failed', error);
+      throw error;
+    });
+  },
+
+  /**
+   * query webcast layout for webinar
+   * @returns {Promise}
+   */
+  async queryWebcastLayout() {
+    return this.request({
+      method: HTTP_VERBS.GET,
+      uri: `${this.webcastInstanceUrl}/layout`,
+      headers: {
+        authorization: await this.webex.credentials.getUserToken(),
+        trackingId: `${config.trackingIdPrefix}_${uuid.v4().toString()}`,
+      },
+    }).catch((error) => {
+      LoggerProxy.logger.error('Meeting:webinar#queryWebcastLayout failed', error);
+      throw error;
+    });
+  },
+
+  /**
+   * update webcast layout for webinar
+   * @param {object} layout
+   * @returns {Promise}
+   */
+  async updateWebcastLayout(layout) {
+    return this.request({
+      method: HTTP_VERBS.PUT,
+      uri: `${this.webcastInstanceUrl}/layout`,
+      headers: {
+        authorization: await this.webex.credentials.getUserToken(),
+        trackingId: `${config.trackingIdPrefix}_${uuid.v4().toString()}`,
+        [HEADERS.CONTENT_TYPE]: HEADERS.CONTENT_TYPE_VALUE.APPLICATION_JSON,
+      },
+      body: {
+        layout: {
+          videoLayout: layout.videoLayout,
+          contentLayout: layout.contentLayout,
+          syncStageLayout: layout.syncStageLayout,
+          syncStageInMeeting: layout.syncStageInMeeting,
+        },
+      },
+    }).catch((error) => {
+      LoggerProxy.logger.error('Meeting:webinar#updateWebcastLayout failed', error);
+      throw error;
+    });
+  },
+
+  /**
+   * search webcast attendee by query string
+   * @param {string} queryString
+   * @returns {Promise}
+   */
+  async searchWebcastAttendee(queryString = '') {
+    return this.request({
+      method: HTTP_VERBS.GET,
+      uri: `${this.webcastInstanceUrl}/attendees?keyword=${queryString}`,
+      headers: {
+        authorization: await this.webex.credentials.getUserToken(),
+        trackingId: `${config.trackingIdPrefix}_${uuid.v4().toString()}`,
+      },
+    }).catch((error) => {
+      LoggerProxy.logger.error('Meeting:webinar#searchWebcastAttendee failed', error);
+      throw error;
+    });
+  },
+
+  /**
+   * expel webcast attendee by participantId
+   * @param {string} participantId
+   * @returns {Promise}
+   */
+  async expelWebcastAttendee(participantId) {
+    return this.request({
+      method: HTTP_VERBS.DELETE,
+      uri: `${this.webcastInstanceUrl}/attendees/${participantId}`,
+      headers: {
+        authorization: await this.webex.credentials.getUserToken(),
+        trackingId: `${config.trackingIdPrefix}_${uuid.v4().toString()}`,
+      },
+    }).catch((error) => {
+      LoggerProxy.logger.error('Meeting:webinar#expelWebcastAttendee failed', error);
+      throw error;
+    });
   },
 });
 

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -112,6 +112,13 @@ const Webinar = WebexPlugin.extend({
    * @returns {Promise}
    */
   async startWebcast(meeting, layout) {
+    if (!meeting) {
+      LoggerProxy.logger.error(
+        `Meeting:webinar#startWebcast failed --> meeting parameter : ${meeting}`
+      );
+      throw new Error('Meeting parameter does not meet expectations');
+    }
+
     return this.request({
       method: HTTP_VERBS.PUT,
       uri: `${this.webcastInstanceUrl}/streaming`,
@@ -203,20 +210,39 @@ const Webinar = WebexPlugin.extend({
   },
 
   /**
-   * search webcast attendee by query string
+   * view all webcast attendees
    * @param {string} queryString
    * @returns {Promise}
    */
-  async searchWebcastAttendee(queryString = '') {
+  async viewAllWebcastAttendees() {
     return this.request({
       method: HTTP_VERBS.GET,
-      uri: `${this.webcastInstanceUrl}/attendees?keyword=${queryString}`,
+      uri: `${this.webcastInstanceUrl}/attendees`,
       headers: {
         authorization: await this.webex.credentials.getUserToken(),
         trackingId: `${config.trackingIdPrefix}_${uuid.v4().toString()}`,
       },
     }).catch((error) => {
-      LoggerProxy.logger.error('Meeting:webinar#searchWebcastAttendee failed', error);
+      LoggerProxy.logger.error('Meeting:webinar#viewAllWebcastAttendees failed', error);
+      throw error;
+    });
+  },
+
+  /**
+   * search webcast attendees by query string
+   * @param {string} queryString
+   * @returns {Promise}
+   */
+  async searchWebcastAttendees(queryString = '') {
+    return this.request({
+      method: HTTP_VERBS.GET,
+      uri: `${this.webcastInstanceUrl}/attendees?keyword=${encodeURIComponent(queryString)}`,
+      headers: {
+        authorization: await this.webex.credentials.getUserToken(),
+        trackingId: `${config.trackingIdPrefix}_${uuid.v4().toString()}`,
+      },
+    }).catch((error) => {
+      LoggerProxy.logger.error('Meeting:webinar#searchWebcastAttendees failed', error);
       throw error;
     });
   },

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -2,7 +2,7 @@ import {assert, expect} from '@webex/test-helper-chai';
 import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 import Webinar from '@webex/plugin-meetings/src/webinar';
 import MockWebex from '@webex/test-helper-mock-webex';
-import { v4 as uuidv4 } from 'uuid';
+import uuid from 'uuid';
 import sinon from 'sinon';
 
 describe('plugin-meetings', () => {
@@ -16,7 +16,7 @@ describe('plugin-meetings', () => {
         beforeEach(() => {
             // @ts-ignore
             getUserTokenStub = sinon.stub().resolves('test-token'); 
-            uuidStub = sinon.stub(uuidv4, 'v4').returns('test-uuid');            
+            uuidStub = sinon.stub(uuid,'v4').returns('test-uuid');            
             webex = new MockWebex({});
             webex.internal.mercury.on = sinon.stub();
             webinar = new Webinar({}, {parent: webex});
@@ -349,20 +349,6 @@ describe('plugin-meetings', () => {
           assert.calledWith(webex.request, {
             method: "GET",
             uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${queryString}`,
-            headers: {
-              authorization: 'test-token',
-              trackingId: 'webex-js-sdk_test-uuid',
-            },
-          });
-          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
-        });
-
-        it(`if queryString not exist, use empty string`, async () => {
-          const result = await webinar.searchWebcastAttendee(undefined);
-          assert.calledOnce(webex.request);
-          assert.calledWith(webex.request, {
-            method: "GET",
-            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -356,6 +356,20 @@ describe('plugin-meetings', () => {
           });
           assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
         });
+
+        it(`if queryString not exist, use empty string`, async () => {
+          const result = await webinar.searchWebcastAttendee(undefined);
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            method: "GET",
+            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=`,
+            headers: {
+              authorization: 'test-token',
+              trackingId: 'webex-js-sdk_test-uuid',
+            },
+          });
+          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+        });
   
         it('handles API call failures gracefully', async () => {
           webex.request.rejects(new Error('API_ERROR'));

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -213,6 +213,21 @@ describe('plugin-meetings', () => {
           assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
         });
 
+        it('should handle undefined meeting parameter', async () => {
+          const errorLogger = sinon.stub(LoggerProxy.logger, 'error');
+
+          try {
+            await webinar.startWebcast(undefined, layout);
+            assert.fail('startWebcast should throw an error');
+          } catch (error) {
+            assert.equal(error.message, 'Meeting parameter does not meet expectations', 'should throw the correct error');
+            assert.calledOnce(errorLogger);
+            assert.calledWith(errorLogger, `Meeting:webinar#startWebcast failed --> meeting parameter : ${undefined}`);
+          } finally {
+            errorLogger.restore();
+          }
+        });
+
         it('handles API call failures gracefully', async () => {
           webex.request.rejects(new Error('API_ERROR'));
           const errorLogger = sinon.stub(LoggerProxy.logger, 'error');
@@ -224,9 +239,9 @@ describe('plugin-meetings', () => {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
             assert.calledWith(errorLogger, 'Meeting:webinar#startWebcast failed', sinon.match.instanceOf(Error));
+          } finally {
+            errorLogger.restore();
           }
-
-          errorLogger.restore();
         });
       });
 
@@ -260,9 +275,9 @@ describe('plugin-meetings', () => {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
             assert.calledWith(errorLogger, 'Meeting:webinar#stopWebcast failed', sinon.match.instanceOf(Error));
-          }
-  
-          errorLogger.restore();
+          } finally {
+            errorLogger.restore();
+          }  
         });
       });
 
@@ -293,9 +308,9 @@ describe('plugin-meetings', () => {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
             assert.calledWith(errorLogger, 'Meeting:webinar#queryWebcastLayout failed', sinon.match.instanceOf(Error));
-          }
-  
-          errorLogger.restore();
+          } finally {
+            errorLogger.restore();
+          }  
         });
       });
 
@@ -335,20 +350,84 @@ describe('plugin-meetings', () => {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
             assert.calledWith(errorLogger, 'Meeting:webinar#updateWebcastLayout failed', sinon.match.instanceOf(Error));
-          }
-  
-          errorLogger.restore();
+          } finally {
+            errorLogger.restore();
+          }  
         });
       });
       
-      describe("#searchWebcastAttendee", () => {
-        const queryString = 'queryString'
-        it(`sends a GET request to search the webcast attendee`, async () => {
-          const result = await webinar.searchWebcastAttendee(queryString);
+      describe("#searchWebcastAttendees", () => {
+        const queryString = 'queryString';
+        const specialCharsQuery = 'query@string!';
+        const emptyQuery = '';
+      
+        it("sends a GET request to search the webcast attendees", async () => {
+          const result = await webinar.searchWebcastAttendees(queryString);
           assert.calledOnce(webex.request);
           assert.calledWith(webex.request, {
             method: "GET",
-            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${queryString}`,
+            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${encodeURIComponent(queryString)}`,
+            headers: {
+              authorization: 'test-token',
+              trackingId: 'webex-js-sdk_test-uuid',
+            },
+          });
+          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+        });
+      
+        it('handles API call failures gracefully', async () => {
+          webex.request.rejects(new Error('API_ERROR'));
+          const errorLogger = sinon.stub(LoggerProxy.logger, 'error');
+      
+          try {
+            await webinar.searchWebcastAttendees(queryString);
+            assert.fail('searchWebcastAttendees should throw an error');
+          } catch (error) {
+            assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
+            assert.calledOnce(errorLogger);
+            assert.calledWith(errorLogger, 'Meeting:webinar#searchWebcastAttendees failed', sinon.match.instanceOf(Error));
+          } finally {
+            errorLogger.restore();
+          }
+        });
+      
+        it("should handle empty query string", async () => {
+          const result = await webinar.searchWebcastAttendees(emptyQuery);
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            method: "GET",
+            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${encodeURIComponent(emptyQuery)}`,
+            headers: {
+              authorization: 'test-token',
+              trackingId: 'webex-js-sdk_test-uuid',
+            },
+          });
+          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+        });
+      
+        it("should handle query string with special characters", async () => {
+          const result = await webinar.searchWebcastAttendees(specialCharsQuery);
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            method: "GET",
+            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${encodeURIComponent(specialCharsQuery)}`,
+            headers: {
+              authorization: 'test-token',
+              trackingId: 'webex-js-sdk_test-uuid',
+            },
+          });
+          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+        });
+      });
+      
+
+      describe("#viewAllWebcastAttendees", () => {
+        it(`sends a GET request to view all the webcast attendees`, async () => {
+          const result = await webinar.viewAllWebcastAttendees();
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            method: "GET",
+            uri: `${webinar.webcastInstanceUrl}/attendees`,
             headers: {
               authorization: 'test-token',
               trackingId: 'webex-js-sdk_test-uuid',
@@ -362,15 +441,15 @@ describe('plugin-meetings', () => {
           const errorLogger = sinon.stub(LoggerProxy.logger, 'error');
   
           try {
-            await webinar.searchWebcastAttendee(queryString);
-            assert.fail('searchWebcastAttendee should throw an error');
+            await webinar.viewAllWebcastAttendees();
+            assert.fail('viewAllWebcastAttendees should throw an error');
           } catch (error) {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
-            assert.calledWith(errorLogger, 'Meeting:webinar#searchWebcastAttendee failed', sinon.match.instanceOf(Error));
-          }
-  
-          errorLogger.restore();
+            assert.calledWith(errorLogger, 'Meeting:webinar#viewAllWebcastAttendees failed', sinon.match.instanceOf(Error));
+          } finally {
+            errorLogger.restore();
+          }  
         });
       });
             
@@ -401,9 +480,9 @@ describe('plugin-meetings', () => {
             assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
             assert.calledOnce(errorLogger);
             assert.calledWith(errorLogger, 'Meeting:webinar#expelWebcastAttendee failed', sinon.match.instanceOf(Error));
+          } finally {
+            errorLogger.restore();
           }
-  
-          errorLogger.restore();
         });
       });
     })

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -2,6 +2,7 @@ import {assert, expect} from '@webex/test-helper-chai';
 import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 import Webinar from '@webex/plugin-meetings/src/webinar';
 import MockWebex from '@webex/test-helper-mock-webex';
+import { v4 as uuidv4 } from 'uuid';
 import sinon from 'sinon';
 
 describe('plugin-meetings', () => {
@@ -9,16 +10,26 @@ describe('plugin-meetings', () => {
 
         let webex;
         let webinar;
+        let uuidStub;
+        let getUserTokenStub; 
 
         beforeEach(() => {
             // @ts-ignore
+            getUserTokenStub = sinon.stub().resolves('test-token'); 
+            uuidStub = sinon.stub(uuidv4, 'v4').returns('test-uuid');            
             webex = new MockWebex({});
             webex.internal.mercury.on = sinon.stub();
             webinar = new Webinar({}, {parent: webex});
             webinar.locusUrl = 'locusUrl';
+            webinar.webcastInstanceUrl = 'webcastInstanceUrl';
             webex.request = sinon.stub().returns(Promise.resolve('REQUEST_RETURN_VALUE'));
             webex.meetings = {};
+            webex.credentials.getUserToken = getUserTokenStub;
             webex.meetings.getMeetingByType = sinon.stub();
+        });
+
+        afterEach(() => {
+          sinon.restore(); 
         });
 
         describe('#locusUrlUpdate', () => {
@@ -168,6 +179,232 @@ describe('plugin-meetings', () => {
         });
       });
 
+      describe("#startWebcast", () => {
+        const meeting = {
+          locusId: 'locusId',
+          correlationId: 'correlationId',
+        }
+        const layout = {
+          videoLayout: 'Prominent',
+          contentLayout: 'Prominent',
+          syncStageLayout: false,
+          syncStageInMeeting: false,
+        }
+        it(`sends a PUT request to start the webcast`, async () => {
+          const result = await webinar.startWebcast(meeting, layout);
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            method: "PUT",
+            uri: `${webinar.webcastInstanceUrl}/streaming`,
+            headers: {
+              authorization: 'test-token',
+              trackingId: 'webex-js-sdk_test-uuid',
+              'Content-Type': 'application/json'
+            },
+            body: {
+              action: 'start',
+              meetingInfo: {
+                locusId: meeting.locusId,
+                correlationId: meeting.correlationId,
+              },
+              layout,
+            }
+          });
+          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+        });
 
+        it('handles API call failures gracefully', async () => {
+          webex.request.rejects(new Error('API_ERROR'));
+          const errorLogger = sinon.stub(LoggerProxy.logger, 'error');
+
+          try {
+            await webinar.startWebcast(meeting, layout);
+            assert.fail('startWebcast should throw an error');
+          } catch (error) {
+            assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
+            assert.calledOnce(errorLogger);
+            assert.calledWith(errorLogger, 'Meeting:webinar#startWebcast failed', sinon.match.instanceOf(Error));
+          }
+
+          errorLogger.restore();
+        });
+      });
+
+      describe("#stopWebcast", () => {
+        it(`sends a PUT request to stop the webcast`, async () => {
+          const result = await webinar.stopWebcast();
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            method: "PUT",
+            uri: `${webinar.webcastInstanceUrl}/streaming`,
+            headers: {
+              authorization: 'test-token',
+              trackingId: 'webex-js-sdk_test-uuid',
+              'Content-Type': 'application/json'
+            },
+            body: {
+              action: 'stop',
+            }
+          });
+          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+        });
+  
+        it('handles API call failures gracefully', async () => {
+          webex.request.rejects(new Error('API_ERROR'));
+          const errorLogger = sinon.stub(LoggerProxy.logger, 'error');
+  
+          try {
+            await webinar.stopWebcast();
+            assert.fail('stopWebcast should throw an error');
+          } catch (error) {
+            assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
+            assert.calledOnce(errorLogger);
+            assert.calledWith(errorLogger, 'Meeting:webinar#stopWebcast failed', sinon.match.instanceOf(Error));
+          }
+  
+          errorLogger.restore();
+        });
+      });
+
+
+      describe("#queryWebcastLayout", () => {
+        it(`sends a GET request to query the webcast layout`, async () => {
+          const result = await webinar.queryWebcastLayout();
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            method: "GET",
+            uri: `${webinar.webcastInstanceUrl}/layout`,
+            headers: {
+              authorization: 'test-token',
+              trackingId: 'webex-js-sdk_test-uuid',
+            },
+          });
+          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+        });
+  
+        it('handles API call failures gracefully', async () => {
+          webex.request.rejects(new Error('API_ERROR'));
+          const errorLogger = sinon.stub(LoggerProxy.logger, 'error');
+  
+          try {
+            await webinar.queryWebcastLayout();
+            assert.fail('queryWebcastLayout should throw an error');
+          } catch (error) {
+            assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
+            assert.calledOnce(errorLogger);
+            assert.calledWith(errorLogger, 'Meeting:webinar#queryWebcastLayout failed', sinon.match.instanceOf(Error));
+          }
+  
+          errorLogger.restore();
+        });
+      });
+
+      describe("#updateWebcastLayout", () => {
+        const layout = {
+          videoLayout: 'Prominent',
+          contentLayout: 'Prominent',
+          syncStageLayout: false,
+          syncStageInMeeting: false,
+        }
+        it(`sends a PUT request to update the webcast layout`, async () => {
+          const result = await webinar.updateWebcastLayout(layout);
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            method: "PUT",
+            uri: `${webinar.webcastInstanceUrl}/layout`,
+            headers: {
+              authorization: 'test-token',
+              trackingId: 'webex-js-sdk_test-uuid',
+              'Content-Type': 'application/json'
+            },
+            body: {
+              layout
+            }
+          });
+          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+        });
+  
+        it('handles API call failures gracefully', async () => {
+          webex.request.rejects(new Error('API_ERROR'));
+          const errorLogger = sinon.stub(LoggerProxy.logger, 'error');
+  
+          try {
+            await webinar.updateWebcastLayout(layout);
+            assert.fail('updateWebcastLayout should throw an error');
+          } catch (error) {
+            assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
+            assert.calledOnce(errorLogger);
+            assert.calledWith(errorLogger, 'Meeting:webinar#updateWebcastLayout failed', sinon.match.instanceOf(Error));
+          }
+  
+          errorLogger.restore();
+        });
+      });
+      
+      describe("#searchWebcastAttendee", () => {
+        const queryString = 'queryString'
+        it(`sends a GET request to search the webcast attendee`, async () => {
+          const result = await webinar.searchWebcastAttendee(queryString);
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            method: "GET",
+            uri: `${webinar.webcastInstanceUrl}/attendees?keyword=${queryString}`,
+            headers: {
+              authorization: 'test-token',
+              trackingId: 'webex-js-sdk_test-uuid',
+            },
+          });
+          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+        });
+  
+        it('handles API call failures gracefully', async () => {
+          webex.request.rejects(new Error('API_ERROR'));
+          const errorLogger = sinon.stub(LoggerProxy.logger, 'error');
+  
+          try {
+            await webinar.searchWebcastAttendee(queryString);
+            assert.fail('searchWebcastAttendee should throw an error');
+          } catch (error) {
+            assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
+            assert.calledOnce(errorLogger);
+            assert.calledWith(errorLogger, 'Meeting:webinar#searchWebcastAttendee failed', sinon.match.instanceOf(Error));
+          }
+  
+          errorLogger.restore();
+        });
+      });
+            
+      describe("#expelWebcastAttendee", () => {
+        const participantId = 'participantId'
+        it(`sends a DELETE request to expel the webcast attendee`, async () => {
+          const result = await webinar.expelWebcastAttendee(participantId);
+          assert.calledOnce(webex.request);
+          assert.calledWith(webex.request, {
+            method: "DELETE",
+            uri: `${webinar.webcastInstanceUrl}/attendees/${participantId}`,
+            headers: {
+              authorization: 'test-token',
+              trackingId: 'webex-js-sdk_test-uuid',
+            },
+          });
+          assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");
+        });
+  
+        it('handles API call failures gracefully', async () => {
+          webex.request.rejects(new Error('API_ERROR'));
+          const errorLogger = sinon.stub(LoggerProxy.logger, 'error');
+  
+          try {
+            await webinar.expelWebcastAttendee(participantId);
+            assert.fail('expelWebcastAttendee should throw an error');
+          } catch (error) {
+            assert.equal(error.message, 'API_ERROR', 'should throw the correct error');
+            assert.calledOnce(errorLogger);
+            assert.calledWith(errorLogger, 'Meeting:webinar#expelWebcastAttendee failed', sinon.match.instanceOf(Error));
+          }
+  
+          errorLogger.restore();
+        });
+      });
     })
 })


### PR DESCRIPTION
This PR is about webcast API, including start/stop webcast, query webcast layout, update webcast layout, search webcast attendee and expel webcast attendee.

# COMPLETES #< INSERT LINK TO ISSUE >

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-478620

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant for managing HTTP headers related to content type.
	- Added methods for enhanced management of webcasts, including starting, stopping, querying, updating layouts, and managing attendees.

- **Bug Fixes**
	- Improved error handling for new webcast management methods.

- **Tests**
	- Expanded test suite to cover new webcast functionalities and improved error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->