### PR TITLE
fix(plugin-meetings): remove all llm events added by meetings when meeting is cleaned up

### DIFF
--- a/packages/@webex/plugin-meetings/src/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/index.ts
@@ -120,6 +120,10 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
     }
   }
 
+  /**
+   * Remove event listeners
+   * @returns {undefined}
+   */
   public deregisterEvents() {
     if (this.hasSubscribedToEvents) {
       // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/index.ts
@@ -120,6 +120,13 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
     }
   }
 
+  public deregisterEvents() {
+    if (this.hasSubscribedToEvents) {
+      // @ts-ignore
+      this.webex.internal.llm.off('event:relay.event', this.eventDataProcessor);
+    }
+  }
+
   /**
    * set locusUrl
    * @param {string} locusUrl

--- a/packages/@webex/plugin-meetings/src/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/index.ts
@@ -123,7 +123,11 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
   public deregisterEvents() {
     if (this.hasSubscribedToEvents) {
       // @ts-ignore
+      this.webex.internal.mercury.off('event:locus.approval_request', this.eventCommandProcessor);
+
+      // @ts-ignore
       this.webex.internal.llm.off('event:relay.event', this.eventDataProcessor);
+
       this.hasSubscribedToEvents = false;
     }
   }

--- a/packages/@webex/plugin-meetings/src/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/src/annotation/index.ts
@@ -124,6 +124,7 @@ class AnnotationChannel extends WebexPlugin implements IAnnotationChannel {
     if (this.hasSubscribedToEvents) {
       // @ts-ignore
       this.webex.internal.llm.off('event:relay.event', this.eventDataProcessor);
+      this.hasSubscribedToEvents = false;
     }
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5349,8 +5349,8 @@ export default class Meeting extends StatelessWebexPlugin {
         this.voiceaListenerCallbacks[VOICEAEVENTS.NEW_CAPTION]
       );
 
-      // @ts-ignore - fix types
-      this.webex.internal.voicea.degisterEvents();
+      // @ts-ignore
+      this.webex.internal.voicea.deregisterEvents();
 
       this.areVoiceaEventsSetup = false;
       this.triggerStopReceivingTranscriptionEvent();
@@ -8702,6 +8702,8 @@ export default class Meeting extends StatelessWebexPlugin {
       this.stopTranscription();
       this.transcription = undefined;
     }
+
+    this.annotation.deregisterEvents();
 
     // @ts-ignore - fix types
     this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5295,7 +5295,16 @@ export default class Meeting extends StatelessWebexPlugin {
           (this.config.receiveReactions || options.receiveReactions) &&
           this.isReactionsSupported()
         ) {
-          const {name} = this.members.membersCollection.get(e.data.sender.participantId);
+          const member = this.members.membersCollection.get(e.data.sender.participantId);
+          if (!member) {
+            // @ts-ignore -- fix type
+            LoggerProxy.logger.warn(
+              `Meeting:index#processRelayEvent --> Skipping handling of ${REACTION_RELAY_TYPES.REACTION} for ${this.id}. participantId ${e.data.sender.participantId} does not exist in membersCollection.`
+            );
+            break;
+          }
+
+          const {name} = member;
           const processedReaction: ProcessedReaction = {
             reaction: e.data.reaction,
             sender: {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5349,6 +5349,9 @@ export default class Meeting extends StatelessWebexPlugin {
         this.voiceaListenerCallbacks[VOICEAEVENTS.NEW_CAPTION]
       );
 
+      // @ts-ignore - fix types
+      this.webex.internal.voicea.degisterEvents();
+
       this.areVoiceaEventsSetup = false;
       this.triggerStopReceivingTranscriptionEvent();
     }
@@ -8699,6 +8702,9 @@ export default class Meeting extends StatelessWebexPlugin {
       this.stopTranscription();
       this.transcription = undefined;
     }
+
+    // @ts-ignore - fix types
+    this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);
   };
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
@@ -417,14 +417,24 @@ describe('live-annotation', () => {
     describe('#deregisterEvents', () => {
       let llmOn;
       let llmOff;
+      let mercuryOn;
+      let mercuryOff;
 
       beforeEach(() => {
         llmOn = sinon.spy(webex.internal.llm, 'on');
         llmOff = sinon.spy(webex.internal.llm, 'off');
+        mercuryOn = sinon.spy(webex.internal.mercury, 'on');
+        mercuryOff = sinon.spy(webex.internal.mercury, 'off');
       });
 
       it('cleans up events', () => {
         annotationService.locusUrlUpdate(locusUrl);
+        assert.calledWith(
+          mercuryOn,
+          'event:locus.approval_request',
+          annotationService.eventCommandProcessor,
+          annotationService
+        );
         assert.calledWith(
           llmOn,
           'event:relay.event',
@@ -435,12 +445,18 @@ describe('live-annotation', () => {
 
         annotationService.deregisterEvents();
         assert.calledWith(llmOff, 'event:relay.event', annotationService.eventDataProcessor);
+        assert.calledWith(
+          mercuryOff,
+          'event:locus.approval_request',
+          annotationService.eventCommandProcessor
+        );
         assert.match(annotationService.hasSubscribedToEvents, false);
       });
 
       it('does not call llm off if events have not been registered', () => {
         annotationService.deregisterEvents();
         assert.notCalled(llmOff);
+        assert.notCalled(mercuryOff);
       });
     });
   });

--- a/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/annotation/index.ts
@@ -413,6 +413,35 @@ describe('live-annotation', () => {
         });
       });
     });
-  });
 
+    describe('#deregisterEvents', () => {
+      let llmOn;
+      let llmOff;
+
+      beforeEach(() => {
+        llmOn = sinon.spy(webex.internal.llm, 'on');
+        llmOff = sinon.spy(webex.internal.llm, 'off');
+      });
+
+      it('cleans up events', () => {
+        annotationService.locusUrlUpdate(locusUrl);
+        assert.calledWith(
+          llmOn,
+          'event:relay.event',
+          annotationService.eventDataProcessor,
+          annotationService
+        );
+        assert.match(annotationService.hasSubscribedToEvents, true);
+
+        annotationService.deregisterEvents();
+        assert.calledWith(llmOff, 'event:relay.event', annotationService.eventDataProcessor);
+        assert.match(annotationService.hasSubscribedToEvents, false);
+      });
+
+      it('does not call llm off if events have not been registered', () => {
+        annotationService.deregisterEvents();
+        assert.notCalled(llmOff);
+      });
+    });
+  });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1238,14 +1238,13 @@ describe('plugin-meetings', () => {
           webex.internal.voicea.off = sinon.stub();
           webex.internal.voicea.listenToEvents = sinon.stub();
           webex.internal.voicea.turnOnCaptions = sinon.stub();
-          webex.internal.voicea.degisterEvents = sinon.stub();
+          webex.internal.voicea.deregisterEvents = sinon.stub();
         });
 
         it('should stop listening to voicea events and also trigger a stop event', () => {
           meeting.stopTranscription();
           assert.equal(webex.internal.voicea.off.callCount, 4);
           assert.equal(meeting.areVoiceaEventsSetup, false);
-          assert.called(webex.internal.voicea.degisterEvents);
           assert.calledWith(
             TriggerProxy.trigger,
             sinon.match.instanceOf(Meeting),
@@ -1266,7 +1265,6 @@ describe('plugin-meetings', () => {
           webex.internal.voicea.off = sinon.stub();
           webex.internal.voicea.setCaptionLanguage = sinon.stub();
           webex.internal.voicea.requestLanguage = sinon.stub();
-          webex.internal.voicea.degisterEvents = sinon.stub();
         });
 
         afterEach(() => {
@@ -1337,7 +1335,6 @@ describe('plugin-meetings', () => {
           meeting.transcription = {languageOptions: {}};
           webex.internal.voicea.on = sinon.stub();
           webex.internal.voicea.off = sinon.stub();
-          webex.internal.voicea.degisterEvents = sinon.stub();
           webex.internal.voicea.setSpokenLanguage = sinon.stub();
           meeting.roles = ['MODERATOR'];
         });
@@ -5059,8 +5056,10 @@ describe('plugin-meetings', () => {
           meeting.logger.error = sinon.stub().returns(true);
           meeting.updateLLMConnection = sinon.stub().returns(Promise.resolve());
           webex.internal.voicea.off = sinon.stub().returns(true);
-          webex.internal.voicea.degisterEvents = sinon.stub();
+          meeting.stopTranscription = sinon.stub();
+          meeting.transcription = {};
 
+          meeting.annotation.deregisterEvents = sinon.stub();
           webex.internal.llm.off = sinon.stub();
 
           // A meeting needs to be joined to leave
@@ -5082,11 +5081,9 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.closePeerConnections);
           assert.calledOnce(meeting.unsetRemoteStreams);
           assert.calledOnce(meeting.unsetPeerConnections);
-          assert.calledWith(
-            webex.internal.llm.off,
-            'event:relay.event',
-            sinon.match.instanceOf(Function)
-          );
+          assert.calledOnce(meeting.stopTranscription);
+          assert.calledOnce(meeting.annotation.deregisterEvents);
+          assert.calledWith(webex.internal.llm.off, 'event:relay.event', meeting.processRelayEvent);
         });
 
         it('should reset call diagnostic latencies correctly', async () => {
@@ -6969,6 +6966,7 @@ describe('plugin-meetings', () => {
           meeting.transcription = {};
           meeting.stopTranscription = sinon.stub();
 
+          meeting.annotation.deregisterEvents = sinon.stub();
           webex.internal.llm.off = sinon.stub();
 
           // A meeting needs to be joined to end
@@ -6991,11 +6989,9 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting?.unsetRemoteStreams);
           assert.calledOnce(meeting?.unsetPeerConnections);
           assert.calledOnce(meeting?.stopTranscription);
-          assert.calledWith(
-            webex.internal.llm.off,
-            'event:relay.event',
-            sinon.match.instanceOf(Function)
-          );
+
+          assert.called(meeting.annotation.deregisterEvents);
+          assert.calledWith(webex.internal.llm.off, 'event:relay.event', meeting.processRelayEvent);
         });
       });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1238,12 +1238,14 @@ describe('plugin-meetings', () => {
           webex.internal.voicea.off = sinon.stub();
           webex.internal.voicea.listenToEvents = sinon.stub();
           webex.internal.voicea.turnOnCaptions = sinon.stub();
+          webex.internal.voicea.degisterEvents = sinon.stub();
         });
 
         it('should stop listening to voicea events and also trigger a stop event', () => {
           meeting.stopTranscription();
           assert.equal(webex.internal.voicea.off.callCount, 4);
           assert.equal(meeting.areVoiceaEventsSetup, false);
+          assert.called(webex.internal.voicea.degisterEvents);
           assert.calledWith(
             TriggerProxy.trigger,
             sinon.match.instanceOf(Meeting),
@@ -1264,6 +1266,7 @@ describe('plugin-meetings', () => {
           webex.internal.voicea.off = sinon.stub();
           webex.internal.voicea.setCaptionLanguage = sinon.stub();
           webex.internal.voicea.requestLanguage = sinon.stub();
+          webex.internal.voicea.degisterEvents = sinon.stub();
         });
 
         afterEach(() => {
@@ -1334,6 +1337,7 @@ describe('plugin-meetings', () => {
           meeting.transcription = {languageOptions: {}};
           webex.internal.voicea.on = sinon.stub();
           webex.internal.voicea.off = sinon.stub();
+          webex.internal.voicea.degisterEvents = sinon.stub();
           webex.internal.voicea.setSpokenLanguage = sinon.stub();
           meeting.roles = ['MODERATOR'];
         });
@@ -5055,6 +5059,9 @@ describe('plugin-meetings', () => {
           meeting.logger.error = sinon.stub().returns(true);
           meeting.updateLLMConnection = sinon.stub().returns(Promise.resolve());
           webex.internal.voicea.off = sinon.stub().returns(true);
+          webex.internal.voicea.degisterEvents = sinon.stub();
+
+          webex.internal.llm.off = sinon.stub();
 
           // A meeting needs to be joined to leave
           meeting.meetingState = 'ACTIVE';
@@ -5075,6 +5082,11 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.closePeerConnections);
           assert.calledOnce(meeting.unsetRemoteStreams);
           assert.calledOnce(meeting.unsetPeerConnections);
+          assert.calledWith(
+            webex.internal.llm.off,
+            'event:relay.event',
+            sinon.match.instanceOf(Function)
+          );
         });
 
         it('should reset call diagnostic latencies correctly', async () => {
@@ -6957,6 +6969,8 @@ describe('plugin-meetings', () => {
           meeting.transcription = {};
           meeting.stopTranscription = sinon.stub();
 
+          webex.internal.llm.off = sinon.stub();
+
           // A meeting needs to be joined to end
           meeting.meetingState = 'ACTIVE';
           meeting.state = 'JOINED';
@@ -6977,6 +6991,11 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting?.unsetRemoteStreams);
           assert.calledOnce(meeting?.unsetPeerConnections);
           assert.calledOnce(meeting?.stopTranscription);
+          assert.calledWith(
+            webex.internal.llm.off,
+            'event:relay.event',
+            sinon.match.instanceOf(Function)
+          );
         });
       });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1567,6 +1567,55 @@ describe('plugin-meetings', () => {
             fakeProcessedReaction
           );
         });
+
+        it('should fail quietly if participantId does not exist in membersCollection', () => {
+          LoggerProxy.logger.warn = sinon.stub();
+          meeting.isReactionsSupported = sinon.stub().returns(true);
+          meeting.config.receiveReactions = true;
+          const fakeSendersName = 'Fake reactors name';
+          const fakeReactionPayload = {
+            type: 'fake_type',
+            codepoints: 'fake_codepoints',
+            shortcodes: 'fake_shortcodes',
+            tone: {
+              type: 'fake_tone_type',
+              codepoints: 'fake_tone_codepoints',
+              shortcodes: 'fake_tone_shortcodes',
+            },
+          };
+          const fakeSenderPayload = {
+            participantId: 'fake_participant_id',
+          };
+          const fakeProcessedReaction = {
+            reaction: fakeReactionPayload,
+            sender: {
+              id: fakeSenderPayload.participantId,
+              name: fakeSendersName,
+            },
+          };
+          const fakeRelayEvent = {
+            data: {
+              relayType: REACTION_RELAY_TYPES.REACTION,
+              reaction: fakeReactionPayload,
+              sender: fakeSenderPayload,
+            },
+          };
+          meeting.processRelayEvent(fakeRelayEvent);
+          assert.calledWith(
+            LoggerProxy.logger.warn,
+            `Meeting:index#processRelayEvent --> Skipping handling of react for ${meeting.id}. participantId fake_participant_id does not exist in membersCollection.`
+          );
+          assert.neverCalledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {
+              file: 'meeting/index',
+              function: 'join',
+            },
+            EVENT_TRIGGERS.MEETING_RECEIVE_REACTIONS,
+            fakeProcessedReaction
+          );
+        });
       });
 
       describe('#handleLLMOnline', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [#SPARK-603924](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-603924)

## This pull request addresses

Meeting reactions not being recieved when a user joins a second meeting without refreshing the browser.

## by making the following changes

Deregister llm `event:relay.event` events added by meeting, voicea and annotations when meeting gets cleaned up as these are not being cleaned up when a meeting is left/ended.

Also, deregisters the mercury events when clearing meeting data as well.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Updated unit tests
- Manual testing with locally linking with Cantina (follow steps in Jira comment to replicate)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
