### PR TITLE
fix(calling): add fedramp support for call-setting client

### DIFF
--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -263,7 +263,7 @@ async function initCalling(e) {
     calling: !fedrampBox.checked,
     contact: !fedrampBox.checked,
     callHistory: true,
-    callSettings: !fedrampBox.checked,
+    callSettings: true,
     voicemail: true,
   }
 
@@ -1633,31 +1633,31 @@ async function fetchVoicemailSetting() {
     visibility = vmCheckbox.checked ? 'initial' : 'none';
     vmDiv.style.display = visibility;
 
-    form.alwaysCb.checked = voicemail.sendAllCalls.enabled;
+    form.alwaysCb.checked = voicemail.sendAllCalls?.enabled;
     form.alwaysCb.disabled = false;
 
-    form.busyCb.checked = voicemail.sendBusyCalls.enabled;
+    form.busyCb.checked = voicemail.sendBusyCalls?.enabled;
     form.busyCb.disabled = false;
 
-    form.vmNotAnsweredCb.checked = voicemail.sendUnansweredCalls.enabled;
-    form.vmNotAnsweredRings.value = voicemail.sendUnansweredCalls.numberOfRings;
+    form.vmNotAnsweredCb.checked = voicemail.sendUnansweredCalls?.enabled;
+    form.vmNotAnsweredRings.value = voicemail.sendUnansweredCalls?.numberOfRings;
     visibility = form.vmNotAnsweredCb.checked ? 'initial' : 'none';
     form.vmNotAnsweredRings.style.display = visibility;
     form.vmNotAnsweredCb.disabled = false;
     form.vmNotAnsweredRings.disabled = false;
 
-    form.notifCb.checked = voicemail.messageStorage.mwiEnabled;
+    form.notifCb.checked = voicemail.messageStorage?.mwiEnabled;
     form.notifCb.disabled = false;
 
-    form.notifEmailCb.checked = voicemail.notifications.enabled;
-    form.notifEmailId.value = voicemail.notifications.destination;
+    form.notifEmailCb.checked = voicemail.notifications?.enabled;
+    form.notifEmailId.value = voicemail.notifications?.destination;
     visibility = form.notifEmailCb.checked ? 'initial' : 'none';
     form.notifEmailId.style.display = visibility;
     form.notifEmailCb.disabled = false;
     form.notifEmailId.disabled = false;
 
-    form.vmEmailCb.checked = voicemail.emailCopyOfMessage.enabled;
-    form.vmEmailId.value = voicemail.emailCopyOfMessage.emailId;
+    form.vmEmailCb.checked = voicemail.emailCopyOfMessage?.enabled;
+    form.vmEmailId.value = voicemail.emailCopyOfMessage?.emailId;
     visibility = form.vmEmailCb.checked ? 'initial' : 'none';
     form.vmEmailId.style.display = visibility;
     form.vmEmailCb.disabled = false;

--- a/packages/calling/src/CallSettings/WxCallBackendConnector.test.ts
+++ b/packages/calling/src/CallSettings/WxCallBackendConnector.test.ts
@@ -532,6 +532,70 @@ describe('Call Settings Client Tests for WxCallBackendConnector', () => {
       });
     });
 
+    it('Success: Get Call Forward Always setting in Fedramp with limited options in payload', async () => {
+      const responsePayload = <WebexRequestPayload>(<unknown>{
+        statusCode: 200,
+        body: {
+          callForwarding: {
+            always: {
+              enabled: false,
+              destination: '+13015554270',
+              ringReminderEnabled: false,
+              destinationVoicemailEnabled: true,
+            },
+            busy: {
+              enabled: false,
+              destinationVoicemailEnabled: false,
+            },
+            noAnswer: {
+              enabled: false,
+              numberOfRings: 3,
+              systemMaxNumberOfRings: 20,
+              destinationVoicemailEnabled: false,
+            },
+          },
+          businessContinuity: {
+            enabled: false,
+            destination: '+13015554270',
+            destinationVoicemailEnabled: true,
+          },
+        },
+      });
+
+      const voicemailResponsePayload = <WebexRequestPayload>(<unknown>{
+        statusCode: 200,
+        body: {
+          enabled: true,
+          voiceMessageForwardingEnabled: true,
+        },
+      });
+
+      webex.request
+        .mockResolvedValueOnce(responsePayload)
+        .mockResolvedValueOnce(voicemailResponsePayload);
+      const response = await callSettingsClient.getCallForwardAlwaysSetting();
+      const callSetting = response.data.callSetting as CallForwardAlwaysSetting;
+
+      expect(response.statusCode).toBe(200);
+      expect(response.message).toBe(SUCCESS_MESSAGE);
+
+      expect(callSetting.destination).toBe(undefined);
+      expect(callSetting.enabled).toBe(false);
+      expect(callSetting.destinationVoicemailEnabled).toBe(true);
+      expect(callSetting.ringReminderEnabled).toBe(false);
+
+      expect(webex.request).toBeCalledTimes(2);
+      expect(webex.request).toBeCalledWith({
+        method: HTTP_METHODS.GET,
+        uri: callForwardingUri,
+      });
+
+      expect(webex.request).toBeCalledWith({
+        method: HTTP_METHODS.GET,
+        uri: voicemailUri,
+      });
+    });
+
     it('Success: Get Call Forward Always setting when set to disabled and voicemail request fails', async () => {
       callForwardPayload.callForwarding.always.enabled = false;
       const responsePayload = <WebexRequestPayload>(<unknown>{

--- a/packages/calling/src/CallSettings/WxCallBackendConnector.ts
+++ b/packages/calling/src/CallSettings/WxCallBackendConnector.ts
@@ -450,7 +450,7 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
         const vm = vmResponse.data.callSetting as VoicemailSetting;
 
         /** CFA is enabled to voicemail */
-        if (vm.enabled && vm.sendAllCalls.enabled) {
+        if (vm.enabled && vm.sendAllCalls?.enabled) {
           const response = {
             ...cfResponse,
             data: {

--- a/packages/calling/src/CallSettings/types.ts
+++ b/packages/calling/src/CallSettings/types.ts
@@ -122,7 +122,7 @@ export type VoicemailSetting = {
    * Object to configure properties for enabling/disabling the forwarding of all the incoming calls to voicemail.
    * Please note that this setting can only be adjusted when voicemail is enabled.
    */
-  sendAllCalls: {
+  sendAllCalls?: {
     /**
      * This indicates if the voicemail is enabled/disabled for all the incoming calls.
      */


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # Adhoc

## This pull request addresses

- Adds support for call-setting client in fedramp for calling. While fetching voicemail settings, the prod and fedramp response body was different and because of that calling sdk was failling to populate the response. 

Response in Fedramp
```
{
  "enabled": true,
  "voiceMessageForwardingEnabled": true
} 
```

Response on Prod
```
{
    "enabled": true,
    "sendAllCalls": {
        "enabled": true
    },
    "sendBusyCalls": {
        "enabled": true,
        "greeting": "DEFAULT",
        "greetingUploaded": false
    },
    "sendUnansweredCalls": {
        "enabled": true,
        "greeting": "DEFAULT",
        "greetingUploaded": false,
        "numberOfRings": 3,
        "systemMaxNumberOfRings": 20
    },
    "notifications": {
        "enabled": false
    },
    "transferToNumber": {
        "enabled": false
    },
    "emailCopyOfMessage": {
        "enabled": false
    },
    "messageStorage": {
        "mwiEnabled": true,
        "storageType": "INTERNAL",
        "externalEmail": "wamulla@cisco.com"
    },
    "faxMessage": {
        "enabled": false
    },
    "voiceMessageForwardingEnabled": true
}  
```

## by making the following changes

Made sendAllCalls to be optional to pass the proper response 

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- https://app.vidcast.io/share/adc3433e-0ace-4368-8a87-175b77cf8e83
- Ran fedramp env and fetched all settings
- Updated always forwarding setting and fetched the call settings

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
