### PR TITLE
fix(webex-core): add fedramp domains to ensure catalog can find valid domains

### DIFF
--- a/packages/@webex/webex-core/src/lib/services/constants.js
+++ b/packages/@webex/webex-core/src/lib/services/constants.js
@@ -19,7 +19,12 @@ const COMMERCIAL_ALLOWED_DOMAINS = [
 ];
 
 // The default FedRAMP domains that SDK can make requests to outside of service catalog
-const FEDRAMP_ALLOWED_DOMAINS = ['gov.ciscospark.com', 'webex.com'];
+const FEDRAMP_ALLOWED_DOMAINS = [
+  'gov.ciscospark.com',
+  'gov.webex.com',
+  'webexgobv.us',
+  'wxgovtest.webex.com',
+];
 
 export {
   SERVICE_CATALOGS_ENUM_TYPES,

--- a/packages/@webex/webex-core/src/lib/services/constants.js
+++ b/packages/@webex/webex-core/src/lib/services/constants.js
@@ -18,4 +18,13 @@ const COMMERCIAL_ALLOWED_DOMAINS = [
   'broadcloudpbx.net',
 ];
 
-export {SERVICE_CATALOGS_ENUM_TYPES, NAMESPACE, SERVICE_CATALOGS, COMMERCIAL_ALLOWED_DOMAINS};
+// The default FedRAMP domains that SDK can make requests to outside of service catalog
+const FEDRAMP_ALLOWED_DOMAINS = ['gov.ciscospark.com', 'webex.com'];
+
+export {
+  SERVICE_CATALOGS_ENUM_TYPES,
+  NAMESPACE,
+  SERVICE_CATALOGS,
+  COMMERCIAL_ALLOWED_DOMAINS,
+  FEDRAMP_ALLOWED_DOMAINS,
+};

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -8,7 +8,7 @@ import ServiceCatalog from './service-catalog';
 import ServiceRegistry from './service-registry';
 import ServiceState from './service-state';
 import fedRampServices from './service-fed-ramp';
-import {COMMERCIAL_ALLOWED_DOMAINS} from './constants';
+import {COMMERCIAL_ALLOWED_DOMAINS, FEDRAMP_ALLOWED_DOMAINS} from './constants';
 
 const trailingSlashes = /(?:^\/)|(?:\/$)/;
 
@@ -1002,6 +1002,8 @@ const Services = WebexPlugin.extend({
       // if not fedramp, append on the commercialAllowedDomains
       if (!fedramp) {
         services.allowedDomains = union(services.allowedDomains, COMMERCIAL_ALLOWED_DOMAINS);
+      } else {
+        services.allowedDomains = union(services.allowedDomains, FEDRAMP_ALLOWED_DOMAINS);
       }
 
       // Check for allowed host domains.


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [SPARK-672516](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-672516)

## This pull request addresses

We are unable to enable transcriptions in meetings in the FedRAMP environment. This is happening due to a 401 error arriving from the board.gov.ciscospark.com service.
```
POST https://board.gov.ciscospark.com/datachannel/api/v1/locus/aHR0cHM6Ly9sb2N1cy5nb3YuY2lzY29zcGFyay5jb20vbG9jdXMvYXBpL3YxL2xvY2kvNTdkNzdlMWQtZWJjZC0zYjI0LWI1NzktYjRjNzg3ZWEwNjc0/registrations
```
The reason for failure is token not being sent by the SDK.
`requiresCredentials` is responsible for checking whether a particular request needs to go out with the access token or not. In FedRAMP, it determines that the token shouldn't be sent.
Meeting tested with: varsha.ciscofedsales@ciscofedsales.webex.com

In this meeting, the trusted domain list is `[ciscofedsales.webex.com]` and no other domains are present in the trusted list.
In the commercial environment, the array looks like this:
```
[
    "wbx2.com",
    "ciscospark.com",
    "webex.com",
    "webexapis.com",
    "broadcloudpbx.com",
    "broadcloud.eu",
    "broadcloud.com.au",
    "broadcloudpbx.net",
]
```

Due to this difference, any URLs that do NOT match the catalog service entries will come to this valid domain checking and fail here as well. The board datachannel URL is an example of this.
We do not see this problem in Commercial and BTS because the valid domain check passes in those environments.

## by making the following changes

Adding a valid set of domains available for Webex services in FedRAMP.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Joined a meeting in FedRAMP environment and ensured that the transcription API was successful.
Linked the webex-js-sdk repo with the webex-web-client and tested joining a meeting from web.webex.com

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
