### PR TITLE
fix(presenter-permissions): expose presenterAssignmentNotAllowed in member

### DIFF
--- a/packages/@webex/plugin-meetings/src/member/index.ts
+++ b/packages/@webex/plugin-meetings/src/member/index.ts
@@ -23,6 +23,7 @@ export default class Member {
   isInMeeting: any;
   isModerator: any;
   isModeratorAssignmentProhibited: any;
+  isPresenterAssignmentProhibited: any;
   isMutable: any;
   isNotAdmitted: any;
   isRecording: any;
@@ -259,6 +260,14 @@ export default class Member {
 
     /**
      * @instance
+     * @type {Boolean}
+     * @public
+     * @memberof Member
+     */
+    this.isPresenterAssignmentProhibited = null;
+
+    /**
+     * @instance
      * @type {IExternalRoles}
      * @public
      * @memberof Member
@@ -309,6 +318,8 @@ export default class Member {
       this.isModerator = MemberUtil.isModerator(participant);
       this.isModeratorAssignmentProhibited =
         MemberUtil.isModeratorAssignmentProhibited(participant);
+      this.isPresenterAssignmentProhibited =
+        MemberUtil.isPresenterAssignmentProhibited(participant);
       this.processStatus(participant);
       this.processRoles(participant as ParticipantWithRoles);
       // must be done last

--- a/packages/@webex/plugin-meetings/src/member/util.ts
+++ b/packages/@webex/plugin-meetings/src/member/util.ts
@@ -127,6 +127,9 @@ MemberUtil.isDevice = (participant: any) => participant && participant.type === 
 MemberUtil.isModeratorAssignmentProhibited = (participant) =>
   participant && participant.moderatorAssignmentNotAllowed;
 
+MemberUtil.isPresenterAssignmentProhibited = (participant) =>
+  participant && participant.presenterAssignmentNotAllowed;
+
 /**
  * checks to see if the participant id is the same as the passed id
  * there are multiple ids that can be used

--- a/packages/@webex/plugin-meetings/test/unit/spec/member/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/member/index.js
@@ -50,6 +50,13 @@ describe('member', () => {
   
       assert.calledOnceWithExactly(MemberUtil.canReclaimHost, participant);
     });
+
+    it('checks that processParticipant calls isPresenterAssignmentProhibited', () => {
+      sinon.spy(MemberUtil, 'isPresenterAssignmentProhibited');
+      member.processParticipant(participant);
+  
+      assert.calledOnceWithExactly(MemberUtil.isPresenterAssignmentProhibited, participant);
+    });
   })
 
   describe('#processMember', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/member/util.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/member/util.js
@@ -572,13 +572,13 @@ describe('plugin-meetings', () => {
         presenterAssignmentNotAllowed: false,
       };
 
-      assert.isFalse(MemberUtil.isBrb(participant));
+      assert.isFalse(MemberUtil.isPresenterAssignmentProhibited(participant));
     });
 
     it('returns undefined when isPresenterAssignmentProhibited is undefined', () => {
       const participant = {};
 
-      assert.isUndefined(MemberUtil.isBrb(participant));
+      assert.isUndefined(MemberUtil.isPresenterAssignmentProhibited(participant));
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/member/util.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/member/util.js
@@ -557,6 +557,30 @@ describe('plugin-meetings', () => {
       testResult(false, undefined, false);
     });
   });
+
+  describe('MemberUtil.isPresenterAssignmentProhibited', () => {
+    it('returns true when isPresenterAssignmentProhibited is true', () => {
+      const participant = {
+        presenterAssignmentNotAllowed: true
+      };
+
+      assert.isTrue(MemberUtil.isPresenterAssignmentProhibited(participant));
+    });
+
+    it('returns false when isPresenterAssignmentProhibited is false', () => {
+      const participant = {
+        presenterAssignmentNotAllowed: false,
+      };
+
+      assert.isFalse(MemberUtil.isBrb(participant));
+    });
+
+    it('returns undefined when isPresenterAssignmentProhibited is undefined', () => {
+      const participant = {};
+
+      assert.isUndefined(MemberUtil.isBrb(participant));
+    });
+  });
 });
 
 describe('extractMediaStatus', () => {


### PR DESCRIPTION
# COMPLETES #
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-636316

## This pull request addresses

The participant DTO variable presenterAssignmentNotAllowed was not exposed before these changes. Web Client needs them to know if to allow a user to be made presenter or not.

## by making the following changes

adding isPresenterAssignmentProhibited to the Member object

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Manual test with web client that shows that, when user is PSTN only, their isPresenterAssignmentProhibited = false. 

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [X] I discussed changes with code owners prior to submitting this pull request

- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
