### PR TITLE
fix(internal-plugin-mercury): replace 1050 with valid 3050 code

### DIFF
--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -113,7 +113,7 @@ const Mercury = WebexPlugin.extend({
     return this.disconnect(
       this.config.beforeLogoutOptionsCloseReason &&
         !normalReconnectReasons.includes(this.config.beforeLogoutOptionsCloseReason)
-        ? {code: 1050, reason: this.config.beforeLogoutOptionsCloseReason}
+        ? {code: 3050, reason: this.config.beforeLogoutOptionsCloseReason}
         : undefined
     );
   },
@@ -480,7 +480,7 @@ const Mercury = WebexPlugin.extend({
           // if (code == 1011 && reason !== ping error) metric: unexpected disconnect
           break;
         case 1000:
-        case 1050: // 1050 indicates logout form of closure, default to old behavior, use config reason defined by consumer to proceed with the permanent block
+        case 3050: // 3050 indicates logout form of closure, default to old behavior, use config reason defined by consumer to proceed with the permanent block
           if (normalReconnectReasons.includes(reason)) {
             this.logger.info(`${this.namespace}: socket disconnected; reconnecting`);
             this._emit('offline.transient', event);

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -128,6 +128,9 @@ export default class Socket extends EventEmitter {
         return;
       }
 
+      const originalCode = options.code;
+      const originalReason = options.reason;
+
       options = defaults(options, {
         code: 1000,
         reason: 'Done',
@@ -138,8 +141,8 @@ export default class Socket extends EventEmitter {
           this.logger.info(`socket,${this._domain}: no close event received, forcing closure`);
           resolve(
             this.onclose(
-              options.code === 3050
-                ? {code: 3050, reason: options.reason}
+              originalCode
+                ? {code: originalCode, reason: originalReason || 'Done (unknown)'}
                 : {
                     code: 1000,
                     reason: 'Done (forced)',

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -122,15 +122,8 @@ export default class Socket extends EventEmitter {
       }
 
       options = options || {};
-      if (
-        options.code &&
-        options.code !== 1000 &&
-        options.code !== 1050 &&
-        (options.code < 3000 || options.code > 4999)
-      ) {
-        reject(
-          new Error('`options.code` must be 1000 or 1050 or between 3000 and 4999 (inclusive)')
-        );
+      if (options.code && options.code !== 1000 && (options.code < 3000 || options.code > 4999)) {
+        reject(new Error('`options.code` must be 1000 or between 3000 and 4999 (inclusive)'));
 
         return;
       }
@@ -145,8 +138,8 @@ export default class Socket extends EventEmitter {
           this.logger.info(`socket,${this._domain}: no close event received, forcing closure`);
           resolve(
             this.onclose(
-              options.code === 1050
-                ? {code: 1050, reason: options.reason}
+              options.code === 3050
+                ? {code: 3050, reason: options.reason}
                 : {
                     code: 1000,
                     reason: 'Done (forced)',

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -521,18 +521,18 @@ describe('plugin-mercury', () => {
         );
       });
 
-      it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send code 1050 for logout', () => {
+      it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send code 3050 for logout', () => {
         sinon.stub(mercury, 'disconnect');
         mercury.config.beforeLogoutOptionsCloseReason = 'done (permanent)';
         mercury.logout();
-        assert.calledWith(mercury.disconnect, {code: 1050, reason: 'done (permanent)'});
+        assert.calledWith(mercury.disconnect, {code: 3050, reason: 'done (permanent)'});
       });
 
-      it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send code 1050 for logout if the reason is different than standard', () => {
+      it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send code 3050 for logout if the reason is different than standard', () => {
         sinon.stub(mercury, 'disconnect');
         mercury.config.beforeLogoutOptionsCloseReason = 'test';
         mercury.logout();
-        assert.calledWith(mercury.disconnect, {code: 1050, reason: 'test'});
+        assert.calledWith(mercury.disconnect, {code: 3050, reason: 'test'});
       });
 
       it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send undefined for logout if the reason is same as standard', () => {
@@ -565,7 +565,7 @@ describe('plugin-mercury', () => {
             assert.isUndefined(mercury.mockWebSocket, 'Mercury does not have a mockWebSocket');
           }));
 
-      it('disconnects the WebSocket with code 1050', () =>
+      it('disconnects the WebSocket with code 3050', () =>
         mercury
           .connect()
           .then(() => {
@@ -574,7 +574,7 @@ describe('plugin-mercury', () => {
             const promise = mercury.disconnect();
 
             mockWebSocket.emit('close', {
-              code: 1050,
+              code: 3050,
               reason: 'done (permanent)',
             });
 

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
@@ -593,7 +593,46 @@ describe('plugin-mercury', () => {
             assert.called(spy);
             assert.calledWith(spy, {
               code: 1000,
-              reason: 'Done (forced)',
+              reason: 'test',
+            });
+          });
+        });
+      });
+
+      it('signals closure if no close frame is received within the specified window, and uses default options as 1000 if the code is not 3050', () => {
+        const socket = new Socket();
+        const promise = socket.open('ws://example.com', mockoptions);
+
+        mockWebSocket.readyState = 1;
+        mockWebSocket.emit('open');
+        mockWebSocket.emit('message', {
+          data: JSON.stringify({
+            id: uuid.v4(),
+            data: {
+              eventType: 'mercury.buffer_state',
+            },
+          }),
+        });
+
+        return promise.then(() => {
+          const spy = sinon.spy();
+
+          socket.on('close', spy);
+          mockWebSocket.close = () =>
+            new Promise(() => {
+              /* eslint no-inline-comments: [0] */
+            });
+          mockWebSocket.removeAllListeners('close');
+
+          const promise = socket.close({code: 1000});
+
+          clock.tick(mockoptions.forceCloseDelay);
+
+          return promise.then(() => {
+            assert.called(spy);
+            assert.calledWith(spy, {
+              code: 1000,
+              reason: 'Done (unknown)',
             });
           });
         });

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
@@ -452,7 +452,7 @@ describe('plugin-mercury', () => {
         Promise.all([
           assert.isRejected(
             socket.close({code: 1001}),
-            /`options.code` must be 1000 or 1050 or between 3000 and 4999 \(inclusive\)/
+            /`options.code` must be 1000 or between 3000 and 4999 \(inclusive\)/
           ),
           socket.close({code: 1000}),
         ]));
@@ -468,10 +468,10 @@ describe('plugin-mercury', () => {
       it('accepts the logout reason', () =>
             socket
               .close({
-                code: 1050,
+                code: 3050,
                 reason: 'done (permanent)',
               })
-              .then(() => assert.calledWith(mockWebSocket.close, 1050, 'done (permanent)')));
+              .then(() => assert.calledWith(mockWebSocket.close, 3050, 'done (permanent)')));
 
       it('can safely be called called multiple times', () => {
         const p1 = socket.close();
@@ -521,7 +521,7 @@ describe('plugin-mercury', () => {
         });
       });
 
-      it('signals closure if no close frame is received within the specified window, but uses the initial options as 1050 if specified by options call', () => {
+      it('signals closure if no close frame is received within the specified window, but uses the initial options as 3050 if specified by options call', () => {
         const socket = new Socket();
         const promise = socket.open('ws://example.com', mockoptions);
 
@@ -546,21 +546,21 @@ describe('plugin-mercury', () => {
             });
           mockWebSocket.removeAllListeners('close');
 
-          const promise = socket.close({code: 1050, reason: 'done (permanent)'});
+          const promise = socket.close({code: 3050, reason: 'done (permanent)'});
 
           clock.tick(mockoptions.forceCloseDelay);
 
           return promise.then(() => {
             assert.called(spy);
             assert.calledWith(spy, {
-              code: 1050,
+              code: 3050,
               reason: 'done (permanent)',
             });
           });
         });
       });
 
-      it('signals closure if no close frame is received within the specified window, and uses default options as 1000 if the code is not 1050', () => {
+      it('signals closure if no close frame is received within the specified window, and uses default options as 1000 if the code is not 3050', () => {
         const socket = new Socket();
         const promise = socket.open('ws://example.com', mockoptions);
 
@@ -705,9 +705,9 @@ describe('plugin-mercury', () => {
         );
       });
 
-      describe('when it receives close code 1050', () => {
-        it(`emits code 1050 for code 1050`, () => {
-          const code = 1050;
+      describe('when it receives close code 3050', () => {
+        it(`emits code 3050 for code 3050`, () => {
+          const code = 3050;
           const reason = 'done (permanent)';
           const spy = sinon.spy();
 


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

We were force closing with a 1050 code. This is invalid, only 1000 and 3000-3999 are allowed in https://datatracker.ietf.org/doc/html/rfc6455

## by making the following changes

Changed to use 3050 instead

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
