### PR TITLE
fix: refactored how incremental logs work

### DIFF
--- a/packages/@webex/plugin-logger/test/unit/spec/logger.js
+++ b/packages/@webex/plugin-logger/test/unit/spec/logger.js
@@ -82,21 +82,21 @@ describe('plugin-logger', () => {
 
     it('stores the specified message in the log buffer', () => {
       webex.logger.log('test');
-      assert.lengthOf(webex.logger.buffer, 1);
-      assert.match(webex.logger.buffer[0][3], /test/);
+      assert.lengthOf(webex.logger.buffer.buffer, 1);
+      assert.match(webex.logger.buffer.buffer[0][3], /test/);
     });
 
     it('adds the date to the beggining of the buffer entry', () => {
       webex.logger.log('test date');
 
       // Convert string back to date object
-      const logDate = new Date(webex.logger.buffer[0][1]);
+      const logDate = new Date(webex.logger.buffer.buffer[0][1]);
 
       // eslint-disable-next-line no-restricted-globals
-      assert.isTrue(logDate instanceof Date && isNaN(webex.logger.buffer[0][1]));
-      assert.isString(webex.logger.buffer[0][0]);
-      assert.isString(webex.logger.buffer[0][1]);
-      assert.match(webex.logger.buffer[0][3], /test date/);
+      assert.isTrue(logDate instanceof Date && isNaN(webex.logger.buffer.buffer[0][1]));
+      assert.isString(webex.logger.buffer.buffer[0][0]);
+      assert.isString(webex.logger.buffer.buffer[0][1]);
+      assert.match(webex.logger.buffer.buffer[0][3], /test date/);
     });
 
     it('stores the specified message in the client and sdk log buffer', () => {
@@ -104,28 +104,28 @@ describe('plugin-logger', () => {
       webex.config.logger.clientName = 'someclient';
       webex.logger.log('testsdk');
       webex.logger.client_log('testclient');
-      assert.lengthOf(webex.logger.sdkBuffer, 1);
-      assert.isString(webex.logger.sdkBuffer[0][0]);
-      assert.isString(webex.logger.sdkBuffer[0][1]);
-      assert.match(webex.logger.sdkBuffer[0][2], /wx-js-sdk/);
-      assert.match(webex.logger.sdkBuffer[0][3], /testsdk/);
-      assert.lengthOf(webex.logger.clientBuffer, 1);
-      assert.isString(webex.logger.clientBuffer[0][0]);
-      assert.isString(webex.logger.clientBuffer[0][1]);
-      assert.match(webex.logger.clientBuffer[0][2], /someclient/);
-      assert.match(webex.logger.clientBuffer[0][3], /testclient/);
+      assert.lengthOf(webex.logger.sdkBuffer.buffer, 1);
+      assert.isString(webex.logger.sdkBuffer.buffer[0][0]);
+      assert.isString(webex.logger.sdkBuffer.buffer[0][1]);
+      assert.match(webex.logger.sdkBuffer.buffer[0][2], /wx-js-sdk/);
+      assert.match(webex.logger.sdkBuffer.buffer[0][3], /testsdk/);
+      assert.lengthOf(webex.logger.clientBuffer.buffer, 1);
+      assert.isString(webex.logger.clientBuffer.buffer[0][0]);
+      assert.isString(webex.logger.clientBuffer.buffer[0][1]);
+      assert.match(webex.logger.clientBuffer.buffer[0][2], /someclient/);
+      assert.match(webex.logger.clientBuffer.buffer[0][3], /testclient/);
     });
 
     it('prevents the buffer from overflowing', () => {
       webex.config.logger.historyLength = 2;
       webex.logger.log(1);
-      assert.lengthOf(webex.logger.buffer, 1);
+      assert.lengthOf(webex.logger.buffer.buffer, 1);
       webex.logger.log(2);
-      assert.lengthOf(webex.logger.buffer, 2);
+      assert.lengthOf(webex.logger.buffer.buffer, 2);
       webex.logger.log(3);
-      assert.lengthOf(webex.logger.buffer, 2);
-      assert.equal(webex.logger.buffer[0][3], 2);
-      assert.equal(webex.logger.buffer[1][3], 3);
+      assert.lengthOf(webex.logger.buffer.buffer, 2);
+      assert.equal(webex.logger.buffer.buffer[0][3], 2);
+      assert.equal(webex.logger.buffer.buffer[1][3], 3);
     });
 
     it('prevents the client and sdk buffer from overflowing', () => {
@@ -133,20 +133,20 @@ describe('plugin-logger', () => {
       webex.config.logger.separateLogBuffers = true;
       webex.logger.log(1);
       webex.logger.client_log(3);
-      assert.lengthOf(webex.logger.sdkBuffer, 1);
-      assert.lengthOf(webex.logger.clientBuffer, 1);
+      assert.lengthOf(webex.logger.sdkBuffer.buffer, 1);
+      assert.lengthOf(webex.logger.clientBuffer.buffer, 1);
       webex.logger.log(2);
       webex.logger.client_log(2);
-      assert.lengthOf(webex.logger.sdkBuffer, 2);
-      assert.lengthOf(webex.logger.clientBuffer, 2);
+      assert.lengthOf(webex.logger.sdkBuffer.buffer, 2);
+      assert.lengthOf(webex.logger.clientBuffer.buffer, 2);
       webex.logger.log(3);
       webex.logger.client_log(1);
-      assert.lengthOf(webex.logger.sdkBuffer, 2);
-      assert.lengthOf(webex.logger.clientBuffer, 2);
-      assert.equal(webex.logger.sdkBuffer[0][3], 2);
-      assert.equal(webex.logger.sdkBuffer[1][3], 3);
-      assert.equal(webex.logger.sdkBuffer[0][3], 2);
-      assert.equal(webex.logger.clientBuffer[1][3], 1);
+      assert.lengthOf(webex.logger.sdkBuffer.buffer, 2);
+      assert.lengthOf(webex.logger.clientBuffer.buffer, 2);
+      assert.equal(webex.logger.sdkBuffer.buffer[0][3], 2);
+      assert.equal(webex.logger.sdkBuffer.buffer[1][3], 3);
+      assert.equal(webex.logger.sdkBuffer.buffer[0][3], 2);
+      assert.equal(webex.logger.clientBuffer.buffer[1][3], 1);
     });
 
     // Node handles custom errors correctly, so this test is browser specific
@@ -164,7 +164,7 @@ describe('plugin-logger', () => {
       });
 
       webex.logger.log(error);
-      assert.lengthOf(webex.logger.buffer, 1);
+      assert.lengthOf(webex.logger.buffer.buffer, 1);
       assert.match(console.log.args[0][1], /WebexHttpError/);
     });
 
@@ -182,8 +182,8 @@ describe('plugin-logger', () => {
       });
 
       webex.logger.log(error);
-      assert.lengthOf(webex.logger.buffer, 1);
-      assert.match(webex.logger.buffer[0][3], /WebexHttpError/g);
+      assert.lengthOf(webex.logger.buffer.buffer, 1);
+      assert.match(webex.logger.buffer.buffer[0][3], /WebexHttpError/g);
     });
 
     it('formats objects as strings passed to the logger for readability not [Object object]', async () => {
@@ -200,12 +200,12 @@ describe('plugin-logger', () => {
       }
 
       webex.logger.log('foo', 'bar', obj);
-      assert.lengthOf(webex.logger.buffer, 1);
-      assert.lengthOf(webex.logger.buffer[0], 6);
-      assert.deepEqual(webex.logger.buffer[0][2], 'wx-js-sdk');
-      assert.deepEqual(webex.logger.buffer[0][3], 'foo');
-      assert.deepEqual(webex.logger.buffer[0][4], 'bar');
-      assert.deepEqual(webex.logger.buffer[0][5], '{"headers":{"trackingid":"123"},"test":"object","nested":{"test2":"object2"}}');
+      assert.lengthOf(webex.logger.buffer.buffer, 1);
+      assert.lengthOf(webex.logger.buffer.buffer[0], 6);
+      assert.deepEqual(webex.logger.buffer.buffer[0][2], 'wx-js-sdk');
+      assert.deepEqual(webex.logger.buffer.buffer[0][3], 'foo');
+      assert.deepEqual(webex.logger.buffer.buffer[0][4], 'bar');
+      assert.deepEqual(webex.logger.buffer.buffer[0][5], '{"headers":{"trackingid":"123"},"test":"object","nested":{"test2":"object2"}}');
     });
 
     it('formats objects as strings passed to the logger for readability not [Object object] w/ circular reference', async () => {
@@ -224,12 +224,12 @@ describe('plugin-logger', () => {
       obj.selfReference = obj;
 
       webex.logger.log('foo', 'bar', obj);
-      assert.lengthOf(webex.logger.buffer, 1);
-      assert.lengthOf(webex.logger.buffer[0], 6);
-      assert.deepEqual(webex.logger.buffer[0][2], 'wx-js-sdk');
-      assert.deepEqual(webex.logger.buffer[0][3], 'foo');
-      assert.deepEqual(webex.logger.buffer[0][4], 'bar');
-      assert.deepEqual(webex.logger.buffer[0][5], '{"headers":{"trackingid":"123"},"test":"object","nested":{"test2":"object2"}}');
+      assert.lengthOf(webex.logger.buffer.buffer, 1);
+      assert.lengthOf(webex.logger.buffer.buffer[0], 6);
+      assert.deepEqual(webex.logger.buffer.buffer[0][2], 'wx-js-sdk');
+      assert.deepEqual(webex.logger.buffer.buffer[0][3], 'foo');
+      assert.deepEqual(webex.logger.buffer.buffer[0][4], 'bar');
+      assert.deepEqual(webex.logger.buffer.buffer[0][5], '{"headers":{"trackingid":"123"},"test":"object","nested":{"test2":"object2"}}');
     });
 
     it('formats Errors correctly', async () => {
@@ -237,10 +237,10 @@ describe('plugin-logger', () => {
       const err = new Error('fake error for testing')
 
       webex.logger.log('I got this error:', err);
-      assert.lengthOf(webex.logger.buffer, 1);
-      assert.deepEqual(webex.logger.buffer[0][2], 'wx-js-sdk');
-      assert.deepEqual(webex.logger.buffer[0][3], 'I got this error:');
-      assert.deepEqual(webex.logger.buffer[0][4], 'Error: fake error for testing');
+      assert.lengthOf(webex.logger.buffer.buffer, 1);
+      assert.deepEqual(webex.logger.buffer.buffer[0][2], 'wx-js-sdk');
+      assert.deepEqual(webex.logger.buffer.buffer[0][3], 'I got this error:');
+      assert.deepEqual(webex.logger.buffer.buffer[0][4], 'Error: fake error for testing');
 
     });
   });
@@ -1206,7 +1206,7 @@ describe('plugin-logger', () => {
       webex.logger.logToBuffer('sdklog');
       webex.logger.client_logToBuffer('clientlog');
 
-      assert.lengthOf(webex.logger.buffer, 2);
+      assert.lengthOf(webex.logger.buffer.buffer, 2);
 
       logSpies.forEach((logSpy) => {
         assert.notCalled(logSpy);
@@ -1219,8 +1219,8 @@ describe('plugin-logger', () => {
       webex.logger.logToBuffer('sdklog');
       webex.logger.client_logToBuffer('clientlog');
 
-      assert.lengthOf(webex.logger.sdkBuffer, 1);
-      assert.lengthOf(webex.logger.clientBuffer, 1);
+      assert.lengthOf(webex.logger.sdkBuffer.buffer, 1);
+      assert.lengthOf(webex.logger.clientBuffer.buffer, 1);
 
       logSpies.forEach((logSpy) => {
         assert.notCalled(logSpy);
@@ -1229,7 +1229,7 @@ describe('plugin-logger', () => {
   });
   describe('limit', () => {
     function logMessages() {
-      return webex.logger.buffer.map((item) => item[3]);
+      return webex.logger.buffer.buffer.map((item) => item[3]);
     }
 
     it('can be increased in runtime', () => {
@@ -1239,12 +1239,12 @@ describe('plugin-logger', () => {
       }
 
       assert.deepEqual(logMessages(), [5, 6, 7, 8, 9]);
-      assert.lengthOf(webex.logger.buffer, 5);
+      assert.lengthOf(webex.logger.buffer.buffer, 5);
 
       webex.logger.config.historyLength = 10;
       webex.logger.log(10);
       assert.deepEqual(logMessages(), [5, 6, 7, 8, 9, 10]);
-      assert.lengthOf(webex.logger.buffer, 6);
+      assert.lengthOf(webex.logger.buffer.buffer, 6);
     });
 
     it('can be decreased in runtime', () => {
@@ -1253,16 +1253,16 @@ describe('plugin-logger', () => {
       }
 
       assert.deepEqual(logMessages(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-      assert.lengthOf(webex.logger.buffer, 10);
+      assert.lengthOf(webex.logger.buffer.buffer, 10);
 
       webex.logger.config.historyLength = 5;
 
       // Log buffer truncated when the next log added
-      assert.lengthOf(webex.logger.buffer, 10);
+      assert.lengthOf(webex.logger.buffer.buffer, 10);
 
       webex.logger.log(10);
       assert.deepEqual(logMessages(), [6, 7, 8, 9, 10]);
-      assert.lengthOf(webex.logger.buffer, 5);
+      assert.lengthOf(webex.logger.buffer.buffer, 5);
     });
   });
 });

--- a/packages/@webex/plugin-logger/test/unit/spec/logger.js
+++ b/packages/@webex/plugin-logger/test/unit/spec/logger.js
@@ -888,6 +888,317 @@ describe('plugin-logger', () => {
 
       checkAscending(logs);
     });
+
+    describe('diff vs full logs', () => {
+      let counter;
+      let clock;
+
+      const doSomeLogs = (count) => {
+        // do alternate logs from client and sdk
+        for (let i = 0; i < count; i += 1) {
+          if (webex.config.logger.separateLogBuffers) {
+            webex.logger.client_log(counter);
+            clock.tick(1000);
+          }
+          webex.logger.log(counter);
+          clock.tick(1000);
+
+          counter += 1;
+        }
+      };
+
+      beforeEach(() => {
+        counter = 0;
+        clock = sinon.useFakeTimers();
+      });
+
+      afterEach(() => {
+        clock.restore();
+      });
+
+      it('sends diff logs correctly (with separateLogBuffers)', async () => {
+        webex.config.logger.separateLogBuffers = true;
+        webex.config.logger.clientName = 'someclient';
+
+        doSomeLogs(5);
+
+        const logs1 = webex.logger.formatLogs({diff: true});
+
+        assert.deepEqual(logs1.split('\n'), [
+          ',1970-01-01T00:00:00.000Z,someclient,0',
+          ',1970-01-01T00:00:01.000Z,wx-js-sdk,0',
+          ',1970-01-01T00:00:02.000Z,someclient,1',
+          ',1970-01-01T00:00:03.000Z,wx-js-sdk,1',
+          ',1970-01-01T00:00:04.000Z,someclient,2',
+          ',1970-01-01T00:00:05.000Z,wx-js-sdk,2',
+          ',1970-01-01T00:00:06.000Z,someclient,3',
+          ',1970-01-01T00:00:07.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:08.000Z,someclient,4',
+          ',1970-01-01T00:00:09.000Z,wx-js-sdk,4',
+        ]);
+
+        // log more lines
+        doSomeLogs(2);
+
+        const logs2 = webex.logger.formatLogs({diff: true});
+
+        // only the logs added after previous call to formatLogs() should be returned
+        assert.deepEqual(logs2.split('\n'), [
+          ',1970-01-01T00:00:10.000Z,someclient,5',
+          ',1970-01-01T00:00:11.000Z,wx-js-sdk,5',
+          ',1970-01-01T00:00:12.000Z,someclient,6',
+          ',1970-01-01T00:00:13.000Z,wx-js-sdk,6',
+        ]);
+
+        // now ask for full logs - it should contain all 15 logs
+        const fullLogs1 = webex.logger.formatLogs();
+
+        assert.deepEqual(fullLogs1.split('\n'), [
+          ',1970-01-01T00:00:00.000Z,someclient,0',
+          ',1970-01-01T00:00:01.000Z,wx-js-sdk,0',
+          ',1970-01-01T00:00:02.000Z,someclient,1',
+          ',1970-01-01T00:00:03.000Z,wx-js-sdk,1',
+          ',1970-01-01T00:00:04.000Z,someclient,2',
+          ',1970-01-01T00:00:05.000Z,wx-js-sdk,2',
+          ',1970-01-01T00:00:06.000Z,someclient,3',
+          ',1970-01-01T00:00:07.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:08.000Z,someclient,4',
+          ',1970-01-01T00:00:09.000Z,wx-js-sdk,4',
+          ',1970-01-01T00:00:10.000Z,someclient,5',
+          ',1970-01-01T00:00:11.000Z,wx-js-sdk,5',
+          ',1970-01-01T00:00:12.000Z,someclient,6',
+          ',1970-01-01T00:00:13.000Z,wx-js-sdk,6',
+        ]);
+
+        // asking for full logs should not affect the next diff
+        const logs3 = webex.logger.formatLogs({diff: true});
+
+        // expect empty logs, because we didn't log anything since previous call to formatLogs with diff=true
+        assert.deepEqual(logs3.split('\n'), ['']);
+
+        // add more logs again
+        doSomeLogs(1);
+
+        const logs4 = webex.logger.formatLogs({diff: true});
+
+        assert.deepEqual(logs4.split('\n'), [
+          ',1970-01-01T00:00:14.000Z,someclient,7',
+          ',1970-01-01T00:00:15.000Z,wx-js-sdk,7',
+        ]);
+
+        // and check that full log contains everything right from the beginning irrespective of any previous calls to formatLogs()
+        const fullLogs2 = webex.logger.formatLogs();
+
+        assert.deepEqual(fullLogs2.split('\n'), [
+          ',1970-01-01T00:00:00.000Z,someclient,0',
+          ',1970-01-01T00:00:01.000Z,wx-js-sdk,0',
+          ',1970-01-01T00:00:02.000Z,someclient,1',
+          ',1970-01-01T00:00:03.000Z,wx-js-sdk,1',
+          ',1970-01-01T00:00:04.000Z,someclient,2',
+          ',1970-01-01T00:00:05.000Z,wx-js-sdk,2',
+          ',1970-01-01T00:00:06.000Z,someclient,3',
+          ',1970-01-01T00:00:07.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:08.000Z,someclient,4',
+          ',1970-01-01T00:00:09.000Z,wx-js-sdk,4',
+          ',1970-01-01T00:00:10.000Z,someclient,5',
+          ',1970-01-01T00:00:11.000Z,wx-js-sdk,5',
+          ',1970-01-01T00:00:12.000Z,someclient,6',
+          ',1970-01-01T00:00:13.000Z,wx-js-sdk,6',
+          ',1970-01-01T00:00:14.000Z,someclient,7',
+          ',1970-01-01T00:00:15.000Z,wx-js-sdk,7',
+        ]);
+      });
+
+      it('sends diff logs correctly (without separateLogBuffers)', async () => {
+        webex.config.logger.separateLogBuffers = false;
+
+        doSomeLogs(5);
+
+        const logs1 = webex.logger.formatLogs({diff: true});
+
+        assert.deepEqual(logs1.split('\n'), [
+          ',1970-01-01T00:00:00.000Z,wx-js-sdk,0',
+          ',1970-01-01T00:00:01.000Z,wx-js-sdk,1',
+          ',1970-01-01T00:00:02.000Z,wx-js-sdk,2',
+          ',1970-01-01T00:00:03.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:04.000Z,wx-js-sdk,4',
+        ]);
+
+        // log more lines
+        doSomeLogs(2);
+
+        const logs2 = webex.logger.formatLogs({diff: true});
+
+        // only the logs added after previous call to formatLogs() should be returned
+        assert.deepEqual(logs2.split('\n'), [
+          ',1970-01-01T00:00:05.000Z,wx-js-sdk,5',
+          ',1970-01-01T00:00:06.000Z,wx-js-sdk,6',
+        ]);
+
+        // now ask for full logs - it should contain all 7 logs
+        const fullLogs1 = webex.logger.formatLogs();
+
+        assert.deepEqual(fullLogs1.split('\n'), [
+          ',1970-01-01T00:00:00.000Z,wx-js-sdk,0',
+          ',1970-01-01T00:00:01.000Z,wx-js-sdk,1',
+          ',1970-01-01T00:00:02.000Z,wx-js-sdk,2',
+          ',1970-01-01T00:00:03.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:04.000Z,wx-js-sdk,4',
+          ',1970-01-01T00:00:05.000Z,wx-js-sdk,5',
+          ',1970-01-01T00:00:06.000Z,wx-js-sdk,6',
+        ]);
+
+        // asking for full logs should not affect the next diff
+        const logs3 = webex.logger.formatLogs({diff: true});
+
+        // expect empty logs, because we didn't log anything since previous call to formatLogs with diff=true
+        assert.deepEqual(logs3.split('\n'), ['']);
+
+        // add more logs again
+        doSomeLogs(1);
+
+        const logs4 = webex.logger.formatLogs({diff: true});
+
+        assert.deepEqual(logs4.split('\n'), [',1970-01-01T00:00:07.000Z,wx-js-sdk,7']);
+
+        // and check that full log contains everything right from the beginning irrespective of any previous calls to formatLogs()
+        const fullLogs2 = webex.logger.formatLogs();
+
+        assert.deepEqual(fullLogs2.split('\n'), [
+          ',1970-01-01T00:00:00.000Z,wx-js-sdk,0',
+          ',1970-01-01T00:00:01.000Z,wx-js-sdk,1',
+          ',1970-01-01T00:00:02.000Z,wx-js-sdk,2',
+          ',1970-01-01T00:00:03.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:04.000Z,wx-js-sdk,4',
+          ',1970-01-01T00:00:05.000Z,wx-js-sdk,5',
+          ',1970-01-01T00:00:06.000Z,wx-js-sdk,6',
+          ',1970-01-01T00:00:07.000Z,wx-js-sdk,7',
+        ]);
+      });
+
+      it('works correctly when history limit is reached (with separateLogBuffers)', async () => {
+        webex.config.logger.separateLogBuffers = true;
+        webex.config.logger.clientName = 'someclient';
+        webex.config.logger.historyLength = 5;
+
+        // fill up the history
+        doSomeLogs(5);
+
+        const logsFull1 = webex.logger.formatLogs({diff: false});
+
+        assert.deepEqual(logsFull1.split('\n'), [
+          ',1970-01-01T00:00:00.000Z,someclient,0',
+          ',1970-01-01T00:00:01.000Z,wx-js-sdk,0',
+          ',1970-01-01T00:00:02.000Z,someclient,1',
+          ',1970-01-01T00:00:03.000Z,wx-js-sdk,1',
+          ',1970-01-01T00:00:04.000Z,someclient,2',
+          ',1970-01-01T00:00:05.000Z,wx-js-sdk,2',
+          ',1970-01-01T00:00:06.000Z,someclient,3',
+          ',1970-01-01T00:00:07.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:08.000Z,someclient,4',
+          ',1970-01-01T00:00:09.000Z,wx-js-sdk,4',
+        ]);
+
+        // log more lines, this should cause removal of the oldest logs
+        doSomeLogs(2);
+
+        const logsFull2 = webex.logger.formatLogs({diff: false});
+
+        const last5Logs = [
+          ',1970-01-01T00:00:04.000Z,someclient,2',
+          ',1970-01-01T00:00:05.000Z,wx-js-sdk,2',
+          ',1970-01-01T00:00:06.000Z,someclient,3',
+          ',1970-01-01T00:00:07.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:08.000Z,someclient,4',
+          ',1970-01-01T00:00:09.000Z,wx-js-sdk,4',
+          ',1970-01-01T00:00:10.000Z,someclient,5',
+          ',1970-01-01T00:00:11.000Z,wx-js-sdk,5',
+          ',1970-01-01T00:00:12.000Z,someclient,6',
+          ',1970-01-01T00:00:13.000Z,wx-js-sdk,6',
+        ];
+        assert.deepEqual(logsFull2.split('\n'), last5Logs);
+
+        // check also the diff logs - they should also have just last 5 logs
+        const logsDiff1 = webex.logger.formatLogs({diff: true});
+        assert.deepEqual(logsDiff1.split('\n'), last5Logs);
+
+        // add more logs again and check full and diff logs
+        doSomeLogs(1);
+
+        const logsFull3 = webex.logger.formatLogs({diff: false});
+
+        assert.deepEqual(logsFull3.split('\n'), [
+          ',1970-01-01T00:00:06.000Z,someclient,3',
+          ',1970-01-01T00:00:07.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:08.000Z,someclient,4',
+          ',1970-01-01T00:00:09.000Z,wx-js-sdk,4',
+          ',1970-01-01T00:00:10.000Z,someclient,5',
+          ',1970-01-01T00:00:11.000Z,wx-js-sdk,5',
+          ',1970-01-01T00:00:12.000Z,someclient,6',
+          ',1970-01-01T00:00:13.000Z,wx-js-sdk,6',
+          ',1970-01-01T00:00:14.000Z,someclient,7',
+          ',1970-01-01T00:00:15.000Z,wx-js-sdk,7',
+        ]);
+
+        const logsDiff2 = webex.logger.formatLogs({diff: true});
+        assert.deepEqual(logsDiff2.split('\n'), [
+          ',1970-01-01T00:00:14.000Z,someclient,7',
+          ',1970-01-01T00:00:15.000Z,wx-js-sdk,7',
+        ]);
+      });
+
+      it('works correctly when history limit is reached (without separateLogBuffers)', async () => {
+        webex.config.logger.separateLogBuffers = false;
+        webex.config.logger.historyLength = 5;
+
+        // fill up the history
+        doSomeLogs(5);
+
+        const logsFull1 = webex.logger.formatLogs({diff: false});
+
+        assert.deepEqual(logsFull1.split('\n'), [
+          ',1970-01-01T00:00:00.000Z,wx-js-sdk,0',
+          ',1970-01-01T00:00:01.000Z,wx-js-sdk,1',
+          ',1970-01-01T00:00:02.000Z,wx-js-sdk,2',
+          ',1970-01-01T00:00:03.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:04.000Z,wx-js-sdk,4',
+        ]);
+
+        // log more lines, this should cause removal of the oldest logs
+        doSomeLogs(2);
+
+        const logsFull2 = webex.logger.formatLogs({diff: false});
+
+        const last5Logs = [
+          ',1970-01-01T00:00:02.000Z,wx-js-sdk,2',
+          ',1970-01-01T00:00:03.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:04.000Z,wx-js-sdk,4',
+          ',1970-01-01T00:00:05.000Z,wx-js-sdk,5',
+          ',1970-01-01T00:00:06.000Z,wx-js-sdk,6',
+        ];
+        assert.deepEqual(logsFull2.split('\n'), last5Logs);
+
+        // check also the diff logs - they should also have just last 5 logs
+        const logsDiff1 = webex.logger.formatLogs({diff: true});
+        assert.deepEqual(logsDiff1.split('\n'), last5Logs);
+
+        // add more logs again and check full and diff logs
+        doSomeLogs(1);
+
+        const logsFull3 = webex.logger.formatLogs({diff: false});
+
+        assert.deepEqual(logsFull3.split('\n'), [
+          ',1970-01-01T00:00:03.000Z,wx-js-sdk,3',
+          ',1970-01-01T00:00:04.000Z,wx-js-sdk,4',
+          ',1970-01-01T00:00:05.000Z,wx-js-sdk,5',
+          ',1970-01-01T00:00:06.000Z,wx-js-sdk,6',
+          ',1970-01-01T00:00:07.000Z,wx-js-sdk,7',
+        ]);
+
+        const logsDiff2 = webex.logger.formatLogs({diff: true});
+        assert.deepEqual(logsDiff2.split('\n'), [',1970-01-01T00:00:07.000Z,wx-js-sdk,7']);
+      });
+    });
   });
 
   describe('#logToBuffer()', () => {


### PR DESCRIPTION
## This pull request addresses
We want to have incremental logs, but also in some cases we want to upload the full logs:
- when user sends feedback (because then we get an automatic jira created and logs get attached to it)
- when tester/developer runs webex.logger.formatLogs() from js console

## by making the following changes
Changed how incremental logs work. Instead of clearing the buffers on each upload we now keep track of the last uploaded positions from the buffers. This allows us to upload a full log if we want to and if we want a diff log, we just upload the subset of the buffers (from the last sent position). Sending/requesting a full log does not affect the next diff log.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, tested manually with web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
