### PR TITLE
feat(contact-center): fixed-dest-agent-id-obtaining

### DIFF
--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -271,6 +271,7 @@ export default class TaskManager extends EventEmitter {
           case CC_EVENTS.AGENT_CONSULTING:
             // Received when agent is in an active consult state
             // TODO: Check if we can use backend consult state instead of isConsulted
+            task = this.updateTaskData(task, payload.data);
             if (task.data.isConsulted) {
               // Fire only if you are the agent who received the consult request
               task.emit(TASK_EVENTS.TASK_CONSULT_ACCEPTED, task);

--- a/packages/@webex/contact-center/src/services/task/index.ts
+++ b/packages/@webex/contact-center/src/services/task/index.ts
@@ -1,7 +1,11 @@
 import EventEmitter from 'events';
 import {CALL_EVENT_KEYS, LocalMicrophoneStream} from '@webex/calling';
 import {CallId} from '@webex/calling/dist/types/common/types';
-import {getErrorDetails, deriveConsultTransferDestinationType} from '../core/Utils';
+import {
+  getErrorDetails,
+  deriveConsultTransferDestinationType,
+  getDestinationAgentId,
+} from '../core/Utils';
 import {LoginOption} from '../../types';
 import {TASK_FILE} from '../../constants';
 import {METHODS} from './constants';
@@ -1310,13 +1314,19 @@ export default class Task extends EventEmitter implements ITask {
     consultTransferPayload?: ConsultTransferPayLoad
   ): Promise<TaskResponse> {
     try {
+      // Get the destination agent ID using custom logic from participants data
+      const destAgentId = getDestinationAgentId(
+        this.data.interaction?.participants,
+        this.data.agentId
+      );
+
       // Resolve the target id (queue consult transfers go to the accepted agent)
-      if (!this.data.destAgentId) {
+      if (!destAgentId) {
         throw new Error('No agent has accepted this queue consult yet');
       }
 
       LoggerProxy.info(
-        `Initiating consult transfer to ${consultTransferPayload?.to || this.data.destAgentId}`,
+        `Initiating consult transfer to ${consultTransferPayload?.to || destAgentId}`,
         {
           module: TASK_FILE,
           method: METHODS.CONSULT_TRANSFER,
@@ -1326,9 +1336,9 @@ export default class Task extends EventEmitter implements ITask {
       // Obtain payload based on desktop logic using TaskData
       const finalDestinationType = deriveConsultTransferDestinationType(this.data);
 
-      // By default we always use `destAgentId` as the target id
+      // By default we always use the computed destAgentId as the target id
       const consultTransferRequest: ConsultTransferPayLoad = {
-        to: this.data.destAgentId,
+        to: destAgentId,
         destinationType: finalDestinationType,
       };
 
@@ -1350,9 +1360,7 @@ export default class Task extends EventEmitter implements ITask {
       );
 
       LoggerProxy.log(
-        `Consult transfer completed successfully to ${
-          consultTransferPayload?.to || this.data.destAgentId
-        }`,
+        `Consult transfer completed successfully to ${consultTransferPayload?.to || destAgentId}`,
         {
           module: TASK_FILE,
           method: METHODS.CONSULT_TRANSFER,
@@ -1365,11 +1373,16 @@ export default class Task extends EventEmitter implements ITask {
     } catch (error) {
       const {error: detailedError} = getErrorDetails(error, METHODS.CONSULT_TRANSFER, TASK_FILE);
       const failedDestinationType = deriveConsultTransferDestinationType(this.data);
+      const failedDestAgentId = getDestinationAgentId(
+        this.data.interaction?.participants,
+        this.data.agentId,
+        this.data.destAgentId
+      );
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.TASK_TRANSFER_FAILED,
         {
           taskId: this.data.interactionId,
-          destination: this.data.destAgentId || '',
+          destination: failedDestAgentId || '',
           destinationType: failedDestinationType,
           isConsultTransfer: true,
           error: error.toString(),

--- a/packages/@webex/contact-center/src/services/task/index.ts
+++ b/packages/@webex/contact-center/src/services/task/index.ts
@@ -1375,8 +1375,7 @@ export default class Task extends EventEmitter implements ITask {
       const failedDestinationType = deriveConsultTransferDestinationType(this.data);
       const failedDestAgentId = getDestinationAgentId(
         this.data.interaction?.participants,
-        this.data.agentId,
-        this.data.destAgentId
+        this.data.agentId
       );
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.TASK_TRANSFER_FAILED,

--- a/packages/@webex/contact-center/test/unit/spec/services/core/Utils.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/core/Utils.ts
@@ -276,4 +276,54 @@ describe('Utils', () => {
       });
     });
   });
+
+  describe('getDestinationAgentId', () => {
+    const currentAgentId = 'agent-current-123';
+
+    it('returns another Agent id when present and not in wrap-up', () => {
+      const participants: any = {
+        [currentAgentId]: {type: 'Agent', id: currentAgentId, isWrapUp: false},
+        agent1: {type: 'Agent', id: 'agent-1', isWrapUp: false},
+        customer1: {type: 'Customer', id: 'cust-1', isWrapUp: false},
+      };
+
+      const result = Utils.getDestinationAgentId(participants, currentAgentId);
+      expect(result).toBe('agent-1');
+    });
+
+    it('ignores self and wrap-up participants', () => {
+      const participants: any = {
+        [currentAgentId]: {type: 'Agent', id: currentAgentId, isWrapUp: false},
+        agentWrap: {type: 'Agent', id: 'agent-wrap', isWrapUp: true},
+      };
+
+      const result = Utils.getDestinationAgentId(participants, currentAgentId);
+      expect(result).toBe('');
+    });
+
+    it('supports DN, EpDn and entryPoint types', () => {
+      const participantsDN: any = {
+        [currentAgentId]: {type: 'Agent', id: currentAgentId, isWrapUp: false},
+        dn1: {type: 'DN', id: 'dn-1', isWrapUp: false},
+      };
+      expect(Utils.getDestinationAgentId(participantsDN, currentAgentId)).toBe('dn-1');
+
+      const participantsEpDn: any = {
+        [currentAgentId]: {type: 'Agent', id: currentAgentId, isWrapUp: false},
+        epdn1: {type: 'EpDn', id: 'epdn-1', isWrapUp: false},
+      };
+      expect(Utils.getDestinationAgentId(participantsEpDn, currentAgentId)).toBe('epdn-1');
+
+      const participantsEntry: any = {
+        [currentAgentId]: {type: 'Agent', id: currentAgentId, isWrapUp: false},
+        entry1: {type: 'entryPoint', id: 'entry-1', isWrapUp: false},
+      };
+      expect(Utils.getDestinationAgentId(participantsEntry, currentAgentId)).toBe('entry-1');
+    });
+
+    it('returns empty string when participants is missing or empty', () => {
+      expect(Utils.getDestinationAgentId(undefined as any, currentAgentId)).toBe('');
+      expect(Utils.getDestinationAgentId({} as any, currentAgentId)).toBe('');
+    });
+  });
 });

--- a/packages/@webex/contact-center/test/unit/spec/services/task/index.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/index.ts
@@ -39,6 +39,7 @@ describe('Task', () => {
   let loggerInfoSpy;
   let loggerLogSpy;
   let loggerErrorSpy;
+  let getDestinationAgentIdSpy;
 
   const taskId = '0ae913a4-c857-4705-8d49-76dd3dde75e4';
   const mockTrack = {} as MediaStreamTrack;
@@ -141,6 +142,11 @@ describe('Task', () => {
       },
     };
 
+    // Mock destination agent id resolution from participants
+    getDestinationAgentIdSpy = jest
+      .spyOn(Utils, 'getDestinationAgentId')
+      .mockReturnValue(taskDataMock.destAgentId);
+
     // Create an instance of Task
     task = new Task(contactMock, webCallingService, taskDataMock);
 
@@ -163,6 +169,7 @@ describe('Task', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('test the on spy', async () => {
@@ -862,6 +869,9 @@ describe('Task', () => {
       to: 'some-queue-id',
       destinationType: CONSULT_TRANSFER_DESTINATION_TYPE.QUEUE,
     };
+
+    // For this negative case, ensure computed destination is empty
+    getDestinationAgentIdSpy.mockReturnValueOnce('');
 
     await expect(
       taskWithoutDestAgentId.consultTransfer(queueConsultTransferPayload)


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< AD-HOC>

## This pull request addresses

* In the previous PR to ensure consultTransfer to dial number works, we had removed a task.updateTaskData for the CONSULTING event.
* This caused an issue on widgets as now for receiving consult, we were looking at some value inside that updated data for UI changes.
* Hence e2e tests were failing
* Now, we also were incorrectly reading the `destAgentId` from the task data - agent desktop has a different method.

## by making the following changes

* Fixed the consult UI issue by re-adding the update task data.
* We are now extracting the `destAgentId` from the task data but in the same way agent desktop does.
* The logic is a bit weird but they simply use the `this.data.interactions.participants` object and extratc the id of the non-user agent there
* Added unit tests for the same

E2E Tests for Consult passing in widgets - 

<img width="2032" height="1091" alt="Screenshot 2025-09-16 at 12 39 54 PM" src="https://github.com/user-attachments/assets/bd6f9e2c-fd88-44d4-9d6a-4c0677032d46" />


<img width="2032" height="1091" alt="Screenshot 2025-09-16 at 2 20 48 PM" src="https://github.com/user-attachments/assets/a1f02a03-964f-4066-bddc-36b49f5604b4" />


Widgets Vidcast showing consult transfer working - https://app.vidcast.io/share/2562d51c-3e3c-41fc-9960-50c8c8d55913

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Ran e2e tests on widgets locally
* Basic call control tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Cursor
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
