### PR TITLE
feat(plugin-cc): add task sync on reload

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -185,6 +185,8 @@ function updateButtonsPostEndCall() {
   showConsultButton()
   disableTransferControls();
   consultTabBtn.disabled = true;
+  incomingDetailsElm.innerText = '';
+  pauseResumeRecordingElm.innerText = 'Pause Recording';
 }
 
 function showInitiateConsultDialog() {
@@ -589,28 +591,8 @@ function register() {
     });
 
     webex.cc.on('task:sync', (currentTask) => {
-      task = currentTask;
-      
-      const {state, isTerminated} = task.data.interaction;
-
-      if (!isTerminated) {
-        holdResumeElm.disabled = false;
-        holdResumeElm.innerText = 'Hold';
-        pauseResumeRecordingElm.disabled = false;
-        pauseResumeRecordingElm.innerText = 'Pause Recording';
-        endElm.disabled = false;
-        enableConsultControls(); // Enable consult controls
-        enableTransferControls(); // Enable transfer controls
-
-        return;
-      }
-
-      if (state === 'connected') {
-        wrapupCodesDropdownElm.disabled = false;
-        wrapupElm.disabled = false;
-      }
+      handleTaskSync(currentTask);
     });
-  
 
     webex.cc.on('agent:stateChange', (data) => {
       if (data && typeof data === 'object' && data.type === 'AgentStateChangeSuccess') {
@@ -626,6 +608,74 @@ function register() {
       }
     });
     
+}
+
+function handleTaskSync(currentTask) {
+  task = currentTask;
+      
+  if (!task || !task.data) {
+    console.error('task:sync --> No task data found.');
+    
+    return;
+  }
+
+  console.log('Task: ', task);
+
+  const { data, webCallingService } = task;
+  const { interaction, interactionId, mediaResourceId, agentId  } = data;
+  const {
+    state,
+    isTerminated,
+    media,
+    participants,
+    callAssociatedDetails,
+    callProcessingDetails
+  } = interaction;
+
+  if (isTerminated) {
+    // wrapup
+    if (state === 'wrapUp' && !participants[agentId].isWrappedUp) {
+      wrapupCodesDropdownElm.disabled = false;
+      wrapupElm.disabled = false;
+    }
+
+    return;
+  }
+
+  // answer & decline incoming calls
+  const callerDisplay = callAssociatedDetails?.ani;
+  if (webCallingService.loginOption === 'BROWSER') {
+    answerElm.disabled = false;
+    declineElm.disabled = false;
+
+    incomingDetailsElm.innerText = `Call from ${callerDisplay}`;
+  } else {
+    incomingDetailsElm.innerText = `Call from ${callerDisplay}...please answer on the endpoint where the agent's extension is registered`;
+  }
+
+  // end button
+  const hasParticipants = Object.keys(participants).length > 1;
+  endElm.disabled = !hasParticipants;
+
+  // consult, transfer
+  // TODO: Test the consult and transfer features and update the conditions accordingly
+  consultTabBtn.disabled = !hasParticipants; // Enable consult controls
+  transferElm.disabled = !hasParticipants; // Enable transfer controls
+  
+  // TODO: consultTransferBtn
+  // console.log('consultState >>>>>>>>', participants[agentId].consultState);
+
+  // hold/resume call
+  const isHold = media && media[mediaResourceId] && media[mediaResourceId].isHold;
+  holdResumeElm.disabled = isTerminated;
+  holdResumeElm.innerText = isHold ? 'Resume' : 'Hold';
+
+  // pause/resume recording
+  if (callProcessingDetails) {
+    const {pauseResumeEnabled, isPaused} = callProcessingDetails;
+    pauseResumeRecordingElm.disabled = !pauseResumeEnabled;
+    pauseResumeRecordingElm.innerText = isPaused === 'true' ? 'Resume Recording' : 'Pause Recording';
+  }
 }
 
 function populateWrapupCodesDropdown() {

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -588,6 +588,30 @@ function register() {
       incomingCallListener.dispatchEvent(taskEvents);
     });
 
+    webex.cc.on('task:sync', (currentTask) => {
+      task = currentTask;
+      
+      const {state, isTerminated} = task.data.interaction;
+
+      if (!isTerminated) {
+        holdResumeElm.disabled = false;
+        holdResumeElm.innerText = 'Hold';
+        pauseResumeRecordingElm.disabled = false;
+        pauseResumeRecordingElm.innerText = 'Pause Recording';
+        endElm.disabled = false;
+        enableConsultControls(); // Enable consult controls
+        enableTransferControls(); // Enable transfer controls
+
+        return;
+      }
+
+      if (state === 'connected') {
+        wrapupCodesDropdownElm.disabled = false;
+        wrapupElm.disabled = false;
+      }
+    });
+  
+
     webex.cc.on('agent:stateChange', (data) => {
       if (data && typeof data === 'object' && data.type === 'AgentStateChangeSuccess') {
         const DEFAULT_CODE = '0'; // Default code when no aux code is present

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -639,15 +639,13 @@ function register() {
 
 function handleTaskHydrate(currentTask) {
   task = currentTask;
-      
+
   if (!task || !task.data || !task.data.interaction) {
     console.error('task:hydrate --> No task data found.');
     alert('task:hydrate --> No task data found.');
     
     return;
   }
-
-  console.log('Task: ', task);
 
   const { data, webCallingService } = task;
   const { interaction, mediaResourceId, agentId } = data;

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -590,8 +590,8 @@ function register() {
       incomingCallListener.dispatchEvent(taskEvents);
     });
 
-    webex.cc.on('task:sync', (currentTask) => {
-      handleTaskSync(currentTask);
+    webex.cc.on('task:hydrate', (currentTask) => {
+      handleTaskHydrate(currentTask);
     });
 
     webex.cc.on('agent:stateChange', (data) => {
@@ -610,11 +610,12 @@ function register() {
     
 }
 
-function handleTaskSync(currentTask) {
+function handleTaskHydrate(currentTask) {
   task = currentTask;
       
-  if (!task || !task.data) {
-    console.error('task:sync --> No task data found.');
+  if (!task || !task.data || !task.data.interaction) {
+    console.error('task:hydrate --> No task data found.');
+    alert('task:hydrate --> No task data found.');
     
     return;
   }

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -622,7 +622,7 @@ function handleTaskSync(currentTask) {
   console.log('Task: ', task);
 
   const { data, webCallingService } = task;
-  const { interaction, interactionId, mediaResourceId, agentId  } = data;
+  const { interaction, mediaResourceId, agentId } = data;
   const {
     state,
     isTerminated,
@@ -656,25 +656,30 @@ function handleTaskSync(currentTask) {
   // end button
   const hasParticipants = Object.keys(participants).length > 1;
   endElm.disabled = !hasParticipants;
-
-  // consult, transfer
-  // TODO: Test the consult and transfer features and update the conditions accordingly
-  consultTabBtn.disabled = !hasParticipants; // Enable consult controls
-  transferElm.disabled = !hasParticipants; // Enable transfer controls
   
-  // TODO: consultTransferBtn
-  // console.log('consultState >>>>>>>>', participants[agentId].consultState);
-
   // hold/resume call
   const isHold = media && media[mediaResourceId] && media[mediaResourceId].isHold;
   holdResumeElm.disabled = isTerminated;
   holdResumeElm.innerText = isHold ? 'Resume' : 'Hold';
 
-  // pause/resume recording
   if (callProcessingDetails) {
-    const {pauseResumeEnabled, isPaused} = callProcessingDetails;
+    const { pauseResumeEnabled, isPaused } = callProcessingDetails;
+
+    // pause/resume recording
     pauseResumeRecordingElm.disabled = !pauseResumeEnabled;
     pauseResumeRecordingElm.innerText = isPaused === 'true' ? 'Resume Recording' : 'Pause Recording';
+  }
+
+  // end consult, consult transfer buttons
+  const { consultMediaResourceId, destAgentId, destinationType } = data;
+  if (consultMediaResourceId && destAgentId && destinationType) {
+    const destination = participants[destAgentId];
+    destinationTypeDropdown.value = destinationType;
+    consultDestinationInput.value = destination.dn; 
+
+    consultTabBtn.style.display = 'none';
+    endConsultBtn.style.display = 'inline-block';
+    consultTransferBtn.style.display = 'inline-block';
   }
 }
 

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -79,11 +79,17 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     this.trigger(TASK_EVENTS.TASK_INCOMING, task);
   };
 
+  private handleTaskSync = (task: ITask) => {
+    // @ts-ignore
+    this.trigger(TASK_EVENTS.TASK_SYNC, task);
+  };
+
   /**
    * An Incoming Call listener.
    */
   private incomingTaskListener() {
     this.taskManager.on(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
+    this.taskManager.on(TASK_EVENTS.TASK_SYNC, this.handleTaskSync);
   }
 
   /**
@@ -347,7 +353,6 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       // To handle re-registration of event listeners on silent relogin
       this.incomingTaskListener();
-      this.taskManager.registerIncomingCallEvent();
 
       if (lastStateChangeReason === 'agent-wss-disconnect') {
         LoggerProxy.info(

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -81,7 +81,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
   private handleTaskSync = (task: ITask) => {
     // @ts-ignore
-    this.trigger(TASK_EVENTS.TASK_SYNC, task);
+    this.trigger(TASK_EVENTS.TASK_HYDRATE, task);
   };
 
   /**
@@ -89,7 +89,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    */
   private incomingTaskListener() {
     this.taskManager.on(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
-    this.taskManager.on(TASK_EVENTS.TASK_SYNC, this.handleTaskSync);
+    this.taskManager.on(TASK_EVENTS.TASK_HYDRATE, this.handleTaskSync);
   }
 
   /**
@@ -203,7 +203,6 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       this.services.webSocketManager.on('message', this.handleWebSocketMessage);
       this.incomingTaskListener();
-      this.taskManager.registerIncomingCallEvent();
 
       return loginResponse;
     } catch (error) {
@@ -231,6 +230,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       this.taskManager.unregisterIncomingCallEvent();
       this.taskManager.off(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
+      this.taskManager.off(TASK_EVENTS.TASK_HYDRATE, this.handleTaskSync);
       this.services.webSocketManager.off('message', this.handleWebSocketMessage);
 
       return logoutResponse;

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -79,7 +79,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     this.trigger(TASK_EVENTS.TASK_INCOMING, task);
   };
 
-  private handleTaskSync = (task: ITask) => {
+  private handleTaskHydrate = (task: ITask) => {
     // @ts-ignore
     this.trigger(TASK_EVENTS.TASK_HYDRATE, task);
   };
@@ -89,7 +89,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    */
   private incomingTaskListener() {
     this.taskManager.on(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
-    this.taskManager.on(TASK_EVENTS.TASK_HYDRATE, this.handleTaskSync);
+    this.taskManager.on(TASK_EVENTS.TASK_HYDRATE, this.handleTaskHydrate);
   }
 
   /**
@@ -230,7 +230,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       this.taskManager.unregisterIncomingCallEvent();
       this.taskManager.off(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
-      this.taskManager.off(TASK_EVENTS.TASK_HYDRATE, this.handleTaskSync);
+      this.taskManager.off(TASK_EVENTS.TASK_HYDRATE, this.handleTaskHydrate);
       this.services.webSocketManager.off('message', this.handleWebSocketMessage);
 
       return logoutResponse;

--- a/packages/@webex/plugin-cc/src/services/config/types.ts
+++ b/packages/@webex/plugin-cc/src/services/config/types.ts
@@ -55,6 +55,7 @@ export const CC_EVENTS = {
   AGENT_WRAPUP: 'AgentWrapup',
   AGENT_WRAPPEDUP: 'AgentWrappedUp',
   AGENT_WRAPUP_FAILED: 'AgentWrapupFailed',
+  AGENT_CONTACT: 'AgentContact',
 } as const;
 
 export type WelcomeEvent = {

--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -65,6 +65,11 @@ export default class TaskManager extends EventEmitter {
       const payload = JSON.parse(event);
       if (payload.data) {
         switch (payload.data.type) {
+          case CC_EVENTS.AGENT_CONTACT:
+            this.currentTask = new Task(this.contact, this.webCallingService, payload.data);
+            this.taskCollection[payload.data.interactionId] = this.currentTask;
+            this.emit(TASK_EVENTS.TASK_SYNC, this.currentTask);
+            break;
           case CC_EVENTS.AGENT_CONTACT_RESERVED:
             this.currentTask = new Task(this.contact, this.webCallingService, payload.data);
             this.currentTask.data = {...this.currentTask.data, isConsulted: false}; // Ensure isConsulted prop exists

--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -68,7 +68,7 @@ export default class TaskManager extends EventEmitter {
           case CC_EVENTS.AGENT_CONTACT:
             this.currentTask = new Task(this.contact, this.webCallingService, payload.data);
             this.taskCollection[payload.data.interactionId] = this.currentTask;
-            this.emit(TASK_EVENTS.TASK_SYNC, this.currentTask);
+            this.emit(TASK_EVENTS.TASK_HYDRATE, this.currentTask);
             break;
           case CC_EVENTS.AGENT_CONTACT_RESERVED:
             this.currentTask = new Task(this.contact, this.webCallingService, payload.data);

--- a/packages/@webex/plugin-cc/src/services/task/types.ts
+++ b/packages/@webex/plugin-cc/src/services/task/types.ts
@@ -49,7 +49,7 @@ export const TASK_EVENTS = {
   TASK_END: 'task:end',
   TASK_WRAPUP: 'task:wrapup',
   TASK_REJECT: 'task:rejected',
-  TASK_SYNC: 'task:sync',
+  TASK_HYDRATE: 'task:hydrate',
 } as const;
 
 export type TASK_EVENTS = Enum<typeof TASK_EVENTS>;

--- a/packages/@webex/plugin-cc/src/services/task/types.ts
+++ b/packages/@webex/plugin-cc/src/services/task/types.ts
@@ -49,6 +49,7 @@ export const TASK_EVENTS = {
   TASK_END: 'task:end',
   TASK_WRAPUP: 'task:wrapup',
   TASK_REJECT: 'task:rejected',
+  TASK_SYNC: 'task:sync',
 } as const;
 
 export type TASK_EVENTS = Enum<typeof TASK_EVENTS>;

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -21,8 +21,7 @@ import {CC_FILE, AGENT_STATE_CHANGE, AGENT_MULTI_LOGIN} from '../../../src/const
 import '../../../__mocks__/workerMock';
 import {Profile} from '../../../src/services/config/types';
 import TaskManager from '../../../src/services/task/TaskManager';
-import { TASK_EVENTS } from '../../../src/services/task/types';
-
+import {TASK_EVENTS} from '../../../src/services/task/types';
 
 jest.mock('../../../src/logger-proxy', () => ({
   __esModule: true,
@@ -46,7 +45,6 @@ describe('webex.cc', () => {
   let mockContact;
   let mockTaskManager;
   let mockWebSocketManager;
-
 
   beforeEach(() => {
     webex = MockWebex({
@@ -85,7 +83,7 @@ describe('webex.cc', () => {
       end: jest.fn(),
       wrapup: jest.fn(),
       cancelTask: jest.fn(),
-      cancelCtq: jest.fn()
+      cancelCtq: jest.fn(),
     };
 
     // Mock Services instance
@@ -104,7 +102,7 @@ describe('webex.cc', () => {
       connectionService: {
         on: jest.fn(),
       },
-      contact: mockContact
+      contact: mockContact,
     };
 
     mockTaskManager = {
@@ -121,8 +119,8 @@ describe('webex.cc', () => {
       on: jest.fn(),
       off: jest.fn(),
       emit: jest.fn(),
-      unregisterIncomingCallEvent: jest.fn()
-    }
+      unregisterIncomingCallEvent: jest.fn(),
+    };
 
     jest.spyOn(Services, 'getInstance').mockReturnValue(mockServicesInstance);
     jest.spyOn(TaskManager, 'getTaskManager').mockReturnValue(mockTaskManager);
@@ -338,10 +336,10 @@ describe('webex.cc', () => {
         },
       });
       expect(configSpy).toHaveBeenCalled();
-      expect(LoggerProxy.log).toHaveBeenCalledWith(
-        'agent config is fetched successfully',
-        {module: CC_FILE, method: 'mockConstructor'}
-      );
+      expect(LoggerProxy.log).toHaveBeenCalledWith('agent config is fetched successfully', {
+        module: CC_FILE,
+        method: 'mockConstructor',
+      });
       expect(reloadSpy).not.toHaveBeenCalled();
       expect(result).toEqual(mockAgentProfile);
     });
@@ -398,44 +396,40 @@ describe('webex.cc', () => {
         },
       });
       expect(result).toEqual({});
-       
+
       const onSpy = jest.spyOn(mockTaskManager, 'on');
       const emitSpy = jest.spyOn(webex.cc, 'trigger');
       const ccEmitSpy = jest.spyOn(webex.cc, 'emit');
       const incomingCallCb = onSpy.mock.calls[0][1];
-      
+
       expect(onSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, incomingCallCb);
-      
+
       incomingCallCb(mockTask);
-  
+
       expect(emitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, mockTask);
-       // Verify message event listener
-      const messageCallback = mockWebSocketManager.on.mock.calls.find(call => call[0] === 'message')[1];
+      // Verify message event listener
+      const messageCallback = mockWebSocketManager.on.mock.calls.find(
+        (call) => call[0] === 'message'
+      )[1];
       const agentStateChangeEventData = {
         type: CC_EVENTS.AGENT_STATE_CHANGE,
-        data: { some: 'data' },
+        data: {some: 'data'},
       };
 
       const agentMultiLoginEventData = {
         type: CC_EVENTS.AGENT_MULTI_LOGIN,
         data: {some: 'data'},
-      }
+      };
 
       // Simulate receiving a message event
       messageCallback(JSON.stringify(agentStateChangeEventData));
 
-      expect(ccEmitSpy).toHaveBeenCalledWith(
-        AGENT_STATE_CHANGE,
-        agentStateChangeEventData.data
-      );
+      expect(ccEmitSpy).toHaveBeenCalledWith(AGENT_STATE_CHANGE, agentStateChangeEventData.data);
 
       // Simulate receiving a message event
       messageCallback(JSON.stringify(agentMultiLoginEventData));
 
-      expect(ccEmitSpy).toHaveBeenCalledWith(
-        AGENT_MULTI_LOGIN,
-        agentMultiLoginEventData.data
-      )
+      expect(ccEmitSpy).toHaveBeenCalledWith(AGENT_MULTI_LOGIN, agentMultiLoginEventData.data);
     });
 
     it('should login successfully with other LoginOption', async () => {
@@ -507,7 +501,14 @@ describe('webex.cc', () => {
 
       expect(stationLogoutMock).toHaveBeenCalledWith({data: data});
       expect(mockTaskManager.unregisterIncomingCallEvent).toHaveBeenCalledWith();
-      expect(mockTaskManager.off).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, expect.any(Function));
+      expect(mockTaskManager.off).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_INCOMING,
+        expect.any(Function)
+      );
+      expect(mockTaskManager.off).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_HYDRATE,
+        expect.any(Function)
+      );
       expect(mockWebSocketManager.off).toHaveBeenCalledWith('message', expect.any(Function));
       expect(result).toEqual(response);
     });
@@ -574,7 +575,7 @@ describe('webex.cc', () => {
 
       webex.cc['handleTaskSync'](task);
 
-      expect(triggerSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_SYNC, task);
+      expect(triggerSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_HYDRATE, task);
     });
   });
 
@@ -804,7 +805,10 @@ describe('webex.cc', () => {
       expect(registerWebCallingLineSpy).toHaveBeenCalled();
       expect(incomingTaskListenerSpy).toHaveBeenCalled();
       expect(webSocketManagerOnSpy).toHaveBeenCalledWith('message', expect.any(Function));
-      expect(mockTaskManager.on).toHaveBeenCalledWith(TASK_EVENTS.TASK_SYNC, expect.any(Function));
+      expect(mockTaskManager.on).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_HYDRATE,
+        expect.any(Function)
+      );
     });
 
     it('should handle AGENT_NOT_FOUND error silently', async () => {
@@ -824,14 +828,14 @@ describe('webex.cc', () => {
         {module: CC_FILE, method: 'silentRelogin'}
       );
     });
-  
+
     it('should handle errors during silent relogin', async () => {
       const error = new Error('Error while performing silentReLogin');
       jest.spyOn(webex.cc.services.agent, 'reload').mockRejectedValue(error);
-  
+
       await expect(webex.cc['silentRelogin']()).rejects.toThrow(error);
     });
-  
+
     it('should update agentConfig with deviceType during silent relogin for EXTENSION', async () => {
       const mockReLoginResponse = {
         data: {
@@ -842,22 +846,22 @@ describe('webex.cc', () => {
           dn: '12345',
         },
       };
-  
+
       // Mock the agentConfig
       webex.cc.agentConfig = {
         agentId: 'agentId',
         agentProfileID: 'test-agent-profile-id',
         isAgentLoggedIn: false,
       } as Profile;
-  
+
       const registerWebCallingLineSpy = jest.spyOn(
         webex.cc.webCallingService,
         'registerWebCallingLine'
       );
       jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue(mockReLoginResponse);
-  
+
       await webex.cc['silentRelogin']();
-  
+
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.EXTENSION);
       expect(webex.cc.agentConfig.defaultDn).toBe('12345');
     });
@@ -873,18 +877,18 @@ describe('webex.cc', () => {
           subStatus: 'subStatusValue',
         },
       };
-  
+
       // Mock the agentConfig
       webex.cc.agentConfig = {
         agentId: 'agentId',
         agentProfileID: 'test-agent-profile-id',
         isAgentLoggedIn: false,
       } as Profile;
-  
+
       jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue(mockReLoginResponse);
-  
+
       await webex.cc['silentRelogin']();
-  
+
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.AGENT_DN);
       expect(webex.cc.agentConfig.defaultDn).toBe('67890');
     });
@@ -901,10 +905,7 @@ describe('webex.cc', () => {
     it('should set up connectionLost and message event listener', () => {
       webex.cc.setupEventListeners();
 
-      expect(connectionServiceOnSpy).toHaveBeenCalledWith(
-        'connectionLost',
-        expect.any(Function)
-      );
+      expect(connectionServiceOnSpy).toHaveBeenCalledWith('connectionLost', expect.any(Function));
     });
   });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -569,11 +569,11 @@ describe('webex.cc', () => {
       );
     });
 
-    it('should trigger TASK_SYNC event with the task', () => {
+    it('should trigger TASK_HYDRATE event with the task', () => {
       const task = {id: 'task1'};
       const triggerSpy = jest.spyOn(webex.cc, 'trigger');
 
-      webex.cc['handleTaskSync'](task);
+      webex.cc['handleTaskHydrate'](task);
 
       expect(triggerSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_HYDRATE, task);
     });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -567,6 +567,15 @@ describe('webex.cc', () => {
         {module: CC_FILE, method: 'stationReLogin'}
       );
     });
+
+    it('should trigger TASK_SYNC event with the task', () => {
+      const task = {id: 'task1'};
+      const triggerSpy = jest.spyOn(webex.cc, 'trigger');
+
+      webex.cc['handleTaskSync'](task);
+
+      expect(triggerSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_SYNC, task);
+    });
   });
 
   describe('setAgentStatus', () => {
@@ -776,10 +785,6 @@ describe('webex.cc', () => {
         webex.cc.webCallingService,
         'registerWebCallingLine'
       );
-      const registerIncomingCallEventSpy = jest.spyOn(
-        webex.cc.taskManager,
-        'registerIncomingCallEvent'
-      );
       const incomingTaskListenerSpy = jest.spyOn(webex.cc, 'incomingTaskListener');
       const webSocketManagerOnSpy = jest.spyOn(webex.cc.services.webSocketManager, 'on');
       await webex.cc['silentRelogin']();
@@ -797,9 +802,9 @@ describe('webex.cc', () => {
       expect(webex.cc.agentConfig.isAgentLoggedIn).toBe(true);
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.BROWSER);
       expect(registerWebCallingLineSpy).toHaveBeenCalled();
-      expect(registerIncomingCallEventSpy).toHaveBeenCalled();
       expect(incomingTaskListenerSpy).toHaveBeenCalled();
       expect(webSocketManagerOnSpy).toHaveBeenCalledWith('message', expect.any(Function));
+      expect(mockTaskManager.on).toHaveBeenCalledWith(TASK_EVENTS.TASK_SYNC, expect.any(Function));
     });
 
     it('should handle AGENT_NOT_FOUND error silently', async () => {
@@ -902,5 +907,4 @@ describe('webex.cc', () => {
       );
     });
   });
-
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -306,6 +306,20 @@ describe('TaskManager', () => {
     expect(offSpy).toHaveBeenCalledWith(LINE_EVENTS.INCOMING_CALL, offSpy.mock.calls[1][1]);
   });
 
+  it('should emit TASK_SYNC event on AGENT_CONTACT event', () => {
+    const payload = {
+      data: {
+        ...initalPayload.data,
+        type: CC_EVENTS.AGENT_CONTACT,
+      },
+    };
+
+    const taskEmitSpy = jest.spyOn(taskManager, 'emit');
+    webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+    expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_SYNC, taskManager.currentTask);
+  });
+
   it('should emit TASK_END event on AGENT_WRAPUP event', () => {
     webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
 

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -308,7 +308,7 @@ describe('TaskManager', () => {
     expect(offSpy).toHaveBeenCalledWith(LINE_EVENTS.INCOMING_CALL, offSpy.mock.calls[1][1]);
   });
 
-  it('should emit TASK_SYNC event on AGENT_CONTACT event', () => {
+  it('should emit TASK_HYDRATE event on AGENT_CONTACT event', () => {
     const payload = {
       data: {
         ...initalPayload.data,

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -9,8 +9,7 @@ import Task from '../../../../../src/services/task';
 import {TASK_EVENTS} from '../../../../../src/services/task/types';
 import WebCallingService from '../../../../../src/services/WebCallingService';
 import config from '../../../../../src/config';
-import { wrap } from 'module';
-
+import {wrap} from 'module';
 
 describe('TaskManager', () => {
   let mockCall;
@@ -80,8 +79,8 @@ describe('TaskManager', () => {
       accept: jest.fn(),
       decline: jest.fn(),
       updateTaskData: jest.fn(),
-      data: taskDataMock
-    }
+      data: taskDataMock,
+    };
     taskManager.call = mockCall;
   });
 
@@ -281,8 +280,8 @@ describe('TaskManager', () => {
         type: CC_EVENTS.CONTACT_ENDED,
         agentId: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
         eventTime: 1733211616959,
-        eventType: "RoutingMessage",
-        interaction: {"state": "new"},
+        eventType: 'RoutingMessage',
+        interaction: {state: 'new'},
         interactionId: taskId,
         orgId: '6ecef209-9a34-4ed1-a07a-7ddd1dbe925a',
         trackingId: '575c0ec2-618c-42af-a61c-53aeb0a221ee',
@@ -298,7 +297,10 @@ describe('TaskManager', () => {
 
     expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_END, {wrapupRequired: false});
     expect(webCallListenerSpy).toHaveBeenCalledWith();
-    expect(callOffSpy).toHaveBeenCalledWith(CALL_EVENT_KEYS.REMOTE_MEDIA, callOffSpy.mock.calls[0][1]);
+    expect(callOffSpy).toHaveBeenCalledWith(
+      CALL_EVENT_KEYS.REMOTE_MEDIA,
+      callOffSpy.mock.calls[0][1]
+    );
 
     taskManager.unregisterIncomingCallEvent();
     expect(offSpy.mock.calls.length).toBe(2); // 1 for incoming call and 1 for remote media
@@ -317,7 +319,8 @@ describe('TaskManager', () => {
     const taskEmitSpy = jest.spyOn(taskManager, 'emit');
     webSocketManagerMock.emit('message', JSON.stringify(payload));
 
-    expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_SYNC, taskManager.currentTask);
+    expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_HYDRATE, taskManager.currentTask);
+    expect(taskManager.taskCollection[payload.data.interactionId]).toBe(taskManager.currentTask);
   });
 
   it('should emit TASK_END event on AGENT_WRAPUP event', () => {
@@ -531,7 +534,6 @@ describe('TaskManager', () => {
       },
     };
 
-
     webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
 
     // Always spy on the updated task object after CONTACT_RESERVED is emitted
@@ -564,32 +566,32 @@ describe('TaskManager', () => {
     const reservedPayload = {
       data: {
         type: CC_EVENTS.AGENT_CONTACT_RESERVED,
-        agentId: "723a8ffb-a26e-496d-b14a-ff44fb83b64f",
+        agentId: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
         eventTime: 1733211616959,
-        eventType: "RoutingMessage",
+        eventType: 'RoutingMessage',
         interaction: {},
         interactionId: taskId,
-        orgId: "6ecef209-9a34-4ed1-a07a-7ddd1dbe925a",
-        trackingId: "575c0ec2-618c-42af-a61c-53aeb0a221ee",
+        orgId: '6ecef209-9a34-4ed1-a07a-7ddd1dbe925a',
+        trackingId: '575c0ec2-618c-42af-a61c-53aeb0a221ee',
         mediaResourceId: '0ae913a4-c857-4705-8d49-76dd3dde75e4',
         destAgentId: 'ebeb893b-ba67-4f36-8418-95c7492b28c2',
         owner: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
         queueMgr: 'aqm',
       },
     };
-  
+
     webSocketManagerMock.emit('message', JSON.stringify(reservedPayload));
-  
+
     const ronaPayload = {
       data: {
         type: CC_EVENTS.AGENT_CONTACT_OFFER_RONA,
-        agentId: "723a8ffb-a26e-496d-b14a-ff44fb83b64f",
+        agentId: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
         eventTime: 1733211616959,
-        eventType: "RoutingMessage",
+        eventType: 'RoutingMessage',
         interaction: {},
         interactionId: taskId,
-        orgId: "6ecef209-9a34-4ed1-a07a-7ddd1dbe925a",
-        trackingId: "575c0ec2-618c-42af-a61c-53aeb0a221ee",
+        orgId: '6ecef209-9a34-4ed1-a07a-7ddd1dbe925a',
+        trackingId: '575c0ec2-618c-42af-a61c-53aeb0a221ee',
         mediaResourceId: '0ae913a4-c857-4705-8d49-76dd3dde75e4',
         destAgentId: 'ebeb893b-ba67-4f36-8418-95c7492b28c2',
         owner: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
@@ -597,12 +599,12 @@ describe('TaskManager', () => {
         reason: 'USER_REJECTED',
       },
     };
-  
+
     taskManager.taskCollection[taskId] = taskManager.currentTask;
     const taskEmitSpy = jest.spyOn(taskManager.currentTask, 'emit');
-  
+
     webSocketManagerMock.emit('message', JSON.stringify(ronaPayload));
-  
+
     expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_REJECT, ronaPayload.data.reason);
     expect(taskManager.getTask(taskId)).toBeUndefined();
   });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #<[SPARK-610352](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-610352) >

## This pull request addresses

Adds event to sync the task on page refresh/reload.

e.g.

```js
    webex.cc.on('task:sync', (currentTask) => {
        task = currentTask;
    });
```

## by making the following changes

Able to get the current task and update the samples page

<!-- You may include screenshots -->

Vidcast - https://app.vidcast.io/share/36105f68-ca3c-40b9-a108-6731a1be4ba3

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

Manual Testig

- Tested with the `Extension` Agent login - Seems to be working fine
- Tested with `Browser` Agent login - There is one issue with the mobius device registration where when we do the `silentRelogin` we get 403 error on first registration try, then DELETE request goes followed by device registration successful -- causing the call to disconnect and we get the wrap up state in place. This requires investigation in calling SDK. I will update this scenario in the test plan if it's not there already

**Tested the following controls:**

- Answer/Decline
- hold/resume
- end 
- pause/resume recording
- wrapUp

**Code added but needs more testing as it's behaving bit flaky**

- consult
- consultTransfer
- transfer (Seems to be working as expected, could be tested few more times to be sure)

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
