### PR TITLE
fix: removed unused deltaParticipants

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -48,7 +48,6 @@ export default class LocusInfo extends EventsScope {
   aclUrl: any;
   baseSequence: any;
   created: any;
-  deltaParticipants: any;
   identities: any;
   membership: any;
   participants: any;
@@ -284,17 +283,6 @@ export default class LocusInfo extends EventsScope {
      * @property {Object} person - Contains person data.
      */
 
-    /**
-     * Stored participant changes between the last event and the current event.
-     * All previously stored events are overwritten between events.
-     *
-     * @instance
-     * @type {Array<DeltaParticipant>}
-     * @private
-     * @member LocusInfo
-     */
-    this.deltaParticipants = [];
-
     this.updateLocusCache(locus);
     // above section only updates the locusInfo object
     // The below section makes sure it updates the locusInfo as well as updates the meeting object
@@ -400,7 +388,6 @@ export default class LocusInfo extends EventsScope {
       return;
     }
 
-    this.updateParticipantDeltas(locus.participants);
     this.scheduledMeeting = locus.meeting || null;
     this.participants = locus.participants;
     const isReplaceMembers = ControlsUtils.isNeedReplaceMembers(this.controls, locus.controls);
@@ -753,55 +740,6 @@ export default class LocusInfo extends EventsScope {
         }
       );
     }
-  }
-
-  /**
-   * Update the deltaParticipants property of this object based on a list of
-   * provided participants.
-   *
-   * @param {Array} [participants] - The participants to update against.
-   * @returns {void}
-   */
-  updateParticipantDeltas(participants: Array<any> = []) {
-    // Used to find a participant within a participants collection.
-    const findParticipant = (participant, collection) =>
-      collection.find((item) => item.person.id === participant.person.id);
-
-    // Generates an object that indicates which state properties have changed.
-    const generateDelta = (prevState: any = {}, newState: any = {}) => {
-      // Setup deltas.
-      const deltas = {
-        audioStatus: prevState.audioStatus !== newState.audioStatus,
-        videoSlidesStatus: prevState.videoSlidesStatus !== newState.videoSlidesStatus,
-        videoStatus: prevState.videoStatus !== newState.videoStatus,
-      };
-
-      // Clean the object
-      Object.keys(deltas).forEach((key) => {
-        if (deltas[key] !== true) {
-          delete deltas[key];
-        }
-      });
-
-      return deltas;
-    };
-
-    this.deltaParticipants = participants.reduce((collection, participant) => {
-      const existingParticipant = findParticipant(participant, this.participants || []) || {};
-
-      const delta = generateDelta(existingParticipant.status, participant.status);
-
-      const changed = Object.keys(delta).length > 0;
-
-      if (changed) {
-        collection.push({
-          person: participant.person,
-          delta,
-        });
-      }
-
-      return collection;
-    }, []);
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -834,39 +834,6 @@ describe('plugin-meetings', () => {
         );
       });
 
-      it('should update the deltaParticipants object', () => {
-        const prev = locusInfo.deltaParticipants;
-
-        locusInfo.updateParticipantDeltas(newParticipants);
-
-        assert.notEqual(locusInfo.deltaParticipants, prev);
-      });
-
-      it('should update the delta property on all changed states', () => {
-        locusInfo.updateParticipantDeltas(newParticipants);
-
-        const [exampleParticipant] = locusInfo.deltaParticipants;
-
-        assert.isTrue(exampleParticipant.delta.audioStatus);
-        assert.isTrue(exampleParticipant.delta.videoSlidesStatus);
-        assert.isTrue(exampleParticipant.delta.videoStatus);
-      });
-
-      it('should include the person details of the changed participant', () => {
-        locusInfo.updateParticipantDeltas(newParticipants);
-
-        const [exampleParticipant] = locusInfo.deltaParticipants;
-
-        assert.equal(exampleParticipant.person, newParticipants[0].person);
-      });
-
-      it('should clear deltaParticipants when no changes occured', () => {
-        locusInfo.participants = [...newParticipants];
-
-        locusInfo.updateParticipantDeltas(locusInfo.participants);
-
-        assert.isTrue(locusInfo.deltaParticipants.length === 0);
-      });
 
       it('should call with participant display name', () => {
         const failureParticipant = [
@@ -2196,7 +2163,6 @@ describe('plugin-meetings', () => {
       it('onFullLocus() updates the working-copy of locus parser', () => {
         const eventType = 'fakeEvent';
 
-        sandbox.stub(locusInfo, 'updateParticipantDeltas');
         sandbox.stub(locusInfo, 'updateLocusInfo');
         sandbox.stub(locusInfo, 'updateParticipants');
         sandbox.stub(locusInfo, 'isMeetingActive');
@@ -2216,7 +2182,6 @@ describe('plugin-meetings', () => {
         const oldWorkingCopy = locusParser.workingCopy;
 
         const spies = [
-          sandbox.stub(locusInfo, 'updateParticipantDeltas'),
           sandbox.stub(locusInfo, 'updateLocusInfo'),
           sandbox.stub(locusInfo, 'updateParticipants'),
           sandbox.stub(locusInfo, 'isMeetingActive'),
@@ -3064,7 +3029,6 @@ describe('plugin-meetings', () => {
       beforeEach(() => {
         clock = sinon.useFakeTimers();
 
-        sinon.stub(locusInfo, 'updateParticipantDeltas');
         sinon.stub(locusInfo, 'updateParticipants');
         sinon.stub(locusInfo, 'isMeetingActive');
           sinon.stub(locusInfo, 'handleOneOnOneEvent');


### PR DESCRIPTION
## This pull request addresses
deltaParticipants in LocusInfo is set but never read.

## by making the following changes
Removed it

Looks like it was added long time ago as part of some work for adding metrics, but seems that we don't send these metrics anymore.

old PR that introduced it:
https://github.com/webex/webex-js-sdk/pull/1803

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
