### PR TITLE
fix(plugin-cc): set autoResumed to false if payload is empty

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -1046,7 +1046,8 @@ function togglePauseResumeRecording() {
     });
   } else {
     pauseResumeRecordingElm.disabled = true;
-    task.resumeRecording({ autoResumed: autoResumed }).then(() => {
+    const resumeParams = autoResumed ? { autoResumed: autoResumed } : undefined;
+    task.resumeRecording(resumeParams).then(() => {
       console.info('Recording resumed successfully');
       pauseResumeRecordingElm.innerText = 'Pause Recording';
       pauseResumeRecordingElm.disabled = false;

--- a/packages/@webex/plugin-cc/src/services/task/index.ts
+++ b/packages/@webex/plugin-cc/src/services/task/index.ts
@@ -274,9 +274,7 @@ export default class Task extends EventEmitter implements ITask {
     resumeRecordingPayload: ResumeRecordingPayload
   ): Promise<TaskResponse> {
     try {
-      if (typeof resumeRecordingPayload === 'undefined') {
-        resumeRecordingPayload = {autoResumed: false};
-      }
+      resumeRecordingPayload ??= {autoResumed: false};
 
       const result = await this.contact.resumeRecording({
         interactionId: this.data.interactionId,

--- a/packages/@webex/plugin-cc/src/services/task/index.ts
+++ b/packages/@webex/plugin-cc/src/services/task/index.ts
@@ -274,6 +274,10 @@ export default class Task extends EventEmitter implements ITask {
     resumeRecordingPayload: ResumeRecordingPayload
   ): Promise<TaskResponse> {
     try {
+      if (typeof resumeRecordingPayload === 'undefined') {
+        resumeRecordingPayload = {autoResumed: false};
+      }
+
       const result = await this.contact.resumeRecording({
         interactionId: this.data.interactionId,
         data: resumeRecordingPayload,

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/index.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/index.ts
@@ -696,6 +696,19 @@ describe('Task', () => {
     });
   });
 
+  it('should resume the recording of the task if the payload is empty', async () => {
+    const resumePayload = {
+      autoResumed: false,
+    };
+
+    await task.resumeRecording();
+
+    expect(contactMock.resumeRecording).toHaveBeenCalledWith({
+      interactionId: taskId,
+      data: resumePayload,
+    });
+  });
+
   it('should handle errors in resumeRecording method', async () => {
     const error = {
       details: {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES Ad-hoc

## This pull request addresses

The Resume Recording API was mandating autoResumed parameter while it wasn't required unless enabled

**The Problem (SDK Sample vs Widget)**

| App | Request | Code | Note |
| --- | --- | --- | --- |
| SDK Sample | <img width="759" alt="Screenshot 2025-03-26 at 10 41 37 AM" src="https://github.com/user-attachments/assets/a9778c71-4c09-400d-b469-8f030bd12ee7" /> | ![Screenshot 2025-03-26 at 10 47 22 AM](https://github.com/user-attachments/assets/4d3991e9-7041-4766-87af-d1df38ce8bb6)| Note that there's a payload always |
| Widget | <img width="763" alt="Screenshot 2025-03-26 at 10 41 44 AM" src="https://github.com/user-attachments/assets/14afe853-284c-473a-b70e-70ccf5649bda" /> | ![Screenshot 2025-03-26 at 10 45 42 AM](https://github.com/user-attachments/assets/047f2c13-4804-4158-8c80-7afb9908ad8d) | Note that the payload is empty always which triggers a GET request instead of POST |



## by making the following changes

- Adding a payload with `autoResumed` to be false whenever payload is undefined
- The Sample app is also altered to not send any payload if the autoResumed box is not checked

**Screen recording of fix**

https://github.com/user-attachments/assets/1ed9c53a-4752-42fc-9e83-5284ab142881

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Tested in the sample app with both autoResumed checked and not checked

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
