### PR TITLE
fix(plugin-meetings): do not fallback on reachability stop call

### DIFF
--- a/packages/@webex/plugin-meetings/src/reachability/index.ts
+++ b/packages/@webex/plugin-meetings/src/reachability/index.ts
@@ -288,7 +288,7 @@ export default class Reachability extends EventsScope {
         {}
       );
       this.sendMetric(true);
-      this.resolveReachabilityPromise();
+      this.resolveReachabilityPromise(false);
     }
   }
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-661187](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-661187)

## This pull request addresses

Sometimes when no media clusters were reached, and stopReachability was called it actually won't stop doing reachability checks if min number of clusters were provided.

It will do a fallback, and keep trying to fetch reachable clusters.

Fix it in the way, to stop fallbacking on reachability stop request.

## by making the following changes

Ensure that we don't fallback on `resolveReachabilityPromise`.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested with JS-SDK sample app, and added unit test

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
