### PR TITLE
fix(plugin-cc): fixed-broken-transfer-issue

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -463,6 +463,7 @@ async function initiateConsultTransfer() {
     console.log('Consult transfer initiated successfully');
     consultTransferBtn.disabled = true; // Disable the consult transfer button after initiating consult transfer
     consultTransferBtn.style.display = 'none'; // Hide the consult transfer button after initiating consult transfer
+    endConsultBtn.style.display = 'none';
   } catch (error) {
     console.error('Failed to initiate consult transfer', error);
   }

--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -224,10 +224,7 @@ export default class TaskManager extends EventEmitter {
             task.emit(TASK_EVENTS.TASK_CONSULT_QUEUE_CANCELLED, task);
             break;
           case CC_EVENTS.AGENT_WRAPUP:
-            // Only update if task exists
-            if (task) {
-              task = this.updateTaskData(task, payload.data);
-            }
+            task = this.updateTaskData(task, payload.data);
             break;
           case CC_EVENTS.AGENT_WRAPPEDUP:
             this.removeTaskFromCollection(task);
@@ -240,10 +237,30 @@ export default class TaskManager extends EventEmitter {
   }
 
   private updateTaskData(task: ITask, taskData: TaskData): ITask {
-    const currentTask = task.updateTaskData(taskData);
-    this.taskCollection[taskData.interactionId] = currentTask;
+    if (!task) {
+      return undefined;
+    }
 
-    return currentTask;
+    if (!taskData?.interactionId) {
+      LoggerProxy.warn('Received task update with missing interactionId', {
+        module: TASK_MANAGER_FILE,
+        method: 'updateTaskData',
+      });
+    }
+
+    try {
+      const currentTask = task.updateTaskData(taskData);
+      this.taskCollection[taskData.interactionId] = currentTask;
+
+      return currentTask;
+    } catch (error) {
+      LoggerProxy.error(`Failed to update task ${taskData.interactionId}`, {
+        module: TASK_MANAGER_FILE,
+        method: 'updateTaskData',
+      });
+
+      return task;
+    }
   }
 
   private removeTaskFromCollection(task: ITask) {

--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -224,7 +224,10 @@ export default class TaskManager extends EventEmitter {
             task.emit(TASK_EVENTS.TASK_CONSULT_QUEUE_CANCELLED, task);
             break;
           case CC_EVENTS.AGENT_WRAPUP:
-            task = this.updateTaskData(task, payload.data);
+            // Only update if task exists
+            if (task) {
+              task = this.updateTaskData(task, payload.data);
+            }
             break;
           case CC_EVENTS.AGENT_WRAPPEDUP:
             this.removeTaskFromCollection(task);

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -1103,6 +1103,78 @@ describe('TaskManager', () => {
     });
     webSocketManagerMock.emit('message', JSON.stringify(payload));
     expect(updateSpy).toHaveBeenCalledWith(payload.data);
-});
+  });
+
+  it('should not attempt cleanup twice when AGENT_CONTACT_UNASSIGNED is followed by AGENT_WRAPUP', () => {
+    webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+    const task = taskManager.getTask(taskId);
+    const unregisterSpy = jest.spyOn(task, 'unregisterWebCallListeners');
+    const cleanUpCallSpy = jest.spyOn(webCallingService, 'cleanUpCall');
+    const unassignedPayload = {
+      data: {
+        type: CC_EVENTS.AGENT_CONTACT_UNASSIGNED,
+        agentId: initalPayload.data.agentId,
+        interaction: { mediaType: 'telephony' },
+        interactionId: initalPayload.data.interactionId,
+        orgId: initalPayload.data.orgId,
+        trackingId: initalPayload.data.trackingId,
+        mediaResourceId: initalPayload.data.mediaResourceId,
+        destAgentId: initalPayload.data.destAgentId,
+        owner: initalPayload.data.owner,
+        queueMgr: initalPayload.data.queueMgr,
+      },
+    };
+    webSocketManagerMock.emit('message', JSON.stringify(unassignedPayload));
+    expect(unregisterSpy).toHaveBeenCalledTimes(1);
+    expect(cleanUpCallSpy).toHaveBeenCalledTimes(1);
+    unregisterSpy.mockClear();
+    cleanUpCallSpy.mockClear();
+    const wrapupPayload = {
+      data: {
+        type: CC_EVENTS.AGENT_WRAPUP,
+        interactionId: taskId,
+        interaction: { mediaType: 'telephony' },
+      },
+    };
+    webSocketManagerMock.emit('message', JSON.stringify(wrapupPayload));
+    expect(unregisterSpy).not.toHaveBeenCalled();
+    expect(cleanUpCallSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not attempt cleanup twice when AGENT_VTEAM_TRANSFERRED is followed by AGENT_WRAPUP', () => {
+    webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+    const task = taskManager.getTask(taskId);
+    const unregisterSpy = jest.spyOn(task, 'unregisterWebCallListeners');
+    const cleanUpCallSpy = jest.spyOn(webCallingService, 'cleanUpCall');
+    const transferredPayload = {
+      data: {
+        type: CC_EVENTS.AGENT_VTEAM_TRANSFERRED,
+        agentId: initalPayload.data.agentId,
+        interaction: { mediaType: 'telephony' },
+        interactionId: initalPayload.data.interactionId,
+        orgId: initalPayload.data.orgId,
+        trackingId: initalPayload.data.trackingId,
+        mediaResourceId: initalPayload.data.mediaResourceId,
+        destAgentId: initalPayload.data.destAgentId,
+        owner: initalPayload.data.owner,
+        queueMgr: initalPayload.data.queueMgr,
+      },
+    };
+    webSocketManagerMock.emit('message', JSON.stringify(transferredPayload));
+    expect(unregisterSpy).toHaveBeenCalledTimes(1);
+    expect(cleanUpCallSpy).toHaveBeenCalledTimes(1);
+    unregisterSpy.mockClear();
+    cleanUpCallSpy.mockClear();
+    const wrapupPayload = {
+      data: {
+        type: CC_EVENTS.AGENT_WRAPUP,
+        interactionId: taskId,
+        interaction: { mediaType: 'telephony' },
+      },
+    };
+    webSocketManagerMock.emit('message', JSON.stringify(wrapupPayload));
+    expect(unregisterSpy).not.toHaveBeenCalled();
+    expect(cleanUpCallSpy).not.toHaveBeenCalled();
+  });
 });
 

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -1087,5 +1087,22 @@ describe('TaskManager', () => {
     // The task should still exist in the collection based on current implementation
     expect(taskManager.getTask(taskId)).toBeDefined();
   });
+
+  it('should update task data on AGENT_WRAPUP event', () => {
+    const payload = {
+        data: {
+            type: CC_EVENTS.AGENT_WRAPUP,
+            interactionId: taskId,
+            wrapUpRequired: true,
+        },
+    };
+    const task = taskManager.getTask(taskId);
+    const updateSpy = jest.spyOn(task, 'updateTaskData').mockImplementation((data) => {
+        task.data = { ...(task.data || {}), ...(data || {}) };
+        return task;
+    });
+    webSocketManagerMock.emit('message', JSON.stringify(payload));
+    expect(updateSpy).toHaveBeenCalledWith(payload.data);
+});
 });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< Ad-HOC >

## This pull request addresses

* The `blind transfer` as well as `queue transfer` were both broken in the SDK.
* Attempting any of these was giving an error `task is not defined`
* The reason was because whenever we transferred, we had a recent change in the SDK code which cleared the task from the list on two events - AGENT_VTEAM_TRANSFERRED (for queue) and AGENT_CONTACT_UNASSIGNED (for agent transfer).
* Then when the wrapup state was shown, we got the AgentWrapup event wherein, we were updating the task, which was null, hence the SDK threw an error.

## by making the following changes

* Added a null check for the wrapup event (workaround)
* Added unit tests to ensure task update only happens when we have a task existing.

Transfer vidcast - https://app.vidcast.io/share/a14a14f2-eaeb-43ad-a7d3-707a3e325d63
Consult Transfer vidcast - https://app.vidcast.io/share/6c3787ea-9156-4df8-91ac-90a870929323

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested blind transfer for both agents and queues
* Tested consult for both agents and queues
* Tested consult-transfer for both agents and queues
* Tested regular call and end call
* Tetsed receiving of consult for both agent and queues.

Reviewer Testing logs between Agent5 and Agent11:
[Agent5ConsoleLogs.log](https://github.com/user-attachments/files/19962056/Agent5ConsoleLogs.log)
[Agent11ConsoleLogs.log](https://github.com/user-attachments/files/19962061/Agent11ConsoleLogs.log)


### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
