### PR TITLE
fix(metrics): setDelaySubmitClientEvents too early call

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -74,6 +74,7 @@ class Metrics extends WebexPlugin {
       // @ts-ignore
       this.callDiagnosticMetrics = new CallDiagnosticMetrics({}, {parent: this.webex});
       this.isReady = true;
+      this.setDelaySubmitClientEvents(this.delaySubmitClientEvents);
     });
   }
 
@@ -409,7 +410,7 @@ class Metrics extends WebexPlugin {
   public setDelaySubmitClientEvents(shouldDelay: boolean) {
     this.delaySubmitClientEvents = shouldDelay;
 
-    if (!shouldDelay) {
+    if (this.isReady && !shouldDelay) {
       return this.callDiagnosticMetrics.submitDelayedClientEvents();
     }
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/new-metrics.ts
@@ -278,6 +278,27 @@ describe('internal-plugin-metrics', () => {
 
         sinon.assert.match(webex.internal.newMetrics.delaySubmitClientEvents, false);
       });
+
+      it('should not fail when called before webex is ready', () => {
+
+        // Create mock
+        webex = mockWebex()
+
+        webex.internal.newMetrics.callDiagnosticLatencies.saveTimestamp = sinon.stub();
+        webex.internal.newMetrics.callDiagnosticLatencies.clearTimestamps = sinon.stub();
+        webex.setTimingsAndFetch = sinon.stub();
+
+        sinon.assert.match(webex.internal.newMetrics.delaySubmitClientEvents, false);
+
+        // Call the method before webex is ready, will not throw error
+        webex.internal.newMetrics.setDelaySubmitClientEvents(false);
+        webex.internal.newMetrics.setDelaySubmitClientEvents(true);
+
+        webex.internal.newMetrics.setDelaySubmitClientEvents(false);
+        // Webex is ready
+        webex.emit('ready');
+
+      });
     });
   });
 });


### PR DESCRIPTION



<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-660106](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-660106)

## This pull request addresses

It is possible to call `setDelaySubmitClientEvents` before `callDiagnosticMetrics` created which happens after webex ready event.

For example when `setDelaySubmitClientEvents` called from a post message handler.

## by making the following changes

`setDelaySubmitClientEvents` check isReady state before call any method from `callDiagnosticMetrics`. Also we call `setDelaySubmitClientEvents` when webex is ready.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
