### PR TITLE
fix(plugin-meetings): fix brb state

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/brbState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/brbState.ts
@@ -95,6 +95,9 @@ export class BrbState {
     return this.sendLocalBrbStateToServer(sendSlotManager)
       .then(() => {
         this.state.syncToServerInProgress = false;
+
+        this.handleServerBrbUpdate(this.state.client.enabled);
+
         LoggerProxy.logger.info(
           `Meeting:brbState#applyClientStateToServer: sync with server completed`
         );

--- a/packages/@webex/plugin-meetings/src/meeting/brbState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/brbState.ts
@@ -96,6 +96,9 @@ export class BrbState {
       .then(() => {
         this.state.syncToServerInProgress = false;
 
+        // This is a workaround for the fact that the server does not send the brb state
+        // in the locus update when a user joins with multiple devices.
+        // In the future, this could be improved with a new brb locus update handler
         this.handleServerBrbUpdate(this.state.client.enabled);
 
         LoggerProxy.logger.info(

--- a/packages/@webex/plugin-meetings/src/meeting/brbState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/brbState.ts
@@ -99,6 +99,7 @@ export class BrbState {
         // This is a workaround for the fact that the server does not send the brb state
         // in the locus update when a user joins from multiple devices but not all devices are requested brb.
         // In the future, this could be improved with a new brb locus update handler
+        // https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-655626
         this.handleServerBrbUpdate(this.state.client.enabled);
 
         LoggerProxy.logger.info(

--- a/packages/@webex/plugin-meetings/src/meeting/brbState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/brbState.ts
@@ -97,7 +97,7 @@ export class BrbState {
         this.state.syncToServerInProgress = false;
 
         // This is a workaround for the fact that the server does not send the brb state
-        // in the locus update when a user joins with multiple devices.
+        // in the locus update when a user joins from multiple devices but not all devices are requested brb.
         // In the future, this could be improved with a new brb locus update handler
         this.handleServerBrbUpdate(this.state.client.enabled);
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/brbState.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/brbState.ts
@@ -110,5 +110,24 @@ describe('plugin-meetings', () => {
 
       assert.isTrue(brbState.state.server.enabled);
     });
+
+    it('invokes handleServerBrbUpdate with correct client state after syncing with server', async () => {
+      const sendLocalBrbStateToServerStub = sinon
+        .stub(brbState as any, 'sendLocalBrbStateToServer')
+        .resolves();
+
+      const handleServerBrbUpdateSpy = sinon.spy(brbState, 'handleServerBrbUpdate');
+
+      await brbState.enable(true, meeting.sendSlotManager);
+
+      assert.isTrue(sendLocalBrbStateToServerStub.calledOnce);
+
+      assert.isTrue(handleServerBrbUpdateSpy.calledOnceWith(brbState.state.client.enabled));
+
+      assert.isFalse(brbState.state.syncToServerInProgress);
+
+      sendLocalBrbStateToServerStub.restore();
+      handleServerBrbUpdateSpy.restore();
+    });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/brbState.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/brbState.ts
@@ -113,7 +113,7 @@ describe('plugin-meetings', () => {
 
     it('invokes handleServerBrbUpdate with correct client state after syncing with server', async () => {
       const sendLocalBrbStateToServerStub = sinon
-        .stub(brbState as any, 'sendLocalBrbStateToServer')
+        .stub(brbState, 'sendLocalBrbStateToServer')
         .resolves();
 
       const handleServerBrbUpdateSpy = sinon.spy(brbState, 'handleServerBrbUpdate');


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [SPARK-655626](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-655626)

## This pull request addresses

When a user steps away while using multiple devices during a single call, the SDK's existing logic waits for the 'brb' update state from the Locus side, that won't happen because locus will set brb update only after all devices request brb enabling. This results in unnecessary request loops on the client now. This PR addresses the issue by updating the logic to avoid these request loops and improve efficiency.

## by making the following changes

updates BrbState implementation for sendLocalBrbStateToServer

<!-- You may include screenshots -->

Vidcast for fix: https://app.vidcast.io/share/19135395-6eb2-4788-9289-5218cfaf12e3

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- unit tests
- web client manual and auto test cases

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
