### PR TITLE
fix: added ability to add TURN server urls from console

### DIFF
--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -183,6 +183,20 @@ Media.createMediaConnection = (
     });
   }
 
+  const devTurnServers = (window as any).webexTurnServers;
+
+  if (devTurnServers) {
+    console.log('adding webexTurnServers:', devTurnServers);
+
+    for (const devTurnServer of devTurnServers) {
+      iceServers.push({
+        urls: devTurnServer.url || turnServerInfo.url.replace('.public', '.ds.public'),
+        username: devTurnServer.username || turnServerInfo?.username || '',
+        credential: devTurnServer.password || turnServerInfo?.password || '',
+      });
+    }
+  }
+
   if (isMultistream) {
     const config: MultistreamConnectionConfig = {
       iceServers,


### PR DESCRIPTION
temporary hack to allow the ipv6 testing team to add more TURN servers when we join meetings