### PR TITLE
feat(plugin-cc): add getQueues() method

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -168,6 +168,13 @@ function initOauth() {
   });
 }
 
+function toggleIfQueueConsultEnabled () {
+  document.querySelectorAll('option[value="queue"]').forEach(item => {
+    if(webex && !webex.cc.agentConfig.allowConsultToQueue) item.style.display = 'none';
+    else item.style.display = 'block';
+  });
+}
+
 const taskEvents = new CustomEvent('task:incoming', {
   detail: {
     task: task,
@@ -236,7 +243,6 @@ async function getQueueListForTelephonyChannel() {
   }
 }
 
-
 async function onConsultTypeSelectionChanged(){
 
   consultDestinationHolderElm.innerHTML = '';
@@ -259,20 +265,34 @@ async function onConsultTypeSelectionChanged(){
     refreshButton.onclick = refreshBuddyAgentsForConsult;
     consultDestinationHolderElm.appendChild(refreshButton);
   } else if (destinationTypeDropdown.value === 'queue') {
-    const queueList = await getQueueListForTelephonyChannel();
-
-    if(queueList.length > 0) {
-      // Make consultDestinationInput into a dropdown
-      consultDestinationInput = document.createElement('select');
-      consultDestinationInput.id = 'consultDestination';
-
-      queueList.forEach((queue) => {
-        const option = document.createElement('option');
-        option.text = queue.name;
-        option.value = queue.id;
-        consultDestinationInput.appendChild(option);
-      });
+    async function refreshQueueListForConsult() {
+      const queueList = await getQueueListForTelephonyChannel();
+  
+      if(queueList.length > 0) {
+        // Make consultDestinationInput into a dropdown
+        consultDestinationInput = document.createElement('select');
+        consultDestinationInput.id = 'consultDestination';
+  
+        queueList.forEach((queue) => {
+          const option = document.createElement('option');
+          option.text = queue.name;
+          option.value = queue.id;
+          consultDestinationInput.appendChild(option);
+        });
+      } else {
+        consultDestinationInput.disabled = true;
+        consultDestinationInput.innerText = 'No queues available';
+      }
     }
+
+    await refreshQueueListForConsult();
+
+    // Add a refresh button to refresh the queue list
+    const refreshButton = document.createElement('button');
+    refreshButton.id = 'refresh-queue-list';
+    refreshButton.innerHTML = 'Refresh queue list <i class="fa fa-refresh"></i>';
+    refreshButton.onclick = refreshQueueListForConsult;
+    consultDestinationHolderElm.appendChild(refreshButton);
   } else {
     // Make consultDestinationInput into a text input
     consultDestinationInput = document.createElement('input');
@@ -508,6 +528,7 @@ function registerTaskListeners(task) {
     endElm.disabled = false;
     enableConsultControls(); // Enable consult controls
     enableTransferControls(); // Enable transfer controls
+    toggleIfQueueConsultEnabled();
   });
   task.on('task:media', (track) => {
     document.getElementById('remote-audio').srcObject = new MediaStream([track]);

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -225,6 +225,18 @@ function toggleTransferOptions() {
   transferOptionsElm.style.display = isTransferOptionsShown ? 'block' : 'none';
 }
 
+async function getQueueListForTelephonyChannel() {
+  try {
+    let queueList = await webex.cc.getQueues();
+    queueList = queueList.filter(queue => queue.channelType === 'TELEPHONY');
+  
+    return queueList;
+  } catch (error) {
+    console.log('Failed to fetch queue list', error);
+  }
+}
+
+
 async function onConsultTypeSelectionChanged(){
 
   consultDestinationHolderElm.innerHTML = '';
@@ -246,6 +258,21 @@ async function onConsultTypeSelectionChanged(){
     refreshButton.innerHTML = 'Refresh agent list <i class="fa fa-refresh"></i>';
     refreshButton.onclick = refreshBuddyAgentsForConsult;
     consultDestinationHolderElm.appendChild(refreshButton);
+  } else if (destinationTypeDropdown.value === 'queue') {
+    const queueList = await getQueueListForTelephonyChannel();
+
+    if(queueList.length > 0) {
+      // Make consultDestinationInput into a dropdown
+      consultDestinationInput = document.createElement('select');
+      consultDestinationInput.id = 'consultDestination';
+
+      queueList.forEach((queue) => {
+        const option = document.createElement('option');
+        option.text = queue.name;
+        option.value = queue.id;
+        consultDestinationInput.appendChild(option);
+      });
+    }
   } else {
     // Make consultDestinationInput into a text input
     consultDestinationInput = document.createElement('input');
@@ -274,6 +301,20 @@ async function onTransferTypeSelectionChanged() {
 
     const agentNodeList = await fetchBuddyAgentsNodeList();
     agentNodeList.forEach(n => { transferDestinationInput.appendChild(n) });
+  } else if (document.querySelector('#transfer-destination-type').value === 'queue') {
+    const queueList = await getQueueListForTelephonyChannel();
+    if (queueList.length > 0) {
+      // Make transferDestinationInput into a dropdown
+      transferDestinationInput = document.createElement('select');
+      transferDestinationInput.id = 'transfer-destination';
+
+      queueList.forEach((queue) => {
+        const option = document.createElement('option');
+        option.text = queue.name;
+        option.value = queue.id;
+        transferDestinationInput.appendChild(option);
+      });
+    }
   } else {
     // Make transferDestinationInput into a text input
     transferDestinationInput = document.createElement('input');

--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -174,13 +174,13 @@
                     <legend>Consult Options</legend>
                     <div id="initiate-consult-controls">
                       <select id="consult-destination-type" onchange="onConsultTypeSelectionChanged()">
-                        <option value="queue" selected>Queue</option>
+                        <option value="queue">Queue</option>
                         <option value="agent">Agent</option>
-                        <option value="dialNumber">Dial Number</option>
+                        <option value="dialNumber" selected>Dial Number</option>
                         <option value="entryPoint">Entry Point</option>
                       </select>
                       <div id="consult-destination-holder">
-                        <input id="consult-destination" placeholder="Enter destination" value="" type="text" />
+                        <input id="consult-destination" placeholder="Enter Destination" value="" type="text" />
                       </div>
                       <button id="initate-consult" onclick="initiateConsult()" class="btn--green">Initiate Consult</button>
                       <button onclick="closeConsultDialog()" id="close-consult-dialog" class="btn--red">Cancel</button>
@@ -190,9 +190,9 @@
                 <fieldset id="transfer-options" style="display: none;">
                   <legend>Transfer Options</legend>
                   <select id="transfer-destination-type" onchange="onTransferTypeSelectionChanged()">
-                    <option value="queue" selected>Queue</option>
+                    <option value="queue">Queue</option>
                     <option value="agent">Agent</option>
-                    <option value="dialNumber">Dial Number</option>
+                    <option value="dialNumber" selected>Dial Number</option>
                   </select>
                   <div id="transfer-destination-holder">
                     <input id="transfer-destination" placeholder="Enter destination" value="" type="text" />

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -38,7 +38,12 @@ import {
   CC_AGENT_EVENTS,
   ContactServiceQueue,
 } from './services/config/types';
-import {AGENT_STATE_AVAILABLE, AGENT_STATE_AVAILABLE_ID} from './services/config/constants';
+import {
+  AGENT_STATE_AVAILABLE,
+  AGENT_STATE_AVAILABLE_ID,
+  DEFAULT_PAGE,
+  DEFAULT_PAGE_SIZE,
+} from './services/config/constants';
 import {ConnectionLostDetails} from './services/core/websocket/types';
 import TaskManager from './services/task/TaskManager';
 import WebCallingService from './services/WebCallingService';
@@ -519,10 +524,28 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
   /**
    * This is used for getting the list of queues.
-   * @returns @returns {Promise<ContactServiceQueue[]>}
+   * @param search - optional
+   * @param filter - optional
+   * @param page - default is 0
+   * @param pageSize - default is 100
+   * @returns Promise<ContactServiceQueue[]>
    * @throws Error
+   *
+   * @example
+   * ```typescript
+   * const search = 'queue';
+   * const filter = 'id == "e23ad456-1ebd-1b43-b9d0-34f39c7dcb5e"';
+   * const page = 0;
+   * const pageSize = 100;
+   * const result = await webex.cc.getQueues(page, pageSize, search, filter);
+   * ```
    */
-  public async getQueues(): Promise<ContactServiceQueue[]> {
+  public async getQueues(
+    search?: string,
+    filter?: string,
+    page = DEFAULT_PAGE,
+    pageSize = DEFAULT_PAGE_SIZE
+  ): Promise<ContactServiceQueue[]> {
     const orgId = this.$webex.credentials.getOrgId();
 
     if (!orgId) {
@@ -534,6 +557,6 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       throw new Error('Organization ID is not available.');
     }
 
-    return this.services.config.getQueues(orgId);
+    return this.services.config.getQueues(orgId, page, pageSize, search, filter);
   }
 }

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -31,7 +31,13 @@ import HttpRequest from './services/core/HttpRequest';
 import LoggerProxy from './logger-proxy';
 import {StateChange, Logout, StateChangeSuccess} from './services/agent/types';
 import {getErrorDetails} from './services/core/Utils';
-import {Profile, WelcomeEvent, CC_EVENTS, CC_AGENT_EVENTS} from './services/config/types';
+import {
+  Profile,
+  WelcomeEvent,
+  CC_EVENTS,
+  CC_AGENT_EVENTS,
+  ContactServiceQueue,
+} from './services/config/types';
 import {AGENT_STATE_AVAILABLE, AGENT_STATE_AVAILABLE_ID} from './services/config/constants';
 import {ConnectionLostDetails} from './services/core/websocket/types';
 import TaskManager from './services/task/TaskManager';
@@ -511,8 +517,22 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     }
   }
 
-  public async getQueues() {
+  /**
+   * This is used for getting the list of queues.
+   * @returns @returns {Promise<ContactServiceQueue[]>}
+   * @throws Error
+   */
+  public async getQueues(): Promise<ContactServiceQueue[]> {
     const orgId = this.$webex.credentials.getOrgId();
+
+    if (!orgId) {
+      LoggerProxy.error('Organization ID is not available.', {
+        module: CC_FILE,
+        method: this.getQueues.name,
+      });
+
+      throw new Error('Organization ID is not available.');
+    }
 
     return this.services.config.getQueues(orgId);
   }

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -510,4 +510,10 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       throw detailedError;
     }
   }
+
+  public async getQueues() {
+    const orgId = this.$webex.credentials.getOrgId();
+
+    return this.services.config.getQueues(orgId);
+  }
 }

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -537,7 +537,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    * const filter = 'id == "e23ad456-1ebd-1b43-b9d0-34f39c7dcb5e"';
    * const page = 0;
    * const pageSize = 100;
-   * const result = await webex.cc.getQueues(page, pageSize, search, filter);
+   * const result = await webex.cc.getQueues(search, filter, page, pageSize);
    * ```
    */
   public async getQueues(
@@ -549,12 +549,12 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     const orgId = this.$webex.credentials.getOrgId();
 
     if (!orgId) {
-      LoggerProxy.error('Organization ID is not available.', {
+      LoggerProxy.error('Org ID not found.', {
         module: CC_FILE,
         method: this.getQueues.name,
       });
 
-      throw new Error('Organization ID is not available.');
+      throw new Error('Org ID not found.');
     }
 
     return this.services.config.getQueues(orgId, page, pageSize, search, filter);

--- a/packages/@webex/plugin-cc/src/services/config/constants.ts
+++ b/packages/@webex/plugin-cc/src/services/config/constants.ts
@@ -43,4 +43,5 @@ export const endPointMap = {
   tenantData: (orgId: string) => `organization/${orgId}/v2/tenant-configuration?agentView=true`,
   urlMapping: (orgId: string) => `organization/${orgId}/v2/org-url-mapping?sort=name,ASC`,
   dialPlan: (orgId: string) => `organization/${orgId}/dial-plan?agentView=true`,
+  queueList: (orgId: string) => `organization/${orgId}/v2/contact-service-queue`,
 };

--- a/packages/@webex/plugin-cc/src/services/config/constants.ts
+++ b/packages/@webex/plugin-cc/src/services/config/constants.ts
@@ -43,5 +43,6 @@ export const endPointMap = {
   tenantData: (orgId: string) => `organization/${orgId}/v2/tenant-configuration?agentView=true`,
   urlMapping: (orgId: string) => `organization/${orgId}/v2/org-url-mapping?sort=name,ASC`,
   dialPlan: (orgId: string) => `organization/${orgId}/dial-plan?agentView=true`,
-  queueList: (orgId: string) => `organization/${orgId}/v2/contact-service-queue`,
+  queueList: (orgId: string, queryParams: string) =>
+    `organization/${orgId}/v2/contact-service-queue?${queryParams}`,
 };

--- a/packages/@webex/plugin-cc/src/services/config/index.ts
+++ b/packages/@webex/plugin-cc/src/services/config/index.ts
@@ -536,7 +536,11 @@ export default class AgentConfigService {
   /**
    * Fetches the list of queues for the given orgId.
    * @param {string} orgId
-   * @returns {Promise<ContactServiceQueue[]>}
+   * @param {number} page
+   * @param {number} pageSize
+   * @param {string} search - optional search string
+   * @param {string} filter - optional filter string
+   * @returns Promise<ContactServiceQueue[]>
    */
   public async getQueues(
     orgId: string,
@@ -561,7 +565,7 @@ export default class AgentConfigService {
         throw new Error(`API call failed with ${response.statusCode}`);
       }
 
-      LoggerProxy.log('getQueues api success.', {module: CONFIG_FILE_NAME, method: 'getQueues'});
+      LoggerProxy.log('getQueues API success.', {module: CONFIG_FILE_NAME, method: 'getQueues'});
 
       return response.body?.data;
     } catch (error) {

--- a/packages/@webex/plugin-cc/src/services/config/index.ts
+++ b/packages/@webex/plugin-cc/src/services/config/index.ts
@@ -538,9 +538,19 @@ export default class AgentConfigService {
    * @param {string} orgId
    * @returns {Promise<ContactServiceQueue[]>}
    */
-  public async getQueues(orgId: string): Promise<ContactServiceQueue[]> {
+  public async getQueues(
+    orgId: string,
+    page: number,
+    pageSize: number,
+    search?: string,
+    filter?: string
+  ): Promise<ContactServiceQueue[]> {
     try {
-      const resource = endPointMap.queueList(orgId);
+      let queryParams = `page=${page}&pageSize=${pageSize}&desktopProfileFilter=true`;
+      if (search) queryParams += `&search=${search}`;
+      if (filter) queryParams += `&filter=${filter}`;
+
+      const resource = endPointMap.queueList(orgId, queryParams);
       const response = await this.httpReq.request({
         service: WCC_API_GATEWAY,
         resource,
@@ -553,7 +563,7 @@ export default class AgentConfigService {
 
       LoggerProxy.log('getQueues api success.', {module: CONFIG_FILE_NAME, method: 'getQueues'});
 
-      return Promise.resolve(response.body?.data);
+      return response.body?.data;
     } catch (error) {
       LoggerProxy.error(`getQueues API call failed with ${error}`, {
         module: CONFIG_FILE_NAME,

--- a/packages/@webex/plugin-cc/src/services/config/index.ts
+++ b/packages/@webex/plugin-cc/src/services/config/index.ts
@@ -13,6 +13,7 @@ import {
   Profile,
   ListTeamsResponse,
   AuxCode,
+  ContactServiceQueue,
 } from './types';
 import HttpRequest from '../core/HttpRequest';
 import {WCC_API_GATEWAY} from '../constants';
@@ -527,6 +528,36 @@ export default class AgentConfigService {
       LoggerProxy.error(`getDialPlanData API call failed with ${error}`, {
         module: CONFIG_FILE_NAME,
         method: 'getDialPlanData',
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Fetches the list of queues for the given orgId.
+   * @param {string} orgId
+   * @returns {Promise<ContactServiceQueue[]>}
+   */
+  public async getQueues(orgId: string): Promise<ContactServiceQueue[]> {
+    try {
+      const resource = endPointMap.queueList(orgId);
+      const response = await this.httpReq.request({
+        service: WCC_API_GATEWAY,
+        resource,
+        method: HTTP_METHODS.GET,
+      });
+
+      if (response.statusCode !== 200) {
+        throw new Error(`API call failed with ${response.statusCode}`);
+      }
+
+      LoggerProxy.log('getQueues api success.', {module: CONFIG_FILE_NAME, method: 'getQueues'});
+
+      return Promise.resolve(response.body?.data);
+    } catch (error) {
+      LoggerProxy.error(`getQueues API call failed with ${error}`, {
+        module: CONFIG_FILE_NAME,
+        method: 'getQueues',
       });
       throw error;
     }

--- a/packages/@webex/plugin-cc/src/services/config/types.ts
+++ b/packages/@webex/plugin-cc/src/services/config/types.ts
@@ -585,3 +585,41 @@ export type Profile = {
   lastStateChangeTimestamp?: number;
   lastIdleCodeChangeTimestamp?: number;
 };
+
+export type CallDistributionGroup = {
+  agentGroups: {teamId: string}[];
+  order: number;
+  duration: number;
+};
+
+export type ContactServiceQueue = {
+  id: string;
+  name: string;
+  description: string;
+  queueType: string;
+  checkAgentAvailability: boolean;
+  channelType: string;
+  serviceLevelThreshold: number;
+  maxActiveContacts: number;
+  maxTimeInQueue: number;
+  defaultMusicInQueueMediaFileId: string;
+  timezone: string;
+  active: boolean;
+  outdialCampaignEnabled: boolean;
+  monitoringPermitted: boolean;
+  parkingPermitted: boolean;
+  recordingPermitted: boolean;
+  recordingAllCallsPermitted: boolean;
+  pauseRecordingPermitted: boolean;
+  recordingPauseDuration: number;
+  controlFlowScriptUrl: string;
+  ivrRequeueUrl: string;
+  routingType: string;
+  queueRoutingType: string;
+  queueSkillRequirements: object[];
+  agents: object[];
+  callDistributionGroups: CallDistributionGroup[];
+  links: Array<string>;
+  createdTime: string;
+  lastUpdatedTime: string;
+};

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -16,13 +16,21 @@ import config from '../../../src/config';
 import {CC_EVENTS} from '../../../src/services/config/types';
 import LoggerProxy from '../../../src/logger-proxy';
 import * as Utils from '../../../src/services/core/Utils';
-import {CC_FILE, AGENT_STATE_CHANGE, AGENT_MULTI_LOGIN, OUTDIAL_DIRECTION, OUTBOUND_TYPE, ATTRIBUTES, OUTDIAL_MEDIA_TYPE} from '../../../src/constants';
+import {
+  CC_FILE,
+  AGENT_STATE_CHANGE,
+  AGENT_MULTI_LOGIN,
+  OUTDIAL_DIRECTION,
+  OUTBOUND_TYPE,
+  ATTRIBUTES,
+  OUTDIAL_MEDIA_TYPE,
+} from '../../../src/constants';
 
 // Mock the Worker API
 import '../../../__mocks__/workerMock';
 import {Profile} from '../../../src/services/config/types';
 import TaskManager from '../../../src/services/task/TaskManager';
-import { AgentContact, TASK_EVENTS } from '../../../src/services/task/types';
+import {AgentContact, TASK_EVENTS} from '../../../src/services/task/types';
 import MetricsManager from '../../../src/metrics/MetricsManager';
 
 jest.mock('../../../src/logger-proxy', () => ({
@@ -401,7 +409,6 @@ describe('webex.cc', () => {
         'registerWebCallingLine'
       );
 
-
       const mockData = {
         data: {
           loginOption: LoginOption.BROWSER,
@@ -416,7 +423,7 @@ describe('webex.cc', () => {
         orgId: 'orgId',
         type: 'StationLoginSuccess',
         eventType: 'STATION_LOGIN',
-      }
+      };
 
       const stationLoginMock = jest
         .spyOn(webex.cc.services.agent, 'stationLogin')
@@ -498,7 +505,7 @@ describe('webex.cc', () => {
         orgId: 'orgId',
         type: 'StationLoginSuccess',
         eventType: 'STATION_LOGIN',
-      }
+      };
 
       const stationLoginMock = jest
         .spyOn(webex.cc.services.agent, 'stationLogin')
@@ -1035,13 +1042,37 @@ describe('webex.cc', () => {
 
       jest.spyOn(webex.cc.services.dialer, 'startOutdial').mockRejectedValue(error);
 
-      await expect(webex.cc.startOutdial(invalidDestination)).rejects.toThrow(error.details.data.reason);
+      await expect(webex.cc.startOutdial(invalidDestination)).rejects.toThrow(
+        error.details.data.reason
+      );
 
       expect(LoggerProxy.error).toHaveBeenCalledWith(
         `startOutdial failed with trackingId: ${error.details.trackingId}`,
         {module: CC_FILE, method: 'startOutdial'}
       );
       expect(getErrorDetailsSpy).toHaveBeenCalledWith(error, 'startOutdial', CC_FILE);
+    });
+  });
+
+  describe('getQueues', () => {
+    it('should return queues response when successful', async () => {
+      const mockQueuesResponse = [
+        {
+          queueId: 'queue1',
+          queueName: 'Queue 1',
+        },
+        {
+          queueId: 'queue2',
+          queueName: 'Queue 2',
+        },
+      ];
+
+      webex.cc.services.config.getQueues = jest.fn().mockResolvedValue(mockQueuesResponse);
+
+      const result = await webex.cc.getQueues();
+
+      expect(webex.cc.services.config.getQueues).toHaveBeenCalled();
+      expect(result).toEqual(mockQueuesResponse);
     });
   });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1096,5 +1096,22 @@ describe('webex.cc', () => {
         expect(webex.cc.services.config.getQueues).not.toHaveBeenCalled();
       }
     });
+
+    it('shoule throw an error if config getQueues throws an error', async () => {
+      webex.cc.services.config.getQueues = jest.fn().mockRejectedValue(new Error('Test error.'));
+
+      try {
+        await webex.cc.getQueues();
+      } catch (error) {
+        expect(error).toEqual(new Error('Test error.'));
+        expect(webex.cc.services.config.getQueues).toHaveBeenCalledWith(
+          'mockOrgId',
+          0,
+          100,
+          undefined,
+          undefined
+        );
+      }
+    });
   });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1088,11 +1088,12 @@ describe('webex.cc', () => {
       try {
         await webex.cc.getQueues();
       } catch (error) {
-        expect(error).toEqual(new Error('Organization ID is not available.'));
-        expect(LoggerProxy.error).toHaveBeenCalledWith('Organization ID is not available.', {
+        expect(error).toEqual(new Error('Org ID not found.'));
+        expect(LoggerProxy.error).toHaveBeenCalledWith('Org ID not found.', {
           module: CC_FILE,
           method: 'getQueues',
         });
+        expect(webex.cc.services.config.getQueues).not.toHaveBeenCalled();
       }
     });
   });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1071,7 +1071,13 @@ describe('webex.cc', () => {
 
       const result = await webex.cc.getQueues();
 
-      expect(webex.cc.services.config.getQueues).toHaveBeenCalledWith('mockOrgId');
+      expect(webex.cc.services.config.getQueues).toHaveBeenCalledWith(
+        'mockOrgId',
+        0,
+        100,
+        undefined,
+        undefined
+      );
       expect(result).toEqual(mockQueuesResponse);
     });
 

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1071,8 +1071,23 @@ describe('webex.cc', () => {
 
       const result = await webex.cc.getQueues();
 
-      expect(webex.cc.services.config.getQueues).toHaveBeenCalled();
+      expect(webex.cc.services.config.getQueues).toHaveBeenCalledWith('mockOrgId');
       expect(result).toEqual(mockQueuesResponse);
+    });
+
+    it('shoule throw an error if orgId is not present', async () => {
+      jest.spyOn(webex.credentials, 'getOrgId').mockResolvedValue(undefined);
+      webex.cc.services.config.getQueues = jest.fn();
+
+      try {
+        await webex.cc.getQueues();
+      } catch (error) {
+        expect(error).toEqual(new Error('Organization ID is not available.'));
+        expect(LoggerProxy.error).toHaveBeenCalledWith('Organization ID is not available.', {
+          module: CC_FILE,
+          method: 'getQueues',
+        });
+      }
     });
   });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/services/config/index.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/config/index.ts
@@ -966,6 +966,11 @@ describe('AgentConfigService', () => {
         'getQueues API call failed with Error: API call failed',
         {module: CONFIG_FILE_NAME, method: 'getQueues'}
       );
+      expect(mockHttpRequest.request).toHaveBeenCalledWith({
+        service: mockWccAPIURL,
+        resource: `organization/${mockOrgId}/v2/contact-service-queue`,
+        method: 'GET',
+      });
     });
 
     it('should throw an error if the API call returns a non-200 status code', async () => {
@@ -979,6 +984,11 @@ describe('AgentConfigService', () => {
         'getQueues API call failed with Error: API call failed with 500',
         {module: CONFIG_FILE_NAME, method: 'getQueues'}
       );
+      expect(mockHttpRequest.request).toHaveBeenCalledWith({
+        service: mockWccAPIURL,
+        resource: `organization/${mockOrgId}/v2/contact-service-queue`,
+        method: 'GET',
+      });
     });
   });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/services/config/index.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/config/index.ts
@@ -927,4 +927,58 @@ describe('AgentConfigService', () => {
       );
     });
   });
+
+  describe('getQueues', () => {
+    const mockQueues = [
+      {id: 'queue1', name: 'Queue 1'},
+      {id: 'queue2', name: 'Queue 2'},
+    ];
+
+    const mockError = new Error('API call failed');
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return a list of queues successfully', async () => {
+      const mockResponse = {statusCode: 200, body: {data: mockQueues}};
+      mockHttpRequest.request.mockResolvedValue(mockResponse);
+
+      const result = await agentConfigService.getQueues(mockOrgId);
+
+      expect(mockHttpRequest.request).toHaveBeenCalledWith({
+        service: mockWccAPIURL,
+        resource: `organization/${mockOrgId}/v2/contact-service-queue`,
+        method: 'GET',
+      });
+      expect(result).toEqual(mockQueues);
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getQueues api success.', {
+        module: CONFIG_FILE_NAME,
+        method: 'getQueues',
+      });
+    });
+
+    it('should throw an error if the API call fails', async () => {
+      mockHttpRequest.request.mockRejectedValue(mockError);
+
+      await expect(agentConfigService.getQueues(mockOrgId)).rejects.toThrow('API call failed');
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getQueues API call failed with Error: API call failed',
+        {module: CONFIG_FILE_NAME, method: 'getQueues'}
+      );
+    });
+
+    it('should throw an error if the API call returns a non-200 status code', async () => {
+      const mockResponse = {statusCode: 500};
+      mockHttpRequest.request.mockResolvedValue(mockResponse);
+
+      await expect(agentConfigService.getQueues(mockOrgId)).rejects.toThrow(
+        'API call failed with 500'
+      );
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'getQueues API call failed with Error: API call failed with 500',
+        {module: CONFIG_FILE_NAME, method: 'getQueues'}
+      );
+    });
+  });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/services/config/index.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/config/index.ts
@@ -952,7 +952,7 @@ describe('AgentConfigService', () => {
         method: 'GET',
       });
       expect(result).toEqual(mockQueues);
-      expect(LoggerProxy.log).toHaveBeenCalledWith('getQueues api success.', {
+      expect(LoggerProxy.log).toHaveBeenCalledWith('getQueues API success.', {
         module: CONFIG_FILE_NAME,
         method: 'getQueues',
       });

--- a/packages/@webex/plugin-cc/test/unit/spec/services/config/index.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/config/index.ts
@@ -944,11 +944,11 @@ describe('AgentConfigService', () => {
       const mockResponse = {statusCode: 200, body: {data: mockQueues}};
       mockHttpRequest.request.mockResolvedValue(mockResponse);
 
-      const result = await agentConfigService.getQueues(mockOrgId);
+      const result = await agentConfigService.getQueues(mockOrgId, 0, 100, 'queue', 'id==someid');
 
       expect(mockHttpRequest.request).toHaveBeenCalledWith({
         service: mockWccAPIURL,
-        resource: `organization/${mockOrgId}/v2/contact-service-queue`,
+        resource: `organization/${mockOrgId}/v2/contact-service-queue?page=0&pageSize=100&desktopProfileFilter=true&search=queue&filter=id==someid`,
         method: 'GET',
       });
       expect(result).toEqual(mockQueues);
@@ -961,14 +961,16 @@ describe('AgentConfigService', () => {
     it('should throw an error if the API call fails', async () => {
       mockHttpRequest.request.mockRejectedValue(mockError);
 
-      await expect(agentConfigService.getQueues(mockOrgId)).rejects.toThrow('API call failed');
+      await expect(agentConfigService.getQueues(mockOrgId, 0, 100)).rejects.toThrow(
+        'API call failed'
+      );
       expect(LoggerProxy.error).toHaveBeenCalledWith(
         'getQueues API call failed with Error: API call failed',
         {module: CONFIG_FILE_NAME, method: 'getQueues'}
       );
       expect(mockHttpRequest.request).toHaveBeenCalledWith({
         service: mockWccAPIURL,
-        resource: `organization/${mockOrgId}/v2/contact-service-queue`,
+        resource: `organization/${mockOrgId}/v2/contact-service-queue?page=0&pageSize=100&desktopProfileFilter=true`,
         method: 'GET',
       });
     });
@@ -977,7 +979,7 @@ describe('AgentConfigService', () => {
       const mockResponse = {statusCode: 500};
       mockHttpRequest.request.mockResolvedValue(mockResponse);
 
-      await expect(agentConfigService.getQueues(mockOrgId)).rejects.toThrow(
+      await expect(agentConfigService.getQueues(mockOrgId, 0, 100)).rejects.toThrow(
         'API call failed with 500'
       );
       expect(LoggerProxy.error).toHaveBeenCalledWith(
@@ -986,7 +988,7 @@ describe('AgentConfigService', () => {
       );
       expect(mockHttpRequest.request).toHaveBeenCalledWith({
         service: mockWccAPIURL,
-        resource: `organization/${mockOrgId}/v2/contact-service-queue`,
+        resource: `organization/${mockOrgId}/v2/contact-service-queue?page=0&pageSize=100&desktopProfileFilter=true`,
         method: 'GET',
       });
     });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-567681](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-567681) >

## This pull request addresses

While performing consult or transfer we have option to choose the type of consult such as agent, DN, queue etc.
We needed to fetch the list of queues to perform the consult/transfer operation for queue as a result and for that we have added a method inside `cc.ts` file as `getQueues()`.

## by making the following changes

Added a method `getQueues(orgId)` inside the `packages/@webex/plugin-cc/src/services/config/index.ts` and exposed to the developer through `cc.ts` file with the same name.

We are able to get the list of queue.


**Vidcast** - https://app.vidcast.io/share/abe60753-715a-4811-b655-e0a40cb7c303

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Able to get the list of queue
- Filtering those queue inside the samples app to perform consult and transfer through queue.
  - **Consult** API is returning 202 status code but the next line is not being executed causing the buttons to remain in the same state --- NEED FURTHER TESTING AND CLARIFICATION
  - In case of error --- We are not able to get the server error message because we are creating our own error message and throwing that for the application to consume. NEED LARGER TEAM DISCUSSION ON THIS.
  - In case of **Transfer** it seems to be working fine.

**Note**: Based on the requirement mentioned on the ticket, the `getQueues()` method is working as expected.

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
