### PR TITLE
feat(classification): add classificationId to param for instant meeting request

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -269,6 +269,7 @@ export enum ScreenShareFloorStatus {
 type FetchMeetingInfoParams = {
   password?: string;
   registrationId?: string;
+  classificationId?: string;
   captchaCode?: string;
   extraParams?: Record<string, any>;
   sendCAevents?: boolean;
@@ -1902,6 +1903,7 @@ export default class Meeting extends StatelessWebexPlugin {
     extraParams = {},
     sendCAevents = false,
     registrationId = null,
+    classificationId = null,
   }): Promise<void> {
     try {
       const captchaInfo = captchaCode
@@ -1918,7 +1920,9 @@ export default class Meeting extends StatelessWebexPlugin {
         this.locusId,
         extraParams,
         {meetingId: this.id, sendCAevents},
-        registrationId
+        registrationId,
+        null,
+        classificationId
       );
 
       this.parseMeetingInfo(info?.body, this.destination, info?.errors);

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -1331,6 +1331,7 @@ export default class Meetings extends WebexPlugin {
    * @param {Object} [meetingInfo] - Pre-fetched complete meeting info
    * @param {String} [meetingLookupUrl] - meeting info prefetch url
    * @param {string} sessionCorrelationId - the optional specified sessionCorrelationId (callStateForMetrics.sessionCorrelationId) can be provided instead
+   * @param {String} classificationId - If space support classification, it will provide it while start instant meeting
    * @returns {Promise<Meeting>} A new Meeting.
    * @public
    * @memberof Meetings
@@ -1345,7 +1346,8 @@ export default class Meetings extends WebexPlugin {
     callStateForMetrics: CallStateForMetrics = undefined,
     meetingInfo = undefined,
     meetingLookupUrl = undefined,
-    sessionCorrelationId: string = undefined
+    sessionCorrelationId: string = undefined,
+    classificationId: string = undefined
   ) {
     // Validate meeting information based on the provided destination and
     // type. This must be performed prior to determining if the meeting is
@@ -1415,7 +1417,8 @@ export default class Meetings extends WebexPlugin {
               callStateForMetrics,
               failOnMissingMeetingInfo,
               meetingInfo,
-              meetingLookupUrl
+              meetingLookupUrl,
+              classificationId
             ).then((createdMeeting: any) => {
               // If the meeting was successfully created.
               if (createdMeeting && createdMeeting.on) {
@@ -1529,6 +1532,7 @@ export default class Meetings extends WebexPlugin {
    * @param {Boolean} failOnMissingMeetingInfo - whether to throw an error if meeting info fails to fetch (for calls that are not 1:1 or content share)
    * @param {Object} [meetingInfo] - Pre-fetched complete meeting info
    * @param {String} [meetingLookupUrl] - meeting info prefetch url
+   * @param {String} classificationId see create()
    * @returns {Promise} a new meeting instance complete with meeting info and destination
    * @private
    * @memberof Meetings
@@ -1541,7 +1545,8 @@ export default class Meetings extends WebexPlugin {
     callStateForMetrics: CallStateForMetrics = undefined,
     failOnMissingMeetingInfo = false,
     meetingInfo = undefined,
-    meetingLookupUrl = undefined
+    meetingLookupUrl = undefined,
+    classificationId = undefined
   ) {
     const meeting = new Meeting(
       {
@@ -1589,6 +1594,7 @@ export default class Meetings extends WebexPlugin {
       // @ts-ignore
       const {enableUnifiedMeetings} = this.config.experimental;
       const meetingInfoOptions = {
+        classificationId,
         extraParams: infoExtraParams,
         sendCAevents: !!callStateForMetrics?.correlationId, // if client sends correlation id as argument of public create(), then it means that this meeting creation is part of a pre-join intent from user
       };

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -218,6 +218,7 @@ describe('plugin-meetings', () => {
             invitees: invitee,
             installedOrgID: undefined,
             schedule: true,
+            classificationId: undefined,
           },
         });
 
@@ -652,7 +653,8 @@ describe('plugin-meetings', () => {
         assert.calledOnceWithExactly(
           meetingInfo.createAdhocSpaceMeeting,
           'conversationUrl',
-          installedOrgID
+          installedOrgID,
+          null,
         );
         assert.notCalled(webex.request);
         meetingInfo.createAdhocSpaceMeeting.restore();
@@ -1148,6 +1150,7 @@ describe('plugin-meetings', () => {
     describe('createAdhocSpaceMeeting', () => {
       const conversationUrl = 'https://conversationUrl/xxx';
       const installedOrgID = '12345';
+      const classificationId = '123456';
 
       const setup = () => {
         const invitee = [];
@@ -1173,7 +1176,7 @@ describe('plugin-meetings', () => {
           body: conversation,
         });
 
-        const result = await meetingInfo.createAdhocSpaceMeeting(conversationUrl, installedOrgID);
+        const result = await meetingInfo.createAdhocSpaceMeeting(conversationUrl, installedOrgID, classificationId);
 
         assert.calledWith(webex.request, {
           uri: conversationUrl,
@@ -1192,6 +1195,7 @@ describe('plugin-meetings', () => {
             invitees: invitee,
             installedOrgID: installedOrgID,
             schedule: false,
+            classificationId,
           },
         });
         assert.calledOnce(Metrics.sendBehavioralMetric);
@@ -1206,7 +1210,7 @@ describe('plugin-meetings', () => {
         webex.request = sinon.stub().resolves({
           body: conversation,
         });
-        await meetingInfo.createAdhocSpaceMeeting(conversationUrl, installedOrgID);
+        await meetingInfo.createAdhocSpaceMeeting(conversationUrl, installedOrgID, classificationId);
 
         assert.calledWith(webex.request, {
           uri: conversationUrl,
@@ -1224,6 +1228,7 @@ describe('plugin-meetings', () => {
             invitees: invitee,
             installedOrgID,
             schedule: false,
+            classificationId,
           },
         });
         assert(Metrics.sendBehavioralMetric.calledOnce);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -7462,6 +7462,8 @@ describe('plugin-meetings', () => {
             'locus-id',
             {extraParam1: 'value1', permissionToken: FAKE_PERMISSION_TOKEN},
             {meetingId: meeting.id, sendCAevents: true},
+            null,
+            null,
             null
           );
           assert.deepEqual(meeting.meetingInfo, {
@@ -7508,6 +7510,8 @@ describe('plugin-meetings', () => {
             'locus-id',
             {extraParam1: 'value1', permissionToken: FAKE_PERMISSION_TOKEN},
             {meetingId: meeting.id, sendCAevents: true},
+            null,
+            null,
             null
           );
           assert.deepEqual(meeting.meetingInfo, {
@@ -7563,6 +7567,8 @@ describe('plugin-meetings', () => {
               permissionToken: FAKE_PERMISSION_TOKEN,
             },
             {meetingId: meeting.id, sendCAevents: true},
+            null,
+            null,
             null
           );
           assert.deepEqual(meeting.meetingInfo, {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1099,6 +1099,7 @@ describe('plugin-meetings', () => {
         const FAKE_USE_RANDOM_DELAY = true;
         const correlationId = 'my-correlationId';
         const sessionCorrelationId = 'my-session-correlationId';
+        const classificationId = 'my-classificationId';
         const callStateForMetrics = {
           sessionCorrelationId: 'my-session-correlationId2',
           correlationId: 'my-correlationId2',
@@ -1119,7 +1120,8 @@ describe('plugin-meetings', () => {
             callStateForMetrics,
             undefined,
             undefined,
-            sessionCorrelationId
+            sessionCorrelationId,
+            classificationId
           );
           assert.calledOnceWithExactly(fakeMeeting.updateCallStateForMetrics, {
             ...callStateForMetrics,
@@ -1198,6 +1200,13 @@ describe('plugin-meetings', () => {
           await checkCallCreateMeeting(
             [test1, test2, FAKE_USE_RANDOM_DELAY, {}, undefined, true, callStateForMetrics],
             [test1, test2, FAKE_USE_RANDOM_DELAY, {}, callStateForMetrics, true]
+          );
+        });
+
+        it('calls createMeeting with classificationId and returns its promise', async () => {
+          await checkCallCreateMeeting(
+            [test1, test2, FAKE_USE_RANDOM_DELAY, {}, undefined, true, callStateForMetrics, undefined, undefined, undefined, classificationId],
+            [test1, test2, FAKE_USE_RANDOM_DELAY, {}, callStateForMetrics, true, undefined, undefined, classificationId],
           );
         });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES 

## This pull request addresses
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-708188

## by making the following changes
Add new param field named 'classificationId' to start instant meeting request.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
After packaging, use it as a dependency in cantina. When starting instant meeting, pass the classificationId as a method parameter and check whether the network request carries this parameter.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
