### PR TITLE
feat(plugin-meetings): support 540p resolution

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -1189,6 +1189,7 @@ export const QUALITY_LEVELS = {
   HIGH: 'HIGH',
   '360p': '360p',
   '480p': '480p',
+  '540p': '540p',
   '720p': '720p',
   '1080p': '1080p',
 };
@@ -1215,6 +1216,18 @@ export const AVAILABLE_RESOLUTIONS = {
       height: {
         max: 480,
         ideal: 480,
+      },
+    },
+  },
+  '540p': {
+    video: {
+      width: {
+        max: 960,
+        ideal: 960,
+      },
+      height: {
+        max: 540,
+        ideal: 540,
       },
     },
   },

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -124,7 +124,6 @@ export class MediaRequestManager {
   private getDegradedClientRequests(clientRequests: ClientRequestsMap) {
     const maxFsLimits = [
       MAX_FS_VALUES['1080p'],
-      MAX_FS_VALUES['1080p'],
       MAX_FS_VALUES['720p'],
       MAX_FS_VALUES['540p'],
       MAX_FS_VALUES['360p'],

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -15,7 +15,7 @@ import {cloneDeepWith, debounce, isEmpty} from 'lodash';
 import LoggerProxy from '../common/logs/logger-proxy';
 
 import {ReceiveSlot, ReceiveSlotEvents} from './receiveSlot';
-import {getMaxFs} from './remoteMedia';
+import {MAX_FS_VALUES} from './remoteMedia';
 
 export interface ActiveSpeakerPolicyInfo {
   policy: 'active-speaker';
@@ -123,12 +123,13 @@ export class MediaRequestManager {
 
   private getDegradedClientRequests(clientRequests: ClientRequestsMap) {
     const maxFsLimits = [
-      getMaxFs('best'),
-      getMaxFs('large'),
-      getMaxFs('medium'),
-      getMaxFs('small'),
-      getMaxFs('very small'),
-      getMaxFs('thumbnail'),
+      MAX_FS_VALUES['1080p'],
+      MAX_FS_VALUES['1080p'],
+      MAX_FS_VALUES['720p'],
+      MAX_FS_VALUES['540p'],
+      MAX_FS_VALUES['360p'],
+      MAX_FS_VALUES['180p'],
+      MAX_FS_VALUES['90p'],
     ];
 
     // reduce max-fs until total macroblocks is below limit

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -95,7 +95,7 @@ export class RemoteMedia extends EventsScope {
    * Set by setSizeHint() based on video element dimensions.
    * When > 0, this value takes precedence over options.resolution in sendMediaRequest().
    */
-  public maxFrameSize = 0;
+  private maxFrameSize = 0;
 
   /**
    * Constructs RemoteMedia instance

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -19,17 +19,18 @@ export type RemoteVideoResolution =
   | 'large' // 1080p or less
   | 'best'; // highest possible resolution
 
-const MAX_FS_VALUES = {
+export const MAX_FS_VALUES = {
   '90p': 60,
   '180p': 240,
   '360p': 920,
+  '540p': 2040,
   '720p': 3600,
   '1080p': 8192,
 };
 
 /**
  * Converts pane size into h264 maxFs
- * @param {PaneSize} paneSize
+ * @param {RemoteVideoResolution} paneSize
  * @returns {number}
  */
 export function getMaxFs(paneSize: RemoteVideoResolution): number {
@@ -90,6 +91,13 @@ export class RemoteMedia extends EventsScope {
   public readonly id: RemoteMediaId;
 
   /**
+   * The max frame size of the media request, used for logging and media requests.
+   * Set by setSizeHint() based on video element dimensions.
+   * When > 0, this value takes precedence over options.resolution in sendMediaRequest().
+   */
+  public maxFrameSize = 0;
+
+  /**
    * Constructs RemoteMedia instance
    *
    * @param receiveSlot
@@ -136,13 +144,32 @@ export class RemoteMedia extends EventsScope {
       fs = MAX_FS_VALUES['180p'];
     } else if (height < getThresholdHeight(360)) {
       fs = MAX_FS_VALUES['360p'];
+    } else if (height < getThresholdHeight(540)) {
+      fs = MAX_FS_VALUES['540p'];
     } else if (height <= 720) {
       fs = MAX_FS_VALUES['720p'];
     } else {
       fs = MAX_FS_VALUES['1080p'];
     }
 
+    this.maxFrameSize = fs;
     this.receiveSlot?.setMaxFs(fs);
+  }
+
+  /**
+   * Get the current effective maxFs value that would be used in media requests
+   * @returns {number | undefined} The maxFs value, or undefined if no constraints
+   */
+  public getEffectiveMaxFs(): number | undefined {
+    if (this.maxFrameSize > 0) {
+      return this.maxFrameSize;
+    }
+
+    if (this.options.resolution) {
+      return getMaxFs(this.options.resolution);
+    }
+
+    return undefined;
   }
 
   /**
@@ -185,6 +212,9 @@ export class RemoteMedia extends EventsScope {
       throw new Error('sendMediaRequest() called on an invalidated RemoteMedia instance');
     }
 
+    // Use maxFrameSize from setSizeHint if available, otherwise fallback to options.resolution
+    const maxFs = this.getEffectiveMaxFs();
+
     this.mediaRequestId = this.mediaRequestManager.addRequest(
       {
         policyInfo: {
@@ -192,9 +222,9 @@ export class RemoteMedia extends EventsScope {
           csi,
         },
         receiveSlots: [this.receiveSlot],
-        codecInfo: this.options.resolution && {
+        codecInfo: maxFs && {
           codec: 'h264',
-          maxFs: getMaxFs(this.options.resolution),
+          maxFs,
         },
       },
       commit

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
@@ -215,6 +215,9 @@ export class RemoteMediaGroup {
   private sendActiveSpeakerMediaRequest(commit: boolean) {
     this.cancelActiveSpeakerMediaRequest(false);
 
+    // Calculate the effective maxFs based on all unpinned RemoteMedia instances
+    const effectiveMaxFs = this.getEffectiveMaxFsForActiveSpeaker();
+
     this.mediaRequestId = this.mediaRequestManager.addRequest(
       {
         policyInfo: {
@@ -230,9 +233,9 @@ export class RemoteMediaGroup {
         receiveSlots: this.unpinnedRemoteMedia.map((remoteMedia) =>
           remoteMedia.getUnderlyingReceiveSlot()
         ) as ReceiveSlot[],
-        codecInfo: this.options.resolution && {
+        codecInfo: effectiveMaxFs && {
           codec: 'h264',
-          maxFs: getMaxFs(this.options.resolution),
+          maxFs: effectiveMaxFs,
         },
       },
       commit
@@ -299,5 +302,37 @@ export class RemoteMediaGroup {
     return (
       this.unpinnedRemoteMedia.includes(remoteMedia) || this.pinnedRemoteMedia.includes(remoteMedia)
     );
+  }
+
+  /**
+   * Calculate the effective maxFs for the active speaker media request based on unpinned RemoteMedia instances
+   * @returns {number | undefined} The calculated maxFs value, or undefined if no constraints
+   * @private
+   */
+  private getEffectiveMaxFsForActiveSpeaker(): number | undefined {
+    // Get all effective maxFs values from unpinned RemoteMedia instances
+    const maxFsValues = this.unpinnedRemoteMedia
+      .map((remoteMedia) => remoteMedia.getEffectiveMaxFs())
+      .filter((maxFs): maxFs is number => maxFs !== undefined);
+
+    // Use the highest maxFs value to ensure we don't under-request resolution for any instance
+    if (maxFsValues.length > 0) {
+      return Math.max(...maxFsValues);
+    }
+
+    // Fall back to group's resolution option
+    if (this.options.resolution) {
+      return getMaxFs(this.options.resolution);
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Get the current effective maxFs that would be used for the active speaker media request
+   * @returns {number | undefined} The effective maxFs value
+   */
+  public getEffectiveMaxFs(): number | undefined {
+    return this.getEffectiveMaxFsForActiveSpeaker();
   }
 }

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
@@ -313,7 +313,7 @@ export class RemoteMediaGroup {
     // Get all effective maxFs values from unpinned RemoteMedia instances
     const maxFsValues = this.unpinnedRemoteMedia
       .map((remoteMedia) => remoteMedia.getEffectiveMaxFs())
-      .filter((maxFs): maxFs is number => maxFs !== undefined);
+      .filter((maxFs) => maxFs !== undefined);
 
     // Use the highest maxFs value to ensure we don't under-request resolution for any instance
     if (maxFsValues.length > 0) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -905,7 +905,7 @@ describe('MediaRequestManager', () => {
     // request 10 "large" 1080p streams
     addActiveSpeakerRequest(255, fakeReceiveSlots.slice(0, 10), getMaxFs('large'), true);
 
-    // check that resulting requests are 10 "small" 360p streams
+    // check that resulting requests are 10 "small" 540p streams
     checkMediaRequestsSent([
       {
         policy: 'active-speaker',

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -905,7 +905,7 @@ describe('MediaRequestManager', () => {
     // request 10 "large" 1080p streams
     addActiveSpeakerRequest(255, fakeReceiveSlots.slice(0, 10), getMaxFs('large'), true);
 
-    // check that resulting requests are 10 "small" 540p streams
+    // check that resulting requests are 10 540p streams
     checkMediaRequestsSent([
       {
         policy: 'active-speaker',

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -3,7 +3,7 @@ import {MediaRequestManager} from '@webex/plugin-meetings/src/multistream/mediaR
 import {ReceiveSlot} from '@webex/plugin-meetings/src/multistream/receiveSlot';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
-import {getMaxFs} from '@webex/plugin-meetings/src/multistream/remoteMedia';
+import {getMaxFs, MAX_FS_VALUES} from '@webex/plugin-meetings/src/multistream/remoteMedia';
 import FakeTimers from '@sinonjs/fake-timers';
 import * as InternalMediaCoreModule from '@webex/internal-media-core';
 import { expect } from 'chai';
@@ -36,12 +36,15 @@ describe('MediaRequestManager', () => {
   const CROSS_POLICY_DUPLICATION = true;
   const MAX_FPS = 3000;
   const MAX_FS_360p = 920;
+  const MAX_FS_540p = 2040;
   const MAX_FS_720p = 3600;
   const MAX_FS_1080p = 8192;
   const MAX_MBPS_360p = 27600;
+  const MAX_MBPS_540p = 61200;
   const MAX_MBPS_720p = 108000;
   const MAX_MBPS_1080p = 245760;
   const MAX_PAYLOADBITSPS_360p = 640000;
+  const MAX_PAYLOADBITSPS_540p = 880000;
   const MAX_PAYLOADBITSPS_720p = 2500000;
   const MAX_PAYLOADBITSPS_1080p = 4000000;
 
@@ -82,7 +85,14 @@ describe('MediaRequestManager', () => {
   });
 
   // helper function for adding an active speaker request
-  const addActiveSpeakerRequest = (priority, receiveSlots, maxFs, commit = false, preferLiveVideo = true, namedMediaGroups = undefined) =>
+  const addActiveSpeakerRequest = (
+    priority,
+    receiveSlots,
+    maxFs,
+    commit = false,
+    preferLiveVideo = true,
+    namedMediaGroups = undefined
+  ) =>
     mediaRequestManager.addRequest(
       {
         policyInfo: {
@@ -216,6 +226,9 @@ describe('MediaRequestManager', () => {
       },
       false
     );
+
+
+
     mediaRequestManager.addRequest(
       {
         policyInfo: {
@@ -898,9 +911,9 @@ describe('MediaRequestManager', () => {
         policy: 'active-speaker',
         priority: 255,
         receiveSlots: fakeWcmeSlots.slice(0, 10),
-        maxPayloadBitsPerSecond: MAX_PAYLOADBITSPS_360p,
-        maxFs: getMaxFs('small'),
-        maxMbps: MAX_MBPS_360p,
+        maxPayloadBitsPerSecond: MAX_PAYLOADBITSPS_540p,
+        maxFs:  MAX_FS_VALUES['540p'],
+        maxMbps: MAX_MBPS_540p,
       },
     ]);
   });

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -276,17 +276,18 @@ describe('RemoteMedia', () => {
 
   describe('getEffectiveMaxFs()', () => {
     it('returns maxFrameSize when it is greater than 0', () => {
-      remoteMedia.maxFrameSize = 1000;
-      
+      remoteMedia.setSizeHint(960, 540);
+
       const result = remoteMedia.getEffectiveMaxFs();
-      
-      assert.strictEqual(result, 1000);
+
+      assert.strictEqual(result, 2040);
     });
 
     it('returns getMaxFs result when maxFrameSize is 0 and resolution is provided', () => {
-      remoteMedia.maxFrameSize = 0;
+      remoteMedia.setSizeHint(0, 0);
+
       // remoteMedia was created with {resolution: 'medium'} in beforeEach
-      
+
       const result = remoteMedia.getEffectiveMaxFs();
       
       // 'medium' resolution should map to 720p which is 3600
@@ -294,7 +295,8 @@ describe('RemoteMedia', () => {
     });
 
     it('returns undefined when maxFrameSize is 0 and no resolution is provided', () => {
-      remoteMedia.maxFrameSize = 0;
+      remoteMedia.setSizeHint(0, 0);
+
       // Create a new RemoteMedia without resolution option
       const remoteMediaWithoutResolution = new RemoteMedia(fakeReceiveSlot, fakeMediaRequestManager);
       
@@ -304,13 +306,13 @@ describe('RemoteMedia', () => {
     });
 
     it('prioritizes maxFrameSize over resolution option', () => {
-      remoteMedia.maxFrameSize = 500;
+      remoteMedia.setSizeHint(640, 360);
       // remoteMedia was created with {resolution: 'medium'} in beforeEach
-      
+
       const result = remoteMedia.getEffectiveMaxFs();
       
       // Should return maxFrameSize (500) instead of resolution-based value (3600)
-      assert.strictEqual(result, 500);
+      assert.strictEqual(result, 920);
     });
 
     it('works correctly with different resolution options', () => {
@@ -325,8 +327,8 @@ describe('RemoteMedia', () => {
 
       testCases.forEach(({ resolution, expected }) => {
         const testRemoteMedia = new RemoteMedia(fakeReceiveSlot, fakeMediaRequestManager, { resolution });
-        testRemoteMedia.maxFrameSize = 0; // Ensure maxFrameSize doesn't interfere
-        
+        testRemoteMedia.setSizeHint(0, 0); // Ensure maxFrameSize doesn't interfere
+
         const result = testRemoteMedia.getEffectiveMaxFs();
         
         assert.strictEqual(result, expected, `Failed for resolution: ${resolution}`);

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -3,7 +3,7 @@ import 'jsdom-global/register';
 import EventEmitter from 'events';
 
 import {MediaType} from '@webex/internal-media-core';
-import {RemoteMedia, RemoteMediaEvents} from '@webex/plugin-meetings/src/multistream/remoteMedia';
+import {RemoteMedia, RemoteMediaEvents, RemoteVideoResolution} from '@webex/plugin-meetings/src/multistream/remoteMedia';
 import {ReceiveSlotEvents} from '@webex/plugin-meetings/src/multistream/receiveSlot';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
@@ -257,7 +257,9 @@ describe('RemoteMedia', () => {
         {height: 198, fs: 920}, // 360p
         {height: 360, fs: 920},
         {height: 395, fs: 920},
-        {height: 396, fs: 3600}, // 720p
+        {height: 396, fs: 2040}, // 540p
+        {height: 540, fs: 2040},
+        {height: 610, fs: 3600}, // 720p
         {height: 720, fs: 3600},
         {height: 721, fs: 8192}, // 1080p
         {height: 1080, fs: 8192},
@@ -270,5 +272,65 @@ describe('RemoteMedia', () => {
         });
       }
     );
+  });
+
+  describe('getEffectiveMaxFs()', () => {
+    it('returns maxFrameSize when it is greater than 0', () => {
+      remoteMedia.maxFrameSize = 1000;
+      
+      const result = remoteMedia.getEffectiveMaxFs();
+      
+      assert.strictEqual(result, 1000);
+    });
+
+    it('returns getMaxFs result when maxFrameSize is 0 and resolution is provided', () => {
+      remoteMedia.maxFrameSize = 0;
+      // remoteMedia was created with {resolution: 'medium'} in beforeEach
+      
+      const result = remoteMedia.getEffectiveMaxFs();
+      
+      // 'medium' resolution should map to 720p which is 3600
+      assert.strictEqual(result, 3600);
+    });
+
+    it('returns undefined when maxFrameSize is 0 and no resolution is provided', () => {
+      remoteMedia.maxFrameSize = 0;
+      // Create a new RemoteMedia without resolution option
+      const remoteMediaWithoutResolution = new RemoteMedia(fakeReceiveSlot, fakeMediaRequestManager);
+      
+      const result = remoteMediaWithoutResolution.getEffectiveMaxFs();
+      
+      assert.strictEqual(result, undefined);
+    });
+
+    it('prioritizes maxFrameSize over resolution option', () => {
+      remoteMedia.maxFrameSize = 500;
+      // remoteMedia was created with {resolution: 'medium'} in beforeEach
+      
+      const result = remoteMedia.getEffectiveMaxFs();
+      
+      // Should return maxFrameSize (500) instead of resolution-based value (3600)
+      assert.strictEqual(result, 500);
+    });
+
+    it('works correctly with different resolution options', () => {
+      const testCases: Array<{ resolution: RemoteVideoResolution; expected: number }> = [
+        { resolution: 'thumbnail', expected: 60 },
+        { resolution: 'very small', expected: 240 },
+        { resolution: 'small', expected: 920 },
+        { resolution: 'medium', expected: 3600 },
+        { resolution: 'large', expected: 8192 },
+        { resolution: 'best', expected: 8192 },
+      ];
+
+      testCases.forEach(({ resolution, expected }) => {
+        const testRemoteMedia = new RemoteMedia(fakeReceiveSlot, fakeMediaRequestManager, { resolution });
+        testRemoteMedia.maxFrameSize = 0; // Ensure maxFrameSize doesn't interfere
+        
+        const result = testRemoteMedia.getEffectiveMaxFs();
+        
+        assert.strictEqual(result, expected, `Failed for resolution: ${resolution}`);
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [WEBEX-436170](https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-436170) >

## This pull request addresses

The changes introduce support for 540p (960x540) video resolution as an intermediate quality level between 360p and 720p in the Webex JS SDK's multistream video functionality. This enhancement provides better bandwidth utilization and video quality optimization for medium-sized video elements.

## by making the following changes

📹 Resolution Support
* Added 540p (960x540) to [QUALITY_LEVELS](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [AVAILABLE_RESOLUTIONS](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) constants
* Defined 540p frame size as 2040 macroblocks
* Added corresponding bandwidth and bitrate constants for 540p streams
🎯 Dynamic Resolution Selection
* Enhanced setSizeHint() method in RemoteMedia class to detect 540p threshold
* Updated height-based resolution mapping: 396-539px now maps to 540p instead of jumping directly to 720p
🔧 Media Request Management
* Updated degradation sequence in MediaRequestManage to include 540p: 1080p → 720p → 540p → 360p → 180p → 90p
* Enhanced RemoteMediaGroup to support 540p in active speaker media requests
* Exported MAX_FS_VALUES for cross-module compatibility
🧪 Test Coverage
* Added comprehensive unit tests for 540p resolution handling
* Updated test constants and degradation test scenarios
* Verified size hint detection and media request generation

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
