### PR TITLE
fix: meeting not in the collection when initial Locus parsing is done

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -747,7 +747,7 @@ export default class Meeting extends StatelessWebexPlugin {
    * @constructor
    * @memberof Meeting
    */
-  constructor(attrs: any, options: object, callback) {
+  constructor(attrs: any, options: object, callback: (meeting: Meeting) => void) {
     super({}, options);
     /**
      * @instance

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -743,10 +743,11 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * @param {Object} attrs
    * @param {Object} options
+   * @param {Function} callback - if provided, it will be called with the newly created meeting object as soon as the meeting.id is set
    * @constructor
    * @memberof Meeting
    */
-  constructor(attrs: any, options: object) {
+  constructor(attrs: any, options: object, callback) {
     super({}, options);
     /**
      * @instance
@@ -772,6 +773,11 @@ export default class Meeting extends StatelessWebexPlugin {
      * @memberof Meeting
      */
     this.id = uuid.v4();
+
+    if (callback) {
+      callback(this);
+    }
+
     /**
      * Call state used for metrics
      * @instance

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1560,10 +1560,11 @@ export default class Meetings extends WebexPlugin {
       {
         // @ts-ignore
         parent: this.webex,
+      },
+      (newMeeting) => {
+        this.meetingCollection.set(newMeeting);
       }
     );
-
-    this.meetingCollection.set(meeting);
 
     try {
       // if no participant has joined the scheduled meeting (meaning meeting is not active) and we get a locusEvent,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -368,6 +368,35 @@ describe('plugin-meetings', () => {
           assert.instanceOf(meeting.simultaneousInterpretation, SimultaneousInterpretation);
           assert.instanceOf(meeting.webinar, Webinar);
         });
+
+        it('should call the callback with the meeting that has id already set', () => {
+          let meetingIdFromCallback;
+          // check that the meeting id is already set correctly at the time when the callback is called
+          const meetingCreationCallback = sinon.stub().callsFake((meeting) => {
+            meetingIdFromCallback = meeting.id;
+          });
+
+          meeting = new Meeting(
+            {
+              userId: uuid1,
+              resource: uuid2,
+              deviceUrl: uuid3,
+              locus: {url: url1},
+              destination: testDestination,
+              destinationType: DESTINATION_TYPE.MEETING_ID,
+              correlationId,
+              selfId: uuid1,
+            },
+            {
+              parent: webex,
+            },
+            meetingCreationCallback
+          );
+          assert.exists(meeting.id);
+          assert.calledOnceWithExactly(meetingCreationCallback, meeting);
+          assert.equal(meeting.id, meetingIdFromCallback);
+        });
+
         it('creates MediaRequestManager instances', () => {
           assert.instanceOf(meeting.mediaRequestManagers.audio, MediaRequestManager);
           assert.instanceOf(meeting.mediaRequestManagers.video, MediaRequestManager);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1716,6 +1716,7 @@ describe('plugin-meetings', () => {
               {file: 'meetings', function: 'fetchMeetingInfo'},
               'meeting:meetingInfoAvailable'
             );
+            assert.equal(webex.meetings.meetingCollection.get(meeting.id), meeting);
           };
 
           it('creates the meeting from a successful meeting info fetch promise testing', async () => {


### PR DESCRIPTION
# COMPLETES #[SPARK-472344](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-472344)

## This pull request addresses
There are some cases of CA events being sent with mediaType: 'share' without the proper rest of the event body. After investigating I've found that it's because when a user refreshes the page while they are sharing, on next page load we do Locus sync and recreated the meeting, there might be a timing issue where Locus will still think we have the share floor and sends us the floor status. This triggers SDK to send a metric, but the code for sending the metric fails to find the meeting object in the meeting collection and sends a half empty CA event. This is because the parsing of Locus DTO is done in the meeting constructor and at that point in time, the meeting object is not yet inserted into the meeting collection. 

## by making the following changes
Added a callback parameter to Meeting constructor, so that this callback is called immediately after the meeting id is set and in that callback we can then insert the new meeting object into the meeting collection. This ensures that the rest of the meeting constructor code that does a lot of other things (like Locus DTO parsing) has the meeting object already in the collection and won't fail to look it up.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
