### PR TITLE
fix(plugin-meetings): fixed-user-policy-undefined-issue

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -575,6 +575,7 @@ const MeetingUtil = {
 
   canUserRenameOthers: (displayHints) => displayHints.includes(DISPLAY_HINTS.CAN_RENAME_OTHERS),
 
+  // Default value for policies in case we get an undefined value (ie permissionToken is not availableo)
   canShareWhiteBoard: (displayHints, policies = {}) =>
     displayHints.includes(DISPLAY_HINTS.SHARE_WHITEBOARD) &&
     !!policies[SELF_POLICY.SUPPORT_WHITEBOARD],

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -577,7 +577,6 @@ const MeetingUtil = {
 
   canShareWhiteBoard: (displayHints, policies = {}) =>
     displayHints.includes(DISPLAY_HINTS.SHARE_WHITEBOARD) &&
-    policies &&
     !!policies[SELF_POLICY.SUPPORT_WHITEBOARD],
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -575,7 +575,7 @@ const MeetingUtil = {
 
   canUserRenameOthers: (displayHints) => displayHints.includes(DISPLAY_HINTS.CAN_RENAME_OTHERS),
 
-  // Default empty value for policies in case we get an undefined value (ie permissionToken is not availableo)
+  // Default empty value for policies if we get an undefined value (ie permissionToken is not available)
   canShareWhiteBoard: (displayHints, policies = {}) =>
     displayHints.includes(DISPLAY_HINTS.SHARE_WHITEBOARD) &&
     !!policies[SELF_POLICY.SUPPORT_WHITEBOARD],

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -575,7 +575,7 @@ const MeetingUtil = {
 
   canUserRenameOthers: (displayHints) => displayHints.includes(DISPLAY_HINTS.CAN_RENAME_OTHERS),
 
-  // Default value for policies in case we get an undefined value (ie permissionToken is not availableo)
+  // Default empty value for policies in case we get an undefined value (ie permissionToken is not availableo)
   canShareWhiteBoard: (displayHints, policies = {}) =>
     displayHints.includes(DISPLAY_HINTS.SHARE_WHITEBOARD) &&
     !!policies[SELF_POLICY.SUPPORT_WHITEBOARD],

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -575,8 +575,9 @@ const MeetingUtil = {
 
   canUserRenameOthers: (displayHints) => displayHints.includes(DISPLAY_HINTS.CAN_RENAME_OTHERS),
 
-  canShareWhiteBoard: (displayHints, policies) =>
+  canShareWhiteBoard: (displayHints, policies = {}) =>
     displayHints.includes(DISPLAY_HINTS.SHARE_WHITEBOARD) &&
+    policies &&
     !!policies[SELF_POLICY.SUPPORT_WHITEBOARD],
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -777,6 +777,10 @@ describe('plugin-meetings', () => {
           }),
           false
         );
+        assert.deepEqual(
+          MeetingUtil.canShareWhiteBoard(['SHARE_WHITEBOARD'], undefined),
+          false
+        );
       });
     });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< AD-HOC ISSUE >

## This pull request addresses

* In the meetings plugin, for a customer, they were seeing the following errors when joining the meeting - 
```
wx-js-sdk,Meeting:util#joinMeetingOptions --> Error joining the call, ,TypeError: Cannot read properties of undefined (reading 'supportWhiteboard')
    at Object.canShareWhiteBoard (https://unpkg.com/webex@next/umd/webex.min.js:2:2160210)

```
* The reason was because a recent PR had changed the `canShareWhiteBoard` method in the meeting utils.
* So, in plugin meetings, we use the `permissionToken` which we get from meeting info and decode it to get the user policies object which contains the various values regarding permissions. We have a util method in meetings to extract this.
* In that method, we were not checking for a non-null value of the user policy object and hence whenever it was undefined we got a crash.

## by making the following changes

* Simply adding both a check and a default value (empty for user policies) results in `false` value for undefined policieis.
* Unit tests also reflect the same fix.


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Joined a meeting from the sdk sample app and ensured everything was working smoothly (with `null` permissionToken)

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
