### PR TITLE
feat(plugin-meetings): chain errors with causes

### DIFF
--- a/packages/@webex/plugin-meetings/src/common/errors/webex-errors.ts
+++ b/packages/@webex/plugin-meetings/src/common/errors/webex-errors.ts
@@ -152,12 +152,19 @@ WebExMeetingsErrors[IceGatheringFailed.CODE] = IceGatheringFailed;
  * @extends WebexMeetingsError
  * @property {number} code - 30203
  * @property {string} message - 'Failed to add media'
+ * @property {Error} [cause] - The underlying error that caused the failure
  */
 class AddMediaFailed extends WebexMeetingsError {
   static CODE = 30203;
+  cause?: Error;
 
-  constructor() {
+  /**
+   * Creates a new AddMediaFailed error
+   * @param {Error} [cause] - The underlying error that caused the media addition to fail
+   */
+  constructor(cause?: Error) {
     super(AddMediaFailed.CODE, 'Failed to add media');
+    this.cause = cause;
   }
 }
 export {AddMediaFailed};

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2762,7 +2762,8 @@ describe('plugin-meetings', () => {
               turnDiscoverySkippedReason: undefined,
             });
           meeting.meetingState = 'ACTIVE';
-          meeting.mediaProperties.waitForMediaConnectionConnected.rejects({iceConnected: false});
+          const error = {iceConnected: false}
+          meeting.mediaProperties.waitForMediaConnectionConnected.rejects(error);
 
           const forceRtcMetricsSend = sinon.stub().resolves();
           const closeMediaConnectionStub = sinon.stub();
@@ -2780,6 +2781,7 @@ describe('plugin-meetings', () => {
             })
             .catch((err) => {
               errorThrown = err;
+              assert.instanceOf(err.cause, Error);
               assert.instanceOf(err, AddMediaFailed);
             });
 
@@ -2836,6 +2838,7 @@ describe('plugin-meetings', () => {
             },
             options: {
               meetingId: meeting.id,
+              rawError: error,
             },
           });
           assert.calledWith(webex.internal.newMetrics.submitClientEvent.thirdCall, {
@@ -2847,6 +2850,7 @@ describe('plugin-meetings', () => {
             },
             options: {
               meetingId: meeting.id,
+              rawError: error,
             },
           });
 
@@ -2975,10 +2979,13 @@ describe('plugin-meetings', () => {
               },
               turnDiscoverySkippedReason: undefined,
             });
+
+          const mediaConnectionError = new Error('fake error');
+
           meeting.mediaProperties.waitForMediaConnectionConnected = sinon
             .stub()
             .onFirstCall()
-            .rejects()
+            .rejects(mediaConnectionError)
             .onSecondCall()
             .resolves();
 
@@ -3047,6 +3054,7 @@ describe('plugin-meetings', () => {
             },
             options: {
               meetingId: meeting.id,
+              rawError: mediaConnectionError,
             },
           });
           assert.calledWith(webex.internal.newMetrics.submitClientEvent.thirdCall, {
@@ -3957,6 +3965,9 @@ describe('plugin-meetings', () => {
                   },
                   options: {
                     meetingId: meeting.id,
+                    rawError: {
+                      iceConnected: false,
+                    }
                   },
                 },
               ]);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

https://github.com/webex/webex-js-sdk/pull/4260 added the CA error cache. However some errors are thrown that are not also sent in CA events. To address this I've done the following:

1. Add a cause attribute to the AddMediaFailed error.
2. Chain the errors using the cause attribute

This way a client can still inspect the errors to see whether any triggering error in the chain has been sent in a CA event

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
