### PR TITLE
fix(brbState): skip source state override when brb fails

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/brbState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/brbState.ts
@@ -58,8 +58,11 @@ export class BrbState {
   public enable(enabled: boolean, sendSlotManager: SendSlotManager) {
     this.state.client.enabled = enabled;
 
-    return this.applyClientStateToServer(sendSlotManager).finally(() => {
-      sendSlotManager.setSourceStateOverride(MediaType.VideoMain, enabled ? 'away' : null);
+    return this.applyClientStateToServer(sendSlotManager).then(() => {
+      sendSlotManager.setSourceStateOverride(
+        MediaType.VideoMain,
+        this.state.client.enabled ? 'away' : null
+      );
     });
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/brbState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/brbState.ts
@@ -59,10 +59,7 @@ export class BrbState {
     this.state.client.enabled = enabled;
 
     return this.applyClientStateToServer(sendSlotManager).finally(() => {
-      sendSlotManager.setSourceStateOverride(
-        MediaType.VideoMain,
-        this.state.client.enabled ? 'away' : null
-      );
+      sendSlotManager.setSourceStateOverride(MediaType.VideoMain, enabled ? 'away' : null);
     });
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/brbState.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/brbState.ts
@@ -58,6 +58,7 @@ export class BrbState {
   public enable(enabled: boolean, sendSlotManager: SendSlotManager) {
     this.state.client.enabled = enabled;
 
+    // Don't set the source state override if enabling brb fails
     return this.applyClientStateToServer(sendSlotManager).then(() => {
       sendSlotManager.setSourceStateOverride(
         MediaType.VideoMain,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/brbState.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/brbState.ts
@@ -146,9 +146,7 @@ describe('plugin-meetings', () => {
       await expect(enablePromise).to.be.rejectedWith(error);
 
       assert.isFalse(brbState.state.syncToServerInProgress);
-      assert.isTrue(
-        meeting.sendSlotManager.setSourceStateOverride.calledWith(MediaType.VideoMain, 'away')
-      );
+      expect(meeting.sendSlotManager.setSourceStateOverride.called).to.be.false;
     });
   });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-683756](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-683756)

## This pull request addresses

> After spamming step away more than ~10 times fast there is an issue in the current step away flow that Hover set overrides apply but not locus update for step away, this leads to away Pane view but no info from mute auto or participant section. 

## by making the following changes

Don't set source state override when setBrb fails (for example 429 too many requests)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Automatic tests
- Spam brb until 429 error occurs

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
