### PR TITLE
fix(meetings): added enableReachabilityChecks to config

### DIFF
--- a/packages/@webex/plugin-meetings/src/config.ts
+++ b/packages/@webex/plugin-meetings/src/config.ts
@@ -95,6 +95,7 @@ export default {
     // This only applies to non-multistream meetings
     iceCandidatesGatheringTimeout: undefined,
     backendIpv6NativeSupport: false,
+    enableReachabilityChecks: true,
     reachabilityGetClusterTimeout: 5000,
     logUploadIntervalMultiplicationFactor: 0, // if set to 0 or undefined, logs won't be uploaded periodically, if you want periodic logs, recommended value is 1
   },

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -854,7 +854,7 @@ export default class Meetings extends WebexPlugin {
       this.executeRegistrationStep(
         () =>
           this.startReachability('registration').catch((error) => {
-            LoggerProxy.logger.error(`Meetings:index#register --> GDM error, ${error.message}`);
+            LoggerProxy.logger.warn(`Meetings:index#register --> startReachability failed:`, error);
           }),
         'startReachability'
       ),

--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -143,6 +143,10 @@ export default class Reachability extends EventsScope {
    * @memberof Reachability
    */
   public async gatherReachability(trigger: string): Promise<ReachabilityResults> {
+    // @ts-ignore
+    if (!this.webex.config.meetings.enableReachabilityChecks) {
+      throw new Error('enableReachabilityChecks is disabled in config');
+    }
     // Fetch clusters and measure latency
     try {
       this.lastTrigger = trigger;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -441,6 +441,19 @@ describe('plugin-meetings', () => {
           assert.isTrue(webex.meetings.registered);
         });
 
+        it('resolves even if startReachability() rejects', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+          webex.meetings.startReachability = sinon.stub().rejects(new Error('fake error'));
+
+          await webex.meetings.register();
+          assert.calledOnceWithExactly(webex.internal.device.register, undefined);
+          assert.called(webex.internal.services.getMeetingPreferences);
+          assert.called(webex.internal.services.fetchClientRegionInfo);
+          assert.called(webex.internal.mercury.connect);
+          assert.isTrue(webex.meetings.registered);
+        });
+
         it('passes on the device registration options', async () => {
           webex.canAuthorize = true;
           webex.meetings.registered = false;

--- a/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/reachability/index.ts
@@ -538,6 +538,14 @@ describe('gatherReachability', () => {
     assert.equal(storedResultForJoinCookie, JSON.stringify(expectedJoinCookie));
   };
 
+  it('rejects if reachability is disabled in config', async () => {
+    webex.config.meetings.enableReachabilityChecks = false;
+
+    const reachability = new Reachability(webex);
+
+    await assert.isRejected(reachability.gatherReachability('test'), 'enableReachabilityChecks is disabled in config');
+  });
+
   [
     // ========================================================================
     {

--- a/packages/@webex/test-helper-mock-webex/src/index.js
+++ b/packages/@webex/test-helper-mock-webex/src/index.js
@@ -210,6 +210,7 @@ function makeWebex(options) {
             mqaMetricsInterval: 60000,
             autoSendMQA: true,
           },
+          enableReachabilityChecks: true,
         },
       },
       initialize: function initialize(attrs) {


### PR DESCRIPTION
# COMPLETES #[SPARK-639700](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-639700)

## This pull request addresses
Some clients of SDK don't have RTCPeerConnection available and don't need reachability, but SDK always starts reachability - for these clients it fails and causes problems

## by making the following changes
Added a config entry to disable reachability, it's enabled by default so should not impact any other clients.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
