### PR TITLE
fix(calling): remove STUN server list for windows chromium webrtc workaround

### DIFF
--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -189,14 +189,21 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
    * @ignore
    */
   public async init() {
-    try {
-      await windowsChromiumIceWarmup({
-        iceServers: [],
-        timeoutMs: 1000,
-      });
-      log.info(`ICE warmup completed`, '' as LogContext);
-    } catch (err) {
-      log.warn(`ICE warmup failed: ${err}`, '' as LogContext);
+    // Only for Windows Chromium based browsers we need to do the ICE warmup
+    if (typeof window !== 'undefined' && window?.navigator?.userAgent) {
+      const ua = window.navigator.userAgent;
+      if (ua.toLowerCase().includes('windows')) {
+        log.info('Starting ICE warmup for Windows Chromium based browser', '' as LogContext);
+        try {
+          await windowsChromiumIceWarmup({
+            iceServers: [],
+            timeoutMs: 1000,
+          });
+          log.info(`ICE warmup completed`, '' as LogContext);
+        } catch (err) {
+          log.warn(`ICE warmup failed: ${err}`, '' as LogContext);
+        }
+      }
     }
 
     await this.getMobiusServers();

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -191,10 +191,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
   public async init() {
     try {
       await windowsChromiumIceWarmup({
-        iceServers: [
-          {urls: 'stun:stun01a-us.bcld.webex.com:5004'},
-          {urls: 'stun:stun02a-us.bcld.webex.com:5004'},
-        ],
+        iceServers: [],
         timeoutMs: 1000,
       });
       log.info(`ICE warmup completed`, '' as LogContext);

--- a/packages/calling/src/CallingClient/windowsChromiumIceWarmupUtils.ts
+++ b/packages/calling/src/CallingClient/windowsChromiumIceWarmupUtils.ts
@@ -38,13 +38,7 @@ function waitForIceComplete(pc: RTCPeerConnection, timeoutMs: number) {
   });
 }
 
-export default async function windowsChromiumIceWarmup({
-  iceServers = [
-    {urls: 'stun:stun01a-us.bcld.webex.com:5004'},
-    {urls: 'stun:stun02a-us.bcld.webex.com:5004'},
-  ],
-  timeoutMs = 1000,
-}) {
+export default async function windowsChromiumIceWarmup({iceServers = [], timeoutMs = 1000}) {
   const pc1 = new RTCPeerConnection({iceServers, iceCandidatePoolSize: 1});
   const pc2 = new RTCPeerConnection({iceServers, iceCandidatePoolSize: 1});
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-706829](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-706829)

## This pull request addresses

Remove STUN server list from the windows chromium webrtc workaround

## by making the following changes

- Remove STUN server list from the windows chromium webrtc workaround
- Add condition to run only in windows

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested on windows 

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
