### PR TITLE
fix(meetings): addMedia() promise sometimes doesn't resolve

### DIFF
--- a/packages/@webex/plugin-meetings/src/index.ts
+++ b/packages/@webex/plugin-meetings/src/index.ts
@@ -27,7 +27,6 @@ registerPlugin('meetings', Meetings, {
 });
 
 export {
-  getDevices,
   LocalStream,
   LocalDisplayStream,
   LocalSystemAudioStream,

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -31,7 +31,6 @@ import {
 } from '@webex/internal-media-core';
 
 import {
-  getDevices,
   LocalStream,
   LocalCameraStream,
   LocalDisplayStream,
@@ -6779,32 +6778,6 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
-   * Handles device logging
-   *
-   * @private
-   * @static
-   * @param {boolean} isAudioEnabled
-   * @param {boolean} isVideoEnabled
-   * @returns {Promise<void>}
-   */
-
-  private static async handleDeviceLogging(isAudioEnabled, isVideoEnabled): Promise<void> {
-    try {
-      let devices = [];
-      if (isVideoEnabled && isAudioEnabled) {
-        devices = await getDevices();
-      } else if (isVideoEnabled) {
-        devices = await getDevices(Media.DeviceKind.VIDEO_INPUT);
-      } else if (isAudioEnabled) {
-        devices = await getDevices(Media.DeviceKind.AUDIO_INPUT);
-      }
-      MeetingUtil.handleDeviceLogging(devices);
-    } catch {
-      // getDevices may fail if we don't have browser permissions, that's ok, we still can have a media connection
-    }
-  }
-
-  /**
    * Returns a promise. This promise is created once the local sdp offer has been successfully created and is resolved
    * once the remote sdp answer has been received.
    *
@@ -7305,12 +7278,6 @@ export default class Meeting extends StatelessWebexPlugin {
         forceTurnDiscovery,
         turnServerInfo
       );
-
-      if (audioEnabled || videoEnabled) {
-        await Meeting.handleDeviceLogging(audioEnabled, videoEnabled);
-      } else {
-        LoggerProxy.logger.info(`${LOG_HEADER} device logging not required`);
-      }
 
       if (this.mediaProperties.hasLocalShareStream()) {
         await this.enqueueScreenShareFloorRequest();

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -496,15 +496,6 @@ const MeetingUtil = {
     }
   },
 
-  handleDeviceLogging: (devices = []) => {
-    const LOG_HEADER = 'MeetingUtil#handleDeviceLogging -->';
-
-    devices.forEach((device) => {
-      LoggerProxy.logger.log(LOG_HEADER, `deviceId = ${device.deviceId}`);
-      LoggerProxy.logger.log(LOG_HEADER, 'settings', JSON.stringify(device));
-    });
-  },
-
   endMeetingForAll: (meeting) => {
     if (meeting.meetingState === FULL_STATE.INACTIVE) {
       return Promise.reject(new MeetingNotActiveError());

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -3556,14 +3556,6 @@ describe('plugin-meetings', () => {
           });
         });
 
-        it('succeeds even if getDevices() throws', async () => {
-          meeting.meetingState = 'ACTIVE';
-
-          sinon.stub(InternalMediaCoreModule, 'getDevices').rejects(new Error('fake error'));
-
-          await meeting.addMedia();
-        });
-
         describe('CA ice failures checks', () => {
           [
             {
@@ -4190,7 +4182,6 @@ describe('plugin-meetings', () => {
           });
 
           it('addMedia() works correctly when media is enabled with streams to publish', async () => {
-            const handleDeviceLoggingSpy = sinon.spy(Meeting, 'handleDeviceLogging');
             await meeting.addMedia({localStreams: {microphone: fakeMicrophoneStream}});
             await simulateRoapOffer();
             await simulateRoapOk();
@@ -4221,12 +4212,9 @@ describe('plugin-meetings', () => {
 
             // and that these were the only /media requests that were sent
             assert.calledTwice(locusMediaRequestStub);
-
-            assert.calledOnce(handleDeviceLoggingSpy);
           });
 
           it('addMedia() works correctly when media is enabled with streams to publish and stream is user muted', async () => {
-            const handleDeviceLoggingSpy = sinon.spy(Meeting, 'handleDeviceLogging');
             fakeMicrophoneStream.userMuted = true;
 
             await meeting.addMedia({localStreams: {microphone: fakeMicrophoneStream}});
@@ -4258,7 +4246,6 @@ describe('plugin-meetings', () => {
 
             // and that these were the only /media requests that were sent
             assert.calledTwice(locusMediaRequestStub);
-            assert.calledOnce(handleDeviceLoggingSpy);
           });
 
           it('addMedia() works correctly when media is enabled with tracks to publish and track is ended', async () => {
@@ -4330,7 +4317,6 @@ describe('plugin-meetings', () => {
           });
 
           it('addMedia() works correctly when media is disabled with streams to publish', async () => {
-            const handleDeviceLoggingSpy = sinon.spy(Meeting, 'handleDeviceLogging');
             await meeting.addMedia({
               localStreams: {microphone: fakeMicrophoneStream},
               audioEnabled: false,
@@ -4364,20 +4350,6 @@ describe('plugin-meetings', () => {
 
             // and that these were the only /media requests that were sent
             assert.calledTwice(locusMediaRequestStub);
-            assert.calledOnce(handleDeviceLoggingSpy);
-          });
-
-          it('handleDeviceLogging not called when media is disabled', async () => {
-            const handleDeviceLoggingSpy = sinon.spy(Meeting, 'handleDeviceLogging');
-            await meeting.addMedia({
-              localStreams: {microphone: fakeMicrophoneStream},
-              audioEnabled: false,
-              videoEnabled: false,
-            });
-            await simulateRoapOffer();
-            await simulateRoapOk();
-
-            assert.notCalled(handleDeviceLoggingSpy);
           });
 
           it('addMedia() works correctly when media is disabled with no streams to publish', async () => {
@@ -4411,20 +4383,6 @@ describe('plugin-meetings', () => {
 
             // and that these were the only /media requests that were sent
             assert.calledTwice(locusMediaRequestStub);
-          });
-
-          it('addMedia() works correctly when media is disabled with no streams to publish', async () => {
-            const handleDeviceLoggingSpy = sinon.spy(Meeting, 'handleDeviceLogging');
-            await meeting.addMedia({audioEnabled: false});
-            //calling handleDeviceLogging with audioEnaled as true adn videoEnabled as false
-            assert.calledWith(handleDeviceLoggingSpy, false, true);
-          });
-
-          it('addMedia() works correctly when video is disabled with no streams to publish', async () => {
-            const handleDeviceLoggingSpy = sinon.spy(Meeting, 'handleDeviceLogging');
-            await meeting.addMedia({videoEnabled: false});
-            //calling handleDeviceLogging audioEnabled as true videoEnabled as false
-            assert.calledWith(handleDeviceLoggingSpy, true, false);
           });
 
           it('addMedia() works correctly when video is disabled with no streams to publish', async () => {
@@ -4491,13 +4449,6 @@ describe('plugin-meetings', () => {
 
             // and that these were the only /media requests that were sent
             assert.calledTwice(locusMediaRequestStub);
-          });
-
-          it('addMedia() works correctly when both shareAudio and shareVideo is disabled with no streams publish', async () => {
-            const handleDeviceLoggingSpy = sinon.spy(Meeting, 'handleDeviceLogging');
-            await meeting.addMedia({shareAudioEnabled: false, shareVideoEnabled: false});
-            //calling handleDeviceLogging with audioEnabled true and videoEnabled as true
-            assert.calledWith(handleDeviceLoggingSpy, true, true);
           });
 
           describe('publishStreams()/unpublishStreams() calls', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -165,21 +165,6 @@ describe('plugin-meetings', () => {
           assert(LoggerProxy.logger.log.called, 'log called');
         });
       });
-
-      describe('#handleDeviceLogging', () => {
-        it('should not log if called without devices', () => {
-          MeetingUtil.handleDeviceLogging();
-          assert(!LoggerProxy.logger.log.called, 'log not called');
-        });
-
-        it('should log device settings', () => {
-          const mockDevices = [{deviceId: 'device-1'}, {deviceId: 'device-2'}];
-
-          assert(MeetingUtil.handleDeviceLogging, 'is defined');
-          MeetingUtil.handleDeviceLogging(mockDevices);
-          assert(LoggerProxy.logger.log.called, 'log called');
-        });
-      });
     });
 
     describe('addSequence', () => {


### PR DESCRIPTION
# COMPLETES #[SPARK-604493](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-604493)

## This pull request addresses
User was stuck on "connecting...." screen forever. Looking at logs it looks like `Meeting.addMedia()` never resolved and most likely because it was stuck inside `handleDeviceLogging()`. I think so, because from the logs I can see that for sure `Meeting.establishMediaConnection()` resolved and we don't see the logs for sending the add_media_success metric and also don't see the logs from `handleDeviceLogging()` while both `audioEnabled` and `videoEnabled` were set to true, so we should see the logs listing the devices.  Kacper (who is the user that reported the issue) said he had permissions, but there was some strange issue with his camera, looks like browser was not able to access it.

## by making the following changes
`handleDeviceLogging()` calls getDevices() from webrtc-core and that function tries to ensure that there are permissions for listing the devices, so it calls query permissions api and in some edge cases it might even call getUserMedia(), which is not really something we would want to happen during addMedia(), so overall it feels like handleDeviceLogging() can potentially cause problems and I don't see much benefit of the logging it does. Web app already logs all cameras, mics and speakers earlier and we log if anything changes, so we don't need it being logged during meeting join.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed `getDevices` export from meetings plugin
	- Eliminated device logging functionality
	- Removed related test cases for device logging and error handling

- **Tests**
	- Deleted test suites related to device logging and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->