### PR TITLE
chore(node-kms): bump to 0.4.1

### DIFF
--- a/packages/@webex/internal-plugin-encryption/package.json
+++ b/packages/@webex/internal-plugin-encryption/package.json
@@ -50,7 +50,7 @@
     "isomorphic-webcrypto": "^2.3.8",
     "lodash": "^4.17.21",
     "node-jose": "^2.2.0",
-    "node-kms": "^0.4.0",
+    "node-kms": "^0.4.1",
     "node-scr": "^0.3.0",
     "pkijs": "^2.1.84",
     "safe-buffer": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8361,7 +8361,7 @@ __metadata:
     isomorphic-webcrypto: ^2.3.8
     lodash: ^4.17.21
     node-jose: ^2.2.0
-    node-kms: ^0.4.0
+    node-kms: ^0.4.1
     node-scr: ^0.3.0
     pkijs: ^2.1.84
     prettier: ^2.7.1
@@ -26282,16 +26282,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-kms@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "node-kms@npm:0.4.0"
+"node-kms@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "node-kms@npm:0.4.1"
   dependencies:
     es6-promise: ^2.0.1
     lodash.clone: ^3.0.2
     lodash.clonedeep: ^3.0.1
-    node-jose: ^2.0.0
+    node-jose: ^2.2.0
     uuid: ^2.0.1
-  checksum: 00d27958ec84c1dac786ddcaccf227e619bbd201943467620a18df4128d1e79f3a69742f9bdf1fd9a4cafe1e3a554b99b353c718c55063bf75f71b2b66af8fad
+  checksum: e68542feac20ef35e575811c4ad6255b41ae5888c9c5a5b68604fc964c956a5b9f478fe5ee587f172d697e57121b78cecd6101a0dc007bd627a9c4d23dd5707f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES #[SPARK-670966](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-670966)

## This pull request addresses

- security vulnerability https://github.com/cisco/node-jose/security/advisories/GHSA-5h4j-qrvg-9xhw

## by making the following changes

- in @webex/internal-plugin-encryption, bump node-kms version to 0.4.1, which contains the bump for node-jose 2.2.0

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [x] I have updated the documentation accordingly