### PR TITLE
feat(calling): provide line event on failed keepalive

### DIFF
--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -389,6 +389,10 @@ function createDevice() {
     unregisterElm.disabled = false;
   });
 
+  line.on('line:keepalive_failed', () => {
+    console.log('line:keepalive_failed');
+  });
+
   // Start listening for incoming calls
   line.on('line:incoming_call', (callObj) => {
     call = callObj;

--- a/packages/calling/src/CallingClient/line/index.ts
+++ b/packages/calling/src/CallingClient/line/index.ts
@@ -196,6 +196,9 @@ export default class Line extends Eventing<LineEventTypes> implements ILine {
           this.emit(event, lineError);
         }
         break;
+      case LINE_EVENTS.KEEPALIVE_FAILED:
+        this.emit(event);
+        break;
       default:
         break;
     }

--- a/packages/calling/src/CallingClient/line/types.ts
+++ b/packages/calling/src/CallingClient/line/types.ts
@@ -19,6 +19,7 @@ export enum LINE_EVENTS {
   REGISTERED = 'registered',
   UNREGISTERED = 'unregistered',
   INCOMING_CALL = 'line:incoming_call',
+  KEEPALIVE_FAILED = 'line:keepalive_failed',
 }
 
 /**

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -558,9 +558,10 @@ describe('Registration Tests', () => {
 
       expect(reg.getStatus()).toBe(RegistrationStatus.ACTIVE);
       expect(reg.keepaliveTimer).toBe(timer);
-      expect(lineEmitter).nthCalledWith(1, LINE_EVENTS.RECONNECTING);
-      expect(lineEmitter).nthCalledWith(2, LINE_EVENTS.RECONNECTED);
-      expect(lineEmitter).toBeCalledTimes(2);
+      expect(lineEmitter).nthCalledWith(1, LINE_EVENTS.KEEPALIVE_FAILED);
+      expect(lineEmitter).nthCalledWith(2, LINE_EVENTS.RECONNECTING);
+      expect(lineEmitter).nthCalledWith(3, LINE_EVENTS.RECONNECTED);
+      expect(lineEmitter).toBeCalledTimes(3);
     });
 
     it('verify failure keep-alive cases: Restore failure', async () => {
@@ -600,16 +601,24 @@ describe('Registration Tests', () => {
 
       expect(webex.request).toBeCalledTimes(7);
       expect(reg.keepaliveTimer).toBe(undefined);
-      expect(lineEmitter).nthCalledWith(1, LINE_EVENTS.RECONNECTING);
+      expect(lineEmitter).nthCalledWith(1, LINE_EVENTS.KEEPALIVE_FAILED);
+      expect(lineEmitter).nthCalledWith(2, LINE_EVENTS.RECONNECTING);
+      expect(lineEmitter).nthCalledWith(3, LINE_EVENTS.KEEPALIVE_FAILED);
       expect(lineEmitter).nthCalledWith(4, LINE_EVENTS.RECONNECTING);
-      expect(lineEmitter).nthCalledWith(5, LINE_EVENTS.UNREGISTERED);
+      expect(lineEmitter).nthCalledWith(5, LINE_EVENTS.KEEPALIVE_FAILED);
+      expect(lineEmitter).nthCalledWith(6, LINE_EVENTS.RECONNECTING);
+      expect(lineEmitter).nthCalledWith(7, LINE_EVENTS.KEEPALIVE_FAILED);
+      expect(lineEmitter).nthCalledWith(8, LINE_EVENTS.RECONNECTING);
+      expect(lineEmitter).nthCalledWith(9, LINE_EVENTS.KEEPALIVE_FAILED);
+
+      expect(lineEmitter).nthCalledWith(10, LINE_EVENTS.UNREGISTERED);
 
       /** there will be 2 registration attempts */
-      expect(lineEmitter).nthCalledWith(6, LINE_EVENTS.CONNECTING);
-      expect(lineEmitter).nthCalledWith(7, LINE_EVENTS.UNREGISTERED);
-      expect(lineEmitter).nthCalledWith(8, LINE_EVENTS.CONNECTING);
-      expect(lineEmitter).nthCalledWith(9, LINE_EVENTS.UNREGISTERED);
-      expect(lineEmitter).toBeCalledTimes(9);
+      expect(lineEmitter).nthCalledWith(11, LINE_EVENTS.CONNECTING);
+      expect(lineEmitter).nthCalledWith(12, LINE_EVENTS.UNREGISTERED);
+      expect(lineEmitter).nthCalledWith(13, LINE_EVENTS.CONNECTING);
+      expect(lineEmitter).nthCalledWith(14, LINE_EVENTS.UNREGISTERED);
+      expect(lineEmitter).toBeCalledTimes(14);
     });
 
     it('verify failure keep-alive cases: Restore Success', async () => {

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -724,6 +724,8 @@ export class Registration implements IRegistration {
               logContext
             );
 
+            this.lineEmitter(LINE_EVENTS.KEEPALIVE_FAILED);
+
             const abort = await handleRegistrationErrors(
               error,
               (clientError, finalError) => {

--- a/packages/calling/src/Events/types.ts
+++ b/packages/calling/src/Events/types.ts
@@ -199,6 +199,7 @@ export type LineEventTypes = {
   [LINE_EVENTS.REGISTERED]: (lineInfo: ILine) => void;
   [LINE_EVENTS.UNREGISTERED]: () => void;
   [LINE_EVENTS.INCOMING_CALL]: (callObj: ICall) => void;
+  [LINE_EVENTS.KEEPALIVE_FAILED]: () => void;
 };
 
 export type CallEventTypes = {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-607142](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-607142) >

## This pull request addresses

This PR provides an event on the line object for every failed keepalive. This helps to create a better UX for the end user.

**TODO**: Update the calling doc with this additional event.

## by making the following changes

Client can listen to `line:keepalive_failed` event to show the Agent the current status of registration (mobius) server on the UI.

**sample code**

```js
line.on('line:keepalive_failed', () => {
  // Add your UI/UX logic here
  console.log('Keepalive failed...');
});
```


**Screenshots**

<img width="1586" alt="Screenshot 2025-02-03 at 11 06 48 AM" src="https://github.com/user-attachments/assets/6295d327-c811-4fbc-9378-dde12a825b96" />

The screenshot shows the console log with the event received in the samples app. It also shows the blocked primary server domain causing the keepalive to fail.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

Manual testing done

- Took a cc user's access token
- Ran the samples app and registered the user with cc flow
- Blocked the primary server URL
- Observed failed keepalive triggering the `line:keepalive_failed` event on line object.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
