### PR TITLE
fix(meeting): In meeting options can't work in breakout

### DIFF
--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -49,6 +49,14 @@ export default class ControlsOptionsManager {
   private locusUrl: string;
 
   /**
+   * @instance
+   * @type {string}
+   * @private
+   * @memberof ControlsOptionsManager
+   */
+  private mainLocusUrl: string;
+
+  /**
    * @param {MeetingRequest} request
    * @param {Object} options
    * @constructor
@@ -93,6 +101,16 @@ export default class ControlsOptionsManager {
    */
   public setLocusUrl(url: string) {
     this.locusUrl = url;
+  }
+
+  /**
+   * @param {string} url
+   * @returns {void}
+   * @public
+   * @memberof ControlsOptionsManager
+   */
+  public setMainLocusUrl(url: string) {
+    this.mainLocusUrl = url;
   }
 
   /**
@@ -160,11 +178,16 @@ export default class ControlsOptionsManager {
     });
 
     return payloads.reduce((previous, payload) => {
+      const extraBody =
+        this.mainLocusUrl && this.mainLocusUrl !== this.locusUrl
+          ? {authorizingLocusUrl: this.locusUrl}
+          : {};
+
       return previous.then(() =>
         // @ts-ignore
         this.request.request({
-          uri: `${this.locusUrl}/${CONTROLS}`,
-          body: payload,
+          uri: `${this.mainLocusUrl || this.locusUrl}/${CONTROLS}`,
+          body: {...payload, ...extraBody},
           method: HTTP_VERBS.PATCH,
         })
       );
@@ -241,11 +264,15 @@ export default class ControlsOptionsManager {
     if (error) {
       return Promise.reject(error);
     }
+    const extraBody =
+      this.mainLocusUrl && this.mainLocusUrl !== this.locusUrl
+        ? {authorizingLocusUrl: this.locusUrl}
+        : {};
 
     // @ts-ignore
     return this.request.request({
-      uri: `${this.locusUrl}/${CONTROLS}`,
-      body,
+      uri: `${this.mainLocusUrl || this.locusUrl}/${CONTROLS}`,
+      body: {...body, ...extraBody},
       method: HTTP_VERBS.PATCH,
     });
   }

--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -95,22 +95,16 @@ export default class ControlsOptionsManager {
 
   /**
    * @param {string} url
+   * @param {boolean} isMainLocus
    * @returns {void}
    * @public
    * @memberof ControlsOptionsManager
    */
-  public setLocusUrl(url: string) {
+  public setLocusUrl(url: string, isMainLocus?: boolean) {
     this.locusUrl = url;
-  }
-
-  /**
-   * @param {string} url
-   * @returns {void}
-   * @public
-   * @memberof ControlsOptionsManager
-   */
-  public setMainLocusUrl(url: string) {
-    this.mainLocusUrl = url;
+    if (isMainLocus) {
+      this.mainLocusUrl = url;
+    }
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -343,7 +343,7 @@ export default class LocusInfo extends EventsScope {
     // For 1:1 space meeting the conversation Url does not exist in locus.conversation
     this.updateConversationUrl(locus.conversationUrl, locus.info);
     this.updateControls(locus.controls, locus.self);
-    this.updateLocusUrl(locus.url);
+    this.updateLocusUrl(locus.url, ControlsUtils.isMainSessionDTO(locus));
     this.updateFullState(locus.fullState);
     this.updateMeetingInfo(locus.info);
     this.updateEmbeddedApps(locus.embeddedApps);
@@ -549,7 +549,7 @@ export default class LocusInfo extends EventsScope {
     this.updateCreated(locus.created);
     this.updateFullState(locus.fullState);
     this.updateHostInfo(locus.host);
-    this.updateLocusUrl(locus.url);
+    this.updateLocusUrl(locus.url, ControlsUtils.isMainSessionDTO(locus));
     this.updateMeetingInfo(locus.info, locus.self);
     this.updateMediaShares(locus.mediaShares);
     this.updateParticipantsUrl(locus.participantsUrl);
@@ -1732,10 +1732,11 @@ export default class LocusInfo extends EventsScope {
   /**
    * handles when the locus.url is updated
    * @param {String} url
+   * @param {Boolean} isMainLocus
    * @returns {undefined}
    * emits internal event locus_info_update_url
    */
-  updateLocusUrl(url: string) {
+  updateLocusUrl(url: string, isMainLocus = true) {
     if (url && this.url !== url) {
       this.url = url;
       this.updateMeeting({locusUrl: url});
@@ -1745,7 +1746,7 @@ export default class LocusInfo extends EventsScope {
           function: 'updateLocusUrl',
         },
         EVENTS.LOCUS_INFO_UPDATE_URL,
-        url
+        {url, isMainLocus}
       );
     }
   }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3367,10 +3367,7 @@ export default class Meeting extends StatelessWebexPlugin {
         this.locusUrl = url;
         this.locusId = this.locusUrl?.split('/').pop();
         this.recordingController.setLocusUrl(this.locusUrl);
-        this.controlsOptionsManager.setLocusUrl(this.locusUrl);
-        if (isMainLocus) {
-          this.controlsOptionsManager.setMainLocusUrl(url);
-        }
+        this.controlsOptionsManager.setLocusUrl(this.locusUrl, !!isMainLocus);
         this.webinar.locusUrlUpdate(url);
 
         Trigger.trigger(

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3356,27 +3356,34 @@ export default class Meeting extends StatelessWebexPlugin {
    * @memberof Meeting
    */
   private setUpLocusUrlListener() {
-    this.locusInfo.on(EVENTS.LOCUS_INFO_UPDATE_URL, (payload) => {
-      this.members.locusUrlUpdate(payload);
-      this.breakouts.locusUrlUpdate(payload);
-      this.simultaneousInterpretation.locusUrlUpdate(payload);
-      this.annotation.locusUrlUpdate(payload);
-      this.locusUrl = payload;
-      this.locusId = this.locusUrl?.split('/').pop();
-      this.recordingController.setLocusUrl(this.locusUrl);
-      this.controlsOptionsManager.setLocusUrl(this.locusUrl);
-      this.webinar.locusUrlUpdate(payload);
+    this.locusInfo.on(
+      EVENTS.LOCUS_INFO_UPDATE_URL,
+      (payload: {url: string; isMainLocus?: boolean}) => {
+        const {url, isMainLocus} = payload;
+        this.members.locusUrlUpdate(url);
+        this.breakouts.locusUrlUpdate(url);
+        this.simultaneousInterpretation.locusUrlUpdate(url);
+        this.annotation.locusUrlUpdate(url);
+        this.locusUrl = url;
+        this.locusId = this.locusUrl?.split('/').pop();
+        this.recordingController.setLocusUrl(this.locusUrl);
+        this.controlsOptionsManager.setLocusUrl(this.locusUrl);
+        if (isMainLocus) {
+          this.controlsOptionsManager.setMainLocusUrl(url);
+        }
+        this.webinar.locusUrlUpdate(url);
 
-      Trigger.trigger(
-        this,
-        {
-          file: 'meeting/index',
-          function: 'setUpLocusSelfListener',
-        },
-        EVENT_TRIGGERS.MEETING_LOCUS_URL_UPDATE,
-        {locusUrl: payload}
-      );
-    });
+        Trigger.trigger(
+          this,
+          {
+            file: 'meeting/index',
+            function: 'setUpLocusSelfListener',
+          },
+          EVENT_TRIGGERS.MEETING_LOCUS_URL_UPDATE,
+          {locusUrl: url}
+        );
+      }
+    );
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
@@ -206,7 +206,7 @@ describe('plugin-meetings', () => {
               it('should call request with mainLocusUrl and locusUrl as authorizingLocusUrl if mainLocusUrl is exist and not same with locusUrl', () => {
                 const restorable = Util.canUpdate;
                 Util.canUpdate = sinon.stub().returns(true);
-                manager.setMainLocusUrl('test/main');
+                manager.mainLocusUrl = 'test/main';
 
                 const audio = {scope: 'audio', properties: {a: 1, b: 2}};
                 const reactions = {scope: 'reactions', properties: {c: 3, d: 4}};
@@ -342,7 +342,7 @@ describe('plugin-meetings', () => {
 
               it('request with mainLocusUrl and make locusUrl as authorizingLocusUrl if mainLocusUrl is exist and not same with locusUrl', () => {
                 manager.setDisplayHints(['MUTE_ALL', 'DISABLE_HARD_MUTE', 'DISABLE_MUTE_ON_ENTRY']);
-                manager.setMainLocusUrl(`test/main`);
+                manager.mainLocusUrl = `test/main`;
 
                 const result = manager.setMuteAll(true, true, true, ['attendee']);
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
@@ -133,6 +133,7 @@ describe('plugin-meetings', () => {
 
                 manager.set({
                   locusUrl: 'test/id',
+                  mainLocusUrl: '',
                   displayHints: [],
                 });
               });
@@ -201,6 +202,38 @@ describe('plugin-meetings', () => {
                     Util.canUpdate = restorable;
                   });
               });
+
+              it('should call request with mainLocusUrl and locusUrl as authorizingLocusUrl if mainLocusUrl is exist and not same with locusUrl', () => {
+                const restorable = Util.canUpdate;
+                Util.canUpdate = sinon.stub().returns(true);
+                manager.setMainLocusUrl('test/main');
+
+                const audio = {scope: 'audio', properties: {a: 1, b: 2}};
+                const reactions = {scope: 'reactions', properties: {c: 3, d: 4}};
+
+                return manager.update(audio, reactions)
+                  .then(() => {
+                    assert.calledWith(request.request, {
+                      uri: 'test/main/controls',
+                      body: {
+                        audio: audio.properties,
+                        authorizingLocusUrl: 'test/id'
+                      },
+                      method: HTTP_VERBS.PATCH,
+                    });
+
+                    assert.calledWith(request.request, {
+                      uri: 'test/main/controls',
+                      body: {
+                        reactions: reactions.properties,
+                        authorizingLocusUrl: 'test/id'
+                      },
+                      method: HTTP_VERBS.PATCH,
+                    });
+
+                    Util.canUpdate = restorable;
+                  });
+              });
             });
 
             describe('Mute/Unmute All', () => {
@@ -214,6 +247,7 @@ describe('plugin-meetings', () => {
 
                 manager.set({
                   locusUrl: 'test/id',
+                  mainLocusUrl: '',
                   displayHints: [],
                 })
               });
@@ -301,6 +335,19 @@ describe('plugin-meetings', () => {
 
                 assert.calledWith(request.request, {  uri: 'test/id/controls',
                   body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['attendee'] } },
+                  method: HTTP_VERBS.PATCH});
+
+                assert.deepEqual(result, request.request.firstCall.returnValue);
+              });
+
+              it('request with mainLocusUrl and make locusUrl as authorizingLocusUrl if mainLocusUrl is exist and not same with locusUrl', () => {
+                manager.setDisplayHints(['MUTE_ALL', 'DISABLE_HARD_MUTE', 'DISABLE_MUTE_ON_ENTRY']);
+                manager.setMainLocusUrl(`test/main`);
+
+                const result = manager.setMuteAll(true, true, true, ['attendee']);
+
+                assert.calledWith(request.request, {  uri: 'test/main/controls',
+                  body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['attendee'] }, authorizingLocusUrl: 'test/id' },
                   method: HTTP_VERBS.PATCH});
 
                 assert.deepEqual(result, request.request.firstCall.returnValue);

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -3020,6 +3020,45 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#updateLocusUrl', () => {
+      it('trigger LOCUS_INFO_UPDATE_URL event with isMainLocus is true as default', () => {
+        const fakeUrl = "https://fake.com/locus";
+        locusInfo.emitScoped = sinon.stub();
+        locusInfo.updateLocusUrl(fakeUrl);
+
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateLocusUrl',
+          },
+          EVENTS.LOCUS_INFO_UPDATE_URL,
+          {
+            url: fakeUrl,
+            isMainLocus: true
+          },
+        );
+      });
+      it('trigger LOCUS_INFO_UPDATE_URL event with isMainLocus is false', () => {
+        const fakeUrl = "https://fake.com/locus";
+        locusInfo.emitScoped = sinon.stub();
+        locusInfo.updateLocusUrl(fakeUrl, false);
+
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateLocusUrl',
+          },
+          EVENTS.LOCUS_INFO_UPDATE_URL,
+          {
+            url: fakeUrl,
+            isMainLocus: false
+          },
+        );
+      });
+    });
+
     // semi-integration tests that use real LocusInfo with real Parser
     // and test various scenarios related to handling out-of-order Locus delta events
     describe('handling of out-of-order Locus delta events', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -10554,8 +10554,7 @@ describe('plugin-meetings', () => {
 
           meeting.members = {locusUrlUpdate: sinon.stub().returns(Promise.resolve(test1))};
           meeting.recordingController = {setLocusUrl: sinon.stub().returns(undefined)};
-          meeting.controlsOptionsManager = {setLocusUrl: sinon.stub().returns(undefined),
-            setMainLocusUrl: sinon.stub().returns(undefined)};
+          meeting.controlsOptionsManager = {setLocusUrl: sinon.stub().returns(undefined)};
 
           meeting.breakouts.locusUrlUpdate = sinon.stub();
           meeting.annotation.locusUrlUpdate = sinon.stub();
@@ -10572,8 +10571,7 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(meeting.annotation.locusUrlUpdate, newLocusUrl);
           assert.calledWith(meeting.members.locusUrlUpdate, newLocusUrl);
           assert.calledWith(meeting.recordingController.setLocusUrl, newLocusUrl);
-          assert.calledWith(meeting.controlsOptionsManager.setLocusUrl, newLocusUrl);
-          assert.notCalled(meeting.controlsOptionsManager.setMainLocusUrl);
+          assert.calledWith(meeting.controlsOptionsManager.setLocusUrl, newLocusUrl, false);
           assert.calledWith(meeting.simultaneousInterpretation.locusUrlUpdate, newLocusUrl);
           assert.calledWith(meeting.webinar.locusUrlUpdate, newLocusUrl);
           assert.equal(meeting.locusUrl, newLocusUrl);
@@ -10597,8 +10595,7 @@ describe('plugin-meetings', () => {
           const newLocusUrl = 'newLocusUrl/12345';
           const payload = {url: newLocusUrl, isMainLocus: true}
 
-          meeting.controlsOptionsManager = {setLocusUrl: sinon.stub().returns(undefined),
-            setMainLocusUrl: sinon.stub().returns(undefined)};
+          meeting.controlsOptionsManager = {setLocusUrl: sinon.stub().returns(undefined)};
 
           meeting.locusInfo.emit(
             {function: 'test', file: 'test'},
@@ -10606,8 +10603,7 @@ describe('plugin-meetings', () => {
             payload
           );
 
-          assert.calledWith(meeting.controlsOptionsManager.setLocusUrl, newLocusUrl);
-          assert.calledWith(meeting.controlsOptionsManager.setMainLocusUrl, newLocusUrl);
+          assert.calledWith(meeting.controlsOptionsManager.setLocusUrl, newLocusUrl, true);
 
           done();
         });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -10550,10 +10550,12 @@ describe('plugin-meetings', () => {
       describe('#setUpLocusUrlListener', () => {
         it('listens to the locus url update event', (done) => {
           const newLocusUrl = 'newLocusUrl/12345';
+          const payload = {url: newLocusUrl}
 
           meeting.members = {locusUrlUpdate: sinon.stub().returns(Promise.resolve(test1))};
           meeting.recordingController = {setLocusUrl: sinon.stub().returns(undefined)};
-          meeting.controlsOptionsManager = {setLocusUrl: sinon.stub().returns(undefined)};
+          meeting.controlsOptionsManager = {setLocusUrl: sinon.stub().returns(undefined),
+            setMainLocusUrl: sinon.stub().returns(undefined)};
 
           meeting.breakouts.locusUrlUpdate = sinon.stub();
           meeting.annotation.locusUrlUpdate = sinon.stub();
@@ -10563,7 +10565,7 @@ describe('plugin-meetings', () => {
           meeting.locusInfo.emit(
             {function: 'test', file: 'test'},
             'LOCUS_INFO_UPDATE_URL',
-            newLocusUrl
+            payload
           );
           assert.calledWith(meeting.members.locusUrlUpdate, newLocusUrl);
           assert.calledOnceWithExactly(meeting.breakouts.locusUrlUpdate, newLocusUrl);
@@ -10571,6 +10573,7 @@ describe('plugin-meetings', () => {
           assert.calledWith(meeting.members.locusUrlUpdate, newLocusUrl);
           assert.calledWith(meeting.recordingController.setLocusUrl, newLocusUrl);
           assert.calledWith(meeting.controlsOptionsManager.setLocusUrl, newLocusUrl);
+          assert.notCalled(meeting.controlsOptionsManager.setMainLocusUrl);
           assert.calledWith(meeting.simultaneousInterpretation.locusUrlUpdate, newLocusUrl);
           assert.calledWith(meeting.webinar.locusUrlUpdate, newLocusUrl);
           assert.equal(meeting.locusUrl, newLocusUrl);
@@ -10587,6 +10590,24 @@ describe('plugin-meetings', () => {
             EVENT_TRIGGERS.MEETING_LOCUS_URL_UPDATE,
             {locusUrl: 'newLocusUrl/12345'}
           );
+
+          done();
+        });
+        it('update mainLocusUrl for controlsOptionManager if payload.isMainLocus as true', (done) => {
+          const newLocusUrl = 'newLocusUrl/12345';
+          const payload = {url: newLocusUrl, isMainLocus: true}
+
+          meeting.controlsOptionsManager = {setLocusUrl: sinon.stub().returns(undefined),
+            setMainLocusUrl: sinon.stub().returns(undefined)};
+
+          meeting.locusInfo.emit(
+            {function: 'test', file: 'test'},
+            'LOCUS_INFO_UPDATE_URL',
+            payload
+          );
+
+          assert.calledWith(meeting.controlsOptionsManager.setLocusUrl, newLocusUrl);
+          assert.calledWith(meeting.controlsOptionsManager.setMainLocusUrl, newLocusUrl);
 
           done();
         });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-478810

## This pull request addresses

To fix issue that host/cohost can't change meeting options In Breakout. Check the spec document of it,  the host/cohost want to change meeting options, need to use main locus url as request url and the breakout url as an parameter "authorizingLocusUrl"

## by making the following changes

Cache the mainLocusUrl in controls-options-manager
Use the mainLocusUrl and locusUrl as authorizingLocusUrl into request body if they are differenct

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
