### PR TITLE
fix: metric meetingUserCount

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6965,10 +6965,10 @@ export default class Meeting extends StatelessWebexPlugin {
         }
       }
 
-      // Count members that are in the meeting.
+      // Count members that are in the meeting or in the lobby.
       const {members} = this.getMembers().membersCollection;
       event.data.intervalMetadata.meetingUserCount = Object.values(members).filter(
-        (member: Member) => member.isInMeeting
+        (member: Member) => member.isInMeeting || member.isInLobby
       ).length;
 
       // @ts-ignore

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -4038,7 +4038,7 @@ describe('plugin-meetings', () => {
                 member2: {isInMeeting: false, isInLobby: true},
                 member3: {isInMeeting: false, isInLobby: false},
                 member4: {isInMeeting: true, isInLobby: false},
-              },
+              }
             };
             sinon.stub(meeting, 'getMembers').returns({membersCollection: fakeMembersCollection});
             const fakeData = {intervalMetadata: {}};

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -4031,7 +4031,7 @@ describe('plugin-meetings', () => {
             });
           });
 
-          it.only('counts the number of members that are in the meeting or lobby for MEDIA_QUALITY event', async () => {
+          it('counts the number of members that are in the meeting or lobby for MEDIA_QUALITY event', async () => {
             let fakeMembersCollection = {
               members: {
                 member1: {isInMeeting: true, isInLobby: false},

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -487,7 +487,7 @@ describe('plugin-meetings', () => {
 
         it('pstnCorrelationId getter/setter should work correctly', () => {
           const testPstnCorrelationId = uuid.v4();
-          
+
           meeting.pstnCorrelationId = testPstnCorrelationId;
           assert.equal(meeting.pstnCorrelationId, testPstnCorrelationId);
           assert.equal(meeting.callStateForMetrics.pstnCorrelationId, testPstnCorrelationId);
@@ -1992,10 +1992,10 @@ describe('plugin-meetings', () => {
           it('should handle join failure', async () => {
             MeetingUtil.isPinOrGuest = sinon.stub().returns(false);
             webex.internal.newMetrics.submitClientEvent = sinon.stub();
-            
+
             await meeting.join().catch(() => {
               assert.calledOnce(MeetingUtil.joinMeeting);
-              
+
               // Assert that client.locus.join.response error event is not sent from this function, it is now emitted from MeetingUtil.joinMeeting
               assert.calledOnce(webex.internal.newMetrics.submitClientEvent);
               assert.calledWithMatch(
@@ -4031,12 +4031,13 @@ describe('plugin-meetings', () => {
             });
           });
 
-          it('counts the number of members that are in the meeting for MEDIA_QUALITY event', async () => {
+          it.only('counts the number of members that are in the meeting or lobby for MEDIA_QUALITY event', async () => {
             let fakeMembersCollection = {
               members: {
-                member1: {isInMeeting: true},
-                member2: {isInMeeting: true},
-                member3: {isInMeeting: false},
+                member1: {isInMeeting: true, isInLobby: false},
+                member2: {isInMeeting: false, isInLobby: true},
+                member3: {isInMeeting: false, isInLobby: false},
+                member4: {isInMeeting: true, isInLobby: false},
               },
             };
             sinon.stub(meeting, 'getMembers').returns({membersCollection: fakeMembersCollection});
@@ -4055,11 +4056,12 @@ describe('plugin-meetings', () => {
               },
               payload: {
                 intervals: [
-                  sinon.match.has('intervalMetadata', sinon.match.has('meetingUserCount', 2)),
+                  sinon.match.has('intervalMetadata', sinon.match.has('meetingUserCount', 3)),
                 ],
               },
             });
-            fakeMembersCollection.members.member2.isInMeeting = false;
+            // Move member2 from lobby to neither in meeting nor lobby
+            fakeMembersCollection.members.member2.isInLobby = false;
 
             statsAnalyzerStub.emit(
               {file: 'test', function: 'test'},
@@ -4074,7 +4076,7 @@ describe('plugin-meetings', () => {
               },
               payload: {
                 intervals: [
-                  sinon.match.has('intervalMetadata', sinon.match.has('meetingUserCount', 1)),
+                  sinon.match.has('intervalMetadata', sinon.match.has('meetingUserCount', 2)),
                 ],
               },
             });
@@ -6548,7 +6550,7 @@ describe('plugin-meetings', () => {
             clientUrl: meeting.deviceUrl,
           });
           assert.notCalled(meeting.meetingRequest.dialOut);
-          
+
           // Verify pstnCorrelationId was set
           assert.exists(meeting.pstnCorrelationId);
           assert.notEqual(meeting.pstnCorrelationId, meeting.correlationId);
@@ -6625,7 +6627,7 @@ describe('plugin-meetings', () => {
             throw new Error('Promise resolved when it should have rejected');
           } catch (e) {
             assert.equal(e, error);
-            
+
             // Verify behavioral metric was sent with dial_in_correlation_id
             assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.ADD_DIAL_IN_FAILURE, {
               correlation_id: meeting.correlationId,
@@ -6636,7 +6638,7 @@ describe('plugin-meetings', () => {
               reason: error.error.message,
               stack: error.stack,
             });
-            
+
             // Verify pstnCorrelationId was cleared after error
             assert.equal(meeting.pstnCorrelationId, undefined);
           }
@@ -6652,7 +6654,7 @@ describe('plugin-meetings', () => {
             throw new Error('Promise resolved when it should have rejected');
           } catch (e) {
             assert.equal(e, error);
-            
+
             // Verify behavioral metric was sent with dial_out_correlation_id
             assert.calledWith(Metrics.sendBehavioralMetric, BEHAVIORAL_METRICS.ADD_DIAL_OUT_FAILURE, {
               correlation_id: meeting.correlationId,
@@ -6663,7 +6665,7 @@ describe('plugin-meetings', () => {
               reason: error.error.message,
               stack: error.stack,
             });
-            
+
             // Verify pstnCorrelationId was cleared after error
             assert.equal(meeting.pstnCorrelationId, undefined);
           }
@@ -6686,12 +6688,12 @@ describe('plugin-meetings', () => {
 
         it('should disconnect phone audio and clear pstnCorrelationId', async () => {
           meeting.pstnCorrelationId = 'test-pstn-correlation-id';
-          
+
           await meeting.disconnectPhoneAudio();
-          
+
           // Verify that pstnCorrelationId is cleared
           assert.equal(meeting.pstnCorrelationId, undefined);
-          
+
           // Verify that MeetingUtil.disconnectPhoneAudio was called for both dial-in and dial-out
           assert.calledTwice(MeetingUtil.disconnectPhoneAudio);
           assert.calledWith(MeetingUtil.disconnectPhoneAudio, meeting, meeting.dialInUrl);
@@ -6702,9 +6704,9 @@ describe('plugin-meetings', () => {
           meeting.dialInDeviceStatus = 'IDLE';
           meeting.dialOutDeviceStatus = 'IDLE';
           meeting.pstnCorrelationId = 'test-pstn-correlation-id';
-          
+
           await meeting.disconnectPhoneAudio();
-          
+
           // Verify that pstnCorrelationId is still cleared even when no phone connection is active
           assert.equal(meeting.pstnCorrelationId, undefined);
            // And verify no disconnect was attempted


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [SPARK-715071](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-715071)

## This pull request addresses

Updates the calculation for meetingUserCount metric to align it with other Webex clients. 

## by making the following changes

Includes calculation for meetingUserCount in lobby participant logic.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested manually with the sample app and Webex client

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
