### PR TITLE
fix(plugin-meetings): join fails when paired with a device and Orpheus report-version != 1

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -140,7 +140,11 @@ const MeetingUtil = {
         meeting.isMultistream,
         MeetingUtil.getIpVersion(webex)
       );
-      reachability = await webex.meetings.reachability.getReachabilityReportToAttachToRoap();
+      if (options.roapMessage) {
+        // we only need to attach reachability if we are sending a roap message
+        // sending reachability on its own will cause Locus to reject our join request
+        reachability = await webex.meetings.reachability.getReachabilityReportToAttachToRoap();
+      }
     } catch (e) {
       LoggerProxy.logger.error(
         'Meeting:util#joinMeeting --> Error getting reachability or clientMediaPreferences:',

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -469,6 +469,17 @@ describe('plugin-meetings', () => {
         assert.calledOnce(meeting.meetingRequest.joinMeeting);
       });
 
+      it('should not attach reachability if there is no roap message', async () => {
+        await MeetingUtil.joinMeeting(meeting, {});
+
+        assert.notCalled(webex.meetings.reachability.getReachabilityReportToAttachToRoap);
+        assert.calledOnce(meeting.meetingRequest.joinMeeting);
+
+        const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
+        assert.isUndefined(parameter.reachability);
+        assert.isUndefined(parameter.roapMessage);
+      });
+
       it('should handle failed clientMediaPreferences retrieval', async () => {
         webex.meetings.reachability.getClientMediaPreferences.rejects(new Error('fake error'));
         meeting.isMultistream = true;


### PR DESCRIPTION
# COMPLETES #[SPARK-616956](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-616956)

## This pull request addresses
When Orpheus API report-version == 1 and the app calls Meeting.join() instead of Meeting.joinWithMedia() then we try to attach reachability to the Locus join request. That causes Locus to reject the request, because it doesn't like having reachability in it without any roap message.

## by making the following changes
Don't attach reachability if we don't have any Roap message to send.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
