### PR TITLE
fix(cc-sdk): fixed-consult-transfer-events

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -1102,6 +1102,7 @@ function wrapupCall() {
   const auxCodeId = wrapupCodesDropdownElm.options[wrapupCodesDropdownElm.selectedIndex].value;
   task.wrapup({wrapUpReason: wrapupReason, auxCodeId: auxCodeId}).then(() => {
     console.info('Call wrapped up successfully');
+    holdResumeElm.innerText = 'Hold';
     holdResumeElm.disabled = true;
     endElm.disabled = true;
     wrapupCodesDropdownElm.disabled = true;

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -304,10 +304,11 @@ async function initiateConsult() {
   try {
     await task.consult(consultPayload);
     console.log('Consult initiated successfully');
+    // Disable the blind transfer button after initiating consult, only enable it once consult is confirmed
+    disableCallControlPostConsult();
+    disableTransferControls();
     hideConsultButton();
     showEndConsultButton();
-    consultTransferBtn.style.display = 'inline-block'; // Show the consult transfer button
-    consultTransferBtn.disabled = false; // Enable the consult transfer button
   } catch (error) {
     console.error('Failed to initiate consult', error);
     alert('Failed to initiate consult');
@@ -440,6 +441,20 @@ function disableTransferControls() {
   transferElm.disabled = true;
 }
 
+// Disable all buttons post consulting
+function disableCallControlPostConsult() {
+  holdResumeElm.disabled = true;
+  pauseResumeRecordingElm.disabled = true;
+  endElm.disabled = true;
+}
+
+// Enable all buttons post consulting
+function enableCallControlPostConsult() {
+  holdResumeElm.disabled = false;
+  pauseResumeRecordingElm.disabled = false;
+  endElm.disabled = false;
+}
+
 // Register task listeners
 function registerTaskListeners(task) {
   task.on('task:assigned', (task) => {
@@ -456,12 +471,15 @@ function registerTaskListeners(task) {
   task.on('task:media', (track) => {
     document.getElementById('remote-audio').srcObject = new MediaStream([track]);
   });
-  task.on('task:end', () => {
-    answerElm.disabled = true;
-    declineElm.disabled = true;
+  task.on('task:end', (wrapupData) => {
     incomingDetailsElm.innerText = '';
-    if (!endElm.disabled) {
-      console.info('Call ended successfully by the external user');
+    if (!wrapupData.wrapupRequired) {
+      answerElm.disabled = true;
+      declineElm.disabled = true;
+      console.log('Call ended without call being answered');
+    }
+    else {
+      console.info('Call ended successfully');
       updateButtonsPostEndCall();
     }
   });
@@ -483,6 +501,12 @@ function registerTaskListeners(task) {
     consultTransferBtn.disabled = true; // Disable the consult transfer button since we are not yet owner of the call
   });
 
+  task.on('task:consulting', (task) => {
+    // When we are consulting with the other agent
+    consultTransferBtn.style.display = 'inline-block'; // Show the consult transfer button
+    consultTransferBtn.disabled = false; // Enable the consult transfer button
+  });
+
   task.on('task:consultQueueFailed', (task) => {
     // When trying to consult queue fails
     console.error(`Received task:consultQueueFailed for task: ${task.interactionId}`);
@@ -500,6 +524,8 @@ function registerTaskListeners(task) {
   task.on('task:consultEnd', (task) => {
     hideEndConsultButton();
     showConsultButton();
+    enableTransferControls();
+    enableCallControlPostConsult();
     consultTransferBtn.style.display = 'none';
     consultTransferBtn.disabled = true;
 

--- a/packages/@webex/plugin-cc/src/services/config/types.ts
+++ b/packages/@webex/plugin-cc/src/services/config/types.ts
@@ -41,6 +41,7 @@ export const CC_TASK_EVENTS = {
   AGENT_CONTACT: 'AgentContact',
   AGENT_OFFER_CONTACT: 'AgentOfferContact',
   AGENT_CONTACT_ASSIGNED: 'AgentContactAssigned',
+  AGENT_CONTACT_UNASSIGNED: 'AgentContactUnassigned',
 } as const;
 
 // Define the CC_AGENT_EVENTS object

--- a/packages/@webex/plugin-cc/src/services/task/types.ts
+++ b/packages/@webex/plugin-cc/src/services/task/types.ts
@@ -44,6 +44,7 @@ export const TASK_EVENTS = {
   TASK_CONSULT_QUEUE_CANCELLED: 'task:consultQueueCancelled',
   TASK_CONSULT_QUEUE_FAILED: 'task:consultQueueFailed',
   TASK_CONSULT_ACCEPTED: 'task:consultAccepted',
+  TASK_CONSULTING: 'task:consulting',
   TASK_PAUSE: 'task:pause',
   TASK_RESUME: 'task:resume',
   TASK_END: 'task:end',

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -333,7 +333,8 @@ describe('TaskManager', () => {
     taskManager.currentTask.data = payload.data;
     webSocketManagerMock.emit('message', JSON.stringify(payload));
 
-    expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_END);
+    expect(taskEmitSpy.mock.calls[1][0]).toBe(TASK_EVENTS.TASK_END);
+    expect(taskEmitSpy.mock.calls[1][1]).toEqual({ wrapupRequired: false });
     expect(webCallListenerSpy).toHaveBeenCalledWith();
     expect(callOffSpy).toHaveBeenCalledWith(
       CALL_EVENT_KEYS.REMOTE_MEDIA,
@@ -739,5 +740,42 @@ describe('TaskManager', () => {
     expect(taskEmitSpy).not.toHaveBeenCalled();
     expect(taskUpdateTaskDataSpy).not.toHaveBeenCalled();
   });
+
+  it('should emit TASK_CONSULTING event on AGENT_CONSULTING when isConsulted is false', () => {
+    webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+    taskManager.currentTask.data.isConsulted = false;
+    const taskEmitSpy = jest.spyOn(taskManager.currentTask, 'emit');
+    const consultingPayload = {
+      data: {
+        ...initalPayload.data,
+        type: CC_EVENTS.AGENT_CONSULTING,
+      },
+    };
+    webSocketManagerMock.emit('message', JSON.stringify(consultingPayload));
+    expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_CONSULTING, taskManager.currentTask);
+  });
+
+  it('should emit TASK_END event on AGENT_CONTACT_UNASSIGNED', () => {
+    webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+    const taskEmitSpy = jest.spyOn(taskManager.currentTask, 'emit');
+    const unassignedPayload = {
+      data: {
+        type: CC_EVENTS.AGENT_CONTACT_UNASSIGNED,
+        agentId: initalPayload.data.agentId,
+        eventTime: initalPayload.data.eventTime,
+        eventType: initalPayload.data.eventType,
+        interaction: {},
+        interactionId: initalPayload.data.interactionId,
+        orgId: initalPayload.data.orgId,
+        trackingId: initalPayload.data.trackingId,
+        mediaResourceId: initalPayload.data.mediaResourceId,
+        destAgentId: initalPayload.data.destAgentId,
+        owner: initalPayload.data.owner,
+        queueMgr: initalPayload.data.queueMgr,
+      },
+    };
+    webSocketManagerMock.emit('message', JSON.stringify(unassignedPayload));
+    expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_END, { wrapupRequired: true });
+  });
 });
-  
+

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -333,8 +333,10 @@ describe('TaskManager', () => {
     taskManager.currentTask.data = payload.data;
     webSocketManagerMock.emit('message', JSON.stringify(payload));
 
-    expect(taskEmitSpy.mock.calls[1][0]).toBe(TASK_EVENTS.TASK_END);
-    expect(taskEmitSpy.mock.calls[1][1]).toEqual({ wrapupRequired: false });
+    expect(taskEmitSpy).toHaveBeenCalledWith(
+      TASK_EVENTS.TASK_END, 
+      { wrapupRequired: false }
+    );
     expect(webCallListenerSpy).toHaveBeenCalledWith();
     expect(callOffSpy).toHaveBeenCalledWith(
       CALL_EVENT_KEYS.REMOTE_MEDIA,
@@ -345,6 +347,36 @@ describe('TaskManager', () => {
     expect(offSpy.mock.calls.length).toBe(2); // 1 for incoming call and 1 for remote media
     expect(offSpy).toHaveBeenCalledWith(CALL_EVENT_KEYS.REMOTE_MEDIA, offSpy.mock.calls[0][1]);
     expect(offSpy).toHaveBeenCalledWith(LINE_EVENTS.INCOMING_CALL, offSpy.mock.calls[1][1]);
+  });
+
+  it('should emit TASK_END event with wrapupRequired on regular call end', () => {
+    webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+
+    const taskEmitSpy = jest.spyOn(taskManager.currentTask, 'emit');
+    const payload = {
+      data: {
+        type: CC_EVENTS.CONTACT_ENDED,
+        agentId: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
+        eventTime: 1733211616959,
+        eventType: 'RoutingMessage',
+        interaction: {state: 'connected'},
+        interactionId: taskId,
+        orgId: '6ecef209-9a34-4ed1-a07a-7ddd1dbe925a',
+        trackingId: '575c0ec2-618c-42af-a61c-53aeb0a221ee',
+        mediaResourceId: '0ae913a4-c857-4705-8d49-76dd3dde75e4',
+        destAgentId: 'ebeb893b-ba67-4f36-8418-95c7492b28c2',
+        owner: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
+        queueMgr: 'aqm',
+      },
+    };
+
+    taskManager.currentTask.data = payload.data;
+    webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+    expect(taskEmitSpy).toHaveBeenCalledWith(
+      TASK_EVENTS.TASK_END, 
+      { wrapupRequired: true }
+    );
   });
 
   it('should emit TASK_HYDRATE event on AGENT_CONTACT event', () => {
@@ -741,7 +773,7 @@ describe('TaskManager', () => {
     expect(taskUpdateTaskDataSpy).not.toHaveBeenCalled();
   });
 
-  it('should emit TASK_CONSULTING event on AGENT_CONSULTING when isConsulted is false', () => {
+  it('should emit TASK_CONSULTING event when agent is consulting', () => {
     webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
     taskManager.currentTask.data.isConsulted = false;
     const taskEmitSpy = jest.spyOn(taskManager.currentTask, 'emit');


### PR DESCRIPTION
# COMPLETES #< [SPARK-568988](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-568988) >

## This pull request addresses

* Currently, we are not **properly** emitting events related to transfer/consult from the SDK.
* We are not emitting an event when blind transfer is completed so as to indicate to the agent attempting the transfer that we need to wrapup.
* Secondly, in consult, we are not indicating when the consult has been accepted on the user side (this was causing issues for widgets).
* Earlier, we were not emitting TASK_END event with `wrapup_required` payload - this is needed both for our users and our widgets to properly wrapup tasks for regular task discconnects and transfer.



## by making the following changes

* Code has been added to fix and add the events.
* We are now listening for AGENT_CONTACT_UNASSIGNED and emitting the `task:end` event with a payload `wrapupRequired:true`. This is to indicate to the end user/widgets that we need wrapup.
* Only in the case of the caller declining the call before agent could answer, we send a `wrapupRequired:false`
* Sample app fixes for certain issues

## Vidcasts
[WebRTC Working](https://app.vidcast.io/share/7ca99553-7a52-43e2-ab03-79f03c9f1b43)
[Extension/Softphone Working](https://app.vidcast.io/share/d7105282-5427-4c5c-a478-b6664fd39cd3)

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested call accept/decline on both webrtc and extension
* Tested blind transfer.
* Tested consult/consult transfer (both from agent initiating and from other side initiating)
* Tested consult cancel
* Tested end user declining call as well

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
