### PR TITLE
fix: add socket error and metrics

### DIFF
--- a/packages/@webex/contact-center/src/cc.ts
+++ b/packages/@webex/contact-center/src/cc.ts
@@ -704,12 +704,38 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
                   module: CC_FILE,
                   method: METHODS.CONNECT_WEBSOCKET,
                 });
+
+                // Track successful Mercury connection
+                this.metricsManager.trackEvent(
+                  METRIC_EVENT_NAMES.WEBSOCKET_REGISTER_SUCCESS,
+                  {
+                    connectionType: 'mercury',
+                    agentId: this.agentConfig?.agentId,
+                  },
+                  ['operational']
+                );
               })
               .catch((error) => {
                 LoggerProxy.error(`Error occurred during mercury.connect() ${error}`, {
                   module: CC_FILE,
                   method: METHODS.CONNECT_WEBSOCKET,
+                  error,
                 });
+
+                // Track Mercury connection failure
+                this.metricsManager.trackEvent(
+                  METRIC_EVENT_NAMES.WEBSOCKET_REGISTER_FAILED,
+                  {
+                    connectionType: 'mercury',
+                    error: error?.toString() || 'Mercury connection failed',
+                    errorMessage: error?.message || 'Unknown error',
+                    agentId: this.agentConfig?.agentId,
+                  },
+                  ['operational']
+                );
+
+                // Note: Not throwing here as Mercury connection failure shouldn't block
+                // the overall registration, but it will prevent WebRTC calling
               });
           }
           if (this.$config && this.$config.allowAutomatedRelogin) {

--- a/packages/@webex/contact-center/src/metrics/constants.ts
+++ b/packages/@webex/contact-center/src/metrics/constants.ts
@@ -84,6 +84,7 @@ export const METRIC_EVENT_NAMES = {
   FETCH_BUDDY_AGENTS_FAILED: 'Fetch Buddy Agents Failed',
   WEBSOCKET_REGISTER_SUCCESS: 'Websocket Register Success',
   WEBSOCKET_REGISTER_FAILED: 'Websocket Register Failed',
+  WEBSOCKET_CONNECTION_ERROR: 'Websocket Connection Error',
   AGENT_RONA: 'Agent RONA',
   AGENT_CONTACT_ASSIGN_FAILED: 'Agent Contact Assign Failed',
   AGENT_INVITE_FAILED: 'Agent Invite Failed',

--- a/packages/@webex/contact-center/src/services/core/websocket/WebSocketManager.ts
+++ b/packages/@webex/contact-center/src/services/core/websocket/WebSocketManager.ts
@@ -7,6 +7,8 @@ import LoggerProxy from '../../../logger-proxy';
 import workerScript from './keepalive.worker';
 import {KEEPALIVE_WORKER_INTERVAL, CLOSE_SOCKET_TIMEOUT, METHODS} from '../constants';
 import {WEB_SOCKET_MANAGER_FILE} from '../../../constants';
+import MetricsManager from '../../../metrics/MetricsManager';
+import {METRIC_EVENT_NAMES} from '../../../metrics/constants';
 
 /**
  * WebSocketManager handles the WebSocket connection for Contact Center operations.
@@ -137,6 +139,19 @@ export class WebSocketManager extends EventEmitter {
           `[WebSocketStatus] | event=socketConnectionFailed | WebSocket connection failed ${event}`,
           {module: WEB_SOCKET_MANAGER_FILE, method: METHODS.CONNECT}
         );
+
+        // Track WebSocket connection error in metrics
+        MetricsManager.getInstance({webex: this.webex}).trackEvent(
+          METRIC_EVENT_NAMES.WEBSOCKET_CONNECTION_ERROR,
+          {
+            error: event?.toString() || 'WebSocket connection error',
+            errorType: event?.type || 'unknown',
+            connectionUrl: this.url || 'unknown',
+            onlineStatus: navigator.onLine,
+          },
+          ['operational']
+        );
+
         reject();
       };
 

--- a/packages/@webex/contact-center/src/services/task/index.ts
+++ b/packages/@webex/contact-center/src/services/task/index.ts
@@ -462,19 +462,6 @@ export default class Task extends EventEmitter implements ITask {
     } catch (error) {
       const err = generateTaskErrorObject(error, METHODS.TOGGLE_MUTE, TASK_FILE);
 
-      // Track mute toggle failure metrics
-      this.metricsManager.trackEvent(
-        METRIC_EVENT_NAMES.TASK_ACCEPT_FAILED, // Reuse existing metric or add new one
-        {
-          taskId: this.data?.interactionId,
-          operation: 'toggleMute',
-          error: error.toString(),
-          trackingId: err.data?.trackingId,
-          errorMessage: err.data?.message,
-        },
-        ['operational']
-      );
-
       throw err;
     }
   }

--- a/packages/@webex/contact-center/src/services/task/index.ts
+++ b/packages/@webex/contact-center/src/services/task/index.ts
@@ -212,10 +212,33 @@ export default class Task extends EventEmitter implements ITask {
           method: METHODS.SETUP_AUTO_WRAPUP_TIMER,
           interactionId: this.data.interactionId,
         });
-        await this.wrapup({
-          wrapUpReason: defaultWrapupReason.name,
-          auxCodeId: defaultWrapupReason.id,
-        });
+        try {
+          await this.wrapup({
+            wrapUpReason: defaultWrapupReason.name,
+            auxCodeId: defaultWrapupReason.id,
+          });
+        } catch (error) {
+          // Track auto-wrapup failure metrics
+          this.metricsManager.trackEvent(
+            METRIC_EVENT_NAMES.TASK_WRAPUP_FAILED,
+            {
+              taskId: this.data?.interactionId,
+              wrapUpCode: defaultWrapupReason.id,
+              wrapUpReason: defaultWrapupReason.name,
+              isAutoWrapup: true,
+              error: error.toString(),
+              errorMessage: error?.message || 'Auto-wrapup failed',
+            },
+            ['operational', 'behavioral', 'business']
+          );
+
+          LoggerProxy.error(`Auto-wrapup failed: ${error}`, {
+            module: TASK_FILE,
+            method: METHODS.SETUP_AUTO_WRAPUP_TIMER,
+            interactionId: this.data?.interactionId,
+            error,
+          });
+        }
       });
     }
   }
@@ -394,7 +417,7 @@ export default class Task extends EventEmitter implements ITask {
           taskId: this.data.interactionId,
           error: error.toString(),
           ...taskErrorProps,
-          ...MetricsManager.getCommonTrackingFieldForAQMResponseFailed(error.details as Failure),
+          ...MetricsManager.getCommonTrackingFieldForAQMResponseFailed(error?.details as Failure),
         },
         ['operational', 'behavioral', 'business']
       );
@@ -438,6 +461,20 @@ export default class Task extends EventEmitter implements ITask {
       return Promise.resolve();
     } catch (error) {
       const err = generateTaskErrorObject(error, METHODS.TOGGLE_MUTE, TASK_FILE);
+
+      // Track mute toggle failure metrics
+      this.metricsManager.trackEvent(
+        METRIC_EVENT_NAMES.TASK_ACCEPT_FAILED, // Reuse existing metric or add new one
+        {
+          taskId: this.data?.interactionId,
+          operation: 'toggleMute',
+          error: error.toString(),
+          trackingId: err.data?.trackingId,
+          errorMessage: err.data?.message,
+        },
+        ['operational']
+      );
+
       throw err;
     }
   }
@@ -496,10 +533,10 @@ export default class Task extends EventEmitter implements ITask {
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.TASK_DECLINE_FAILED,
         {
-          taskId: this.data.interactionId,
+          taskId: this.data?.interactionId,
           error: error.toString(),
           ...taskErrorProps,
-          ...MetricsManager.getCommonTrackingFieldForAQMResponseFailed(error.details || {}),
+          ...MetricsManager.getCommonTrackingFieldForAQMResponseFailed(error?.details || {}),
         },
         ['operational', 'behavioral']
       );

--- a/packages/@webex/contact-center/test/unit/spec/cc.ts
+++ b/packages/@webex/contact-center/test/unit/spec/cc.ts
@@ -426,6 +426,7 @@ describe('webex.cc', () => {
         {
           module: CC_FILE,
           method: 'connectWebsocket',
+          error: mockError,
         }
       );
       expect(connectWebsocketSpy).toHaveBeenCalled();

--- a/packages/@webex/contact-center/test/unit/spec/services/core/websocket/WebSocketManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/core/websocket/WebSocketManager.ts
@@ -253,6 +253,14 @@ describe('WebSocketManager', () => {
     const MetricsManagerModule = require('../../../../../../src/metrics/MetricsManager');
     jest.spyOn(MetricsManagerModule.default, 'getInstance').mockReturnValue(mockMetricsManager);
 
+    // Mock navigator.onLine to be true for this test
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        onLine: true,
+      },
+      configurable: true,
+    });
+
     await webSocketManager.initWebSocket({ body: fakeSubscribeRequest });
 
     const errorEvent = new Event('error');

--- a/packages/@webex/contact-center/test/unit/spec/services/core/websocket/WebSocketManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/core/websocket/WebSocketManager.ts
@@ -74,6 +74,8 @@ describe('WebSocketManager', () => {
 
     mockWebex = {
       request: jest.fn(),
+      once: jest.fn(),
+      ready: false,
     } as unknown as WebexSDK;
 
     mockWorker = {
@@ -231,6 +233,43 @@ describe('WebSocketManager', () => {
     expect(LoggerProxy.error).toHaveBeenCalledWith(
       '[WebSocketStatus] | event=socketConnectionFailed | WebSocket connection failed [object Event]',
       { module: WEB_SOCKET_MANAGER_FILE, method: 'connect' }
+    );
+  });
+
+  it('should track metrics on WebSocket error event', async () => {
+    const subscribeResponse = {
+      body: {
+        webSocketUrl: 'wss://fake-url',
+      },
+    };
+
+    (mockWebex.request as jest.Mock).mockResolvedValueOnce(subscribeResponse);
+
+    // Mock MetricsManager
+    const mockMetricsManager = {
+      trackEvent: jest.fn(),
+    };
+    
+    const MetricsManagerModule = require('../../../../../../src/metrics/MetricsManager');
+    jest.spyOn(MetricsManagerModule.default, 'getInstance').mockReturnValue(mockMetricsManager);
+
+    await webSocketManager.initWebSocket({ body: fakeSubscribeRequest });
+
+    const errorEvent = new Event('error');
+    Object.defineProperty(errorEvent, 'type', { value: 'error', writable: false });
+    
+    MockWebSocket.inst.onerror(errorEvent);
+
+    // Verify metrics tracking was called
+    expect(mockMetricsManager.trackEvent).toHaveBeenCalledWith(
+      'Websocket Connection Error',
+      {
+        error: '[object Event]',
+        errorType: 'error',
+        connectionUrl: 'wss://fake-url',
+        onlineStatus: true,
+      },
+      ['operational']
     );
   });
 

--- a/packages/@webex/contact-center/test/unit/spec/services/task/index.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/index.ts
@@ -1381,6 +1381,51 @@ describe('Task', () => {
       interactionId: task.data.interactionId,
     });
   });
+
+  it('should track metrics on toggleMute error with safe error property access', async () => {
+    const error = {
+      details: {
+        trackingId: '1234',
+        data: {
+          reason: 'Mute Failed',
+        },
+      },
+    };
+
+    jest.spyOn(webCallingService, 'muteUnmuteCall').mockImplementation(() => {
+      throw error;
+    });
+
+    await expect(task.toggleMute()).rejects.toThrow();
+    
+    // Verify metrics tracking was called with safe error property access
+    expect(mockMetricsManager.trackEvent).toHaveBeenCalledWith(
+      METRIC_EVENT_NAMES.TASK_ACCEPT_FAILED,
+      {
+        taskId: taskDataMock.interactionId,
+        error: error.toString(),
+        errorMessage: 'Mute Failed',
+        trackingId: '1234',
+        operation: 'toggleMute',
+      },
+      ['operational']
+    );
+  });
+
+  it('should handle toggleMute error when error object is missing properties', async () => {
+    const incompleteError = {
+      message: 'Mute operation failed'
+    };
+
+    jest.spyOn(webCallingService, 'muteUnmuteCall').mockImplementation(() => {
+      throw incompleteError;
+    });
+
+    await expect(task.toggleMute()).rejects.toThrow();
+    
+    // Should still track metrics even with incomplete error object
+    expect(mockMetricsManager.trackEvent).toHaveBeenCalled();
+  });
   
   describe('AutoWrapup initialization tests', () => {    
     beforeEach(() => {

--- a/packages/@webex/contact-center/test/unit/spec/services/task/index.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/index.ts
@@ -1382,50 +1382,6 @@ describe('Task', () => {
     });
   });
 
-  it('should track metrics on toggleMute error with safe error property access', async () => {
-    const error = {
-      details: {
-        trackingId: '1234',
-        data: {
-          reason: 'Mute Failed',
-        },
-      },
-    };
-
-    jest.spyOn(webCallingService, 'muteUnmuteCall').mockImplementation(() => {
-      throw error;
-    });
-
-    await expect(task.toggleMute()).rejects.toThrow();
-    
-    // Verify metrics tracking was called with safe error property access
-    expect(mockMetricsManager.trackEvent).toHaveBeenCalledWith(
-      METRIC_EVENT_NAMES.TASK_ACCEPT_FAILED,
-      {
-        taskId: taskDataMock.interactionId,
-        error: error.toString(),
-        errorMessage: 'Mute Failed',
-        trackingId: '1234',
-        operation: 'toggleMute',
-      },
-      ['operational']
-    );
-  });
-
-  it('should handle toggleMute error when error object is missing properties', async () => {
-    const incompleteError = {
-      message: 'Mute operation failed'
-    };
-
-    jest.spyOn(webCallingService, 'muteUnmuteCall').mockImplementation(() => {
-      throw incompleteError;
-    });
-
-    await expect(task.toggleMute()).rejects.toThrow();
-    
-    // Should still track metrics even with incomplete error object
-    expect(mockMetricsManager.trackEvent).toHaveBeenCalled();
-  });
   
   describe('AutoWrapup initialization tests', () => {    
     beforeEach(() => {


### PR DESCRIPTION
Small PR to add error metrics for socket 

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
