### PR TITLE
fix(plugin-cc): fixed multi stage consult ui bug

### DIFF
--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -179,7 +179,10 @@ export default class TaskManager extends EventEmitter {
             break;
           case CC_EVENTS.AGENT_CONSULT_CREATED:
             // Received when self agent initiates a consult
-            task = this.updateTaskData(task, payload.data);
+            task = this.updateTaskData(task, {
+              ...payload.data,
+              isConsulted: false, // This ensures that the task consult status is always reset
+            });
             // Do not emit anything since this be received only as a result of an API invocation(handled by a promise)
             break;
           case CC_EVENTS.AGENT_OFFER_CONSULT:

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -491,7 +491,12 @@ describe('TaskManager', () => {
     webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
     const taskUpdateTaskDataSpy = jest.spyOn(taskManager.getTask(taskId), 'updateTaskData');
     webSocketManagerMock.emit('message', JSON.stringify(payload));
-    expect(taskUpdateTaskDataSpy).toHaveBeenCalledWith(payload.data);
+    expect(taskUpdateTaskDataSpy).toHaveBeenCalledWith({
+      ...payload.data,
+      isConsulted: false,
+    });
+    const task = taskManager.getTask(taskId);
+    expect(task.data.isConsulted).toBe(false);
   });
 
   it('handle AGENT_OFFER_CONTACT event', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< AD-HOC >

## This pull request addresses

* We found a major bug in the widgets repo, wherein when we did a multi stage consult (i.e. consult transfered from agent1 to agent2 and again consulted from agent2 to agent1, we were not seeing call controls)
* This was due to the task object not being refreshed in SDK, hence it contained the same old `isConsulted=true` variable.


## by making the following changes

* We now always set the `isConsulted` variable to false whenever we start a consult and only set it to true on the event CONSULT_ACCEPTED which comes only when the agent getting the consult is the recepient.
* Tests have also been added.

https://app.vidcast.io/share/569cd55d-7f74-4d65-ba6c-6f0ba0242a73

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested consult and consult to queue in widgets and sample app.
* Tested agent consult and ensured nothing is broken
* Tested with agent desktop and 2 widgets
* Tested the multi stage consult
* Tested regular call end and ending from user end.
* Tested transfer flows and ensured they are working fine.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
