### PR TITLE
fix(calling): batched the SCIM query to fix complex query issue

### DIFF
--- a/packages/calling/src/Contacts/ContactsClient.ts
+++ b/packages/calling/src/Contacts/ContactsClient.ts
@@ -368,14 +368,26 @@ export class ContactsClient implements IContacts {
       // Resolve cloud contacts
       if (Object.keys(cloudContactsMap).length) {
         const contactIdList = Object.keys(cloudContactsMap);
-        const query = contactIdList.map((item) => `${SCIM_ID_FILTER} "${item}"`).join(OR);
-        const result = await scimQuery(query);
-        const resolvedContacts = this.resolveCloudContacts(
-          cloudContactsMap,
-          result.body as SCIMListResponse
-        );
-        if (resolvedContacts) {
-          resolvedContacts.map((item) => contactList.push(item));
+        const TOTAL_CONTACTS = contactIdList.length;
+        const MAX_CONTACTS_PER_QUERY = 50;
+
+        for (let i = 0; i < TOTAL_CONTACTS; i += MAX_CONTACTS_PER_QUERY) {
+          const contactIdListChunk = contactIdList.slice(i, i + MAX_CONTACTS_PER_QUERY);
+          const query = contactIdListChunk.map((item) => `${SCIM_ID_FILTER} "${item}"`).join(OR);
+          const result = await scimQuery(query);
+
+          const slicedCloudContactsMap = Object.fromEntries(
+            Object.entries(cloudContactsMap).slice(i, i + MAX_CONTACTS_PER_QUERY)
+          );
+
+          const resolvedContacts = this.resolveCloudContacts(
+            slicedCloudContactsMap,
+            result.body as SCIMListResponse
+          );
+
+          if (resolvedContacts) {
+            resolvedContacts.forEach((item) => contactList.push(item));
+          }
         }
       }
 

--- a/packages/calling/src/Contacts/ContactsClient.ts
+++ b/packages/calling/src/Contacts/ContactsClient.ts
@@ -368,25 +368,32 @@ export class ContactsClient implements IContacts {
       // Resolve cloud contacts
       if (Object.keys(cloudContactsMap).length) {
         const contactIdList = Object.keys(cloudContactsMap);
-        const TOTAL_CONTACTS = contactIdList.length;
+        const totalContacts = contactIdList.length;
         const MAX_CONTACTS_PER_QUERY = 50;
 
-        for (let i = 0; i < TOTAL_CONTACTS; i += MAX_CONTACTS_PER_QUERY) {
-          const contactIdListChunk = contactIdList.slice(i, i + MAX_CONTACTS_PER_QUERY);
-          const query = contactIdListChunk.map((item) => `${SCIM_ID_FILTER} "${item}"`).join(OR);
-          const result = await scimQuery(query);
+        for (let i = 0; i < totalContacts; i += MAX_CONTACTS_PER_QUERY) {
+          try {
+            const contactIdListChunk = contactIdList.slice(i, i + MAX_CONTACTS_PER_QUERY);
+            const query = contactIdListChunk.map((item) => `${SCIM_ID_FILTER} "${item}"`).join(OR);
+            const result = await scimQuery(query);
 
-          const slicedCloudContactsMap = Object.fromEntries(
-            Object.entries(cloudContactsMap).slice(i, i + MAX_CONTACTS_PER_QUERY)
-          );
+            const slicedCloudContactsMap = Object.fromEntries(
+              Object.entries(cloudContactsMap).slice(i, i + MAX_CONTACTS_PER_QUERY)
+            );
 
-          const resolvedContacts = this.resolveCloudContacts(
-            slicedCloudContactsMap,
-            result.body as SCIMListResponse
-          );
+            const resolvedContacts = this.resolveCloudContacts(
+              slicedCloudContactsMap,
+              result.body as SCIMListResponse
+            );
 
-          if (resolvedContacts) {
-            resolvedContacts.forEach((item) => contactList.push(item));
+            if (resolvedContacts) {
+              resolvedContacts.forEach((item) => contactList.push(item));
+            }
+          } catch (error: any) {
+            log.warn(
+              `Error processing contact chunk ${i}-${i + MAX_CONTACTS_PER_QUERY}`,
+              loggerContext
+            );
           }
         }
       }


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-604263](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-604263) >

## This pull request addresses

The SCIM api was throwing a complex query error when passed a huge number of query params

## by making the following changes

Batched the number of user ids in the query params to make SCIM call as a result we don't send a huge number of ids at once and instead collect the batched result and return them at once.

In the screenshots below you can see that for 63 contacts, 2 SCIM requests are sent with response of 50 and 13 respectively.

**Note**: Have attached the HAR file on the JIRA for reference (For the screenshots shown below)

**Screenshots**

<img width="1712" alt="Screenshot 2025-01-28 at 2 48 27 PM" src="https://github.com/user-attachments/assets/7c35906b-9fc3-41b8-99bb-2cf73de40ea4" />

<img width="1719" alt="Screenshot 2025-01-28 at 2 48 19 PM" src="https://github.com/user-attachments/assets/6a56c179-ea8a-43df-b78e-45228d57e41a" />

<img width="1723" alt="Screenshot 2025-01-28 at 2 48 08 PM" src="https://github.com/user-attachments/assets/bbeee9ce-8e1c-4511-a759-30f6559bc5b6" />


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

Performed the following manual tests

Started the query string length with 20 user ids then kept on increasing by 10. It failed when used 60 user ids in the query string, till 50 it worked fine so, kept the PAGE_SIZE to 50.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
