### PR TITLE
revert: mercury plugin changes of cc websocket

### DIFF
--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -236,8 +236,6 @@ const Mercury = WebexPlugin.extend({
           token: token.toString(),
           trackingId: `${this.webex.sessionId}_${Date.now()}`,
           logger: this.logger,
-          authorizationRequired: this.config.authorizationRequired ?? true,
-          acknowledgementRequired: this.config.acknowledgementRequired ?? true,
         };
 
         // if the consumer has supplied request options use them
@@ -426,11 +424,8 @@ const Mercury = WebexPlugin.extend({
   },
 
   _getEventHandlers(eventType) {
-    const handlers = [];
-    if (!eventType) {
-      return handlers;
-    }
     const [namespace, name] = eventType.split('.');
+    const handlers = [];
 
     if (!this.webex[namespace] && !this.webex.internal[namespace]) {
       return handlers;
@@ -542,15 +537,13 @@ const Mercury = WebexPlugin.extend({
       )
       .then(() => {
         this._emit('event', event.data);
-        if (data.eventType) {
-          const [namespace] = data.eventType.split('.');
+        const [namespace] = data.eventType.split('.');
 
-          if (namespace === data.eventType) {
-            this._emit(`event:${namespace}`, envelope);
-          } else {
-            this._emit(`event:${namespace}`, envelope);
-            this._emit(`event:${data.eventType}`, envelope);
-          }
+        if (namespace === data.eventType) {
+          this._emit(`event:${namespace}`, envelope);
+        } else {
+          this._emit(`event:${namespace}`, envelope);
+          this._emit(`event:${data.eventType}`, envelope);
         }
       })
       .catch((reason) => {

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -727,21 +727,6 @@ describe('plugin-mercury', () => {
           return res;
         });
       });
-
-      it('_onmessage without eventType', () => {
-        sinon.spy(mercury, '_getEventHandlers');
-        sinon.spy(mercury, '_emit');
-        const event = {data: {data: {eventType: undefined, mydata: 'some data'}}};
-        mercury.logger.error.restore();
-        sinon.stub(mercury.logger, 'error');
-        return Promise.resolve(mercury._onmessage(event)).then(() => {
-          assert.calledWith(mercury._getEventHandlers, undefined);
-          assert.calledWith(mercury._emit, 'event', event.data);
-          assert.notCalled(mercury.logger.error);
-          mercury._emit.restore();
-          mercury._getEventHandlers.restore();
-        });
-      });
     });
 
     describe('#_applyOverrides()', () => {

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
@@ -139,7 +139,6 @@ describe('plugin-mercury', () => {
         ));
 
       it('accepts a logLevelToken option', () => {
-        const acknowledgeSpy = sinon.spy(socket, '_acknowledge');
         const promise = socket.open('ws://example.com', {
           forceCloseDelay: mockoptions.forceCloseDelay,
           pingInterval: mockoptions.pingInterval,
@@ -148,7 +147,6 @@ describe('plugin-mercury', () => {
           token: 'mocktoken',
           trackingId: 'mocktrackingid',
           logLevelToken: 'mocklogleveltoken',
-          acknowledgementRequired: true,
         });
 
         mockWebSocket.readyState = 1;
@@ -164,82 +162,8 @@ describe('plugin-mercury', () => {
         });
 
         return promise.then(() => {
-          assert.called(acknowledgeSpy);
           assert.equal(socket.logLevelToken, 'mocklogleveltoken');
         });
-      });
-
-      it('accepts acknowledgementRequired option as false and skip acknowledge', () => {
-        const acknowledgeSpy = sinon.spy(socket, '_acknowledge');
-        const promise = socket.open('ws://example.com', {
-          forceCloseDelay: mockoptions.forceCloseDelay,
-          pingInterval: mockoptions.pingInterval,
-          pongTimeout: mockoptions.pongTimeout,
-          logger: console,
-          token: 'mocktoken',
-          trackingId: 'mocktrackingid',
-          logLevelToken: 'mocklogleveltoken',
-          acknowledgementRequired: false,
-        });
-
-        mockWebSocket.readyState = 1;
-        mockWebSocket.emit('open');
-
-        mockWebSocket.emit('message', {
-          data: JSON.stringify({
-            id: uuid.v4(),
-            data: {
-              eventType: 'mercury.buffer_state',
-            },
-          }),
-        });
-
-        return promise.then(() => {
-          assert.notCalled(acknowledgeSpy);
-          assert.equal(socket.logLevelToken, 'mocklogleveltoken');
-        });
-      });
-
-      it('accepts authorizationRequired option as false and skip authorize', () => {
-        const s = new Socket();
-        const authorizeSpy = sinon.spy(socket, '_authorize');
-        socket.open('ws://example.com', {
-          forceCloseDelay: mockoptions.forceCloseDelay,
-          pingInterval: mockoptions.pingInterval,
-          pongTimeout: mockoptions.pongTimeout,
-          logger: console,
-          token: 'mocktoken',
-          trackingId: 'mocktrackingid',
-          logLevelToken: 'mocklogleveltoken',
-          authorizationRequired: false,
-        });
-
-          mockWebSocket.readyState = 1;
-          mockWebSocket.emit('open');
-
-          assert.notCalled(authorizeSpy);
-          assert.called(socket._ping);
-        });
-
-      it('accepts authorizationRequired option as true and calles authorize', () => {
-        const s = new Socket();
-        const authorizeSpy = sinon.spy(socket, '_authorize');
-        socket.open('ws://example.com', {
-          forceCloseDelay: mockoptions.forceCloseDelay,
-          pingInterval: mockoptions.pingInterval,
-          pongTimeout: mockoptions.pongTimeout,
-          logger: console,
-          token: 'mocktoken',
-          trackingId: 'mocktrackingid',
-          logLevelToken: 'mocklogleveltoken',
-          authorizationRequired: true,
-        });
-
-          mockWebSocket.readyState = 1;
-          mockWebSocket.emit('open');
-
-          assert.called(authorizeSpy);
-          assert.called(socket._ping);
       });
     });
 


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses
This is to revert changes of mercury which were done as part of cc sdk but no longer needed as we are using websocket directly.

## by making the following changes


<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested
Test login and loading of messages, replying to messages and creating threads, reactions
Start a meeting and check for audio and video 2 ways
Start whiteboard in the meeting (this is what broke in the web client)
Try breakout rooms and other features like muting, unmuting other participants, locking and unlocking the meeting. Recording the meeting
Go to your meetings tab in web client and see if the new recording was listed and you're able to access it (open the link and play it)
< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >
https://app.vidcast.io/share/d21bec15-2bda-4415-98da-77de5007d0b3
https://app.vidcast.io/share/79e338ed-7ba3-4532-8934-ea601ac26863
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
