### PR TITLE
feat(plugin-cc): user state second timer implemented

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -808,9 +808,10 @@ function doAgentLogin() {
     const DEFAULT_CODE = '0'; // Default code when no aux code is present
     const auxCodeId = response.data.auxCodeId?.trim() !== '' ? response.data.auxCodeId : DEFAULT_CODE;
     const lastStateChangeTimestamp = response.data.lastStateChangeTimestamp;
+    const lastIdleCodeChangeTimestamp = response.data.lastIdleCodeChangeTimestamp;
     const index = [...idleCodesDropdown.options].findIndex(option => option.value === auxCodeId);
     idleCodesDropdown.selectedIndex = index !== -1 ? index : 0;
-        startStateTimer(lastStateChangeTimestamp, lastIdleCodeChangeTimestamp);
+    startStateTimer(lastStateChangeTimestamp, lastIdleCodeChangeTimestamp);
     
   }).catch((error) => {
     console.log('Agent Login failed', error);

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -581,21 +581,38 @@ function initWebex(e) {
 
 credentialsFormElm.addEventListener('submit', initWebex);
 
-function startStateTimer(startTime) {
+function startStateTimer(lastStateChangeTimestamp, lastIdleCodeChangeTimestamp) {
+
+  if (lastStateChangeTimestamp === null) {
+    return;
+  }
+  
   if (stateTimer) {
     clearInterval(stateTimer);
   }
 
   stateTimer = setInterval(() => {
     const currentTime = new Date().getTime();
-    const timeDifference = currentTime - startTime;
+    const stateTimeDifference = currentTime - new Date(lastStateChangeTimestamp).getTime();
+    const idleCodeChangeTimeDifference = lastIdleCodeChangeTimestamp ? currentTime - new Date(lastIdleCodeChangeTimestamp).getTime() : null;
 
-    const hours = String(Math.floor(timeDifference / (1000 * 60 * 60))).padStart(2, '0');
-    const minutes = String(Math.floor((timeDifference % (1000 * 60 * 60)) / (1000 * 60))).padStart(2, '0');
-    const seconds = String(Math.floor((timeDifference % (1000 * 60)) / 1000)).padStart(2, '0');
-    if(timerElm)
-    {
-      timerElm.innerHTML = `${hours}:${minutes}:${seconds}`;
+    const stateHours = String(Math.floor(stateTimeDifference / (1000 * 60 * 60))).padStart(2, '0');
+    const stateMinutes = String(Math.floor((stateTimeDifference % (1000 * 60 * 60)) / (1000 * 60))).padStart(2, '0');
+    const stateSeconds = String(Math.floor((stateTimeDifference % (1000 * 60)) / 1000)).padStart(2, '0');
+
+    let timerDisplay = `${stateHours}:${stateMinutes}:${stateSeconds}`;
+
+    if (idleCodeChangeTimeDifference !== null && lastStateChangeTimestamp !== lastIdleCodeChangeTimestamp) {
+      console.log('Idle code change time difference: ', lastStateChangeTimestamp, " ",lastIdleCodeChangeTimestamp);
+      const idleCodeChangeHours = String(Math.floor(idleCodeChangeTimeDifference / (1000 * 60 * 60))).padStart(2, '0');
+      const idleCodeChangeMinutes = String(Math.floor((idleCodeChangeTimeDifference % (1000 * 60 * 60)) / (1000 * 60))).padStart(2, '0');
+      const idleCodeChangeSeconds = String(Math.floor((idleCodeChangeTimeDifference % (1000 * 60)) / 1000)).padStart(2, '0');
+
+      timerDisplay = `${idleCodeChangeHours}:${idleCodeChangeMinutes}:${idleCodeChangeSeconds}`+ " / " + timerDisplay;
+    }
+
+    if (timerElm) {
+      timerElm.innerHTML = timerDisplay;
     }
   }, 1000);
 }
@@ -646,7 +663,7 @@ function register() {
             if (agentProfile.lastStateAuxCodeId && agentProfile.lastStateAuxCodeId === idleCodes.id)
             {
               option.selected = true;
-              startStateTimer(agentProfile.lastStateChangeTimestamp)
+              startStateTimer(agentProfile.lastStateChangeTimestamp, agentProfile.lastIdleCodeChangeTimestamp);
             }
             idleCodesDropdown.add(option);
           }
@@ -670,7 +687,7 @@ function register() {
       if (data && typeof data === 'object' && data.type === 'AgentStateChangeSuccess') {
         const DEFAULT_CODE = '0'; // Default code when no aux code is present
         idleCodesDropdown.value = data.auxCodeId?.trim() !== '' ? data.auxCodeId : DEFAULT_CODE;
-        startStateTimer(data.lastStateChangeTimestamp);
+        startStateTimer(data.lastStateChangeTimestamp, data.lastIdleCodeChangeTimestamp);
       }
     });
 
@@ -793,7 +810,7 @@ function doAgentLogin() {
     const lastStateChangeTimestamp = response.data.lastStateChangeTimestamp;
     const index = [...idleCodesDropdown.options].findIndex(option => option.value === auxCodeId);
     idleCodesDropdown.selectedIndex = index !== -1 ? index : 0;
-        startStateTimer(new Date(lastStateChangeTimestamp));
+        startStateTimer(lastStateChangeTimestamp, lastIdleCodeChangeTimestamp);
     
   }).catch((error) => {
     console.log('Agent Login failed', error);

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -349,12 +349,17 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   private async silentRelogin(): Promise<void> {
     try {
       const reLoginResponse = await this.services.agent.reload();
-      const {agentId, lastStateChangeReason, deviceType, dn, lastStateChangeTimestamp} =
-        reLoginResponse.data;
+      const {
+        agentId,
+        lastStateChangeReason,
+        deviceType,
+        dn,
+        lastStateChangeTimestamp,
+        lastIdleCodeChangeTimestamp,
+      } = reLoginResponse.data;
       let {auxCodeId} = reLoginResponse.data;
-      this.agentConfig.lastStateChangeTimestamp = lastStateChangeTimestamp
-        ? new Date(lastStateChangeTimestamp)
-        : new Date();
+      this.agentConfig.lastStateChangeTimestamp = lastStateChangeTimestamp;
+      this.agentConfig.lastIdleCodeChangeTimestamp = lastIdleCodeChangeTimestamp;
 
       // To handle re-registration of event listeners on silent relogin
       this.incomingTaskListener();
@@ -375,10 +380,11 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           const agentStatusResponse = (await this.setAgentState(
             stateChangeData
           )) as StateChangeSuccess;
-          this.agentConfig.lastStateChangeTimestamp = agentStatusResponse.data
-            .lastStateChangeTimestamp
-            ? new Date(agentStatusResponse.data.lastStateChangeTimestamp)
-            : new Date();
+          this.agentConfig.lastStateChangeTimestamp =
+            agentStatusResponse.data.lastStateChangeTimestamp;
+
+          this.agentConfig.lastIdleCodeChangeTimestamp =
+            agentStatusResponse.data.lastIdleCodeChangeTimestamp;
         } catch (error) {
           LoggerProxy.error(
             `event=requestAutoStateChange | Error requesting state change to available on socket reconnect: ${error}`,

--- a/packages/@webex/plugin-cc/src/services/config/types.ts
+++ b/packages/@webex/plugin-cc/src/services/config/types.ts
@@ -568,5 +568,6 @@ export type Profile = {
   maskSensitiveData?: boolean;
   isAgentLoggedIn?: boolean;
   lastStateAuxCodeId?: string;
-  lastStateChangeTimestamp?: Date;
+  lastStateChangeTimestamp?: number;
+  lastIdleCodeChangeTimestamp?: number;
 };

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -774,6 +774,7 @@ describe('webex.cc', () => {
           agentId: 'agentId',
           lastStateChangeReason: 'agent-wss-disconnect',
           lastStateChangeTimestamp: 1738575135188,
+          lastIdleCodeChangeTimestamp: 1738575135189,
           deviceType: LoginOption.BROWSER,
           dn: '12345',
         },
@@ -788,7 +789,7 @@ describe('webex.cc', () => {
 
       const date = new Date();
       const setAgentStateSpy = jest.spyOn(webex.cc, 'setAgentState').mockResolvedValue({
-        data: {lastStateChangeTimestamp: date.getTime()},
+        data: {lastStateChangeTimestamp: 1234, lastIdleCodeChangeTimestamp: 12345},
       } as unknown as SetStateResponse);
       jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue(mockReLoginResponse);
 
@@ -812,7 +813,8 @@ describe('webex.cc', () => {
       });
       expect(webex.cc.agentConfig.isAgentLoggedIn).toBe(true);
       expect(webex.cc.agentConfig.lastStateAuxCodeId).toBe('0');
-      expect(webex.cc.agentConfig.lastStateChangeTimestamp).toStrictEqual(date); // it should be updated with the new timestamp of setAgentState response
+      expect(webex.cc.agentConfig.lastStateChangeTimestamp).toStrictEqual(1234); // it should be updated with the new timestamp of setAgentState response
+      expect(webex.cc.agentConfig.lastIdleCodeChangeTimestamp).toStrictEqual(12345);
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.BROWSER);
       expect(registerWebCallingLineSpy).toHaveBeenCalled();
       expect(incomingTaskListenerSpy).toHaveBeenCalled();
@@ -856,6 +858,7 @@ describe('webex.cc', () => {
           deviceType: LoginOption.EXTENSION,
           dn: '12345',
           lastStateChangeTimestamp: 1738575135188,
+          lastIdleCodeChangeTimestamp: 1738575135189,
         },
       };
 
@@ -877,7 +880,8 @@ describe('webex.cc', () => {
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.EXTENSION);
       expect(webex.cc.agentConfig.defaultDn).toBe('12345');
       expect(webex.cc.agentConfig.lastStateAuxCodeId).toBe('auxCodeId');
-      expect(webex.cc.agentConfig.lastStateChangeTimestamp).toStrictEqual(new Date(1738575135188));
+      expect(webex.cc.agentConfig.lastStateChangeTimestamp).toStrictEqual(1738575135188);
+      expect(webex.cc.agentConfig.lastIdleCodeChangeTimestamp).toStrictEqual(1738575135189);
     });
 
     it('should update agentConfig with deviceType during silent relogin for AGENT_DN', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-568107

## This pull request addresses

showing the second timer for idle code change in user-state

## by making the following changes

added new field lastIdleCodeChangeTimestamp to profile to get the idle code change time stamp.
changed the timestamp type to number to make it consistent in other API's like login, state-change

<!-- You may include screenshots -->
https://app.vidcast.io/share/aa797417-9f3f-45be-8a33-9eacbbd5a823
### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
after login.
state change to available => one timer should show and start from 0
state change to Idle1(meeting) => one timer should show and start from 0
state change to idle2(lunch break) => two timer should show one should start from 0 other should continue from chnage from available.
state change to available => one timer should show and start from 0

reload also should persist the previous timers.

Updated CC SDK Test plan(https://confluence-eng-gpk2.cisco.com/conf/display/WSDK/CC+SDK+Test+Plans)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
