### PR TITLE
fix(plugin-cc): removed the cleanup for transfer

### DIFF
--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -129,7 +129,6 @@ export default class TaskManager extends EventEmitter {
               ...payload.data,
               wrapUpRequired: true,
             });
-            this.handleTaskCleanup(task);
             task.emit(TASK_EVENTS.TASK_END, task);
             break;
           case CC_EVENTS.AGENT_CONTACT_OFFER_RONA:
@@ -170,7 +169,6 @@ export default class TaskManager extends EventEmitter {
               ...payload.data,
               wrapUpRequired: true,
             });
-            this.handleTaskCleanup(task);
             task.emit(TASK_EVENTS.TASK_END, task);
             break;
           case CC_EVENTS.AGENT_CTQ_CANCEL_FAILED:

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -1125,8 +1125,8 @@ describe('TaskManager', () => {
       },
     };
     webSocketManagerMock.emit('message', JSON.stringify(unassignedPayload));
-    expect(unregisterSpy).toHaveBeenCalledTimes(1);
-    expect(cleanUpCallSpy).toHaveBeenCalledTimes(1);
+    expect(unregisterSpy).not.toHaveBeenCalled();
+    expect(cleanUpCallSpy).not.toHaveBeenCalled();
     unregisterSpy.mockClear();
     cleanUpCallSpy.mockClear();
     const wrapupPayload = {
@@ -1141,7 +1141,7 @@ describe('TaskManager', () => {
     expect(cleanUpCallSpy).not.toHaveBeenCalled();
   });
 
-  it('should not attempt cleanup twice when AGENT_VTEAM_TRANSFERRED is followed by AGENT_WRAPUP', () => {
+  it('should not attempt cleanup when AGENT_VTEAM_TRANSFERRED is followed by AGENT_WRAPUP', () => {
     webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
     const task = taskManager.getTask(taskId);
     const unregisterSpy = jest.spyOn(task, 'unregisterWebCallListeners');
@@ -1161,8 +1161,8 @@ describe('TaskManager', () => {
       },
     };
     webSocketManagerMock.emit('message', JSON.stringify(transferredPayload));
-    expect(unregisterSpy).toHaveBeenCalledTimes(1);
-    expect(cleanUpCallSpy).toHaveBeenCalledTimes(1);
+    expect(unregisterSpy).not.toHaveBeenCalled();
+    expect(cleanUpCallSpy).not.toHaveBeenCalled();
     unregisterSpy.mockClear();
     cleanUpCallSpy.mockClear();
     const wrapupPayload = {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< AD-HOC ISSUE >

## This pull request addresses

* The `blind transfer` as well as `queue transfer` were both broken in the SDK.
* Attempting any of these was giving an error `task is not defined`
* The reason was because whenever we transferred, we had a recent change in the SDK code which cleared the task from the list on two events - AGENT_VTEAM_TRANSFERRED (for queue) and AGENT_CONTACT_UNASSIGNED (for agent transfer) if the task state was new.
* Then when the wrapup event came to the SDK, we were checking if any corresponding `task` existed, hence in our case the task was empty and so widgets was never notified of the event and did not clear up the wrapup UI.
* This was only observed on blind transfer as we were clearing the task there.


## by making the following changes

* Removed the clear task in the event handling of `AGENT_VTEAM_TRANSFERRED` & `AGENT_CONTACT_UNASSIGNED`.
* Tested solidly with widgets including edge cases and checked all flows. Nothing broke.
* Tested with SDK samples and it all seemed to be working fine - did not see any breakages except existing sample app UI issues.

Vidcast - https://app.vidcast.io/share/0e07f1c7-221b-4a31-a6d1-4c68e2a60a73

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

### Tested on SDK (Both WebRTC and Extension)
* Tested blind agent transfer
* Tested blind queue transfer
* Tested regular call accept and decline
* Tested call end and wrapup functionality.
* Tested queue consult and cancel consult

### Tested on Widgets
* Tested blind agent transfer
* Tested blind queue transfer
* Tested regular call accept and decline
* Tested call end and wrapup functionality.
* Tested queue consult and cancel consult
* Tested queue consult, end consult and consult transfer
* Tested multi stage queue consult

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
