### PR TITLE
fix(plugin-meetings): stop reachability when joining a meeting

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6719,6 +6719,9 @@ export default class Meeting extends StatelessWebexPlugin {
         new RtcMetrics(this.webex, {meetingId: this.id}, this.correlationId)
       : undefined;
 
+    // ongoing reachability checks slow down new media connections especially on Firefox, so we stop them
+    this.getWebexObject().meetings.reachability.stopReachability();
+
     const mc = Media.createMediaConnection(
       this.isMultistream,
       this.getMediaConnectionDebugId(),

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -246,6 +246,7 @@ describe('plugin-meetings', () => {
       isAnyPublicClusterReachable: sinon.stub().resolves(true),
       getReachabilityResults: sinon.stub().resolves(undefined),
       getReachabilityMetrics: sinon.stub().resolves({}),
+      stopReachability: sinon.stub(),
     };
     webex.internal.llm.on = sinon.stub();
     webex.internal.newMetrics.callDiagnosticLatencies = new CallDiagnosticLatencies(
@@ -2095,6 +2096,7 @@ describe('plugin-meetings', () => {
               someReachabilityMetric1: 'some value1',
               someReachabilityMetric2: 'some value2',
             }),
+            stopReachability: sinon.stub(),
           };
 
           const forceRtcMetricsSend = sinon.stub().resolves();
@@ -2514,6 +2516,7 @@ describe('plugin-meetings', () => {
           assert.calledOnce(meeting.setMercuryListener);
           assert.calledOnce(fakeMediaConnection.initiateOffer);
           assert.equal(meeting.allowMediaInLobby, allowMediaInLobby);
+          assert.calledOnce(webex.meetings.reachability.stopReachability);
         };
 
         it('should attach the media and return promise', async () => {
@@ -2709,6 +2712,7 @@ describe('plugin-meetings', () => {
           webex.meetings.reachability = {
             isWebexMediaBackendUnreachable: sinon.stub().resolves(false),
             getReachabilityMetrics: sinon.stub().resolves(),
+            stopReachability: sinon.stub(),
           };
           const MOCK_CLIENT_ERROR_CODE = 2004;
           const generateClientErrorCodeForIceFailureStub = sinon
@@ -2917,6 +2921,7 @@ describe('plugin-meetings', () => {
               .onCall(2)
               .resolves(false),
             getReachabilityMetrics: sinon.stub().resolves({}),
+            stopReachability: sinon.stub(),
           };
           const getErrorPayloadForClientErrorCodeStub =
             (webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode =
@@ -3211,6 +3216,7 @@ describe('plugin-meetings', () => {
               someReachabilityMetric1: 'some value1',
               someReachabilityMetric2: 'some value2',
             }),
+            stopReachability: sinon.stub(),
           };
           meeting.iceCandidatesCount = 3;
           meeting.iceCandidateErrors.set('701_error', 3);
@@ -3715,6 +3721,7 @@ describe('plugin-meetings', () => {
 
               webex.meetings.reachability = {
                 isWebexMediaBackendUnreachable: sinon.stub().resolves(unreachable || false),
+                stopReachability: sinon.stub(),
               };
 
               const generateClientErrorCodeForIceFailureStub = sinon


### PR DESCRIPTION
# COMPLETES #[SPARK-629490](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-629490)

## This pull request addresses
If reachability is till being done in the background when we create a media connection, gathering of local candidates is very slow on Firefox, this delays meeting join and sometimes even causes Homer to timeout and join to fail.

## by making the following changes
Stopping reachability when we create a media connection, this is after we've already sent the reachability results to the backend, so continuing reachability doesn't add value. 

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
