### PR TITLE
feat(meeting-join): allow client.call.initiated to be suppressed

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -723,6 +723,10 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       clientEventObject.joinFlowVersion = joinFlowVersion;
     }
 
+    if (options.meetingJoinPhase) {
+      clientEventObject.meetingJoinPhase = options.meetingJoinPhase;
+    }
+
     return clientEventObject;
   }
 
@@ -768,6 +772,10 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
 
     if (options.joinFlowVersion) {
       clientEventObject.joinFlowVersion = options.joinFlowVersion;
+    }
+
+    if (options.meetingJoinPhase) {
+      clientEventObject.meetingJoinPhase = options.meetingJoinPhase;
     }
 
     return clientEventObject;

--- a/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
+++ b/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
@@ -111,6 +111,7 @@ export type MetricEventVerb =
   | 'exit';
 
 export type MetricEventJoinFlowVersion = 'Other' | 'NewFTE';
+export type MetricEventMeetingJoinPhase = 'pre-join' | 'join' | 'in-meeting';
 
 export type SubmitClientEventOptions = {
   meetingId?: string;
@@ -126,6 +127,7 @@ export type SubmitClientEventOptions = {
   webexConferenceIdStr?: string;
   globalMeetingId?: string;
   joinFlowVersion?: MetricEventJoinFlowVersion;
+  meetingJoinPhase?: MetricEventMeetingJoinPhase;
 };
 
 export type SubmitMQEOptions = {

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -2759,11 +2759,12 @@ describe('internal-plugin-metrics', () => {
         });
       });
 
-      it('includes expected joinFlowVersion from options when in-meeting', async () => {
+      it('includes expected joinFlowVersion and meetingJoinPhase from options when in-meeting', async () => {
         // meetingId means in-meeting
         const options = {
           meetingId: fakeMeeting.id,
           joinFlowVersion: 'NewFTE',
+          meetingJoinPhase: 'join',
         };
 
         const triggered = new Date();
@@ -2776,6 +2777,11 @@ describe('internal-plugin-metrics', () => {
         assert.equal(
           fetchOptions.body.metrics[0].eventPayload.event.joinFlowVersion,
           options.joinFlowVersion
+        );
+
+        assert.equal(
+          fetchOptions.body.metrics[0].eventPayload.event.meetingJoinPhase,
+          options.meetingJoinPhase
         );
       });
 
@@ -2815,12 +2821,13 @@ describe('internal-plugin-metrics', () => {
         );
       });
 
-      it('includes expected joinFlowVersion from options during prejoin', async () => {
+      it('includes expected joinFlowVersion and meetingJoinPhase from options during prejoin', async () => {
         // correlationId and no meeting id means prejoin
         const options = {
           correlationId: 'myCorrelationId',
           preLoginId: 'myPreLoginId',
           joinFlowVersion: 'NewFTE',
+          meetingJoinPhase: 'pre-join',
         };
 
         const triggered = new Date();
@@ -2833,6 +2840,11 @@ describe('internal-plugin-metrics', () => {
         assert.equal(
           fetchOptions.body.metrics[0].eventPayload.event.joinFlowVersion,
           options.joinFlowVersion
+        );
+
+        assert.equal(
+          fetchOptions.body.metrics[0].eventPayload.event.meetingJoinPhase,
+          options.meetingJoinPhase
         );
       });
     });

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5381,16 +5381,19 @@ export default class Meeting extends StatelessWebexPlugin {
       this.meetingFiniteStateMachine.reset();
     }
 
-    // @ts-ignore
-    this.webex.internal.newMetrics.submitClientEvent({
-      name: 'client.call.initiated',
-      payload: {
-        trigger: this.callStateForMetrics.joinTrigger || 'user-interaction',
-        isRoapCallEnabled: true,
-        pstnAudioType: options?.pstnAudioType,
-      },
-      options: {meetingId: this.id},
-    });
+    // send client.call.initiated unless told not to
+    if (options.sendCallInitiated !== false) {
+      // @ts-ignore
+      this.webex.internal.newMetrics.submitClientEvent({
+        name: 'client.call.initiated',
+        payload: {
+          trigger: this.callStateForMetrics.joinTrigger || 'user-interaction',
+          isRoapCallEnabled: true,
+          pstnAudioType: options?.pstnAudioType,
+        },
+        options: {meetingId: this.id},
+      });
+    }
 
     LoggerProxy.logger.log('Meeting:index#join --> Joining a meeting');
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1705,6 +1705,12 @@ describe('plugin-meetings', () => {
             sinon.assert.called(setCorrelationIdSpy);
             assert.equal(meeting.correlationId, '123');
           });
+
+          it('should not send client.call.initiated if told not to', async () => {
+            await meeting.join({sendCallInitiated: false});
+
+            sinon.assert.notCalled(webex.internal.newMetrics.submitClientEvent);
+          });
         });
 
         describe('failure', () => {
@@ -2514,7 +2520,7 @@ describe('plugin-meetings', () => {
           meeting.mediaProperties.webrtcMediaConnection = undefined;
           checkLogCounter(60, 6);
 
-          clock.tick(120*1000*60);
+          clock.tick(120 * 1000 * 60);
           assert.equal(logUploadCounter, 6);
 
           clock.restore();
@@ -3741,8 +3747,12 @@ describe('plugin-meetings', () => {
             meeting.setMercuryListener = sinon.stub();
             meeting.locusInfo.onFullLocus = sinon.stub();
             meeting.webex.meetings.geoHintInfo = {regionCode: 'EU', countryCode: 'UK'};
-            meeting.webex.meetings.reachability.getReachabilityReportToAttachToRoap = sinon.stub().resolves({id: 'fake reachability'});
-            meeting.webex.meetings.reachability.getClientMediaPreferences = sinon.stub().resolves({id: 'fake clientMediaPreferences'});
+            meeting.webex.meetings.reachability.getReachabilityReportToAttachToRoap = sinon
+              .stub()
+              .resolves({id: 'fake reachability'});
+            meeting.webex.meetings.reachability.getClientMediaPreferences = sinon
+              .stub()
+              .resolves({id: 'fake clientMediaPreferences'});
             meeting.roap.doTurnDiscovery = sinon.stub().resolves({
               turnServerInfo: {
                 url: 'turns:turn-server-url:443?transport=tcp',
@@ -3928,8 +3938,14 @@ describe('plugin-meetings', () => {
           const checkSdpOfferSent = ({audioMuted, videoMuted}) => {
             const {sdp, seq, tieBreaker} = roapOfferMessage;
 
-            assert.calledWith(meeting.webex.meetings.reachability.getClientMediaPreferences, meeting.isMultistream, 0);
-            assert.calledWith(meeting.webex.meetings.reachability.getReachabilityReportToAttachToRoap);
+            assert.calledWith(
+              meeting.webex.meetings.reachability.getClientMediaPreferences,
+              meeting.isMultistream,
+              0
+            );
+            assert.calledWith(
+              meeting.webex.meetings.reachability.getReachabilityReportToAttachToRoap
+            );
 
             assert.calledWith(locusMediaRequestStub, {
               method: 'PUT',
@@ -7860,7 +7876,9 @@ describe('plugin-meetings', () => {
           });
 
           it('should collect ice candidates', () => {
-            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE]({candidate: {candidate: 'candidate'}});
+            eventListeners[MediaConnectionEventNames.ICE_CANDIDATE]({
+              candidate: {candidate: 'candidate'},
+            });
 
             assert.equal(meeting.iceCandidatesCount, 1);
           });
@@ -8166,10 +8184,10 @@ describe('plugin-meetings', () => {
             meeting.statsAnalyzer.stopAnalyzer = sinon.stub().resolves();
             meeting.reconnectionManager = {
               reconnect: sinon.stub().resolves(),
-              resetReconnectionTimer: () => {}
+              resetReconnectionTimer: () => {},
             };
             meeting.currentMediaStatus = {
-              video: true
+              video: true,
             };
 
             await mockFailedEvent();
@@ -9097,7 +9115,7 @@ describe('plugin-meetings', () => {
             {state}
           );
 
-          assert.calledOnceWithExactly( meeting.webinar.updatePracticeSessionStatus, state);
+          assert.calledOnceWithExactly(meeting.webinar.updatePracticeSessionStatus, state);
           assert.calledWith(
             TriggerProxy.trigger,
             meeting,


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-601353

## This pull request addresses

Allows `sendCallInitiated: false` to be passed to to meeting.join() to suppress sending the `client.call.initiated` CA metric.

Also adds support for meetingJoinPhase client event option.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Ran unit tests

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `meetingJoinPhase` for enhanced tracking of meeting phases during event submissions.
	- Added option to control sending of `client.call.initiated` event when joining a meeting.
- **Bug Fixes**
	- Improved flexibility of meeting join process by allowing event submission to be suppressed.
- **Tests**
	- Updated test cases to validate the inclusion of `meetingJoinPhase` in relevant scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->