### PR TITLE
feat(plugin-meetings): add ipver related labels to CA events

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6796,6 +6796,10 @@ export default class Meeting extends StatelessWebexPlugin {
             // @ts-ignore
             this.webex.internal.newMetrics.submitClientEvent({
               name: 'client.ice.start',
+              payload: {
+                // @ts-ignore
+                labels: MeetingUtil.getCaEventLabelsForIpVersion(this.webex),
+              },
               options: {
                 meetingId: this.id,
               },

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -115,6 +115,28 @@ const MeetingUtil = {
     return IP_VERSION.unknown;
   },
 
+  /**
+   * Returns CA event labels related to Orpheus ipver parameter that can be sent to CA with any CA event
+   * @param {any} webex instance
+   * @returns {Array<string>|undefined} array of CA event labels or undefined if no labels should be sent
+   */
+  getCaEventLabelsForIpVersion(webex: any): Array<string> | undefined {
+    const ipver = MeetingUtil.getIpVersion(webex);
+
+    switch (ipver) {
+      case IP_VERSION.unknown:
+        return undefined;
+      case IP_VERSION.only_ipv4:
+        return ['hasIpv4_true'];
+      case IP_VERSION.only_ipv6:
+        return ['hasIpv6_true'];
+      case IP_VERSION.ipv4_and_ipv6:
+        return ['hasIpv4_true', 'hasIpv6_true'];
+      default:
+        return undefined;
+    }
+  },
+
   joinMeeting: async (meeting, options) => {
     if (!meeting) {
       return Promise.reject(new ParameterError('You need a meeting object.'));

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -9020,11 +9020,16 @@ describe('plugin-meetings', () => {
             meeting.hasMediaConnectionConnectedAtLeastOnce = false;
             meeting.setupMediaConnectionListeners();
 
+            sinon.stub(MeetingUtil, 'getCaEventLabelsForIpVersion').returns(['fake labels']);
+
             simulateConnectionStateChange(ConnectionState.Connecting);
 
             assert.calledOnce(webex.internal.newMetrics.submitClientEvent);
             assert.calledWithMatch(webex.internal.newMetrics.submitClientEvent, {
               name: 'client.ice.start',
+              payload: {
+                labels: ['fake labels'],
+              },
               options: {
                 meetingId: meeting.id,
               },

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -1310,6 +1310,27 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('getCaEventLabelsForIpVersion', () => {
+      [
+        {ipver: IP_VERSION.unknown, expectedLabels: undefined},
+        {ipver: IP_VERSION.only_ipv4, expectedLabels: ['hasIpv4_true']},
+        {ipver: IP_VERSION.only_ipv6, expectedLabels: ['hasIpv6_true']},
+        {
+          ipver: IP_VERSION.ipv4_and_ipv6,
+          expectedLabels: ['hasIpv4_true', 'hasIpv6_true'],
+        },
+      ].forEach(({ipver, expectedLabels}) => {
+        it(`returns expected labels when ipver=${ipver}`, () => {
+          sinon.stub(MeetingUtil, 'getIpVersion').returns(ipver);
+
+          const result = MeetingUtil.getCaEventLabelsForIpVersion(webex);
+
+          assert.calledOnceWithExactly(MeetingUtil.getIpVersion, webex);
+          assert.deepEqual(result, expectedLabels);
+        });
+      });
+    });
+
     describe('getChangeMeetingFloorErrorPayload', () => {
       [
         {


### PR DESCRIPTION
## This pull request addresses
Our CA results don't have information about `ipver` parameter used (which tells us if we were on ipv4 or ipv6 network)

## by making the following changes
This is a follow up PR to PR#4494 - in that PR I added ipver related information to behavioral metrics. In this PR I'm adding it to CA events. CA doesn't have a field defined for ipver, but instead clients can send any labels they want with any CA event and then the labels are concatenated into `clientLabels` in CA result. UCF clients send "hasIpv4_true" and "hasIpv6_true" labels with their CA event "client.ice.end", so I'm doing the same for web - sending same labels, but I've decided to send them with "client.ice.start", because this way we will still have them in CA result even if we never reach "client.ice.end" - for example if user closes the browser before we connected.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
