### PR TITLE
fix(invite-failed): moved-agent-invite-failed-to-reject-task

### DIFF
--- a/packages/@webex/plugin-cc/src/metrics/constants.ts
+++ b/packages/@webex/plugin-cc/src/metrics/constants.ts
@@ -23,6 +23,7 @@ type Enum<T extends Record<string, unknown>> = T[keyof T];
  * @property {string} WEBSOCKET_REGISTER_FAILED - Event name for failed websocket registration.
  * @property {string} AGENT_RONA - Event name for agent RONA (Ring No Answer).
  * @property {string} AGENT_CONTACT_ASSIGN_FAILED - Event name for failed agent contact assignment.
+ * @property {string} AGENT_INVITE_FAILED - Event name for failed agent invite.
  *
  * @property {string} TASK_ACCEPT_SUCCESS - Event name for successful task acceptance.
  * @property {string} TASK_ACCEPT_FAILED - Event name for failed task acceptance.
@@ -78,6 +79,7 @@ export const METRIC_EVENT_NAMES = {
   WEBSOCKET_REGISTER_FAILED: 'Websocket Register Failed',
   AGENT_RONA: 'Agent RONA',
   AGENT_CONTACT_ASSIGN_FAILED: 'Agent Contact Assign Failed',
+  AGENT_INVITE_FAILED: 'Agent Invite Failed',
 
   // Basic Tasks
   TASK_ACCEPT_SUCCESS: 'Task Accept Success',

--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -201,12 +201,13 @@ export default class TaskManager extends EventEmitter {
           case CC_EVENTS.AGENT_CONTACT_ASSIGN_FAILED:
           case CC_EVENTS.AGENT_INVITE_FAILED: {
             task = this.updateTaskData(task, payload.data);
-            let metricEventName: keyof typeof METRIC_EVENT_NAMES = 'AGENT_RONA';
-            if (payload.data.type === CC_EVENTS.AGENT_CONTACT_ASSIGN_FAILED) {
-              metricEventName = 'AGENT_CONTACT_ASSIGN_FAILED';
-            } else if (payload.data.type === CC_EVENTS.AGENT_INVITE_FAILED) {
-              metricEventName = 'AGENT_INVITE_FAILED';
-            }
+
+            const eventTypeToMetricMap: Record<string, keyof typeof METRIC_EVENT_NAMES> = {
+              [CC_EVENTS.AGENT_CONTACT_ASSIGN_FAILED]: 'AGENT_CONTACT_ASSIGN_FAILED',
+              [CC_EVENTS.AGENT_INVITE_FAILED]: 'AGENT_INVITE_FAILED',
+            };
+            const metricEventName: keyof typeof METRIC_EVENT_NAMES =
+              eventTypeToMetricMap[payload.data.type] || 'AGENT_RONA';
 
             this.metricsManager.trackEvent(
               METRIC_EVENT_NAMES[metricEventName],

--- a/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/src/services/task/TaskManager.ts
@@ -199,11 +199,17 @@ export default class TaskManager extends EventEmitter {
             break;
           case CC_EVENTS.AGENT_CONTACT_OFFER_RONA:
           case CC_EVENTS.AGENT_CONTACT_ASSIGN_FAILED:
+          case CC_EVENTS.AGENT_INVITE_FAILED: {
             task = this.updateTaskData(task, payload.data);
+            let metricEventName: keyof typeof METRIC_EVENT_NAMES = 'AGENT_RONA';
+            if (payload.data.type === CC_EVENTS.AGENT_CONTACT_ASSIGN_FAILED) {
+              metricEventName = 'AGENT_CONTACT_ASSIGN_FAILED';
+            } else if (payload.data.type === CC_EVENTS.AGENT_INVITE_FAILED) {
+              metricEventName = 'AGENT_INVITE_FAILED';
+            }
+
             this.metricsManager.trackEvent(
-              payload.data.type === CC_EVENTS.AGENT_CONTACT_ASSIGN_FAILED
-                ? METRIC_EVENT_NAMES.AGENT_CONTACT_ASSIGN_FAILED
-                : METRIC_EVENT_NAMES.AGENT_RONA,
+              METRIC_EVENT_NAMES[metricEventName],
               {
                 ...MetricsManager.getCommonTrackingFieldForAQMResponse(payload.data),
                 taskId: payload.data.interactionId,
@@ -214,8 +220,8 @@ export default class TaskManager extends EventEmitter {
             this.handleTaskCleanup(task);
             task.emit(TASK_EVENTS.TASK_REJECT, payload.data.reason);
             break;
+          }
           case CC_EVENTS.CONTACT_ENDED:
-          case CC_EVENTS.AGENT_INVITE_FAILED:
             task = this.updateTaskData(task, {
               ...payload.data,
               wrapUpRequired: payload.data.interaction.state !== 'new',

--- a/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/plugin-cc/test/unit/spec/services/task/TaskManager.ts
@@ -381,10 +381,11 @@ describe('TaskManager', () => {
     );
   });
 
-  it('should emit TASK_END event on AGENT_INVITE_FAILED event', () => {
+  it('should emit TASK_REJECT event on AGENT_INVITE_FAILED event', () => {
     webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
 
       const taskEmitSpy = jest.spyOn(taskManager.getTask(taskId), 'emit');
+      const metricsTrackSpy = jest.spyOn(taskManager.metricsManager, 'trackEvent');
       const payload = {
         data: {
           type: CC_EVENTS.AGENT_INVITE_FAILED,
@@ -399,6 +400,7 @@ describe('TaskManager', () => {
           destAgentId: 'ebeb893b-ba67-4f36-8418-95c7492b28c2',
           owner: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
           queueMgr: 'aqm',
+          reason: 'INVITE_FAILED',
         },
       };
 
@@ -409,9 +411,12 @@ describe('TaskManager', () => {
         { ...payload.data}
       );
       expect(taskEmitSpy).toHaveBeenCalledWith(
-        TASK_EVENTS.TASK_END, 
-        taskManager.getTask(taskId)
+        TASK_EVENTS.TASK_REJECT, 
+        payload.data.reason
       );
+      // Verify the correct metric event name is used for AGENT_INVITE_FAILED
+      expect(metricsTrackSpy).toHaveBeenCalled();
+      expect(metricsTrackSpy.mock.calls[0][0]).toBe('Agent Invite Failed');
   });
 
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6910

## This pull request addresses
This PR restructures the handling of [AGENT_INVITE_FAILED] events in the TaskManager to align with other rejection events and implements dedicated metrics tracking.

< DESCRIBE THE CONTEXT OF THE ISSUE >

- Moved [CC_EVENTS.AGENT_INVITE_FAILED] from the [CONTACT_ENDED] case to the rejection events case
- Combined with [AGENT_CONTACT_OFFER_RONA] and [AGENT_CONTACT_ASSIGN_FAILED] for consistent rejection handling
- Changed event emission from [TASK_END] to [TASK_REJECT] with reason parameter

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
