### PR TITLE
Meeting joined time convert

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -736,6 +736,10 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
     if (joinFlowVersion) {
       clientEventObject.joinFlowVersion = joinFlowVersion;
     }
+    const meetingJoinedTime = meeting.isoLocalClientMeetingJoinTime;
+    if (meetingJoinedTime) {
+      clientEventObject.meetingJoinedTime = meetingJoinedTime;
+    }
 
     if (options.meetingJoinPhase) {
       clientEventObject.meetingJoinPhase = options.meetingJoinPhase;

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1687,6 +1687,19 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
+   * Setter - sets isoLocalClientMeetingJoinTime
+   * This will be set once on meeting join, and not updated again
+   * @param {string | undefined} time in ISO format
+   */
+  set isoLocalClientMeetingJoinTime(time: string | undefined) {
+    if (!time) {
+      this.#isoLocalClientMeetingJoinTime = new Date().toISOString();
+    } else {
+      this.#isoLocalClientMeetingJoinTime = time;
+    }
+  }
+
+  /**
    * Set meeting info and trigger `MEETING_INFO_AVAILABLE` event
    * @param {any} info
    * @param {string} [meetingLookupUrl] Lookup url, defined when the meeting info fetched
@@ -5717,8 +5730,6 @@ export default class Meeting extends StatelessWebexPlugin {
 
         // @ts-ignore
         this.webex.internal.device.meetingStarted();
-
-        this.#isoLocalClientMeetingJoinTime = new Date().toISOString();
 
         LoggerProxy.logger.log('Meeting:index#join --> Success');
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1689,13 +1689,27 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * Setter - sets isoLocalClientMeetingJoinTime
    * This will be set once on meeting join, and not updated again
-   * @param {string | undefined} time in ISO format
+   * this will always produce an ISO string
+   * If the iso string is invalid, it will fallback to the current system time
+   * @param {string | undefined} time
    */
   set isoLocalClientMeetingJoinTime(time: string | undefined) {
+    const fallback = new Date().toISOString();
     if (!time) {
-      this.#isoLocalClientMeetingJoinTime = new Date().toISOString();
+      this.#isoLocalClientMeetingJoinTime = fallback;
     } else {
-      this.#isoLocalClientMeetingJoinTime = time;
+      const date = new Date(time);
+
+      // Check if the date is valid
+      if (Number.isNaN(date.getTime())) {
+        LoggerProxy.logger.info(
+          // @ts-ignore
+          `Meeting:index#isoLocalClientMeetingJoinTime --> Invalid date provided: ${time}. Falling back to system clock.`
+        );
+        this.#isoLocalClientMeetingJoinTime = fallback;
+      } else {
+        this.#isoLocalClientMeetingJoinTime = date.toISOString();
+      }
     }
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -180,7 +180,7 @@ const MeetingUtil = {
       .then((res) => {
         const parsed = MeetingUtil.parseLocusJoin(res);
         meeting.setLocus(parsed);
-
+        meeting.isoLocalClientMeetingJoinTime = res?.headers?.date; // read from header if exist, else fall back to system clock : https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-555657
         webex.internal.newMetrics.submitClientEvent({
           name: 'client.locus.join.response',
           payload: {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -210,6 +210,7 @@ describe('plugin-meetings', () => {
   let membersSpy;
   let meetingRequestSpy;
   let correlationId;
+  let isoLocalClientMeetingJoinTime;
   let uploadEvent;
 
   beforeEach(() => {
@@ -1690,10 +1691,6 @@ describe('plugin-meetings', () => {
         describe('successful', () => {
           beforeEach(() => {
             sandbox.stub(MeetingUtil, 'joinMeeting').returns(Promise.resolve(joinMeetingResult));
-          });
-
-          afterEach(() => {
-            assert.exists(meeting.isoLocalClientMeetingJoinTime);
           });
 
           it('should join the meeting and return promise', async () => {
@@ -7527,6 +7524,25 @@ describe('plugin-meetings', () => {
             correlationId: uuid1,
             sessionCorrelationId: '',
           });
+        });
+      });
+
+      describe('#setIsoLocalClientMeetingJoinTime', () => {
+        it('should set the isoLocalClientMeetingJoinTime when passed in', () => {
+          assert.equal(meeting.isoLocalClientMeetingJoinTime, isoLocalClientMeetingJoinTime);
+          meeting.isoLocalClientMeetingJoinTime = 'test';
+          assert.equal(meeting.isoLocalClientMeetingJoinTime, 'test');
+          meeting.isoLocalClientMeetingJoinTime = 'test2';
+          assert.equal(meeting.isoLocalClientMeetingJoinTime, 'test2');
+        });
+
+        it('should set the isoLocalClientMeetingJoin time once and only once when not passed in', () => {
+          assert.equal(meeting.isoLocalClientMeetingJoinTime, isoLocalClientMeetingJoinTime);
+          meeting.isoLocalClientMeetingJoinTime = undefined;
+          const time = meeting.isoLocalClientMeetingJoinTime;
+          assert.equal(meeting.isoLocalClientMeetingJoinTime, time);
+          meeting.isoLocalClientMeetingJoinTime = 'test2';
+          assert.equal(meeting.isoLocalClientMeetingJoinTime, 'test2');
         });
       });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -7527,22 +7527,24 @@ describe('plugin-meetings', () => {
         });
       });
 
-      describe('#setIsoLocalClientMeetingJoinTime', () => {
-        it('should set the isoLocalClientMeetingJoinTime when passed in', () => {
-          assert.equal(meeting.isoLocalClientMeetingJoinTime, isoLocalClientMeetingJoinTime);
-          meeting.isoLocalClientMeetingJoinTime = 'test';
-          assert.equal(meeting.isoLocalClientMeetingJoinTime, 'test');
-          meeting.isoLocalClientMeetingJoinTime = 'test2';
-          assert.equal(meeting.isoLocalClientMeetingJoinTime, 'test2');
-        });
-
-        it('should set the isoLocalClientMeetingJoin time once and only once when not passed in', () => {
-          assert.equal(meeting.isoLocalClientMeetingJoinTime, isoLocalClientMeetingJoinTime);
+      describe('#setIsoLocalClientMeetingJoinTime', () => {      
+        it('should fallback to system clock ISO string when given an undefined value', () => {
+          const currentSystemTime = new Date().toISOString();
           meeting.isoLocalClientMeetingJoinTime = undefined;
-          const time = meeting.isoLocalClientMeetingJoinTime;
-          assert.equal(meeting.isoLocalClientMeetingJoinTime, time);
-          meeting.isoLocalClientMeetingJoinTime = 'test2';
-          assert.equal(meeting.isoLocalClientMeetingJoinTime, 'test2');
+          assert.equal(meeting.isoLocalClientMeetingJoinTime, currentSystemTime);
+        });
+      
+        it('should fallback to system clock ISO string when given an invalid value', () => {
+          const currentSystemTime = new Date().toISOString();
+          meeting.isoLocalClientMeetingJoinTime = 'invalid-date';
+          assert.equal(meeting.isoLocalClientMeetingJoinTime, currentSystemTime);
+        });
+      
+        it('should set the isoLocalClientMeetingJoinTime correctly for a valid date string', () => {
+          const validDateString = 'Tue, 01 Apr 2025 13:00:36 GMT';
+          const expectedISOString = new Date(validDateString).toISOString();
+          meeting.isoLocalClientMeetingJoinTime = validDateString;
+          assert.equal(meeting.isoLocalClientMeetingJoinTime, expectedISOString);
         });
       });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -460,6 +460,50 @@ describe('plugin-meetings', () => {
         });
       });
 
+
+      it('#Should call `meetingRequest.joinMeeting and handle a date header in the response : isoLocalClientMeetingJoinedTime', async () => {
+        meeting.isMultistream = true;
+
+        const FAKE_REACHABILITY_REPORT = {
+          id: 'fake reachability report',
+        };
+        const FAKE_CLIENT_MEDIA_PREFERENCES = {
+          id: 'fake client media preferences',
+        };
+
+        webex.meetings.reachability.getReachabilityReportToAttachToRoap.resolves(FAKE_REACHABILITY_REPORT);
+        webex.meetings.reachability.getClientMediaPreferences.resolves(FAKE_CLIENT_MEDIA_PREFERENCES);
+
+        sinon
+          .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4')
+          .get(() => true);
+        sinon
+          .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6')
+          .get(() => true);
+
+        meeting.meetingRequest.joinMeeting.resolves({
+          headers: {
+            date: 'test'
+          },
+          body: {
+            mediaConnections: [{mediaId: 'test'}],
+            locus: {
+              url: 'test',
+              self: {
+                id: 'test'
+              }
+            }
+          }
+        })
+
+        await MeetingUtil.joinMeeting(meeting, {
+          reachability: 'reachability',
+          roapMessage: 'roapMessage',
+        });
+
+        assert.equal(meeting.isoLocalClientMeetingJoinTime, 'test');
+      });
+
       it('should handle failed reachability report retrieval', async () => {
         webex.meetings.reachability.getReachabilityReportToAttachToRoap.rejects(
           new Error('fake error')


### PR DESCRIPTION
## This pull request addresses

fixes meeting joined time to convert the date string from locus to an ISO format

## by making the following changes
```
  /**
   * Setter - sets isoLocalClientMeetingJoinTime
   * This will be set once on meeting join, and not updated again
   * this will always produce an ISO string
   * If the iso string is invalid, it will fallback to the current system time
   * @param {string | undefined} time
   */
  set isoLocalClientMeetingJoinTime(time: string | undefined) {
    const fallback = new Date().toISOString();
    if (!time) {
      this.#isoLocalClientMeetingJoinTime = fallback;
    } else {
      const date = new Date(time);

      // Check if the date is valid
      if (Number.isNaN(date.getTime())) {
        LoggerProxy.logger.info(
          // @ts-ignore
          `Meeting:index#isoLocalClientMeetingJoinTime --> Invalid date provided: ${time}. Falling back to system clock.`
        );
        this.#isoLocalClientMeetingJoinTime = fallback;
      } else {
        this.#isoLocalClientMeetingJoinTime = date.toISOString();
      }
    }
  }
  ```
  
this is the only thing that changed vs the revert 

validated live with @Coread 

![Screenshot 2025-04-01 at 9 03 33 AM](https://github.com/user-attachments/assets/3c7f5882-1425-4583-9000-25a4833c8425)


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

manual test and verify with correlationID
update unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
