### PR TITLE
fix: add extra logging on media state change

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -22,7 +22,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/internal-media-core": "2.14.3",
+    "@webex/internal-media-core": "2.14.4",
     "@webex/ts-events": "^1.1.0",
     "@webex/web-media-effects": "2.19.0"
   },

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@webex/common": "workspace:*",
     "@webex/event-dictionary-ts": "^1.0.1688",
-    "@webex/internal-media-core": "2.14.3",
+    "@webex/internal-media-core": "2.14.4",
     "@webex/internal-plugin-conversation": "workspace:*",
     "@webex/internal-plugin-device": "workspace:*",
     "@webex/internal-plugin-llm": "workspace:*",

--- a/packages/@webex/plugin-meetings/src/media/MediaConnectionAwaiter.ts
+++ b/packages/@webex/plugin-meetings/src/media/MediaConnectionAwaiter.ts
@@ -111,6 +111,8 @@ export default class MediaConnectionAwaiter {
 
     this.clearCallbacks();
 
+    LoggerProxy.logger.warn('Media:MediaConnectionAwaiter#connectionStateChange --> Resolving');
+
     this.defer.resolve();
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3351,6 +3351,10 @@ export default class Meeting extends StatelessWebexPlugin {
     // The second on is if the audio is muted, we need to tell the statsAnalyzer when
     // the audio is muted or the user is not willing to send media
     this.locusInfo.on(LOCUSINFO.EVENTS.MEDIA_STATUS_CHANGE, (status) => {
+      LoggerProxy.logger.info(
+        'Meeting:index#setUpLocusInfoSelfListener --> MEDIA_STATUS_CHANGE received, processing...'
+      );
+
       if (this.statsAnalyzer) {
         this.statsAnalyzer.updateMediaStatus({
           actual: status,
@@ -3364,6 +3368,10 @@ export default class Meeting extends StatelessWebexPlugin {
             receiveShare: this.mediaProperties.mediaDirection?.receiveShare,
           },
         });
+      } else {
+        LoggerProxy.logger.warn(
+          'Meeting:index#setUpLocusInfoSelfListener --> MEDIA_STATUS_CHANGE, statsAnalyzer is not available.'
+        );
       }
     });
 
@@ -7462,6 +7470,9 @@ export default class Meeting extends StatelessWebexPlugin {
           throw error;
         }
       }
+
+      LoggerProxy.logger.info(`${LOG_HEADER} media connected, finalizing...`);
+
       if (this.mediaProperties.hasLocalShareStream()) {
         await this.enqueueScreenShareFloorRequest();
       }

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
@@ -66,6 +66,21 @@ describe('MediaProperties', () => {
       assert.equal(numTransports, 0);
     });
 
+    it('handles time out in the case when getStats() is not resolving', async () => {
+      // Promise that never resolves
+      mockMC.getStats = new Promise(() => {});
+
+      const promise = mediaProperties.getCurrentConnectionInfo();
+
+      await clock.tickAsync(1000);
+
+      const {connectionType, selectedCandidatePairChanges, numTransports} = await promise;
+
+      assert.equal(connectionType, 'unknown');
+      assert.equal(selectedCandidatePairChanges, -1);
+      assert.equal(numTransports, 0);
+    });
+
     describe('selectedCandidatePairChanges and numTransports', () => {
       it('returns correct values when getStats() returns no transport stats at all', async () => {
         mockMC.getStats.resolves([{type: 'something', id: '1234'}]);

--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@types/platform": "1.3.4",
-    "@webex/internal-media-core": "2.14.3",
+    "@webex/internal-media-core": "2.14.4",
     "@webex/media-helpers": "workspace:*",
     "async-mutex": "0.4.0",
     "buffer": "6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7820,7 +7820,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.38.1
     "@typescript-eslint/parser": 5.38.1
     "@web/dev-server": 0.4.5
-    "@webex/internal-media-core": 2.14.3
+    "@webex/internal-media-core": 2.14.4
     "@webex/media-helpers": "workspace:*"
     async-mutex: 0.4.0
     buffer: 6.0.3
@@ -8111,9 +8111,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:2.14.3":
-  version: 2.14.3
-  resolution: "@webex/internal-media-core@npm:2.14.3"
+"@webex/internal-media-core@npm:2.14.4":
+  version: 2.14.4
+  resolution: "@webex/internal-media-core@npm:2.14.4"
   dependencies:
     "@babel/runtime": ^7.18.9
     "@babel/runtime-corejs2": ^7.25.0
@@ -8126,7 +8126,7 @@ __metadata:
     uuid: ^8.3.2
     webrtc-adapter: ^8.1.2
     xstate: ^4.30.6
-  checksum: 8b282cb6d56e1108f0bea5a68c637d281b791f20159dbfac50b20469b0a3562703086cc7b2e0543d986857d63565048fe767e74805c9b709229005ffddf43dbd
+  checksum: 94680bc2fe8f0a01e16dc97ccfd17faff51e5afbbc20426d445835dafba9c983d4935d35d124b68d7da5ae82525317256f612794bae3ecbc99fcb33ebad5da06
   languageName: node
   linkType: hard
 
@@ -8885,7 +8885,7 @@ __metadata:
     "@babel/preset-typescript": 7.22.11
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.14.3
+    "@webex/internal-media-core": 2.14.4
     "@webex/jest-config-legacy": "workspace:*"
     "@webex/legacy-tools": "workspace:*"
     "@webex/test-helper-chai": "workspace:*"
@@ -9122,7 +9122,7 @@ __metadata:
     "@webex/common": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
     "@webex/event-dictionary-ts": ^1.0.1688
-    "@webex/internal-media-core": 2.14.3
+    "@webex/internal-media-core": 2.14.4
     "@webex/internal-plugin-conversation": "workspace:*"
     "@webex/internal-plugin-device": "workspace:*"
     "@webex/internal-plugin-llm": "workspace:*"


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-635466](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-635466)

## This pull request addresses

Additional logging to get better understanding what is going on during the call initialization.
Also, modifies `getCurrentConnectionInfo` not to wait for getStats call longer than 1 second.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
