### PR TITLE
fix(plugin-meetings): sip 1-1 calls cannot connect

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts
@@ -17,6 +17,7 @@ export const DTLS_HANDSHAKE_FAILED_CLIENT_CODE = 2008;
 export const ICE_FAILED_WITH_TURN_TLS_CLIENT_CODE = 2010;
 export const ICE_FAILED_WITHOUT_TURN_TLS_CLIENT_CODE = 2009;
 export const ICE_AND_REACHABILITY_FAILED_CLIENT_CODE = 2011;
+export const MULTISTREAM_NOT_AVAILABLE_CLIENT_CODE = 2012;
 export const WBX_APP_API_URL = 'wbxappapi'; // MeetingInfo WebexAppApi response object normally contains a body.url that includes the string 'wbxappapi'
 
 export const WEBEX_SUB_SERVICE_TYPES: Record<string, ClientSubServiceType> = {
@@ -127,6 +128,7 @@ export const ERROR_DESCRIPTIONS = {
   ICE_FAILED_WITHOUT_TURN_TLS: 'ICEFailedWithoutTURN_TLS',
   ICE_FAILED_WITH_TURN_TLS: 'ICEFailedWithTURN_TLS',
   ICE_AND_REACHABILITY_FAILED: 'ICEAndReachabilityFailed',
+  MULTISTREAM_NOT_AVAILABLE: 'MultistreamNotAvailable',
   SDP_OFFER_CREATION_ERROR: 'SdpOfferCreationError',
   SDP_OFFER_CREATION_ERROR_MISSING_CODEC: 'SdpOfferCreationErrorMissingCodec',
   WDM_RESTRICTED_REGION: 'WdmRestrictedRegion',
@@ -408,6 +410,11 @@ export const CLIENT_ERROR_CODE_TO_ERROR_PAYLOAD: Record<number, Partial<ClientEv
     errorDescription: ERROR_DESCRIPTIONS.ICE_AND_REACHABILITY_FAILED,
     category: 'expected',
     fatal: true,
+  },
+  [MULTISTREAM_NOT_AVAILABLE_CLIENT_CODE]: {
+    errorDescription: ERROR_DESCRIPTIONS.MULTISTREAM_NOT_AVAILABLE,
+    category: 'expected',
+    fatal: false,
   },
   2050: {
     errorDescription: ERROR_DESCRIPTIONS.SDP_OFFER_CREATION_ERROR,

--- a/packages/@webex/plugin-meetings/src/common/errors/multistream-not-supported-error.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/multistream-not-supported-error.ts
@@ -1,0 +1,30 @@
+import {ERROR_DICTIONARY} from '../../constants';
+
+/**
+ * Error thrown when we try to do multistream, but fail. This error
+ * is not exported outside of plugin-meetings, because it's handled
+ * internally.
+ */
+export default class MultistreamNotSupportedError extends Error {
+  code: any;
+  error: any;
+  sdkMessage: any;
+
+  /**
+   *
+   * @constructor
+   * @param {String} [message]
+   * @param {Object} [error]
+   */
+  constructor(
+    message: string = ERROR_DICTIONARY.MULTISTREAM_NOT_SUPPORTED.MESSAGE,
+    error: any = null
+  ) {
+    super(message);
+    this.name = ERROR_DICTIONARY.MULTISTREAM_NOT_SUPPORTED.NAME;
+    this.sdkMessage = ERROR_DICTIONARY.MULTISTREAM_NOT_SUPPORTED.MESSAGE;
+    this.error = error;
+    this.stack = error ? error.stack : new Error().stack;
+    this.code = ERROR_DICTIONARY.MULTISTREAM_NOT_SUPPORTED.CODE;
+  }
+}

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -545,6 +545,11 @@ export const ERROR_DICTIONARY = {
     MESSAGE: 'An error occurred while the join webinar.',
     CODE: 16,
   },
+  MULTISTREAM_NOT_SUPPORTED: {
+    NAME: 'MultistreamNotSupported',
+    MESSAGE: 'Client asked for multistream backend (Homer), but got something else instead',
+    CODE: 17,
+  },
 };
 
 export const FLOOR_ACTION = {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -161,6 +161,7 @@ import {LocusMediaRequest} from './locusMediaRequest';
 import {ConnectionStateHandler, ConnectionStateEvent} from './connectionStateHandler';
 import JoinWebinarError from '../common/errors/join-webinar-error';
 import Member from '../member';
+import MultistreamNotSupportedError from '../common/errors/multistream-not-supported-error';
 
 // default callback so we don't call an undefined function, but in practice it should never be used
 const DEFAULT_ICE_PHASE_CALLBACK = () => 'JOIN_MEETING_FINAL';
@@ -4627,11 +4628,12 @@ export default class Meeting extends StatelessWebexPlugin {
    * Close the peer connections and remove them from the class.
    * Cleanup any media connection related things.
    *
+   * @param {boolean} resetMuteStates whether to also rese the audio/video mute state information
    * @returns {Promise}
    * @public
    * @memberof Meeting
    */
-  public closePeerConnections() {
+  public closePeerConnections(resetMuteStates = true) {
     if (this.mediaProperties.webrtcMediaConnection) {
       if (this.remoteMediaManager) {
         this.remoteMediaManager.stop();
@@ -4648,8 +4650,10 @@ export default class Meeting extends StatelessWebexPlugin {
       this.setNetworkStatus(undefined);
     }
 
-    this.audio = null;
-    this.video = null;
+    if (resetMuteStates) {
+      this.audio = null;
+      this.video = null;
+    }
 
     return Promise.resolve();
   }
@@ -4909,7 +4913,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @param {Object} options - options to join with media
    * @param {JoinOptions} [options.joinOptions] - see #join()
    * @param {AddMediaOptions} [options.mediaOptions] - see #addMedia()
-   * @returns {Promise} -- {join: see join(), media: see addMedia()}
+   * @returns {Promise} -- {join: see join(), media: see addMedia(), multistreamEnabled: flag to indicate if we managed to join in multistream mode}
    * @public
    * @memberof Meeting
    * @example
@@ -4999,6 +5003,7 @@ export default class Meeting extends StatelessWebexPlugin {
       return {
         join: joinResponse,
         media: mediaResponse,
+        multistreamEnabled: this.isMultistream,
       };
     } catch (error) {
       LoggerProxy.logger.error('Meeting:index#joinWithMedia --> ', error);
@@ -5007,7 +5012,17 @@ export default class Meeting extends StatelessWebexPlugin {
 
       this.roap.abortTurnDiscovery();
 
-      if (joined && isRetry) {
+      // if this was the first attempt, let's do a retry
+      let shouldRetry = !isRetry;
+
+      if (CallDiagnosticUtils.isSdpOfferCreationError(error)) {
+        // errors related to offer creation (for example missing H264 codec) will happen again no matter how many times we try,
+        // so there is no point doing a retry
+        shouldRetry = false;
+      }
+
+      // we only want to call leave if join was successful and this was a retry or we won't be doing any more retries
+      if (joined && (isRetry || !shouldRetry)) {
         try {
           await this.leave({resourceId: joinOptions?.resourceId, reason: 'joinWithMedia failure'});
         } catch (e) {
@@ -5030,15 +5045,6 @@ export default class Meeting extends StatelessWebexPlugin {
           type: error.name,
         }
       );
-
-      // if this was the first attempt, let's do a retry
-      let shouldRetry = !isRetry;
-
-      if (CallDiagnosticUtils.isSdpOfferCreationError(error)) {
-        // errors related to offer creation (for example missing H264 codec) will happen again no matter how many times we try,
-        // so there is no point doing a retry
-        shouldRetry = false;
-      }
 
       if (shouldRetry) {
         LoggerProxy.logger.warn('Meeting:index#joinWithMedia --> retrying call to joinWithMedia');
@@ -6064,6 +6070,11 @@ export default class Meeting extends StatelessWebexPlugin {
   public roapMessageReceived = (roapMessage: RoapMessage) => {
     const mediaServer = MeetingsUtil.getMediaServer(roapMessage.sdp);
 
+    if (this.isMultistream && mediaServer !== 'homer') {
+      throw new MultistreamNotSupportedError(
+        `Client asked for multistream backend (Homer), but got ${mediaServer} instead`
+      );
+    }
     this.mediaProperties.webrtcMediaConnection.roapMessageReceived(roapMessage);
 
     if (mediaServer) {
@@ -6186,16 +6197,20 @@ export default class Meeting extends StatelessWebexPlugin {
                 logText: `${LOG_HEADER} Roap Offer`,
               }
             ).catch((error) => {
+              const multistreamNotSupported = error instanceof MultistreamNotSupportedError;
+
               // @ts-ignore
               this.webex.internal.newMetrics.submitClientEvent({
                 name: 'client.media-engine.remote-sdp-received',
                 payload: {
-                  canProceed: false,
+                  canProceed: multistreamNotSupported,
                   errors: [
                     // @ts-ignore
                     this.webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode(
                       {
-                        clientErrorCode: CALL_DIAGNOSTIC_CONFIG.MISSING_ROAP_ANSWER_CLIENT_CODE,
+                        clientErrorCode: multistreamNotSupported
+                          ? CALL_DIAGNOSTIC_CONFIG.MULTISTREAM_NOT_AVAILABLE_CLIENT_CODE
+                          : CALL_DIAGNOSTIC_CONFIG.MISSING_ROAP_ANSWER_CLIENT_CODE,
                       }
                     ),
                   ],
@@ -6203,7 +6218,7 @@ export default class Meeting extends StatelessWebexPlugin {
                 options: {meetingId: this.id, rawError: error},
               });
 
-              this.deferSDPAnswer.reject(new Error('failed to send ROAP SDP offer'));
+              this.deferSDPAnswer.reject(error);
               clearTimeout(this.sdpResponseTimer);
               this.sdpResponseTimer = undefined;
             });
@@ -7093,7 +7108,9 @@ export default class Meeting extends StatelessWebexPlugin {
 
       const mc = await this.createMediaConnection(turnServerInfo, bundlePolicy);
 
-      LoggerProxy.logger.info(`${LOG_HEADER} media connection created`);
+      LoggerProxy.logger.info(
+        `${LOG_HEADER} media connection created this.isMultistream=${this.isMultistream}`
+      );
 
       if (this.isMultistream) {
         this.remoteMediaManager = new RemoteMediaManager(
@@ -7169,6 +7186,33 @@ export default class Meeting extends StatelessWebexPlugin {
       this.closePeerConnections();
       this.unsetPeerConnections();
     }
+  }
+
+  /**
+   * Cleans up stats analyzer, peer connection and other things before
+   * we can create a new transcoded media connection
+   *
+   * @private
+   * @returns {Promise<void>}
+   */
+  private async downgradeFromMultistreamToTranscoded(): Promise<void> {
+    if (this.statsAnalyzer) {
+      await this.statsAnalyzer.stopAnalyzer();
+    }
+    this.statsAnalyzer = null;
+
+    this.isMultistream = false;
+
+    if (this.mediaProperties.webrtcMediaConnection) {
+      // close peer connection, but don't reset mute state information, because we will want to use it on the retry
+      this.closePeerConnections(false);
+
+      this.mediaProperties.unsetPeerConnection();
+    }
+
+    this.locusMediaRequest?.downgradeFromMultistreamToTranscoded();
+
+    this.createStatsAnalyzer();
   }
 
   /**
@@ -7365,13 +7409,33 @@ export default class Meeting extends StatelessWebexPlugin {
 
       this.createStatsAnalyzer();
 
-      await this.establishMediaConnection(
-        remoteMediaManagerConfig,
-        bundlePolicy,
-        forceTurnDiscovery,
-        turnServerInfo
-      );
+      try {
+        await this.establishMediaConnection(
+          remoteMediaManagerConfig,
+          bundlePolicy,
+          forceTurnDiscovery,
+          turnServerInfo
+        );
+      } catch (error) {
+        if (error instanceof MultistreamNotSupportedError) {
+          LoggerProxy.logger.warn(
+            `${LOG_HEADER} we asked for multistream backend (Homer), but got transcoded backend, recreating media connection...`
+          );
 
+          await this.downgradeFromMultistreamToTranscoded();
+
+          // Establish new media connection with forced TURN discovery
+          // We need to do TURN discovery again, because backend will be creating a new confluence, so it might land on a different node or cluster
+          await this.establishMediaConnection(
+            remoteMediaManagerConfig,
+            bundlePolicy,
+            true,
+            undefined
+          );
+        } else {
+          throw error;
+        }
+      }
       if (this.mediaProperties.hasLocalShareStream()) {
         await this.enqueueScreenShareFloorRequest();
       }
@@ -8341,7 +8405,7 @@ export default class Meeting extends StatelessWebexPlugin {
     if (layoutType) {
       if (!LAYOUT_TYPES.includes(layoutType)) {
         return this.rejectWithErrorLog(
-          'Meeting:index#changeVideoLayout --> cannot change video layout, invalid layoutType received.'
+          `Meeting:index#changeVideoLayout --> cannot change video layout, invalid layoutType "${layoutType}" received.`
         );
       }
 
@@ -8736,10 +8800,12 @@ export default class Meeting extends StatelessWebexPlugin {
 
       return;
     }
-    const {keepAliveUrl} = this.joinedWith;
+
     const keepAliveInterval = (this.joinedWith.keepAliveSecs - 1) * 750; // taken from UCF
 
     this.keepAliveTimerId = setInterval(() => {
+      const {keepAliveUrl} = this.joinedWith;
+
       this.meetingRequest.keepAlive({keepAliveUrl}).catch((error) => {
         LoggerProxy.logger.warn(
           `Meeting:index#startKeepAlive --> Stopping sending keepAlives to ${keepAliveUrl} after error ${error}`

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4628,7 +4628,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * Close the peer connections and remove them from the class.
    * Cleanup any media connection related things.
    *
-   * @param {boolean} resetMuteStates whether to also rese the audio/video mute state information
+   * @param {boolean} resetMuteStates whether to also reset the audio/video mute state information
    * @returns {Promise}
    * @public
    * @memberof Meeting

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -342,4 +342,11 @@ export class LocusMediaRequest extends WebexPlugin {
   public isConfluenceCreated() {
     return this.confluenceState === 'created';
   }
+
+  /**
+   * This method needs to be called when we downgrade from multistream to transcoded connection.
+   */
+  public downgradeFromMultistreamToTranscoded() {
+    this.config.preferTranscoding = true;
+  }
 }

--- a/packages/@webex/plugin-meetings/src/meetings/util.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/util.ts
@@ -90,7 +90,8 @@ MeetingsUtil.getMediaServer = (sdp) => {
       .find((line) => line.startsWith('o='))
       .split(' ')
       .shift()
-      .replace('o=', '');
+      .replace('o=', '')
+      .toLowerCase();
   } catch {
     mediaServer = undefined;
   }

--- a/packages/@webex/plugin-meetings/src/roap/index.ts
+++ b/packages/@webex/plugin-meetings/src/roap/index.ts
@@ -231,14 +231,16 @@ export default class Roap extends StatelessWebexPlugin {
               headers,
             } = remoteSdp.roapMessage;
 
-            roapAnswer = {
-              seq: answerSeq,
-              messageType,
-              sdp: sdps[0],
-              errorType,
-              errorCause,
-              headers,
-            };
+            if (messageType === ROAP.ROAP_TYPES.ANSWER) {
+              roapAnswer = {
+                seq: answerSeq,
+                messageType,
+                sdp: sdps[0],
+                errorType,
+                errorCause,
+                headers,
+              };
+            }
           }
         }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -93,6 +93,7 @@ import CaptchaError from '../../../../src/common/errors/captcha-error';
 import PermissionError from '../../../../src/common/errors/permission';
 import JoinWebinarError from '../../../../src/common/errors/join-webinar-error';
 import IntentToJoinError from '../../../../src/common/errors/intent-to-join';
+import MultistreamNotSupportedError from '../../../../src/common/errors/multistream-not-supported-error';;
 import testUtils from '../../../utils/testUtils';
 import {
   MeetingInfoV2CaptchaError,
@@ -652,7 +653,7 @@ describe('plugin-meetings', () => {
         const fakeTurnServerInfo = {id: 'fake turn info'};
         const fakeJoinResult = {id: 'join result'};
 
-        const joinOptions = {correlationId: '12345'};
+        const joinOptions = {correlationId: '12345', enableMultistream: true};
         const mediaOptions = {audioEnabled: true, allowMediaInLobby: true};
 
         let generateTurnDiscoveryRequestMessageStub;
@@ -661,7 +662,10 @@ describe('plugin-meetings', () => {
         let addMediaInternalStub;
 
         beforeEach(() => {
-          meeting.join = sinon.stub().returns(Promise.resolve(fakeJoinResult));
+          meeting.join = sinon.stub().callsFake((joinOptions) => {
+            meeting.isMultistream = joinOptions.enableMultistream;
+            return Promise.resolve(fakeJoinResult)
+          });
           addMediaInternalStub = sinon
             .stub(meeting, 'addMediaInternal')
             .returns(Promise.resolve(test4));
@@ -700,7 +704,7 @@ describe('plugin-meetings', () => {
             mediaOptions
           );
 
-          assert.deepEqual(result, {join: fakeJoinResult, media: test4});
+          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
 
           // resets joinWithMediaRetryInfo
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
@@ -733,7 +737,7 @@ describe('plugin-meetings', () => {
             mediaOptions
           );
 
-          assert.deepEqual(result, {join: fakeJoinResult, media: test4});
+          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
           assert.equal(meeting.turnServerUsed, false);
         });
 
@@ -768,7 +772,7 @@ describe('plugin-meetings', () => {
             mediaOptions
           );
 
-          assert.deepEqual(result, {join: fakeJoinResult, media: test4});
+          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
         });
 
         it('should reject if join() fails', async () => {
@@ -855,7 +859,8 @@ describe('plugin-meetings', () => {
             }
           );
 
-          assert.deepEqual(result, {join: fakeJoinResult, media: test4});
+          // expect multistreamEnabled: false, because this test overrides the join meeting.join stub so it doesn't set the isMultistream flag
+          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: false});
 
           // resets joinWithMediaRetryInfo
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
@@ -944,7 +949,7 @@ describe('plugin-meetings', () => {
             mediaOptions,
           });
 
-          assert.deepEqual(result, {join: fakeJoinResult, media: test4});
+          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
 
           assert.calledOnce(meeting.join);
           assert.notCalled(leaveStub);
@@ -1038,6 +1043,7 @@ describe('plugin-meetings', () => {
             getConnectionState: sinon.stub().returns(ConnectionState.Connected),
             initiateOffer: sinon.stub().resolves({}),
             on: sinon.stub(),
+            createSendSlot: sinon.stub(),
           };
 
           /* Setup the stubs so that the first call to addMediaInternal() fails
@@ -1054,12 +1060,14 @@ describe('plugin-meetings', () => {
 
           sinon.stub(meeting.roap, 'doTurnDiscovery').resolves({turnServerInfo: 'fake turn info'});
 
+          // calling joinWithMedia() with enableMultistream=false, because this test uses real addMediaInternal() implementation
+          // and it requires less stubs when it's without multistream
           const result = await meeting.joinWithMedia({
-            joinOptions,
+            joinOptions: {...joinOptions, enableMultistream: false},
             mediaOptions,
           });
 
-          assert.deepEqual(result, {join: fakeJoinResult, media: undefined});
+          assert.deepEqual(result, {join: fakeJoinResult, media: undefined, multistreamEnabled: false});
 
           assert.calledOnce(meeting.join);
 
@@ -1134,6 +1142,7 @@ describe('plugin-meetings', () => {
           addMediaError.name = 'SdpOfferCreationError';
 
           meeting.addMediaInternal.rejects(addMediaError);
+          sinon.stub(meeting, 'leave').resolves();
 
           await assert.isRejected(
             meeting.joinWithMedia({
@@ -1162,6 +1171,7 @@ describe('plugin-meetings', () => {
               type: addMediaError.name,
             }
           );
+          assert.calledOnceWithExactly(meeting.leave, {resourceId: undefined, reason: 'joinWithMedia failure'})
         });
       });
 
@@ -3957,6 +3967,7 @@ describe('plugin-meetings', () => {
               initiateOffer: sinon.stub().resolves({}),
               update: sinon.stub().resolves({}),
               on: sinon.stub(),
+              roapMessageReceived: sinon.stub()
             };
 
             fakeMultistreamRoapMediaConnection = {
@@ -4043,8 +4054,10 @@ describe('plugin-meetings', () => {
           };
 
           // simulates a Roap offer being generated by the RoapMediaConnection
-          const simulateRoapOffer = async () => {
-            meeting.deferSDPAnswer = {resolve: sinon.stub()};
+          const simulateRoapOffer = async (stubWaitingForAnswer = true) => {
+            if (stubWaitingForAnswer) {
+              meeting.deferSDPAnswer = {resolve: sinon.stub()};
+            }
             const roapListener = getRoapListener();
 
             await roapListener({roapMessage: roapOfferMessage});
@@ -4153,8 +4166,9 @@ describe('plugin-meetings', () => {
             remoteQualityLevel,
             expectedDebugId,
             meetingId,
+            expectMultistream = isMultistream,
           }) => {
-            if (isMultistream) {
+            if (expectMultistream) {
               const {iceServers} = mediaConnectionConfig;
 
               assert.calledOnceWithMatch(
@@ -4978,6 +4992,211 @@ describe('plugin-meetings', () => {
               assert.notCalled(fakeRoapMediaConnection.update);
             })
           );
+
+          if (isMultistream) {
+            describe('fallback from multistream to transcoded', () => {
+              let multistreamEventListeners;
+              let transcodedEventListeners;
+              let mockStatsAnalyzerCtor;
+
+              const setupFakeRoapMediaConnection = (fakeRoapMediaConnection, eventListeners) => {
+                fakeRoapMediaConnection.on.callsFake((eventName, cb) => {
+                  eventListeners[eventName] = cb;
+                });
+                fakeRoapMediaConnection.initiateOffer.callsFake(() => {
+                  // simulate offer being generated
+                  eventListeners[MediaConnectionEventNames.LOCAL_SDP_OFFER_GENERATED]();
+
+                  return Promise.resolve();
+                });
+              };
+
+              beforeEach(() => {
+                multistreamEventListeners = {};
+                transcodedEventListeners = {};
+
+                meeting.config.stats.enableStatsAnalyzer = true;
+
+                setupFakeRoapMediaConnection(fakeRoapMediaConnection, transcodedEventListeners);
+                setupFakeRoapMediaConnection(
+                  fakeMultistreamRoapMediaConnection,
+                  multistreamEventListeners
+                );
+
+                mockStatsAnalyzerCtor = sinon
+                  .stub(InternalMediaCoreModule, 'StatsAnalyzer')
+                  .callsFake(() => {
+                    return {on: sinon.stub(), stopAnalyzer: sinon.stub()};
+                  });
+
+                webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode =
+                  sinon.stub();
+
+                // setup the mock so that we get an SDP answer not from Homer
+                locusMediaRequestStub.callsFake(() => {
+                  return Promise.resolve({
+                    body: {
+                      locus: {},
+                      mediaConnections: [
+                        {
+                          remoteSdp:
+                            '{"audioMuted":false,"videoMuted":true,"roapMessage":{"messageType":"ANSWER","version":"2","seq":1,"sdps":["v=0\\r\\no=linus 0 1 IN IP4 23.89.67.4\\r\\ns=-\\r\\nc=IN IP4 23.89.67.4\\r\\n"],"headers":["noOkInTransaction"]},"type":"SDP"}',
+                        },
+                      ],
+                    },
+                  });
+                });
+
+                sinon.stub(meeting, 'closePeerConnections');
+                sinon.stub(meeting.mediaProperties, 'unsetPeerConnection');
+                sinon.stub(meeting.locusMediaRequest, 'downgradeFromMultistreamToTranscoded');
+              });
+
+              const runCheck = async (turnServerInfo, forceTurnDiscovery) => {
+                // we're calling addMediaInternal() with mic stream,
+                // so that we also verify that audioMute, videoMute info is correctly sent to backend
+                const addMediaPromise = meeting.addMediaInternal(
+                  () => '',
+                  turnServerInfo,
+                  forceTurnDiscovery,
+                  {
+                    localStreams: {microphone: fakeMicrophoneStream},
+                  }
+                );
+                await testUtils.flushPromises();
+                await simulateRoapOffer(false);
+
+                // check MultistreamRoapMediaConnection was created correctly
+                checkMediaConnectionCreated({
+                  expectMultistream: true,
+                  mediaConnectionConfig: expectedMediaConnectionConfig,
+                  localStreams: {
+                    audio: fakeMicrophoneStream,
+                    video: undefined,
+                    screenShareVideo: undefined,
+                    screenShareAudio: undefined,
+                  },
+                  direction: {
+                    audio: 'sendrecv',
+                    video: 'sendrecv',
+                    screenShare: 'recvonly',
+                  },
+                  remoteQualityLevel: 'HIGH',
+                  expectedDebugId,
+                  meetingId: meeting.id,
+                });
+
+                // check that stats analyzer was created with the right config and store the reference to it so that we can later check that it was stopped
+                assert.calledOnceWithExactly(
+                  mockStatsAnalyzerCtor,
+                  sinon.match({
+                    isMultistream: true,
+                  })
+                );
+                const initialStatsAnalyzer = mockStatsAnalyzerCtor.returnValues[0];
+                mockStatsAnalyzerCtor.resetHistory();
+
+                // TURN discovery was done (if needed)
+                if (turnServerInfo) {
+                  assert.notCalled(meeting.roap.doTurnDiscovery);
+                } else {
+                  assert.calledWith(meeting.roap.doTurnDiscovery, meeting, false, false);
+                }
+
+                // and SDP offer was sent with the right audioMuted/videoMuted values
+                checkSdpOfferSent({audioMuted: false, videoMuted: true});
+
+                await testUtils.flushPromises();
+
+                // at this point the meeting should have been downgraded to transcoded
+                assert.equal(meeting.isMultistream, false);
+
+                // old stats analyzer stopped and new one created
+                assert.calledOnce(initialStatsAnalyzer.stopAnalyzer);
+                assert.calledOnceWithExactly(
+                  mockStatsAnalyzerCtor,
+                  sinon.match({
+                    isMultistream: false,
+                  })
+                );
+
+                // and correct cleanup of other things should have been done
+                assert.calledOnceWithExactly(meeting.closePeerConnections, false);
+                assert.calledOnceWithExactly(meeting.mediaProperties.unsetPeerConnection);
+                assert.calledOnceWithExactly(
+                  meeting.locusMediaRequest.downgradeFromMultistreamToTranscoded
+                );
+
+                // new connection should have been created
+                checkMediaConnectionCreated({
+                  expectMultistream: false,
+                  mediaConnectionConfig: expectedMediaConnectionConfig,
+                  localStreams: {
+                    audio: fakeMicrophoneStream,
+                    video: undefined,
+                    screenShareVideo: undefined,
+                    screenShareAudio: undefined,
+                  },
+                  direction: {
+                    audio: 'sendrecv',
+                    video: 'sendrecv',
+                    screenShare: 'recvonly',
+                  },
+                  remoteQualityLevel: 'HIGH',
+                  expectedDebugId,
+                  meetingId: meeting.id,
+                });
+
+                // and new TURN discovery done (no matter if it was being done before or not)
+                assert.calledWith(meeting.roap.doTurnDiscovery, meeting, true, true);
+
+                // simulate new offer
+                await simulateRoapOffer(false);
+                checkSdpOfferSent({audioMuted: false, videoMuted: true});
+
+                // overall there should have been 2 calls to locusMediaRequestStub, because 2 offers were sent
+                assert.calledTwice(locusMediaRequestStub);
+
+                // simulate answer being processed correctly
+                transcodedEventListeners[MediaConnectionEventNames.REMOTE_SDP_ANSWER_PROCESSED]();
+
+                // check that addMedia finally resolved
+                await addMediaPromise;
+              };
+
+              it('addMedia() falls back to transcoded if SDP answer is not from Homer', async () => {
+                // call addMediaInternal like addMedia() does it
+                await runCheck(undefined, false);
+              });
+
+              it('addMediaInternal() correctly falls back to transcoded if SDP answer is not from Homer (joinWithMedia() case)', async () => {
+                // call addMediaInternal the way joinWithMedia() does it - with TURN info already provided
+                // and check that when we fallback to transcoded we still do another TURN discovery
+                await runCheck(
+                  {
+                    url: 'turns:turn-server-url:443?transport=tcp',
+                    username: 'turn user',
+                    password: 'turn password',
+                  },
+                  false
+                );
+              });
+
+              it('addMediaInternal() correctly falls back to transcoded if SDP answer is not from Homer (joinWithMedia() retry case)', async () => {
+                // call addMediaInternal the way joinWithMedia() does it when it does a retry - with TURN info already provided
+                // but also with forceTurnDiscovery=true - this shouldn't affect the flow for fallback to transcoded in any way
+                // but doing it just for completeness
+                await runCheck(
+                  {
+                    url: 'turns:turn-server-url:443?transport=tcp',
+                    username: 'turn user',
+                    password: 'turn password',
+                  },
+                  true
+                );
+              });
+            });
+          }
         })
       );
 
@@ -8552,8 +8771,7 @@ describe('plugin-meetings', () => {
             assert.calledWith(meeting.roapMessageReceived, fakeAnswer);
           });
 
-          it('handles OFFER message correctly when request fails', async () => {
-            const fakeError = new Error('fake error');
+          const runOfferSendingFailureTest = async (fakeError, canProceed, expectedErrorCode) => {
             const clock = sinon.useFakeTimers();
             sinon.spy(clock, 'clearTimeout');
             meeting.deferSDPAnswer = {reject: sinon.stub()};
@@ -8591,19 +8809,31 @@ describe('plugin-meetings', () => {
             assert.equal(meeting.sdpResponseTimer, undefined);
 
             assert.calledOnceWithExactly(getErrorPayloadForClientErrorCodeStub, {
-              clientErrorCode: 2007,
+              clientErrorCode: expectedErrorCode,
             });
             assert.calledWithMatch(webex.internal.newMetrics.submitClientEvent, {
               name: 'client.media-engine.remote-sdp-received',
               payload: {
-                canProceed: false,
-                errors: [{errorCode: 2007, fatal: true}],
+                canProceed,
+                errors: [{errorCode: expectedErrorCode, fatal: true}],
               },
               options: {
                 meetingId: meeting.id,
                 rawError: fakeError,
               },
             });
+          };
+
+          it('handles OFFER message correctly when request fails', async () => {
+            const fakeError = new Error('fake error');
+
+            await runOfferSendingFailureTest(fakeError, false, 2007);
+          });
+
+          it('handles OFFER message correctly when we get a non-homer answer', async () => {
+            const fakeError = new MultistreamNotSupportedError();
+
+            await runOfferSendingFailureTest(fakeError, true, 2012);
           });
 
           it('handles ANSWER message correctly', () => {
@@ -9703,14 +9933,39 @@ describe('plugin-meetings', () => {
         it('should close the webrtc media connection, and return a promise', async () => {
           const setNetworkStatusSpy = sinon.spy(meeting, 'setNetworkStatus');
           meeting.mediaProperties.webrtcMediaConnection = {close: sinon.stub()};
+
+          meeting.audio = {id: 'fakeAudioMuteState'};
+          meeting.video = {id: 'fakeVideoMuteState'};
+
           const pcs = meeting.closePeerConnections();
 
           assert.exists(pcs.then);
           await pcs;
           assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.close);
           assert.calledOnceWithExactly(setNetworkStatusSpy, undefined);
+          assert.equal(meeting.audio, null);
+          assert.equal(meeting.video, null);
+        });
+
+        it('should close the webrtc media connection, but keep audio and video props unchanged if called with resetMuteStates=false', async () => {
+          const setNetworkStatusSpy = sinon.spy(meeting, 'setNetworkStatus');
+          meeting.mediaProperties.webrtcMediaConnection = {close: sinon.stub()};
+
+          const fakeAudio = {id: 'fakeAudioMuteState'};
+          const fakeVideo = {id: 'fakeVideoMuteState'};
+
+          meeting.audio = fakeAudio;
+          meeting.video = fakeVideo;
+
+          await meeting.closePeerConnections(false);
+
+          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.close);
+          assert.calledOnceWithExactly(setNetworkStatusSpy, undefined);
+          assert.equal(meeting.audio, fakeAudio);
+          assert.equal(meeting.video, fakeVideo);
         });
       });
+
       describe('#unsetPeerConnections', () => {
         it('should unset the peer connections', () => {
           meeting.mediaProperties.unsetPeerConnection = sinon.stub().returns(true);
@@ -12301,9 +12556,12 @@ describe('plugin-meetings', () => {
         it('startKeepAlive starts the keep alive', async () => {
           meeting.meetingRequest.keepAlive = sinon.stub().returns(Promise.resolve());
 
+          const keepAliveUrl1 = 'keep.alive.url1';
+          const keepAliveUrl2 = 'keep.alive.url2';
+
           assert.isNull(meeting.keepAliveTimerId);
           meeting.joinedWith = {
-            keepAliveUrl: defaultKeepAliveUrl,
+            keepAliveUrl: keepAliveUrl1,
             keepAliveSecs: defaultKeepAliveSecs,
           };
           meeting.startKeepAlive();
@@ -12312,12 +12570,15 @@ describe('plugin-meetings', () => {
           assert.notCalled(meeting.meetingRequest.keepAlive);
           await progressTime(defaultExpectedInterval);
           assert.calledOnceWithExactly(meeting.meetingRequest.keepAlive, {
-            keepAliveUrl: defaultKeepAliveUrl,
+            keepAliveUrl: keepAliveUrl1,
           });
+          // joinedWith keep alive url might change (when we fallback from multistream to transcoded)
+          meeting.joinedWith.keepAliveUrl = keepAliveUrl2;
+
           await progressTime(defaultExpectedInterval);
           assert.calledTwice(meeting.meetingRequest.keepAlive);
-          assert.alwaysCalledWithExactly(meeting.meetingRequest.keepAlive, {
-            keepAliveUrl: defaultKeepAliveUrl,
+          assert.calledWith(meeting.meetingRequest.keepAlive, {
+            keepAliveUrl: keepAliveUrl2,
           });
         });
         it('startKeepAlive handles existing keepAliveTimerId', async () => {
@@ -12914,6 +13175,27 @@ describe('plugin-meetings', () => {
       );
       assert.calledOnceWithExactly(getMediaServer, 'fake sdp');
       assert.equal(meeting.mediaProperties.webrtcMediaConnection.mediaServer, 'homer');
+    });
+
+    it('throws MultistreamNotSupportedError if we get a non-homer SDP answer', async () => {
+      const fakeMessage = {messageType: 'ANSWER', sdp: 'fake sdp'};
+
+      meeting.isMultistream = true;
+      meeting.mediaProperties.webrtcMediaConnection = {
+        roapMessageReceived: sinon.stub(),
+      };
+
+      sinon.stub(MeetingsUtil, 'getMediaServer').returns('linus');
+
+      try {
+        await meeting.roapMessageReceived(fakeMessage);
+
+        assert.fail('Expected MultistreamNotSupportedError to be thrown');
+      } catch(e) {
+        assert.isTrue(e instanceof MultistreamNotSupportedError);
+      }
+
+      assert.notCalled(meeting.mediaProperties.webrtcMediaConnection.roapMessageReceived);
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
@@ -290,4 +290,14 @@ describe('plugin-meetings', () => {
       assert.equal(MeetingsUtil.isValidBreakoutLocus(newLocus), true);
     });
   });
+
+  describe('#getMediaServer', () => {
+    it('returns the contents of o-line lower cased', () => {
+      const sdp1 = 'v=0\r\no=homer 0 1 IN IP4 23.89.67.81\r\ns=-\r\nc=IN IP4 23.89.67.81\r\nb=TIAS:128000\r\nt=0 0\r\na=ice-lite\r\n'
+      assert.equal(MeetingsUtil.getMediaServer(sdp1), 'homer');
+
+      const sdp2 = 'v=0\r\no=HOMER 0 1 IN IP4 23.89.67.81\r\ns=-\r\nc=IN IP4 23.89.67.81\r\nb=TIAS:128000\r\nt=0 0\r\na=ice-lite\r\n'
+      assert.equal(MeetingsUtil.getMediaServer(sdp2), 'homer');
+    });
+  })
 });


### PR DESCRIPTION
# COMPLETES #[SPARK-612371](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-612371)

## This pull request addresses
We've recently changed web app to use multistream for all types of meeting and calls, but it turns out that there are still some types of calls the Homer doesn't support: these are SIP 1-1 calls. Homer will support them in a few months, but for now when we try to connect we receive an SDP answer from Linus instead of Homer and multistream code cannot handle that.

## by making the following changes
Added handling for the case when received SDP answer is not from Homer - we fallback to a transcoded meeting and re-create the media connection, send new TURN discovery request and new SDP offer.

Overview how this works:
 - when we get SDP answer not from homer as we expect, `Meeting.roapMessageReceived()` will throw `MultistreamNotSupportedError`
 - as a result, `Meeting.establishMediaConnection()` will also throw that error and it will be caught in `Meeting.addMediaInternal()` which calls `Meeting.downgradeFromMultistreamToTranscoded()` and then `Meeting.establishMediaConnection()` again - this time forcing TURN discovery to be done too.
 - `Meeting.downgradeFromMultistreamToTranscoded()` does the cleanup of all things that were setup for multistream

Corresponding web app PR: 
https://sqbu-github.cisco.com/WebExSquared/webex-web-client/pull/7514
(web app needs to just check if multistream is enabled after joinWithMedia() resolves and if not, update its UI to transcoded one).


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual e2e test with web app and sip device

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
