### PR TITLE
fix(plugin-meetings): too many media requests sent to Homer

### DIFF
--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -10,7 +10,7 @@ import {
   RecommendedOpusBitrates,
   NamedMediaGroup,
 } from '@webex/internal-media-core';
-import {cloneDeepWith, debounce, isEmpty} from 'lodash';
+import {cloneDeepWith, debounce, isEmpty, max, throttle} from 'lodash';
 
 import LoggerProxy from '../common/logs/logger-proxy';
 
@@ -63,6 +63,7 @@ const CODEC_DEFAULTS = {
 };
 
 const DEBOUNCED_SOURCE_UPDATE_TIME = 1000;
+const THROTTLED_SEND_REQUESTS_TIME = 2000; // used for sendRequests() calls triggered by Homer updates
 
 type DegradationPreferences = {
   maxMacroblocksLimit: number;
@@ -93,6 +94,7 @@ export class MediaRequestManager {
   private sourceUpdateListener: () => void;
 
   private debouncedSourceUpdateListener: () => void;
+  private throttledSendRequests: () => void;
 
   private previousStreamRequests: Array<StreamRequest> = [];
 
@@ -113,6 +115,10 @@ export class MediaRequestManager {
     this.debouncedSourceUpdateListener = debounce(
       this.sourceUpdateListener,
       DEBOUNCED_SOURCE_UPDATE_TIME
+    );
+    this.throttledSendRequests = throttle(
+      this.sendRequests.bind(this),
+      THROTTLED_SEND_REQUESTS_TIME
     );
   }
 
@@ -398,7 +404,7 @@ export class MediaRequestManager {
     mediaRequest.handleMaxFs = eventHandler;
 
     mediaRequest.receiveSlots.forEach((rs) => {
-      rs.on(ReceiveSlotEvents.SourceUpdate, this.sourceUpdateListener);
+      rs.on(ReceiveSlotEvents.SourceUpdate, this.throttledSendRequests);
       rs.on(ReceiveSlotEvents.MaxFsUpdate, mediaRequest.handleMaxFs);
     });
 
@@ -413,7 +419,7 @@ export class MediaRequestManager {
     const mediaRequest = this.clientRequests[requestId];
 
     mediaRequest?.receiveSlots.forEach((rs) => {
-      rs.off(ReceiveSlotEvents.SourceUpdate, this.sourceUpdateListener);
+      rs.off(ReceiveSlotEvents.SourceUpdate, this.throttledSendRequests);
       rs.off(ReceiveSlotEvents.MaxFsUpdate, mediaRequest.handleMaxFs);
     });
 
@@ -438,6 +444,6 @@ export class MediaRequestManager {
     this.numTotalSources = numTotalSources;
     this.numLiveSources = numLiveSources;
 
-    this.sendRequests();
+    this.throttledSendRequests();
   }
 }

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -1118,13 +1118,157 @@ describe('MediaRequestManager', () => {
     });
   });
 
-  describe('trimming of requested receive slots', () => {
+  describe('throttling of calls to sendMediaRequests() caused by notifications from Homer', () => {
+    let clock;
+    const sourceUpdateHandlers = [];
+
     beforeEach(() => {
+      clock = sinon.useFakeTimers();
       mediaRequestManager = new MediaRequestManager(sendMediaRequestsCallback, {
         degradationPreferences,
         kind: 'video',
         trimRequestsToNumOfSources: true,
       });
+
+      sourceUpdateHandlers.length = 0;
+
+      fakeReceiveSlots.forEach((slot) => {
+        slot.on.callsFake((eventName, handler) => {
+          if (eventName === 'sourceUpdate') {
+            sourceUpdateHandlers.push({handler, slot});
+          }
+        });
+      });
+
+      // add some requests and commit them
+      addActiveSpeakerRequest(
+        255,
+        [
+          fakeReceiveSlots[0],
+          fakeReceiveSlots[1],
+          fakeReceiveSlots[2],
+          fakeReceiveSlots[3],
+          fakeReceiveSlots[4],
+          fakeReceiveSlots[4],
+        ],
+        MAX_FS_1080p,
+        false
+      );
+
+      mediaRequestManager.setNumCurrentSources(5, 5);
+      mediaRequestManager.setDegradationPreferences({maxMacroblocksLimit: 8192});
+      mediaRequestManager.commit();
+
+      // advance time to reach a stable state after any initial throttling
+      clock.tick(9999);
+      sendMediaRequestsCallback.resetHistory();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('throttles calls to sendMediaRequests() when multiple source updates happen', () => {
+      // simulate multiple source update changes
+      sourceUpdateHandlers.forEach(({handler, slot}) => {
+        slot.sourceState = `avatar`;
+        handler();
+      });
+
+      // The throttled sendMediaRequests should execute immediately on first call, then throttle subsequent calls
+      clock.tick(1);
+      assert.calledOnce(sendMediaRequestsCallback);
+
+      // after 1s simulate more updates -> they should not trigger any more calls to sendRequests()
+      clock.tick(1000);
+      sourceUpdateHandlers.forEach(({handler, slot}) => {
+        slot.sourceState = `live`;
+        handler();
+      });
+      clock.tick(1);
+      // still only 1 call due to throttling
+      assert.calledOnce(sendMediaRequestsCallback);
+
+      // now advance time by another 1s (past the throttle period) -> this should trigger another call to sendRequests()
+      clock.tick(1000);
+      assert.calledTwice(sendMediaRequestsCallback);
+
+      // and no more calls after that
+      clock.tick(9999);
+      assert.calledTwice(sendMediaRequestsCallback);
+    });
+
+    it('throttles calls to sendMediaRequests() when setNumCurrentSources() is called', () => {
+      // change number of available streams
+      mediaRequestManager.setNumCurrentSources(4, 4);
+
+      // The throttled function should execute immediately on first call, then throttle subsequent calls
+      clock.tick(1);
+      assert.calledOnce(sendMediaRequestsCallback);
+
+      // after 1s simulate more updates -> they should not trigger any more calls to sendRequests()
+      clock.tick(1000);
+      mediaRequestManager.setNumCurrentSources(3, 3);
+      clock.tick(1);
+      // still only 1 call due to throttling
+      assert.calledOnce(sendMediaRequestsCallback);
+
+      // now advance time by another 1s (past the throttle period) -> this should trigger another call to sendRequests()
+      clock.tick(1000);
+      assert.calledTwice(sendMediaRequestsCallback);
+
+      // and no more calls after that
+      clock.tick(9999);
+      assert.calledTwice(sendMediaRequestsCallback);
+    });
+
+    it('throttles calls to sendMediaRequests() when setNumCurrentSources() is called AND source updates happen', () => {
+      // change number of available streams and simulate source updates
+      mediaRequestManager.setNumCurrentSources(4, 4);
+      sourceUpdateHandlers.forEach(({handler, slot}) => {
+        slot.sourceState = `avatar`;
+        handler();
+      });
+
+      // The throttled function should execute immediately on first call, then throttle subsequent calls
+      clock.tick(1);
+      assert.calledOnce(sendMediaRequestsCallback);
+
+      // after 1s simulate more updates -> they should not trigger any more calls to sendRequests()
+      clock.tick(1000);
+      mediaRequestManager.setNumCurrentSources(3, 3);
+      sourceUpdateHandlers.forEach(({handler, slot}) => {
+        slot.sourceState = `live`;
+        handler();
+      });
+      clock.tick(1);
+      // still only 1 call due to throttling
+      assert.calledOnce(sendMediaRequestsCallback);
+
+      // now advance time by another 1s (past the throttle period) -> this should trigger another call to sendRequests()
+      clock.tick(1000);
+      assert.calledTwice(sendMediaRequestsCallback);
+
+      // and no more calls after that
+      clock.tick(9999);
+      assert.calledTwice(sendMediaRequestsCallback);
+    });
+  });
+
+  describe('trimming of requested receive slots', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+      mediaRequestManager = new MediaRequestManager(sendMediaRequestsCallback, {
+        degradationPreferences,
+        kind: 'video',
+        trimRequestsToNumOfSources: true,
+      });
+    });
+
+    afterEach(() => {
+      clock.restore();
     });
 
     const limitNumAvailableStreams = (preferLiveVideo, limit) => {
@@ -1133,6 +1277,8 @@ describe('MediaRequestManager', () => {
       } else {
         mediaRequestManager.setNumCurrentSources(limit, 1);
       }
+      // Advance time to trigger the throttled sendRequests
+      clock.tick(2000);
     };
 
     [true, false].forEach((preferLiveVideo) =>


### PR DESCRIPTION
# COMPLETES #[SPARK-719044](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-719044)

## This pull request addresses
Sometimes we can get into a state where we will be flooding Homer with media requests:
it's caused by an optimization in Homer where they send us "live" source state for a remote participant after they receive a media request from us even before they are 100% sure that that participant is actually sending video, so if that participant is actually not sending video, very soon afterwards (within milliseconds) they send us another update with "avatar" source state. Each such update may cause us to send a new media request (because we have different number of live remote participants, so we adjust the maxFs in the requests to not go over the `this.degradationPreferences.maxMacroblocksLimit`). Our new media requests can trigger Homer again to send us a fake "live", so we get into a loop.

## by making the following changes
Added throttling of sendMediaRequests() that's called as a result of Homer notifications:
- for source update changes
- for number of sources available

Homer team wanted us to throttle this at 5s, but I've set it to 2s, because 5s seems a bit long. In the logs from the jira Homer was sending us the fake "live" followed by "avatar" within milliseconds, so 2s should be enough in most cases.

There is 1 use case where user can see the delay caused by this throttling:
- when there are less than 6 other participants and user ticks the "Hide participants without video" option and one remote participant mutes their video - at that point we receive 2 notifications from Homer, first one is the source update, followed by the change of numLiveSources, so because of the throttling, we send new media request after the source update and before numLiveSources change and only send the 2nd media request that results from numLiveSources change after 2s - as a result user will see the avatar of that person for 2s. 

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
