### PR TITLE
feat(plugin-cc): added social channel support to sample app

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -714,7 +714,7 @@ function updateCallControlUI(task) {
 
   if (isNew) {
     disableAllCallControls();
-  } else if (task.data.interaction.mediaType === 'chat' || task.data.interaction.mediaType === 'email') {
+  } else if (task.data.interaction.mediaType === 'chat' || task.data.interaction.mediaType === 'email' || task.data.interaction.mediaType == 'social') {
     holdResumeElm.disabled = true;
     muteElm.disabled = true;
     pauseResumeRecordingElm.disabled = true;
@@ -1501,7 +1501,7 @@ function enableAnswerDeclineButtons(task) {
     } else {
       incomingDetailsElm.innerText = `Call from ${callerDisplay}...please answer on the endpoint where the agent's extension is registered`;
     }
-  } else if (task.data.interaction.mediaType === 'chat') {
+  } else if (task.data.interaction.mediaType === 'chat' || task.data.interaction.mediaType === 'social') {
     answerElm.disabled = !isNew;
     declineElm.disabled = true;
     incomingDetailsElm.innerText = `Chat from ${callerDisplay}`;
@@ -1524,7 +1524,7 @@ function handleTaskSelect(task) {
   engageElm.innerHTML = ``;
   engageElm.style.height = "100px"
   currentTask = task
- if (task.data.interaction.mediaType === 'chat' && isBundleLoaded && !task.data.wrapUpRequired) {
+ if ((task.data.interaction.mediaType === 'chat' || task.data.interaction.mediaType == 'social') && isBundleLoaded && !task.data.wrapUpRequired) {
     loadChatWidget(task);
   } else if (task.data.interaction.mediaType === 'email' && isBundleLoaded && !task.data.wrapUpRequired) {
     loadEmailWidget(task);

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -711,10 +711,11 @@ function updateCallControlUI(task) {
   wrapupCodesDropdownElm.disabled = true;
   const hasParticipants = Object.keys(participants).length > 1;
   const isNew = task.data.interaction.state === 'new';
+  const digitalChannels = ['chat', 'email', 'social'];
 
   if (isNew) {
     disableAllCallControls();
-  } else if (task.data.interaction.mediaType === 'chat' || task.data.interaction.mediaType === 'email' || task.data.interaction.mediaType == 'social') {
+  } else if (digitalChannels.includes(task.data.interaction.mediaType)) {
     holdResumeElm.disabled = true;
     muteElm.disabled = true;
     pauseResumeRecordingElm.disabled = true;
@@ -1492,6 +1493,7 @@ function renderTaskList(taskList) {
 function enableAnswerDeclineButtons(task) {
   const callerDisplay = task.data.interaction?.callAssociatedDetails?.ani;
   const isNew = task.data.interaction.state === 'new'
+  const chatAndSocial = ['chat', 'social'];
   if (task.data.interaction.mediaType === 'telephony') {
     if (webex.cc.taskManager.webCallingService.loginOption === 'BROWSER') {
       answerElm.disabled = !isNew;
@@ -1501,7 +1503,7 @@ function enableAnswerDeclineButtons(task) {
     } else {
       incomingDetailsElm.innerText = `Call from ${callerDisplay}...please answer on the endpoint where the agent's extension is registered`;
     }
-  } else if (task.data.interaction.mediaType === 'chat' || task.data.interaction.mediaType === 'social') {
+  } else if (chatAndSocial.includes(task.data.interaction.mediaType)) {
     answerElm.disabled = !isNew;
     declineElm.disabled = true;
     incomingDetailsElm.innerText = `Chat from ${callerDisplay}`;
@@ -1523,8 +1525,9 @@ function handleTaskSelect(task) {
   enableAnswerDeclineButtons(task);
   engageElm.innerHTML = ``;
   engageElm.style.height = "100px"
+  const chatAndSocial = ['chat', 'social'];
   currentTask = task
- if ((task.data.interaction.mediaType === 'chat' || task.data.interaction.mediaType == 'social') && isBundleLoaded && !task.data.wrapUpRequired) {
+ if (chatAndSocial.includes(task.data.interaction.mediaType) && isBundleLoaded && !task.data.wrapUpRequired) {
     loadChatWidget(task);
   } else if (task.data.interaction.mediaType === 'email' && isBundleLoaded && !task.data.wrapUpRequired) {
     loadEmailWidget(task);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #ADHOC

## This pull request addresses
The missing social channel support in cc sdk samples
< DESCRIBE THE CONTEXT OF THE ISSUE >
currently CCSDK samples support chat and email as part of digital channels. We want to add facebook and other social channels as well.
## by making the following changes
Added additional condition of 'social' to the existing 'chat' condition.

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->
https://app.vidcast.io/share/bd5e6119-7002-4162-b733-effa05bb27f3
### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Initiate facebook chat from the facebook businesspage of sandbox and see the incoming task in sdk sample page.

Accept the task and see if the digital channels section loaded the facebookchat.

send and receive messages.

check task controls of chat visible or not. end the task and wrapup.(should work)


https://app.vidcast.io/share/bd5e6119-7002-4162-b733-effa05bb27f3


## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
