### PR TITLE
feat(meetings): add meetings.registrationStatus flags for JMF debugging

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1389,3 +1389,12 @@ export const DESTINATION_TYPE = {
 } as const;
 
 export type DESTINATION_TYPE = Enum<typeof DESTINATION_TYPE>;
+
+export const INITIAL_REGISTRATION_STATUS = {
+  fetchWebexSite: false,
+  getGeoHint: false,
+  startReachability: false,
+  deviceRegister: false,
+  mercuryConnect: false,
+  checkH264Support: false,
+};

--- a/packages/@webex/plugin-meetings/src/meetings/meetings.types.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/meetings.types.ts
@@ -21,3 +21,13 @@ export const MEETING_KEY = {
 } as const;
 
 export type MEETING_KEY = Enum<typeof MEETING_KEY>;
+
+// finer grained status for registration steps
+export type MeetingRegistrationStatus = {
+  fetchWebexSite: boolean;
+  getGeoHint: boolean;
+  startReachability: boolean;
+  deviceRegister: boolean;
+  mercuryConnect: boolean;
+  checkH264Support: boolean;
+};


### PR DESCRIPTION
## This pull request addresses

Adds flags for each individual step of meetings registration so we can debug where some of our prejoins are hanging.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
