### PR TITLE
fix(cart2): make sure set correct locus url to llm lib

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -489,12 +489,12 @@ export default class LocusInfo extends EventsScope {
     this.updateCreated(locus.created);
     this.updateFullState(locus.fullState);
     this.updateHostInfo(locus.host);
+    this.updateLocusUrl(locus.url);
     this.updateMeetingInfo(locus.info, locus.self);
     this.updateMediaShares(locus.mediaShares);
     this.updateParticipantsUrl(locus.participantsUrl);
     this.updateReplace(locus.replace);
     this.updateSelf(locus.self);
-    this.updateLocusUrl(locus.url);
     this.updateAclUrl(locus.aclUrl);
     this.updateBasequence(locus.baseSequence);
     this.updateSequence(locus.sequence);

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -305,7 +305,7 @@ describe('plugin-meetings', () => {
           {state: newControls.rdcControl}
         );
       });
-      
+
       it('should trigger the CONTROLS_POLLING_QA_CHANGED event when necessary', () => {
         locusInfo.controls = {};
         locusInfo.emitScoped = sinon.stub();
@@ -2108,6 +2108,42 @@ describe('plugin-meetings', () => {
         assert.isFunction(locusParser.onDeltaAction);
       });
 
+      it('#updateLocusInfo invokes updateLocusUrl before updateMeetingInfo', () => {
+        const callOrder = [];
+        locusInfo.updateControls = sinon.stub();
+        locusInfo.updateConversationUrl = sinon.stub();
+        locusInfo.updateCreated = sinon.stub();
+        locusInfo.updateFullState = sinon.stub();
+        locusInfo.updateHostInfo = sinon.stub();
+        locusInfo.updateMeetingInfo = sinon.stub().callsFake(() => {
+          callOrder.push('updateMeetingInfo');
+        });
+        locusInfo.updateMediaShares = sinon.stub();
+        locusInfo.updateParticipantsUrl = sinon.stub();
+        locusInfo.updateReplace = sinon.stub();
+        locusInfo.updateSelf = sinon.stub();
+        locusInfo.updateLocusUrl = sinon.stub().callsFake(() => {
+          callOrder.push('updateLocusUrl');
+        });
+        locusInfo.updateAclUrl = sinon.stub();
+        locusInfo.updateBasequence = sinon.stub();
+        locusInfo.updateSequence = sinon.stub();
+        locusInfo.updateMemberShip = sinon.stub();
+        locusInfo.updateIdentifiers = sinon.stub();
+        locusInfo.updateEmbeddedApps = sinon.stub();
+        locusInfo.updateResources = sinon.stub();
+        locusInfo.compareAndUpdate = sinon.stub();
+
+        locusInfo.updateLocusInfo(locus);
+
+        // Ensure updateLocusUrl is called before updateMeetingInfo if both are called
+        const idxLocusUrl = callOrder.indexOf('updateLocusUrl');
+        const idxMeetingInfo = callOrder.indexOf('updateMeetingInfo');
+        if (idxLocusUrl !== -1 && idxMeetingInfo !== -1) {
+          assert.isBelow(idxLocusUrl, idxMeetingInfo, 'updateLocusUrl should be called before updateMeetingInfo');
+        }
+      });
+
       it('#updateLocusInfo ignores breakout LEFT message', () => {
         const newLocus = {
           self: {
@@ -2158,6 +2194,8 @@ describe('plugin-meetings', () => {
         assert.notCalled(locusInfo.updateResources);
         assert.notCalled(locusInfo.compareAndUpdate);
       });
+
+
 
       it('onFullLocus() updates the working-copy of locus parser', () => {
         const eventType = 'fakeEvent';

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -2108,40 +2108,36 @@ describe('plugin-meetings', () => {
         assert.isFunction(locusParser.onDeltaAction);
       });
 
-      it('#updateLocusInfo invokes updateLocusUrl before updateMeetingInfo', () => {
+      it("#updateLocusInfo invokes updateLocusUrl before updateMeetingInfo", () => {
         const callOrder = [];
-        locusInfo.updateControls = sinon.stub();
-        locusInfo.updateConversationUrl = sinon.stub();
-        locusInfo.updateCreated = sinon.stub();
-        locusInfo.updateFullState = sinon.stub();
-        locusInfo.updateHostInfo = sinon.stub();
-        locusInfo.updateMeetingInfo = sinon.stub().callsFake(() => {
-          callOrder.push('updateMeetingInfo');
+        sinon.stub(locusInfo, "updateControls");
+        sinon.stub(locusInfo, "updateConversationUrl");
+        sinon.stub(locusInfo, "updateCreated");
+        sinon.stub(locusInfo, "updateFullState");
+        sinon.stub(locusInfo, "updateHostInfo");
+        sinon.stub(locusInfo, "updateMeetingInfo").callsFake(() => {
+          callOrder.push("updateMeetingInfo");
         });
-        locusInfo.updateMediaShares = sinon.stub();
-        locusInfo.updateParticipantsUrl = sinon.stub();
-        locusInfo.updateReplace = sinon.stub();
-        locusInfo.updateSelf = sinon.stub();
-        locusInfo.updateLocusUrl = sinon.stub().callsFake(() => {
-          callOrder.push('updateLocusUrl');
+        sinon.stub(locusInfo, "updateMediaShares");
+        sinon.stub(locusInfo, "updateParticipantsUrl");
+        sinon.stub(locusInfo, "updateReplace");
+        sinon.stub(locusInfo, "updateSelf");
+        sinon.stub(locusInfo, "updateLocusUrl").callsFake(() => {
+          callOrder.push("updateLocusUrl");
         });
-        locusInfo.updateAclUrl = sinon.stub();
-        locusInfo.updateBasequence = sinon.stub();
-        locusInfo.updateSequence = sinon.stub();
-        locusInfo.updateMemberShip = sinon.stub();
-        locusInfo.updateIdentifiers = sinon.stub();
-        locusInfo.updateEmbeddedApps = sinon.stub();
-        locusInfo.updateResources = sinon.stub();
-        locusInfo.compareAndUpdate = sinon.stub();
+        sinon.stub(locusInfo, "updateAclUrl");
+        sinon.stub(locusInfo, "updateBasequence");
+        sinon.stub(locusInfo, "updateSequence");
+        sinon.stub(locusInfo, "updateMemberShip");
+        sinon.stub(locusInfo, "updateIdentifiers");
+        sinon.stub(locusInfo, "updateEmbeddedApps");
+        sinon.stub(locusInfo, "updateResources");
+        sinon.stub(locusInfo, "compareAndUpdate");
 
         locusInfo.updateLocusInfo(locus);
 
         // Ensure updateLocusUrl is called before updateMeetingInfo if both are called
-        const idxLocusUrl = callOrder.indexOf('updateLocusUrl');
-        const idxMeetingInfo = callOrder.indexOf('updateMeetingInfo');
-        if (idxLocusUrl !== -1 && idxMeetingInfo !== -1) {
-          assert.isBelow(idxLocusUrl, idxMeetingInfo, 'updateLocusUrl should be called before updateMeetingInfo');
-        }
+        assert.deepEqual(callOrder, ['updateLocusUrl', 'updateMeetingInfo']);
       });
 
       it('#updateLocusInfo ignores breakout LEFT message', () => {
@@ -3070,8 +3066,8 @@ describe('plugin-meetings', () => {
 
         sinon.stub(locusInfo, 'updateParticipantDeltas');
         sinon.stub(locusInfo, 'updateParticipants');
-        sinon.stub(locusInfo, 'isMeetingActive'),
-          sinon.stub(locusInfo, 'handleOneOnOneEvent'),
+        sinon.stub(locusInfo, 'isMeetingActive');
+          sinon.stub(locusInfo, 'handleOneOnOneEvent');
           (updateLocusInfoStub = sinon.stub(locusInfo, 'updateLocusInfo'));
         syncRequestStub = sinon.stub().resolves({body: {}});
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

When host/cohost join breakout and return to main session, cannot turn on/off manual caption successfully, because of the locus url in llm lib is not correct.

## by making the following changes

Invoke updateLocusUrl() before invoke updateMeetingInfo() to make sure that the locus url is updated before set it to llm lib

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Web client host start meeting and turn on manual caption successfully
Host start a breakout, and join the breakout.
Host return to main session and turn off manual captoion successfulluy

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
