### PR TITLE
feat(cc-sdk): upload logs on errors

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -767,7 +767,7 @@ function generateWebexConfig({credentials}) {
     appPlatform: 'testClient',
     fedramp: false,
     logger: {
-      level: 'log'
+      level: 'info'
     },
     credentials,
     // Any other sdk config we need

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -156,6 +156,9 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         module: CC_FILE,
         method: this.register.name,
       });
+      this.webexRequest.uploadLogs({
+        correlationId: error?.trackingId,
+      });
 
       throw error;
     }

--- a/packages/@webex/plugin-cc/src/services/core/Utils.ts
+++ b/packages/@webex/plugin-cc/src/services/core/Utils.ts
@@ -21,7 +21,7 @@ export const getErrorDetails = (error: any, methodName: string, moduleName: stri
     });
     // we can add more conditions here if not needed for specific cases eg: silentReLogin
     WebexRequest.getInstance().uploadLogs({
-      correlationId: failure?.data?.trackingId,
+      correlationId: failure?.trackingId,
     });
   }
 

--- a/packages/@webex/plugin-cc/src/services/core/Utils.ts
+++ b/packages/@webex/plugin-cc/src/services/core/Utils.ts
@@ -2,6 +2,7 @@ import * as Err from './Err';
 import {WebexRequestPayload} from '../../types';
 import {Failure} from './GlobalTypes';
 import LoggerProxy from '../../logger-proxy';
+import WebexRequest from './WebexRequest';
 
 const getCommonErrorDetails = (errObj: WebexRequestPayload) => {
   return {
@@ -17,6 +18,10 @@ export const getErrorDetails = (error: any, methodName: string, moduleName: stri
     LoggerProxy.error(`${methodName} failed with trackingId: ${failure?.trackingId}`, {
       module: moduleName,
       method: methodName,
+    });
+    // we can add more conditions here if not needed for specific cases eg: silentReLogin
+    WebexRequest.getInstance().uploadLogs({
+      correlationId: failure?.data?.trackingId,
     });
   }
 

--- a/packages/@webex/plugin-cc/src/services/core/WebexRequest.ts
+++ b/packages/@webex/plugin-cc/src/services/core/WebexRequest.ts
@@ -53,9 +53,9 @@ class WebexRequest {
     const feedbackId = crypto.randomUUID();
     try {
       const response = await this.webex.internal.support.submitLogs({...metaData, feedbackId});
-      LoggerProxy.info(`Logs uploaded successfully`, {
+      LoggerProxy.info(`Logs uploaded successfully with feedbackId: ${feedbackId}`, {
         module: WEBEX_REQUEST_FILE,
-        method: this.uploadLogs.name,
+        method: 'uploadLogs',
       });
 
       MetricsManager.getInstance().trackEvent(
@@ -63,6 +63,7 @@ class WebexRequest {
         {
           trackingId: response?.trackingid,
           feedbackId,
+          correlationId: metaData?.correlationId,
         },
         ['behavioral']
       );
@@ -71,12 +72,13 @@ class WebexRequest {
         trackingid: response.trackingid,
         ...(response.url ? {url: response.url} : {}),
         ...(response.userId ? {userId: response.userId} : {}),
+        ...(response.correlationId ? {correlationId: response.correlationId} : {}),
         feedbackId,
       };
     } catch (error) {
       LoggerProxy.error(`Error uploading logs: ${error}`, {
         module: WEBEX_REQUEST_FILE,
-        method: this.uploadLogs.name,
+        method: 'uploadLogs',
       });
 
       MetricsManager.getInstance().trackEvent(

--- a/packages/@webex/plugin-cc/src/services/core/WebexRequest.ts
+++ b/packages/@webex/plugin-cc/src/services/core/WebexRequest.ts
@@ -52,7 +52,11 @@ class WebexRequest {
   public async uploadLogs(metaData: LogsMetaData = {}): Promise<UploadLogsResponse> {
     const feedbackId = crypto.randomUUID();
     try {
-      const response = await this.webex.internal.support.submitLogs({...metaData, feedbackId});
+      const response = await this.webex.internal.support.submitLogs(
+        {...metaData, feedbackId},
+        undefined, // we dont send logs but take from webex logger
+        {type: 'diff'} // this is to take the diff logs from previous upload
+      );
       LoggerProxy.info(`Logs uploaded successfully with feedbackId: ${feedbackId}`, {
         module: WEBEX_REQUEST_FILE,
         method: 'uploadLogs',

--- a/packages/@webex/plugin-cc/src/services/core/WebexRequest.ts
+++ b/packages/@webex/plugin-cc/src/services/core/WebexRequest.ts
@@ -90,6 +90,7 @@ class WebexRequest {
         {
           stack: error?.stack,
           feedbackId,
+          correlationId: metaData?.correlationId,
         },
         ['behavioral']
       );

--- a/packages/@webex/plugin-cc/src/services/core/aqm-reqs.ts
+++ b/packages/@webex/plugin-cc/src/services/core/aqm-reqs.ts
@@ -96,7 +96,7 @@ export default class AqmReqs {
             clear();
             const notifFail = c.notifFail!;
             if ('errId' in notifFail) {
-              LoggerProxy.log(`Routing request failed: ${msg}`, {
+              LoggerProxy.log(`Routing request failed: ${JSON.stringify(msg)}`, {
                 module: AQM_REQS_FILE,
                 method: 'createPromise',
               });

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -90,7 +90,6 @@ export enum LOGGING_LEVEL {
 }
 
 export type LogsMetaData = {
-  trackingid?: string;
   feedbackId?: string;
   correlationId?: string;
 };
@@ -100,6 +99,7 @@ export type UploadLogsResponse = {
   url?: string;
   userId?: string;
   feedbackId?: string;
+  correlationId?: string;
 };
 interface IWebexInternal {
   mercury: {

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -139,7 +139,13 @@ interface IWebexInternal {
     submitBusinessEvent: SubmitBusinessEvent;
   };
   support: {
-    submitLogs: (metaData: LogsMetaData, logs: any, options: object) => Promise<UploadLogsResponse>;
+    submitLogs: (
+      metaData: LogsMetaData,
+      logs: string,
+      options: {
+        type: 'diff' | 'full';
+      }
+    ) => Promise<UploadLogsResponse>;
   };
 }
 export interface WebexSDK {

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -139,7 +139,7 @@ interface IWebexInternal {
     submitBusinessEvent: SubmitBusinessEvent;
   };
   support: {
-    submitLogs: (metaData: LogsMetaData) => Promise<UploadLogsResponse>;
+    submitLogs: (metaData: LogsMetaData, logs: any, options: object) => Promise<UploadLogsResponse>;
   };
 }
 export interface WebexSDK {

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -34,6 +34,7 @@ import {AgentContact, TASK_EVENTS} from '../../../src/services/task/types';
 import MetricsManager from '../../../src/metrics/MetricsManager';
 import { METRIC_EVENT_NAMES } from '../../../src/metrics/constants';
 import Mercury from '@webex/internal-plugin-mercury';
+import WebexRequest from '../../../src//services/core/WebexRequest';
 
 
 jest.mock('../../../src/logger-proxy', () => ({
@@ -60,6 +61,7 @@ describe('webex.cc', () => {
   let mockMetricsManager;
   let mockWebSocketManager;
   let getErrorDetailsSpy;
+  let mockWebexRequest;
 
   beforeEach(() => {
     webex = MockWebex({
@@ -76,7 +78,7 @@ describe('webex.cc', () => {
         getOrgId: jest.fn(() => 'mockOrgId'),
       },
       config: config,
-      once: jest.fn((event, callback) => callback()),
+      once: jest.fn((event, callback) => callback()),    
     }) as unknown as WebexSDK;
 
     mockWebSocketManager = {
@@ -147,9 +149,15 @@ describe('webex.cc', () => {
       timeEvent: jest.fn(),
     };
 
+    mockWebexRequest = {
+      request: jest.fn(),
+      uploadLogs: jest.fn(),
+    };
+
     jest.spyOn(MetricsManager, 'getInstance').mockReturnValue(mockMetricsManager);
     jest.spyOn(Services, 'getInstance').mockReturnValue(mockServicesInstance);
     jest.spyOn(TaskManager, 'getTaskManager').mockReturnValue(mockTaskManager);
+    jest.spyOn(WebexRequest, 'getInstance').mockReturnValue(mockWebexRequest);
     // Instantiate ContactCenter to ensure it's fully initialized
     webex.cc = new ContactCenter({parent: webex});
     getErrorDetailsSpy = jest.spyOn(Utils, 'getErrorDetails');

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -34,7 +34,7 @@ import {AgentContact, TASK_EVENTS} from '../../../src/services/task/types';
 import MetricsManager from '../../../src/metrics/MetricsManager';
 import { METRIC_EVENT_NAMES } from '../../../src/metrics/constants';
 import Mercury from '@webex/internal-plugin-mercury';
-import WebexRequest from '../../../src//services/core/WebexRequest';
+import WebexRequest from '../../../src/services/core/WebexRequest';
 
 
 jest.mock('../../../src/logger-proxy', () => ({

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/Utils.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/Utils.ts
@@ -182,7 +182,7 @@ describe('Utils', () => {
         { module: moduleName, method: methodName }
       );
       
-      // Check if uploadLogs uses the trackingId from the data level
+      // Check if uploadLogs uses the trackingId from the details level
       expect(WebexRequest.getInstance().uploadLogs).toHaveBeenCalledWith({
         correlationId: detailsTrackingId,
       });

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/Utils.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/Utils.ts
@@ -1,0 +1,159 @@
+import * as Utils from '../../../../../src/services/core/Utils';
+import LoggerProxy from '../../../../../src/logger-proxy';
+import WebexRequest from '../../../../../src/services/core/WebexRequest';
+import { WebexRequestPayload } from '../../../../../src/types';
+
+// Mock dependencies
+jest.mock('../../../../../src/logger-proxy', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    initialize: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../../src/services/core/WebexRequest', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn().mockReturnValue({
+      uploadLogs: jest.fn(),
+    }),
+  },
+}));
+
+// Mock Err module
+jest.mock('../../../../../src/services/core/Err', () => {
+  return {
+    __esModule: true,
+    Details: class Details {
+      code: string;
+      data: any;
+      constructor(code: string, data: any) {
+        this.code = code;
+        this.data = data;
+      }
+    }
+  };
+});
+
+describe('Utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Skip getCommonErrorDetails tests as it's a private function
+  // and we'll test its behavior through createErrDetailsObject instead
+
+  describe('getErrorDetails', () => {
+    const methodName = 'testMethod';
+    const moduleName = 'testModule';
+
+    it('should extract reason from error details', () => {
+      const error = {
+        details: {
+          data: {
+            reason: 'Test reason',
+          },
+          trackingId: 'test-tracking-id',
+        },
+      };
+
+      const result = Utils.getErrorDetails(error, methodName, moduleName);
+
+      expect(result).toEqual({
+        error: new Error('Test reason'),
+        reason: 'Test reason',
+      });
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        `${methodName} failed with trackingId: test-tracking-id`,
+        { module: moduleName, method: methodName }
+      );
+    });
+
+    it('should use default reason when reason is not provided', () => {
+      const error = {
+        details: {
+          data: {},
+          trackingId: 'test-tracking-id',
+        },
+      };
+
+      const result = Utils.getErrorDetails(error, methodName, moduleName);
+
+      expect(result).toEqual({
+        error: new Error(`Error while performing ${methodName}`),
+        reason: `Error while performing ${methodName}`,
+      });
+    });
+
+    it('should upload logs when reason is AGENT_NOT_FOUND and method is silentReLogin', () => {
+      const error = {
+        details: {
+          data: {
+            reason: 'AGENT_NOT_FOUND',
+            trackingId: 'test-tracking-id',
+          },
+        },
+      };
+
+      Utils.getErrorDetails(error, 'silentReLogin', moduleName);
+
+      expect(LoggerProxy.error).not.toHaveBeenCalled();
+      expect(WebexRequest.getInstance().uploadLogs).not.toHaveBeenCalledWith();
+    });
+
+    it('should upload logs for normal error scenarios', () => {
+      const trackingId = 'normal-error-tracking-id';
+      const error = {
+        details: {
+          data: {
+            reason: 'SOME_OTHER_ERROR',
+            trackingId: trackingId,
+          },
+          trackingId: trackingId,
+        },
+      };
+
+      Utils.getErrorDetails(error, 'someMethod', moduleName);
+
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        'someMethod failed with trackingId: normal-error-tracking-id',
+        { module: moduleName, method: 'someMethod' }
+      );
+      expect(WebexRequest.getInstance().uploadLogs).toHaveBeenCalledWith({
+        correlationId: trackingId,
+      });
+    });
+  });
+
+  describe('createErrDetailsObject', () => {
+    it('should create error details object with correct parameters', () => {
+      const errObj: WebexRequestPayload = {
+        headers: { trackingid: 'test-tracking-id' },
+        body: { message: 'Error message' },
+      };
+
+      const result = Utils.createErrDetailsObject(errObj);
+
+      expect(result.code).toBe('Service.reqs.generic.failure');
+      expect(result.data).toEqual({
+        trackingId: 'test-tracking-id',
+        msg: { message: 'Error message' },
+      });
+    });
+
+    it('should handle missing data in error payload', () => {
+      const errObj: WebexRequestPayload = {};
+
+      const result = Utils.createErrDetailsObject(errObj);
+
+      expect(result.code).toBe('Service.reqs.generic.failure');
+      expect(result.data).toEqual({
+        trackingId: undefined,
+        msg: undefined,
+      });
+    });
+  });
+});

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/Utils.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/Utils.ts
@@ -88,7 +88,7 @@ describe('Utils', () => {
       });
     });
 
-    it('should upload logs when reason is AGENT_NOT_FOUND and method is silentReLogin', () => {
+    it('should not upload logs when reason is AGENT_NOT_FOUND and method is silentReLogin', () => {
       const error = {
         details: {
           data: {

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/Utils.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/Utils.ts
@@ -184,7 +184,7 @@ describe('Utils', () => {
       
       // Check if uploadLogs uses the trackingId from the data level
       expect(WebexRequest.getInstance().uploadLogs).toHaveBeenCalledWith({
-        correlationId: dataTrackingId,
+        correlationId: detailsTrackingId,
       });
     });
   });

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/Utils.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/Utils.ts
@@ -101,7 +101,7 @@ describe('Utils', () => {
       Utils.getErrorDetails(error, 'silentReLogin', moduleName);
 
       expect(LoggerProxy.error).not.toHaveBeenCalled();
-      expect(WebexRequest.getInstance().uploadLogs).not.toHaveBeenCalledWith();
+      expect(WebexRequest.getInstance().uploadLogs).not.toHaveBeenCalled();
     });
 
     it('should upload logs for normal error scenarios', () => {
@@ -124,6 +124,67 @@ describe('Utils', () => {
       );
       expect(WebexRequest.getInstance().uploadLogs).toHaveBeenCalledWith({
         correlationId: trackingId,
+      });
+    });
+
+    it('should handle null or undefined error object gracefully', () => {
+      // This should throw an error because the function tries to access error.details
+      expect(() => {
+        Utils.getErrorDetails(null, methodName, moduleName);
+      }).toThrow(TypeError);
+      
+      expect(() => {
+        Utils.getErrorDetails(undefined, methodName, moduleName);
+      }).toThrow(TypeError);
+    });
+
+    it('should handle error objects with unexpected structure', () => {
+      const unexpectedError = {
+        // No details property
+        message: 'Unexpected error structure',
+        code: 500
+      };
+
+      const result = Utils.getErrorDetails(unexpectedError, methodName, moduleName);
+
+      // Should use default error message when structure is unexpected
+      expect(result).toEqual({
+        error: new Error(`Error while performing ${methodName}`),
+        reason: `Error while performing ${methodName}`,
+      });
+      
+      // Should not throw when accessing properties with optional chaining
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        `${methodName} failed with trackingId: undefined`,
+        { module: moduleName, method: methodName }
+      );
+    });
+
+    it('should prioritize trackingId from the correct location when present in multiple places', () => {
+      const detailsTrackingId = 'details-level-tracking-id';
+      const dataTrackingId = 'data-level-tracking-id';
+      
+      const error = {
+        details: {
+          data: {
+            reason: 'TEST_REASON',
+            trackingId: dataTrackingId, // This should be used for uploadLogs
+          },
+          trackingId: detailsTrackingId, // This should be used for error logging
+        },
+      };
+
+      Utils.getErrorDetails(error, methodName, moduleName);
+
+      // Check if error logging uses the trackingId from the details level
+      expect(LoggerProxy.error).toHaveBeenCalledWith(
+        `${methodName} failed with trackingId: ${detailsTrackingId}`,
+        { module: moduleName, method: methodName }
+      );
+      
+      // Check if uploadLogs uses the trackingId from the data level
+      expect(WebexRequest.getInstance().uploadLogs).toHaveBeenCalledWith({
+        correlationId: dataTrackingId,
       });
     });
   });

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/WebexRequest.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/WebexRequest.ts
@@ -116,7 +116,7 @@ describe('WebexRequest', () => {
         {feedbackId: "mocked-uuid-12345", trackingId: '1234'}, 
         ["behavioral"]
       );
-      expect(mockWebex.internal.support.submitLogs).toHaveBeenCalledWith({... mockMetaData, feedbackId: "mocked-uuid-12345"});
+      expect(mockWebex.internal.support.submitLogs).toHaveBeenCalledWith({... mockMetaData, feedbackId: "mocked-uuid-12345"}, undefined, {type: 'diff'});
     });
 
     it('should log and throw an error if the upload fails', async () => {

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/WebexRequest.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/WebexRequest.ts
@@ -108,7 +108,7 @@ describe('WebexRequest', () => {
 
       expect(result).toEqual({...mockResponse, feedbackId: "mocked-uuid-12345"});
       expect(LoggerProxy.info).toHaveBeenCalledWith(
-        `Logs uploaded successfully`,
+        `Logs uploaded successfully with feedbackId: mocked-uuid-12345`,
         {module: WEBEX_REQUEST_FILE, method: 'uploadLogs'}
       );
       expect(mockMetricsManager.trackEvent).toBeCalledWith(

--- a/packages/@webex/plugin-cc/test/unit/spec/services/core/WebexRequest.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/core/WebexRequest.ts
@@ -120,7 +120,7 @@ describe('WebexRequest', () => {
     });
 
     it('should log and throw an error if the upload fails', async () => {
-      const mockMetaData = { key: 'value' };
+      const mockMetaData = { key: 'value' , correlationId: 'correlation-id' };
       const mockError = new Error('Upload failed');
       mockError.stack = "My stack"
       mockWebex.internal = {
@@ -136,7 +136,7 @@ describe('WebexRequest', () => {
       );
       expect(mockMetricsManager.trackEvent).toBeCalledWith(
         "Upload Logs Failed", 
-        {stack: "My stack", feedbackId: "mocked-uuid-12345"}, 
+        {stack: "My stack", feedbackId: "mocked-uuid-12345", correlationId: 'correlation-id'}, 
         ["behavioral"]
       );
     });

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/index.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/index.ts
@@ -18,6 +18,7 @@ import {
   ConsultTransferPayLoad,
   TransferPayLoad,
 } from '../../../../../src/services/task/types';
+import WebexRequest from '../../../../../src/services/core/WebexRequest';
 
 jest.mock('@webex/calling');
 
@@ -28,6 +29,7 @@ describe('Task', () => {
   let taskDataMock;
   let webCallingService;
   let getErrorDetailsSpy;
+  let mockWebexRequest;
   let webex: WebexSDK;
 
   const taskId = '0ae913a4-c857-4705-8d49-76dd3dde75e4';
@@ -66,6 +68,14 @@ describe('Task', () => {
       webex,
       config.cc.callingClientConfig as CallingClientConfig
     );
+
+    mockWebexRequest = {
+      request: jest.fn(),
+      uploadLogs: jest.fn(),
+    };
+
+    jest.spyOn(WebexRequest, 'getInstance').mockReturnValue(mockWebexRequest);
+
 
     webCallingService.loginOption = LoginOption.BROWSER;
     onSpy = jest.spyOn(webCallingService, 'on');

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/index.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/index.ts
@@ -18,6 +18,7 @@ import {
   ConsultTransferPayLoad,
   TransferPayLoad,
 } from '../../../../../src/services/task/types';
+import WebexRequest from '../../../../../src/services/core/WebexRequest';
 import MetricsManager from '../../../../../src/metrics/MetricsManager';
 import {METRIC_EVENT_NAMES} from '../../../../../src/metrics/constants';
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6333

## This pull request addresses

Upload the logs when any error occurs in CC SDK.

## by making the following changes

added upload logs in catch blocks. And i.e in common place which is getErrorDetails in Utils.ts

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Simulate any error scenario and check mats with feedbackid printed in console logs.
eg: try to login without entering dn.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
