### PR TITLE
fix(plugin-meetings): double reconnection

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5227,7 +5227,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @public
    * @memberof Meeting
    */
-  public reconnect(options?: object) {
+  public async reconnect(options?: object) {
     LoggerProxy.logger.log(
       `Meeting:index#reconnect --> attempting to reconnect meeting ${this.id}`
     );
@@ -5245,7 +5245,7 @@ export default class Meeting extends StatelessWebexPlugin {
       );
     }
 
-    this.cleanUpBeforeReconnection();
+    await this.cleanUpBeforeReconnection();
 
     return this.reconnectionManager
       .reconnect(options, async () => {
@@ -7445,6 +7445,11 @@ export default class Meeting extends StatelessWebexPlugin {
     }
   }
 
+  /**
+   * Cleans up stats analyzer and media connection before we can reconnect
+   *
+   * @returns {Promise<void>}
+   */
   private async cleanUpBeforeReconnection(): Promise<void> {
     try {
       // when media fails, we want to upload a webrtc dump to see whats going on
@@ -7453,6 +7458,10 @@ export default class Meeting extends StatelessWebexPlugin {
 
       if (this.statsAnalyzer) {
         await this.statsAnalyzer.stopAnalyzer();
+      }
+
+      if (this.mediaProperties.webrtcMediaConnection) {
+        this.mediaProperties.webrtcMediaConnection.closeMediaConnection();
       }
     } catch (error) {
       LoggerProxy.logger.error(

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -7460,7 +7460,7 @@ export default class Meeting extends StatelessWebexPlugin {
         await this.statsAnalyzer.stopAnalyzer();
       }
 
-      if (this.mediaProperties.webrtcMediaConnection) {
+      if (this.mediaProperties.webrtcMediaConnection && !this.isMultistream) {
         this.mediaProperties.webrtcMediaConnection.closeMediaConnection();
       }
     } catch (error) {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-633399](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-633399)

## This pull request addresses

It's easiest to reproduce on Mac, Firefox, Transcoded Meeting, without VPN
I'm not sure if it's happening on other systems/ browsers/ meetings/ network conditions

### What's happening:
1. Client is connected
2. Wi-Fi is turned off
3. js-sdk waits for ice to automatically reconnect
4. if it fails, it will start it's own reconnection
5. Wi-Fi is turned on

6. Peer Connection from step 1 reconnected automatically and started stats-analyzer
7. js-sdk reconnect process is still working, overriding peer connection and again starting stats-analyzer

Problem:
- Client is reconnected twice (in step 6 and 7)
- Stats Analyzer is started twice
  - Because it's first started on step 6 with old connection, it will produce negative values

## by making the following changes

When reconnecting, it should terminate old media connection so it won't automatically connect

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Manual test from `What's Happening` section
< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
