### PR TITLE
feat(plugin-meetings): ability to remove participants/members from a meeting

### DIFF
--- a/packages/@webex/plugin-meetings/src/member/types.ts
+++ b/packages/@webex/plugin-meetings/src/member/types.ts
@@ -109,4 +109,5 @@ export interface Participant {
   status: ParticipantMediaStatus;
   type: string;
   url: ParticipantUrl;
+  isRemoved: boolean; // JS-SDK internal field to indicate in updates when the participant is removed
 }

--- a/packages/@webex/plugin-meetings/src/members/collection.ts
+++ b/packages/@webex/plugin-meetings/src/members/collection.ts
@@ -40,6 +40,17 @@ export default class MembersCollection {
   }
 
   /**
+   * Removes a member from the collection
+   * @param {String} id
+   * @returns {void}
+   */
+  remove(id: string) {
+    if (this.members[id]) {
+      delete this.members[id];
+    }
+  }
+
+  /**
    * @returns {void}
    * reset members
    */

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -772,7 +772,7 @@ describe('plugin-meetings', () => {
           },
         };
         locusInfo.emitScoped = sinon.stub();
-        locusInfo.updateParticipants({});
+        locusInfo.updateParticipants({}, []);
 
         // if this assertion fails, double-check the attributes used in
         // the updateParticipants function in locus-info/index.js
@@ -790,6 +790,7 @@ describe('plugin-meetings', () => {
             selfId: '2',
             hostId: '3',
             isReplace: undefined,
+            removedParticipantIds: [],
           }
         );
         // note: in a real use case, recordingId, selfId, and hostId would all be the same
@@ -814,7 +815,7 @@ describe('plugin-meetings', () => {
         };
 
         locusInfo.emitScoped = sinon.stub();
-        locusInfo.updateParticipants({}, true);
+        locusInfo.updateParticipants({}, [], true);
 
         assert.calledWith(
           locusInfo.emitScoped,
@@ -830,6 +831,7 @@ describe('plugin-meetings', () => {
             selfId: '2',
             hostId: '3',
             isReplace: true,
+            removedParticipantIds: [],
           }
         );
       });
@@ -847,7 +849,7 @@ describe('plugin-meetings', () => {
         ];
 
         locusInfo.emitScoped = sinon.stub();
-        locusInfo.updateParticipants(failureParticipant);
+        locusInfo.updateParticipants(failureParticipant, []);
         assert.calledWith(
           locusInfo.emitScoped,
           {
@@ -2050,7 +2052,7 @@ describe('plugin-meetings', () => {
 
         fakeLocus = {
           meeting: true,
-          participants: true,
+          participants: [],
           url: 'newLocusUrl',
           syncUrl: 'newSyncUrl',
         };
@@ -2525,7 +2527,7 @@ describe('plugin-meetings', () => {
       });
 
       it('onDeltaLocus handle delta data', () => {
-        fakeLocus.participants = {};
+        fakeLocus.participants = [];
         const fakeBreakout = {
           sessionId: 'sessionId',
           groupId: 'groupId',
@@ -2542,11 +2544,11 @@ describe('plugin-meetings', () => {
         };
         locusInfo.updateParticipants = sinon.stub();
         locusInfo.onDeltaLocus(fakeLocus);
-        assert.calledWith(locusInfo.updateParticipants, {}, false);
+        assert.calledWith(locusInfo.updateParticipants, [], undefined, false);
 
         fakeLocus.controls.breakout.sessionId = 'sessionId2';
         locusInfo.onDeltaLocus(fakeLocus);
-        assert.calledWith(locusInfo.updateParticipants, {}, true);
+        assert.calledWith(locusInfo.updateParticipants, [], undefined, true);
       });
 
       it('onDeltaLocus merges delta participants with existing participants', () => {
@@ -2563,7 +2565,7 @@ describe('plugin-meetings', () => {
           existingParticipants,
           FAKE_DELTA_PARTICIPANTS
         );
-        assert.calledWith(locusInfo.updateParticipants, FAKE_DELTA_PARTICIPANTS, false);
+        assert.calledWith(locusInfo.updateParticipants, FAKE_DELTA_PARTICIPANTS, undefined, false);
       });
 
       [true, false].forEach((isDelta) =>
@@ -3074,6 +3076,7 @@ describe('plugin-meetings', () => {
               id: 'test person id',
             },
           },
+          participants: [],
         });
 
         updateLocusInfoStub.resetHistory();

--- a/packages/@webex/plugin-meetings/test/unit/spec/members/collection.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/members/collection.js
@@ -1,0 +1,120 @@
+const { default: MembersCollection } = require("../../../../src/members/collection");
+const { default: Member } = require("../../../../src/member");
+const { assert } = require('@webex/test-helper-chai');
+
+
+describe('plugin-meetings', () => {
+  describe('MembersCollection', () => {
+    let collection;
+    let member1;
+    let member2;
+    const participant1 = { controls: {}, status: {} };
+    const participant2 = { controls: {}, status: {} };
+
+    beforeEach(() => {
+      collection = new MembersCollection();
+      member1 = new Member(participant1);
+      member2 = new Member(participant2);
+    });
+
+    it('starts with no members', () => {
+      assert.equal(Object.keys(collection.getAll()).length, 0);
+    });
+
+    it('can add members', () => {      
+      collection.set('member1', member1);
+      assert.equal(Object.keys(collection.getAll()).length, 1);
+      assert.equal(collection.get('member1'), member1);
+
+      collection.set('member2', member2);
+      assert.equal(Object.keys(collection.getAll()).length, 2);
+      assert.equal(collection.get('member2'), member2);
+    });
+
+    it('can remove members', () => {
+      // Add some members first
+      collection.set('member1', member1);
+      collection.set('member2', member2);
+      assert.equal(Object.keys(collection.getAll()).length, 2);
+
+      // Remove one member
+      collection.remove('member1');
+      assert.equal(Object.keys(collection.getAll()).length, 1);
+      assert.equal(collection.get('member1'), undefined);
+      assert.equal(collection.get('member2'), member2);
+
+      // Remove another member
+      collection.remove('member2');
+      assert.equal(Object.keys(collection.getAll()).length, 0);
+      assert.equal(collection.get('member2'), undefined);
+
+      // Removing non-existent member should not cause errors
+      collection.remove('nonExistent');
+      assert.equal(Object.keys(collection.getAll()).length, 0);
+    });
+
+    describe('reset', () => {
+      it('removes all members', () => {
+        // Add some members first
+        collection.set('member1', member1);
+        collection.set('member2', member2);
+        assert.equal(Object.keys(collection.getAll()).length, 2);
+
+        // Reset should clear all members
+        collection.reset();
+        assert.equal(Object.keys(collection.getAll()).length, 0);
+        assert.equal(collection.get('member1'), undefined);
+        assert.equal(collection.get('member2'), undefined);
+      });
+    });
+
+    describe('setAll', () => {
+      it('replaces all members with new collection', () => {
+        // Add initial member
+        collection.set('member1', member1);
+        assert.equal(Object.keys(collection.getAll()).length, 1);
+
+        // Set all with new collection
+        const newMembers = {
+          'member2': member2,
+          'member3': new Member(participant1)
+        };
+        collection.setAll(newMembers);
+
+        assert.equal(Object.keys(collection.getAll()).length, 2);
+        assert.equal(collection.get('member1'), undefined);
+        assert.equal(collection.get('member2'), member2);
+        assert.exists(collection.get('member3'));
+      });
+    });
+
+    describe('get', () => {
+      it('returns undefined for non-existent members', () => {
+        assert.equal(collection.get('nonExistent'), undefined);
+      });
+
+      it('returns correct member for existing id', () => {
+        collection.set('member1', member1);
+        assert.equal(collection.get('member1'), member1);
+      });
+    });
+
+    describe('getAll', () => {
+      it('returns empty object when no members', () => {
+        const allMembers = collection.getAll();
+        assert.isObject(allMembers);
+        assert.equal(Object.keys(allMembers).length, 0);
+      });
+
+      it('returns all members', () => {
+        collection.set('member1', member1);
+        collection.set('member2', member2);
+        
+        const allMembers = collection.getAll();
+        assert.equal(Object.keys(allMembers).length, 2);
+        assert.equal(allMembers.member1, member1);
+        assert.equal(allMembers.member2, member2);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# COMPLETES #[SPARK-697765](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-697765)

## This pull request addresses
Currently SDK doesn't support removal of participants from a meeting (when users leave a meeting, they are still there, but in "not joined" state. As part of webinar 5k work and introduction of Locus hash trees, we need to support complete removal of participants.

## by making the following changes
API addition: 
- added `delta.removedIds` field to the "members:update" event emitted by Meeting.members. Related web app PR that adds handling for the new field (already merged): https://sqbu-github.cisco.com/WebExSquared/webex-web-client/pull/9128

internal changes:
- added `removedParticipantIds` field to the `LOCUS_INFO_UPDATE_PARTICIPANTS` event emitted by LocusInfo and added handling of that new field inside `Members.locusParticipantsUpdate()`
- for now `removedParticipantIds` in `LOCUS_INFO_UPDATE_PARTICIPANTS` are always empty, because the code for filling them will be added in another PR along with other hash tree changes



### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual tests end-2-end with Locus from webinar 5k workshop branch

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
