### PR TITLE
fix(deps-dev): drop usage of @ciscospark/test-users-legacy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,9 +222,6 @@
     "yakbak": "^5.0.1",
     "yargs": "^16.2.0"
   },
-  "optionalDependencies": {
-    "@ciscospark/test-users-legacy": "^1.2.0"
-  },
   "browser": {
     "./src/client/client/client.js": "./src/client/client/client.shim.js",
     "./src/client/client/processors/request/request.js": "./src/client/client/processors/request/request.shim.js",

--- a/packages/@webex/internal-plugin-lyra/package.json
+++ b/packages/@webex/internal-plugin-lyra/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",
-    "@ciscospark/test-users-legacy": "^1.2.0",
     "@types/randomstring": "^1",
     "@webex/babel-config-legacy": "workspace:*",
     "@webex/eslint-config-legacy": "workspace:*",

--- a/packages/@webex/internal-plugin-user/test/integration/spec/user.js
+++ b/packages/@webex/internal-plugin-user/test/integration/spec/user.js
@@ -19,8 +19,11 @@ import {merge} from 'lodash';
 // for test users in EU (Federation) and US
 // Also try US user with Federation enabled
 const runs = [
-  // This line can be ommited until a future pull request is generated to update @ciscospark/test-users-legacy
-  // {it: 'with EU user with Federation enabled', EUUser: true, attrs: {config: {credentials: {federation: true}}}},
+  {
+    it: 'with EU user with Federation enabled',
+    EUUser: true,
+    attrs: {config: {credentials: {federation: true}}},
+  },
   {it: 'with US user without Federation enabled', EUUser: false, attrs: {}},
   {
     it: 'with US user with Federation enabled',

--- a/packages/@webex/test-helper-test-users/package.json
+++ b/packages/@webex/test-helper-test-users/package.json
@@ -8,9 +8,6 @@
     "url": "https://github.com/webex/webex-js-sdk.git",
     "directory": "packages/@webex/test-helper-test-users"
   },
-  "optionalDependencies": {
-    "@ciscospark/test-users-legacy": "^1.0.2"
-  },
   "engines": {
     "node": ">=18"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,18 +1767,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ciscospark/test-users-legacy@npm:^1.0.2, @ciscospark/test-users-legacy@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@ciscospark/test-users-legacy@npm:1.2.0"
-  dependencies:
-    btoa: ^1.1.2
-    lodash: ^4.17.4
-    node-random-name: ^1.0.1
-    request: ^2.81.0
-  checksum: 63a74dc19338c26b54bc96694a4acf4947fc3c68e536d0738cc932f6dc962b1da1fc12008d8ce72f9462ec20bd9d3c121796e3220f3ef5980c1fe5fa0a7c146a
-  languageName: node
-  linkType: hard
-
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
   resolution: "@colors/colors@npm:1.5.0"
@@ -8110,7 +8098,6 @@ __metadata:
   resolution: "@webex/internal-plugin-lyra@workspace:packages/@webex/internal-plugin-lyra"
   dependencies:
     "@babel/core": ^7.17.10
-    "@ciscospark/test-users-legacy": ^1.2.0
     "@types/randomstring": ^1
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/common": "workspace:*"
@@ -9468,7 +9455,6 @@ __metadata:
   resolution: "@webex/test-helper-test-users@workspace:packages/@webex/test-helper-test-users"
   dependencies:
     "@babel/core": ^7.17.10
-    "@ciscospark/test-users-legacy": ^1.0.2
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
     "@webex/jest-config-legacy": "workspace:*"
@@ -9481,9 +9467,6 @@ __metadata:
     eslint: ^8.24.0
     lodash: ^4.17.21
     prettier: ^2.7.1
-  dependenciesMeta:
-    "@ciscospark/test-users-legacy":
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -12080,7 +12063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"btoa@npm:^1.1.2, btoa@npm:^1.2.1":
+"btoa@npm:^1.2.1":
   version: 1.2.1
   resolution: "btoa@npm:1.2.1"
   bin:
@@ -28796,7 +28779,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"request@npm:^2.81.0, request@npm:^2.88.0":
+"request@npm:^2.88.0":
   version: 2.88.2
   resolution: "request@npm:2.88.2"
   dependencies:
@@ -33908,7 +33891,6 @@ __metadata:
     "@babel/template": ^7.14.5
     "@babel/traverse": ^7.14.9
     "@babel/types": ^7.14.9
-    "@ciscospark/test-users-legacy": ^1.2.0
     "@commitlint/cli": ^17.1.2
     "@commitlint/config-conventional": ^17.1.0
     "@sinonjs/fake-timers": ^6.0.1
@@ -34026,9 +34008,6 @@ __metadata:
     webpack-dev-server: ^4.3.1
     yakbak: ^5.0.1
     yargs: ^16.2.0
-  dependenciesMeta:
-    "@ciscospark/test-users-legacy":
-      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-737609 >

## This pull request addresses

It seems the '@ciscospark/test-users-legacy' is not referenced in the code base. It was referenced by 'internal-plugin-lyra'  some time back, but the update did not remove the declaration of test-users-legacy.

'@ciscospark/test-users-legacy' is an old dependency (not touched in 6 years) and might block dependency upgrades for consuming project. One example is dependency 'requests' which is abandoned and also have many known CVE vulnerabilities attached.


## by making the following changes

1.Drop '@ciscospark/test-users-legacy' from the package.json files where it is referenced

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
