### PR TITLE
fix(taskManager): added-agent-invite-failed-event

### DIFF
--- a/packages/@webex/plugin-cc/src/services/config/types.ts
+++ b/packages/@webex/plugin-cc/src/services/config/types.ts
@@ -42,6 +42,7 @@ export const CC_TASK_EVENTS = {
   AGENT_OFFER_CONTACT: 'AgentOfferContact',
   AGENT_CONTACT_ASSIGNED: 'AgentContactAssigned',
   AGENT_CONTACT_UNASSIGNED: 'AgentContactUnassigned',
+  AGENT_INVITE_FAILED: 'AgentInviteFailed',
 } as const;
 
 // Define the CC_AGENT_EVENTS object

--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -143,6 +143,7 @@ export default class TaskManager extends EventEmitter {
             task.emit(TASK_EVENTS.TASK_REJECT, payload.data.reason);
             break;
           case CC_EVENTS.CONTACT_ENDED:
+          case CC_EVENTS.AGENT_INVITE_FAILED:
             task = this.updateTaskData(task, {
               ...payload.data,
               wrapUpRequired: payload.data.interaction.state !== 'new',

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -382,6 +382,39 @@ describe('TaskManager', () => {
     );
   });
 
+  it('should emit TASK_END event on AGENT_INVITE_FAILED event', () => {
+    webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+
+      const taskEmitSpy = jest.spyOn(taskManager.getTask(taskId), 'emit');
+      const payload = {
+        data: {
+          type: CC_EVENTS.AGENT_INVITE_FAILED,
+          agentId: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
+          eventTime: 1733211616959,
+          eventType: 'RoutingMessage',
+          interaction: {state: 'connected'},
+          interactionId: taskId,
+          orgId: '6ecef209-9a34-4ed1-a07a-7ddd1dbe925a',
+          trackingId: '575c0ec2-618c-42af-a61c-53aeb0a221ee',
+          mediaResourceId: '0ae913a4-c857-4705-8d49-76dd3dde75e4',
+          destAgentId: 'ebeb893b-ba67-4f36-8418-95c7492b28c2',
+          owner: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
+          queueMgr: 'aqm',
+        },
+      };
+
+      taskManager.getTask(taskId).updateTaskData(payload.data);
+      webSocketManagerMock.emit('message', JSON.stringify(payload));
+      expect(taskEmitSpy).toHaveBeenCalledWith(
+        CC_EVENTS.AGENT_INVITE_FAILED, 
+        { ...payload.data}
+      );
+      expect(taskEmitSpy).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_END, 
+        taskManager.getTask(taskId)
+      );
+  });
+
   it('should emit TASK_HYDRATE event on AGENT_CONTACT event', () => {
     const payload = {
       data: {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

This pull request addresses while testing extension login, the agent is not logged in to receive the extension call. However, tasks are still appearing in the Task List section. This indicates that the task list is not being cleared appropriately when the agent is not logged in

Jira Link: https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6290

Vidcast Link: https://app.vidcast.io/share/bf243e05-8317-4ace-9217-db463376d373

## by making the following changes

Added an event called AgentInviteFailed to ensure the Task List is cleared when the agent is not logged in. This prevents tasks from appearing in the list if the agent is not authenticated, maintaining consistency with the agent's login state

<!-- You may include screenshots -->

After the fix

<img width="678" alt="Screenshot 2025-05-12 at 9 35 14 PM" src="https://github.com/user-attachments/assets/417e8d94-2555-4a69-b3b9-7174a13c876d" />

Before the fix
<img width="678" alt="Screenshot 2025-05-12 at 9 20 59 PM" src="https://github.com/user-attachments/assets/f7521bd8-7a7f-4c60-9034-af272defde15" />

Test Results:
<img width="1045" alt="Screenshot 2025-05-13 at 1 06 56 PM" src="https://github.com/user-attachments/assets/68f3a649-93d3-4ae3-9a8e-a6dcbdf3eda8" />


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested locally on the CC Widgets side by connecting to the local Webex-js-sdk with the AgentInviteFailed event changes. Attached below is the Vidcast that captures the behavior.

Vidcast Link: https://app.vidcast.io/share/bf243e05-8317-4ace-9217-db463376d373

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
