### PR TITLE
feat(plugin-cc): added-update-profile

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -1132,7 +1132,6 @@ function logoutAgent() {
 
 async function updateAgentDeviceType() {
   const payload = {
-    teamId: teamsDropdown.value,
     loginOption: agentDeviceType,
     dialNumber: dialNumber.value
   };
@@ -1154,7 +1153,6 @@ async function applyupdateAgentDeviceType() {
   const loginOption = updateLoginOptionElm.value;
   const newDial = loginOption === 'BROWSER' ? '' : updateDialNumberElm.value;
   const payload = {
-    teamId: teamsDropdown.value,
     loginOption,
     dialNumber: newDial,
   };

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -35,8 +35,8 @@ const idleCodesDropdown = document.querySelector('#idleCodesDropdown')
 const setAgentStatusButton = document.querySelector('#setAgentStatus');
 const logoutAgentElm = document.querySelector('#logoutAgent');
 const buddyAgentsDropdownElm = document.getElementById('buddyAgentsDropdown');
-const updateProfileElm = document.querySelector('#updateProfile');
-const updateFieldsContainer = document.querySelector('#updateProfileFields');
+const updateAgentDeviceTypeElm = document.querySelector('#updateAgentDeviceType');
+const updateFieldsContainer = document.querySelector('#updateAgentDeviceTypeFields');
 const updateLoginOptionElm = document.querySelector('#updateLoginOption');
 const updateDialNumberElm = document.querySelector('#updateDialNumber');
 const incomingCallListener = document.querySelector('#incomingsection');
@@ -941,7 +941,7 @@ function register() {
       console.log('Agent re-login successful', data);
       loginAgentElm.disabled = true;
       logoutAgentElm.classList.remove('hidden');
-      updateProfileElm.classList.remove('hidden');
+      updateAgentDeviceTypeElm.classList.remove('hidden');
 
       agentLogin.value = data.deviceType;
       agentDeviceType = data.deviceType;
@@ -960,7 +960,7 @@ function register() {
       console.log('Agent station-login success', data);
       loginAgentElm.disabled = true;
       logoutAgentElm.classList.remove('hidden');
-      updateProfileElm.classList.remove('hidden');
+      updateAgentDeviceTypeElm.classList.remove('hidden');
       updateFieldsContainer.classList.add('hidden');
 
       agentLogin.value = data.deviceType;
@@ -1066,7 +1066,7 @@ function doAgentLogin() {
     console.log('Agent Logged in successfully', response);
     loginAgentElm.disabled = true;
     logoutAgentElm.classList.remove('hidden');
-    updateProfileElm.classList.remove('hidden');
+    updateAgentDeviceTypeElm.classList.remove('hidden');
     // Read auxCode and lastStateChangeTimestamp from login response
     const DEFAULT_CODE = '0'; // Default code when no aux code is present
     const auxCodeId = response.data.auxCodeId?.trim() !== '' ? response.data.auxCodeId : DEFAULT_CODE;
@@ -1104,7 +1104,7 @@ function logoutAgent() {
     .then((response) => {
       console.log('Agent logged out successfully', response);
       loginAgentElm.disabled = false;
-      updateProfileElm.classList.add('hidden');
+      updateAgentDeviceTypeElm.classList.add('hidden');
       updateFieldsContainer.classList.add('hidden');
 
      // Clear the timer when the agent logs out.
@@ -1129,14 +1129,13 @@ function logoutAgent() {
   });
 }
 
-async function updateProfile() {
+async function updateAgentDeviceType() {
   const payload = {
-    teamId: teamsDropdown.value,
     loginOption: agentDeviceType,
     dialNumber: dialNumber.value
   };
   try {
-    const response = await webex.cc.updateProfile(payload);
+    const response = await webex.cc.updateAgentDeviceType(payload);
     console.log('Profile updated successfully', response);
   }
   catch (error) {
@@ -1145,20 +1144,19 @@ async function updateProfile() {
   }
 }
 
-function showUpdateProfileUI() {
+function showupdateAgentDeviceTypeUI() {
   updateFieldsContainer.classList.toggle('hidden');
 }
 
-async function applyUpdateProfile() {
+async function applyupdateAgentDeviceType() {
   const loginOption = updateLoginOptionElm.value;
   const newDial = loginOption === 'BROWSER' ? '' : updateDialNumberElm.value;
   const payload = {
-    teamId: teamsDropdown.value,
     loginOption,
     dialNumber: newDial,
   };
   try {
-    const resp = await webex.cc.updateProfile(payload);
+    const resp = await webex.cc.updateAgentDeviceType(payload);
     console.log('Profile updated', resp);
     updateFieldsContainer.classList.add('hidden');
     // Reflect new values in main UI

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -1132,6 +1132,7 @@ function logoutAgent() {
 
 async function updateAgentDeviceType() {
   const payload = {
+    teamId: teamsDropdown.value,
     loginOption: agentDeviceType,
     dialNumber: dialNumber.value
   };
@@ -1153,6 +1154,7 @@ async function applyupdateAgentDeviceType() {
   const loginOption = updateLoginOptionElm.value;
   const newDial = loginOption === 'BROWSER' ? '' : updateDialNumberElm.value;
   const payload = {
+    teamId: teamsDropdown.value,
     loginOption,
     dialNumber: newDial,
   };

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -35,6 +35,10 @@ const idleCodesDropdown = document.querySelector('#idleCodesDropdown')
 const setAgentStatusButton = document.querySelector('#setAgentStatus');
 const logoutAgentElm = document.querySelector('#logoutAgent');
 const buddyAgentsDropdownElm = document.getElementById('buddyAgentsDropdown');
+const updateProfileElm = document.querySelector('#updateProfile');
+const updateFieldsContainer = document.querySelector('#updateProfileFields');
+const updateLoginOptionElm = document.querySelector('#updateLoginOption');
+const updateDialNumberElm = document.querySelector('#updateDialNumber');
 const incomingCallListener = document.querySelector('#incomingsection');
 const incomingDetailsElm = document.querySelector('#incoming-task');
 const answerElm = document.querySelector('#answer');
@@ -873,21 +877,12 @@ function register() {
             teamsDropdown.add(option);
         });
         const loginVoiceOptions = agentProfile.loginVoiceOptions;
-        agentLogin.innerHTML = '<option value="" selected>Choose Agent Login ...</option>'; // Clear previously selected option on agentLogin.
+        populateLoginOptions(
+          loginVoiceOptions.filter((o) => agentProfile.webRtcEnabled || o !== 'BROWSER')
+        );
         dialNumber.value = agentProfile.defaultDn ? agentProfile.defaultDn : '';
         dialNumber.disabled = agentProfile.defaultDn ? false : true;
         if (loginVoiceOptions.length > 0) loginAgentElm.disabled = false;
-        loginVoiceOptions.forEach((voiceOptions)=> {
-          if (!agentProfile.webRtcEnabled && voiceOptions === 'BROWSER') {
-            // Skiping the addition of browser option for webrtc disabled case
-            return;
-          }
-          const option = document.createElement('option');
-          option.text = voiceOptions;
-          option.value = voiceOptions;
-          agentLogin.add(option);
-          option.selected = agentProfile.isAgentLoggedIn && voiceOptions === agentProfile.deviceType;
-        });
 
         if (agentProfile.isAgentLoggedIn) {
           loginAgentElm.disabled = true;
@@ -942,10 +937,48 @@ function register() {
       }
     });
 
-    webex.cc.on('agent:stationLoginSuccess', (data) => {
-      console.log('Agent station login success', data);
+    webex.cc.on('agent:reloginSuccess', (data) => {
+      console.log('Agent re-login successful', data);
+      loginAgentElm.disabled = true;
+      logoutAgentElm.classList.remove('hidden');
+      updateProfileElm.classList.remove('hidden');
+
+      agentLogin.value = data.deviceType;
+      agentDeviceType = data.deviceType;
+
+      if (data.deviceType === 'BROWSER') {
+        dialNumber.disabled = true;
+        dialNumber.value = '';
+      }
+      else {
+        dialNumber.disabled = false;
+        dialNumber.value = data.dn || '';
+      }
     });
-    
+
+    webex.cc.on('agent:stationLoginSuccess', (data) => {
+      console.log('Agent station-login success', data);
+      loginAgentElm.disabled = true;
+      logoutAgentElm.classList.remove('hidden');
+      updateProfileElm.classList.remove('hidden');
+      updateFieldsContainer.classList.add('hidden');
+
+      agentLogin.value = data.deviceType;
+      agentDeviceType = data.deviceType;
+      if (data.deviceType === 'BROWSER') {
+        dialNumber.disabled = true;
+        dialNumber.value = '';
+      }
+      else {
+        dialNumber.disabled = false;
+        dialNumber.value = data.dn || '';
+      }
+
+      const auxId  = data.auxCodeId?.trim() || '0';
+      const idx    = [...idleCodesDropdown.options].findIndex(o => o.value === auxId);
+      idleCodesDropdown.selectedIndex = idx >= 0 ? idx : 0;
+      startStateTimer(data.lastStateChangeTimestamp, data.lastIdleCodeChangeTimestamp);
+    });
 }
 
 // New function to handle unregistration
@@ -1028,12 +1061,12 @@ function doAgentLogin() {
     teamId: teamsDropdown.value,
     loginOption: agentDeviceType,
     dialNumber: dialNumber.value
-  }).then((response) => {
+  })
+  .then((response) => {
     console.log('Agent Logged in successfully', response);
     loginAgentElm.disabled = true;
     logoutAgentElm.classList.remove('hidden');
-    updateUnregisterButtonState();
-    
+    updateProfileElm.classList.remove('hidden');
     // Read auxCode and lastStateChangeTimestamp from login response
     const DEFAULT_CODE = '0'; // Default code when no aux code is present
     const auxCodeId = response.data.auxCodeId?.trim() !== '' ? response.data.auxCodeId : DEFAULT_CODE;
@@ -1067,9 +1100,12 @@ function setAgentStatus() {
 
 
 function logoutAgent() {
-  webex.cc.stationLogout({logoutReason: 'logout'}).then((response) => {
-    console.log('Agent logged out successfully', response);
-    loginAgentElm.disabled = false;
+  webex.cc.stationLogout({logoutReason: 'logout'})
+    .then((response) => {
+      console.log('Agent logged out successfully', response);
+      loginAgentElm.disabled = false;
+      updateProfileElm.classList.add('hidden');
+      updateFieldsContainer.classList.add('hidden');
 
      // Clear the timer when the agent logs out.
      if (stateTimer) {
@@ -1091,6 +1127,50 @@ function logoutAgent() {
   ).catch((error) => {
     console.log('Agent logout failed', error);
   });
+}
+
+async function updateProfile() {
+  const payload = {
+    teamId: teamsDropdown.value,
+    loginOption: agentDeviceType,
+    dialNumber: dialNumber.value
+  };
+  try {
+    const response = await webex.cc.updateProfile(payload);
+    console.log('Profile updated successfully', response);
+  }
+  catch (error) {
+    console.error('Profile update failed', error);
+    alert('Profile update failed');
+  }
+}
+
+function showUpdateProfileUI() {
+  updateFieldsContainer.classList.toggle('hidden');
+}
+
+async function applyUpdateProfile() {
+  const loginOption = updateLoginOptionElm.value;
+  const newDial = loginOption === 'BROWSER' ? '' : updateDialNumberElm.value;
+  const payload = {
+    teamId: teamsDropdown.value,
+    loginOption,
+    dialNumber: newDial,
+  };
+  try {
+    const resp = await webex.cc.updateProfile(payload);
+    console.log('Profile updated', resp);
+    updateFieldsContainer.classList.add('hidden');
+    // Reflect new values in main UI
+    agentLogin.value = loginOption;
+    agentDeviceType = loginOption;
+    dialNumber.value = newDial;
+    dialNumber.disabled = loginOption === 'BROWSER';
+  }
+  catch (err) {
+    console.error('Profile update failed', err);
+    alert('Profile update failed');
+  }
 }
 
 function showAgentStatePopup(reason) {
@@ -1557,3 +1637,20 @@ function loadEmailWidget(task) {
     ></imi-email-composer>
   `;
 }
+
+function populateLoginOptions(options) {
+  agentLogin.innerHTML = '<option value="" selected>Choose Agent Login …</option>';
+  updateLoginOptionElm.innerHTML = '<option value="" selected>Choose Login Option …</option>';
+  options.forEach((opt) => {
+    const opt1 = document.createElement('option');
+    opt1.value = opt1.text = opt;
+    agentLogin.add(opt1);
+    updateLoginOptionElm.add(opt1.cloneNode(true));
+  });
+}
+
+updateLoginOptionElm.addEventListener('change', (e) => {
+  updateDialNumberElm.disabled = e.target.value === 'BROWSER';
+});
+
+idleCodesDropdown.addEventListener('change', handleAgentStatus);

--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -130,14 +130,14 @@
                   <input id="dialNumber" name="dialNumber" placeholder="Dial Number" value="" type="text">
                   <button id="loginAgent" disabled class="btn btn-primary my-3" onclick="doAgentLogin()">Login</button>
                   <button id="logoutAgent" class="btn btn-primary my-3 ml-2 hidden" onclick="logoutAgent()">Logout</button>
-                  <button id="updateProfile" class="btn btn-primary my-3 ml-2 hidden" onclick="showUpdateProfileUI()">Update Profile</button>
+                  <button id="updateAgentDeviceType" class="btn btn-primary my-3 ml-2 hidden" onclick="showupdateAgentDeviceTypeUI()">Update Profile</button>
 
-                  <div id="updateProfileFields" class="hidden" style="margin-top:1rem;">
+                  <div id="updateAgentDeviceTypeFields" class="hidden" style="margin-top:1rem;">
                     <select id="updateLoginOption" class="form-control w-auto">
                       <option value="" selected hidden>Choose Login Option …</option>
                     </select>
                     <input id="updateDialNumber" placeholder="Dial Number" value="" type="text" class="form-control w-auto my-2" />
-                    <button id="applyUpdateProfile" class="btn btn-secondary" onclick="applyUpdateProfile()">Apply</button>
+                    <button id="applyupdateAgentDeviceType" class="btn btn-secondary" onclick="applyupdateAgentDeviceType()">Apply</button>
                   </div>
                 </fieldset>
                 <fieldset style="display: flex; flex-direction: column; align-items: flex-start; gap: 10px;">

--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -130,6 +130,15 @@
                   <input id="dialNumber" name="dialNumber" placeholder="Dial Number" value="" type="text">
                   <button id="loginAgent" disabled class="btn btn-primary my-3" onclick="doAgentLogin()">Login</button>
                   <button id="logoutAgent" class="btn btn-primary my-3 ml-2 hidden" onclick="logoutAgent()">Logout</button>
+                  <button id="updateProfile" class="btn btn-primary my-3 ml-2 hidden" onclick="showUpdateProfileUI()">Update Profile</button>
+
+                  <div id="updateProfileFields" class="hidden" style="margin-top:1rem;">
+                    <select id="updateLoginOption" class="form-control w-auto">
+                      <option value="" selected hidden>Choose Login Option …</option>
+                    </select>
+                    <input id="updateDialNumber" placeholder="Dial Number" value="" type="text" class="form-control w-auto my-2" />
+                    <button id="applyUpdateProfile" class="btn btn-secondary" onclick="applyUpdateProfile()">Apply</button>
+                  </div>
                 </fieldset>
                 <fieldset style="display: flex; flex-direction: column; align-items: flex-start; gap: 10px;">
                   <legend>Agent status</legend>

--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -137,7 +137,7 @@
                       <option value="" selected hidden>Choose Login Option …</option>
                     </select>
                     <input id="updateDialNumber" placeholder="Dial Number" value="" type="text" class="form-control w-auto my-2" />
-                    <button id="applyupdateAgentDeviceType" class="btn btn-secondary" onclick="applyupdateAgentDeviceType()">Apply</button>
+                    <button id="applyupdateAgentDeviceType" class="btn btn-secondary" onclick="applyupdateAgentDeviceType()">Save</button>
                   </div>
                 </fieldset>
                 <fieldset style="display: flex; flex-direction: column; align-items: flex-start; gap: 10px;">

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -874,13 +874,29 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    * messages, and client-side events, then securely submits them to Webex's diagnostics
    * service. The returned tracking ID, feedbackID can be provided to Webex support for faster
    * issue resolution.
-   * @returns Promise<SubmitLogsResponse>
+   * @returns Promise<UploadLogsResponse>
    * @throws Error
    */
   public async uploadLogs(): Promise<UploadLogsResponse> {
     return this.webexRequest.uploadLogs();
   }
 
+  /**
+   * Updates the agent device type.
+   * This method allows the agent to change their device type (e.g., from BROWSER to EXTENSION or anything else).
+   * It will also throw an error if the new device type is the same as the current one.
+   * @param data - The data required to update the agent device type, including the new login option and dial number.
+   * @returns Promise<StationLoginResponse>
+   * @throws Error
+   * @example
+   * ```typescript
+   * const data = {
+   *   loginOption: 'EXTENSION',
+   *   dialNumber: '1234567890',
+   * };
+   * const result = await webex.cc.updateAgentDeviceType(data);
+   * ```
+   */
   public async updateAgentDeviceType(data: AgentDeviceUpdate): Promise<StationLoginResponse> {
     this.metricsManager.timeEvent([
       METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_SUCCESS,
@@ -895,12 +911,19 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     try {
       // ensure we change device type
       if (this.webCallingService?.loginOption === data.loginOption) {
-        const message = 'Device type is same as current device type';
+        const message = 'New Device type is same as current device type';
+        const trackingId = `WXCCSDK_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
         const err: any = new Error(message);
         err.details = {
+          type: 'Identical Device Change Failure',
+          orgId: this.$webex.credentials.getOrgId(),
+          trackingId,
           data: {
+            agentId: this.agentConfig.agentId,
+            trackingId,
+            reasonCode: 'R002',
+            orgId: this.$webex.credentials.getOrgId(),
             reason: message,
-            status: 400,
           },
         };
         throw err;

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -17,6 +17,7 @@ import {
   SubscribeRequest,
   UploadLogsResponse,
   UpdateDeviceTypeResponse,
+  GenericError,
 } from './types';
 import {
   READY,
@@ -919,7 +920,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       if (this.webCallingService?.loginOption === data.loginOption) {
         const message =
           'Will not proceed with device update as new Device type is same as current device type';
-        const err: any = new Error(message);
+        const err = new Error(message) as GenericError;
         err.details = {
           type: 'Identical Device Change Failure',
           orgId: this.$webex.credentials.getOrgId(),

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -879,4 +879,61 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   public async uploadLogs(): Promise<UploadLogsResponse> {
     return this.webexRequest.uploadLogs();
   }
+
+  public async updateProfile(data: AgentLogin): Promise<StationLoginResponse> {
+    this.metricsManager.timeEvent([
+      METRIC_EVENT_NAMES.PROFILE_UPDATE_SUCCESS,
+      METRIC_EVENT_NAMES.PROFILE_UPDATE_FAILED,
+    ]);
+
+    LoggerProxy.info('updateProfile | starting profile update', {
+      module: CC_FILE,
+      method: 'updateProfile',
+    });
+
+    try {
+      // Throw an error if the loginOption is of the same type as the current device type
+      if (this.webCallingService && this.webCallingService.loginOption === data.loginOption) {
+        throw new Error('Device type is same as current device type');
+      }
+
+      await this.stationLogout({
+        logoutReason: 'User requested logout',
+      });
+
+      const resp = await this.stationLogin(data);
+
+      this.metricsManager.trackEvent(
+        METRIC_EVENT_NAMES.PROFILE_UPDATE_SUCCESS,
+        {
+          ...MetricsManager.getCommonTrackingFieldForAQMResponse(resp),
+          loginType: data.loginOption,
+        },
+        ['behavioral', 'business', 'operational']
+      );
+
+      LoggerProxy.log('updateProfile | profile updated successfully', {
+        module: CC_FILE,
+        method: 'updateProfile',
+      });
+
+      return resp;
+    } catch (error) {
+      const failure = error.details as Failure;
+      this.metricsManager.trackEvent(
+        METRIC_EVENT_NAMES.PROFILE_UPDATE_FAILED,
+        {
+          ...MetricsManager.getCommonTrackingFieldForAQMResponseFailed(failure),
+          loginType: data.loginOption,
+        },
+        ['behavioral', 'business', 'operational']
+      );
+
+      LoggerProxy.error(`updateProfile | error updating profile: ${error}`, {
+        module: CC_FILE,
+        method: 'updateProfile',
+      });
+      throw error;
+    }
+  }
 }

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -907,7 +907,9 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED,
     ]);
 
-    LoggerProxy.info('updateAgentDeviceType | starting profile update', {
+    const trackingId = `WX_CC_SDK_${uuidv4()}`;
+
+    LoggerProxy.info(`[${trackingId}] updateAgentDeviceType | starting profile update`, {
       module: CC_FILE,
       method: this.updateAgentDeviceType.name,
     });
@@ -915,8 +917,8 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     try {
       // ensure we change device type
       if (this.webCallingService?.loginOption === data.loginOption) {
-        const message = 'New Device type is same as current device type';
-        const trackingId = `WX_CC_SDK_${uuidv4()}`;
+        const message =
+          'Will not proceed with device update as new Device type is same as current device type';
         const err: any = new Error(message);
         err.details = {
           type: 'Identical Device Change Failure',
@@ -924,7 +926,6 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           trackingId,
           data: {
             agentId: this.agentConfig.agentId,
-            trackingId,
             reasonCode: 'R002',
             orgId: this.$webex.credentials.getOrgId(),
             reason: message,
@@ -954,7 +955,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         ['behavioral', 'business', 'operational']
       );
 
-      LoggerProxy.log('updateAgentDeviceType | profile updated successfully', {
+      LoggerProxy.log(`[${trackingId}] updateAgentDeviceType | profile updated successfully`, {
         module: CC_FILE,
         method: this.updateAgentDeviceType.name,
       });
@@ -976,10 +977,13 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         ['behavioral', 'business', 'operational']
       );
 
-      LoggerProxy.error(`updateAgentDeviceType | error updating profile: ${error}`, {
-        module: CC_FILE,
-        method: this.updateAgentDeviceType.name,
-      });
+      LoggerProxy.error(
+        `[${trackingId}] updateAgentDeviceType | error updating profile: ${error}`,
+        {
+          module: CC_FILE,
+          method: this.updateAgentDeviceType.name,
+        }
+      );
       throw error;
     }
   }

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -15,6 +15,7 @@ import {
   BuddyAgents,
   SubscribeRequest,
   UploadLogsResponse,
+  UpdateDeviceTypeResponse,
 } from './types';
 import {
   READY,
@@ -886,7 +887,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    * This method allows the agent to change their device type (e.g., from BROWSER to EXTENSION or anything else).
    * It will also throw an error if the new device type is the same as the current one.
    * @param data - The data required to update the agent device type, including the new login option and dial number.
-   * @returns Promise<StationLoginResponse>
+   * @returns Promise<UpdateDeviceTypeResponse>
    * @throws Error
    * @example
    * ```typescript
@@ -897,7 +898,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    * const result = await webex.cc.updateAgentDeviceType(data);
    * ```
    */
-  public async updateAgentDeviceType(data: AgentDeviceUpdate): Promise<StationLoginResponse> {
+  public async updateAgentDeviceType(data: AgentDeviceUpdate): Promise<UpdateDeviceTypeResponse> {
     this.metricsManager.timeEvent([
       METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_SUCCESS,
       METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED,
@@ -956,7 +957,12 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         method: this.updateAgentDeviceType.name,
       });
 
-      return resp;
+      const deviceTypeUpdateResponse: UpdateDeviceTypeResponse = {
+        ...resp,
+        type: 'AgentDeviceTypeUpdateSuccess',
+      };
+
+      return deviceTypeUpdateResponse;
     } catch (error) {
       const failure = (error as any).details as Failure;
       this.metricsManager.trackEvent(

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -1,5 +1,6 @@
 import {WebexPlugin} from '@webex/webex-core';
 import EventEmitter from 'events';
+import {v4 as uuidv4} from 'uuid';
 import {
   SetStateResponse,
   CCPluginConfig,
@@ -886,7 +887,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    * Updates the agent device type.
    * This method allows the agent to change their device type (e.g., from BROWSER to EXTENSION or anything else).
    * It will also throw an error if the new device type is the same as the current one.
-   * @param data - The data required to update the agent device type, including the new login option and dial number.
+   * @param data type is AgentDeviceUpdate - The data required to update the agent device type, including the new login option and dial number.
    * @returns Promise<UpdateDeviceTypeResponse>
    * @throws Error
    * @example
@@ -913,7 +914,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       // ensure we change device type
       if (this.webCallingService?.loginOption === data.loginOption) {
         const message = 'New Device type is same as current device type';
-        const trackingId = `WXCCSDK_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+        const trackingId = `WX_CC_SDK_${uuidv4()}`;
         const err: any = new Error(message);
         err.details = {
           type: 'Identical Device Change Failure',
@@ -934,9 +935,8 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         logoutReason: 'User requested agent device change',
       });
 
-      const teamId = this.agentConfig?.teams?.[0]?.teamId ?? EMPTY_STRING;
       const loginPayload: AgentLogin = {
-        teamId,
+        teamId: data.teamId,
         loginOption: data.loginOption,
         dialNumber: data.dialNumber,
       };

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -928,7 +928,6 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           data: {
             agentId: this.agentConfig.agentId,
             reasonCode: 'R002',
-            orgId: this.$webex.credentials.getOrgId(),
             reason: message,
           },
         };
@@ -968,7 +967,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       return deviceTypeUpdateResponse;
     } catch (error) {
-      const failure = (error as any).details as Failure;
+      const failure = (error as GenericError).details as Failure;
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED,
         {

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -7,6 +7,7 @@ import {
   WebexSDK,
   LoginOption,
   AgentLogin,
+  AgentDeviceUpdate,
   StationLoginResponse,
   StationLogoutResponse,
   StationReLoginResponse,
@@ -880,31 +881,38 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     return this.webexRequest.uploadLogs();
   }
 
-  public async updateProfile(data: AgentLogin): Promise<StationLoginResponse> {
+  public async updateAgentDeviceType(data: AgentDeviceUpdate): Promise<StationLoginResponse> {
     this.metricsManager.timeEvent([
-      METRIC_EVENT_NAMES.PROFILE_UPDATE_SUCCESS,
-      METRIC_EVENT_NAMES.PROFILE_UPDATE_FAILED,
+      METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_SUCCESS,
+      METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED,
     ]);
 
-    LoggerProxy.info('updateProfile | starting profile update', {
+    LoggerProxy.info('updateAgentDeviceType | starting profile update', {
       module: CC_FILE,
-      method: 'updateProfile',
+      method: this.updateAgentDeviceType.name,
     });
 
     try {
-      // Throw an error if the loginOption is of the same type as the current device type
+      // ensure we change device type
       if (this.webCallingService && this.webCallingService.loginOption === data.loginOption) {
         throw new Error('Device type is same as current device type');
       }
 
       await this.stationLogout({
-        logoutReason: 'User requested logout',
+        logoutReason: 'User requested agent device change',
       });
 
-      const resp = await this.stationLogin(data);
+      const teamId = this.agentConfig?.teams?.[0]?.teamId ?? EMPTY_STRING;
+      const loginPayload: AgentLogin = {
+        teamId,
+        loginOption: data.loginOption,
+        dialNumber: data.dialNumber,
+      };
+
+      const resp = await this.stationLogin(loginPayload);
 
       this.metricsManager.trackEvent(
-        METRIC_EVENT_NAMES.PROFILE_UPDATE_SUCCESS,
+        METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_SUCCESS,
         {
           ...MetricsManager.getCommonTrackingFieldForAQMResponse(resp),
           loginType: data.loginOption,
@@ -912,16 +920,16 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         ['behavioral', 'business', 'operational']
       );
 
-      LoggerProxy.log('updateProfile | profile updated successfully', {
+      LoggerProxy.log('updateAgentDeviceType | profile updated successfully', {
         module: CC_FILE,
-        method: 'updateProfile',
+        method: this.updateAgentDeviceType.name,
       });
 
       return resp;
     } catch (error) {
-      const failure = error.details as Failure;
+      const failure = (error as any).details as Failure;
       this.metricsManager.trackEvent(
-        METRIC_EVENT_NAMES.PROFILE_UPDATE_FAILED,
+        METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED,
         {
           ...MetricsManager.getCommonTrackingFieldForAQMResponseFailed(failure),
           loginType: data.loginOption,
@@ -929,9 +937,9 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         ['behavioral', 'business', 'operational']
       );
 
-      LoggerProxy.error(`updateProfile | error updating profile: ${error}`, {
+      LoggerProxy.error(`updateAgentDeviceType | error updating profile: ${error}`, {
         module: CC_FILE,
-        method: 'updateProfile',
+        method: this.updateAgentDeviceType.name,
       });
       throw error;
     }

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -894,8 +894,16 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
     try {
       // ensure we change device type
-      if (this.webCallingService && this.webCallingService.loginOption === data.loginOption) {
-        throw new Error('Device type is same as current device type');
+      if (this.webCallingService?.loginOption === data.loginOption) {
+        const message = 'Device type is same as current device type';
+        const err: any = new Error(message);
+        err.details = {
+          data: {
+            reason: message,
+            status: 400,
+          },
+        };
+        throw err;
       }
 
       await this.stationLogout({

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -370,6 +370,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       const resp = await loginResponse;
       const {channelsMap, ...loginData} = resp.data;
+      this.agentConfig.currentTeamId = resp.data.teamId;
       const response = {
         ...loginData,
         mmProfile: {
@@ -702,6 +703,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       let {auxCodeId} = reLoginResponse.data;
       this.agentConfig.lastStateChangeTimestamp = lastStateChangeTimestamp;
       this.agentConfig.lastIdleCodeChangeTimestamp = lastIdleCodeChangeTimestamp;
+      this.agentConfig.currentTeamId = reLoginResponse.data.teamId;
       await this.handleDeviceType(deviceType as LoginOption, dn);
 
       if (lastStateChangeReason === 'agent-wss-disconnect') {
@@ -936,7 +938,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       });
 
       const loginPayload: AgentLogin = {
-        teamId: data.teamId,
+        teamId: this.agentConfig.currentTeamId ?? EMPTY_STRING,
         loginOption: data.loginOption,
         dialNumber: data.dialNumber,
       };

--- a/packages/@webex/plugin-cc/src/metrics/behavioral-events.ts
+++ b/packages/@webex/plugin-cc/src/metrics/behavioral-events.ts
@@ -271,6 +271,20 @@ const eventTaxonomyMap: Record<string, BehavioralEventTaxonomy> = {
     target: 'upload_logs',
     verb: 'fail',
   },
+
+  // update profile
+  [METRIC_EVENT_NAMES.PROFILE_UPDATE_SUCCESS]: {
+    product,
+    agent: 'user',
+    target: 'profile_update',
+    verb: 'complete',
+  },
+  [METRIC_EVENT_NAMES.PROFILE_UPDATE_FAILED]: {
+    product,
+    agent: 'user',
+    target: 'profile_update',
+    verb: 'fail',
+  },
 };
 
 export function getEventTaxonomy(name: METRIC_EVENT_NAMES): BehavioralEventTaxonomy | undefined {

--- a/packages/@webex/plugin-cc/src/metrics/behavioral-events.ts
+++ b/packages/@webex/plugin-cc/src/metrics/behavioral-events.ts
@@ -273,13 +273,13 @@ const eventTaxonomyMap: Record<string, BehavioralEventTaxonomy> = {
   },
 
   // update profile
-  [METRIC_EVENT_NAMES.PROFILE_UPDATE_SUCCESS]: {
+  [METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_SUCCESS]: {
     product,
     agent: 'user',
     target: 'profile_update',
     verb: 'complete',
   },
-  [METRIC_EVENT_NAMES.PROFILE_UPDATE_FAILED]: {
+  [METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED]: {
     product,
     agent: 'user',
     target: 'profile_update',

--- a/packages/@webex/plugin-cc/src/metrics/behavioral-events.ts
+++ b/packages/@webex/plugin-cc/src/metrics/behavioral-events.ts
@@ -276,13 +276,13 @@ const eventTaxonomyMap: Record<string, BehavioralEventTaxonomy> = {
   [METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_SUCCESS]: {
     product,
     agent: 'user',
-    target: 'profile_update',
+    target: 'agent_device_type_update',
     verb: 'complete',
   },
   [METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED]: {
     product,
     agent: 'user',
-    target: 'profile_update',
+    target: 'agent_device_type_update',
     verb: 'fail',
   },
 };

--- a/packages/@webex/plugin-cc/src/metrics/constants.ts
+++ b/packages/@webex/plugin-cc/src/metrics/constants.ts
@@ -50,6 +50,9 @@ export const METRIC_EVENT_NAMES = {
   UPLOAD_LOGS_FAILED: 'Upload Logs Failed',
   WEBSOCKET_DEREGISTER_SUCCESS: 'Websocket Deregister Success',
   WEBSOCKET_DEREGISTER_FAIL: 'Websocket Deregister Failed',
+
+  PROFILE_UPDATE_SUCCESS: 'Profile Update Success',
+  PROFILE_UPDATE_FAILED: 'Profile Update Failed',
 } as const;
 
 // Derive the type using the utility type

--- a/packages/@webex/plugin-cc/src/metrics/constants.ts
+++ b/packages/@webex/plugin-cc/src/metrics/constants.ts
@@ -51,8 +51,8 @@ export const METRIC_EVENT_NAMES = {
   WEBSOCKET_DEREGISTER_SUCCESS: 'Websocket Deregister Success',
   WEBSOCKET_DEREGISTER_FAIL: 'Websocket Deregister Failed',
 
-  PROFILE_UPDATE_SUCCESS: 'Profile Update Success',
-  PROFILE_UPDATE_FAILED: 'Profile Update Failed',
+  AGENT_DEVICE_TYPE_UPDATE_SUCCESS: 'Profile Update Success',
+  AGENT_DEVICE_TYPE_UPDATE_FAILED: 'Profile Update Failed',
 } as const;
 
 // Derive the type using the utility type

--- a/packages/@webex/plugin-cc/src/metrics/constants.ts
+++ b/packages/@webex/plugin-cc/src/metrics/constants.ts
@@ -51,8 +51,8 @@ export const METRIC_EVENT_NAMES = {
   WEBSOCKET_DEREGISTER_SUCCESS: 'Websocket Deregister Success',
   WEBSOCKET_DEREGISTER_FAIL: 'Websocket Deregister Failed',
 
-  AGENT_DEVICE_TYPE_UPDATE_SUCCESS: 'Profile Update Success',
-  AGENT_DEVICE_TYPE_UPDATE_FAILED: 'Profile Update Failed',
+  AGENT_DEVICE_TYPE_UPDATE_SUCCESS: 'Agent Device Type Update Success',
+  AGENT_DEVICE_TYPE_UPDATE_FAILED: 'Agent Device Type Update Failed',
 } as const;
 
 // Derive the type using the utility type

--- a/packages/@webex/plugin-cc/src/services/agent/types.ts
+++ b/packages/@webex/plugin-cc/src/services/agent/types.ts
@@ -108,6 +108,10 @@ export type StationLoginSuccessResponse = {
   notifsTrackingId: string;
 };
 
+export type DeviceTypeUpdateSuccess = Omit<StationLoginSuccessResponse, 'type'> & {
+  type: 'AgentDeviceTypeUpdateSuccess';
+};
+
 export type Logout = {
   logoutReason?:
     | 'User requested logout'

--- a/packages/@webex/plugin-cc/src/services/agent/types.ts
+++ b/packages/@webex/plugin-cc/src/services/agent/types.ts
@@ -108,7 +108,12 @@ export type StationLoginSuccessResponse = {
   notifsTrackingId: string;
 };
 
-export type Logout = {logoutReason?: 'User requested logout' | 'Inactivity Logout'};
+export type Logout = {
+  logoutReason?:
+    | 'User requested logout'
+    | 'Inactivity Logout'
+    | 'User requested agent device change';
+};
 
 export type AgentState = 'Available' | 'Idle' | 'RONA' | string;
 

--- a/packages/@webex/plugin-cc/src/services/config/types.ts
+++ b/packages/@webex/plugin-cc/src/services/config/types.ts
@@ -615,6 +615,7 @@ export type Profile = {
   tenantTimezone?: string;
   loginVoiceOptions?: LoginOption[];
   deviceType?: LoginOption;
+  currentTeamId?: string;
   webRtcEnabled: boolean;
   organizationIdleCodes?: Entity[];
   isRecordingManagementEnabled?: boolean;

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -282,6 +282,19 @@ export type BuddyAgents = {
   state?: 'Available' | 'Idle';
 };
 
+/**
+ * Generic CC SDK error containing structured details.
+ * details.data can be any structured object.
+ */
+export interface GenericError extends Error {
+  details: {
+    type: string;
+    orgId: string;
+    trackingId: string;
+    data: Record<string, any>;
+  };
+}
+
 export type StationLoginResponse = Agent.StationLoginSuccessResponse | Error;
 export type StationLogoutResponse = Agent.LogoutSuccess | Error;
 export type StationReLoginResponse = Agent.ReloginSuccess | Error;

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -247,7 +247,7 @@ export type AgentLogin = {
   loginOption: LoginOption;
 };
 
-export type AgentDeviceUpdate = Pick<AgentLogin, 'loginOption' | 'dialNumber'>;
+export type AgentDeviceUpdate = Pick<AgentLogin, 'teamId' | 'loginOption' | 'dialNumber'>;
 
 export type RequestBody =
   | SubscribeRequest

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -246,6 +246,9 @@ export type AgentLogin = {
 
   loginOption: LoginOption;
 };
+
+export type AgentDeviceUpdate = Pick<AgentLogin, 'loginOption' | 'dialNumber'>;
+
 export type RequestBody =
   | SubscribeRequest
   | Agent.Logout

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -287,3 +287,4 @@ export type StationLogoutResponse = Agent.LogoutSuccess | Error;
 export type StationReLoginResponse = Agent.ReloginSuccess | Error;
 export type SetStateResponse = Agent.StateChangeSuccess | Error;
 export type BuddyAgentsResponse = Agent.BuddyAgentsSuccess | Error;
+export type UpdateDeviceTypeResponse = Agent.DeviceTypeUpdateSuccess | Error;

--- a/packages/@webex/plugin-cc/src/types.ts
+++ b/packages/@webex/plugin-cc/src/types.ts
@@ -247,7 +247,7 @@ export type AgentLogin = {
   loginOption: LoginOption;
 };
 
-export type AgentDeviceUpdate = Pick<AgentLogin, 'teamId' | 'loginOption' | 'dialNumber'>;
+export type AgentDeviceUpdate = Pick<AgentLogin, 'loginOption' | 'dialNumber'>;
 
 export type RequestBody =
   | SubscribeRequest

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1615,12 +1615,12 @@ describe('webex.cc', () => {
     beforeEach(() => {
       webex.cc.agentConfig = {
         ...webex.cc.agentConfig,
-        teams: [{teamId: 'teamId'}],
+        currentTeamId: 'teamId',
       } as any;
     });
 
     it('should logout then login and return AgentDeviceTypeUpdateSuccess type', async () => {
-      const data = {loginOption: LoginOption.EXTENSION, dialNumber: '98765', teamId: 'teamId'};
+      const data = {loginOption: LoginOption.EXTENSION, dialNumber: '98765'};
       const mockResp = {
         eventType: 'AgentDesktopMessage',
         agentId: 'agentId',

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1611,73 +1611,72 @@ describe('webex.cc', () => {
     });
   });
 
-  describe('updateProfile', () => {
-    const data = {
-      loginOption: LoginOption.EXTENSION,
-      teamId: 'teamId',
-      dialNumber: '98765',
-    };
-
-    const mockStationLoginResponse = {
-      loginOption: data.loginOption,
-      agentId: 'agent1',
-      teamId: data.teamId,
-      siteId: 'site1',
-      roles: [AGENT],
-      trackingId: 'track123',
-      eventType: 'DESKTOP_MESSAGE',
-      mmProfile: { chat: 0, email: 0, social: 0, telephony: 0 },
-      notifsTrackingId: 'notifs123',
-    };
+  describe('updateAgentDeviceType', () => {
+    beforeEach(() => {
+      // provide a dummy team so CC picks it up
+      webex.cc.agentConfig = {
+        ...webex.cc.agentConfig,
+        teams: [{teamId: 'teamId'}],
+      } as any;
+    });
 
     it('should logout then login and return station login response', async () => {
-      const logoutSpy = jest
-        .spyOn(webex.cc, 'stationLogout')
-        .mockResolvedValue({} as any);
-      const loginSpy = jest
-        .spyOn(webex.cc, 'stationLogin')
-        .mockResolvedValue(mockStationLoginResponse as any);
+      const data = {
+        loginOption: LoginOption.EXTENSION,
+        dialNumber: '98765',
+      };
+      const mockStationLoginResponse = { /* ... */ };
+
+      const logoutSpy = jest.spyOn(webex.cc, 'stationLogout').mockResolvedValue({} as any);
+      const loginSpy = jest.spyOn(webex.cc, 'stationLogin').mockResolvedValue(mockStationLoginResponse as any);
       const trackSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
       const logSpy = jest.spyOn(LoggerProxy, 'log');
 
-      const result = await webex.cc.updateProfile(data);
+      const result = await webex.cc.updateAgentDeviceType(data);
 
-      expect(logoutSpy).toHaveBeenCalledWith({ logoutReason: 'User requested logout' });
-      expect(loginSpy).toHaveBeenCalledWith(data);
+      expect(logoutSpy).toHaveBeenCalledWith({logoutReason: 'User requested agent device change'});
+      expect(loginSpy).toHaveBeenCalledWith({
+        teamId: 'teamId',
+        loginOption: data.loginOption,
+        dialNumber: data.dialNumber,
+      });
       expect(trackSpy).toHaveBeenCalledWith(
-        METRIC_EVENT_NAMES.PROFILE_UPDATE_SUCCESS,
-        expect.objectContaining({ loginType: data.loginOption }),
+        METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_SUCCESS,
+        expect.objectContaining({loginType: data.loginOption}),
         ['behavioral', 'business', 'operational']
       );
-      expect(logSpy).toHaveBeenCalledWith('updateProfile | profile updated successfully', {
+      expect(logSpy).toHaveBeenCalledWith('updateAgentDeviceType | profile updated successfully', {
         module: CC_FILE,
-        method: 'updateProfile',
+        method: 'updateAgentDeviceType',
       });
       expect(result).toEqual(mockStationLoginResponse);
     });
 
-    it('should handle error during updateProfile and track failure', async () => {
+    it('should handle error during updateAgentDeviceType and track failure', async () => {
+      const data = {
+        loginOption: LoginOption.EXTENSION,
+        dialNumber: '98765',
+      };
       const error = new Error('update error');
       jest.spyOn(webex.cc, 'stationLogout').mockRejectedValue(error);
       const trackSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
       const errorSpy = jest.spyOn(LoggerProxy, 'error');
 
-      await expect(webex.cc.updateProfile(data)).rejects.toThrow(error);
+      await expect(webex.cc.updateAgentDeviceType(data)).rejects.toThrow(error);
       expect(trackSpy).toHaveBeenCalledWith(
-        METRIC_EVENT_NAMES.PROFILE_UPDATE_FAILED,
-        expect.objectContaining({ loginType: data.loginOption }),
+        METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED,
+        expect.objectContaining({loginType: data.loginOption}),
         ['behavioral', 'business', 'operational']
       );
       expect(errorSpy).toHaveBeenCalledWith(
-        `updateProfile | error updating profile: ${error}`,
-        { module: CC_FILE, method: 'updateProfile' }
+        `updateAgentDeviceType | error updating profile: ${error}`,
+        {module: CC_FILE, method: 'updateAgentDeviceType'}
       );
     });
 
     it('should throw when requested loginOption equals current device type', async () => {
       const data = {
         loginOption: LoginOption.BROWSER,
-        teamId: 'teamId',
         dialNumber: '11111',
       };
       // mock current device type
@@ -1685,17 +1684,17 @@ describe('webex.cc', () => {
       const trackSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
       const errorSpy = jest.spyOn(LoggerProxy, 'error');
 
-      await expect(webex.cc.updateProfile(data)).rejects.toThrow(
+      await expect(webex.cc.updateAgentDeviceType(data)).rejects.toThrow(
         'Device type is same as current device type'
       );
       expect(trackSpy).toHaveBeenCalledWith(
-        METRIC_EVENT_NAMES.PROFILE_UPDATE_FAILED,
+        METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED,
         expect.objectContaining({loginType: data.loginOption}),
         ['behavioral', 'business', 'operational']
       );
       expect(errorSpy).toHaveBeenCalledWith(
-        `updateProfile | error updating profile: Error: Device type is same as current device type`,
-        {module: CC_FILE, method: 'updateProfile'}
+        `updateAgentDeviceType | error updating profile: Error: Device type is same as current device type`,
+        {module: CC_FILE, method: 'updateAgentDeviceType'}
       );
     });
   });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1613,97 +1613,110 @@ describe('webex.cc', () => {
 
   describe('updateAgentDeviceType', () => {
     beforeEach(() => {
-      // provide a dummy team so CC picks it up
       webex.cc.agentConfig = {
         ...webex.cc.agentConfig,
         teams: [{teamId: 'teamId'}],
       } as any;
     });
 
-    it('should logout then login and return station login response', async () => {
-      const data = {
-        loginOption: LoginOption.EXTENSION,
+    it('should logout then login and return AgentDeviceTypeUpdateSuccess type', async () => {
+      const data = {loginOption: LoginOption.EXTENSION, dialNumber: '98765'};
+      const mockResp = {
+        eventType: 'AgentDesktopMessage',
+        agentId: 'agentId',
+        trackingId: 'track-1',
+        auxCodeId: 'aux-1',
+        teamId: 'teamId',
+        agentSessionId: 'sessId',
+        orgId: 'org-1',
+        interactionIds: ['i1'],
+        status: 'LoggedIn',
+        subStatus: 'Available',
+        siteId: 'site-1',
+        lastIdleCodeChangeTimestamp: 1,
+        lastStateChangeTimestamp: 2,
+        profileType: 'type',
+        mmProfile: {chat: 0, email: 0, social: 0, telephony: 0},
         dialNumber: '98765',
+        roles: ['role'],
+        supervisorSessionId: undefined,
+        notifsTrackingId: 'notif-1',
+        type: 'AgentDeviceTypeUpdateSuccess',
       };
-      const mockStationLoginResponse = { /* ... */ };
 
-      const logoutSpy = jest.spyOn(webex.cc, 'stationLogout').mockResolvedValue({} as any);
-      const loginSpy = jest.spyOn(webex.cc, 'stationLogin').mockResolvedValue(mockStationLoginResponse as any);
-      const trackSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
-      const logSpy = jest.spyOn(LoggerProxy, 'log');
+      jest.spyOn(webex.cc, 'stationLogout').mockResolvedValue({});
+      jest.spyOn(webex.cc, 'stationLogin').mockResolvedValue(mockResp as any);
 
       const result = await webex.cc.updateAgentDeviceType(data);
 
-      expect(logoutSpy).toHaveBeenCalledWith({logoutReason: 'User requested agent device change'});
-      expect(loginSpy).toHaveBeenCalledWith({
+      expect(webex.cc.stationLogout).toHaveBeenCalledWith({logoutReason: 'User requested agent device change'});
+      expect(webex.cc.stationLogin).toHaveBeenCalledWith({
         teamId: 'teamId',
         loginOption: data.loginOption,
         dialNumber: data.dialNumber,
       });
-      expect(trackSpy).toHaveBeenCalledWith(
-        METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_SUCCESS,
-        expect.objectContaining({loginType: data.loginOption}),
-        ['behavioral', 'business', 'operational']
-      );
-      expect(logSpy).toHaveBeenCalledWith('updateAgentDeviceType | profile updated successfully', {
-        module: CC_FILE,
-        method: 'updateAgentDeviceType',
-      });
-      expect(result).toEqual(mockStationLoginResponse);
+      expect(result).toEqual(mockResp);
     });
 
-    it('should handle error during updateAgentDeviceType and track failure', async () => {
-      const data = {
-        loginOption: LoginOption.EXTENSION,
-        dialNumber: '98765',
-      };
-      const error = new Error('update error');
-      jest.spyOn(webex.cc, 'stationLogout').mockRejectedValue(error);
-      const trackSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
-      const errorSpy = jest.spyOn(LoggerProxy, 'error');
+    it('should track failure and throw when stationLogout fails', async () => {
+      const data = {loginOption: LoginOption.EXTENSION, dialNumber: '98765'};
+      const err = new Error('logout failure');
+      jest.spyOn(webex.cc, 'stationLogout').mockRejectedValue(err);
+      const metricSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
+      const logSpy = jest.spyOn(LoggerProxy, 'error');
 
-      await expect(webex.cc.updateAgentDeviceType(data)).rejects.toThrow(error);
-      expect(trackSpy).toHaveBeenCalledWith(
+      await expect(webex.cc.updateAgentDeviceType(data)).rejects.toThrow(err);
+
+      expect(metricSpy).toHaveBeenCalledWith(
         METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED,
         expect.objectContaining({loginType: data.loginOption}),
-        ['behavioral', 'business', 'operational']
+        ['behavioral','business','operational']
       );
-      expect(errorSpy).toHaveBeenCalledWith(
-        `updateAgentDeviceType | error updating profile: ${error}`,
+      expect(logSpy).toHaveBeenCalledWith(
+        `updateAgentDeviceType | error updating profile: ${err}`,
         {module: CC_FILE, method: 'updateAgentDeviceType'}
       );
     });
 
-    it('should throw when requested loginOption equals current device type', async () => {
+    it('should track failure and throw when stationLogin fails', async () => {
+      const data = {loginOption: LoginOption.EXTENSION, dialNumber: '98765'};
+      jest.spyOn(webex.cc, 'stationLogout').mockResolvedValue({});
+      const loginErr = new Error('login failure');
+      jest.spyOn(webex.cc, 'stationLogin').mockRejectedValue(loginErr);
+      const metricSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
+      const logSpy = jest.spyOn(LoggerProxy, 'error');
+
+      await expect(webex.cc.updateAgentDeviceType(data)).rejects.toThrow(loginErr);
+
+      expect(metricSpy).toHaveBeenCalledWith(
+        METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED,
+        expect.objectContaining({loginType: data.loginOption}),
+        ['behavioral','business','operational']
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        `updateAgentDeviceType | error updating profile: ${loginErr}`,
+        {module: CC_FILE, method: 'updateAgentDeviceType'}
+      );
+    });
+
+    it('should throw with detailed error when loginOption equals current device type', async () => {
       jest.spyOn(Date, 'now').mockReturnValue(1000);
       jest.spyOn(Math, 'random').mockReturnValue(0.5);
-      const data = {
-        loginOption: LoginOption.BROWSER,
-        dialNumber: '11111',
-      };
-      // mock current device type
+
+      const data = {loginOption: LoginOption.BROWSER, dialNumber: '11111'};
       webex.cc.webCallingService.loginOption = data.loginOption;
 
-      try {
-        await webex.cc.updateAgentDeviceType(data);
-        fail('Expected error to be thrown');
-      }
-      catch (error: any) {
-        const expectedTrackingId = 'WXCCSDK_1000_500000';
-        expect(error.message).toBe('New Device type is same as current device type');
-        expect(error.details).toEqual({
+      await expect(webex.cc.updateAgentDeviceType(data)).rejects.toMatchObject({
+        message: 'New Device type is same as current device type',
+        details: expect.objectContaining({
           type: 'Identical Device Change Failure',
-          orgId: 'mockOrgId',
-          trackingId: expectedTrackingId,
-          data: {
+          trackingId: 'WXCCSDK_1000_500000',
+          data: expect.objectContaining({
             agentId: webex.cc.agentConfig.agentId,
-            trackingId: expectedTrackingId,
-            reasonCode: 'R002',
-            orgId: 'mockOrgId',
             reason: 'New Device type is same as current device type',
-          },
-        });
-      }
+          }),
+        }),
+      });
     });
   });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -34,7 +34,6 @@ import { METRIC_EVENT_NAMES } from '../../../src/metrics/constants';
 import Mercury from '@webex/internal-plugin-mercury';
 import WebexRequest from '../../../src/services/core/WebexRequest';
 
-
 jest.mock('../../../src/logger-proxy', () => ({
   __esModule: true,
   default: {
@@ -49,6 +48,7 @@ jest.mock('../../../src/services/config');
 jest.mock('../../../src/services/core/websocket/WebSocketManager');
 jest.mock('../../../src/services/core/websocket/connection-service');
 jest.mock('../../../src/services/WebCallingService');
+jest.mock('uuid', () => ({v4: () => 'mock-tracking-uuid'}));
 
 global.URL.createObjectURL = jest.fn(() => 'blob:http://localhost:3000/12345');
 
@@ -1620,7 +1620,7 @@ describe('webex.cc', () => {
     });
 
     it('should logout then login and return AgentDeviceTypeUpdateSuccess type', async () => {
-      const data = {loginOption: LoginOption.EXTENSION, dialNumber: '98765'};
+      const data = {loginOption: LoginOption.EXTENSION, dialNumber: '98765', teamId: 'teamId'};
       const mockResp = {
         eventType: 'AgentDesktopMessage',
         agentId: 'agentId',
@@ -1700,9 +1700,6 @@ describe('webex.cc', () => {
     });
 
     it('should throw with detailed error when loginOption equals current device type', async () => {
-      jest.spyOn(Date, 'now').mockReturnValue(1000);
-      jest.spyOn(Math, 'random').mockReturnValue(0.5);
-
       const data = {loginOption: LoginOption.BROWSER, dialNumber: '11111'};
       webex.cc.webCallingService.loginOption = data.loginOption;
 
@@ -1710,10 +1707,11 @@ describe('webex.cc', () => {
         message: 'New Device type is same as current device type',
         details: expect.objectContaining({
           type: 'Identical Device Change Failure',
-          trackingId: 'WXCCSDK_1000_500000',
+          trackingId: 'WX_CC_SDK_mock-tracking-uuid',
           data: expect.objectContaining({
             agentId: webex.cc.agentConfig.agentId,
             reason: 'New Device type is same as current device type',
+            trackingId: 'WX_CC_SDK_mock-tracking-uuid',
           }),
         }),
       });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1673,7 +1673,7 @@ describe('webex.cc', () => {
         ['behavioral','business','operational']
       );
       expect(logSpy).toHaveBeenCalledWith(
-        `updateAgentDeviceType | error updating profile: ${err}`,
+        `[WX_CC_SDK_mock-tracking-uuid] updateAgentDeviceType | error updating profile: ${err}`,
         {module: CC_FILE, method: 'updateAgentDeviceType'}
       );
     });
@@ -1694,7 +1694,7 @@ describe('webex.cc', () => {
         ['behavioral','business','operational']
       );
       expect(logSpy).toHaveBeenCalledWith(
-        `updateAgentDeviceType | error updating profile: ${loginErr}`,
+        `[WX_CC_SDK_mock-tracking-uuid] updateAgentDeviceType | error updating profile: ${loginErr}`,
         {module: CC_FILE, method: 'updateAgentDeviceType'}
       );
     });
@@ -1704,14 +1704,13 @@ describe('webex.cc', () => {
       webex.cc.webCallingService.loginOption = data.loginOption;
 
       await expect(webex.cc.updateAgentDeviceType(data)).rejects.toMatchObject({
-        message: 'New Device type is same as current device type',
+        message: 'Will not proceed with device update as new Device type is same as current device type',
         details: expect.objectContaining({
           type: 'Identical Device Change Failure',
           trackingId: 'WX_CC_SDK_mock-tracking-uuid',
           data: expect.objectContaining({
             agentId: webex.cc.agentConfig.agentId,
-            reason: 'New Device type is same as current device type',
-            trackingId: 'WX_CC_SDK_mock-tracking-uuid',
+            reason: 'Will not proceed with device update as new Device type is same as current device type',
           }),
         }),
       });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1675,27 +1675,35 @@ describe('webex.cc', () => {
     });
 
     it('should throw when requested loginOption equals current device type', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1000);
+      jest.spyOn(Math, 'random').mockReturnValue(0.5);
       const data = {
         loginOption: LoginOption.BROWSER,
         dialNumber: '11111',
       };
       // mock current device type
       webex.cc.webCallingService.loginOption = data.loginOption;
-      const trackSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
-      const errorSpy = jest.spyOn(LoggerProxy, 'error');
 
-      await expect(webex.cc.updateAgentDeviceType(data)).rejects.toThrow(
-        'Device type is same as current device type'
-      );
-      expect(trackSpy).toHaveBeenCalledWith(
-        METRIC_EVENT_NAMES.AGENT_DEVICE_TYPE_UPDATE_FAILED,
-        expect.objectContaining({loginType: data.loginOption}),
-        ['behavioral', 'business', 'operational']
-      );
-      expect(errorSpy).toHaveBeenCalledWith(
-        `updateAgentDeviceType | error updating profile: Error: Device type is same as current device type`,
-        {module: CC_FILE, method: 'updateAgentDeviceType'}
-      );
+      try {
+        await webex.cc.updateAgentDeviceType(data);
+        fail('Expected error to be thrown');
+      }
+      catch (error: any) {
+        const expectedTrackingId = 'WXCCSDK_1000_500000';
+        expect(error.message).toBe('New Device type is same as current device type');
+        expect(error.details).toEqual({
+          type: 'Identical Device Change Failure',
+          orgId: 'mockOrgId',
+          trackingId: expectedTrackingId,
+          data: {
+            agentId: webex.cc.agentConfig.agentId,
+            trackingId: expectedTrackingId,
+            reasonCode: 'R002',
+            orgId: 'mockOrgId',
+            reason: 'New Device type is same as current device type',
+          },
+        });
+      }
     });
   });
 });

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1610,4 +1610,93 @@ describe('webex.cc', () => {
       });
     });
   });
+
+  describe('updateProfile', () => {
+    const data = {
+      loginOption: LoginOption.EXTENSION,
+      teamId: 'teamId',
+      dialNumber: '98765',
+    };
+
+    const mockStationLoginResponse = {
+      loginOption: data.loginOption,
+      agentId: 'agent1',
+      teamId: data.teamId,
+      siteId: 'site1',
+      roles: [AGENT],
+      trackingId: 'track123',
+      eventType: 'DESKTOP_MESSAGE',
+      mmProfile: { chat: 0, email: 0, social: 0, telephony: 0 },
+      notifsTrackingId: 'notifs123',
+    };
+
+    it('should logout then login and return station login response', async () => {
+      const logoutSpy = jest
+        .spyOn(webex.cc, 'stationLogout')
+        .mockResolvedValue({} as any);
+      const loginSpy = jest
+        .spyOn(webex.cc, 'stationLogin')
+        .mockResolvedValue(mockStationLoginResponse as any);
+      const trackSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
+      const logSpy = jest.spyOn(LoggerProxy, 'log');
+
+      const result = await webex.cc.updateProfile(data);
+
+      expect(logoutSpy).toHaveBeenCalledWith({ logoutReason: 'User requested logout' });
+      expect(loginSpy).toHaveBeenCalledWith(data);
+      expect(trackSpy).toHaveBeenCalledWith(
+        METRIC_EVENT_NAMES.PROFILE_UPDATE_SUCCESS,
+        expect.objectContaining({ loginType: data.loginOption }),
+        ['behavioral', 'business', 'operational']
+      );
+      expect(logSpy).toHaveBeenCalledWith('updateProfile | profile updated successfully', {
+        module: CC_FILE,
+        method: 'updateProfile',
+      });
+      expect(result).toEqual(mockStationLoginResponse);
+    });
+
+    it('should handle error during updateProfile and track failure', async () => {
+      const error = new Error('update error');
+      jest.spyOn(webex.cc, 'stationLogout').mockRejectedValue(error);
+      const trackSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
+      const errorSpy = jest.spyOn(LoggerProxy, 'error');
+
+      await expect(webex.cc.updateProfile(data)).rejects.toThrow(error);
+      expect(trackSpy).toHaveBeenCalledWith(
+        METRIC_EVENT_NAMES.PROFILE_UPDATE_FAILED,
+        expect.objectContaining({ loginType: data.loginOption }),
+        ['behavioral', 'business', 'operational']
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        `updateProfile | error updating profile: ${error}`,
+        { module: CC_FILE, method: 'updateProfile' }
+      );
+    });
+
+    it('should throw when requested loginOption equals current device type', async () => {
+      const data = {
+        loginOption: LoginOption.BROWSER,
+        teamId: 'teamId',
+        dialNumber: '11111',
+      };
+      // mock current device type
+      webex.cc.webCallingService.loginOption = data.loginOption;
+      const trackSpy = jest.spyOn(mockMetricsManager, 'trackEvent');
+      const errorSpy = jest.spyOn(LoggerProxy, 'error');
+
+      await expect(webex.cc.updateProfile(data)).rejects.toThrow(
+        'Device type is same as current device type'
+      );
+      expect(trackSpy).toHaveBeenCalledWith(
+        METRIC_EVENT_NAMES.PROFILE_UPDATE_FAILED,
+        expect.objectContaining({loginType: data.loginOption}),
+        ['behavioral', 'business', 'operational']
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        `updateProfile | error updating profile: Error: Device type is same as current device type`,
+        {module: CC_FILE, method: 'updateProfile'}
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #<[CAI-6447](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6447)>

## This pull request addresses

* As per EPIC requirements, we need an option for the user to update their login type (ie profile) whilst they are already logged in, rather than _manually_ logging out and logging back in.
* SDK did not _directly_ support such a functionality.

## by making the following changes

* In the SDK, we expose a public method which takes in `LoginOption` as a data and it includes the new login type.
* This method internally calls logout and login successively and send correct metrics.
* Sample app changes and unit tests changes to incorporate this method and fix few issues.

Vidcast - https://app.vidcast.io/share/5f69a914-fafc-4184-ac3e-761fd77ff173

SS of metrics - 
![Screenshot 2025-05-13 at 4 37 21 PM](https://github.com/user-attachments/assets/47f2a61e-db37-4213-852c-5949e6aa1490)


SS of error with clean logs - 
![Screenshot 2025-05-14 at 8 43 49 PM](https://github.com/user-attachments/assets/632e7c02-f5dd-42d4-80bc-8c2806278bd2)


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Manually logged in / logged out and tried to change status.
* Changed the profile and tried to change status
* Changed profile and recieved calls on both EXTENSION and BROWSER
* Tried out consult and transfer flows on updated profile.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
