### PR TITLE
fix: updated metric to only send for error/triaging purposes

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -221,14 +221,6 @@ export class LocusMediaRequest extends WebexPlugin {
         localMedias.roapMessage = request.roapMessage;
         localMedias.reachability = request.reachability;
         body.clientMediaPreferences = request.clientMediaPreferences;
-
-        // @ts-ignore
-        this.webex.internal.newMetrics.submitClientEvent({
-          name: 'client.locus.media.request',
-          options: {
-            meetingId: this.config.meetingId,
-          },
-        });
         break;
     }
 
@@ -267,16 +259,6 @@ export class LocusMediaRequest extends WebexPlugin {
       .then((result) => {
         if (isRequestAffectingConfluenceState(request)) {
           this.confluenceState = 'created';
-        }
-
-        if (request.type === 'RoapMessage') {
-          // @ts-ignore
-          this.webex.internal.newMetrics.submitClientEvent({
-            name: 'client.locus.media.response',
-            options: {
-              meetingId: this.config.meetingId,
-            },
-          });
         }
 
         return result;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
@@ -169,26 +169,6 @@ describe('LocusMediaRequest.send()', () => {
     mockWebex.internal.newMetrics.submitClientEvent.resetHistory();
   };
 
-  const checkMetrics = (expectedMetrics: boolean = true) => {
-    if (expectedMetrics) {
-      assert.calledWith(mockWebex.internal.newMetrics.submitClientEvent, {
-        name: 'client.locus.media.request',
-        options: {
-          meetingId: 'meetingId',
-        },
-      });
-
-      assert.calledWith(mockWebex.internal.newMetrics.submitClientEvent, {
-        name: 'client.locus.media.response',
-        options: {
-          meetingId: 'meetingId',
-        },
-      });
-    } else {
-      assert.notCalled(mockWebex.internal.newMetrics.submitClientEvent);
-    }
-  };
-
   it('sends a roap message', async () => {
     const result = await sendRoapMessage('OFFER');
 
@@ -201,8 +181,6 @@ describe('LocusMediaRequest.send()', () => {
       upload: sinon.match.instanceOf(EventEmitter),
       download: sinon.match.instanceOf(EventEmitter),
     });
-
-    checkMetrics();
   });
 
   it('sends correct metric event when roap message fails', async () => {
@@ -232,8 +210,6 @@ describe('LocusMediaRequest.send()', () => {
       upload: sinon.match.instanceOf(EventEmitter),
       download: sinon.match.instanceOf(EventEmitter),
     });
-
-    checkMetrics(false);
   });
 
   it('sends a local mute request with sequence', async () => {
@@ -282,8 +258,6 @@ describe('LocusMediaRequest.send()', () => {
       upload: sinon.match.instanceOf(EventEmitter),
       download: sinon.match.instanceOf(EventEmitter),
     });
-
-    checkMetrics(false);
   });
 
   it('sends a local mute request with the last audio/video mute values', async () => {
@@ -303,8 +277,6 @@ describe('LocusMediaRequest.send()', () => {
       upload: sinon.match.instanceOf(EventEmitter),
       download: sinon.match.instanceOf(EventEmitter),
     });
-
-    checkMetrics(false);
   });
 
   it('sends only roap when roap and local mute are requested', async () => {
@@ -324,8 +296,6 @@ describe('LocusMediaRequest.send()', () => {
       upload: sinon.match.instanceOf(EventEmitter),
       download: sinon.match.instanceOf(EventEmitter),
     });
-
-    checkMetrics();
   });
 
   describe('queueing', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-651771](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-651771) >

## This pull request addresses

- Issue where client is sending way too many metric events ie: https://logs.o.webex.com/app/discover#/view/bb611660-1ddf-11f0-ba69-a9259937da9c?_g=h@8cf8006&_a=h@4dce3e8

## by making the following changes

- Only making requests for this type when there is an error. No analysis is done using this event so it's only useful for error triaging anyway

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
