### PR TITLE
Ipv6 multi turn urls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: # White-list of deployable tags and branches. Note that all white-listed branches cannot include any `/` characters
       - next
+      - ipv6-multi-turn-urls
 
 env:
   rid: ${{ github.run_id }}-${{ github.run_number }}

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -196,6 +196,7 @@ Media.createMediaConnection = (
       });
     }
   }
+  console.log('iceServers:', iceServers);
 
   if (isMultistream) {
     const config: MultistreamConnectionConfig = {

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -183,6 +183,20 @@ Media.createMediaConnection = (
     });
   }
 
+  const devTurnServers = (window as any).webexTurnServers;
+
+  if (devTurnServers) {
+    console.log('adding webexTurnServers:', devTurnServers);
+
+    for (const devTurnServer of devTurnServers) {
+      iceServers.push({
+        urls: devTurnServer.url || turnServerInfo.url.replace('.public', '.ds.public'),
+        username: devTurnServer.username || turnServerInfo?.username || '',
+        credential: devTurnServer.password || turnServerInfo?.password || '',
+      });
+    }
+  }
+
   if (isMultistream) {
     const config: MultistreamConnectionConfig = {
       iceServers,

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -163,17 +163,17 @@ Media.createMediaConnection = (
   // we might not have any TURN server if TURN discovery failed or wasn't done or
   // we might get an empty TURN url if we land on a video mesh node
   if (turnServerInfo?.url) {
-    if (!isBrowser('firefox')) {
-      let bareTurnServer = turnServerInfo.url;
-      bareTurnServer = bareTurnServer.replace('turns:', 'turn:');
-      bareTurnServer = bareTurnServer.replace('443', '5004');
+    // if (!isBrowser('firefox')) {
+    //   let bareTurnServer = turnServerInfo.url;
+    //   bareTurnServer = bareTurnServer.replace('turns:', 'turn:');
+    //   bareTurnServer = bareTurnServer.replace('443', '5004');
 
-      iceServers.push({
-        urls: bareTurnServer,
-        username: turnServerInfo.username || '',
-        credential: turnServerInfo.password || '',
-      });
-    }
+    //   iceServers.push({
+    //     urls: bareTurnServer,
+    //     username: turnServerInfo.username || '',
+    //     credential: turnServerInfo.password || '',
+    //   });
+    // }
 
     // TURN-TLS server
     iceServers.push({

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
@@ -90,11 +90,11 @@ describe('createMediaConnection', () => {
       roapMediaConnectionConstructorStub,
       {
         iceServers: [
-          {
-            urls: 'turn:turn-server-url:5004?transport=tcp',
-            username: 'turn username',
-            credential: 'turn password',
-          },
+          // {
+          //   urls: 'turn:turn-server-url:5004?transport=tcp',
+          //   username: 'turn username',
+          //   credential: 'turn password',
+          // },
           {
             urls: 'turns:turn-server-url:443?transport=tcp',
             username: 'turn username',
@@ -170,11 +170,11 @@ describe('createMediaConnection', () => {
       multistreamRoapMediaConnectionConstructorStub,
       {
         iceServers: [
-          {
-            urls: 'turn:turn-server-url:5004?transport=tcp',
-            username: 'turn username',
-            credential: 'turn password',
-          },
+          // {
+          //   urls: 'turn:turn-server-url:5004?transport=tcp',
+          //   username: 'turn username',
+          //   credential: 'turn password',
+          // },
           {
             urls: 'turns:turn-server-url:443?transport=tcp',
             username: 'turn username',

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -3772,11 +3772,11 @@ describe('plugin-meetings', () => {
             expectedDebugId = `MC-${meeting.id.substring(0, 4)}`;
             expectedMediaConnectionConfig = {
               iceServers: [
-                {
-                  urls: 'turn:turn-server-url:5004?transport=tcp',
-                  username: 'turn user',
-                  credential: 'turn password',
-                },
+                // {
+                //   urls: 'turn:turn-server-url:5004?transport=tcp',
+                //   username: 'turn user',
+                //   credential: 'turn password',
+                // },
                 {
                   urls: 'turns:turn-server-url:443?transport=tcp',
                   username: 'turn user',

--- a/packages/@webex/webex-core/src/index.js
+++ b/packages/@webex/webex-core/src/index.js
@@ -8,7 +8,6 @@
  * federation requirements, and instead send requests to the environmentally-
  * assigned urls.
  */
-
 import './plugins/logger';
 import './lib/credentials';
 import './lib/services';

--- a/packages/@webex/webex-core/src/index.js
+++ b/packages/@webex/webex-core/src/index.js
@@ -8,6 +8,7 @@
  * federation requirements, and instead send requests to the environmentally-
  * assigned urls.
  */
+
 import './plugins/logger';
 import './lib/credentials';
 import './lib/services';

--- a/packages/tools/package/src/models/package/package.ts
+++ b/packages/tools/package/src/models/package/package.ts
@@ -166,7 +166,14 @@ class Package {
       .then((packageInfo) => {
         this.data.packageInfo = packageInfo;
 
-        const tagVersion = packageInfo['dist-tags'][tag];
+        let updatedPackageInfo = packageInfo;
+
+        if (updatedPackageInfo.version.includes('-')) {
+          const [version] = updatedPackageInfo.version.split('-');
+          updatedPackageInfo = { ...updatedPackageInfo, version };
+        }
+
+        const tagVersion = updatedPackageInfo['dist-tags'][tag];
 
         if (tagVersion) {
           this.data.version = Package.parseVersionStringToObject(tagVersion);
@@ -174,7 +181,7 @@ class Package {
           return this;
         }
 
-        this.data.version = Package.parseVersionStringToObject(`${packageInfo.version}-${tag}.0`);
+        this.data.version = Package.parseVersionStringToObject(`${updatedPackageInfo.version}-${tag}.0`);
 
         return this;
       });

--- a/packages/tools/package/test/module/package/package.test.js
+++ b/packages/tools/package/test/module/package/package.test.js
@@ -327,6 +327,14 @@ describe('Package', () => {
         },
       };
 
+      const inspectResultsWithTagInVersion = {
+        version: '4.5.6-example-tag.1',
+        'dist-tags': {
+          [exampleTag]: '1.2.3-example-tag.4',
+          [Package.CONSTANTS.STABLE_TAG]: '4.5.6',
+        },
+      };
+
       const spies = {};
 
       beforeEach(() => {
@@ -366,6 +374,18 @@ describe('Package', () => {
               .toHaveBeenCalledWith(inspectResults['dist-tags'][exampleTag]);
           }),
       );
+
+      it('should call "parseVersionStringToObject()" with only version if pre-release tag is in version', async () => {
+        spies.Package = {
+          inspect: jest.spyOn(Package, 'inspect').mockResolvedValue(inspectResultsWithTagInVersion),
+          parseVersionStringToObject: jest.spyOn(Package, 'parseVersionStringToObject').mockReturnValue(exampleVersion),
+        };
+
+        await pack.inspect();
+        expect(spies.Package.parseVersionStringToObject).toHaveBeenCalledTimes(1);
+        expect(spies.Package.parseVersionStringToObject)
+          .toHaveBeenCalledWith(inspectResults['dist-tags'][exampleTag]);
+      });
 
       it(
         'should call "Package.parseVersionStringToObject()" with the new tag version if the tag version was not found',


### PR DESCRIPTION
temp changes for investigation on how browsers handle multiple TURN servers

use it by typing in the console before joining a meeting:
```
webexTurnServers = [{url: 'turns://someserver.com:443?transport=tcp', username:'aaa', password: 'pwd'}]
```

