### PR TITLE
feat(plugin-meetings): join alias

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -176,6 +176,7 @@ const MeetingUtil = {
         deviceCapabilities: options.deviceCapabilities,
         liveAnnotationSupported: options.liveAnnotationSupported,
         clientMediaPreferences,
+        alias: options.alias,
       })
       .then((res) => {
         const parsed = MeetingUtil.parseLocusJoin(res);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -516,6 +516,17 @@ describe('plugin-meetings', () => {
         assert.equal(parameter.liveAnnotationSupported, true);
       });
 
+      it('#Should call meetingRequest.joinMeeting with alias passed through', async () => {
+        await MeetingUtil.joinMeeting(meeting, {
+          alias: 'alias name',
+        });
+
+        assert.calledOnce(meeting.meetingRequest.joinMeeting);
+        const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
+
+        assert.equal(parameter.alias, 'alias name');
+      });
+
       it('#Should call meetingRequest.joinMeeting with locale=en_UK, deviceCapabilities=["TEST"] when they are passed in as those values', async () => {
         await MeetingUtil.joinMeeting(meeting, {
           locale: 'en_UK',


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Allow passing in of the **alias** when joining a meeting.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
