### PR TITLE
fix(plugin-cc): Add various case handling in AGENT_CONTACT event handler

### DIFF
--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -89,13 +89,52 @@ export default class TaskManager extends EventEmitter {
         });
         switch (payload.data.type) {
           case CC_EVENTS.AGENT_CONTACT:
-            task = new Task(this.contact, this.webCallingService, {
-              ...payload.data,
-              wrapUpRequired:
-                payload.data.interaction?.participants?.[payload.data.agentId]?.isWrapUp || false,
-            });
-            this.taskCollection[payload.data.interactionId] = task;
-            this.emit(TASK_EVENTS.TASK_HYDRATE, task);
+            // Case1 : Task is already present in taskCollection
+            if (this.taskCollection[payload.data.interactionId]) {
+              LoggerProxy.log(` Task already exists in collection`, {
+                module: TASK_MANAGER_FILE,
+                method: METHODS.REGISTER_TASK_LISTENERS,
+                interactionId: payload.data.interactionId,
+              });
+              break;
+            }
+            // Case2 : Task is not present in taskCollection
+            else if (!this.taskCollection[payload.data.interactionId]) {
+              LoggerProxy.log(`Creating new task in taskManager`, {
+                module: TASK_MANAGER_FILE,
+                method: METHODS.REGISTER_TASK_LISTENERS,
+                interactionId: payload.data.interactionId,
+              });
+              task = new Task(this.contact, this.webCallingService, {
+                ...payload.data,
+                wrapUpRequired:
+                  payload.data.interaction?.participants?.[payload.data.agentId]?.isWrapUp || false,
+              });
+              this.taskCollection[payload.data.interactionId] = task;
+              // Condition 1: The state is=new i.e it is a incoming task
+              if (payload.data.interaction.state === 'new') {
+                LoggerProxy.log(
+                  `Got AGENT_CONTACT for a task with state=new, sending TASK_INCOMING event`,
+                  {
+                    module: TASK_MANAGER_FILE,
+                    method: METHODS.REGISTER_TASK_LISTENERS,
+                    interactionId: payload.data.interactionId,
+                  }
+                );
+                this.emit(TASK_EVENTS.TASK_INCOMING, task);
+              } else {
+                // Condition 2: The state is anything else i.e the task was connected
+                LoggerProxy.log(
+                  `Got AGENT_CONTACT for a task with state=${payload.data.interaction.state}, sending TASK_HYDRATE event`,
+                  {
+                    module: TASK_MANAGER_FILE,
+                    method: METHODS.REGISTER_TASK_LISTENERS,
+                    interactionId: payload.data.interactionId,
+                  }
+                );
+                this.emit(TASK_EVENTS.TASK_HYDRATE, task);
+              }
+            }
             break;
           case CC_EVENTS.AGENT_CONTACT_RESERVED:
             task = new Task(this.contact, this.webCallingService, {

--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -91,16 +91,15 @@ export default class TaskManager extends EventEmitter {
           case CC_EVENTS.AGENT_CONTACT:
             // Case1 : Task is already present in taskCollection
             if (this.taskCollection[payload.data.interactionId]) {
-              LoggerProxy.log(` Task already exists in collection`, {
+              LoggerProxy.log(`Got AGENT_CONTACT: Task already exists in collection`, {
                 module: TASK_MANAGER_FILE,
                 method: METHODS.REGISTER_TASK_LISTENERS,
                 interactionId: payload.data.interactionId,
               });
               break;
-            }
-            // Case2 : Task is not present in taskCollection
-            else if (!this.taskCollection[payload.data.interactionId]) {
-              LoggerProxy.log(`Creating new task in taskManager`, {
+            } else if (!this.taskCollection[payload.data.interactionId]) {
+              // Case2 : Task is not present in taskCollection
+              LoggerProxy.log(`Got AGENT_CONTACT : Creating new task in taskManager`, {
                 module: TASK_MANAGER_FILE,
                 method: METHODS.REGISTER_TASK_LISTENERS,
                 interactionId: payload.data.interactionId,

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -414,7 +414,50 @@ describe('TaskManager', () => {
       );
   });
 
-  it('should emit TASK_HYDRATE event on AGENT_CONTACT event', () => {
+
+  it('should not emit TASK_HYDRATE if task is already present in taskManager', () => {
+    const payload = {
+      data: {
+        ...initalPayload.data,
+        type: CC_EVENTS.AGENT_CONTACT,
+      },
+    };
+    const taskEmitSpy = jest.spyOn(taskManager, 'emit');
+    webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+    expect(taskEmitSpy).not.toHaveBeenCalledWith(
+      TASK_EVENTS.TASK_HYDRATE,
+      taskManager.getTask(taskId)
+    );
+    expect(taskManager.taskCollection[payload.data.interactionId]).toBe(
+      taskManager.getTask(taskId)
+    );
+  });
+
+  it('should emit TASK_INCOMING event on AGENT_CONTACT event if task is new and not in the taskManager ', () => {
+    taskManager.taskCollection = [];
+    const payload = {
+      data: {
+        ...initalPayload.data,
+        interaction: {mediaType: 'telephony', state: 'new'},
+        type: CC_EVENTS.AGENT_CONTACT,
+      },
+    };
+
+    const taskEmitSpy = jest.spyOn(taskManager, 'emit');
+    webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+    expect(taskEmitSpy).toHaveBeenCalledWith(
+      TASK_EVENTS.TASK_INCOMING,
+      taskManager.getTask(taskId)
+    );
+    expect(taskManager.taskCollection[payload.data.interactionId]).toBe(
+      taskManager.getTask(taskId)
+    );
+  });
+
+  it('should emit TASK_HYDRATE event on AGENT_CONTACT event if task is connected and not in the taskManager ', () => {
+    taskManager.taskCollection = [];
     const payload = {
       data: {
         ...initalPayload.data,
@@ -426,7 +469,9 @@ describe('TaskManager', () => {
     webSocketManagerMock.emit('message', JSON.stringify(payload));
 
     expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_HYDRATE, taskManager.getTask(taskId));
-    expect(taskManager.taskCollection[payload.data.interactionId]).toBe(taskManager.getTask(taskId));
+    expect(taskManager.taskCollection[payload.data.interactionId]).toBe(
+      taskManager.getTask(taskId)
+    );
   });
 
   it('should emit TASK_END event on AGENT_WRAPUP event', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[CAI-6597](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6597)

## This pull request addresses

- Task Hydrate was not respecting the various state of the task and wether the task is already present in the taskCollectino or not.

## by making the following changes

- We dont send TASK_HYDRATE if the task is already present in the taskCollection
- We send TASK_INCOMING if the task is not in taskCollection and task's state is new
- We send TASK_HYDRATE of the task is not in taskCollection and state is connected

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

https://app.vidcast.io/share/d639ad00-b941-4e3c-a50b-6a33aeef3023
- checked normal task_hydrate with a connected task
- while a task is incomoing on 1 window, refreshed the other window and recieved TASK_INCOMING on 1 window(where refresh was done) and nothing on the other window(where refresh was not done) 

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
