### PR TITLE
fix(plugin-meetings): canShareWhiteBoard action should be false if supportWhiteboard policy is false

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3997,7 +3997,10 @@ export default class Meeting extends StatelessWebexPlugin {
           canAdmitParticipant: MeetingUtil.canAdmitParticipant(this.userDisplayHints),
           canLock: MeetingUtil.canUserLock(this.userDisplayHints),
           canUnlock: MeetingUtil.canUserUnlock(this.userDisplayHints),
-          canShareWhiteBoard: MeetingUtil.canShareWhiteBoard(this.userDisplayHints),
+          canShareWhiteBoard: MeetingUtil.canShareWhiteBoard(
+            this.userDisplayHints,
+            this.selfUserPolicies
+          ),
           canSetDisallowUnmute: ControlsOptionsUtil.canSetDisallowUnmute(this.userDisplayHints),
           canUnsetDisallowUnmute: ControlsOptionsUtil.canUnsetDisallowUnmute(this.userDisplayHints),
           canSetMuteOnEntry: ControlsOptionsUtil.canSetMuteOnEntry(this.userDisplayHints),

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -575,7 +575,9 @@ const MeetingUtil = {
 
   canUserRenameOthers: (displayHints) => displayHints.includes(DISPLAY_HINTS.CAN_RENAME_OTHERS),
 
-  canShareWhiteBoard: (displayHints) => displayHints.includes(DISPLAY_HINTS.SHARE_WHITEBOARD),
+  canShareWhiteBoard: (displayHints, policies) =>
+    displayHints.includes(DISPLAY_HINTS.SHARE_WHITEBOARD) &&
+    !!policies[SELF_POLICY.SUPPORT_WHITEBOARD],
 
   /**
    * Adds the current locus sequence information to a request body

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -115,9 +115,9 @@ import {ERROR_DESCRIPTIONS} from '@webex/internal-plugin-metrics/src/call-diagno
 import MeetingCollection from '@webex/plugin-meetings/src/meetings/collection';
 
 import {EVENT_TRIGGERS as VOICEAEVENTS} from '@webex/internal-plugin-voicea';
-import { createBrbState } from '@webex/plugin-meetings/src/meeting/brbState';
+import {createBrbState} from '@webex/plugin-meetings/src/meeting/brbState';
 import JoinForbiddenError from '../../../../src/common/errors/join-forbidden-error';
-import { EventEmitter } from 'stream';
+import {EventEmitter} from 'stream';
 
 describe('plugin-meetings', () => {
   const logger = {
@@ -282,7 +282,7 @@ describe('plugin-meetings', () => {
     testDestination = `testDestination-${uuid.v4()}`;
     correlationId = uuid.v4();
     uploadEvent = new EventEmitter();
-    uploadEvent.addListener('progress', () => {})
+    uploadEvent.addListener('progress', () => {});
 
     meeting = new Meeting(
       {
@@ -3884,20 +3884,24 @@ describe('plugin-meetings', () => {
             } catch (err) {
               assert.instanceOf(err, Error);
               assert.equal(err.message, 'setBrb failed');
-              assert.isRejected((Promise.reject()));
+              assert.isRejected(Promise.reject());
             }
           });
 
           it('updates remote mute state when brb is enabled', async () => {
-            meeting.audio = { handleServerRemoteMuteUpdate: sinon.stub() };
+            meeting.audio = {handleServerRemoteMuteUpdate: sinon.stub()};
 
             await meeting.beRightBack(true);
 
-            sinon.assert.calledOnceWithExactly(meeting.audio.handleServerRemoteMuteUpdate, meeting, true);
+            sinon.assert.calledOnceWithExactly(
+              meeting.audio.handleServerRemoteMuteUpdate,
+              meeting,
+              true
+            );
           });
 
           it('does not update remote mute state when brb is disabled', async () => {
-            meeting.audio = { handleServerRemoteMuteUpdate: sinon.stub() };
+            meeting.audio = {handleServerRemoteMuteUpdate: sinon.stub()};
 
             await meeting.beRightBack(false);
 
@@ -3956,7 +3960,10 @@ describe('plugin-meetings', () => {
               .resolves({id: 'fake clientMediaPreferences'});
             meeting.roap.doTurnDiscovery = sinon.stub().resolves({
               turnServerInfo: {
-                urls: ['turns:turn-server-url1:443?transport=tcp', 'turns:turn-server-url2:443?transport=tcp'],
+                urls: [
+                  'turns:turn-server-url1:443?transport=tcp',
+                  'turns:turn-server-url2:443?transport=tcp',
+                ],
                 username: 'turn user',
                 password: 'turn password',
               },
@@ -3974,7 +3981,10 @@ describe('plugin-meetings', () => {
             expectedMediaConnectionConfig = {
               iceServers: [
                 {
-                  urls: ['turns:turn-server-url1:443?transport=tcp', 'turns:turn-server-url2:443?transport=tcp'],
+                  urls: [
+                    'turns:turn-server-url1:443?transport=tcp',
+                    'turns:turn-server-url2:443?transport=tcp',
+                  ],
                   username: 'turn user',
                   credential: 'turn password',
                 },
@@ -4056,9 +4066,11 @@ describe('plugin-meetings', () => {
               .stub(InternalMediaCoreModule, 'MultistreamRoapMediaConnection')
               .returns(fakeMultistreamRoapMediaConnection);
 
-            locusMediaRequestStub = sinon
-              .stub(WebexPlugin.prototype, 'request')
-              .resolves({body: {locus: {fullState: {}}}, upload: sinon.match.instanceOf(EventEmitter), download: sinon.match.instanceOf(EventEmitter)});
+            locusMediaRequestStub = sinon.stub(WebexPlugin.prototype, 'request').resolves({
+              body: {locus: {fullState: {}}},
+              upload: sinon.match.instanceOf(EventEmitter),
+              download: sinon.match.instanceOf(EventEmitter),
+            });
 
             // setup some things and mocks so that the call to join() works
             // (we need to call join() because it creates the LocusMediaRequest instance
@@ -5242,7 +5254,10 @@ describe('plugin-meetings', () => {
                 // and check that when we fallback to transcoded we still do another TURN discovery
                 await runCheck(
                   {
-                    urls: ['turns:turn-server-url1:443?transport=tcp', 'turns:turn-server-url2:443?transport=tcp'],
+                    urls: [
+                      'turns:turn-server-url1:443?transport=tcp',
+                      'turns:turn-server-url2:443?transport=tcp',
+                    ],
                     username: 'turn user',
                     password: 'turn password',
                   },
@@ -5256,7 +5271,10 @@ describe('plugin-meetings', () => {
                 // but doing it just for completeness
                 await runCheck(
                   {
-                    urls: ['turns:turn-server-url1:443?transport=tcp', 'turns:turn-server-url2:443?transport=tcp'],
+                    urls: [
+                      'turns:turn-server-url1:443?transport=tcp',
+                      'turns:turn-server-url2:443?transport=tcp',
+                    ],
                     username: 'turn user',
                     password: 'turn password',
                   },
@@ -10684,6 +10702,11 @@ describe('plugin-meetings', () => {
               requiredDisplayHints: [],
               requiredPolicies: [SELF_POLICY.SUPPORT_POLLING_AND_QA],
             },
+            {
+              actionName: 'canShareWhiteBoard',
+              requiredDisplayHints: [DISPLAY_HINTS.SHARE_WHITEBOARD],
+              requiredPolicies: [SELF_POLICY.SUPPORT_WHITEBOARD],
+            },
           ],
           ({
             actionName,
@@ -11092,7 +11115,7 @@ describe('plugin-meetings', () => {
           assert.calledWith(canSendReactionsSpy, null, userDisplayHints);
           assert.calledWith(canUserRenameSelfAndObservedSpy, userDisplayHints);
           assert.calledWith(canUserRenameOthersSpy, userDisplayHints);
-          assert.calledWith(canShareWhiteBoardSpy, userDisplayHints);
+          assert.calledWith(canShareWhiteBoardSpy, userDisplayHints, selfUserPolicies);
 
           assert.calledWith(ControlsOptionsUtil.hasHints, {
             requiredHints: [DISPLAY_HINTS.MUTE_ALL],

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -66,7 +66,7 @@ describe('plugin-meetings', () => {
 
     describe('#cleanup', () => {
       it('do clean up on meeting object with LLM enabled', async () => {
-        meeting.config = {enableAutomaticLLM : true};
+        meeting.config = {enableAutomaticLLM: true};
         await MeetingUtil.cleanUp(meeting);
         assert.calledOnce(meeting.cleanupLocalStreams);
         assert.calledOnce(meeting.closeRemoteStreams);
@@ -84,7 +84,7 @@ describe('plugin-meetings', () => {
       });
 
       it('do clean up on meeting object with LLM disabled', async () => {
-        meeting.config = {enableAutomaticLLM : false};
+        meeting.config = {enableAutomaticLLM: false};
         await MeetingUtil.cleanUp(meeting);
         assert.calledOnce(meeting.cleanupLocalStreams);
         assert.calledOnce(meeting.closeRemoteStreams);
@@ -392,8 +392,7 @@ describe('plugin-meetings', () => {
           meetingJoinUrl: 'meetingJoinUrl',
           locusUrl: 'locusUrl',
           meetingRequest: {
-            joinMeeting: sinon.stub().returns(
-              Promise.resolve(joinMeetingResponse)),
+            joinMeeting: sinon.stub().returns(Promise.resolve(joinMeetingResponse)),
           },
           getWebexObject: sinon.stub().returns(webex),
           setLocus: sinon.stub(),
@@ -410,23 +409,29 @@ describe('plugin-meetings', () => {
           id: 'fake client media preferences',
         };
 
-        webex.meetings.reachability.getReachabilityReportToAttachToRoap.resolves(FAKE_REACHABILITY_REPORT);
-        webex.meetings.reachability.getClientMediaPreferences.resolves(FAKE_CLIENT_MEDIA_PREFERENCES);
+        webex.meetings.reachability.getReachabilityReportToAttachToRoap.resolves(
+          FAKE_REACHABILITY_REPORT
+        );
+        webex.meetings.reachability.getClientMediaPreferences.resolves(
+          FAKE_CLIENT_MEDIA_PREFERENCES
+        );
 
-        sinon
-          .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4')
-          .get(() => true);
-        sinon
-          .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6')
-          .get(() => true);
+        sinon.stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4').get(() => true);
+        sinon.stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6').get(() => true);
 
         await MeetingUtil.joinMeeting(meeting, {
           reachability: 'reachability',
           roapMessage: 'roapMessage',
         });
 
-        assert.calledOnceWithExactly(webex.meetings.reachability.getReachabilityReportToAttachToRoap);
-        assert.calledOnceWithExactly(webex.meetings.reachability.getClientMediaPreferences, meeting.isMultistream, IP_VERSION.ipv4_and_ipv6);
+        assert.calledOnceWithExactly(
+          webex.meetings.reachability.getReachabilityReportToAttachToRoap
+        );
+        assert.calledOnceWithExactly(
+          webex.meetings.reachability.getClientMediaPreferences,
+          meeting.isMultistream,
+          IP_VERSION.ipv4_and_ipv6
+        );
 
         assert.calledOnce(meeting.meetingRequest.joinMeeting);
         const parameter = meeting.meetingRequest.joinMeeting.getCall(0).args[0];
@@ -436,9 +441,9 @@ describe('plugin-meetings', () => {
         assert.equal(parameter.clientMediaPreferences, FAKE_CLIENT_MEDIA_PREFERENCES);
         assert.equal(parameter.roapMessage, 'roapMessage');
 
-        assert.calledOnce(meeting.setLocus)
+        assert.calledOnce(meeting.setLocus);
         const setLocusParameter = meeting.setLocus.getCall(0).args[0];
-        assert.deepEqual(setLocusParameter, MeetingUtil.parseLocusJoin(joinMeetingResponse))
+        assert.deepEqual(setLocusParameter, MeetingUtil.parseLocusJoin(joinMeetingResponse));
 
         assert.calledWith(webex.internal.newMetrics.submitClientEvent, {
           name: 'client.locus.join.request',
@@ -460,7 +465,6 @@ describe('plugin-meetings', () => {
         });
       });
 
-
       it('#Should call `meetingRequest.joinMeeting and handle a date header in the response : isoLocalClientMeetingJoinedTime', async () => {
         meeting.isMultistream = true;
 
@@ -471,30 +475,30 @@ describe('plugin-meetings', () => {
           id: 'fake client media preferences',
         };
 
-        webex.meetings.reachability.getReachabilityReportToAttachToRoap.resolves(FAKE_REACHABILITY_REPORT);
-        webex.meetings.reachability.getClientMediaPreferences.resolves(FAKE_CLIENT_MEDIA_PREFERENCES);
+        webex.meetings.reachability.getReachabilityReportToAttachToRoap.resolves(
+          FAKE_REACHABILITY_REPORT
+        );
+        webex.meetings.reachability.getClientMediaPreferences.resolves(
+          FAKE_CLIENT_MEDIA_PREFERENCES
+        );
 
-        sinon
-          .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4')
-          .get(() => true);
-        sinon
-          .stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6')
-          .get(() => true);
+        sinon.stub(webex.internal.device.ipNetworkDetector, 'supportsIpV4').get(() => true);
+        sinon.stub(webex.internal.device.ipNetworkDetector, 'supportsIpV6').get(() => true);
 
         meeting.meetingRequest.joinMeeting.resolves({
           headers: {
-            date: 'test'
+            date: 'test',
           },
           body: {
             mediaConnections: [{mediaId: 'test'}],
             locus: {
               url: 'test',
               self: {
-                id: 'test'
-              }
-            }
-          }
-        })
+                id: 'test',
+              },
+            },
+          },
+        });
 
         await MeetingUtil.joinMeeting(meeting, {
           reachability: 'reachability',
@@ -749,8 +753,30 @@ describe('plugin-meetings', () => {
 
     describe('canShareWhiteBoard', () => {
       it('works as expected', () => {
-        assert.deepEqual(MeetingUtil.canShareWhiteBoard(['SHARE_WHITEBOARD']), true);
-        assert.deepEqual(MeetingUtil.canShareWhiteBoard([]), false);
+        assert.deepEqual(
+          MeetingUtil.canShareWhiteBoard(['SHARE_WHITEBOARD'], {
+            [SELF_POLICY.SUPPORT_WHITEBOARD]: true,
+          }),
+          true
+        );
+        assert.deepEqual(
+          MeetingUtil.canShareWhiteBoard([], {
+            [SELF_POLICY.SUPPORT_WHITEBOARD]: true,
+          }),
+          false
+        );
+        assert.deepEqual(
+          MeetingUtil.canShareWhiteBoard(['SHARE_WHITEBOARD'], {
+            [SELF_POLICY.SUPPORT_WHITEBOARD]: false,
+          }),
+          false
+        );
+        assert.deepEqual(
+          MeetingUtil.canShareWhiteBoard([], {
+            [SELF_POLICY.SUPPORT_WHITEBOARD]: false,
+          }),
+          false
+        );
       });
     });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-466470](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-466470)

## This pull request addresses

if the meeting template has whiteboard sharing disabled, the in meeting action canShareWhiteBoard flag still returns true

## by making the following changes

making it return false if the setting is off for the meeting template

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

tested locally with cantina (w/ changes on the cantina side as well)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
