### PR TITLE
Fix tooling for versioning

### DIFF
--- a/packages/@webex/webex-core/src/index.js
+++ b/packages/@webex/webex-core/src/index.js
@@ -8,6 +8,7 @@
  * federation requirements, and instead send requests to the environmentally-
  * assigned urls.
  */
+
 import './plugins/logger';
 import './lib/credentials';
 import './lib/services';

--- a/packages/tools/package/src/models/package/package.ts
+++ b/packages/tools/package/src/models/package/package.ts
@@ -166,7 +166,14 @@ class Package {
       .then((packageInfo) => {
         this.data.packageInfo = packageInfo;
 
-        const tagVersion = packageInfo['dist-tags'][tag];
+        let updatedPackageInfo = packageInfo;
+
+        if (updatedPackageInfo.version.includes('-')) {
+          const [version] = updatedPackageInfo.version.split('-');
+          updatedPackageInfo = { ...updatedPackageInfo, version };
+        }
+
+        const tagVersion = updatedPackageInfo['dist-tags'][tag];
 
         if (tagVersion) {
           this.data.version = Package.parseVersionStringToObject(tagVersion);
@@ -174,7 +181,7 @@ class Package {
           return this;
         }
 
-        this.data.version = Package.parseVersionStringToObject(`${packageInfo.version}-${tag}.0`);
+        this.data.version = Package.parseVersionStringToObject(`${updatedPackageInfo.version}-${tag}.0`);
 
         return this;
       });

--- a/packages/tools/package/test/module/package/package.test.js
+++ b/packages/tools/package/test/module/package/package.test.js
@@ -327,6 +327,14 @@ describe('Package', () => {
         },
       };
 
+      const inspectResultsWithTagInVersion = {
+        version: '4.5.6-example-tag.1',
+        'dist-tags': {
+          [exampleTag]: '1.2.3-example-tag.4',
+          [Package.CONSTANTS.STABLE_TAG]: '4.5.6',
+        },
+      };
+
       const spies = {};
 
       beforeEach(() => {
@@ -366,6 +374,18 @@ describe('Package', () => {
               .toHaveBeenCalledWith(inspectResults['dist-tags'][exampleTag]);
           }),
       );
+
+      it('should call "parseVersionStringToObject()" with only version if pre-release tag is in version', async () => {
+        spies.Package = {
+          inspect: jest.spyOn(Package, 'inspect').mockResolvedValue(inspectResultsWithTagInVersion),
+          parseVersionStringToObject: jest.spyOn(Package, 'parseVersionStringToObject').mockReturnValue(exampleVersion),
+        };
+
+        await pack.inspect();
+        expect(spies.Package.parseVersionStringToObject).toHaveBeenCalledTimes(1);
+        expect(spies.Package.parseVersionStringToObject)
+          .toHaveBeenCalledWith(inspectResults['dist-tags'][exampleTag]);
+      });
 
       it(
         'should call "Package.parseVersionStringToObject()" with the new tag version if the tag version was not found',


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #Adhoc

## This pull request addresses

- When there is a pre-release tag in the latest tag from npm, the tooling was ignoring the passed tag in the cli and using the tag from npm which causes packages like plugin-presence, legacy-tools to also publish to next tag

## by making the following changes

- Added a sanitization step to the inspect command, where if the latest version has some pre-release tag init, it will clear and only consider the major.minor.release as the version. This will allow us to work with packages that dont have a proper latest version in the latest tag

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
- Ran sync, increment, inspect command in the tooling to ensure only the passed tag is considered for the newer versions
![Screenshot 2025-01-20 at 11 28 25 PM](https://github.com/user-attachments/assets/8cb412aa-a202-4aaf-bbcc-76e56982a420)


### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
