### PR TITLE
fix(plugin-meetings): fix mercury connection rejection

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -856,9 +856,12 @@ export default class Meetings extends WebexPlugin {
               );
             }),
         'deviceRegister'
-      ).then(
-        // @ts-ignore
-        this.executeRegistrationStep(() => this.webex.internal.mercury.connect(), 'mercuryConnect')
+      ).then(() =>
+        this.executeRegistrationStep(
+          // @ts-ignore
+          () => this.webex.internal.mercury.connect(),
+          'mercuryConnect'
+        )
       ),
       this.executeRegistrationStep(
         () => Promise.resolve(MeetingsUtil.checkH264Support.call(this)),

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -376,21 +376,21 @@ describe('plugin-meetings', () => {
           assert.isTrue(webex.meetings.registered);
         });
 
-        it('rejects when SDK canAuthorize is false', () => {
+        it('rejects when SDK canAuthorize is false', async () => {
           webex.canAuthorize = false;
-          assert.isRejected(webex.meetings.register());
+          await assert.isRejected(webex.meetings.register());
         });
 
-        it('rejects when device.register fails', () => {
+        it('rejects when device.register fails', async () => {
           webex.canAuthorize = true;
           webex.internal.device.register = sinon.stub().returns(Promise.reject());
-          assert.isRejected(webex.meetings.register());
+          await assert.isRejected(webex.meetings.register());
         });
 
-        it('rejects when mercury.connect fails', () => {
+        it('rejects when mercury.connect fails', async () => {
           webex.canAuthorize = true;
           webex.internal.mercury.connect = sinon.stub().returns(Promise.reject());
-          assert.isRejected(webex.meetings.register());
+          await assert.isRejected(webex.meetings.register());
         });
 
         it('resolves immediately if already registered', async () => {
@@ -500,7 +500,7 @@ describe('plugin-meetings', () => {
             checkH264Support: true,
           });
 
-          await clock.tick(1000);
+          await clock.tick(6000);
           await webex.internal.mercury.connect;
           assert.deepEqual(webex.meetings.registrationStatus, {
             fetchWebexSite: true,
@@ -535,16 +535,16 @@ describe('plugin-meetings', () => {
           });
         });
 
-        it('rejects when device.unregister fails', () => {
+        it('rejects when device.unregister fails', async () => {
           webex.meetings.registered = true;
           webex.internal.device.unregister = sinon.stub().returns(Promise.reject());
-          assert.isRejected(webex.meetings.unregister());
+          await assert.isRejected(webex.meetings.unregister());
         });
 
-        it('rejects when mercury.disconnect fails', () => {
+        it('rejects when mercury.disconnect fails', async () => {
           webex.meetings.registered = true;
           webex.internal.mercury.disconnect = sinon.stub().returns(Promise.reject());
-          assert.isRejected(webex.meetings.unregister());
+          await assert.isRejected(webex.meetings.unregister());
         });
 
         it('resolves immediately if not registered', (done) => {


### PR DESCRIPTION

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

When mercury fails to connect, the error was not propagated so it registration appeared to succeed

## by making the following changes

Wrap the registration step in a function. This was missed by the tests because the relevant asserts were not awaited.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
