### PR TITLE
fix(device): error catch for device deletion

### DIFF
--- a/packages/@webex/internal-plugin-device/src/device.js
+++ b/packages/@webex/internal-plugin-device/src/device.js
@@ -494,9 +494,20 @@ const Device = WebexPlugin.extend({
   register(deviceRegistrationOptions = {}) {
     return this._registerInternal(deviceRegistrationOptions).catch((error) => {
       if (error?.body?.message === 'User has excessive device registrations') {
-        return this.deleteDevices().then(() => {
-          return this._registerInternal(deviceRegistrationOptions);
-        });
+        this.logger.error('devices: user has excessive device registrations', error);
+
+        return this.deleteDevices()
+          .then(() => {
+            return this._registerInternal(deviceRegistrationOptions);
+          })
+          .catch((deleteDevicesError) => {
+            this.logger.error(
+              'devices: failed to delete after user found to have excessive device registrations',
+              deleteDevicesError
+            );
+
+            throw deleteDevicesError;
+          });
       }
       throw error;
     });


### PR DESCRIPTION
# COMPLETES [SPARK-586651](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-586651)

## This pull request addresses

- no catch for failure to delete devices

## by making the following changes

- added catch
- added logging

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during the device registration process.
	- Enhanced logging for scenarios involving excessive device registrations.
	- Added more robust error tracking when device deletion fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->