### PR TITLE
fix(cc-sdk): get RTMS url from u2c to pass it to calling sdk as part of config

### DIFF
--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -63,7 +63,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         connectionConfig: this.getConnectionConfig(),
       });
 
-      this.webCallingService = new WebCallingService(this.$webex, this.$config.callingClientConfig);
+      this.webCallingService = new WebCallingService(this.$webex);
       this.taskManager = TaskManager.getTaskManager(
         this.services.contact,
         this.webCallingService,

--- a/packages/@webex/plugin-cc/src/config.ts
+++ b/packages/@webex/plugin-cc/src/config.ts
@@ -17,7 +17,7 @@ export default {
       },
       serviceData: {
         indicator: 'contactcenter',
-        // TODO: This should be dynamic based on the environment
+        // This is now being read dynamically based on the environment in WebCallingService registerWebCallingLine method
         domain: 'rtw.prod-us1.rtmsprod.net',
       },
     },

--- a/packages/@webex/plugin-cc/src/config.ts
+++ b/packages/@webex/plugin-cc/src/config.ts
@@ -1,5 +1,3 @@
-import {LOGGER} from '@webex/calling';
-
 export default {
   cc: {
     allowMultiLogin: true,
@@ -10,16 +8,6 @@ export default {
     metrics: {
       clientName: 'WEBEX_JS_SDK',
       clientType: 'WebexCCSDK',
-    },
-    callingClientConfig: {
-      logger: {
-        level: LOGGER.INFO,
-      },
-      serviceData: {
-        indicator: 'contactcenter',
-        // This is now being read dynamically based on the environment in WebCallingService registerWebCallingLine method
-        domain: 'rtw.prod-us1.rtmsprod.net',
-      },
     },
   },
 };

--- a/packages/@webex/plugin-cc/src/services/WebCallingService.ts
+++ b/packages/@webex/plugin-cc/src/services/WebCallingService.ts
@@ -63,11 +63,15 @@ export default class WebCallingService extends EventEmitter {
   }
 
   public async registerWebCallingLine(): Promise<void> {
-    /** overriding RTMS URL with u2c catalogue wcc-calling-rtms service */
+    /** overriding/assigning RTMS URL with u2c catalogue wcc-calling-rtms service */
     await this.webex.internal.services.waitForCatalog('postauth');
+
     const rtmsURL = this.webex.internal.services.get('wcc-calling-rtms-domain');
-    if (rtmsURL) {
-      this.callingClientConfig.serviceData.domain = rtmsURL;
+    try {
+      const url = new URL(rtmsURL);
+      this.callingClientConfig.serviceData.domain = url.hostname;
+    } catch (error) {
+      this.webex.logger.error(`Invalid URL: ${rtmsURL}`);
     }
 
     this.callingClient = await createClient(this.webex as any, this.callingClientConfig);

--- a/packages/@webex/plugin-cc/src/services/WebCallingService.ts
+++ b/packages/@webex/plugin-cc/src/services/WebCallingService.ts
@@ -63,6 +63,13 @@ export default class WebCallingService extends EventEmitter {
   }
 
   public async registerWebCallingLine(): Promise<void> {
+    /** overriding RTMS URL with u2c catalogue wcc-calling-rtms service */
+    await this.webex.internal.services.waitForCatalog('postauth');
+    const rtmsURL = this.webex.internal.services.get('wcc-calling-rtms');
+    if (rtmsURL) {
+      this.callingClientConfig.serviceData.domain = rtmsURL;
+    }
+
     this.callingClient = await createClient(this.webex as any, this.callingClientConfig);
     this.line = Object.values(this.callingClient.getLines())[0];
 

--- a/packages/@webex/plugin-cc/src/services/WebCallingService.ts
+++ b/packages/@webex/plugin-cc/src/services/WebCallingService.ts
@@ -5,27 +5,27 @@ import {
   ICallingClient,
   ILine,
   LINE_EVENTS,
-  CallingClientConfig,
+  ServiceIndicator,
   LocalMicrophoneStream,
   CALL_EVENT_KEYS,
+  LOGGER,
 } from '@webex/calling';
 import {LoginOption, WebexSDK} from '../types';
 import {TIMEOUT_DURATION, WEB_CALLING_SERVICE_FILE} from '../constants';
 import LoggerProxy from '../logger-proxy';
+import {DEFAULT_RTMS_DOMAIN, POST_AUTH, WCC_CALLING_RTMS_DOMAIN} from './constants';
 
 export default class WebCallingService extends EventEmitter {
   private callingClient: ICallingClient;
-  private callingClientConfig: CallingClientConfig;
   private line: ILine;
   private call: ICall | undefined;
   private webex: WebexSDK;
   public loginOption: LoginOption;
   private callTaskMap: Map<string, string>;
 
-  constructor(webex: WebexSDK, callingClientConfig: CallingClientConfig) {
+  constructor(webex: WebexSDK) {
     super();
     this.webex = webex;
-    this.callingClientConfig = callingClientConfig;
     this.callTaskMap = new Map();
   }
 
@@ -62,19 +62,41 @@ export default class WebCallingService extends EventEmitter {
     }
   }
 
-  public async registerWebCallingLine(): Promise<void> {
-    /** overriding/assigning RTMS URL with u2c catalogue wcc-calling-rtms service */
-    await this.webex.internal.services.waitForCatalog('postauth');
+  private async getRTMSDomain() {
+    await this.webex.internal.services.waitForCatalog(POST_AUTH);
 
-    const rtmsURL = this.webex.internal.services.get('wcc-calling-rtms-domain');
+    const rtmsURL = this.webex.internal.services.get(WCC_CALLING_RTMS_DOMAIN);
+
     try {
       const url = new URL(rtmsURL);
-      this.callingClientConfig.serviceData.domain = url.hostname;
-    } catch (error) {
-      this.webex.logger.error(`Invalid URL: ${rtmsURL}`);
-    }
 
-    this.callingClient = await createClient(this.webex as any, this.callingClientConfig);
+      return url.hostname;
+    } catch (error) {
+      LoggerProxy.error(
+        `Invalid URL from u2c catalogue: ${rtmsURL} so falling back to default domain`,
+        {
+          module: WEB_CALLING_SERVICE_FILE,
+        }
+      );
+
+      return DEFAULT_RTMS_DOMAIN;
+    }
+  }
+
+  public async registerWebCallingLine(): Promise<void> {
+    const rtmsDomain = await this.getRTMSDomain(); // get the RTMS domain from the u2c catalogue
+
+    const callingClientConfig = {
+      logger: {
+        level: LOGGER.INFO,
+      },
+      serviceData: {
+        indicator: ServiceIndicator.CONTACT_CENTER,
+        domain: rtmsDomain,
+      },
+    };
+
+    this.callingClient = await createClient(this.webex as any, callingClientConfig);
     this.line = Object.values(this.callingClient.getLines())[0];
 
     this.line.on(LINE_EVENTS.UNREGISTERED, () => {

--- a/packages/@webex/plugin-cc/src/services/WebCallingService.ts
+++ b/packages/@webex/plugin-cc/src/services/WebCallingService.ts
@@ -65,7 +65,7 @@ export default class WebCallingService extends EventEmitter {
   public async registerWebCallingLine(): Promise<void> {
     /** overriding RTMS URL with u2c catalogue wcc-calling-rtms service */
     await this.webex.internal.services.waitForCatalog('postauth');
-    const rtmsURL = this.webex.internal.services.get('wcc-calling-rtms');
+    const rtmsURL = this.webex.internal.services.get('wcc-calling-rtms-domain');
     if (rtmsURL) {
       this.callingClientConfig.serviceData.domain = rtmsURL;
     }

--- a/packages/@webex/plugin-cc/src/services/constants.ts
+++ b/packages/@webex/plugin-cc/src/services/constants.ts
@@ -1,4 +1,7 @@
+export const POST_AUTH = 'postauth';
 export const WCC_API_GATEWAY = 'wcc-api-gateway';
+export const WCC_CALLING_RTMS_DOMAIN = 'wcc-calling-rtms-domain';
+export const DEFAULT_RTMS_DOMAIN = 'rtw.prod-us1.rtmsprod.net';
 export const WEBSOCKET_EVENT_TIMEOUT = 20000;
 
 export const AGENT = 'agent';

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -83,7 +83,41 @@ export enum LOGGING_LEVEL {
   info = 'INFO',
   trace = 'TRACE',
 }
-
+interface IWebexInternal {
+  mercury: {
+    on: Listener;
+    off: ListenerOff;
+    connected: boolean;
+    connecting: boolean;
+  };
+  device: {
+    url: string;
+    userId: string;
+    orgId: string;
+    version: string;
+    callingBehavior: string;
+  };
+  presence: unknown;
+  services: {
+    get: (service: string) => string;
+    waitForCatalog: (service: string) => Promise<void>;
+    _hostCatalog: Record<string, ServiceHost[]>;
+    _serviceUrls: {
+      mobius: string;
+      identity: string;
+      janus: string;
+      wdm: string;
+      broadworksIdpProxy: string;
+      hydra: string;
+      mercuryApi: string;
+      'ucmgmt-gateway': string;
+      contactsService: string;
+    };
+  };
+  metrics: {
+    submitClientMetrics: (name: string, data: unknown) => void;
+  };
+}
 export interface WebexSDK {
   version: string;
   canAuthorize: boolean;
@@ -95,41 +129,7 @@ export interface WebexSDK {
   request: <T>(payload: WebexRequestPayload) => Promise<T>;
   once: (event: string, callBack: () => void) => void;
   // internal plugins
-  internal: {
-    mercury: {
-      on: Listener;
-      off: ListenerOff;
-      connected: boolean;
-      connecting: boolean;
-    };
-    device: {
-      url: string;
-      userId: string;
-      orgId: string;
-      version: string;
-      callingBehavior: string;
-    };
-    presence: unknown;
-    services: {
-      get: (service: string) => string;
-      waitForCatalog: (service: string) => Promise<void>;
-      _hostCatalog: Record<string, ServiceHost[]>;
-      _serviceUrls: {
-        mobius: string;
-        identity: string;
-        janus: string;
-        wdm: string;
-        broadworksIdpProxy: string;
-        hydra: string;
-        mercuryApi: string;
-        'ucmgmt-gateway': string;
-        contactsService: string;
-      };
-    };
-    metrics: {
-      submitClientMetrics: (name: string, data: unknown) => void;
-    };
-  };
+  internal: IWebexInternal;
   // public plugins
   logger: Logger;
 }

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -111,6 +111,8 @@ export interface WebexSDK {
     };
     presence: unknown;
     services: {
+      get: (service: string) => string;
+      waitForCatalog: (service: string) => Promise<void>;
       _hostCatalog: Record<string, ServiceHost[]>;
       _serviceUrls: {
         mobius: string;

--- a/packages/@webex/plugin-cc/test/unit/spec/services/WebCallingService.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/WebCallingService.ts
@@ -114,7 +114,7 @@ describe('WebCallingService', () => {
     }, 20000); // Increased timeout to 20 seconds
 
     it('should register WebCallingLine with custom rtms url', async () => {
-      webex.internal.services.get = jest.fn().mockReturnValue('rtw.prod-us2.rtmsprod.net');
+      webex.internal.services.get = jest.fn().mockReturnValue('sip://rtw.prod-us2.rtmsprod.net');
 
       line = callingClient.getLines().line1 as ILine;
       const deviceInfo = {

--- a/packages/@webex/plugin-cc/test/unit/spec/services/WebCallingService.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/WebCallingService.ts
@@ -37,7 +37,13 @@ describe('WebCallingService', () => {
       logger: {
         log: jest.fn(),
         error: jest.fn(),
-        info: jest.fn()
+        info: jest.fn(),
+      },
+      internal: {
+        services: {
+          waitForCatalog: jest.fn().mockResolvedValue(undefined),
+          get: jest.fn().mockReturnValue('rtw.prod-us1.rtmsprod.net'),
+        },
       },
     } as unknown as WebexSDK;
 
@@ -103,7 +109,39 @@ describe('WebCallingService', () => {
       expect(line.register).toHaveBeenCalled();
       expect(LoggerProxy.log).toHaveBeenCalledWith(
         `WxCC-SDK: Desktop registered successfully, mobiusDeviceId: ${deviceInfo.mobiusDeviceId}`,
-        {"method": "registerWebCallingLine", "module": WEB_CALLING_SERVICE_FILE}
+        {method: 'registerWebCallingLine', module: WEB_CALLING_SERVICE_FILE}
+      );
+    }, 20000); // Increased timeout to 20 seconds
+
+    it('should register WebCallingLine with custom rtms url', async () => {
+      webex.internal.services.get = jest.fn().mockReturnValue('rtw.prod-us2.rtmsprod.net');
+
+      line = callingClient.getLines().line1 as ILine;
+      const deviceInfo = {
+        mobiusDeviceId: 'device123',
+        status: 'registered',
+        setError: jest.fn(),
+        getError: jest.fn(),
+        type: 'line',
+        id: 'line1',
+      };
+
+      const registeredHandler = jest.fn();
+      const lineOnSpy = jest.spyOn(line, 'on').mockImplementation((event, handler) => {
+        if (event === LINE_EVENTS.REGISTERED) {
+          registeredHandler.mockImplementation(handler);
+          handler(deviceInfo);
+        }
+      });
+      expect(config.cc.callingClientConfig.serviceData.domain).toBe('rtw.prod-us1.rtmsprod.net');
+      await expect(webRTCCalling.registerWebCallingLine()).resolves.toBeUndefined();
+      expect(config.cc.callingClientConfig.serviceData.domain).toBe('rtw.prod-us2.rtmsprod.net');
+      expect(createClient).toHaveBeenCalledWith(webex, config.cc.callingClientConfig);
+      expect(lineOnSpy).toHaveBeenCalledWith(LINE_EVENTS.REGISTERED, expect.any(Function));
+      expect(line.register).toHaveBeenCalled();
+      expect(LoggerProxy.log).toHaveBeenCalledWith(
+        `WxCC-SDK: Desktop registered successfully, mobiusDeviceId: ${deviceInfo.mobiusDeviceId}`,
+        {method: 'registerWebCallingLine', module: WEB_CALLING_SERVICE_FILE}
       );
     }, 20000); // Increased timeout to 20 seconds
 
@@ -171,7 +209,7 @@ describe('WebCallingService', () => {
     const mockStream = {
       outputStream: {
         getAudioTracks: jest.fn().mockReturnValue(['']),
-      }
+      },
     };
 
     const localAudioStream = mockStream as unknown as LocalMicrophoneStream;
@@ -185,10 +223,14 @@ describe('WebCallingService', () => {
 
     it('should log error and throw when call.answer fails', () => {
       const error = new Error('Failed to answer');
-      mockCall.answer.mockImplementation(() => { throw error; });
+      mockCall.answer.mockImplementation(() => {
+        throw error;
+      });
 
       expect(() => webRTCCalling.answerCall(localAudioStream, 'task-id')).toThrow(error);
-      expect(webex.logger.error).toHaveBeenCalledWith(`Failed to answer call for task-id. Error: ${error}`);
+      expect(webex.logger.error).toHaveBeenCalledWith(
+        `Failed to answer call for task-id. Error: ${error}`
+      );
     });
 
     it('should log when there is no call to answer', () => {
@@ -203,7 +245,7 @@ describe('WebCallingService', () => {
     const mockStream = {
       outputStream: {
         getAudioTracks: jest.fn().mockReturnValue(['']),
-      }
+      },
     };
 
     const localAudioStream = mockStream as unknown as LocalMicrophoneStream;
@@ -233,10 +275,14 @@ describe('WebCallingService', () => {
 
     it('should log error and throw when call.end fails', () => {
       const error = new Error('Failed to end call');
-      mockCall.end.mockImplementation(() => { throw error; });
+      mockCall.end.mockImplementation(() => {
+        throw error;
+      });
 
       expect(() => webRTCCalling.declineCall('task-id')).toThrow(error);
-      expect(webex.logger.error).toHaveBeenCalledWith(`Failed to end call: task-id. Error: ${error}`);
+      expect(webex.logger.error).toHaveBeenCalledWith(
+        `Failed to end call: task-id. Error: ${error}`
+      );
     });
 
     it('should log when there is no call to end', () => {

--- a/packages/@webex/plugin-cc/test/unit/spec/services/WebCallingService.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/WebCallingService.ts
@@ -5,12 +5,10 @@ import {
   ICallingClient,
   ILine,
   LINE_EVENTS,
-  CallingClientConfig,
   CALL_EVENT_KEYS,
   LocalMicrophoneStream,
 } from '@webex/calling';
-import {LoginOption, WebexSDK} from '../../../../src/types';
-import config from '../../../../src/config';
+import { WebexSDK} from '../../../../src/types';
 import LoggerProxy from '../../../../src/logger-proxy';
 import {WEB_CALLING_SERVICE_FILE} from '../../../../src/constants';
 jest.mock('@webex/calling');
@@ -42,7 +40,7 @@ describe('WebCallingService', () => {
       internal: {
         services: {
           waitForCatalog: jest.fn().mockResolvedValue(undefined),
-          get: jest.fn().mockReturnValue('rtw.prod-us1.rtmsprod.net'),
+          get: jest.fn()
         },
       },
     } as unknown as WebexSDK;
@@ -61,7 +59,6 @@ describe('WebCallingService', () => {
 
     webRTCCalling = new WebCallingService(
       webex,
-      config.cc.callingClientConfig as CallingClientConfig
     );
 
     mockCall = {
@@ -83,7 +80,9 @@ describe('WebCallingService', () => {
   });
 
   describe('registerWebCallingLine', () => {
+
     it('should register the web calling line successfully', async () => {
+      webex.internal.services.get.mockReturnValue(undefined); // this is to test fallback to default rtms domain
       line = callingClient.getLines().line1 as ILine;
       const deviceInfo = {
         mobiusDeviceId: 'device123',
@@ -104,7 +103,15 @@ describe('WebCallingService', () => {
 
       await expect(webRTCCalling.registerWebCallingLine()).resolves.toBeUndefined();
 
-      expect(createClient).toHaveBeenCalledWith(webex, config.cc.callingClientConfig);
+      expect(createClient).toHaveBeenCalledWith(webex, {
+        logger: {
+          level: 'info',
+        },
+        serviceData: {
+          indicator: 'contactcenter',
+          domain: 'rtw.prod-us1.rtmsprod.net',
+        },
+      });
       expect(lineOnSpy).toHaveBeenCalledWith(LINE_EVENTS.REGISTERED, expect.any(Function));
       expect(line.register).toHaveBeenCalled();
       expect(LoggerProxy.log).toHaveBeenCalledWith(
@@ -114,7 +121,7 @@ describe('WebCallingService', () => {
     }, 20000); // Increased timeout to 20 seconds
 
     it('should register WebCallingLine with custom rtms url', async () => {
-      webex.internal.services.get = jest.fn().mockReturnValue('sip://rtw.prod-us2.rtmsprod.net');
+      webex.internal.services.get.mockReturnValue('sip://rtw.prod-us2.rtmsprod.net'); 
 
       line = callingClient.getLines().line1 as ILine;
       const deviceInfo = {
@@ -133,10 +140,16 @@ describe('WebCallingService', () => {
           handler(deviceInfo);
         }
       });
-      expect(config.cc.callingClientConfig.serviceData.domain).toBe('rtw.prod-us1.rtmsprod.net');
       await expect(webRTCCalling.registerWebCallingLine()).resolves.toBeUndefined();
-      expect(config.cc.callingClientConfig.serviceData.domain).toBe('rtw.prod-us2.rtmsprod.net');
-      expect(createClient).toHaveBeenCalledWith(webex, config.cc.callingClientConfig);
+      expect(createClient).toHaveBeenCalledWith(webex, {
+        logger: {
+          level: 'info',
+        },
+        serviceData: {
+          indicator: 'contactcenter',
+          domain: 'rtw.prod-us2.rtmsprod.net',
+        },
+      });
       expect(lineOnSpy).toHaveBeenCalledWith(LINE_EVENTS.REGISTERED, expect.any(Function));
       expect(line.register).toHaveBeenCalled();
       expect(LoggerProxy.log).toHaveBeenCalledWith(
@@ -144,6 +157,45 @@ describe('WebCallingService', () => {
         {method: 'registerWebCallingLine', module: WEB_CALLING_SERVICE_FILE}
       );
     }, 20000); // Increased timeout to 20 seconds
+
+    it('should handle error when invalid rtms url is provided', async () => {
+      webex.internal.services.get.mockReturnValue('invalid-url'); 
+
+      line = callingClient.getLines().line1 as ILine;
+      const deviceInfo = {
+        mobiusDeviceId: 'device123',
+        status: 'registered',
+        setError: jest.fn(),
+        getError: jest.fn(),
+        type: 'line',
+        id: 'line1',
+      };
+
+      const registeredHandler = jest.fn();
+      const lineOnSpy = jest.spyOn(line, 'on').mockImplementation((event, handler) => {
+        if (event === LINE_EVENTS.REGISTERED) {
+          registeredHandler.mockImplementation(handler);
+          handler(deviceInfo);
+        }
+      });
+      await expect(webRTCCalling.registerWebCallingLine()).resolves.toBeUndefined();
+      expect(createClient).toHaveBeenCalledWith(webex, {
+        logger: {
+          level: 'info',
+        },
+        serviceData: {
+          indicator: 'contactcenter',
+          domain: 'rtw.prod-us1.rtmsprod.net',
+        },
+      });
+      expect(lineOnSpy).toHaveBeenCalledWith(LINE_EVENTS.REGISTERED, expect.any(Function));
+      expect(line.register).toHaveBeenCalled();
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        `Invalid URL from u2c catalogue: invalid-url so falling back to default domain`,
+        {module: WEB_CALLING_SERVICE_FILE}
+      );
+
+    });
 
     it('should reject if registration times out', async () => {
       line = callingClient.getLines().line1 as ILine;

--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -53,3 +53,4 @@ export {ICall, TransferType} from './CallingClient/calling/types';
 export {LOGGER} from './Logger/types';
 export {LocalMicrophoneStream} from '@webex/media-helpers';
 export {CallingClientConfig} from './CallingClient/types';
+export {ServiceIndicator} from './common/types';


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-586376

## This pull request addresses

The issue of hardcode of RTMS URL

## by making the following changes

Getting RTMS URL from U2C catalogue.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Check u2c catalogue response and see RTMS url is present or not.

Check register line and see RTMS URL in network logs.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.