### PR TITLE
feat(plugin-meetings): added _setLogUploadIntervalMultiplicationFactor

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -700,6 +700,20 @@ export default class Meetings extends WebexPlugin {
   }
 
   /**
+   * API to change log upload interval. Setting the factor to 0 will disable periodic log uploads.
+   *
+   * @param {number} factor new factor value
+   * @returns {void}
+   */
+  private _setLogUploadIntervalMultiplicationFactor(factor: number) {
+    if (typeof factor !== 'number') {
+      return;
+    }
+    // @ts-ignore
+    this.config.logUploadIntervalMultiplicationFactor = factor;
+  }
+
+  /**
    * API to toggle unified meetings
    * @param {Boolean} changeState
    * @private

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -268,6 +268,33 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#_setLogUploadIntervalMultiplicationFactor', () => {
+      it('should have _setLogUploadIntervalMultiplicationFactor', () => {
+        assert.equal(typeof webex.meetings._setLogUploadIntervalMultiplicationFactor, 'function');
+      });
+
+      describe('success', () => {
+        it('should update the config', () => {
+          const someValue = 1.23;
+
+          webex.meetings._setLogUploadIntervalMultiplicationFactor(someValue);
+          assert.equal(webex.meetings.config.logUploadIntervalMultiplicationFactor, someValue);
+        });
+      });
+
+      describe('failure', () => {
+        it('should not accept non-number input', () => {
+          const logUploadIntervalMultiplicationFactor = webex.meetings.config.logUploadIntervalMultiplicationFactor;
+
+          webex.meetings._setLogUploadIntervalMultiplicationFactor('test');
+          assert.equal(
+            webex.meetings.config.logUploadIntervalMultiplicationFactor,
+            logUploadIntervalMultiplicationFactor
+          );
+        });
+      });
+    });
+
     describe('#_toggleUnifiedMeetings', () => {
       it('should have toggleUnifiedMeetings', () => {
         assert.equal(typeof webex.meetings._toggleUnifiedMeetings, 'function');


### PR DESCRIPTION
## This pull request addresses
Web app needs to control periodic log uploads through a feature toggle, so we need to change the config option for this in runtime

## by making the following changes
Added a private method _setLogUploadIntervalMultiplicationFactor() that web app will call - just following the same pattern that was done for other config items controlled via feature toggles.

associated web app PR: https://sqbu-github.cisco.com/WebExSquared/webex-web-client/pull/7656

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manually with the web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
