### PR TITLE
feat(mercury): add stack to an error log

### DIFF
--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -266,7 +266,11 @@ const Mercury = WebexPlugin.extend({
         if (reason.code !== 1006 && this.backoffCall && this.backoffCall.getNumRetries() > 0) {
           this._emit('connection_failed', reason, {retries: this.backoffCall.getNumRetries()});
         }
-        this.logger.info(`${this.namespace}: connection attempt failed`, reason, reason.stack);
+        this.logger.info(
+          `${this.namespace}: connection attempt failed`,
+          reason,
+          !this.backoffCall?.getNumRetries() ? reason.stack : ''
+        );
         // UnknownResponse is produced by IE for any 4XXX; treated it like a bad
         // web socket url and let WDM handle the token checking
         if (reason instanceof UnknownResponse) {

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -266,7 +266,7 @@ const Mercury = WebexPlugin.extend({
         if (reason.code !== 1006 && this.backoffCall && this.backoffCall.getNumRetries() > 0) {
           this._emit('connection_failed', reason, {retries: this.backoffCall.getNumRetries()});
         }
-        this.logger.info(`${this.namespace}: connection attempt failed`, reason);
+        this.logger.info(`${this.namespace}: connection attempt failed`, reason, reason.stack);
         // UnknownResponse is produced by IE for any 4XXX; treated it like a bad
         // web socket url and let WDM handle the token checking
         if (reason instanceof UnknownResponse) {

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -269,7 +269,7 @@ const Mercury = WebexPlugin.extend({
         this.logger.info(
           `${this.namespace}: connection attempt failed`,
           reason,
-          !this.backoffCall?.getNumRetries() ? reason.stack : ''
+          this.backoffCall?.getNumRetries() === 0 ? reason.stack : ''
         );
         // UnknownResponse is produced by IE for any 4XXX; treated it like a bad
         // web socket url and let WDM handle the token checking


### PR DESCRIPTION
Just adding error.stack to an existing log statement.  Hoping this will help be debug a problem in the CIS flow where mercury gets connected too early.

I tested this by blocking requests to mercury and then checking the logs.