### PR TITLE
feat(support): add broadworksCorrelationInfo to upload log meta

### DIFF
--- a/packages/@webex/internal-plugin-support/src/support.js
+++ b/packages/@webex/internal-plugin-support/src/support.js
@@ -143,6 +143,7 @@ const Support = WebexPlugin.extend({
       'callStart',
       'feedbackId',
       'correlationId',
+      'broadworksCorrelationInfo',
       'meetingId',
       'surveySessionId',
       'productAreaTag',

--- a/packages/@webex/internal-plugin-support/test/unit/spec/support.js
+++ b/packages/@webex/internal-plugin-support/test/unit/spec/support.js
@@ -136,6 +136,14 @@ describe('plugin-support', () => {
       assert.equal(found?.value, correlationId);
     });
 
+    it('sends broadworksCorrelationInfo if specified in metadata', () => {
+      const broadworksCorrelationInfo = 'broadworksCorrelationInfo';
+      const result = webex.internal.support._constructFileMetadata({broadworksCorrelationInfo});
+      const found = result.find((attr) => attr.key === 'broadworksCorrelationInfo');
+
+      assert.equal(found?.value, broadworksCorrelationInfo);
+    });
+
     it('sends meetingId if specified in metadata', () => {
       const meetingId = 'meetingId';
       const result = webex.internal.support._constructFileMetadata({meetingId});


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [CAI-6986](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6986) >

## This pull request addresses

This PR adds the missing field **broadworksCorrelationInfo** in the support plugin.

## by making the following changes

This PR adds the missing field **broadworksCorrelationInfo** in the support plugin.

Now we are able to search with the broadworksCorrelationInfo in mats for client logs.

Screenshots

<img width="2487" height="1363" alt="Screenshot 2025-09-22 at 5 59 23 PM" src="https://github.com/user-attachments/assets/a73c5106-e6a1-410c-8fc9-f760c3c53141" />
<img width="2443" height="1336" alt="Screenshot 2025-09-22 at 6 02 14 PM" src="https://github.com/user-attachments/assets/65f4f1ad-8354-45ab-8001-bd2979f8a55f" />



### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
