### PR TITLE
fix(plugin-cc): fixed-multisession-team-update

### DIFF
--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -965,7 +965,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    * @private
    * @param {string} event The raw websocket event message
    */
-  private handleWebsocketMessage = (event: string) => {
+  private handleWebsocketMessage = async (event: string) => {
     const eventData = JSON.parse(event);
     // Re-emit all the events related to agent except keep-alives
     if (!eventData.keepalive && eventData.data && eventData.data.type) {
@@ -1013,6 +1013,10 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           notifsTrackingId: eventData.trackingId,
         };
         this.webCallingService.setLoginOption(loginData.deviceType as LoginOption);
+        this.agentConfig = await this.services.config.getAgentConfig(
+          loginData.orgId,
+          loginData.agentId
+        );
         // @ts-ignore
         this.emit(AGENT_EVENTS.AGENT_STATION_LOGIN_SUCCESS, stationLoginData);
         break;

--- a/packages/@webex/plugin-cc/src/cc.ts
+++ b/packages/@webex/plugin-cc/src/cc.ts
@@ -965,7 +965,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
    * @private
    * @param {string} event The raw websocket event message
    */
-  private handleWebsocketMessage = async (event: string) => {
+  private handleWebsocketMessage = (event: string) => {
     const eventData = JSON.parse(event);
     // Re-emit all the events related to agent except keep-alives
     if (!eventData.keepalive && eventData.data && eventData.data.type) {
@@ -1013,10 +1013,17 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           notifsTrackingId: eventData.trackingId,
         };
         this.webCallingService.setLoginOption(loginData.deviceType as LoginOption);
-        this.agentConfig = await this.services.config.getAgentConfig(
-          loginData.orgId,
-          loginData.agentId
-        );
+        this.services.config
+          .getAgentConfig(loginData.orgId, loginData.agentId)
+          .then((cfg) => {
+            this.agentConfig = cfg;
+          })
+          .catch((err) => {
+            LoggerProxy.error(`Error fetching agent config on station login: ${err}`, {
+              module: CC_FILE,
+              method: METHODS.HANDLE_WEBSOCKET_MESSAGE,
+            });
+          });
         // @ts-ignore
         this.emit(AGENT_EVENTS.AGENT_STATION_LOGIN_SUCCESS, stationLoginData);
         break;

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -112,7 +112,10 @@ describe('webex.cc', () => {
         buddyAgents: jest.fn(),
       },
       config: {
-        getAgentConfig: jest.fn(),
+         getAgentConfig: jest.fn().mockResolvedValue({
+          agentId: 'testAgentId',
+          orgId: 'testOrgId',
+        }),
       },
       webSocketManager: mockWebSocketManager,
       connectionService: {
@@ -1699,7 +1702,7 @@ describe('webex.cc', () => {
 
       messageCallback(JSON.stringify(payload));
 
-      expect(emitSpy).toHaveBeenCalledTimes(1);
+      expect(emitSpy).toHaveBeenCalledTimes(2);
       expect(emitSpy).toHaveBeenCalledWith(
         CC_EVENTS.AGENT_STATION_LOGIN_SUCCESS,
         payload.data

--- a/packages/@webex/plugin-cc/test/unit/spec/cc.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/cc.ts
@@ -1699,20 +1699,11 @@ describe('webex.cc', () => {
 
       messageCallback(JSON.stringify(payload));
 
-      expect(emitSpy).toHaveBeenNthCalledWith(2, AGENT_EVENTS.AGENT_STATION_LOGIN_SUCCESS, {
-        agentId: 'agent-id',
-        teamId: 'team-id',
-        siteId: 'site-id',
-        roles: ['role1', 'role2'],
-        mmProfile: {
-          chat: 2,
-          email: 0,
-          social: 1,
-          telephony: 0,
-        },
-        notifsTrackingId: 'track-123',
-        type: CC_EVENTS.AGENT_STATION_LOGIN_SUCCESS,
-      });
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      expect(emitSpy).toHaveBeenCalledWith(
+        CC_EVENTS.AGENT_STATION_LOGIN_SUCCESS,
+        payload.data
+      );
     });
 
     it('should emit AGENT_RELOGIN_SUCCESS on CC_EVENTS.AGENT_RELOGIN_SUCCESS with mapped payload', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< AD-HOC >

## This pull request addresses

* While testing update agent profile in widgets, we found an issue in an edge case.
* If we had multiple tabs open and we changes the team on one tab, saved changed team once more and then tried to change the team on the second tab, we were getting an error.
* Reason was `agentConfig` of the SDK was not getting updated on the second tab.
* It was a very corner edge case which we could not test on SDK because we did not test in multi session.

## by making the following changes

* Added code to ensure we update the agent config on `AGENT_STATION_LOGIN_SUCCESS`.



### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested updating agent profile in sdk sample app
* Testing by locally linking widgets is a WIP.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
