### PR TITLE
feat: agent state timer implemented

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -546,8 +546,10 @@ function startStateTimer(startTime) {
     const hours = String(Math.floor(timeDifference / (1000 * 60 * 60))).padStart(2, '0');
     const minutes = String(Math.floor((timeDifference % (1000 * 60 * 60)) / (1000 * 60))).padStart(2, '0');
     const seconds = String(Math.floor((timeDifference % (1000 * 60)) / 1000)).padStart(2, '0');
-
-    timerElm.innerHTML = `${hours}:${minutes}:${seconds}`;
+    if(timerElm)
+    {
+      timerElm.innerHTML = `${hours}:${minutes}:${seconds}`;
+    }
   }, 1000);
 }
 

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -652,15 +652,27 @@ async function handleAgentLogin(e) {
 }
 
 function doAgentLogin() {
-  webex.cc.stationLogin({teamId: teamsDropdown.value, loginOption: agentDeviceType, dialNumber: dialNumber.value}).then((response) => {
+  webex.cc.stationLogin({
+    teamId: teamsDropdown.value,
+    loginOption: agentDeviceType,
+    dialNumber: dialNumber.value
+  }).then((response) => {
     console.log('Agent Logged in successfully', response);
     loginAgentElm.disabled = true;
     logoutAgentElm.classList.remove('hidden');
-  }
-  ).catch((error) => {
+    
+    // Read auxCode and lastStateChangeTimestamp from login response
+    const DEFAULT_CODE = '0'; // Default code when no aux code is present
+    const auxCodeId = response.data.auxCodeId?.trim() !== '' ? response.data.auxCodeId : DEFAULT_CODE;
+    const lastStateChangeTimestamp = response.data.lastStateChangeTimestamp;
+    idleCodesDropdown.selectedIndex = idleCodesDropdown.options[0].value === auxCodeId ? 0 : [...idleCodesDropdown.options].findIndex(option => option.value === auxCodeId);
+    startStateTimer(new Date(lastStateChangeTimestamp));
+    
+  }).catch((error) => {
     console.log('Agent Login failed', error);
   });
 }
+
 
 async function handleAgentStatus(event) {
   auxCodeId = event.target.value;

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -12,6 +12,7 @@ let taskId;
 let wrapupCodes = []; // Add this to store wrapup codes
 let isConsultOptionsShown = false;
 let isTransferOptionsShown = false; // Add this variable to track the state of transfer options
+let stateTimer;
 
 const authTypeElm = document.querySelector('#auth-type');
 const credentialsFormElm = document.querySelector('#credentials');
@@ -58,6 +59,7 @@ const initiateConsultDialog = document.querySelector('#initiate-consult-dialog')
 const agentMultiLoginAlert = document.querySelector('#agentMultiLoginAlert');
 const consultTransferBtn = document.querySelector('#consult-transfer');
 const transferElm = document.getElementById('transfer');
+const timerElm = document.querySelector('#timerDisplay');
 
 // Store and Grab `access-token` from sessionStorage
 if (sessionStorage.getItem('date') > new Date().getTime()) {
@@ -532,6 +534,23 @@ function initWebex(e) {
 
 credentialsFormElm.addEventListener('submit', initWebex);
 
+function startStateTimer(startTime) {
+  if (stateTimer) {
+    clearInterval(stateTimer);
+  }
+
+  stateTimer = setInterval(() => {
+    const currentTime = new Date().getTime();
+    const timeDifference = currentTime - startTime;
+
+    const hours = String(Math.floor(timeDifference / (1000 * 60 * 60))).padStart(2, '0');
+    const minutes = String(Math.floor((timeDifference % (1000 * 60 * 60)) / (1000 * 60))).padStart(2, '0');
+    const seconds = String(Math.floor((timeDifference % (1000 * 60)) / 1000)).padStart(2, '0');
+
+    timerElm.innerHTML = `${hours}:${minutes}:${seconds}`;
+  }, 1000);
+}
+
 
 function register() {
     webex.cc.register(true).then((agentProfile) => {
@@ -575,6 +594,11 @@ function register() {
             const option  = document.createElement('option');
             option.text = idleCodes.name;
             option.value = idleCodes.id;
+            if (agentProfile.lastStateAuxCodeId && agentProfile.lastStateAuxCodeId === idleCodes.id)
+            {
+              option.selected = true;
+              startStateTimer(agentProfile.lastStateChangeTimestamp)
+            }
             idleCodesDropdown.add(option);
           }
         });
@@ -592,6 +616,7 @@ function register() {
       if (data && typeof data === 'object' && data.type === 'AgentStateChangeSuccess') {
         const DEFAULT_CODE = '0'; // Default code when no aux code is present
         idleCodesDropdown.value = data.auxCodeId?.trim() !== '' ? data.auxCodeId : DEFAULT_CODE;
+        startStateTimer(data.lastStateChangeTimestamp);
       }
     });
 

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -665,8 +665,9 @@ function doAgentLogin() {
     const DEFAULT_CODE = '0'; // Default code when no aux code is present
     const auxCodeId = response.data.auxCodeId?.trim() !== '' ? response.data.auxCodeId : DEFAULT_CODE;
     const lastStateChangeTimestamp = response.data.lastStateChangeTimestamp;
-    idleCodesDropdown.selectedIndex = idleCodesDropdown.options[0].value === auxCodeId ? 0 : [...idleCodesDropdown.options].findIndex(option => option.value === auxCodeId);
-    startStateTimer(new Date(lastStateChangeTimestamp));
+    const index = [...idleCodesDropdown.options].findIndex(option => option.value === auxCodeId);
+    idleCodesDropdown.selectedIndex = index !== -1 ? index : 0;
+        startStateTimer(new Date(lastStateChangeTimestamp));
     
   }).catch((error) => {
     console.log('Agent Login failed', error);

--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -121,13 +121,16 @@
                   <button id="loginAgent" disabled class="btn btn-primary my-3" onclick="doAgentLogin()">Login</button>
                   <button id="logoutAgent" class="btn btn-primary my-3 ml-2 hidden" onclick="logoutAgent()">Logout</button>
                 </fieldset>
-                <fieldset>
+                <fieldset style="display: flex; flex-direction: column; align-items: flex-start; gap: 10px;">
                   <legend>Agent status</legend>
                   <select name= "idleCodesDropdown" id="idleCodesDropdown" class="form-control w-auto my-3" onchange="handleAgentStatus(event)">
                   <option value="" selected hidden>Select Idle Codes</option>
                   </select>
                   <button id="setAgentStatus" disabled class="btn btn-primary my-3 ml-2" onclick="setAgentStatus()">Set Agent
                     Status</button>
+                  <div class="timer-container my-3">
+                    <span>Timer: </span><span id="timerDisplay">00:00:00</span>
+                  </div>
                 </fieldset>
               </div>
               <fieldset id="buddyAgentsBox">

--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -129,7 +129,7 @@
                   <button id="setAgentStatus" disabled class="btn btn-primary my-3 ml-2" onclick="setAgentStatus()">Set Agent
                     Status</button>
                   <div class="timer-container my-3">
-                    <span>Timer: </span><span id="timerDisplay">00:00:00</span>
+                  <span id="timerDisplay">00:00:00</span>
                   </div>
                 </fieldset>
               </div>

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -19,10 +19,10 @@ import {AGENT, WEB_RTC_PREFIX} from './services/constants';
 import Services from './services';
 import HttpRequest from './services/core/HttpRequest';
 import LoggerProxy from './logger-proxy';
-import {StateChange, Logout} from './services/agent/types';
+import {StateChange, Logout, StateChangeSuccess} from './services/agent/types';
 import {getErrorDetails} from './services/core/Utils';
 import {Profile, WelcomeEvent, CC_EVENTS} from './services/config/types';
-import {AGENT_STATE_AVAILABLE} from './services/config/constants';
+import {AGENT_STATE_AVAILABLE, AGENT_STATE_AVAILABLE_ID} from './services/config/constants';
 import {ConnectionLostDetails} from './services/core/websocket/types';
 import TaskManager from './services/task/TaskManager';
 import WebCallingService from './services/WebCallingService';
@@ -343,7 +343,10 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   private async silentRelogin(): Promise<void> {
     try {
       const reLoginResponse = await this.services.agent.reload();
-      const {auxCodeId, agentId, lastStateChangeReason, deviceType, dn} = reLoginResponse.data;
+      const {agentId, lastStateChangeReason, deviceType, dn, lastIdleCodeChangeTimestamp} =
+        reLoginResponse.data;
+      let {auxCodeId} = reLoginResponse.data;
+      this.agentConfig.lastStateChangeTimestamp = new Date(lastIdleCodeChangeTimestamp);
 
       // To handle re-registration of event listeners on silent relogin
       this.incomingTaskListener();
@@ -354,15 +357,28 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           'event=requestAutoStateChange | Requesting state change to available on socket reconnect',
           {module: CC_FILE, method: this.silentRelogin.name}
         );
+        auxCodeId = AGENT_STATE_AVAILABLE_ID;
         const stateChangeData: StateChange = {
           state: AGENT_STATE_AVAILABLE,
           auxCodeId,
           lastStateChangeReason,
           agentId,
         };
-        await this.setAgentState(stateChangeData);
+        try {
+          const agentStatusResponse = (await this.setAgentState(
+            stateChangeData
+          )) as StateChangeSuccess;
+          this.agentConfig.lastStateChangeTimestamp = new Date(
+            agentStatusResponse.data.lastStateChangeTimestamp
+          );
+        } catch (error) {
+          LoggerProxy.error(
+            `event=requestAutoStateChange | Error requesting state change to available on socket reconnect: ${error}`,
+            {module: CC_FILE, method: this.silentRelogin.name}
+          );
+        }
       }
-
+      this.agentConfig.lastStateAuxCodeId = auxCodeId;
       await this.handleDeviceType(deviceType as LoginOption, dn);
       this.agentConfig.isAgentLoggedIn = true;
       this.services.webSocketManager.on('message', this.handleWebSocketMessage);

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -403,7 +403,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    * Handles the device type specific logic
    */
   private async handleDeviceType(deviceType: LoginOption, dn: string): Promise<void> {
-    switch (deviceType || LoginOption.EXTENSION) {
+    switch (deviceType) {
       case LoginOption.BROWSER:
         await this.webCallingService.registerWebCallingLine();
         break;
@@ -411,6 +411,12 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       case LoginOption.EXTENSION:
         this.agentConfig.defaultDn = dn;
         break;
+      default:
+        LoggerProxy.error(`Unsupported device type: ${deviceType}`, {
+          module: CC_FILE,
+          method: this.handleDeviceType.name,
+        });
+        throw new Error(`Unsupported device type: ${deviceType}`);
     }
     this.webCallingService.setLoginOption(deviceType);
     this.agentConfig.deviceType = deviceType;

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -343,10 +343,12 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   private async silentRelogin(): Promise<void> {
     try {
       const reLoginResponse = await this.services.agent.reload();
-      const {agentId, lastStateChangeReason, deviceType, dn, lastIdleCodeChangeTimestamp} =
+      const {agentId, lastStateChangeReason, deviceType, dn, lastStateChangeTimestamp} =
         reLoginResponse.data;
       let {auxCodeId} = reLoginResponse.data;
-      this.agentConfig.lastStateChangeTimestamp = new Date(lastIdleCodeChangeTimestamp);
+      this.agentConfig.lastStateChangeTimestamp = lastStateChangeTimestamp
+        ? new Date(lastStateChangeTimestamp)
+        : new Date();
 
       // To handle re-registration of event listeners on silent relogin
       this.incomingTaskListener();
@@ -368,9 +370,10 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           const agentStatusResponse = (await this.setAgentState(
             stateChangeData
           )) as StateChangeSuccess;
-          this.agentConfig.lastStateChangeTimestamp = new Date(
-            agentStatusResponse.data.lastStateChangeTimestamp
-          );
+          this.agentConfig.lastStateChangeTimestamp = agentStatusResponse.data
+            .lastStateChangeTimestamp
+            ? new Date(agentStatusResponse.data.lastStateChangeTimestamp)
+            : new Date();
         } catch (error) {
           LoggerProxy.error(
             `event=requestAutoStateChange | Error requesting state change to available on socket reconnect: ${error}`,
@@ -400,7 +403,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    * Handles the device type specific logic
    */
   private async handleDeviceType(deviceType: LoginOption, dn: string): Promise<void> {
-    switch (deviceType) {
+    switch (deviceType || LoginOption.EXTENSION) {
       case LoginOption.BROWSER:
         await this.webCallingService.registerWebCallingLine();
         break;
@@ -408,12 +411,6 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       case LoginOption.EXTENSION:
         this.agentConfig.defaultDn = dn;
         break;
-      default:
-        LoggerProxy.error(`Unsupported device type: ${deviceType}`, {
-          module: CC_FILE,
-          method: this.handleDeviceType.name,
-        });
-        throw new Error(`Unsupported device type: ${deviceType}`);
     }
     this.webCallingService.setLoginOption(deviceType);
     this.agentConfig.deviceType = deviceType;

--- a/packages/@webex/plugin-cc/src/config.ts
+++ b/packages/@webex/plugin-cc/src/config.ts
@@ -2,7 +2,7 @@ import {LOGGER} from '@webex/calling';
 
 export default {
   cc: {
-    allowMultiLogin: false,
+    allowMultiLogin: true,
     allowAutomatedRelogin: true,
     clientType: 'WebexCCSDK',
     isKeepAliveEnabled: false,

--- a/packages/@webex/plugin-cc/src/services/config/types.ts
+++ b/packages/@webex/plugin-cc/src/services/config/types.ts
@@ -565,4 +565,6 @@ export type Profile = {
   lostConnectionRecoveryTimeout: number;
   maskSensitiveData?: boolean;
   isAgentLoggedIn?: boolean;
+  lastStateAuxCodeId?: string;
+  lastStateChangeTimestamp?: Date;
 };

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -398,18 +398,18 @@ describe('webex.cc', () => {
         },
       });
       expect(result).toEqual({});
-       
+
       const onSpy = jest.spyOn(mockTaskManager, 'on');
       const emitSpy = jest.spyOn(webex.cc, 'trigger');
       const ccEmitSpy = jest.spyOn(webex.cc, 'emit');
       const incomingCallCb = onSpy.mock.calls[0][1];
-      
+
       expect(onSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, incomingCallCb);
-      
+
       incomingCallCb(mockTask);
-  
+
       expect(emitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, mockTask);
-       // Verify message event listener
+      // Verify message event listener
       const messageCallback = mockWebSocketManager.on.mock.calls.find(call => call[0] === 'message')[1];
       const agentStateChangeEventData = {
         type: CC_EVENTS.AGENT_STATE_CHANGE,
@@ -755,6 +755,7 @@ describe('webex.cc', () => {
           auxCodeId: 'auxCodeId',
           agentId: 'agentId',
           lastStateChangeReason: 'agent-wss-disconnect',
+          lastIdleCodeChangeTimestamp: 1738575135188,
           deviceType: LoginOption.BROWSER,
           dn: '12345',
         },
@@ -767,9 +768,10 @@ describe('webex.cc', () => {
         isAgentLoggedIn: false,
       } as Profile;
 
-      const setAgentStateSpy = jest
-        .spyOn(webex.cc, 'setAgentState')
-        .mockResolvedValue({} as SetStateResponse);
+      const date = new Date();
+      const setAgentStateSpy = jest.spyOn(webex.cc, 'setAgentState').mockResolvedValue({
+        data: {lastStateChangeTimestamp: date.getTime()},
+      } as unknown as SetStateResponse);
       jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue(mockReLoginResponse);
 
       const registerWebCallingLineSpy = jest.spyOn(
@@ -790,11 +792,13 @@ describe('webex.cc', () => {
       );
       expect(setAgentStateSpy).toHaveBeenCalledWith({
         state: 'Available',
-        auxCodeId: 'auxCodeId',
+        auxCodeId: '0', // even if get auxcodeId from relogin response, it should be 0 for available state
         lastStateChangeReason: 'agent-wss-disconnect',
         agentId: 'agentId',
       });
       expect(webex.cc.agentConfig.isAgentLoggedIn).toBe(true);
+      expect(webex.cc.agentConfig.lastStateAuxCodeId).toBe('0');
+      expect(webex.cc.agentConfig.lastStateChangeTimestamp).toStrictEqual(date); // it should be updated with the new timestamp of setAgentState response
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.BROWSER);
       expect(registerWebCallingLineSpy).toHaveBeenCalled();
       expect(registerIncomingCallEventSpy).toHaveBeenCalled();
@@ -819,42 +823,44 @@ describe('webex.cc', () => {
         {module: CC_FILE, method: 'silentRelogin'}
       );
     });
-  
+
     it('should handle errors during silent relogin', async () => {
       const error = new Error('Error while performing silentReLogin');
       jest.spyOn(webex.cc.services.agent, 'reload').mockRejectedValue(error);
-  
+
       await expect(webex.cc['silentRelogin']()).rejects.toThrow(error);
     });
-  
+
     it('should update agentConfig with deviceType during silent relogin for EXTENSION', async () => {
       const mockReLoginResponse = {
         data: {
           auxCodeId: 'auxCodeId',
           agentId: 'agentId',
-          lastStateChangeReason: 'agent-wss-disconnect',
           deviceType: LoginOption.EXTENSION,
           dn: '12345',
+          lastIdleCodeChangeTimestamp: 1738575135188,
         },
       };
-  
+
       // Mock the agentConfig
       webex.cc.agentConfig = {
         agentId: 'agentId',
         agentProfileID: 'test-agent-profile-id',
         isAgentLoggedIn: false,
       } as Profile;
-  
+
       const registerWebCallingLineSpy = jest.spyOn(
         webex.cc.webCallingService,
         'registerWebCallingLine'
       );
       jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue(mockReLoginResponse);
-  
+
       await webex.cc['silentRelogin']();
-  
+
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.EXTENSION);
       expect(webex.cc.agentConfig.defaultDn).toBe('12345');
+      expect(webex.cc.agentConfig.lastStateAuxCodeId).toBe('auxCodeId');
+      expect(webex.cc.agentConfig.lastStateChangeTimestamp).toStrictEqual(new Date(1738575135188));
     });
 
     it('should update agentConfig with deviceType during silent relogin for AGENT_DN', async () => {
@@ -868,18 +874,18 @@ describe('webex.cc', () => {
           subStatus: 'subStatusValue',
         },
       };
-  
+
       // Mock the agentConfig
       webex.cc.agentConfig = {
         agentId: 'agentId',
         agentProfileID: 'test-agent-profile-id',
         isAgentLoggedIn: false,
       } as Profile;
-  
+
       jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue(mockReLoginResponse);
-  
+
       await webex.cc['silentRelogin']();
-  
+
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.AGENT_DN);
       expect(webex.cc.agentConfig.defaultDn).toBe('67890');
     });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -755,7 +755,7 @@ describe('webex.cc', () => {
           auxCodeId: 'auxCodeId',
           agentId: 'agentId',
           lastStateChangeReason: 'agent-wss-disconnect',
-          lastIdleCodeChangeTimestamp: 1738575135188,
+          lastStateChangeTimestamp: 1738575135188,
           deviceType: LoginOption.BROWSER,
           dn: '12345',
         },
@@ -838,7 +838,7 @@ describe('webex.cc', () => {
           agentId: 'agentId',
           deviceType: LoginOption.EXTENSION,
           dn: '12345',
-          lastIdleCodeChangeTimestamp: 1738575135188,
+          lastStateChangeTimestamp: 1738575135188,
         },
       };
 

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -246,7 +246,7 @@ describe('webex.cc', () => {
           force: true,
           isKeepAliveEnabled: false,
           clientType: 'WebexCCSDK',
-          allowMultiLogin: false,
+          allowMultiLogin: true,
         },
       });
       expect(configSpy).toHaveBeenCalled();


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-608448

## This pull request addresses

Implement Agent State Timer and persisting last state.

## by making the following changes

added lastStateAuxCodeId, lastStateChangeTimestamp to profile to know last change timestamp and last state

<img width="236" alt="Screenshot 2025-02-03 at 3 28 42 PM" src="https://github.com/user-attachments/assets/0d9cf139-1a3d-46e6-a9ab-b32a9cf5cde5" />


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tests: 
1)logged In and changed state to InMeeting => refresh the page and relogin => it should automatically show the state as inMeeting and timer should persist.

2)logged In and changed state to Available => refresh the page and relogin => it should automatically show the state as Available and timer should start from zero(as we do setState) sae behaviour in Agent Desktop.

https://app.vidcast.io/share/33676262-ae97-4bb4-9c40-7cc9f50f49d3

test plan updated: https://confluence-eng-gpk2.cisco.com/conf/display/WSDK/CC+SDK+Test+Plans

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
