### PR TITLE
fix(tooling): handle-quotes-in-commit-message

### DIFF
--- a/packages/tools/package/src/commands/changelog/changelog.executor.ts
+++ b/packages/tools/package/src/commands/changelog/changelog.executor.ts
@@ -13,7 +13,7 @@ export async function getCommits(prevCommit: string) {
   // First, replace all `"` with `\"` ensuring we dont replace any `escape"`
   let sanitizedResult = result.replace(/(?<!\\)(?<!escape)"/g, '\\"');
 
-  // Then, replace `escape"` with `"` ensuring
+  // Then, replace `escape"` with `"`
   sanitizedResult = sanitizedResult.replace(/escape"/g, '"');
 
   return `{${sanitizedResult

--- a/packages/tools/package/src/commands/changelog/changelog.executor.ts
+++ b/packages/tools/package/src/commands/changelog/changelog.executor.ts
@@ -5,9 +5,19 @@ import { Executor } from '@webex/cli-tools';
  * @param scriptPath - Path to the script which we want to run.
  * @returns - Promise that resolves once the script is run and returns the output.
  */
-export async function getCommits(prevCommit:string) {
-  const result = await Executor.execute(`git log --pretty=format:'"%H":"%s",' ${prevCommit}..HEAD`) as string;
-  // Remove trailing comma and wrap the input in curly braces
-  // Replace all occurrences of ":" with "\":\"" and add quotes around keys
-  return `{${result.trim().replace(/,\s*$/, '').replace(/"([^"]+)":/g, '"$1":')}}`;
+export async function getCommits(prevCommit: string) {
+  const result = (await Executor.execute(
+    `git log --pretty=format:'escape"%Hescape":escape"%sescape",' ${prevCommit}..HEAD`,
+  )) as string;
+
+  // First, replace all `"` with `\"` ensuring we dont replace any `escape"`
+  let sanitizedResult = result.replace(/(?<!\\)(?<!escape)"/g, '\\"');
+
+  // Then, replace `escape"` with `"` ensuring
+  sanitizedResult = sanitizedResult.replace(/escape"/g, '"');
+
+  return `{${sanitizedResult
+    .trim()
+    .replace(/,\s*$/, '')
+    .replace(/"([^"]+)":/g, '"$1":')}}`;
 }

--- a/packages/tools/package/test/module/changelog/changelog.executor.test.js
+++ b/packages/tools/package/test/module/changelog/changelog.executor.test.js
@@ -8,7 +8,9 @@ describe('changelogExecutor', () => {
     const executorSpy = jest.spyOn(Executor, 'execute').mockResolvedValue('{ mockCommit: \'mockCommitMessage\' }');
     changelogExecutor.getCommits(mockCommit);
     expect(getCommitsSpy).toHaveBeenCalledWith(mockCommit);
-    // eslint-disable-next-line no-useless-escape
-    expect(executorSpy).toHaveBeenCalledWith(`git log --pretty=format:'\"%H\":\"%s\",' ${mockCommit}..HEAD`);
+    expect(executorSpy).toHaveBeenCalledWith(
+      // eslint-disable-next-line no-useless-escape
+      `git log --pretty=format:'escape\"%Hescape\":escape\"%sescape\",' ${mockCommit}..HEAD`,
+    );
   });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-613656
## This pull request addresses
- Because of the preenc of double quotes in a commit message the changelog fails. It is failling because we do a JSON.parse().

## by making the following changes
- When we fetch the commits Im using a custom identifies to indentify the double quotes for the commitID and commit message -> identifier used = `escape"`

- With this identifier I just had to do a find a replace for this identifer.

- So the flow looks like below now
  -> We get all the commits in the format `'escape"%Hescape":escape"%sescape",'`  {%H is the commitId, %s is the commit message}
  
  -> We replace any double quotes(if any in the commit message) first to `\"`
  -> We replace the new identifier (escape") to double quotes `"`

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
- Locally ran the changelog command and ran samples app to see the changes on the changelog page.

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
