### PR TITLE
feat(byods): added-list-api-change

### DIFF
--- a/packages/byods-demo-server/package.json
+++ b/packages/byods-demo-server/package.json
@@ -3,8 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "NODE_ENV=development BYODS_ENVIRONMENT=production npx ts-node ./src",
-    "dev:hot": "nodemon --exec \"npm run dev\" --watch ./src -e ts"
+    "dev:integration": "NODE_ENV=development BYODS_ENVIRONMENT=integration npx ts-node ./src",
+    "dev:production": "NODE_ENV=development BYODS_ENVIRONMENT=production npx ts-node ./src",
+    "dev:hot": "nodemon --exec \"npm run dev:production\" --watch ./src -e ts"
   },
   "engines": {
     "node": ">=20.x"

--- a/packages/byods-demo-server/package.json
+++ b/packages/byods-demo-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "NODE_ENV=development BYODS_ENVIRONMENT=integration npx ts-node ./src",
+    "dev": "NODE_ENV=development BYODS_ENVIRONMENT=production npx ts-node ./src",
     "dev:hot": "nodemon --exec \"npm run dev\" --watch ./src -e ts"
   },
   "engines": {

--- a/packages/byods/src/data-source-client/index.ts
+++ b/packages/byods/src/data-source-client/index.ts
@@ -7,7 +7,7 @@ import {
   DataSourceResponse,
   DataSourceUpdateRequest,
   Cancellable,
-  DataSourceResponseList,
+  DataSourceListResponse,
 } from './types';
 import {DATASOURCE_ENDPOINT} from './constants';
 import {HttpClient, ApiResponse} from '../http-client/types';
@@ -68,7 +68,7 @@ export default class DataSourceClient {
    */
   public async list(): Promise<ApiResponse<DataSourceResponse[]>> {
     return this.httpClient
-      .get<DataSourceResponseList<DataSourceResponse>>(DATASOURCE_ENDPOINT)
+      .get<DataSourceListResponse<DataSourceResponse>>(DATASOURCE_ENDPOINT)
       .then((response) => ({
         ...response,
         data: response.data.items,

--- a/packages/byods/src/data-source-client/index.ts
+++ b/packages/byods/src/data-source-client/index.ts
@@ -2,7 +2,13 @@ import {decodeJwt, JWTPayload} from 'jose';
 import {ERROR_TYPE} from '../Errors/types';
 import ExtendedError from '../Errors/catalog/ExtendedError';
 import {LoggerConfig} from '../types';
-import {DataSourceRequest, DataSourceResponse, DataSourceUpdateRequest, Cancellable} from './types';
+import {
+  DataSourceRequest,
+  DataSourceResponse,
+  DataSourceUpdateRequest,
+  Cancellable,
+  DataSourceResponseList,
+} from './types';
 import {DATASOURCE_ENDPOINT} from './constants';
 import {HttpClient, ApiResponse} from '../http-client/types';
 import {BYODS_DATA_SOURCE_CLIENT_MODULE, DEFAULT_LOGGER_CONFIG} from '../constants';
@@ -61,7 +67,12 @@ export default class DataSourceClient {
    * const response = await client.list();
    */
   public async list(): Promise<ApiResponse<DataSourceResponse[]>> {
-    return this.httpClient.get<DataSourceResponse[]>(DATASOURCE_ENDPOINT);
+    return this.httpClient
+      .get<DataSourceResponseList<DataSourceResponse>>(DATASOURCE_ENDPOINT)
+      .then((response) => ({
+        ...response,
+        data: response.data.items,
+      }));
   }
 
   /**

--- a/packages/byods/src/data-source-client/index.ts
+++ b/packages/byods/src/data-source-client/index.ts
@@ -7,7 +7,7 @@ import {
   DataSourceResponse,
   DataSourceUpdateRequest,
   Cancellable,
-  DataSourceListResponse,
+  ListResponse,
 } from './types';
 import {DATASOURCE_ENDPOINT} from './constants';
 import {HttpClient, ApiResponse} from '../http-client/types';
@@ -68,7 +68,7 @@ export default class DataSourceClient {
    */
   public async list(): Promise<ApiResponse<DataSourceResponse[]>> {
     return this.httpClient
-      .get<DataSourceListResponse<DataSourceResponse>>(DATASOURCE_ENDPOINT)
+      .get<ListResponse<DataSourceResponse>>(DATASOURCE_ENDPOINT)
       .then((response) => ({
         ...response,
         data: response.data.items,

--- a/packages/byods/src/data-source-client/types.ts
+++ b/packages/byods/src/data-source-client/types.ts
@@ -114,6 +114,15 @@ export interface DataSourceUpdateRequest extends DataSourceRequest {
   errorMessage?: string;
 }
 
+/**
+ * Represents the response from a data source list.
+ *
+ * @public
+ */
+export interface DataSourceResponseList<T> {
+  items: T[];
+}
+
 export interface Cancellable {
   cancel: () => void;
 }

--- a/packages/byods/src/data-source-client/types.ts
+++ b/packages/byods/src/data-source-client/types.ts
@@ -119,7 +119,7 @@ export interface DataSourceUpdateRequest extends DataSourceRequest {
  *
  * @public
  */
-export interface DataSourceResponseList<T> {
+export interface DataSourceListResponse<T> {
   items: T[];
 }
 

--- a/packages/byods/src/data-source-client/types.ts
+++ b/packages/byods/src/data-source-client/types.ts
@@ -115,11 +115,11 @@ export interface DataSourceUpdateRequest extends DataSourceRequest {
 }
 
 /**
- * Represents the response from a data source list.
+ * Represents the response from a list.
  *
  * @public
  */
-export interface DataSourceListResponse<T> {
+export interface ListResponse<T> {
   items: T[];
 }
 

--- a/packages/byods/test/unit/spec/data-source-client/index.ts
+++ b/packages/byods/test/unit/spec/data-source-client/index.ts
@@ -1,5 +1,5 @@
 import DataSourceClient from '../../../../src/data-source-client';
-import { DataSourceRequest, DataSourceResponse, DataSourceResponseList } from '../../../../src/data-source-client/types';
+import { DataSourceRequest, DataSourceResponse, DataSourceListResponse } from '../../../../src/data-source-client/types';
 import { HttpClient, ApiResponse } from '../../../../src/http-client/types';
 import { decodeJwt } from 'jose';
 import log from '../../../../src/Logger';
@@ -100,7 +100,7 @@ describe('DataSourceClient', () => {
   });
 
   it('should list all data sources', async () => {
-    const response: ApiResponse<DataSourceResponseList<DataSourceResponse>> = {
+    const response: ApiResponse<DataSourceListResponse<DataSourceResponse>> = {
       data: {
         items: [
           {

--- a/packages/byods/test/unit/spec/data-source-client/index.ts
+++ b/packages/byods/test/unit/spec/data-source-client/index.ts
@@ -1,5 +1,5 @@
 import DataSourceClient from '../../../../src/data-source-client';
-import { DataSourceRequest, DataSourceResponse, DataSourceListResponse } from '../../../../src/data-source-client/types';
+import { DataSourceRequest, DataSourceResponse, ListResponse } from '../../../../src/data-source-client/types';
 import { HttpClient, ApiResponse } from '../../../../src/http-client/types';
 import { decodeJwt } from 'jose';
 import log from '../../../../src/Logger';
@@ -100,7 +100,7 @@ describe('DataSourceClient', () => {
   });
 
   it('should list all data sources', async () => {
-    const response: ApiResponse<DataSourceListResponse<DataSourceResponse>> = {
+    const response: ApiResponse<ListResponse<DataSourceResponse>> = {
       data: {
         items: [
           {

--- a/packages/byods/test/unit/spec/data-source-client/index.ts
+++ b/packages/byods/test/unit/spec/data-source-client/index.ts
@@ -1,5 +1,5 @@
 import DataSourceClient from '../../../../src/data-source-client';
-import { DataSourceRequest, DataSourceResponse } from '../../../../src/data-source-client/types';
+import { DataSourceRequest, DataSourceResponse, DataSourceResponseList } from '../../../../src/data-source-client/types';
 import { HttpClient, ApiResponse } from '../../../../src/http-client/types';
 import { decodeJwt } from 'jose';
 import log from '../../../../src/Logger';
@@ -100,19 +100,21 @@ describe('DataSourceClient', () => {
   });
 
   it('should list all data sources', async () => {
-    const response: ApiResponse<DataSourceResponse[]> = {
-      data: [
-        {
-          id: '123',
-          schemaId: 'myschemaid',
-          orgId: 'org123',
-          applicationId: 'app123',
-          status: 'active',
-          jwsToken: 'someJwsToken',
-          createdBy: 'someUser',
-          createdAt: '2024-01-01T00:00:00Z',
-        },
-      ],
+    const response: ApiResponse<DataSourceResponseList<DataSourceResponse>> = {
+      data: {
+        items: [
+          {
+            id: '123',
+            schemaId: 'myschemaid',
+            orgId: 'org123',
+            applicationId: 'app123',
+            status: 'active',
+            jwsToken: 'someJwsToken',
+            createdBy: 'someUser',
+            createdAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      },
       status: 200,
     };
     httpClient.get.mockResolvedValue(response);
@@ -120,7 +122,10 @@ describe('DataSourceClient', () => {
     const result = await dataSourceClient.list();
 
     expect(httpClient.get).toHaveBeenCalledWith('/dataSources');
-    expect(result).toEqual(response);
+    expect(result).toEqual({
+      ...response,
+      data: response.data.items,
+    });
   });
 
   it('should update a data source by ID', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-615538](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-615538)

## This pull request addresses

* As per the following server side PR change - https://sqbu-github.cisco.com/WebExSquared/developer-applications/pull/635
* We need to modify our `listDataSources` method to acommodate the change.

## by making the following changes

* Created a new type `DataSourceResponseList` which takes a generic type and has an variable called `items` for the list data.
* Applied this change to the list api method for now.


Vidcast - https://app.vidcast.io/share/1d36745e-8f3f-4375-ac46-e74911a8d613

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

* Cannot test until server side changes are in

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
