### PR TITLE
fix(calling): add broadworksCorrelationInfo and fix the upload logs

### DIFF
--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -3048,6 +3048,8 @@ describe('Supplementary Services tests', () => {
       const warnSpy = jest.spyOn(log, 'warn');
       const metricSpy = jest.spyOn(call['metricManager'], 'submitCallMetric');
 
+      call['broadworksCorrelationInfo'] = 'dummy-broadworks-correlation-info';
+
       await call.completeTransfer(TransferType.BLIND, undefined, transfereeNumber);
       await flushPromises(1);
 
@@ -3068,6 +3070,7 @@ describe('Supplementary Services tests', () => {
       expect(uploadLogsSpy).toHaveBeenCalledWith({
         correlationId: call.getCorrelationId(),
         callId: call.getCallId(),
+        broadworksCorrelationInfo: 'dummy-broadworks-correlation-info',
       });
       /* check whether error event is being emitted by sdk */
       expect(emitSpy).toBeCalledOnceWith(CALL_EVENT_KEYS.TRANSFER_ERROR, expect.any(CallError));

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -1011,6 +1011,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       await uploadLogs({
         correlationId: this.correlationId,
         callId: this.callId,
+        broadworksCorrelationInfo: this.broadworksCorrelationInfo,
       });
     }
   }
@@ -1086,6 +1087,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       await uploadLogs({
         correlationId: this.correlationId,
         callId: this.callId,
+        broadworksCorrelationInfo: this.broadworksCorrelationInfo,
       });
     }
   }
@@ -1161,6 +1163,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       await uploadLogs({
         correlationId: this.correlationId,
         callId: this.callId,
+        broadworksCorrelationInfo: this.broadworksCorrelationInfo,
       });
     }
   }
@@ -1285,6 +1288,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       await uploadLogs({
         correlationId: this.correlationId,
         callId: this.callId,
+        broadworksCorrelationInfo: this.broadworksCorrelationInfo,
       });
     }
   }
@@ -1370,6 +1374,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       await uploadLogs({
         correlationId: this.correlationId,
         callId: this.callId,
+        broadworksCorrelationInfo: this.broadworksCorrelationInfo,
       });
     }
   }
@@ -1557,6 +1562,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         await uploadLogs({
           correlationId: this.correlationId,
           callId: this.callId,
+          broadworksCorrelationInfo: this.broadworksCorrelationInfo,
         });
       }
     }, DEFAULT_SESSION_TIMER);
@@ -1741,6 +1747,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         await uploadLogs({
           correlationId: this.correlationId,
           callId: this.callId,
+          broadworksCorrelationInfo: this.broadworksCorrelationInfo,
         });
       }
     } else {
@@ -1821,6 +1828,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         await uploadLogs({
           correlationId: this.correlationId,
           callId: this.callId,
+          broadworksCorrelationInfo: this.broadworksCorrelationInfo,
         });
       }
     }
@@ -1897,6 +1905,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       await uploadLogs({
         correlationId: this.correlationId,
         callId: this.callId,
+        broadworksCorrelationInfo: this.broadworksCorrelationInfo,
       });
     }
   }
@@ -1950,6 +1959,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       await uploadLogs({
         correlationId: this.correlationId,
         callId: this.callId,
+        broadworksCorrelationInfo: this.broadworksCorrelationInfo,
       });
     }
   }
@@ -2048,6 +2058,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       await uploadLogs({
         correlationId: this.correlationId,
         callId: this.callId,
+        broadworksCorrelationInfo: this.broadworksCorrelationInfo,
       });
     }
   };
@@ -2461,6 +2472,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         await uploadLogs({
           correlationId: this.correlationId,
           callId: this.callId,
+          broadworksCorrelationInfo: this.broadworksCorrelationInfo,
         });
       }
     } else if (transferType === TransferType.CONSULT && transferCallId) {
@@ -2511,6 +2523,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         await uploadLogs({
           correlationId: this.correlationId,
           callId: this.callId,
+          broadworksCorrelationInfo: this.broadworksCorrelationInfo,
         });
       }
     } else {

--- a/packages/calling/src/Metrics/index.ts
+++ b/packages/calling/src/Metrics/index.ts
@@ -36,52 +36,50 @@ class MetricManager implements IMetricManager {
     feedbackId?: string,
     correlationId?: string,
     stack?: string,
-    callId?: string
+    callId?: string,
+    broadworksCorrelationInfo?: string
   ) {
     let data;
 
+    const commonData = {
+      tags: {
+        action,
+        device_id: this.deviceInfo?.device?.deviceId,
+        service_indicator: this.serviceIndicator,
+      },
+      fields: {
+        device_url: this.deviceInfo?.device?.clientDeviceUri,
+        mobius_url: this.deviceInfo?.device?.uri,
+        calling_sdk_version: process.env.CALLING_SDK_VERSION || VERSION,
+        correlation_id: correlationId,
+        broadworksCorrelationInfo,
+        tracking_id: trackingId,
+        feedback_id: feedbackId,
+        call_id: callId,
+      },
+      type,
+    };
+
     switch (name) {
       case METRIC_EVENT.UPLOAD_LOGS_SUCCESS: {
-        data = {
-          tags: {
-            action,
-            device_id: this.deviceInfo?.device?.deviceId,
-            service_indicator: this.serviceIndicator,
-          },
-          fields: {
-            device_url: this.deviceInfo?.device?.clientDeviceUri,
-            mobius_url: this.deviceInfo?.device?.uri,
-            calling_sdk_version: process.env.CALLING_SDK_VERSION || VERSION,
-            correlation_id: correlationId,
-            tracking_id: trackingId,
-            feedback_id: feedbackId,
-            call_id: callId,
-          },
-          type,
-        };
+        data = commonData;
+
         break;
       }
+
       case METRIC_EVENT.UPLOAD_LOGS_FAILED: {
         data = {
-          tags: {
-            action,
-            device_id: this.deviceInfo?.device?.deviceId,
-            service_indicator: this.serviceIndicator,
-          },
+          ...commonData,
           fields: {
-            device_url: this.deviceInfo?.device?.clientDeviceUri,
-            mobius_url: this.deviceInfo?.device?.uri,
-            calling_sdk_version: process.env.CALLING_SDK_VERSION || VERSION,
-            correlation_id: correlationId,
-            tracking_id: trackingId,
-            feedback_id: feedbackId,
+            ...commonData.fields,
             error: stack,
-            call_id: callId,
           },
-          type,
         };
+
+        break;
       }
     }
+
     if (data) {
       this.webex.internal.metrics.submitClientMetrics(name, data);
     }

--- a/packages/calling/src/Metrics/types.ts
+++ b/packages/calling/src/Metrics/types.ts
@@ -49,6 +49,7 @@ export const UPLOAD_LOGS_ACTION = 'upload_logs';
 
 export interface IMetricManager {
   setDeviceInfo: (deviceInfo: IDeviceInfo) => void;
+
   submitRegistrationMetric: (
     name: METRIC_EVENT,
     metricAction: REG_ACTION,
@@ -59,12 +60,14 @@ export interface IMetricManager {
     keepaliveCount?: number,
     error?: LineError | CallingClientError
   ) => void;
+
   submitBNRMetric: (
     name: METRIC_EVENT,
     type: METRIC_TYPE,
     callId: CallId,
     correlationId: CorrelationId
   ) => void;
+
   submitCallMetric: (
     name: METRIC_EVENT,
     metricAction: string,
@@ -73,6 +76,7 @@ export interface IMetricManager {
     correlationId: CorrelationId,
     callError?: CallError
   ) => void;
+
   submitMediaMetric: (
     name: METRIC_EVENT,
     metricAction: string,
@@ -83,6 +87,7 @@ export interface IMetricManager {
     remoteSdp?: string,
     callError?: CallError
   ) => void;
+
   submitVoicemailMetric: (
     name: METRIC_EVENT,
     metricAction: string,
@@ -91,6 +96,7 @@ export interface IMetricManager {
     voicemailError?: string,
     statusCode?: number
   ) => void;
+
   submitUploadLogsMetric: (
     name: METRIC_EVENT,
     metricAction: string,
@@ -99,6 +105,7 @@ export interface IMetricManager {
     feedbackId?: string,
     correlationId?: string,
     stack?: string,
-    callId?: string
+    callId?: string,
+    broadworksCorrelationInfo?: string
   ) => void;
 }

--- a/packages/calling/src/common/Utils.test.ts
+++ b/packages/calling/src/common/Utils.test.ts
@@ -1827,14 +1827,15 @@ describe('uploadLogs', () => {
         'web-calling-sdk-upload-logs-failed',
         {
           fields: {
-            call_id: undefined,
-            calling_sdk_version: 'unknown',
-            correlation_id: 'Failed to upload Logs Error: Upload failed',
             device_url: undefined,
-            error: undefined,
-            feedback_id: 'test-correlation',
             mobius_url: undefined,
-            tracking_id: 'mocked-uuid-12345',
+            calling_sdk_version: 'unknown',
+            correlation_id: 'test-correlation',
+            broadworksCorrelationInfo: undefined,
+            tracking_id: undefined,
+            feedback_id: 'mocked-uuid-12345',
+            call_id: undefined,
+            error: 'Failed to upload Logs Error: Upload failed',
           },
           tags: {action: 'upload_logs', device_id: undefined, service_indicator: 'calling'},
           type: 'behavioral',
@@ -1844,7 +1845,10 @@ describe('uploadLogs', () => {
   });
 
   it('should log error and not throw an error if the upload fails with throw exception false', async () => {
-    const mockMetaData = {correlationId: 'test-correlation'};
+    const mockMetaData = {
+      correlationId: 'test-correlation',
+      broadworksCorrelationInfo: 'test-broadworks-correlation',
+    };
     const mockError = new Error('Upload failed');
 
     // Mock the submitLogs to fail
@@ -1868,14 +1872,15 @@ describe('uploadLogs', () => {
       'web-calling-sdk-upload-logs-failed',
       {
         fields: {
-          call_id: undefined,
-          calling_sdk_version: 'unknown',
-          correlation_id: 'Failed to upload Logs Error: Upload failed',
           device_url: undefined,
-          error: undefined,
-          feedback_id: 'test-correlation',
           mobius_url: undefined,
-          tracking_id: 'mocked-uuid-12345',
+          calling_sdk_version: 'unknown',
+          correlation_id: 'test-correlation',
+          broadworksCorrelationInfo: 'test-broadworks-correlation',
+          tracking_id: undefined,
+          feedback_id: 'mocked-uuid-12345',
+          call_id: undefined,
+          error: 'Failed to upload Logs Error: Upload failed',
         },
         tags: {action: 'upload_logs', device_id: undefined, service_indicator: 'calling'},
         type: 'behavioral',

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -1633,7 +1633,10 @@ export async function uploadLogs(
       METRIC_TYPE.BEHAVIORAL,
       response?.trackingid,
       feedbackId,
-      metaData?.correlationId
+      metaData?.correlationId,
+      undefined,
+      metaData?.callId,
+      metaData?.broadworksCorrelationInfo
     );
 
     return {
@@ -1641,6 +1644,9 @@ export async function uploadLogs(
       ...(response.url ? {url: response.url} : {}),
       ...(response.userId ? {userId: response.userId} : {}),
       ...(response.correlationId ? {correlationId: response.correlationId} : {}),
+      ...(metaData?.broadworksCorrelationInfo
+        ? {broadworksCorrelationInfo: metaData?.broadworksCorrelationInfo}
+        : {}),
       feedbackId,
     };
   } catch (error) {
@@ -1654,9 +1660,12 @@ export async function uploadLogs(
       METRIC_EVENT.UPLOAD_LOGS_FAILED,
       UPLOAD_LOGS_ACTION,
       METRIC_TYPE.BEHAVIORAL,
+      undefined,
       feedbackId,
       metaData?.correlationId,
-      errorLog.message
+      errorLog.message,
+      metaData?.callId,
+      metaData?.broadworksCorrelationInfo
     );
 
     if (throwError) {

--- a/packages/calling/src/common/types.ts
+++ b/packages/calling/src/common/types.ts
@@ -278,6 +278,7 @@ export type LogsMetaData = {
   callId?: string;
   feedbackId?: string;
   correlationId?: string;
+  broadworksCorrelationInfo?: string;
 };
 
 export type UploadLogsResponse = {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #<[CAI-6986](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6986)>

## This pull request addresses

- Adds the `broadworksCorrelationInfo` in the upload logs meta data and amplitude metric.
- Fixes feedbackId and trackingId values

## by making the following changes

Updated the code to utilize the `broadworksCorrelationInfo` coming from mobius for `mobius.call` events and all the subsequent errors in the call will upload the logs and metric with `broadworksCorrelationInfo` which connects all the logs between Mobius <-> SSE <-> MSE


<img width="1746" height="1084" alt="network call - broadworksCorrelationInfo" src="https://github.com/user-attachments/assets/6f78c531-ee00-44f3-95cc-4846b5a52348" />

<img width="1726" height="1039" alt="amplitude - broadworksCorrelationInfo" src="https://github.com/user-attachments/assets/0823cdbe-05d1-4099-aa3c-8deef3468567" />


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify --> Windsurf
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
