### PR TITLE
fix(plugin-cc): spark-33914-wxcc webeximportfix

### DIFF
--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -280,7 +280,6 @@
     }
   </style>
 
-  <script src="../webex.min.js"></script>
   <script src="../contact-center.min.js"></script>
   <script src="app.js"></script>
 </body>

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -110,6 +110,21 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    */
   public async register(): Promise<Profile> {
     try {
+      this.$webex.internal.mercury
+        .connect()
+        .then(() => {
+          LoggerProxy.info('Authentication: webex.internal.mercury.connect successful', {
+            module: CC_FILE,
+            method: this.register.name,
+          });
+        })
+        .catch((error) => {
+          LoggerProxy.warn(`Error occurred during mercury.connect() ${error}`, {
+            module: CC_FILE,
+            method: this.register.name,
+          });
+        });
+
       this.setupEventListeners();
 
       return await this.connectWebsocket();

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -87,6 +87,7 @@ interface IWebexInternal {
   mercury: {
     on: Listener;
     off: ListenerOff;
+    connect: () => Promise<void>;
     connected: boolean;
     connecting: boolean;
   };

--- a/packages/webex/src/contact-center.js
+++ b/packages/webex/src/contact-center.js
@@ -5,6 +5,7 @@ import config from './config';
 
 require('@webex/plugin-authorization');
 require('@webex/plugin-cc');
+require('@webex/internal-plugin-mercury');
 
 const Webex = WebexCore.extend({
   webex: true,

--- a/packages/webex/src/contact-center.js
+++ b/packages/webex/src/contact-center.js
@@ -17,4 +17,4 @@ Webex.init = function init(attrs = {}) {
   return new Webex(attrs);
 };
 
-module.exports = Webex;
+export default Webex;

--- a/packages/webex/src/webex.js
+++ b/packages/webex/src/webex.js
@@ -27,7 +27,6 @@ require('@webex/plugin-rooms');
 require('@webex/plugin-teams');
 require('@webex/plugin-team-memberships');
 require('@webex/plugin-webhooks');
-require('@webex/plugin-cc');
 
 const merge = require('lodash/merge');
 const WebexCore = require('@webex/webex-core').default;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = (env = {NODE_ENV: process.env.NODE_ENV || 'production'}) => ({
       library: {
         name: 'Webex',
         type: 'umd',
+        export: 'default',
       },
     },
   },


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-633914 

## This pull request addresses
Fixed the export from contact-center.js so webex can be imported from the contact center module itself.

## by making the following changes
Fixed the ESM export syntax

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
Initialized WxCC SDK and subscribed to the websocket connection. 
Station login using Extension was successful.

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
