### PR TITLE
fix(plugin-meetings): only send 'client.lobby.entered' when a user joins the lobby for the first time

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/selfUtils.ts
@@ -99,7 +99,7 @@ SelfUtils.getSelves = (oldSelf, newSelf, deviceId) => {
   const current = newSelf && SelfUtils.parse(newSelf, deviceId);
   const updates: any = {};
 
-  updates.isUserUnadmitted = SelfUtils.isUserUnadmitted(current);
+  updates.isUserUnadmitted = SelfUtils.isUserUnadmitted(previous, current);
   updates.isUserAdmitted = SelfUtils.isUserAdmitted(previous, current);
   updates.isVideoMutedByOthersChanged = SelfUtils.videoMutedByOthersChanged(previous, current);
   updates.isMutedByOthersChanged = SelfUtils.mutedByOthersChanged(previous, current);
@@ -330,16 +330,23 @@ SelfUtils.isLocusUserAdmitted = (check: any) =>
   check && check.joinedWith?.intent?.type !== _WAIT_ && check.state === _JOINED_;
 
 /**
- * @param {Object} self
+ * @param {Object} oldSelf
+ * @param {Object} changedSelf
  * @returns {Boolean}
  * @throws {Error} when self is undefined
  */
-SelfUtils.isUserUnadmitted = (self: object) => {
-  if (!self) {
-    throw new ParameterError('self must be defined to determine if self is unadmitted as guest.');
+SelfUtils.isUserUnadmitted = (oldSelf: object, changedSelf: object) => {
+  if (!changedSelf) {
+    throw new ParameterError(
+      'changedSelf must be defined to determine if self is unadmitted as guest.'
+    );
   }
 
-  return SelfUtils.isLocusUserUnadmitted(self);
+  if (SelfUtils.isLocusUserUnadmitted(oldSelf)) {
+    return false;
+  }
+
+  return SelfUtils.isLocusUserUnadmitted(changedSelf);
 };
 
 SelfUtils.moderatorChanged = (oldSelf, changedSelf) => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/selfUtils.js
@@ -1,9 +1,10 @@
 import {assert} from '@webex/test-helper-chai';
 import Sinon from 'sinon';
-import {cloneDeep} from 'lodash';
+import {cloneDeep, defaultsDeep} from 'lodash';
 import SelfUtils from '@webex/plugin-meetings/src/locus-info/selfUtils';
 
 import {self} from './selfConstant';
+import {_IDLE_, _WAIT_} from '@webex/plugin-meetings/src/constants';
 
 describe('plugin-meetings', () => {
   describe('selfUtils', () => {
@@ -181,10 +182,10 @@ describe('plugin-meetings', () => {
     describe('brbChanged', () => {
       it('should return true if brb have changed', () => {
         const current = {
-          brb: {enabled: true}
+          brb: {enabled: true},
         };
         const previous = {
-          brb: {enabled: false}
+          brb: {enabled: false},
         };
 
         assert.isTrue(SelfUtils.brbChanged(previous, current));
@@ -192,10 +193,10 @@ describe('plugin-meetings', () => {
 
       it('should return false if brb have not changed', () => {
         const current = {
-          brb: {enabled: true}
+          brb: {enabled: true},
         };
         const previous = {
-          brb: {enabled: true}
+          brb: {enabled: true},
         };
 
         assert.isFalse(SelfUtils.brbChanged(previous, current));
@@ -337,6 +338,56 @@ describe('plugin-meetings', () => {
 
           assert.equal(updates.localAudioUnmuteRequestedByServer, false);
         });
+      });
+
+      describe('updates.isUserUnadmitted', () => {
+        const testIsUserUnadmitted = (previousObjectDelta, currentObjectDelta, expected) => function () {
+          const previous =
+            previousObjectDelta === undefined ? undefined : defaultsDeep(previousObjectDelta, self);
+          const current = defaultsDeep(currentObjectDelta, self);
+
+          const {updates} = SelfUtils.getSelves(previous, current, self.devices[0].url);
+
+          assert.equal(updates.isUserUnadmitted, expected);
+        };
+
+        it(
+          'should return true when previous is undefined and current is in lobby',
+          testIsUserUnadmitted(
+            undefined,
+            {devices: [{intent: {type: _WAIT_}}], state: _IDLE_},
+            true
+          )
+        );
+
+        it(
+          'should return false when previous is undefined and user is not in meeting',
+          testIsUserUnadmitted(undefined, {devices: [], state: _IDLE_}, false)
+        );
+
+        it(
+          'should return false when previous is undefined and current is in meeting',
+          testIsUserUnadmitted(undefined, {}, false)
+        );
+
+        it(
+          'should return false when previous is in lobby and current is in lobby',
+          testIsUserUnadmitted(
+            {devices: [{intent: {type: _WAIT_}}], state: _IDLE_},
+            {devices: [{intent: {type: _WAIT_}}], state: _IDLE_},
+            false
+          )
+        );
+
+        it(
+          'should return false when previous is in lobby and current is in meeting',
+          testIsUserUnadmitted({devices: [{intent: {type: _WAIT_}}], state: _IDLE_}, {}, false)
+        );
+
+        it(
+          'should return true when previous is in meeting and current is in lobby',
+          testIsUserUnadmitted({}, {devices: [{intent: {type: _WAIT_}}], state: _IDLE_}, true)
+        );
       });
     });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-603197](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-603197)

## This pull request addresses

Client sending a 'client.lobby.entered' event every time a locus object is received when a participant is sitting in the lobby.

## by making the following changes

Compare the previous locus DTO with the current locus DTO. Only fire the 'client.lobby.entered' event iff the previous locus says that we weren't in a lobby and the current locus says that we are.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

Changes the function definition of an internal function.

## The following scenarios were tested
- Linked locally with Cantina, guest/signed in user joining a lobby directly from meeting URL
- Linked locally with Cantina, guest/signed in user being moved to lobby by host
- Linked locally with Cantina, signed in user joining a locked space meeting 

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
