### PR TITLE
fix(plugin-meetings): only check media server in SDP answers and not other ROAP messages

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6099,9 +6099,12 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {undefined}
    */
   public roapMessageReceived = (roapMessage: RoapMessage) => {
-    const mediaServer = MeetingsUtil.getMediaServer(roapMessage.sdp);
+    const mediaServer =
+      roapMessage.messageType === 'ANSWER'
+        ? MeetingsUtil.getMediaServer(roapMessage.sdp)
+        : undefined;
 
-    if (this.isMultistream && mediaServer !== 'homer') {
+    if (this.isMultistream && mediaServer && mediaServer !== 'homer') {
       throw new MultistreamNotSupportedError(
         `Client asked for multistream backend (Homer), but got ${mediaServer} instead`
       );

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -13260,7 +13260,7 @@ describe('plugin-meetings', () => {
 
   describe('#roapMessageReceived', () => {
     it('calls roapMessageReceived on the webrtc media connection', () => {
-      const fakeMessage = {messageType: 'fake', sdp: 'fake sdp'};
+      const fakeMessage = {messageType: 'ANSWER', sdp: 'fake sdp'};
 
       const getMediaServer = sinon.stub(MeetingsUtil, 'getMediaServer').returns('homer');
 
@@ -13297,6 +13297,27 @@ describe('plugin-meetings', () => {
       }
 
       assert.notCalled(meeting.mediaProperties.webrtcMediaConnection.roapMessageReceived);
+    });
+
+    it('does not call getMediaServer for a roap message other than ANSWER', async () => {
+      const fakeMessage = {messageType: 'ERROR', sdp: 'fake sdp'};
+
+      meeting.isMultistream = true;
+      meeting.mediaProperties.webrtcMediaConnection = {
+        roapMessageReceived: sinon.stub(),
+      };
+      meeting.mediaProperties.webrtcMediaConnection.mediaServer = 'linus';
+
+      const getMediaServerStub = sinon.stub(MeetingsUtil, 'getMediaServer').returns('something');
+
+      meeting.roapMessageReceived(fakeMessage);
+
+      assert.calledOnceWithExactly(
+        meeting.mediaProperties.webrtcMediaConnection.roapMessageReceived,
+        fakeMessage
+      );
+      assert.notCalled(getMediaServerStub);
+      assert.equal(meeting.mediaProperties.webrtcMediaConnection.mediaServer, 'linus'); // check that it hasn't been overwritten
     });
   });
 });


### PR DESCRIPTION
## This pull request addresses

I've seen a log where we received an ERROR roap message and roapMessageReceived() called MeetingsUtil.getMediaServer() with it, but because that message doesn't have an SDP so getMediaServer() returned undefined and that caused roapMessageReceived() to throw MultistreamNotSupportedError()

## by making the following changes

Only call MeetingsUtil.getMediaServer() for SDP answers and only throw MultistreamNotSupportedError if we got a wrong media server in the SDP answer.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
