### PR TITLE
feat(plugin-meetings): marking CA errors as handled

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -97,6 +97,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
   private hasLoggedBrowserSerial: boolean;
   private device: any;
   private delayedClientEvents: DelayedClientEvent[] = [];
+  private eventErrorCache: any = {};
 
   // the default validator before piping an event to the batcher
   // this function can be overridden by the user
@@ -556,15 +557,28 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
   }
 
   /**
+   * Clear the error cache
+   */
+  clearErrorCache() {
+    this.eventErrorCache = {};
+  }
+
+  /**
    * Generate error payload for Client Event
    * @param rawError
    */
   generateClientEventErrorPayload(rawError: any) {
+    if (this.eventErrorCache[rawError]) {
+      return [this.eventErrorCache[rawError], true];
+    }
+
     const rawErrorMessage = rawError.message;
     const httpStatusCode = rawError.statusCode;
+    let payload;
+
     if (rawError.name) {
       if (isBrowserMediaErrorName(rawError.name)) {
-        return this.getErrorPayloadForClientErrorCode({
+        payload = this.getErrorPayloadForClientErrorCode({
           serviceErrorCode: undefined,
           clientErrorCode: BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP[rawError.name],
           serviceErrorName: rawError.name,
@@ -574,11 +588,11 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       }
     }
 
-    if (isSdpOfferCreationError(rawError)) {
+    if (isSdpOfferCreationError(rawError) && !payload) {
       // error code is 30005, but that's not specific enough. we also need to check error.cause.type
       const causeType = rawError.cause?.type;
 
-      return this.getErrorPayloadForClientErrorCode({
+      payload = this.getErrorPayloadForClientErrorCode({
         serviceErrorCode: undefined,
         clientErrorCode:
           SDP_OFFER_CREATION_ERROR_MAP[causeType] || SDP_OFFER_CREATION_ERROR_MAP.GENERAL,
@@ -596,8 +610,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
 
     if (serviceErrorCode) {
       const clientErrorCode = SERVICE_ERROR_CODES_TO_CLIENT_ERROR_CODES_MAP[serviceErrorCode];
-      if (clientErrorCode) {
-        return this.getErrorPayloadForClientErrorCode({
+      if (clientErrorCode && !payload) {
+        payload = this.getErrorPayloadForClientErrorCode({
           clientErrorCode,
           serviceErrorCode,
           rawErrorMessage,
@@ -606,8 +620,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       }
 
       // by default, if it is locus error, return new locus err
-      if (isLocusServiceErrorCode(serviceErrorCode)) {
-        return this.getErrorPayloadForClientErrorCode({
+      if (isLocusServiceErrorCode(serviceErrorCode) && !payload) {
+        payload = this.getErrorPayloadForClientErrorCode({
           clientErrorCode: NEW_LOCUS_ERROR_CLIENT_CODE,
           serviceErrorCode,
           rawErrorMessage,
@@ -616,8 +630,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       }
     }
 
-    if (isMeetingInfoServiceError(rawError)) {
-      return this.getErrorPayloadForClientErrorCode({
+    if (isMeetingInfoServiceError(rawError) && !payload) {
+      payload = this.getErrorPayloadForClientErrorCode({
         clientErrorCode: MEETING_INFO_LOOKUP_ERROR_CLIENT_CODE,
         serviceErrorCode,
         rawErrorMessage,
@@ -625,8 +639,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       });
     }
 
-    if (isNetworkError(rawError)) {
-      return this.getErrorPayloadForClientErrorCode({
+    if (isNetworkError(rawError) && !payload) {
+      payload = this.getErrorPayloadForClientErrorCode({
         clientErrorCode: NETWORK_ERROR,
         serviceErrorCode,
         payloadOverrides: rawError.payloadOverrides,
@@ -635,8 +649,8 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       });
     }
 
-    if (isUnauthorizedError(rawError)) {
-      return this.getErrorPayloadForClientErrorCode({
+    if (isUnauthorizedError(rawError) && !payload) {
+      payload = this.getErrorPayloadForClientErrorCode({
         clientErrorCode: AUTHENTICATION_FAILED_CODE,
         serviceErrorCode,
         payloadOverrides: rawError.payloadOverrides,
@@ -645,15 +659,22 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
       });
     }
 
-    // otherwise return unkown error but passing serviceErrorCode and serviceErrorName so that we know the issue
-    return this.getErrorPayloadForClientErrorCode({
-      clientErrorCode: UNKNOWN_ERROR,
-      serviceErrorCode: serviceErrorCode || UNKNOWN_ERROR,
-      serviceErrorName: rawError?.name,
-      payloadOverrides: rawError.payloadOverrides,
-      rawErrorMessage,
-      httpStatusCode,
-    });
+    if (!payload) {
+      // otherwise return unkown error but passing serviceErrorCode and serviceErrorName so that we know the issue
+      payload = this.getErrorPayloadForClientErrorCode({
+        clientErrorCode: UNKNOWN_ERROR,
+        serviceErrorCode: serviceErrorCode || UNKNOWN_ERROR,
+        serviceErrorName: rawError?.name,
+        payloadOverrides: rawError.payloadOverrides,
+        rawErrorMessage,
+        httpStatusCode,
+      });
+    }
+
+    // cache the payload for future use
+    this.eventErrorCache[rawError] = payload;
+
+    return [payload, false];
   }
 
   /**
@@ -834,14 +855,14 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
     const errors: ClientEventPayloadError = [];
 
     if (rawError) {
-      const generatedError = this.generateClientEventErrorPayload(rawError);
+      const [generatedError, cached] = this.generateClientEventErrorPayload(rawError);
       if (generatedError) {
         errors.push(generatedError);
       }
       this.logger.log(
         CALL_DIAGNOSTIC_LOG_IDENTIFIER,
         'CallDiagnosticMetrics: @prepareClientEvent. Generated errors:',
-        `generatedError: ${JSON.stringify(generatedError)}`
+        `generatedError (cached: ${cached}): ${JSON.stringify(generatedError)}`
       );
     }
 

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -97,7 +97,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
   private hasLoggedBrowserSerial: boolean;
   private device: any;
   private delayedClientEvents: DelayedClientEvent[] = [];
-  private eventErrorCache: any = {};
+  private eventErrorCache: WeakMap<any, any> = new WeakMap();
 
   // the default validator before piping an event to the batcher
   // this function can be overridden by the user
@@ -560,7 +560,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
    * Clear the error cache
    */
   clearErrorCache() {
-    this.eventErrorCache = {};
+    this.eventErrorCache = new WeakMap();
   }
 
   /**
@@ -568,8 +568,10 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
    * @param rawError
    */
   generateClientEventErrorPayload(rawError: any) {
-    if (this.eventErrorCache[rawError]) {
-      return [this.eventErrorCache[rawError], true];
+    const cachedError = this.eventErrorCache.get(rawError);
+
+    if (cachedError) {
+      return [cachedError, true];
     }
 
     const rawErrorMessage = rawError.message;
@@ -672,7 +674,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
     }
 
     // cache the payload for future use
-    this.eventErrorCache[rawError] = payload;
+    this.eventErrorCache.set(rawError, payload);
 
     return [payload, false];
   }

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -2562,6 +2562,35 @@ describe('internal-plugin-metrics', () => {
         rawErrorMessage: 'bad times',
       };
 
+      it('should be cached if called twice with the same payload', () => {
+        const error = new Error('bad times');
+        const expectedPayload = {
+          category: 'other',
+          errorCode: 9999,
+          errorData: {errorName: 'Error'},
+          serviceErrorCode: 9999,
+          fatal: true,
+          shownToUser: false,
+          name: 'other',
+          rawErrorMessage: 'bad times',
+          errorDescription: 'UnknownError',
+        }
+
+        const [res, cached] = cd.generateClientEventErrorPayload(error);
+        assert.isFalse(cached);
+        assert.deepEqual(res, expectedPayload);
+
+        const [res2, cached2] = cd.generateClientEventErrorPayload(error);
+        assert.isTrue(cached2);
+        assert.deepEqual(res2, expectedPayload);
+
+        // after clearing the cache, it should be false again
+        cd.clearErrorCache();
+        const [res3, cached3] = cd.generateClientEventErrorPayload(error);
+        assert.isFalse(cached3);
+        assert.deepEqual(res3, expectedPayload);
+      });
+
       const checkNameError = (payload: any, isExpectedToBeCalled: boolean) => {
         const [res, cached] = cd.generateClientEventErrorPayload(payload);
         const expectedResult = {

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -1375,7 +1375,14 @@ describe('internal-plugin-metrics', () => {
         const getIdentifiersSpy = sinon.spy(cd, 'getIdentifiers');
         const getSubServiceTypeSpy = sinon.spy(cd, 'getSubServiceType');
         const validatorSpy = sinon.spy(cd, 'validator');
-        sinon.stub(window.navigator, 'userAgent').get(() => userAgent);
+
+        Object.defineProperty(global, 'navigator', {
+          value: {
+            userAgent,
+          },
+          configurable: true,
+        });
+
         sinon.stub(bowser, 'getParser').returns(userAgent);
 
         const options = {
@@ -1948,7 +1955,7 @@ describe('internal-plugin-metrics', () => {
         assert.deepEqual(webexLoggerLogCalls[2].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @prepareClientEvent. Generated errors:',
-          `generatedError: {"fatal":true,"shownToUser":false,"name":"other","category":"expected","errorCode":4029,"serviceErrorCode":2409005,"errorDescription":"StartRecordingFailed"}`,
+          `generatedError (cached: false): {"fatal":true,"shownToUser":false,"name":"other","category":"expected","errorCode":4029,"serviceErrorCode":2409005,"errorDescription":"StartRecordingFailed"}`,
         ]);
       });
 
@@ -2028,7 +2035,7 @@ describe('internal-plugin-metrics', () => {
         assert.deepEqual(webexLoggerLogCalls[2].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @prepareClientEvent. Generated errors:',
-          `generatedError: {"fatal":true,"shownToUser":false,"name":"other","category":"other","errorCode":9999,"errorData":{"errorName":"Error"},"serviceErrorCode":9999,"rawErrorMessage":"bad times","errorDescription":"UnknownError"}`,
+          `generatedError (cached: false): {"fatal":true,"shownToUser":false,"name":"other","category":"other","errorCode":9999,"errorData":{"errorName":"Error"},"serviceErrorCode":9999,"rawErrorMessage":"bad times","errorDescription":"UnknownError"}`,
         ]);
       });
 
@@ -2101,7 +2108,7 @@ describe('internal-plugin-metrics', () => {
         assert.deepEqual(webexLoggerLogCalls[2].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @prepareClientEvent. Generated errors:',
-          `generatedError: {"fatal":true,"shownToUser":false,"name":"other","category":"other","errorCode":9999,"errorData":{"errorName":"Error"},"serviceErrorCode":9999,"rawErrorMessage":"bad times","errorDescription":"UnknownError"}`,
+          `generatedError (cached: false): {"fatal":true,"shownToUser":false,"name":"other","category":"other","errorCode":9999,"errorData":{"errorName":"Error"},"serviceErrorCode":9999,"rawErrorMessage":"bad times","errorDescription":"UnknownError"}`,
         ]);
       });
 
@@ -2175,7 +2182,7 @@ describe('internal-plugin-metrics', () => {
         assert.deepEqual(webexLoggerLogCalls[2].args, [
           'call-diagnostic-events -> ',
           'CallDiagnosticMetrics: @prepareClientEvent. Generated errors:',
-          `generatedError: {"fatal":true,"shownToUser":false,"name":"other","category":"expected","errorCode":4029,"serviceErrorCode":2409005,"errorDescription":"StartRecordingFailed"}`,
+          `generatedError (cached: false): {"fatal":true,"shownToUser":false,"name":"other","category":"expected","errorCode":4029,"serviceErrorCode":2409005,"errorDescription":"StartRecordingFailed"}`,
         ]);
       });
 
@@ -2556,7 +2563,7 @@ describe('internal-plugin-metrics', () => {
       };
 
       const checkNameError = (payload: any, isExpectedToBeCalled: boolean) => {
-        const res = cd.generateClientEventErrorPayload(payload);
+        const [res, cached] = cd.generateClientEventErrorPayload(payload);
         const expectedResult = {
           category: 'expected',
           errorDescription: 'CameraPermissionDenied',
@@ -2585,7 +2592,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       const checkCodeError = (payload: any, expetedRes: any) => {
-        const res = cd.generateClientEventErrorPayload(payload);
+        const [res, cached] = cd.generateClientEventErrorPayload(payload);
         assert.deepEqual(res, expetedRes);
       };
       it('should generate event error payload correctly', () => {
@@ -2611,7 +2618,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       const checkLocusError = (payload: any, isExpectedToBeCalled: boolean) => {
-        const res = cd.generateClientEventErrorPayload(payload);
+        const [res, cached] = cd.generateClientEventErrorPayload(payload);
         const expectedResult = {
           category: 'signaling',
           errorDescription: 'NewLocusError',
@@ -2639,7 +2646,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       const checkMeetingInfoError = (payload: any, isExpectedToBeCalled: boolean) => {
-        const res = cd.generateClientEventErrorPayload(payload);
+        const [res, cached] = cd.generateClientEventErrorPayload(payload);
         const expectedResult = {
           category: 'signaling',
           errorDescription: 'MeetingInfoLookupError',
@@ -2680,7 +2687,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       it('should return NetworkError code for a NetworkOrCORSERror', () => {
-        const res = cd.generateClientEventErrorPayload(
+        const [res, cached] = cd.generateClientEventErrorPayload(
           new WebexHttpError.NetworkOrCORSError({
             url: 'https://example.com',
             statusCode: 0,
@@ -2724,7 +2731,7 @@ describe('internal-plugin-metrics', () => {
               message: 'No codecs present in m-line with MID 0 after filtering.',
             },
           };
-          const res = cd.generateClientEventErrorPayload(error);
+          const [res, cached] = cd.generateClientEventErrorPayload(error);
           assert.deepEqual(res, {
             category: 'expected',
             errorCode: 2051,
@@ -2750,7 +2757,7 @@ describe('internal-plugin-metrics', () => {
               message: 'empty local SDP',
             },
           };
-          const res = cd.generateClientEventErrorPayload(error);
+          const [res, cached] = cd.generateClientEventErrorPayload(error);
           assert.deepEqual(res, {
             category: 'media',
             errorCode: 2050,
@@ -2775,7 +2782,7 @@ describe('internal-plugin-metrics', () => {
           category: 'expected',
         };
 
-        const res = cd.generateClientEventErrorPayload(error);
+        const [res, cached] = cd.generateClientEventErrorPayload(error);
         assert.deepEqual(res, {
           category: 'expected',
           errorDescription: 'UnknownError',
@@ -2804,7 +2811,7 @@ describe('internal-plugin-metrics', () => {
           category: 'expected',
         };
 
-        const res = cd.generateClientEventErrorPayload(error);
+        const [res, cached] = cd.generateClientEventErrorPayload(error);
         assert.deepEqual(res, {
           category: 'expected',
           errorDescription: 'NetworkError',
@@ -2819,7 +2826,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       it('should return AuthenticationFailed code for an Unauthorized error', () => {
-        const res = cd.generateClientEventErrorPayload(
+        const [res, cached] = cd.generateClientEventErrorPayload(
           new WebexHttpError.Unauthorized({
             url: 'https://example.com',
             statusCode: 0,
@@ -2852,7 +2859,7 @@ describe('internal-plugin-metrics', () => {
           category: 'expected',
         };
 
-        const res = cd.generateClientEventErrorPayload(error);
+        const [res, cached] = cd.generateClientEventErrorPayload(error);
         assert.deepEqual(res, {
           category: 'expected',
           errorDescription: 'AuthenticationFailed',
@@ -2867,7 +2874,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       it('should return unknown error otherwise', () => {
-        const res = cd.generateClientEventErrorPayload({something: 'new', message: 'bad times'});
+        const [res, cached] = cd.generateClientEventErrorPayload({something: 'new', message: 'bad times'});
         assert.deepEqual(res, {
           category: 'other',
           errorDescription: 'UnknownError',
@@ -2881,7 +2888,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       it('should generate event error payload correctly for locus error 2423012', () => {
-        const res = cd.generateClientEventErrorPayload({
+        const [res, cached] = cd.generateClientEventErrorPayload({
           body: {errorCode: 2423012},
           message: 'bad times',
         });
@@ -2897,7 +2904,7 @@ describe('internal-plugin-metrics', () => {
         });
       });
       it('should generate event error payload correctly for locus error 2409062', () => {
-        const res = cd.generateClientEventErrorPayload({
+        const [res, cached] = cd.generateClientEventErrorPayload({
           body: {errorCode: 2409062},
           message: 'bad times',
         });
@@ -2914,7 +2921,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       it('should generate event error payload correctly for locus error 2423021', () => {
-        const res = cd.generateClientEventErrorPayload({
+        const [res, cached] = cd.generateClientEventErrorPayload({
           body: {errorCode: 2423021},
           message: 'bad times',
         });
@@ -2931,7 +2938,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       it('should generate event error payload correctly for wdm error 4404002', () => {
-        const res = cd.generateClientEventErrorPayload({
+        const [res, cached] = cd.generateClientEventErrorPayload({
           body: {errorCode: 4404002},
           message: 'Operation denied due to region restriction',
         });
@@ -2948,7 +2955,7 @@ describe('internal-plugin-metrics', () => {
       });
 
       it('should generate event error payload correctly for wdm error 4404003', () => {
-        const res = cd.generateClientEventErrorPayload({
+        const [res, cached] = cd.generateClientEventErrorPayload({
           body: {errorCode: 4404003},
           message: 'Operation denied due to region restriction',
         });
@@ -2966,7 +2973,7 @@ describe('internal-plugin-metrics', () => {
 
       describe('httpStatusCode', () => {
         it('should include httpStatusCode for browser media errors', () => {
-          const res = cd.generateClientEventErrorPayload({
+          const [res, cached] = cd.generateClientEventErrorPayload({
             name: 'PermissionDeniedError',
             message: 'bad times',
             statusCode: 401,
@@ -2988,7 +2995,7 @@ describe('internal-plugin-metrics', () => {
         });
 
         it('should include httpStatusCode for SdpOfferCreationErrors', () => {
-          const res = cd.generateClientEventErrorPayload({
+          const [res, cached] = cd.generateClientEventErrorPayload({
             name: 'SdpOfferCreationError',
             message: 'bad times',
             statusCode: 404,
@@ -3010,7 +3017,7 @@ describe('internal-plugin-metrics', () => {
         });
 
         it('should include httpStatusCode for service error codes', () => {
-          const res = cd.generateClientEventErrorPayload({
+          const [res, cached] = cd.generateClientEventErrorPayload({
             body: {errorCode: 58400},
             message: 'bad times',
             statusCode: 400,
@@ -3029,7 +3036,7 @@ describe('internal-plugin-metrics', () => {
         });
 
         it('should include httpStatusCode for locus service error codes', () => {
-          const res = cd.generateClientEventErrorPayload({
+          const [res, cached] = cd.generateClientEventErrorPayload({
             body: {errorCode: 2403001},
             message: 'bad times',
             statusCode: 400,
@@ -3048,7 +3055,7 @@ describe('internal-plugin-metrics', () => {
         });
 
         it('should include httpStatusCode for meetingInfo service error codes', () => {
-          const res = cd.generateClientEventErrorPayload({
+          const [res, cached] = cd.generateClientEventErrorPayload({
             body: {data: {meetingInfo: {}}},
             message: 'bad times',
             statusCode: 400,
@@ -3071,7 +3078,7 @@ describe('internal-plugin-metrics', () => {
             statusCode: 400,
             options: {service: '', headers: {}},
           });
-          const res = cd.generateClientEventErrorPayload(error);
+          const [res, cached] = cd.generateClientEventErrorPayload(error);
           assert.deepEqual(res, {
             category: 'network',
             errorCode: 1026,
@@ -3090,7 +3097,7 @@ describe('internal-plugin-metrics', () => {
             statusCode: 401,
             options: {service: '', headers: {}},
           });
-          const res = cd.generateClientEventErrorPayload(error);
+          const [res, cached] = cd.generateClientEventErrorPayload(error);
           assert.deepEqual(res, {
             category: 'network',
             errorCode: 1010,
@@ -3105,7 +3112,7 @@ describe('internal-plugin-metrics', () => {
         });
 
         it('should include httpStatusCode for unknown errors', () => {
-          const res = cd.generateClientEventErrorPayload({
+          const [res, cached] = cd.generateClientEventErrorPayload({
             message: 'bad times',
             statusCode: 404,
           });

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1598,6 +1598,10 @@ export default class Meeting extends StatelessWebexPlugin {
      * @memberof Meeting
      */
     this.#isoLocalClientMeetingJoinTime = undefined;
+
+    // We clear the error cache of CA events on every new meeting instance
+    // @ts-ignore - Fix type
+    this.webex.internal.newMetrics.callDiagnosticMetrics.clearErrorCache();
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5856,22 +5856,11 @@ export default class Meeting extends StatelessWebexPlugin {
           this
         );
 
-        const proxyError = new Proxy(error, {
-          // eslint-disable-next-line require-jsdoc
-          get(target, prop) {
-            if (prop === 'handledBySdk') {
-              return true;
-            }
-
-            return Reflect.get(target, prop);
-          },
-        });
-
-        joinFailed(proxyError);
+        joinFailed(error);
 
         this.deferJoin = undefined;
 
-        return Promise.reject(proxyError);
+        return Promise.reject(error);
       })
       .then((join) => {
         // @ts-ignore - config coming from registerPlugin

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5856,7 +5856,16 @@ export default class Meeting extends StatelessWebexPlugin {
           this
         );
 
-        const proxyError = MeetingUtil.markErrorAsHandledBySdk(error);
+        const proxyError = new Proxy(error, {
+          // eslint-disable-next-line require-jsdoc
+          get(target, prop) {
+            if (prop === 'handledBySdk') {
+              return true;
+            }
+
+            return Reflect.get(target, prop);
+          },
+        });
 
         joinFailed(proxyError);
 
@@ -6245,10 +6254,10 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * Handles ROAP_FAILURE event from the webrtc media connection
    *
-   * @param {Error} roapError
+   * @param {Error} error
    * @returns {void}
    */
-  handleRoapFailure = (roapError) => {
+  handleRoapFailure = (error) => {
     // eslint-disable-next-line @typescript-eslint/no-shadow
     const sendBehavioralMetric = (metricName, error, correlationId) => {
       const data = {
@@ -6263,8 +6272,6 @@ export default class Meeting extends StatelessWebexPlugin {
 
       Metrics.sendBehavioralMetric(metricName, data, metadata);
     };
-
-    const error = MeetingUtil.markErrorAsHandledBySdk(roapError);
 
     if (error instanceof Errors.SdpOfferCreationError) {
       sendBehavioralMetric(BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE, error, this.correlationId);
@@ -6304,7 +6311,7 @@ export default class Meeting extends StatelessWebexPlugin {
         clearTimeout(this.sdpResponseTimer);
         this.sdpResponseTimer = undefined;
 
-        this.deferSDPAnswer.reject(error);
+        this.deferSDPAnswer.reject();
       }
     } else if (error instanceof Errors.SdpError) {
       // this covers also the case of Errors.IceGatheringError which extends Errors.SdpError
@@ -6459,9 +6466,7 @@ export default class Meeting extends StatelessWebexPlugin {
               {
                 logText: `${LOG_HEADER} Roap Offer`,
               }
-            ).catch((originalError) => {
-              const error = MeetingUtil.markErrorAsHandledBySdk(originalError);
-
+            ).catch((error) => {
               const multistreamNotSupported = error instanceof MultistreamNotSupportedError;
 
               // @ts-ignore
@@ -7109,28 +7114,7 @@ export default class Meeting extends StatelessWebexPlugin {
     } catch (error) {
       const {iceConnected} = error;
 
-      let handledBySdk = false;
-
       if (!this.hasMediaConnectionConnectedAtLeastOnce) {
-        const caError =
-          // @ts-ignore
-          this.webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode({
-            clientErrorCode: CallDiagnosticUtils.generateClientErrorCodeForIceFailure({
-              signalingState:
-                this.mediaProperties.webrtcMediaConnection?.multistreamConnection?.pc?.pc
-                  ?.signalingState ||
-                this.mediaProperties.webrtcMediaConnection?.mediaConnection?.pc?.signalingState ||
-                'unknown',
-              iceConnected,
-              turnServerUsed: this.turnServerUsed,
-              unreachable:
-                // @ts-ignore
-                await this.webex.meetings.reachability
-                  .isWebexMediaBackendUnreachable()
-                  .catch(() => false),
-            }),
-          });
-
         // Only send CA event for join flow if we haven't successfully connected media yet
         // @ts-ignore
         this.webex.internal.newMetrics.submitClientEvent({
@@ -7138,25 +7122,37 @@ export default class Meeting extends StatelessWebexPlugin {
           payload: {
             canProceed: !this.turnServerUsed, // If we haven't done turn tls retry yet we will proceed with join attempt
             icePhase: this.addMediaData.icePhaseCallback(),
-            errors: [caError],
+            errors: [
+              // @ts-ignore
+              this.webex.internal.newMetrics.callDiagnosticMetrics.getErrorPayloadForClientErrorCode(
+                {
+                  clientErrorCode: CallDiagnosticUtils.generateClientErrorCodeForIceFailure({
+                    signalingState:
+                      this.mediaProperties.webrtcMediaConnection?.multistreamConnection?.pc?.pc
+                        ?.signalingState ||
+                      this.mediaProperties.webrtcMediaConnection?.mediaConnection?.pc
+                        ?.signalingState ||
+                      'unknown',
+                    iceConnected,
+                    turnServerUsed: this.turnServerUsed,
+                    unreachable:
+                      // @ts-ignore
+                      await this.webex.meetings.reachability
+                        .isWebexMediaBackendUnreachable()
+                        .catch(() => false),
+                  }),
+                }
+              ),
+            ],
           },
           options: {
             meetingId: this.id,
           },
         });
-
-        handledBySdk = true;
       }
-
-      let timedOutError = new Error(
+      throw new Error(
         `Timed out waiting for media connection to be connected, correlationId=${this.correlationId}`
       );
-
-      if (handledBySdk) {
-        timedOutError = MeetingUtil.markErrorAsHandledBySdk(timedOutError);
-      }
-
-      throw timedOutError;
     }
   }
 
@@ -7217,11 +7213,6 @@ export default class Meeting extends StatelessWebexPlugin {
           ROAP_OFFER_ANSWER_EXCHANGE_TIMEOUT / 1000
         } seconds`
       );
-
-      const timeoutError = new Error('Timeout waiting for SDP answer');
-
-      const timeoutErrorProxy = MeetingUtil.markErrorAsHandledBySdk(timeoutError);
-
       // @ts-ignore
       this.webex.internal.newMetrics.submitClientEvent({
         name: 'client.media-engine.remote-sdp-received',
@@ -7234,7 +7225,7 @@ export default class Meeting extends StatelessWebexPlugin {
             }),
           ],
         },
-        options: {meetingId: this.id, rawError: timeoutErrorProxy},
+        options: {meetingId: this.id, rawError: new Error('Timeout waiting for SDP answer')},
       });
 
       deferSDPAnswer.reject(new Error('Timed out waiting for REMOTE SDP ANSWER'));
@@ -7342,14 +7333,7 @@ export default class Meeting extends StatelessWebexPlugin {
         error
       );
 
-      let addMediaFailedError = new AddMediaFailed();
-
-      // @ts-ignore - handledBySdk is added by a proxy
-      if (error.handledBySdk) {
-        addMediaFailedError = MeetingUtil.markErrorAsHandledBySdk(addMediaFailedError);
-      }
-
-      throw addMediaFailedError;
+      throw new AddMediaFailed();
     }
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -6,7 +6,6 @@ import {WebexPlugin} from '@webex/webex-core';
 import {MEDIA, HTTP_VERBS, ROAP} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {ClientMediaPreferences} from '../reachability/reachability.types';
-import MeetingUtil from './util';
 
 export type MediaRequestType = 'RoapMessage' | 'LocalMute';
 export type RequestResult = any;
@@ -264,9 +263,7 @@ export class LocusMediaRequest extends WebexPlugin {
 
         return result;
       })
-      .catch((error) => {
-        let e = error;
-
+      .catch((e) => {
         if (
           isRequestAffectingConfluenceState(request) &&
           this.confluenceState === 'creation in progress'
@@ -275,8 +272,6 @@ export class LocusMediaRequest extends WebexPlugin {
         }
 
         if (request.type === 'RoapMessage') {
-          e = MeetingUtil.markErrorAsHandledBySdk(e);
-
           // @ts-ignore
           this.webex.internal.newMetrics.submitClientEvent({
             name: 'client.locus.media.response',

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -812,24 +812,6 @@ const MeetingUtil = {
       },
     ];
   },
-
-  /**
-   * Creates a proxy object to mark an error as handled by the SDK.
-   * @param {Error} error original error
-   * @returns {Proxy} proxy object with handledBySdk property
-   */
-  markErrorAsHandledBySdk: (error) => {
-    return new Proxy(error, {
-      // eslint-disable-next-line require-jsdoc
-      get(target, prop) {
-        if (prop === 'handledBySdk') {
-          return true;
-        }
-
-        return Reflect.get(target, prop);
-      },
-    });
-  },
 };
 
 export default MeetingUtil;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -243,6 +243,7 @@ describe('plugin-meetings', () => {
       },
     });
 
+    webex.internal.newMetrics.callDiagnosticMetrics.clearErrorCache = sinon.stub();
     webex.internal.support.submitLogs = sinon.stub().returns(Promise.resolve());
     webex.internal.services = {get: sinon.stub().returns('locus-url')};
     webex.credentials.getOrgId = sinon.stub().returns('fake-org-id');

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1809,7 +1809,6 @@ describe('plugin-meetings', () => {
                 await meeting.join();
                 joinSucceeded = true;
               } catch (e) {
-                assert.isTrue(e.handledBySdk)
                 assert.instanceOf(e, IntentToJoinError);
               }
               assert.isFalse(joinSucceeded);
@@ -1862,20 +1861,7 @@ describe('plugin-meetings', () => {
             });
           });
           it('should try to join the meeting and return promise reject', async () => {
-            await meeting.join().catch((e) => {
-              assert.isTrue(e.handledBySdk);
-              assert.calledOnce(MeetingUtil.joinMeeting);
-            });
-          });
-
-          it('should try to join the meeting and return deferred promise reject', async () => {
-
-            // call first
-            meeting.join();
-
-            // call 2nd time will get the deferred promise
-            await meeting.join().catch((e) => {
-              assert.isTrue(e.handledBySdk);
+            await meeting.join().catch(() => {
               assert.calledOnce(MeetingUtil.joinMeeting);
             });
           });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1011,19 +1011,13 @@ describe('plugin-meetings', () => {
             .stub()
             .returns(fakeClientError);
 
-          const promise = meeting.joinWithMedia({
+          // call joinWithMedia() - it should fail
+          await assert.isRejected(
+            meeting.joinWithMedia({
               joinOptions,
               mediaOptions,
             })
-
-          // call joinWithMedia() - it should fail
-          await assert.isRejected(promise);
-
-          const rejectedError = await promise.catch((error) => error);
-
-          // Since the SDK has sent the CA events, we need to mark this error as handled
-          // so the client doesn't try and send CA events again
-          assert.isTrue(rejectedError.handledBySdk);
+          );
 
           // check the right CA events have been sent:
           // calls at index 0 and 2 to submitClientEvent are for "client.media.capabilities" which we don't care about in this test
@@ -8816,21 +8810,14 @@ describe('plugin-meetings', () => {
             clock.restore();
           });
 
-          const checkMetricSent = (event, error, expectedErrorCode) => {
+          const checkMetricSent = (event, error) => {
             assert.calledOnce(webex.internal.newMetrics.submitClientEvent);
-            assert.deepEqual(webex.internal.newMetrics.submitClientEvent.getCall(0).args[0], {
+            assert.calledWithMatch(webex.internal.newMetrics.submitClientEvent, {
               name: event,
               payload: {
                 canProceed: false,
               },
-              options: {
-                rawError: {
-                  ...(error.cause ? {cause: {name: error.cause.name}} : {cause: undefined}),
-                  code: expectedErrorCode,
-                  name: error.name,
-                },
-                meetingId: meeting.id,
-              },
+              options: {rawError: error, meetingId: meeting.id},
             });
           };
 
@@ -8864,7 +8851,7 @@ describe('plugin-meetings', () => {
 
             eventListeners[MediaConnectionEventNames.ROAP_FAILURE](fakeError);
 
-            checkMetricSent('client.media-engine.local-sdp-generated', fakeError, 30005);
+            checkMetricSent('client.media-engine.local-sdp-generated', fakeError);
             checkBehavioralMetricSent(
               BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE,
               Errors.ErrorCode.SdpOfferCreationError,
@@ -8881,7 +8868,7 @@ describe('plugin-meetings', () => {
 
             eventListeners[MediaConnectionEventNames.ROAP_FAILURE](fakeError);
 
-            checkMetricSent('client.media-engine.remote-sdp-received', fakeError, 30006);
+            checkMetricSent('client.media-engine.remote-sdp-received', fakeError);
             checkBehavioralMetricSent(
               BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE,
               Errors.ErrorCode.SdpOfferHandlingError,
@@ -8905,7 +8892,7 @@ describe('plugin-meetings', () => {
 
             eventListeners[MediaConnectionEventNames.ROAP_FAILURE](fakeError);
 
-            checkMetricSent('client.media-engine.remote-sdp-received', fakeError, 30004);
+            checkMetricSent('client.media-engine.remote-sdp-received', fakeError);
             checkBehavioralMetricSent(
               BEHAVIORAL_METRICS.PEERCONNECTION_FAILURE,
               Errors.ErrorCode.SdpAnswerHandlingError,
@@ -8913,7 +8900,6 @@ describe('plugin-meetings', () => {
               fakeRootCauseName
             );
             assert.calledOnce(meeting.deferSDPAnswer.reject);
-            assert.isTrue(meeting.deferSDPAnswer.reject.getCall(0).args[0].handledBySdk);
             assert.calledOnce(clearTimeoutSpy);
           });
 
@@ -8923,7 +8909,7 @@ describe('plugin-meetings', () => {
 
             eventListeners[MediaConnectionEventNames.ROAP_FAILURE](fakeError);
 
-            checkMetricSent('client.media-engine.local-sdp-generated', fakeError, 30002);
+            checkMetricSent('client.media-engine.local-sdp-generated', fakeError);
             // expectedMetadataType is the error name in this case
             checkBehavioralMetricSent(
               BEHAVIORAL_METRICS.INVALID_ICE_CANDIDATE,
@@ -8941,7 +8927,7 @@ describe('plugin-meetings', () => {
 
             eventListeners[MediaConnectionEventNames.ROAP_FAILURE](fakeError);
 
-            checkMetricSent('client.media-engine.local-sdp-generated', fakeError, 30003);
+            checkMetricSent('client.media-engine.local-sdp-generated', fakeError);
             // expectedMetadataType is the error name in this case
             checkBehavioralMetricSent(
               BEHAVIORAL_METRICS.INVALID_ICE_CANDIDATE,
@@ -9135,7 +9121,7 @@ describe('plugin-meetings', () => {
             assert.calledOnceWithExactly(getErrorPayloadForClientErrorCodeStub, {
               clientErrorCode: expectedErrorCode,
             });
-            assert.deepEqual(webex.internal.newMetrics.submitClientEvent.getCall(0).args[0], {
+            assert.calledWithMatch(webex.internal.newMetrics.submitClientEvent, {
               name: 'client.media-engine.remote-sdp-received',
               payload: {
                 canProceed,
@@ -9143,18 +9129,9 @@ describe('plugin-meetings', () => {
               },
               options: {
                 meetingId: meeting.id,
-                rawError: fakeError instanceof MultistreamNotSupportedError ? {
-                  code: fakeError.code,
-                  name: fakeError.name,
-                  sdkMessage: fakeError.sdkMessage,
-                  error: fakeError.error,
-                } : {},
+                rawError: fakeError,
               },
             });
-            const actualError = webex.internal.newMetrics.submitClientEvent.getCall(0).args[0].options.rawError;
-
-            assert.isTrue(actualError.handledBySdk);
-            assert.equal(actualError.message, fakeError.message);
           };
 
           it('handles OFFER message correctly when request fails', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
@@ -185,12 +185,7 @@ describe('LocusMediaRequest.send()', () => {
 
   it('sends correct metric event when roap message fails', async () => {
     webexRequestStub.rejects({code: 300, message: 'fake error'});
-
-    const promise = sendRoapMessage('OFFER');
-    await assert.isRejected(promise);
-
-    const error = await promise.catch((err) => err);
-    assert.isTrue(error.handledBySdk);
+    await assert.isRejected(sendRoapMessage('OFFER'));
 
     assert.calledWith(mockWebex.internal.newMetrics.submitClientEvent, {
       name: 'client.locus.media.response',

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -1185,14 +1185,6 @@ describe('plugin-meetings', () => {
       });
     });
 
-    describe('markErrorAsHandledBySdk', () => {
-      it('should set the error as handled', () => {
-        const error = MeetingUtil.markErrorAsHandledBySdk(new Error('Test error'));
-
-        assert.isTrue(error.handledBySdk);
-      })
-    });
-
     describe('getChangeMeetingFloorErrorPayload', () => {
       [
         {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -182,6 +182,15 @@ describe('plugin-meetings', () => {
         metrics: {
           submitClientMetrics: sinon.stub().returns(Promise.resolve()),
         },
+        newMetrics: {
+          submitClientEvent: sinon.stub(),
+          callDiagnosticLatencies: {
+            measureLatency: sinon.stub().returns(Promise.resolve()),
+          },
+          callDiagnosticMetrics: {
+            clearErrorCache: sinon.stub(),
+          },
+        },
       });
       webex.emit('ready');
     });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

#4253 and #4240 both attempted to mark errors as handled so the client would be free to ignore them, knowing that the SDK had already sent the necessary CA events. This proved to be impossible for some flows, particularly the ROAP flow, whereby the CA metric and the thrown error followed two distinct code paths.

Instead, the error payloads will be cached, so the client can tell if they are generating a new, unique payload for the given error, or merely recreating an error.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
