### PR TITLE
fix(cc-sdk): fixed-queue-transfer

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -247,7 +247,6 @@ function toggleTransferOptions() {
   isTransferOptionsShown = !isTransferOptionsShown;
   const transferOptionsElm = document.querySelector('#transfer-options');
   transferOptionsElm.style.display = isTransferOptionsShown ? 'block' : 'none';
-  updateButtonsPostEndCall();
 }
 
 async function getQueueListForTelephonyChannel() {

--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -130,6 +130,10 @@ export default class TaskManager extends EventEmitter {
             // As soon as the main interaction is unheld, we need to emit TASK_RESUME
             this.updateCurrentTaskDataAndEmitEvent(payload.data, TASK_EVENTS.TASK_RESUME);
             break;
+          case CC_EVENTS.AGENT_VTEAM_TRANSFERRED:
+            this.currentTask.emit(TASK_EVENTS.TASK_END, {wrapupRequired: true});
+            this.handleTaskCleanup();
+            break;
           case CC_EVENTS.AGENT_CTQ_CANCEL_FAILED:
             this.updateCurrentTaskDataAndEmitEvent(
               payload.data,

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -809,5 +809,35 @@ describe('TaskManager', () => {
     webSocketManagerMock.emit('message', JSON.stringify(unassignedPayload));
     expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_END, { wrapupRequired: true });
   });
+
+  it('should emit TASK_END event on AGENT_VTEAM_TRANSFERRED event', () => {
+    webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+    
+    const taskEmitSpy = jest.spyOn(taskManager.currentTask, 'emit');
+    
+    const vteamTransferredPayload = {
+      data: {
+        type: CC_EVENTS.AGENT_VTEAM_TRANSFERRED,
+        agentId: initalPayload.data.agentId,
+        eventTime: initalPayload.data.eventTime,
+        eventType: initalPayload.data.eventType,
+        interaction: {},
+        interactionId: initalPayload.data.interactionId,
+        orgId: initalPayload.data.orgId,
+        trackingId: initalPayload.data.trackingId,
+        mediaResourceId: initalPayload.data.mediaResourceId,
+        destAgentId: initalPayload.data.destAgentId,
+        owner: initalPayload.data.owner,
+        queueMgr: initalPayload.data.queueMgr,
+      },
+    };
+
+    taskManager.taskCollection[taskId] = taskManager.currentTask;
+    
+    webSocketManagerMock.emit('message', JSON.stringify(vteamTransferredPayload));
+    
+    expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_END, { wrapupRequired: true });
+    expect(taskManager.getTask(taskId)).toBeUndefined(); // Verify task was removed from collection
+  });
 });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [SPARK-647920](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-647920) >

## This pull request addresses

* Currently, blind transfer to queue was not calling `task:end` event when the action happened.
* Thus, as a result we were not getting any wrapupRequired in order to wrapup the call after transferring.
* This is causing an issue in widgets.

## by making the following changes

* We listen for the `AgentVTeamTransferred` event on SDK and send out task:end event with wrapup payload.
* This will work out of the box with widgets now.

Vidcast - https://app.vidcast.io/share/aa978abc-4a56-49a1-9b37-11a923430e33

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested blind transfer flow in sdk samples
* Locally linked repo with the widgets and tested

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
