### PR TITLE
fix(meetings): do not reject in meetings.unregister if device unregis…

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -935,6 +935,21 @@ export default class Meetings extends WebexPlugin {
         .disconnect()
         // @ts-ignore
         .then(() => this.webex.internal.device.unregister())
+        .catch((error) => {
+          // If error status code is 404, continue the chain
+          if (error.statusCode === 404) {
+            LoggerProxy.logger.info(
+              'Meetings:index#unregister --> 404 error during device unregister, proceeding normally'
+            );
+
+            return; // returning undefined allows the chain to continue
+          }
+          // For any other status code, break the chain by rethrowing
+          LoggerProxy.logger.error(
+            `Meetings:index#unregister --> Failed to unregister device: ${error.message}`
+          );
+          throw error; // rethrow to break the promise chain
+        })
         .then(() => {
           Trigger.trigger(
             this,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -583,6 +583,24 @@ describe('plugin-meetings', () => {
           await assert.isRejected(webex.meetings.unregister());
         });
 
+        it('does not reject when device.unregister fails with statusCode 404', (done) => {
+          webex.meetings.registered = true;
+          webex.internal.device.unregister = sinon.stub().rejects({statusCode: 404});
+          webex.meetings.unregister().then(() => {
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meetings),
+              {
+                file: 'meetings',
+                function: 'unregister',
+              },
+              'meetings:unregistered'
+            );
+            assert.isFalse(webex.meetings.registered);
+            done();
+          });
+        });
+
         it('rejects when mercury.disconnect fails', async () => {
           webex.meetings.registered = true;
           webex.internal.mercury.disconnect = sinon.stub().returns(Promise.reject());


### PR DESCRIPTION


<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses
currently during meetings.unregister() if the device unregistration fails with a 404, it will cause meetings.unregister to fail. we do not want to reject because there was no device to unregister, meetings.unregister() can resolve 

## by making the following changes
meetings.unregister() checks the statusCode of the error from device.unregister and if 404, it will not reject and instead continue on with it's unregistration steps and resolve

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
