### PR TITLE
fix(plugin-cc): update login option to webCallingService on login

### DIFF
--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -298,6 +298,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       if (this.agentConfig.webRtcEnabled && data.loginOption === LoginOption.BROWSER) {
         await this.webCallingService.registerWebCallingLine();
+        this.webCallingService.setLoginOption(data.loginOption);
       }
 
       const resp = await loginResponse;

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1006,6 +1006,11 @@ describe('webex.cc', () => {
         webex.cc.webCallingService,
         'registerWebCallingLine'
       );
+
+      const setLoginOptionSpy = jest.spyOn(
+        webex.cc.webCallingService,
+        'setLoginOption'
+      );
       const incomingTaskListenerSpy = jest.spyOn(webex.cc, 'incomingTaskListener');
       const webSocketManagerOnSpy = jest.spyOn(webex.cc.services.webSocketManager, 'on');
       await webex.cc['silentRelogin']();
@@ -1026,6 +1031,7 @@ describe('webex.cc', () => {
       expect(webex.cc.agentConfig.lastIdleCodeChangeTimestamp).toStrictEqual(12345);
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.BROWSER);
       expect(registerWebCallingLineSpy).toHaveBeenCalled();
+      expect(setLoginOptionSpy).toHaveBeenCalledWith(LoginOption.BROWSER);
       // TODO: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-626777 Implement the de-register method and close the listener there
       // expect(incomingTaskListenerSpy).toHaveBeenCalled();
       // expect(webSocketManagerOnSpy).toHaveBeenCalledWith('message', expect.any(Function));


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES AdHoc

## This pull request addresses

When the WebRTC calls came in, the accept API was rejecting with errors. 

![Screenshot 2025-04-16 at 5 15 33 PM](https://github.com/user-attachments/assets/8f1ecfd4-e825-444e-92a5-261e4b4376e5)


Digging deeper, found out that the error was because an the following condition wasn't going through and `loginOption` was `undefined` if it is a login case.
<img width="1007" alt="Screenshot 2025-04-16 at 5 43 54 PM" src="https://github.com/user-attachments/assets/62b63d15-2227-4513-a015-9b071632b8bc" />

The relogin worked alright because, on relogin we set this value today via the this.handle

<img width="1132" alt="Screenshot 2025-04-16 at 5 45 02 PM" src="https://github.com/user-attachments/assets/a564a095-97f4-4d28-b80c-036a293565f6" />

## by making the following changes

On the login, when found that it is a WebRTC call and after registering the calling line successfully, the login option is set to BROWSER.

## Demo

https://app.vidcast.io/share/15d09530-ce37-4624-a557-6914e3a6f263

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Tested first time login case in the SDK Samples as well as Widget Samples by locally linking the SDK
- Here's a Vidcast for the same: https://app.vidcast.io/share/15d09530-ce37-4624-a557-6914e3a6f263

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
