### PR TITLE
fix(plugin-meetings): clear sdp timer on answer processing failure

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6209,6 +6209,11 @@ export default class Meeting extends StatelessWebexPlugin {
       error instanceof Errors.SdpOfferHandlingError ||
       error instanceof Errors.SdpAnswerHandlingError
     ) {
+      if (this.sdpResponseTimer) {
+        clearTimeout(this.sdpResponseTimer);
+
+        this.sdpResponseTimer = undefined;
+      }
       sendBehavioralMetric(BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE, error, this.correlationId);
 
       // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6205,15 +6205,7 @@ export default class Meeting extends StatelessWebexPlugin {
         },
         options: {meetingId: this.id, rawError: error},
       });
-    } else if (
-      error instanceof Errors.SdpOfferHandlingError ||
-      error instanceof Errors.SdpAnswerHandlingError
-    ) {
-      if (this.sdpResponseTimer) {
-        clearTimeout(this.sdpResponseTimer);
-
-        this.sdpResponseTimer = undefined;
-      }
+    } else if (error instanceof Errors.SdpOfferHandlingError) {
       sendBehavioralMetric(BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE, error, this.correlationId);
 
       // @ts-ignore
@@ -6224,6 +6216,24 @@ export default class Meeting extends StatelessWebexPlugin {
         },
         options: {meetingId: this.id, rawError: error},
       });
+    } else if (error instanceof Errors.SdpAnswerHandlingError) {
+      sendBehavioralMetric(BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE, error, this.correlationId);
+
+      // @ts-ignore
+      this.webex.internal.newMetrics.submitClientEvent({
+        name: 'client.media-engine.remote-sdp-received',
+        payload: {
+          canProceed: false,
+        },
+        options: {meetingId: this.id, rawError: error},
+      });
+
+      if (this.deferSDPAnswer) {
+        clearTimeout(this.sdpResponseTimer);
+        this.sdpResponseTimer = undefined;
+
+        this.deferSDPAnswer.reject();
+      }
     } else if (error instanceof Errors.SdpError) {
       // this covers also the case of Errors.IceGatheringError which extends Errors.SdpError
       sendBehavioralMetric(BEHAVIORAL_METRICS.INVALID_ICE_CANDIDATE, error, this.correlationId);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -8614,11 +8614,17 @@ describe('plugin-meetings', () => {
           const fakeErrorMessage = 'test error';
           const fakeRootCauseName = 'root cause name';
           const fakeErrorName = 'test error name';
+          let clock;
 
           beforeEach(() => {
+            clock = sinon.useFakeTimers();
             meeting.setupMediaConnectionListeners();
             webex.internal.newMetrics.submitClientEvent.resetHistory();
             Metrics.sendBehavioralMetric.resetHistory();
+          });
+
+          afterEach(() => {
+            clock.restore();
           });
 
           const checkMetricSent = (event, error) => {
@@ -8689,6 +8695,11 @@ describe('plugin-meetings', () => {
           });
 
           it('should send metrics for SdpAnswerHandlingError error', () => {
+            // Add check that timer was closed
+            meeting.sdpResponseTimer = '1234';
+            
+            const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
+
             const fakeError = new Errors.SdpAnswerHandlingError(fakeErrorMessage, {
               name: fakeErrorName,
               cause: {name: fakeRootCauseName},
@@ -8703,6 +8714,7 @@ describe('plugin-meetings', () => {
               fakeErrorMessage,
               fakeRootCauseName
             );
+            assert.calledOnce(clearTimeoutSpy);
           });
 
           it('should send metrics for SdpError error', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -8695,7 +8695,6 @@ describe('plugin-meetings', () => {
           });
 
           it('should send metrics for SdpAnswerHandlingError error', () => {
-            // Add check that timer was closed
             meeting.sdpResponseTimer = '1234';
             
             const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -8696,6 +8696,9 @@ describe('plugin-meetings', () => {
 
           it('should send metrics for SdpAnswerHandlingError error', () => {
             meeting.sdpResponseTimer = '1234';
+            meeting.deferSDPAnswer = {
+              reject: sinon.stub(),
+            };
             
             const clearTimeoutSpy = sinon.spy(clock, 'clearTimeout');
 
@@ -8713,6 +8716,7 @@ describe('plugin-meetings', () => {
               fakeErrorMessage,
               fakeRootCauseName
             );
+            assert.calledOnce(meeting.deferSDPAnswer.reject);
             assert.calledOnce(clearTimeoutSpy);
           });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

## This pull request addresses

This PR resolves an issue which causes meeting to be marked as missing remote answer, even though answer was received.
It can happen, when SDP Answer processing failed from any reason:
* Peer Connection already closed
* Failed to setRemoteDescription
* etc

## by making the following changes

Changes in this PR will ensure that sdpAnswerTimer will be cleared up not only in successful scenarios, but also in failure cases.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested with JS-SDK Sample app

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
