### PR TITLE
feat(plugin-meetings): mark errors as handled if metrics already sent

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5856,11 +5856,22 @@ export default class Meeting extends StatelessWebexPlugin {
           this
         );
 
-        joinFailed(error);
+        const proxyError = new Proxy(error, {
+          // eslint-disable-next-line require-jsdoc
+          get(target, prop) {
+            if (prop === 'handledBySdk') {
+              return true;
+            }
+
+            return Reflect.get(target, prop);
+          },
+        });
+
+        joinFailed(proxyError);
 
         this.deferJoin = undefined;
 
-        return Promise.reject(error);
+        return Promise.reject(proxyError);
       })
       .then((join) => {
         // @ts-ignore - config coming from registerPlugin

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1809,6 +1809,7 @@ describe('plugin-meetings', () => {
                 await meeting.join();
                 joinSucceeded = true;
               } catch (e) {
+                assert.isTrue(e.handledBySdk)
                 assert.instanceOf(e, IntentToJoinError);
               }
               assert.isFalse(joinSucceeded);
@@ -1861,7 +1862,20 @@ describe('plugin-meetings', () => {
             });
           });
           it('should try to join the meeting and return promise reject', async () => {
-            await meeting.join().catch(() => {
+            await meeting.join().catch((e) => {
+              assert.isTrue(e.handledBySdk);
+              assert.calledOnce(MeetingUtil.joinMeeting);
+            });
+          });
+
+          it('should try to join the meeting and return deferred promise reject', async () => {
+
+            // call first
+            meeting.join();
+
+            // call 2nd time will get the deferred promise
+            await meeting.join().catch((e) => {
+              assert.isTrue(e.handledBySdk);
               assert.calledOnce(MeetingUtil.joinMeeting);
             });
           });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

The client needs to be aware of which errors have been handled from a call analyzer perspective and which haven't. This allows the SDK to continue to throw all errors, but the client can decide which to report itself.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
