### PR TITLE
fix(calling): fix u2c v2

### DIFF
--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -150,12 +150,21 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       });
     }
 
-    this.mobiusClusters =
-      (mobiusServiceHost && this.webex.internal.services._hostCatalog[mobiusServiceHost]) ||
-      this.webex.internal.services._hostCatalog[MOBIUS_US_PROD] ||
-      this.webex.internal.services._hostCatalog[MOBIUS_EU_PROD] ||
-      this.webex.internal.services._hostCatalog[MOBIUS_US_INT] ||
-      this.webex.internal.services._hostCatalog[MOBIUS_EU_INT];
+    if (this.webex.internal.services._hostCatalog) {
+      this.mobiusClusters =
+        (mobiusServiceHost && this.webex.internal.services._hostCatalog[mobiusServiceHost]) ||
+        this.webex.internal.services._hostCatalog[MOBIUS_US_PROD] ||
+        this.webex.internal.services._hostCatalog[MOBIUS_EU_PROD] ||
+        this.webex.internal.services._hostCatalog[MOBIUS_US_INT] ||
+        this.webex.internal.services._hostCatalog[MOBIUS_EU_INT];
+    } else {
+      // @ts-ignore
+      const mobiusObject = this.webex.internal.services._services.find(
+        // @ts-ignore
+        (item) => item.serviceName === 'mobius'
+      );
+      this.mobiusClusters = [mobiusObject.serviceUrls[0].baseUrl];
+    }
     this.mobiusHost = '';
 
     this.registerSessionsListener();
@@ -236,7 +245,11 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     const regionInfo = {} as RegionInfo;
 
     for (const mobius of this.mobiusClusters) {
-      this.mobiusHost = `https://${mobius.host}${API_V1}`;
+      if (mobius.host) {
+        this.mobiusHost = `https://${mobius.host}${API_V1}`;
+      } else {
+        this.mobiusHost = mobius as unknown as string;
+      }
 
       try {
         // eslint-disable-next-line no-await-in-loop

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -150,6 +150,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       });
     }
 
+    // TODO: This is a temp fix - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6809
     if (this.webex.internal.services._hostCatalog) {
       this.mobiusClusters =
         (mobiusServiceHost && this.webex.internal.services._hostCatalog[mobiusServiceHost]) ||


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # ADHOC

## This pull request addresses

- when u2c catalog is fetched with format=U2CV2 we get a different response object which doesnt have serviceURLS or hostmap as a key. We get service.

## by making the following changes

- For temporarily supporting U2CV2 host catalog, we are fetching the mobius url from the services object in the service plugin
- 
<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

** This is temporary fix** Tested with calling-sdk cahnges mentioned in this PR - https://github.com/webex/webex-js-sdk/pull/4398 and did device resgisatration with Mobius

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
