### PR TITLE
fix(agent-config): unify-dn-label-across-responses

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -881,7 +881,7 @@ function register() {
         populateLoginOptions(
           loginVoiceOptions.filter((o) => agentProfile.webRtcEnabled || o !== 'BROWSER')
         );
-        dialNumber.value = agentProfile.dn ? agentProfile.dn : '';
+        dialNumber.value = agentProfile.dn ?? '';
         dialNumber.disabled = agentProfile.dn ? false : true;
         if (loginVoiceOptions.length > 0) loginAgentElm.disabled = false;
 

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -882,7 +882,7 @@ function register() {
           loginVoiceOptions.filter((o) => agentProfile.webRtcEnabled || o !== 'BROWSER')
         );
         dialNumber.value = agentProfile.dn ?? '';
-        dialNumber.disabled = agentProfile.dn ? false : true;
+        dialNumber.disabled = !agentProfile.dn;
         if (loginVoiceOptions.length > 0) loginAgentElm.disabled = false;
 
         if (agentProfile.isAgentLoggedIn) {

--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -881,8 +881,8 @@ function register() {
         populateLoginOptions(
           loginVoiceOptions.filter((o) => agentProfile.webRtcEnabled || o !== 'BROWSER')
         );
-        dialNumber.value = agentProfile.defaultDn ? agentProfile.defaultDn : '';
-        dialNumber.disabled = agentProfile.defaultDn ? false : true;
+        dialNumber.value = agentProfile.dn ? agentProfile.dn : '';
+        dialNumber.disabled = agentProfile.dn ? false : true;
         if (loginVoiceOptions.length > 0) loginAgentElm.disabled = false;
 
         if (agentProfile.isAgentLoggedIn) {

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -131,6 +131,8 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       this.setupEventListeners();
 
       const resp = await this.connectWebsocket();
+      // Ensure 'dn' is always populated from 'defaultDn'
+      resp.dn = resp.defaultDn;
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.WEBSOCKET_REGISTER_SUCCESS,
         {
@@ -766,6 +768,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       case LoginOption.AGENT_DN:
       case LoginOption.EXTENSION:
         this.agentConfig.defaultDn = dn;
+        this.agentConfig.dn = dn;
         break;
       default:
         LoggerProxy.error(`Unsupported device type: ${deviceType}`, {

--- a/packages/@webex/plugin-cc/src/services/config/types.ts
+++ b/packages/@webex/plugin-cc/src/services/config/types.ts
@@ -560,6 +560,7 @@ export type Profile = {
   };
   teams: Team[];
   defaultDn: string;
+  dn?: string;
   forceDefaultDn: boolean;
   forceDefaultDnForAgent: boolean;
   regexUS: RegExp | string;

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1154,7 +1154,7 @@ describe('webex.cc', () => {
       await webex.cc['silentRelogin']();
 
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.EXTENSION);
-      expect(webex.cc.agentConfig.defaultDn).toBe('12345');
+      expect(webex.cc.agentConfig.dn).toBe('12345');
       expect(webex.cc.agentConfig.lastStateAuxCodeId).toBe('auxCodeId');
       expect(webex.cc.agentConfig.lastStateChangeTimestamp).toStrictEqual(1738575135188);
       expect(webex.cc.agentConfig.lastIdleCodeChangeTimestamp).toStrictEqual(1738575135189);
@@ -1184,7 +1184,7 @@ describe('webex.cc', () => {
       await webex.cc['silentRelogin']();
 
       expect(webex.cc.agentConfig.deviceType).toBe(LoginOption.AGENT_DN);
-      expect(webex.cc.agentConfig.defaultDn).toBe('67890');
+      expect(webex.cc.agentConfig.dn).toBe('67890');
     });
   });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6467

The inconsistency in dial number labeling across SDK responses. Previously, the label was defaultDn in the Register response, while it appeared as dn in the multi-session event (CC_EVENTS.AGENT_STATION_LOGIN_SUCCESS). This implementation standardizes the label to dn across all relevant responses for consumers of the SDK.

Jira Link: https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6467

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

Updated cc.ts to assign the dial number value using dn instead of defaultDn in the register method.

Modified the Profile type definition to use dn for consistency.

Updated relevant test cases to reflect the change from defaultDn to dn.

Updated app.js to consume the dn property instead of defaultDn.

<!-- You may include screenshots -->
<img width="1111" alt="Screenshot 2025-05-23 at 5 56 53 PM" src="https://github.com/user-attachments/assets/f10bfece-342b-4469-b556-21c70c4299ab" />

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
