### PR TITLE
fix: the TURN urls array keeps growing with reconnections

### DIFF
--- a/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
+++ b/packages/@webex/plugin-meetings/src/roap/turnDiscovery.ts
@@ -31,6 +31,17 @@ export default class TurnDiscovery {
 
   private responseTimer?: ReturnType<typeof setTimeout>;
 
+  /** Resets the turnInfo structure to the defaults
+   * @returns {void}
+   */
+  private resetTurnInfo() {
+    this.turnInfo = {
+      urls: [],
+      username: '',
+      password: '',
+    };
+  }
+
   /**
    * Constructor
    *
@@ -38,11 +49,7 @@ export default class TurnDiscovery {
    */
   constructor(roapRequest: RoapRequest) {
     this.roapRequest = roapRequest;
-    this.turnInfo = {
-      urls: [],
-      username: '',
-      password: '',
-    };
+    this.resetTurnInfo();
   }
 
   /**
@@ -118,6 +125,8 @@ export default class TurnDiscovery {
     ];
 
     const foundHeaders = {};
+
+    this.resetTurnInfo();
 
     headers?.forEach((receivedHeader) => {
       // check if it matches any of our expected headers


### PR DESCRIPTION
# COMPLETES #[SPARK-655541](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-655541)

## This pull request addresses
TURN urls array keeps growing when we reconnect.

## by making the following changes
Resetting the turnInfo structure whenever we handle a new TURN discovery response

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
