### PR TITLE
fix(plugin-meetings): media connection close() is called twice on meeting leave

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4647,6 +4647,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
       this.receiveSlotManager.reset();
       this.mediaProperties.webrtcMediaConnection.close();
+      this.mediaProperties.unsetPeerConnection();
       this.sendSlotManager.reset();
       this.setNetworkStatus(undefined);
     }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -9996,7 +9996,8 @@ describe('plugin-meetings', () => {
       describe('#closePeerConnections', () => {
         it('should close the webrtc media connection, and return a promise', async () => {
           const setNetworkStatusSpy = sinon.spy(meeting, 'setNetworkStatus');
-          meeting.mediaProperties.webrtcMediaConnection = {close: sinon.stub()};
+          const fakeWebrtcMediaConnection = {close: sinon.stub()};
+          meeting.mediaProperties.webrtcMediaConnection = fakeWebrtcMediaConnection;
 
           meeting.audio = {id: 'fakeAudioMuteState'};
           meeting.video = {id: 'fakeVideoMuteState'};
@@ -10005,15 +10006,17 @@ describe('plugin-meetings', () => {
 
           assert.exists(pcs.then);
           await pcs;
-          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.close);
+          assert.calledOnce(fakeWebrtcMediaConnection.close);
           assert.calledOnceWithExactly(setNetworkStatusSpy, undefined);
           assert.equal(meeting.audio, null);
           assert.equal(meeting.video, null);
+          assert.equal(meeting.mediaProperties.webrtcMediaConnection, null);
         });
 
         it('should close the webrtc media connection, but keep audio and video props unchanged if called with resetMuteStates=false', async () => {
           const setNetworkStatusSpy = sinon.spy(meeting, 'setNetworkStatus');
-          meeting.mediaProperties.webrtcMediaConnection = {close: sinon.stub()};
+          const fakeWebrtcMediaConnection = {close: sinon.stub()};
+          meeting.mediaProperties.webrtcMediaConnection = fakeWebrtcMediaConnection;
 
           const fakeAudio = {id: 'fakeAudioMuteState'};
           const fakeVideo = {id: 'fakeVideoMuteState'};
@@ -10023,10 +10026,11 @@ describe('plugin-meetings', () => {
 
           await meeting.closePeerConnections(false);
 
-          assert.calledOnce(meeting.mediaProperties.webrtcMediaConnection.close);
+          assert.calledOnce(fakeWebrtcMediaConnection.close);
           assert.calledOnceWithExactly(setNetworkStatusSpy, undefined);
           assert.equal(meeting.audio, fakeAudio);
           assert.equal(meeting.video, fakeVideo);
+          assert.equal(meeting.mediaProperties.webrtcMediaConnection, null);
         });
       });
 


### PR DESCRIPTION
## This pull request addresses
If you are the last person in the meeting and you leave it and as a result the meeting is destroyed, JS-SDK ends up calling close() twice on the media connection. This causes an error thrown from WCME (because transceiver.stop() is called on a closed peer connection) and it results in an unnecessary extra log upload being done.

## by making the following changes
Reset mediaProperties.webrtcMediaConnection to null after closing it, so next time closePeerConnections() is called, it won't do anything.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual test with web app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
