### PR TITLE
fix(webinar): modify update webcast layout params

### DIFF
--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -196,12 +196,10 @@ const Webinar = WebexPlugin.extend({
         [HEADERS.CONTENT_TYPE]: HEADERS.CONTENT_TYPE_VALUE.APPLICATION_JSON,
       },
       body: {
-        layout: {
-          videoLayout: layout.videoLayout,
-          contentLayout: layout.contentLayout,
-          syncStageLayout: layout.syncStageLayout,
-          syncStageInMeeting: layout.syncStageInMeeting,
-        },
+        videoLayout: layout.videoLayout,
+        contentLayout: layout.contentLayout,
+        syncStageLayout: layout.syncStageLayout,
+        syncStageInMeeting: layout.syncStageInMeeting,
       },
     }).catch((error) => {
       LoggerProxy.logger.error('Meeting:webinar#updateWebcastLayout failed', error);

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -333,7 +333,7 @@ describe('plugin-meetings', () => {
               'Content-Type': 'application/json'
             },
             body: {
-              layout
+              ...layout
             }
           });
           assert.equal(result, "REQUEST_RETURN_VALUE", "should return the resolved value from the request");


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes
modify updateWebcastLayout params

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Simplified webcast layout request structure
	- Enhanced flexibility in layout configuration for webinars

<!-- end of auto-generated comment: release notes by coderabbit.ai -->