### PR TITLE
fix: updated u2c logic to filter out urls with negative priority

### DIFF
--- a/packages/@webex/webex-core/src/lib/services/service-url.js
+++ b/packages/@webex/webex-core/src/lib/services/service-url.js
@@ -60,7 +60,7 @@ const ServiceUrl = AmpState.extend({
       ? this.hosts.filter((host) => host.id === clusterId)
       : this.hosts.filter((host) => host.homeCluster);
 
-    const aliveHosts = filteredHosts.filter((host) => !host.failed && host.priority > 1);
+    const aliveHosts = filteredHosts.filter((host) => !host.failed);
 
     filteredHosts =
       aliveHosts.length === 0
@@ -75,7 +75,9 @@ const ServiceUrl = AmpState.extend({
     return this._generateHostUrl(
       filteredHosts.reduce(
         (previous, current) =>
-          previous.priority > current.priority || !previous.homeCluster ? current : previous,
+          current.priority > 0 && (previous.priority > current.priority || !previous.homeCluster)
+            ? current
+            : previous,
         {}
       ).host
     );

--- a/packages/@webex/webex-core/src/lib/services/service-url.js
+++ b/packages/@webex/webex-core/src/lib/services/service-url.js
@@ -60,7 +60,7 @@ const ServiceUrl = AmpState.extend({
       ? this.hosts.filter((host) => host.id === clusterId)
       : this.hosts.filter((host) => host.homeCluster);
 
-    const aliveHosts = filteredHosts.filter((host) => !host.failed);
+    const aliveHosts = filteredHosts.filter((host) => !host.failed && host.priority > 1);
 
     filteredHosts =
       aliveHosts.length === 0

--- a/packages/@webex/webex-core/test/integration/spec/services/services.js
+++ b/packages/@webex/webex-core/test/integration/spec/services/services.js
@@ -320,6 +320,39 @@ describe('webex-core', () => {
 
         assert.isUndefined(serviceObject);
       });
+
+      it('handles case where there is a priority of -1 for a service url', () => {
+        const negativePriorityTemplate = {
+          defaultUrl: 'https://www.example.com/api/v1',
+          hosts: [
+            {
+              host: 'www.example.com',
+              ttl: -1,
+              priority: 1,
+              id: 'exampleClusterId',
+            },
+            {
+              host: 'www.example-p3.com',
+              ttl: -1,
+              priority: -1,
+              id: 'exampleClusterId',
+            },
+          ],
+          name: 'exampleValid',
+        };
+        negativePriorityUrl = new ServiceUrl(negativePriorityTemplate);
+        catalog._loadServiceUrls('preauth', [negativePriorityUrl]);
+
+        const serviceObject = services.getServiceFromUrl('https://www.example.com/api/v1/somepath');
+
+        assert.equal(serviceObject, {
+          name: negativePriorityTemplate.name,
+          priorityUrl: 'www.example.com',
+          defaultUrl: negativePriorityTemplate.defaultUrl,
+        });
+
+        catalog._unloadServiceUrls('preauth', [negativePriorityUrl]);
+      });
     });
 
     describe('#hasService()', () => {

--- a/packages/@webex/webex-core/test/integration/spec/services/services.js
+++ b/packages/@webex/webex-core/test/integration/spec/services/services.js
@@ -323,33 +323,35 @@ describe('webex-core', () => {
 
       it('handles case where there is a priority of -1 for a service url', () => {
         const negativePriorityTemplate = {
-          defaultUrl: 'https://www.example.com/api/v1',
+          defaultUrl: 'https://www.negative-priority.com/api/v1',
           hosts: [
             {
-              host: 'www.example.com',
+              host: 'www.negative-priority.com',
               ttl: -1,
               priority: 1,
-              id: 'exampleClusterId',
+              id: 'exampleClusterId2',
+              homeCluster: true,
             },
             {
-              host: 'www.example-p3.com',
+              host: 'www.negative-p3.com',
               ttl: -1,
               priority: -1,
               id: 'exampleClusterId',
+              homeCluster: true,
             },
           ],
-          name: 'exampleValid',
+          name: 'negative-priority',
         };
-        negativePriorityUrl = new ServiceUrl(negativePriorityTemplate);
+        const negativePriorityUrl = new ServiceUrl(negativePriorityTemplate);
         catalog._loadServiceUrls('preauth', [negativePriorityUrl]);
 
-        const serviceObject = services.getServiceFromUrl('https://www.example.com/api/v1/somepath');
+        const serviceObject = services.getServiceFromUrl(
+          'https://www.negative-priority.com/api/v1/somepath'
+        );
 
-        assert.equal(serviceObject, {
-          name: negativePriorityTemplate.name,
-          priorityUrl: 'www.example.com',
-          defaultUrl: negativePriorityTemplate.defaultUrl,
-        });
+        assert.equal(serviceObject.name, negativePriorityTemplate.name);
+        assert.equal(serviceObject.defaultUrl, negativePriorityTemplate.defaultUrl);
+        assert.equal(serviceObject.priorityUrl, 'https://www.negative-priority.com/api/v1');
 
         catalog._unloadServiceUrls('preauth', [negativePriorityUrl]);
       });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

- Current u2c logic doesn't support update to u2c backend that marks some service urls with a negative priority (-1)

## by making the following changes

- Updating filter function when looking for the priority host that removes urls with negative priority as well as hosts that are marked as failed (current logic only looks if url is marked as failed)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Manually tested, and tests written

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
