### PR TITLE
fix(cart2): pass meeting id to cantina when update spoken language

### DIFF
--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -510,11 +510,12 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
   /**
    * In meeting Spoken Language changed event
    * @param {string} languageCode
+   * @param {string} meetingId
    * @returns {void}
    */
-  public onSpokenLanguageUpdate = (languageCode: string): void => {
+  public onSpokenLanguageUpdate = (languageCode: string, meetingId): void => {
     // @ts-ignore
-    this.trigger(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, {languageCode});
+    this.trigger(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, {languageCode, meetingId});
     this.currentSpokenLanguage = languageCode;
   };
 

--- a/packages/@webex/internal-plugin-voicea/src/voicea.types.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.types.ts
@@ -83,7 +83,7 @@ interface CaptionLanguageResponse {
 
 interface IVoiceaChannel {
   setSpokenLanguage: (languageCode: string) => Promise<void>;
-  onSpokenLanguageUpdate: (languageCode: string) => void;
+  onSpokenLanguageUpdate: (languageCode: string, meetingId: string) => void;
   requestLanguage: (languageCode: string) => void;
   turnOnCaptions: () => undefined | Promise<void>;
   toggleTranscribing: (activate: boolean, spokenLanguage: string) => undefined | Promise<void>;

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -247,13 +247,13 @@ describe('plugin-voicea', () => {
 
         voiceaService.on(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, spy);
         voiceaService.listenToEvents();
-        voiceaService.onSpokenLanguageUpdate('fr-FR');
+        voiceaService.currentSpokenLanguage = 'fr';
         await voiceaService.processAnnouncementMessage({});
         assert.calledOnceWithExactly(spy, {
           captionLanguages: [],
           spokenLanguages: [],
           maxLanguages: 0,
-          currentSpokenLanguage: 'fr-FR',
+          currentSpokenLanguage: 'fr',
         });
       });
     });
@@ -1029,10 +1029,10 @@ describe('plugin-voicea', () => {
         const triggerSpy = sinon.spy();
         voiceaService.on(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, triggerSpy);
 
-        const languageCode = 'fr-FR';
-        voiceaService.onSpokenLanguageUpdate(languageCode);
+        const languageCode = 'fr';
+        voiceaService.onSpokenLanguageUpdate(languageCode, '123');
         assert.equal(voiceaService.currentSpokenLanguage, languageCode);
-        assert.calledOnceWithExactly(triggerSpy, {languageCode});
+        assert.calledOnceWithExactly(triggerSpy, {languageCode, meetingId: '123'});
       });
     });
   });

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -2762,7 +2762,7 @@ export default class Meeting extends StatelessWebexPlugin {
             this.transcription.languageOptions.currentSpokenLanguage = spokenLanguage;
           }
           // @ts-ignore
-          this.webex.internal.voicea.onSpokenLanguageUpdate(spokenLanguage);
+          this.webex.internal.voicea.onSpokenLanguageUpdate(spokenLanguage, this.id);
 
           Trigger.trigger(
             this,

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -2771,7 +2771,7 @@ export default class Meeting extends StatelessWebexPlugin {
               function: 'setupLocusControlsListener',
             },
             EVENT_TRIGGERS.MEETING_TRANSCRIPTION_SPOKEN_LANGUAGE_UPDATED,
-            {spokenLanguage}
+            {spokenLanguage, meetingId: this.id}
           );
         }
       }

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1240,7 +1240,7 @@ describe('plugin-meetings', () => {
             LOCUSINFO.EVENTS.CONTROLS_MEETING_TRANSCRIPTION_SPOKEN_LANGUAGE_UPDATED,
             {spokenLanguage: 'fr'},
           );
-          assert.calledWith(webex.internal.voicea.onSpokenLanguageUpdate, 'fr');
+          assert.calledWith(webex.internal.voicea.onSpokenLanguageUpdate, 'fr', meeting.id);
           assert.equal(meeting.transcription.languageOptions.currentSpokenLanguage, 'fr');
           assert.calledWith(
             TriggerProxy.trigger,
@@ -4286,11 +4286,11 @@ describe('plugin-meetings', () => {
 
             const error = new Error();
             meeting.meetingRequest.setBrb = sinon.stub().rejects(error);
-        
+
             await expect(
               meeting.beRightBack(true)
-            ).to.be.rejectedWith(error);  
-             
+            ).to.be.rejectedWith(error);
+
             assert.isFalse(meeting.brbState.state.syncToServerInProgress);
           });
         });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Cantina cannot know which meeting updated when sdk update spoken language to it because the activeMeetingId is null when joining meeting

## by making the following changes

Voicea pass meeting id to Cantina with the payload

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Web client join meeting, host change spoken language.
Web client leave meeting, then host change spoken language again.
Web client join the meeting again to check whether get the new language code.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
