### PR TITLE
feat(internal-plugin-metrics): allow for delayed submission of client events

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -732,7 +732,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
         meetingId,
       }),
       webexSubServiceType: this.getSubServiceType(meeting),
-      webClientPreload: (window as any).webClientPreload?.isEnabled,
+      // @ts-ignore
+      webClientPreload: this.webex.meetings?.config?.metrics?.webClientPreload,
     };
 
     const joinFlowVersion = options.joinFlowVersion ?? meeting.callStateForMetrics?.joinFlowVersion;
@@ -785,7 +786,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
         webClientDomain: window.location.hostname,
       },
       loginType: this.getCurLoginType(),
-      webClientPreload: (window as any).webClientPreload?.isEnabled,
+      // @ts-ignore
+      webClientPreload: this.webex.meetings?.config?.metrics?.webClientPreload,
     };
 
     if (options.joinFlowVersion) {

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -40,6 +40,7 @@ import {
   ClientEventPayloadError,
   ClientSubServiceType,
   BrowserLaunchMethodType,
+  DelayedClientEvent,
 } from '../metrics.types';
 import CallDiagnosticEventsBatcher from './call-diagnostic-metrics-batcher';
 import PreLoginMetricsBatcher from '../prelogin-metrics-batcher';
@@ -95,6 +96,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
   private logger: any; // to avoid adding @ts-ignore everywhere
   private hasLoggedBrowserSerial: boolean;
   private device: any;
+  private delayedClientEvents: DelayedClientEvent[] = [];
 
   // the default validator before piping an event to the batcher
   // this function can be overridden by the user
@@ -730,6 +732,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
         meetingId,
       }),
       webexSubServiceType: this.getSubServiceType(meeting),
+      webClientPreload: (window as any).webClientPreload?.isEnabled,
     };
 
     const joinFlowVersion = options.joinFlowVersion ?? meeting.callStateForMetrics?.joinFlowVersion;
@@ -782,6 +785,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
         webClientDomain: window.location.hostname,
       },
       loginType: this.getCurLoginType(),
+      webClientPreload: (window as any).webClientPreload?.isEnabled,
     };
 
     if (options.joinFlowVersion) {
@@ -856,17 +860,36 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
    * @param arg.event - event key
    * @param arg.payload - additional payload to be merged with default payload
    * @param arg.options - payload
+   * @param arg.delaySubmitEvent - a boolean value indicating whether to delay the submission of client events.
    * @throws
    */
   public submitClientEvent({
     name,
     payload,
     options,
+    delaySubmitEvent,
   }: {
     name: ClientEvent['name'];
     payload?: ClientEventPayload;
     options?: SubmitClientEventOptions;
+    delaySubmitEvent?: boolean;
   }) {
+    if (delaySubmitEvent) {
+      // Preserve the time when the event was triggered if delaying the submission to Call Diagnostics
+      const delayedOptions = {
+        ...options,
+        triggeredTime: new Date().toISOString(),
+      };
+
+      this.delayedClientEvents.push({
+        name,
+        payload,
+        options: delayedOptions,
+      });
+
+      return Promise.resolve();
+    }
+
     this.logger.log(
       CALL_DIAGNOSTIC_LOG_IDENTIFIER,
       'CallDiagnosticMetrics: @submitClientEvent. Submit Client Event CA event.',
@@ -881,6 +904,28 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
     this.validator({type: 'ce', event: diagnosticEvent});
 
     return this.submitToCallDiagnostics(diagnosticEvent);
+  }
+
+  /**
+   * Submit Delayed Client Event CA events. Clears delayedClientEvents array after submission.
+   */
+  public submitDelayedClientEvents() {
+    this.logger.log(
+      CALL_DIAGNOSTIC_LOG_IDENTIFIER,
+      'CallDiagnosticMetrics: @submitDelayedClientEvents. Submitting delayed client events.'
+    );
+
+    if (this.delayedClientEvents.length === 0) {
+      return Promise.resolve();
+    }
+
+    const promises = this.delayedClientEvents.map((delayedSubmitClientEventParams) => {
+      return this.submitClientEvent(delayedSubmitClientEventParams);
+    });
+
+    this.delayedClientEvents = [];
+
+    return Promise.all(promises);
   }
 
   /**

--- a/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
+++ b/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
@@ -320,3 +320,9 @@ export interface IMetricsAttributes {
   meetingId?: string;
   callId?: string;
 }
+
+export interface DelayedClientEvent {
+  name: ClientEvent['name'];
+  payload?: RecursivePartial<ClientEvent['payload']>;
+  options?: SubmitClientEventOptions;
+}

--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -401,19 +401,19 @@ class Metrics extends WebexPlugin {
   }
 
   /**
-   * Sets the value of delaySubmitClientEvents. If true, client events will be delayed until submitDelayedClientEvents is called.
+   * Sets the value of delaySubmitClientEvents. If set to true, client events will be delayed until submitDelayedClientEvents is called. If
+   * set to false, delayed client events will be submitted.
    *
    * @param {boolean} shouldDelay - A boolean value indicating whether to delay the submission of client events.
    */
   public setDelaySubmitClientEvents(shouldDelay: boolean) {
     this.delaySubmitClientEvents = shouldDelay;
-  }
 
-  /**
-   * Submits all delayed client events.
-   */
-  public submitDelayedClientEvents() {
-    return this.callDiagnosticMetrics.submitDelayedClientEvents();
+    if (!shouldDelay) {
+      return this.callDiagnosticMetrics.submitDelayedClientEvents();
+    }
+
+    return Promise.resolve();
   }
 }
 

--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -46,6 +46,11 @@ class Metrics extends WebexPlugin {
   isReady = false;
 
   /**
+   * Whether or not to delay the submission of client events.
+   */
+  delaySubmitClientEvents = false;
+
+  /**
    * Constructor
    * @param args
    * @constructor
@@ -290,7 +295,12 @@ class Metrics extends WebexPlugin {
       options: {meetingId: options?.meetingId},
     });
 
-    return this.callDiagnosticMetrics.submitClientEvent({name, payload, options});
+    return this.callDiagnosticMetrics.submitClientEvent({
+      name,
+      payload,
+      options,
+      delaySubmitEvent: this.delaySubmitClientEvents,
+    });
   }
 
   /**
@@ -388,6 +398,22 @@ class Metrics extends WebexPlugin {
    */
   public isServiceErrorExpected(serviceErrorCode: number): boolean {
     return this.callDiagnosticMetrics.isServiceErrorExpected(serviceErrorCode);
+  }
+
+  /**
+   * Sets the value of delaySubmitClientEvents. If true, client events will be delayed until submitDelayedClientEvents is called.
+   *
+   * @param {boolean} shouldDelay - A boolean value indicating whether to delay the submission of client events.
+   */
+  public setDelaySubmitClientEvents(shouldDelay: boolean) {
+    this.delaySubmitClientEvents = shouldDelay;
+  }
+
+  /**
+   * Submits all delayed client events.
+   */
+  public submitDelayedClientEvents() {
+    return this.callDiagnosticMetrics.submitDelayedClientEvents();
   }
 }
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -13,6 +13,8 @@ import {
 } from '@webex/internal-plugin-metrics';
 import uuid from 'uuid';
 import {omit} from 'lodash';
+import { glob } from 'glob';
+import { expect } from 'chai';
 
 //@ts-ignore
 global.window = {location: {hostname: 'whatever'}};
@@ -137,6 +139,7 @@ describe('internal-plugin-metrics', () => {
 
     afterEach(() => {
       sinon.restore();
+      (global as any).window.webClientPreload = undefined;
     });
 
     describe('#validator', () => {
@@ -842,6 +845,7 @@ describe('internal-plugin-metrics', () => {
             userType: 'host',
             isConvergedArchitectureEnabled: undefined,
             webexSubServiceType: undefined,
+            webClientPreload: undefined,
           },
           options
         );
@@ -867,6 +871,7 @@ describe('internal-plugin-metrics', () => {
             userType: 'host',
             isConvergedArchitectureEnabled: undefined,
             webexSubServiceType: undefined,
+            webClientPreload: undefined,
           },
           eventId: 'my-fake-id',
           origin: {
@@ -903,6 +908,7 @@ describe('internal-plugin-metrics', () => {
               userType: 'host',
               isConvergedArchitectureEnabled: undefined,
               webexSubServiceType: undefined,
+              webClientPreload: undefined,
             },
             eventId: 'my-fake-id',
             origin: {
@@ -976,6 +982,7 @@ describe('internal-plugin-metrics', () => {
             userType: 'host',
             isConvergedArchitectureEnabled: undefined,
             webexSubServiceType: undefined,
+            webClientPreload: undefined,
           },
           options
         );
@@ -1002,6 +1009,7 @@ describe('internal-plugin-metrics', () => {
             userType: 'host',
             isConvergedArchitectureEnabled: undefined,
             webexSubServiceType: undefined,
+            webClientPreload: undefined,
           },
           eventId: 'my-fake-id',
           origin: {
@@ -1039,6 +1047,7 @@ describe('internal-plugin-metrics', () => {
               userType: 'host',
               isConvergedArchitectureEnabled: undefined,
               webexSubServiceType: undefined,
+              webClientPreload: undefined,
             },
             eventId: 'my-fake-id',
             origin: {
@@ -1156,6 +1165,7 @@ describe('internal-plugin-metrics', () => {
             },
             loginType: 'login-ci',
             name: 'client.alert.displayed',
+            webClientPreload: undefined
           },
           options
         );
@@ -1177,6 +1187,7 @@ describe('internal-plugin-metrics', () => {
             },
             loginType: 'login-ci',
             name: 'client.alert.displayed',
+            webClientPreload: undefined
           },
           eventId: 'my-fake-id',
           origin: {
@@ -1250,6 +1261,7 @@ describe('internal-plugin-metrics', () => {
             },
             loginType: 'login-ci',
             name: 'client.alert.displayed',
+            webClientPreload: undefined,
           },
           options
         );
@@ -1277,6 +1289,7 @@ describe('internal-plugin-metrics', () => {
               },
               eventData: {webClientDomain: 'whatever'},
               loginType: 'login-ci',
+              webClientPreload: undefined,
             },
           },
           options.preLoginId
@@ -1319,6 +1332,7 @@ describe('internal-plugin-metrics', () => {
             joinFlowVersion: 'Other',
             isConvergedArchitectureEnabled: undefined,
             webexSubServiceType: undefined,
+            webClientPreload: undefined,
           },
           eventId: 'my-fake-id',
           origin: {
@@ -1371,6 +1385,86 @@ describe('internal-plugin-metrics', () => {
             joinFlowVersion: 'Other',
             isConvergedArchitectureEnabled: undefined,
             webexSubServiceType: undefined,
+            webClientPreload: undefined,
+          },
+          eventId: 'my-fake-id',
+          origin: {
+            origin: 'fake-origin',
+          },
+          originTime: {
+            sent: 'not_defined_yet',
+            triggered: now.toISOString(),
+          },
+          senderCountryCode: 'UK',
+          version: 1,
+        });
+      });
+
+      it('should submit client event successfully with webClientPreload', () => {
+        const prepareDiagnosticEventSpy = sinon.spy(cd, 'prepareDiagnosticEvent');
+        const submitToCallDiagnosticsSpy = sinon.spy(cd, 'submitToCallDiagnostics');
+        const generateClientEventErrorPayloadSpy = sinon.spy(cd, 'generateClientEventErrorPayload');
+        sinon.stub(cd, 'getOrigin').returns({origin: 'fake-origin'});
+
+        (global as any).window.webClientPreload = {
+          isEnabled: true,
+        }
+
+        const options = {
+          correlationId: 'correlationId',
+          webexConferenceIdStr: 'webexConferenceIdStr1',
+          globalMeetingId: 'globalMeetingId1',
+          sessionCorrelationId: 'sessionCorrelationId1',
+        };
+
+        cd.submitClientEvent({
+          name: 'client.alert.displayed',
+          options,
+        });
+
+        assert.notCalled(generateClientEventErrorPayloadSpy);
+        assert.calledWith(
+          prepareDiagnosticEventSpy,
+          {
+            canProceed: true,
+            eventData: {
+              webClientDomain: 'whatever',
+            },
+            identifiers: {
+              correlationId: 'correlationId',
+              webexConferenceIdStr: 'webexConferenceIdStr1',
+              sessionCorrelationId: 'sessionCorrelationId1',
+              globalMeetingId: 'globalMeetingId1',
+              deviceId: 'deviceUrl',
+              locusUrl: 'locus-url',
+              orgId: 'orgId',
+              userId: 'userId',
+            },
+            loginType: 'login-ci',
+            name: 'client.alert.displayed',
+            webClientPreload: true,
+          },
+          options
+        );
+        assert.calledWith(submitToCallDiagnosticsSpy, {
+          event: {
+            canProceed: true,
+            eventData: {
+              webClientDomain: 'whatever',
+            },
+            identifiers: {
+              correlationId: 'correlationId',
+              webexConferenceIdStr: 'webexConferenceIdStr1',
+              sessionCorrelationId: 'sessionCorrelationId1',
+              globalMeetingId: 'globalMeetingId1',
+              deviceId: 'deviceUrl',
+              locusUrl: 'locus-url',
+              orgId: 'orgId',
+              userId: 'userId',
+            },
+            loginType: 'login-ci',
+            name: 'client.alert.displayed',
+            webClientPreload: true,
           },
           eventId: 'my-fake-id',
           origin: {
@@ -1442,6 +1536,7 @@ describe('internal-plugin-metrics', () => {
             userType: 'host',
             isConvergedArchitectureEnabled: undefined,
             webexSubServiceType: undefined,
+            webClientPreload: undefined,
           },
           eventId: 'my-fake-id',
           origin: {
@@ -1521,6 +1616,7 @@ describe('internal-plugin-metrics', () => {
             userType: 'host',
             isConvergedArchitectureEnabled: undefined,
             webexSubServiceType: undefined,
+            webClientPreload: undefined,
           },
           eventId: 'my-fake-id',
           origin: {
@@ -1592,6 +1688,7 @@ describe('internal-plugin-metrics', () => {
             ],
             loginType: 'login-ci',
             name: 'client.alert.displayed',
+            webClientPreload: undefined,
           },
           eventId: 'my-fake-id',
           origin: {
@@ -1665,6 +1762,7 @@ describe('internal-plugin-metrics', () => {
             ],
             loginType: 'login-ci',
             name: 'client.alert.displayed',
+            webClientPreload: undefined,
           },
           eventId: 'my-fake-id',
           origin: {
@@ -1747,6 +1845,7 @@ describe('internal-plugin-metrics', () => {
             userType: 'host',
             isConvergedArchitectureEnabled: undefined,
             webexSubServiceType: undefined,
+            webClientPreload: undefined,
           },
           eventId: 'my-fake-id',
           origin: {
@@ -2750,6 +2849,7 @@ describe('internal-plugin-metrics', () => {
                     userType: 'host',
                     isConvergedArchitectureEnabled: undefined,
                     webexSubServiceType: undefined,
+                    webClientPreload: undefined,
                   },
                   eventId: 'my-fake-id',
                   origin: {
@@ -2947,6 +3047,81 @@ describe('internal-plugin-metrics', () => {
         ]);
 
         assert.deepEqual(cd.device, device);
+      });
+    });
+
+    describe('#submitDelayedClientEvents', () => {
+      it('does not call submitClientEvent if there were no delayed events', () => {
+        const submitClientEventSpy = sinon.spy(cd, 'submitClientEvent');
+
+        cd.submitDelayedClientEvents();
+
+        assert.notCalled(submitClientEventSpy);
+      });
+
+      it('calls submitClientEvent for every delayed event and clears delayedClientEvents array', () => {
+        const submitClientEventSpy = sinon.spy(cd, 'submitClientEvent');
+        const submitToCallDiagnosticsSpy = sinon.spy(cd, 'submitToCallDiagnostics');
+
+        const options = {
+          correlationId: 'correlationId',
+        };
+
+        cd.submitClientEvent({
+          name: 'client.alert.displayed',
+          options,
+          delaySubmitEvent: true,
+        });
+
+        cd.submitClientEvent({
+          name: 'client.alert.removed',
+          options,
+          delaySubmitEvent: true,
+        });
+
+        cd.submitClientEvent({
+          name: 'client.call.aborted',
+          options,
+          delaySubmitEvent: true,
+        });
+
+        assert.notCalled(submitToCallDiagnosticsSpy);
+        assert.calledThrice(submitClientEventSpy);
+        submitClientEventSpy.resetHistory();
+
+        cd.submitDelayedClientEvents();
+
+        assert.calledThrice(submitClientEventSpy);
+        assert.calledWith(submitClientEventSpy.firstCall, {
+          name: 'client.alert.displayed',
+          payload: undefined,
+          options: {
+            correlationId: 'correlationId',
+            triggeredTime: now.toISOString(),
+          },
+        });
+        assert.calledWith(submitClientEventSpy.secondCall, {
+          name: 'client.alert.removed',
+          payload: undefined,
+          options: {
+            correlationId: 'correlationId',
+            triggeredTime: now.toISOString(),
+          },
+        });
+        assert.calledWith(submitClientEventSpy.thirdCall, {
+          name: 'client.call.aborted',
+          payload: undefined,
+          options: {
+            correlationId: 'correlationId',
+            triggeredTime: now.toISOString(),
+          },
+        });
+        submitClientEventSpy.resetHistory();
+
+        cd.submitDelayedClientEvents();
+
+        // should not call submitClientEvent again if delayedClientEvents was cleared
+        assert.notCalled(submitClientEventSpy);
       });
     });
   });

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -139,7 +139,6 @@ describe('internal-plugin-metrics', () => {
 
     afterEach(() => {
       sinon.restore();
-      (global as any).window.webClientPreload = undefined;
     });
 
     describe('#validator', () => {
@@ -1406,9 +1405,7 @@ describe('internal-plugin-metrics', () => {
         const generateClientEventErrorPayloadSpy = sinon.spy(cd, 'generateClientEventErrorPayload');
         sinon.stub(cd, 'getOrigin').returns({origin: 'fake-origin'});
 
-        (global as any).window.webClientPreload = {
-          isEnabled: true,
-        }
+        webex.meetings.config.metrics.webClientPreload = true;
 
         const options = {
           correlationId: 'correlationId',

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
@@ -59,6 +59,7 @@ describe('internal-plugin-metrics', () => {
       webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp = sinon.stub();
       webex.internal.newMetrics.callDiagnosticLatencies.clearTimestamps = sinon.stub();
       webex.internal.newMetrics.callDiagnosticMetrics.submitClientEvent = sinon.stub();
+      webex.internal.newMetrics.callDiagnosticMetrics.submitDelayedClientEvents = sinon.stub();
       webex.internal.newMetrics.callDiagnosticMetrics.submitMQE = sinon.stub();
       webex.internal.newMetrics.callDiagnosticMetrics.clientMetricsAliasUser = sinon.stub();
       webex.internal.newMetrics.callDiagnosticMetrics.buildClientEventFetchRequestOptions =
@@ -120,6 +121,7 @@ describe('internal-plugin-metrics', () => {
         name: 'client.alert.displayed',
         payload: undefined,
         options: {meetingId: '123'},
+        delaySubmitEvent: false,
       });
     });
 
@@ -256,6 +258,30 @@ describe('internal-plugin-metrics', () => {
         sinon.assert.calledWith(webex.setTimingsAndFetch, expected);
 
         sinon.restore();
+      });
+    });
+
+    describe('#setDelaySubmitClientEvents', () => {
+      it('sets delaySubmitClientEvents correctly', () => {
+        sinon.assert.match(webex.internal.newMetrics.delaySubmitClientEvents, false);
+
+        webex.internal.newMetrics.setDelaySubmitClientEvents(true);
+
+        sinon.assert.match(webex.internal.newMetrics.delaySubmitClientEvents, true);
+
+        webex.internal.newMetrics.setDelaySubmitClientEvents(false);
+
+        sinon.assert.match(webex.internal.newMetrics.delaySubmitClientEvents, false);
+      });
+    });
+
+    describe('#submitDelayedClientEvents', () => {
+      it('calls submitDelayedClientEvents correctly', () => {
+        webex.internal.newMetrics.submitDelayedClientEvents();
+
+        sinon.assert.calledOnce(webex.internal.newMetrics.callDiagnosticMetrics.submitDelayedClientEvents);
+        sinon.assert.calledWith(webex.internal.newMetrics.callDiagnosticMetrics.submitDelayedClientEvents);
+
       });
     });
   });

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
@@ -262,26 +262,21 @@ describe('internal-plugin-metrics', () => {
     });
 
     describe('#setDelaySubmitClientEvents', () => {
-      it('sets delaySubmitClientEvents correctly', () => {
+      it('sets delaySubmitClientEvents correctly and calls submitDelayedClientEvents when set to false', () => {
         sinon.assert.match(webex.internal.newMetrics.delaySubmitClientEvents, false);
 
         webex.internal.newMetrics.setDelaySubmitClientEvents(true);
+
+        assert.notCalled(webex.internal.newMetrics.callDiagnosticMetrics.submitDelayedClientEvents);
 
         sinon.assert.match(webex.internal.newMetrics.delaySubmitClientEvents, true);
 
         webex.internal.newMetrics.setDelaySubmitClientEvents(false);
 
+        assert.calledOnce(webex.internal.newMetrics.callDiagnosticMetrics.submitDelayedClientEvents);
+        assert.calledWith(webex.internal.newMetrics.callDiagnosticMetrics.submitDelayedClientEvents);
+
         sinon.assert.match(webex.internal.newMetrics.delaySubmitClientEvents, false);
-      });
-    });
-
-    describe('#submitDelayedClientEvents', () => {
-      it('calls submitDelayedClientEvents correctly', () => {
-        webex.internal.newMetrics.submitDelayedClientEvents();
-
-        sinon.assert.calledOnce(webex.internal.newMetrics.callDiagnosticMetrics.submitDelayedClientEvents);
-        sinon.assert.calledWith(webex.internal.newMetrics.callDiagnosticMetrics.submitDelayedClientEvents);
-
       });
     });
   });


### PR DESCRIPTION
… events

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-623039](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-623039)

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-623039

As part of the preload feature on web client we need to delay sending all client events until the user decides to join via web. So, we need a mechanism to delay these events in the sdk.


<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
