### PR TITLE
fix(plugin-cc): fixed webex import with contact-center.min.js

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -656,6 +656,10 @@ function register() {
         dialNumber.disabled = agentProfile.defaultDn ? false : true;
         if (loginVoiceOptions.length > 0) loginAgentElm.disabled = false;
         loginVoiceOptions.forEach((voiceOptions)=> {
+          if (!agentProfile.webRtcEnabled && voiceOptions === 'BROWSER') {
+            // Skiping the addition of browser option for webrtc disabled case
+            return;
+          }
           const option = document.createElement('option');
           option.text = voiceOptions;
           option.value = voiceOptions;

--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -280,7 +280,6 @@
     }
   </style>
 
-  <script src="../webex.min.js"></script>
   <script src="../contact-center.min.js"></script>
   <script src="app.js"></script>
 </body>

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -114,6 +114,21 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    */
   public async register(): Promise<Profile> {
     try {
+      this.$webex.internal.mercury
+        .connect()
+        .then(() => {
+          LoggerProxy.info('Authentication: webex.internal.mercury.connect successful', {
+            module: CC_FILE,
+            method: this.register.name,
+          });
+        })
+        .catch((error) => {
+          LoggerProxy.warn(`Error occurred during mercury.connect() ${error}`, {
+            module: CC_FILE,
+            method: this.register.name,
+          });
+        });
+
       this.setupEventListeners();
 
       return await this.connectWebsocket();

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -167,7 +167,10 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
             method: this.connectWebsocket.name,
           });
 
-          if (this.agentConfig.webRtcEnabled) {
+          if (
+            this.agentConfig.webRtcEnabled &&
+            this.agentConfig.loginVoiceOptions.includes(LoginOption.BROWSER)
+          ) {
             this.$webex.internal.mercury
               .connect()
               .then(() => {
@@ -228,7 +231,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         },
       });
 
-      if (data.loginOption === LoginOption.BROWSER) {
+      if (this.agentConfig.webRtcEnabled && data.loginOption === LoginOption.BROWSER) {
         await this.webCallingService.registerWebCallingLine();
       }
 

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -114,21 +114,6 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    */
   public async register(): Promise<Profile> {
     try {
-      this.$webex.internal.mercury
-        .connect()
-        .then(() => {
-          LoggerProxy.info('Authentication: webex.internal.mercury.connect successful', {
-            module: CC_FILE,
-            method: this.register.name,
-          });
-        })
-        .catch((error) => {
-          LoggerProxy.error(`Error occurred during mercury.connect() ${error}`, {
-            module: CC_FILE,
-            method: this.register.name,
-          });
-        });
-
       this.setupEventListeners();
 
       return await this.connectWebsocket();
@@ -177,10 +162,27 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           const agentId = data.agentId;
           const orgId = this.$webex.credentials.getOrgId();
           this.agentConfig = await this.services.config.getAgentConfig(orgId, agentId);
-          LoggerProxy.log(`agent config is fetched successfully`, {
+          LoggerProxy.log(`Agent config is fetched successfully`, {
             module: CC_FILE,
             method: this.connectWebsocket.name,
           });
+
+          if (this.agentConfig.webRtcEnabled) {
+            this.$webex.internal.mercury
+              .connect()
+              .then(() => {
+                LoggerProxy.info('Authentication: webex.internal.mercury.connect successful', {
+                  module: CC_FILE,
+                  method: this.connectWebsocket.name,
+                });
+              })
+              .catch((error) => {
+                LoggerProxy.error(`Error occurred during mercury.connect() ${error}`, {
+                  module: CC_FILE,
+                  method: this.connectWebsocket.name,
+                });
+              });
+          }
           if (this.$config && this.$config.allowAutomatedRelogin) {
             await this.silentRelogin();
           }

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -123,7 +123,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           });
         })
         .catch((error) => {
-          LoggerProxy.warn(`Error occurred during mercury.connect() ${error}`, {
+          LoggerProxy.error(`Error occurred during mercury.connect() ${error}`, {
             module: CC_FILE,
             method: this.register.name,
           });

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -92,6 +92,7 @@ interface IWebexInternal {
   mercury: {
     on: Listener;
     off: ListenerOff;
+    connect: () => Promise<void>;
     connected: boolean;
     connecting: boolean;
   };

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -438,7 +438,7 @@ describe('webex.cc', () => {
   });
 
   describe('stationLogin', () => {
-    it('should login successfully with LoginOption.BROWSER', async () => {
+    it('should login successfully with LoginOption.BROWSER and webrtc enabled', async () => {
       const mockTask = {};
       const options = {
         teamId: 'teamId',
@@ -453,7 +453,6 @@ describe('webex.cc', () => {
         webex.cc.webCallingService,
         'registerWebCallingLine'
       );
-
 
       const mockData = {
         data: {
@@ -528,6 +527,60 @@ describe('webex.cc', () => {
       messageCallback(JSON.stringify(agentMultiLoginEventData));
 
       expect(ccEmitSpy).toHaveBeenCalledWith(AGENT_MULTI_LOGIN, agentMultiLoginEventData.data);
+    });
+
+    it('should not attempt mobius registration for LoginOption.BROWSER if webrtc is disabled', async () => {
+      const options = {
+        teamId: 'teamId',
+        loginOption: LoginOption.BROWSER,
+      };
+
+      webex.cc.agentConfig = {
+        agentId: 'agentId',
+        webRtcEnabled: false
+      };
+
+      const mockData = {
+        data: {
+          loginOption: LoginOption.BROWSER,
+          agentId: 'agentId',
+          teamId: 'teamId',
+          siteId: 'siteId',
+          roles: [AGENT],
+          trackingId: '1234',
+          eventType: 'DESKTOP_MESSAGE',
+        },
+        trackingId: '1234',
+        orgId: 'orgId',
+        type: 'StationLoginSuccess',
+        eventType: 'STATION_LOGIN',
+      }
+
+      const registerWebCallingLineSpy = jest.spyOn(
+        webex.cc.webCallingService,
+        'registerWebCallingLine'
+      );
+
+      const stationLoginSpy = jest
+        .spyOn(webex.cc.services.agent, 'stationLogin').mockResolvedValue(mockData as unknown as StationLoginSuccess);
+
+      await webex.cc.stationLogin(options);
+
+      expect(registerWebCallingLineSpy).not.toHaveBeenCalled();
+      expect(stationLoginSpy).toHaveBeenCalledWith({
+        data: {
+          dialNumber: 'agentId',
+          teamId: 'teamId',
+          deviceType: LoginOption.BROWSER,
+          isExtension: false,
+          deviceId: `${WEB_RTC_PREFIX}agentId`,
+          roles: [AGENT],
+          teamName: '',
+          siteId: '',
+          usesOtherDN: false,
+          auxCodeId: '',
+        },
+      });
     });
 
     it('should login successfully with other LoginOption', async () => {

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -24,6 +24,7 @@ import {Profile} from '../../../src/services/config/types';
 import TaskManager from '../../../src/services/task/TaskManager';
 import { AgentContact, TASK_EVENTS } from '../../../src/services/task/types';
 import MetricsManager from '../../../src/metrics/MetricsManager';
+import Mercury from '@webex/internal-plugin-mercury';
 
 jest.mock('../../../src/logger-proxy', () => ({
   __esModule: true,
@@ -54,6 +55,7 @@ describe('webex.cc', () => {
     webex = MockWebex({
       children: {
         cc: ContactCenter,
+        mercury: Mercury,
       },
       logger: {
         log: jest.fn(),
@@ -233,6 +235,7 @@ describe('webex.cc', () => {
         webRtcEnabled: false,
         lostConnectionRecoveryTimeout: 0,
       };
+      const mercuryConnect = jest.spyOn(webex.internal.mercury, 'connect').mockResolvedValue(true);
       const connectWebsocketSpy = jest.spyOn(webex.cc, 'connectWebsocket');
       const setupEventListenersSpy = jest.spyOn(webex.cc, 'setupEventListeners');
       const reloadSpy = jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue({
@@ -252,6 +255,7 @@ describe('webex.cc', () => {
 
       const result = await webex.cc.register();
 
+      expect(mercuryConnect).toHaveBeenCalled();
       expect(connectWebsocketSpy).toHaveBeenCalled();
       expect(setupEventListenersSpy).toHaveBeenCalled();
       expect(mockWebSocketManager.initWebSocket).toHaveBeenCalledWith({
@@ -335,6 +339,7 @@ describe('webex.cc', () => {
         webRtcEnabled: false,
         lostConnectionRecoveryTimeout: 0,
       };
+      jest.spyOn(webex.internal.mercury, 'connect').mockResolvedValue(true);
       const connectWebsocketSpy = jest.spyOn(webex.cc, 'connectWebsocket');
       const reloadSpy = jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue({
         data: {
@@ -372,6 +377,7 @@ describe('webex.cc', () => {
     });
 
     it('should log error and reject if registration fails', async () => {
+      jest.spyOn(webex.internal.mercury, 'connect').mockResolvedValue(true);
       const mockError = new Error('Error while performing register');
       mockWebSocketManager.initWebSocket.mockRejectedValue(mockError);
 

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -231,7 +231,7 @@ describe('webex.cc', () => {
       allowConsultToQueue: false,
       agentPersonalStatsEnabled: false,
       isTimeoutDesktopInactivityEnabled: false,
-      webRtcEnabled: false,
+      webRtcEnabled: true,
       lostConnectionRecoveryTimeout: 0,
     };
 
@@ -280,7 +280,7 @@ describe('webex.cc', () => {
       expect(mockWebSocketManager.on).toHaveBeenCalledWith('message', expect.any(Function));
 
       expect(configSpy).toHaveBeenCalled();
-      expect(LoggerProxy.log).toHaveBeenCalledWith('agent config is fetched successfully', {
+      expect(LoggerProxy.log).toHaveBeenCalledWith('Agent config is fetched successfully', {
         module: CC_FILE,
         method: 'mockConstructor',
       });
@@ -319,7 +319,7 @@ describe('webex.cc', () => {
         },
       });
       expect(configSpy).toHaveBeenCalled();
-      expect(LoggerProxy.log).toHaveBeenCalledWith('agent config is fetched successfully', {
+      expect(LoggerProxy.log).toHaveBeenCalledWith('Agent config is fetched successfully', {
         module: CC_FILE,
         method: 'mockConstructor',
       });
@@ -365,7 +365,7 @@ describe('webex.cc', () => {
 
       expect(LoggerProxy.error).toHaveBeenCalledWith(`Error occurred during mercury.connect() ${mockError}`, {
         module: CC_FILE,
-        method: 'register',
+        method: 'mockConstructor',
       });
       expect(connectWebsocketSpy).toHaveBeenCalled();
       expect(setupEventListenersSpy).toHaveBeenCalled();
@@ -390,11 +390,49 @@ describe('webex.cc', () => {
       expect(mockWebSocketManager.on).toHaveBeenCalledWith('message', expect.any(Function));
 
       expect(configSpy).toHaveBeenCalled();
-      expect(LoggerProxy.log).toHaveBeenCalledWith('agent config is fetched successfully', {
+      expect(LoggerProxy.log).toHaveBeenCalledWith('Agent config is fetched successfully', {
         module: CC_FILE,
         method: 'mockConstructor',
       });
       expect(reloadSpy).toHaveBeenCalled();
+      expect(result).toEqual(mockAgentProfile);
+    });
+
+    it('should not attempt for mercury connection when webrtc is disabled', async () => {
+      mockAgentProfile.webRtcEnabled = false;
+      const mercurySpy = jest.spyOn(webex.internal.mercury, 'connect');
+      const connectWebsocketSpy = jest.spyOn(webex.cc, 'connectWebsocket');
+      const setupEventListenersSpy = jest.spyOn(webex.cc, 'setupEventListeners');
+      const reloadSpy = jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue({
+        data: {
+          auxCodeId: 'auxCodeId',
+          agentId: 'agentId',
+          deviceType: LoginOption.EXTENSION,
+          dn: '12345',
+        },
+      });
+      const configSpy = jest
+        .spyOn(webex.cc.services.config, 'getAgentConfig')
+        .mockResolvedValue(mockAgentProfile);
+      mockWebSocketManager.initWebSocket.mockResolvedValue({
+        agentId: 'agent123',
+      });
+
+      const result = await webex.cc.register();
+
+      expect(connectWebsocketSpy).toHaveBeenCalled();
+      expect(setupEventListenersSpy).toHaveBeenCalled();
+      expect(mockWebSocketManager.initWebSocket).toHaveBeenCalledWith({
+        body: {
+          force: true,
+          isKeepAliveEnabled: false,
+          clientType: 'WebexCCSDK',
+          allowMultiLogin: false,
+        },
+      });
+
+      expect(configSpy).toHaveBeenCalled();
+      expect(mercurySpy).not.toHaveBeenCalled();
       expect(result).toEqual(mockAgentProfile);
     });
   });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -190,7 +190,7 @@ describe('webex.cc', () => {
       agentName: 'John',
       teams: [],
       agentProfileID: '',
-      loginVoiceOptions: [],
+      loginVoiceOptions: ['BROWSER', 'EXTENSION'],
       idleCodes: [],
       wrapupCodes: [],
       defaultDn: '',
@@ -447,6 +447,8 @@ describe('webex.cc', () => {
 
       webex.cc.agentConfig = {
         agentId: 'agentId',
+        webRtcEnabled: true,
+        loginVoiceOptions: ['BROWSER', 'EXTENSION', 'AGENT_DN']
       };
 
       const registerWebCallingLineSpy = jest.spyOn(
@@ -584,6 +586,10 @@ describe('webex.cc', () => {
     });
 
     it('should login successfully with other LoginOption', async () => {
+      webex.cc.agentConfig = {
+        webRtcEnabled: true
+      };
+
       const options = {
         teamId: 'teamId',
         loginOption: LoginOption.AGENT_DN,
@@ -630,6 +636,10 @@ describe('webex.cc', () => {
     });
 
     it('should handle error during stationLogin', async () => {
+      webex.cc.agentConfig = {
+        webRtcEnabled: true
+      };
+
       const options = {
         teamId: 'teamId',
         loginOption: LoginOption.EXTENSION,

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -184,57 +184,58 @@ describe('webex.cc', () => {
   });
 
   describe('register', () => {
+    const mockAgentProfile: Profile = {
+      agentId: 'agent123',
+      agentMailId: '',
+      agentName: 'John',
+      teams: [],
+      agentProfileID: '',
+      loginVoiceOptions: [],
+      idleCodes: [],
+      wrapupCodes: [],
+      defaultDn: '',
+      forceDefaultDn: false,
+      forceDefaultDnForAgent: false,
+      regexUS: '',
+      regexOther: '',
+      dialPlan: {
+        type: '',
+        dialPlanEntity: [],
+      },
+      skillProfileId: '',
+      siteId: '',
+      enterpriseId: '',
+      privacyShieldVisible: true,
+      defaultWrapupCode: '',
+      wrapUpData: {
+        wrapUpProps: {
+          autoWrapup: undefined,
+          autoWrapupInterval: undefined,
+          lastAgentRoute: undefined,
+          wrapUpReasonList: [],
+          wrapUpCodesList: undefined,
+          idleCodesAccess: undefined,
+          interactionId: undefined,
+          allowCancelAutoWrapup: undefined,
+        },
+      },
+      isOutboundEnabledForTenant: false,
+      isOutboundEnabledForAgent: false,
+      isAdhocDialingEnabled: false,
+      isAgentAvailableAfterOutdial: false,
+      isCampaignManagementEnabled: false,
+      outDialEp: '',
+      isEndCallEnabled: false,
+      isEndConsultEnabled: false,
+      agentDbId: '',
+      allowConsultToQueue: false,
+      agentPersonalStatsEnabled: false,
+      isTimeoutDesktopInactivityEnabled: false,
+      webRtcEnabled: false,
+      lostConnectionRecoveryTimeout: 0,
+    };
+
     it('should register successfully and return agent profile', async () => {
-      const mockAgentProfile: Profile = {
-        agentId: 'agent123',
-        agentMailId: '',
-        agentName: 'John',
-        teams: [],
-        agentProfileID: '',
-        loginVoiceOptions: [],
-        idleCodes: [],
-        wrapupCodes: [],
-        defaultDn: '',
-        forceDefaultDn: false,
-        forceDefaultDnForAgent: false,
-        regexUS: '',
-        regexOther: '',
-        dialPlan: {
-          type: '',
-          dialPlanEntity: [],
-        },
-        skillProfileId: '',
-        siteId: '',
-        enterpriseId: '',
-        privacyShieldVisible: true,
-        defaultWrapupCode: '',
-        wrapUpData: {
-          wrapUpProps: {
-            autoWrapup: undefined,
-            autoWrapupInterval: undefined,
-            lastAgentRoute: undefined,
-            wrapUpReasonList: [],
-            wrapUpCodesList: undefined,
-            idleCodesAccess: undefined,
-            interactionId: undefined,
-            allowCancelAutoWrapup: undefined,
-          },
-        },
-        isOutboundEnabledForTenant: false,
-        isOutboundEnabledForAgent: false,
-        isAdhocDialingEnabled: false,
-        isAgentAvailableAfterOutdial: false,
-        isCampaignManagementEnabled: false,
-        outDialEp: '',
-        isEndCallEnabled: false,
-        isEndConsultEnabled: false,
-        agentDbId: '',
-        allowConsultToQueue: false,
-        agentPersonalStatsEnabled: false,
-        isTimeoutDesktopInactivityEnabled: false,
-        webRtcEnabled: false,
-        lostConnectionRecoveryTimeout: 0,
-      };
       const mercuryConnect = jest.spyOn(webex.internal.mercury, 'connect').mockResolvedValue(true);
       const connectWebsocketSpy = jest.spyOn(webex.cc, 'connectWebsocket');
       const setupEventListenersSpy = jest.spyOn(webex.cc, 'setupEventListeners');
@@ -289,56 +290,6 @@ describe('webex.cc', () => {
 
     it('should not register when config is undefined', async () => {
       webex.cc.$config = undefined;
-      const mockAgentProfile: Profile = {
-        agentId: 'agent123',
-        agentMailId: '',
-        agentName: 'John',
-        teams: [],
-        loginVoiceOptions: [],
-        idleCodes: [],
-        wrapupCodes: [],
-        defaultDn: '',
-        forceDefaultDn: false,
-        forceDefaultDnForAgent: false,
-        regexUS: '',
-        regexOther: '',
-        agentProfileID: '',
-        dialPlan: {
-          type: '',
-          dialPlanEntity: [],
-        },
-        skillProfileId: '',
-        siteId: '',
-        enterpriseId: '',
-        privacyShieldVisible: false,
-        defaultWrapupCode: '',
-        wrapUpData: {
-          wrapUpProps: {
-            autoWrapup: undefined,
-            autoWrapupInterval: undefined,
-            lastAgentRoute: undefined,
-            wrapUpReasonList: [],
-            wrapUpCodesList: undefined,
-            idleCodesAccess: undefined,
-            interactionId: undefined,
-            allowCancelAutoWrapup: undefined,
-          },
-        },
-        isOutboundEnabledForTenant: false,
-        isOutboundEnabledForAgent: false,
-        isAdhocDialingEnabled: false,
-        isAgentAvailableAfterOutdial: false,
-        isCampaignManagementEnabled: false,
-        outDialEp: '',
-        isEndCallEnabled: false,
-        isEndConsultEnabled: false,
-        agentDbId: '',
-        allowConsultToQueue: false,
-        agentPersonalStatsEnabled: false,
-        isTimeoutDesktopInactivityEnabled: false,
-        webRtcEnabled: false,
-        lostConnectionRecoveryTimeout: 0,
-      };
       jest.spyOn(webex.internal.mercury, 'connect').mockResolvedValue(true);
       const connectWebsocketSpy = jest.spyOn(webex.cc, 'connectWebsocket');
       const reloadSpy = jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue({
@@ -387,6 +338,64 @@ describe('webex.cc', () => {
         module: CC_FILE,
         method: 'register',
       });
+    });
+
+    it('should log error if mercury connect fails but cc.register() should not fail', async () => {
+      const mockError = new Error('Error while performing mercury connect');
+      jest.spyOn(webex.internal.mercury, 'connect').mockRejectedValue(mockError);
+
+      const connectWebsocketSpy = jest.spyOn(webex.cc, 'connectWebsocket');
+      const setupEventListenersSpy = jest.spyOn(webex.cc, 'setupEventListeners');
+      const reloadSpy = jest.spyOn(webex.cc.services.agent, 'reload').mockResolvedValue({
+        data: {
+          auxCodeId: 'auxCodeId',
+          agentId: 'agentId',
+          deviceType: LoginOption.EXTENSION,
+          dn: '12345',
+        },
+      });
+      const configSpy = jest
+        .spyOn(webex.cc.services.config, 'getAgentConfig')
+        .mockResolvedValue(mockAgentProfile);
+      mockWebSocketManager.initWebSocket.mockResolvedValue({
+        agentId: 'agent123',
+      });
+
+      const result = await webex.cc.register();
+
+      expect(LoggerProxy.error).toHaveBeenCalledWith(`Error occurred during mercury.connect() ${mockError}`, {
+        module: CC_FILE,
+        method: 'register',
+      });
+      expect(connectWebsocketSpy).toHaveBeenCalled();
+      expect(setupEventListenersSpy).toHaveBeenCalled();
+      expect(mockWebSocketManager.initWebSocket).toHaveBeenCalledWith({
+        body: {
+          force: true,
+          isKeepAliveEnabled: false,
+          clientType: 'WebexCCSDK',
+          allowMultiLogin: false,
+        },
+      });
+
+
+      expect(mockTaskManager.on).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_INCOMING,
+        expect.any(Function)
+      );
+      expect(mockTaskManager.on).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_HYDRATE,
+        expect.any(Function)
+      );
+      expect(mockWebSocketManager.on).toHaveBeenCalledWith('message', expect.any(Function));
+
+      expect(configSpy).toHaveBeenCalled();
+      expect(LoggerProxy.log).toHaveBeenCalledWith('agent config is fetched successfully', {
+        module: CC_FILE,
+        method: 'mockConstructor',
+      });
+      expect(reloadSpy).toHaveBeenCalled();
+      expect(result).toEqual(mockAgentProfile);
     });
   });
 

--- a/packages/webex/src/contact-center.js
+++ b/packages/webex/src/contact-center.js
@@ -5,6 +5,7 @@ import config from './config';
 
 require('@webex/plugin-authorization');
 require('@webex/plugin-cc');
+require('@webex/internal-plugin-mercury');
 
 const Webex = WebexCore.extend({
   webex: true,
@@ -17,4 +18,4 @@ Webex.init = function init(attrs = {}) {
   return new Webex(attrs);
 };
 
-module.exports = Webex;
+export default Webex;

--- a/packages/webex/src/contact-center.js
+++ b/packages/webex/src/contact-center.js
@@ -1,11 +1,11 @@
 import merge from 'lodash/merge';
 import WebexCore from '@webex/webex-core';
 
-import config from './config';
-
 require('@webex/plugin-authorization');
 require('@webex/plugin-cc');
 require('@webex/internal-plugin-mercury');
+
+const config = require('./config');
 
 const Webex = WebexCore.extend({
   webex: true,

--- a/packages/webex/src/webex.js
+++ b/packages/webex/src/webex.js
@@ -27,7 +27,6 @@ require('@webex/plugin-rooms');
 require('@webex/plugin-teams');
 require('@webex/plugin-team-memberships');
 require('@webex/plugin-webhooks');
-require('@webex/plugin-cc');
 
 const merge = require('lodash/merge');
 const WebexCore = require('@webex/webex-core').default;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = (env = {NODE_ENV: process.env.NODE_ENV || 'production'}) => ({
       library: {
         name: 'Webex',
         type: 'umd',
+        export: 'default',
       },
     },
   },


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-633914 

## This pull request addresses
Fixed the export from contact-center.js so webex can be imported from the contact center module itself.

## by making the following changes
1. Updated index.html to use contact-center.min.js
2. Fixed the ESM export syntax in contact-center.js to export webex object.
3. Triggered device.register and mercury.connect within cc.register() to make desktop login mode work.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
Initialized WxCC SDK and subscribed to the websocket connection. Confirmed WDM registration and mercury connection.
Station login using Extension/Browser was successful.
Call controls working for both modes.

https://app.vidcast.io/share/ee45fdcb-96fd-41b8-ae3b-f25110f00bc3 

Attaching logs for testing with  webtrc disabled:
[ConsoleLogswithwebrtcdisabled.log](https://github.com/user-attachments/files/19568445/ConsoleLogswithwebrtcdisabled.log)

[NetworkLogsWithWerbrtcDisabled.log](https://github.com/user-attachments/files/19568457/NetworkLogsWithWerbrtcDisabled.log)


### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
