### PR TITLE
fix(cc-sdk): fixed-websocket-on-message-event-remove-logout

### DIFF
--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -194,6 +194,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       await loginResponse;
 
+      this.services.webSocketManager.on('message', this.handleWebSocketMessage);
       this.incomingTaskListener();
       this.taskManager.registerIncomingCallEvent();
 
@@ -294,7 +295,6 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    */
   private setupEventListeners() {
     this.services.connectionService.on('connectionLost', this.handleConnectionLost.bind(this));
-    this.services.webSocketManager.on('message', this.handleWebSocketMessage);
   }
 
   /**
@@ -355,6 +355,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       await this.handleDeviceType(deviceType as LoginOption, dn);
       this.agentConfig.isAgentLoggedIn = true;
+      this.services.webSocketManager.on('message', this.handleWebSocketMessage);
     } catch (error) {
       const {reason, error: detailedError} = getErrorDetails(error, 'silentReLogin', CC_FILE);
       if (reason === 'AGENT_NOT_FOUND') {

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -401,6 +401,7 @@ describe('webex.cc', () => {
        
       const onSpy = jest.spyOn(mockTaskManager, 'on');
       const emitSpy = jest.spyOn(webex.cc, 'trigger');
+      const ccEmitSpy = jest.spyOn(webex.cc, 'emit');
       const incomingCallCb = onSpy.mock.calls[0][1];
       
       expect(onSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, incomingCallCb);
@@ -408,6 +409,20 @@ describe('webex.cc', () => {
       incomingCallCb(mockTask);
   
       expect(emitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, mockTask);
+       // Verify message event listener
+      const messageCallback = mockWebSocketManager.on.mock.calls.find(call => call[0] === 'message')[1];
+      const eventData = {
+        type: CC_EVENTS.AGENT_STATE_CHANGE,
+        data: { some: 'data' },
+      };
+
+      // Simulate receiving a message event
+      messageCallback(JSON.stringify(eventData));
+
+      expect(ccEmitSpy).toHaveBeenCalledWith(
+        AGENT_STATE_CHANGE,
+        eventData.data
+      );
     });
 
     it('should login successfully with other LoginOption', async () => {
@@ -853,29 +868,6 @@ describe('webex.cc', () => {
       expect(connectionServiceOnSpy).toHaveBeenCalledWith(
         'connectionLost',
         expect.any(Function)
-      );
-
-      expect(mockWebSocketManager.on).toHaveBeenCalledWith(
-        'message',
-        expect.any(Function)
-      );
-    });
-
-    it('should emit AGENT_STATE_CHANGE when message event is received', () => {
-      webex.cc.setupEventListeners();
-
-      const messageCallback = mockWebSocketManager.on.mock.calls[0][1];
-      const eventData = {
-        type: CC_EVENTS.AGENT_STATE_CHANGE,
-        data: { some: 'data' },
-      };
-
-      // Simulate receiving a message event
-      messageCallback(JSON.stringify(eventData));
-
-      expect(cCEmitSpy).toHaveBeenCalledWith(
-        AGENT_STATE_CHANGE,
-        eventData.data
       );
     });
   });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-592068](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-592068) >

## This pull request addresses

* Currently, in the widgets, whenever we login and then logout and once again login to the widget, we are unable to get any message events.
* This is causing an issue with the agent status and timer as shown in this PR - https://github.com/webex/widgets/pull/352

## by making the following changes

* Changed the code so that we now listen to websocket messages (again only used in widgets as of now) whenever we login/ relogin and stop listening whenever we do logout.

Vidcast of working widgets - https://app.vidcast.io/share/a1cac1b3-83ec-450d-9e63-4a3066287b93

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested out the code by locally linking to the widgets repo.
* Tested the code in the sdk sample app to ensure no older behaviour is broken.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
