### PR TITLE
feat(plugin-meetings): add frameRate property to share video mute event

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -252,7 +252,8 @@
     "mediatype",
     "codev",
     "MFACTOR",
-    "failback"
+    "failback",
+    "HFRS"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/cspell.json
+++ b/cspell.json
@@ -252,8 +252,7 @@
     "mediatype",
     "codev",
     "MFACTOR",
-    "failback",
-    "HFRS"
+    "failback"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -8726,6 +8726,9 @@ export default class Meeting extends StatelessWebexPlugin {
     LoggerProxy.logger.log(
       `Meeting:index#handleShareVideoStreamMuteStateChange --> Share video stream mute state changed to muted ${muted}`
     );
+
+    const shareVideoStreamSettings = this.mediaProperties?.shareVideoStream?.getSettings();
+
     Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEETING_SHARE_VIDEO_MUTE_STATE_CHANGE, {
       correlationId: this.correlationId,
       muted,
@@ -8734,8 +8737,9 @@ export default class Meeting extends StatelessWebexPlugin {
       // SDK to TypeScript 5, which may affect other packages, use bracket notation for now, since
       // all we're doing here is adding metrics.
       // eslint-disable-next-line dot-notation
-      displaySurface: this.mediaProperties?.shareVideoStream?.getSettings()['displaySurface'],
+      displaySurface: shareVideoStreamSettings?.['displaySurface'],
       isMultistream: this.isMultistream,
+      frameRate: shareVideoStreamSettings?.frameRate,
     });
   };
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -12682,6 +12682,31 @@ describe('plugin-meetings', () => {
             });
           });
         });
+
+        describe('handleShareVideoStreamMuteStateChange', () => {
+          it('should emit MEETING_SHARE_VIDEO_MUTE_STATE_CHANGE event with correct fields', async () => {
+            meeting.isMultistream = true;
+            meeting.statsAnalyzer = {shareVideoEncoderImplementation: 'OpenH264'};
+            meeting.mediaProperties.shareVideoStream = {
+              getSettings: sinon.stub().returns({displaySurface: 'monitor', frameRate: 30}),
+            };
+
+            meeting.handleShareVideoStreamMuteStateChange(true);
+
+            assert.calledOnceWithExactly(
+              Metrics.sendBehavioralMetric,
+              BEHAVIORAL_METRICS.MEETING_SHARE_VIDEO_MUTE_STATE_CHANGE,
+              {
+                correlationId: meeting.correlationId,
+                muted: true,
+                encoderImplementation: 'OpenH264',
+                displaySurface: 'monitor',
+                isMultistream: true,
+                frameRate: 30,
+              }
+            );
+          });
+        });
       });
 
       describe('#startKeepAlive', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -12684,7 +12684,7 @@ describe('plugin-meetings', () => {
         });
 
         describe('handleShareVideoStreamMuteStateChange', () => {
-          it('should emit MEETING_SHARE_VIDEO_MUTE_STATE_CHANGE event with correct fields', async () => {
+          it('should emit MEETING_SHARE_VIDEO_MUTE_STATE_CHANGE event with correct fields', () => {
             meeting.isMultistream = true;
             meeting.statsAnalyzer = {shareVideoEncoderImplementation: 'OpenH264'};
             meeting.mediaProperties.shareVideoStream = {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-642242](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-642242)

## This pull request addresses

Trying to figure out whether or not share video mute occurs more often with high framerate share (HFRS). There is Chromium code that suggests the threshold for muting the share video is lower for HFRS than normal share (see associated JIRA for details).

## by making the following changes

Adding a new property `frameRate` to the share video mute event. This will always be 30 for HFRS and 5 for normal share.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

1. Testing locally on the SDK sample app, and checking that we can get the share video framerate in this way.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
