### PR TITLE
fix(internal-plugin-device): Fix device registration deadlock

### DIFF
--- a/packages/@webex/internal-plugin-device/src/device.js
+++ b/packages/@webex/internal-plugin-device/src/device.js
@@ -613,7 +613,18 @@ const Device = WebexPlugin.extend({
     return this.request({
       uri: this.url,
       method: 'DELETE',
-    }).finally(() => this.clear());
+    })
+      .then(() => this.clear())
+      .catch((reason) => {
+        if (reason.statusCode === 404) {
+          this.logger.info(
+            'device: 404 when deleting device, device is already deleted, clearing device'
+          );
+
+          this.clear();
+        }
+        throw reason;
+      });
   },
   /* eslint-enable require-jsdoc */
 

--- a/packages/@webex/internal-plugin-device/src/device.js
+++ b/packages/@webex/internal-plugin-device/src/device.js
@@ -613,7 +613,7 @@ const Device = WebexPlugin.extend({
     return this.request({
       uri: this.url,
       method: 'DELETE',
-    }).then(() => this.clear());
+    }).finally(() => this.clear());
   },
   /* eslint-enable require-jsdoc */
 

--- a/packages/@webex/internal-plugin-device/src/device.js
+++ b/packages/@webex/internal-plugin-device/src/device.js
@@ -489,16 +489,29 @@ const Device = WebexPlugin.extend({
   /**
    * Registers and when fails deletes devices
    */
-  @oneFlight
   @waitForValue('@')
   register(deviceRegistrationOptions = {}) {
-    return this._registerInternal(deviceRegistrationOptions).catch((error) => {
-      if (error?.body?.message === 'User has excessive device registrations') {
-        return this.deleteDevices().then(() => {
-          return this._registerInternal(deviceRegistrationOptions);
-        });
+    this.logger.info('device: registering');
+
+    this.webex.internal.newMetrics.callDiagnosticMetrics.setDeviceInfo(this);
+
+    // Validate that the device can be registered.
+    return this.canRegister().then(() => {
+      // Validate if the device is already registered and refresh instead.
+      if (this.registered) {
+        this.logger.info('device: device already registered, refreshing');
+
+        return this.refresh(deviceRegistrationOptions);
       }
-      throw error;
+
+      return this._registerInternal(deviceRegistrationOptions).catch((error) => {
+        if (error?.body?.message === 'User has excessive device registrations') {
+          return this.deleteDevices().then(() => {
+            return this._registerInternal(deviceRegistrationOptions);
+          });
+        }
+        throw error;
+      });
     });
   },
 
@@ -521,77 +534,63 @@ const Device = WebexPlugin.extend({
   @oneFlight
   @waitForValue('@')
   _registerInternal(deviceRegistrationOptions = {}) {
-    this.logger.info('device: registering');
+    this.logger.info('device: making registration request');
 
-    this.webex.internal.newMetrics.callDiagnosticMetrics.setDeviceInfo(this);
+    // Merge body configurations, overriding defaults.
+    const body = this._getBody();
 
-    // Validate that the device can be registered.
-    return this.canRegister().then(() => {
-      // Validate if the device is already registered and refresh instead.
-      if (this.registered) {
-        this.logger.info('device: device already registered, refreshing');
+    // Merge header configurations, overriding defaults.
+    const headers = {
+      ...(this.config.defaults.headers ? this.config.defaults.headers : {}),
+      ...(this.config.headers ? this.config.headers : {}),
+    };
 
-        return this.refresh(deviceRegistrationOptions);
-      }
-
-      // Merge body configurations, overriding defaults.
-      const body = this._getBody();
-
-      // Merge header configurations, overriding defaults.
-      const headers = {
-        ...(this.config.defaults.headers ? this.config.defaults.headers : {}),
-        ...(this.config.headers ? this.config.headers : {}),
-      };
-
-      // Append a ttl value if the device is marked as ephemeral
-      if (this.config.ephemeral) {
-        body.ttl = this.config.ephemeralDeviceTTL;
-      }
-      this.webex.internal.newMetrics.submitInternalEvent({
-        name: 'internal.register.device.request',
-      });
-
-      const {includeDetails = CatalogDetails.all} = deviceRegistrationOptions;
-
-      // This will be replaced by a `create()` method.
-      return this.request({
-        method: 'POST',
-        service: 'wdm',
-        resource: 'devices',
-        body,
-        headers,
-        qs: {
-          includeUpstreamServices: `${includeDetails}${
-            this.config.energyForecast && this.energyForecastConfig ? ',energyforecast' : ''
-          }`,
-        },
-      })
-        .catch((error) => {
-          this.webex.internal.newMetrics.submitInternalEvent({
-            name: 'internal.register.device.response',
-          });
-
-          throw error;
-        })
-        .then((response) => {
-          // Do not add any processing of response above this as that will affect timestamp
-          this.webex.internal.newMetrics.submitInternalEvent({
-            name: 'internal.register.device.response',
-          });
-
-          this.webex.internal.metrics.submitClientMetrics(
-            METRICS.JS_SDK_WDM_REGISTRATION_SUCCESSFUL
-          );
-
-          return this.processRegistrationSuccess(response);
-        })
-        .catch((error) => {
-          this.webex.internal.metrics.submitClientMetrics(METRICS.JS_SDK_WDM_REGISTRATION_FAILED, {
-            fields: {error},
-          });
-          throw error;
-        });
+    // Append a ttl value if the device is marked as ephemeral
+    if (this.config.ephemeral) {
+      body.ttl = this.config.ephemeralDeviceTTL;
+    }
+    this.webex.internal.newMetrics.submitInternalEvent({
+      name: 'internal.register.device.request',
     });
+
+    const {includeDetails = CatalogDetails.all} = deviceRegistrationOptions;
+
+    // This will be replaced by a `create()` method.
+    return this.request({
+      method: 'POST',
+      service: 'wdm',
+      resource: 'devices',
+      body,
+      headers,
+      qs: {
+        includeUpstreamServices: `${includeDetails}${
+          this.config.energyForecast && this.energyForecastConfig ? ',energyforecast' : ''
+        }`,
+      },
+    })
+      .catch((error) => {
+        this.webex.internal.newMetrics.submitInternalEvent({
+          name: 'internal.register.device.response',
+        });
+
+        throw error;
+      })
+      .then((response) => {
+        // Do not add any processing of response above this as that will affect timestamp
+        this.webex.internal.newMetrics.submitInternalEvent({
+          name: 'internal.register.device.response',
+        });
+
+        this.webex.internal.metrics.submitClientMetrics(METRICS.JS_SDK_WDM_REGISTRATION_SUCCESSFUL);
+
+        return this.processRegistrationSuccess(response);
+      })
+      .catch((error) => {
+        this.webex.internal.metrics.submitClientMetrics(METRICS.JS_SDK_WDM_REGISTRATION_FAILED, {
+          fields: {error},
+        });
+        throw error;
+      });
   },
   /**
    * Unregister the current registered device if available. Unregistering a

--- a/packages/@webex/internal-plugin-device/test/unit/spec/device.js
+++ b/packages/@webex/internal-plugin-device/test/unit/spec/device.js
@@ -419,6 +419,33 @@ describe('plugin-device', () => {
     });
    });
 
+    describe('#unregister()', () => {
+      it('resolves immediately if the device is not registered', async () => {
+        const requestSpy = sinon.spy(device, 'request');
+
+        device.set('registered', false);
+
+        await device.unregister();
+
+        assert.notCalled(requestSpy);
+      });
+
+      it('clears the device in the event of failure', async () => {
+        sinon.stub(device, 'request').rejects(new Error('some error'));
+
+        const clearSpy = sinon.spy(device, 'clear');
+
+        await assert.isRejected(device.unregister());
+
+        assert.calledWith(device.request, {
+          uri: 'https://locus-a.wbx2.com/locus/api/v1/devices/88888888-4444-4444-4444-CCCCCCCCCCCC',
+          method: 'DELETE',
+        });
+
+        assert.calledOnce(clearSpy);
+      });
+    });
+
     describe('#register()', () => {
       const setup = (config = {}) => {
         webex.internal.metrics.submitClientMetrics = sinon.stub();

--- a/packages/@webex/internal-plugin-device/test/unit/spec/device.js
+++ b/packages/@webex/internal-plugin-device/test/unit/spec/device.js
@@ -450,6 +450,7 @@ describe('plugin-device', () => {
 
       it('calls delete devices when errors with User has excessive device registrations', async () => {
         setup();
+        sinon.stub(device, 'canRegister').callsFake(() => Promise.resolve());
         const deleteDeviceSpy = sinon.stub(device, 'deleteDevices').callsFake(() => Promise.resolve());
         const registerStub = sinon.stub(device, '_registerInternal');
         
@@ -468,6 +469,7 @@ describe('plugin-device', () => {
       it('does not call delete devices when some other error', async () => {
         setup();
 
+        sinon.stub(device, 'canRegister').callsFake(() => Promise.resolve());
         const deleteDeviceSpy = sinon.stub(device, 'deleteDevices').callsFake(() => Promise.resolve());
         const registerStub = sinon.stub(device, '_registerInternal').rejects(new Error('some error'));
 
@@ -643,6 +645,23 @@ describe('plugin-device', () => {
         await device.register({includeDetails: CatalogDetails.websocket});
 
         assert.calledWith(refreshSpy, {includeDetails: CatalogDetails.websocket});
+      });
+
+      it('works when request returns 404 when already registered', async () => {
+        setup();
+        
+        sinon.stub(device, 'canRegister').callsFake(() => Promise.resolve());
+
+        const requestStub = sinon.stub(device, 'request');
+
+        requestStub.onFirstCall().rejects({statusCode: 404});
+        requestStub.onSecondCall().resolves({some: 'data'});
+
+        device.set('registered', true);
+
+        await device.register();
+
+        assert.calledWith(device.processRegistrationSuccess, {some: 'data'});
       });
     });
 

--- a/packages/@webex/internal-plugin-device/test/unit/spec/device.js
+++ b/packages/@webex/internal-plugin-device/test/unit/spec/device.js
@@ -430,8 +430,8 @@ describe('plugin-device', () => {
         assert.notCalled(requestSpy);
       });
 
-      it('clears the device in the event of failure', async () => {
-        sinon.stub(device, 'request').rejects(new Error('some error'));
+      it('clears the device in the event of 404', async () => {
+        sinon.stub(device, 'request').rejects({statusCode: 404});
 
         const clearSpy = sinon.spy(device, 'clear');
 
@@ -443,6 +443,21 @@ describe('plugin-device', () => {
         });
 
         assert.calledOnce(clearSpy);
+      });
+
+      it('does not clear the device in the event of non 404 failure', async () => {
+        sinon.stub(device, 'request').rejects(new Error('some error'));
+
+        const clearSpy = sinon.spy(device, 'clear');
+
+        await assert.isRejected(device.unregister());
+
+        assert.calledWith(device.request, {
+          uri: 'https://locus-a.wbx2.com/locus/api/v1/devices/88888888-4444-4444-4444-CCCCCCCCCCCC',
+          method: 'DELETE',
+        });
+
+        assert.notCalled(clearSpy);
       });
     });
 


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

This fixes two issues found in the device plugin:

1. A oneFlight lock caused by a 404 in refresh
2. Failure to clear the device plugin when unregister fails

## by making the following changes

1. Only lock registerInternal internal with oneFlight. Move the code that decides to refresh instead of register outside of registerInternal.

2. Clear the device if we get a 404 as this means it is already deleted. This was already happening if we got a 404 when refreshing.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
