### PR TITLE
feat(appai): add disableWebRedirect:true and handle 307 -> 404 error

### DIFF
--- a/packages/@webex/http-core/src/interceptors/http-status.js
+++ b/packages/@webex/http-core/src/interceptors/http-status.js
@@ -6,6 +6,7 @@ import HttpError from '../http-error';
 import Interceptor from '../lib/interceptor';
 
 const LOCUS_REDIRECT_ERROR = 2000002;
+const APPAPI_REDIRECT_ERROR = 404100;
 
 /**
  * @class
@@ -50,6 +51,14 @@ export default class HttpStatusInterceptor extends Interceptor {
         response.statusCode === 404 &&
         response.body &&
         response.body.errorCode === LOCUS_REDIRECT_ERROR
+      ) {
+        return Promise.resolve(response);
+      }
+      // to handle appapi redirects
+      if (
+        response.statusCode === 404 &&
+        response.body &&
+        response.body.code === APPAPI_REDIRECT_ERROR
       ) {
         return Promise.resolve(response);
       }

--- a/packages/@webex/http-core/test/unit/spec/interceptors/http-status.js
+++ b/packages/@webex/http-core/test/unit/spec/interceptors/http-status.js
@@ -43,6 +43,18 @@ describe('http-core', () => {
 
           assert.isRejected(interceptor.onResponse({}, response));
         });
+        it('resolves on appapi redirect error', () => {
+          const response = {
+            statusCode: 404,
+            body: {
+              code: 404100,
+            },
+          };
+
+          return interceptor.onResponse({}, response).then((result) => {
+            assert.equal(result, response);
+          });
+        });
       });
     });
   });

--- a/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
@@ -617,6 +617,7 @@ export default class MeetingInfoV2 {
    * @param {Object} extraParams
    * @param {Object} options
    * @param {String} registrationId
+   * @param {String} fullSiteUrl
    * @returns {Promise} returns a meeting info object
    * @public
    * @memberof MeetingInfo
@@ -633,7 +634,8 @@ export default class MeetingInfoV2 {
     locusId = null,
     extraParams: object = {},
     options: {meetingId?: string; sendCAevents?: boolean} = {},
-    registrationId: string = null
+    registrationId: string = null,
+    fullSiteUrl: string = null
   ) {
     const {meetingId, sendCAevents} = options;
 
@@ -659,6 +661,7 @@ export default class MeetingInfoV2 {
       locusId,
       extraParams,
       registrationId,
+      disableWebRedirect: true,
     });
 
     // If the body only contains the default properties, we don't have enough to
@@ -684,7 +687,9 @@ export default class MeetingInfoV2 {
 
     const directURI = await MeetingInfoUtil.getDirectMeetingInfoURI(destinationType);
 
-    if (directURI) {
+    if (fullSiteUrl) {
+      requestOptions.uri = `https://${fullSiteUrl}/wbxappapi/v1/meetingInfo`;
+    } else if (directURI) {
       requestOptions.uri = directURI;
     } else {
       requestOptions.service = WBXAPPAPI_SERVICE;

--- a/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/utilv2.ts
@@ -237,6 +237,7 @@ export default class MeetingInfoUtil {
       locusId,
       extraParams,
       registrationId,
+      disableWebRedirect,
     } = options;
     const body: any = {
       ...DEFAULT_MEETING_INFO_REQUEST_BODY,
@@ -294,6 +295,10 @@ export default class MeetingInfoUtil {
 
     if (locusId) {
       body.locusId = locusId;
+    }
+
+    if (disableWebRedirect) {
+      body.disableWebRedirect = disableWebRedirect;
     }
 
     return body;

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -511,6 +511,7 @@ describe('plugin-meetings', () => {
             password: 'abc',
             captchaID: '999',
             captchaVerifyCode: 'aabbcc11',
+            disableWebRedirect: true
           },
         });
         assert.deepEqual(result, requestResponse);
@@ -544,6 +545,7 @@ describe('plugin-meetings', () => {
             supportCountryList: true,
             meetingKey: '1234323',
             installedOrgID,
+            disableWebRedirect: true
           },
         });
         assert.deepEqual(result, requestResponse);
@@ -578,6 +580,7 @@ describe('plugin-meetings', () => {
             supportCountryList: true,
             meetingKey: '1234323',
             locusId,
+            disableWebRedirect: true
           },
         });
         assert.deepEqual(result, requestResponse);
@@ -613,6 +616,7 @@ describe('plugin-meetings', () => {
             supportCountryList: true,
             meetingKey: '1234323',
             ...extraParams,
+            disableWebRedirect: true
           },
         });
         assert.deepEqual(result, requestResponse);
@@ -843,6 +847,7 @@ describe('plugin-meetings', () => {
                 supportCountryList: true,
                 meetingKey: '1234323',
                 ...extraParams,
+                disableWebRedirect: true
               },
             });
             assert.deepEqual(result, requestResponse);
@@ -922,6 +927,7 @@ describe('plugin-meetings', () => {
             supportCountryList: true,
             meetingKey: '1234323',
             ...extraParams,
+            disableWebRedirect: true
           },
         });
         assert.deepEqual(result, requestResponse);

--- a/packages/@webex/webex-core/src/interceptors/redirect.js
+++ b/packages/@webex/webex-core/src/interceptors/redirect.js
@@ -10,6 +10,7 @@ import {Interceptor} from '@webex/http-core';
 const requestHeaderName = 'cisco-no-http-redirect';
 const responseHeaderName = 'cisco-location';
 const LOCUS_REDIRECT_ERROR = 2000002;
+const APPAPI_REDIRECT_ERROR = 404100;
 
 /**
  * @class
@@ -90,6 +91,26 @@ export default class RedirectInterceptor extends Interceptor {
         // for GET requests
         options.uri = response.body.location;
       }
+
+      this.webex.logger.warn('redirect: url redirects needed to', options.uri);
+      options.$redirectCount += 1;
+      if (options.$redirectCount > this.webex.config.maxLocusRedirects) {
+        return Promise.reject(new Error('Maximum redirects exceeded'));
+      }
+
+      return this.webex.request(options);
+    } else if (
+      response.headers &&
+      response.body &&
+      response.body.code === APPAPI_REDIRECT_ERROR &&
+      response.body.data &&
+      response.body.data.siteFullUrl
+    ) {
+      options = clone(options);
+
+      this.webex.logger.warn('redirect: url redirects needed from', options.uri);
+
+      options.uri = options.uri.replace(/(?<=https:\/\/)[^/]+/, response.body.data.siteFullUrl);
 
       this.webex.logger.warn('redirect: url redirects needed to', options.uri);
       options.$redirectCount += 1;

--- a/packages/@webex/webex-core/test/unit/spec/interceptors/redirect.js
+++ b/packages/@webex/webex-core/test/unit/spec/interceptors/redirect.js
@@ -96,6 +96,25 @@ describe('webex-core', () => {
 
           assert.equal(interceptor.onResponse({$redirectCount: 5}, response), response);
         });
+
+        it('redirects GET requests to new url on appapi redirect error', () => {
+          const response = {
+            statusCode: 404,
+            headers: {},
+            body: {
+              code: 404100,
+              data: {
+                siteFullUrl: 'newlocus.example.com'
+              },
+            },
+          };
+
+          interceptor.onResponse({$redirectCount: 0, uri: 'https://test.webex.com/meet/v1/join'}, response);
+          sinon.assert.calledWith(webex.request, {
+            $redirectCount: 1,
+            uri: 'https://newlocus.example.com/meet/v1/join',
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-661053

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >

## by making the following changes

< DESCRIBE YOUR CHANGES >
according the document
https://sqbu-github.cisco.com/sveluval/docs/wiki/Handling-Redirects
webex AppAPI will check whether we will do 307 Redirect, if match replace to return 404 status and error json.
web client use new siteurl to call /meetingInfo API again.


<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [X] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [X] I have not skipped any automated checks
- [X] All existing and new tests passed
- [X] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
