### PR TITLE
fix(encryption): handle redirects from kms

### DIFF
--- a/packages/@webex/internal-plugin-encryption/src/constants.js
+++ b/packages/@webex/internal-plugin-encryption/src/constants.js
@@ -1,3 +1,4 @@
 export const KMS_KEY_REVOKE_FAILURE = 'event:kms:key:revoke:encryption:failure';
 export const KMS_KEY_REVOKE_ERROR_STATUS = 405;
 export const KMS_KEY_REVOKE_ERROR_CODES = [405005, 405006];
+export const KMS_KEY_REDIRECT_ERROR_CODE = 301002;


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-534897

## This pull request addresses

[< DESCRIBE THE CONTEXT OF THE ISSUE >]
https://sqbu-github.cisco.com/pages/WebexSquared/arch-docs/services/kms/arch/kms-510-migrations.html#migrated-data-breadcrumbs
clients were recently made aware of a change needed to handle KMS migrations for federation phase 4. clients must handle this 301 response from KMS.

## by making the following changes

when handling the KMS response, check for the errorCode. if it's 301002 use the redirectUri to get the new KMS key

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
