### PR TITLE
fix(calling): fix the ExtendedError usage in logs and UTs

### DIFF
--- a/packages/calling/src/CallHistory/CallHistory.test.ts
+++ b/packages/calling/src/CallHistory/CallHistory.test.ts
@@ -96,7 +96,13 @@ describe('Call history tests', () => {
       'invoking with days=7, limit=2000, sort=ASC, sortBy=startTime',
       {file: CALL_HISTORY_FILE, method: METHODS.GET_CALL_HISTORY_DATA}
     );
-    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      `Failed to get call history: ${JSON.stringify(failurePayload)}`,
+      {
+        file: CALL_HISTORY_FILE,
+        method: METHODS.GET_CALL_HISTORY_DATA,
+      }
+    );
     expect(uploadLogsSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -117,7 +123,13 @@ describe('Call history tests', () => {
       'invoking with days=0, limit=0, sort=ASC, sortBy=startTime',
       {file: CALL_HISTORY_FILE, method: METHODS.GET_CALL_HISTORY_DATA}
     );
-    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      `Failed to get call history: ${JSON.stringify(failurePayload)}`,
+      {
+        file: CALL_HISTORY_FILE,
+        method: METHODS.GET_CALL_HISTORY_DATA,
+      }
+    );
     expect(uploadLogsSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -299,7 +311,10 @@ describe('Call history tests', () => {
         },
         methodDetails
       );
-      expect(errorSpy).toHaveBeenCalled();
+      expect(errorSpy).toBeCalledWith(
+        expect.stringContaining('Failed to update missed calls'),
+        methodDetails
+      );
       expect(uploadLogsSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -593,10 +608,13 @@ describe('Call history tests', () => {
         },
         methodDetails
       );
-      expect(errorSpy).toHaveBeenCalledWith(expect.any(Error), {
-        file: CALL_HISTORY_FILE,
-        method: METHODS.DELETE_CALL_HISTORY_RECORDS,
-      });
+      expect(errorSpy).toBeCalledWith(
+        expect.stringContaining('Failed to delete call history records'),
+        {
+          file: CALL_HISTORY_FILE,
+          method: METHODS.DELETE_CALL_HISTORY_RECORDS,
+        }
+      );
       expect(uploadLogsSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/calling/src/CallHistory/CallHistory.ts
+++ b/packages/calling/src/CallHistory/CallHistory.ts
@@ -217,8 +217,10 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to get call history: ${err}`);
-      log.error(error, {file: CALL_HISTORY_FILE, method: METHODS.GET_CALL_HISTORY_DATA});
+      log.error(`Failed to get call history: ${JSON.stringify(err)}`, {
+        file: CALL_HISTORY_FILE,
+        method: METHODS.GET_CALL_HISTORY_DATA,
+      });
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -284,8 +286,10 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to update missed calls: ${err}`);
-      log.error(error, {file: CALL_HISTORY_FILE, method: METHODS.UPDATE_MISSED_CALLS});
+      log.error(`Failed to update missed calls: ${JSON.stringify(err)}`, {
+        file: CALL_HISTORY_FILE,
+        method: METHODS.UPDATE_MISSED_CALLS,
+      });
       await uploadLogs();
 
       // Catch the 401 error from try block, return the error object to user
@@ -333,8 +337,10 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
 
       return ucmLineDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to fetch UCM lines data: ${err}`);
-      log.error(error, {file: CALL_HISTORY_FILE, method: METHODS.FETCH_UCM_LINES_DATA});
+      log.error(`Failed to fetch UCM lines data: ${JSON.stringify(err)}`, {
+        file: CALL_HISTORY_FILE,
+        method: METHODS.FETCH_UCM_LINES_DATA,
+      });
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -426,8 +432,7 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to delete call history records: ${err}`);
-      log.error(error, {
+      log.error(`Failed to delete call history records: ${JSON.stringify(err)}`, {
         file: CALL_HISTORY_FILE,
         method: METHODS.DELETE_CALL_HISTORY_RECORDS,
       });

--- a/packages/calling/src/CallHistory/CallHistory.ts
+++ b/packages/calling/src/CallHistory/CallHistory.ts
@@ -1,6 +1,5 @@
 /* eslint-disable dot-notation */
 /* eslint-disable no-underscore-dangle */
-import ExtendedError from '../Errors/catalog/ExtendedError';
 import SDKConnector from '../SDKConnector';
 import {ISDKConnector, WebexSDK} from '../SDKConnector/types';
 import {
@@ -218,8 +217,8 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to get call history: ${err}`) as ExtendedError;
-      log.error(extendedError, {file: CALL_HISTORY_FILE, method: METHODS.GET_CALL_HISTORY_DATA});
+      const error = new Error(`Failed to get call history: ${err}`);
+      log.error(error, {file: CALL_HISTORY_FILE, method: METHODS.GET_CALL_HISTORY_DATA});
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -285,8 +284,8 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to update missed calls: ${err}`) as ExtendedError;
-      log.error(extendedError, {file: CALL_HISTORY_FILE, method: METHODS.UPDATE_MISSED_CALLS});
+      const error = new Error(`Failed to update missed calls: ${err}`);
+      log.error(error, {file: CALL_HISTORY_FILE, method: METHODS.UPDATE_MISSED_CALLS});
       await uploadLogs();
 
       // Catch the 401 error from try block, return the error object to user
@@ -334,8 +333,8 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
 
       return ucmLineDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to fetch UCM lines data: ${err}`) as ExtendedError;
-      log.error(extendedError, {file: CALL_HISTORY_FILE, method: METHODS.FETCH_UCM_LINES_DATA});
+      const error = new Error(`Failed to fetch UCM lines data: ${err}`);
+      log.error(error, {file: CALL_HISTORY_FILE, method: METHODS.FETCH_UCM_LINES_DATA});
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -427,10 +426,8 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(
-        `Failed to delete call history records: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, {
+      const error = new Error(`Failed to delete call history records: ${err}`);
+      log.error(error, {
         file: CALL_HISTORY_FILE,
         method: METHODS.DELETE_CALL_HISTORY_RECORDS,
       });

--- a/packages/calling/src/CallSettings/UcmBackendConnector.test.ts
+++ b/packages/calling/src/CallSettings/UcmBackendConnector.test.ts
@@ -212,7 +212,7 @@ describe('Call Settings Client Tests for UcmBackendConnector', () => {
         method: 'getCallForwardAlwaysSetting',
       });
       expect(log.error).toHaveBeenCalledWith(
-        new Error('Failed to get call forward always setting: [object Object]'),
+        `Failed to get call forward always setting: ${JSON.stringify(responsePayload)}`,
         {
           file: UCM_CONNECTOR_FILE,
           method: 'getCallForwardAlwaysSetting',

--- a/packages/calling/src/CallSettings/UcmBackendConnector.ts
+++ b/packages/calling/src/CallSettings/UcmBackendConnector.ts
@@ -247,8 +247,7 @@ export class UcmBackendConnector implements IUcmBackendConnector {
       return response;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Failed to get call forward always setting: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get call forward always setting: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
 

--- a/packages/calling/src/CallSettings/UcmBackendConnector.ts
+++ b/packages/calling/src/CallSettings/UcmBackendConnector.ts
@@ -1,4 +1,3 @@
-import ExtendedError from 'Errors/catalog/ExtendedError';
 import log from '../Logger';
 import SDKConnector from '../SDKConnector';
 import {ISDKConnector, WebexSDK} from '../SDKConnector/types';
@@ -248,10 +247,8 @@ export class UcmBackendConnector implements IUcmBackendConnector {
       return response;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(
-        `Failed to get call forward always setting: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get call forward always setting: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
 

--- a/packages/calling/src/CallSettings/WxCallBackendConnector.test.ts
+++ b/packages/calling/src/CallSettings/WxCallBackendConnector.test.ts
@@ -185,7 +185,10 @@ describe('Call Settings Client Tests for WxCallBackendConnector', () => {
         file: WEBEX_CALLING_CONNECTOR_FILE,
         method: 'getCallWaitingSetting',
       });
-      expect(errorSpy).toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(`Failed to get call waiting setting: {}`, {
+        file: 'WxCallBackendConnector',
+        method: 'getCallWaitingSetting',
+      });
       expect(logSpy).not.toHaveBeenCalled();
     });
 

--- a/packages/calling/src/CallSettings/WxCallBackendConnector.ts
+++ b/packages/calling/src/CallSettings/WxCallBackendConnector.ts
@@ -133,8 +133,7 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to get call waiting setting: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get call waiting setting: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorInfo = {
@@ -181,8 +180,7 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to get DoNotDisturb setting: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get DoNotDisturb setting: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -232,8 +230,7 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to set DoNotDisturb setting: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to set DoNotDisturb setting: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -275,8 +272,7 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to get Call Forward setting: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get Call Forward setting: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -320,8 +316,7 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to set Call Forward setting: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to set Call Forward setting: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -363,8 +358,7 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to get Voicemail setting: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get Voicemail setting: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -408,9 +402,7 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to set Voicemail setting: ${err}`);
-      log.error(error, loggerContext);
-
+      log.error(`Failed to set Voicemail setting: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;

--- a/packages/calling/src/CallSettings/WxCallBackendConnector.ts
+++ b/packages/calling/src/CallSettings/WxCallBackendConnector.ts
@@ -1,4 +1,3 @@
-import ExtendedError from 'Errors/catalog/ExtendedError';
 import SDKConnector from '../SDKConnector';
 import {ISDKConnector, WebexSDK} from '../SDKConnector/types';
 import {
@@ -134,10 +133,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(
-        `Failed to get call waiting setting: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get call waiting setting: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       const errorInfo = {
@@ -184,10 +181,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(
-        `Failed to get DoNotDisturb setting: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get DoNotDisturb setting: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -237,10 +232,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(
-        `Failed to set DoNotDisturb setting: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to set DoNotDisturb setting: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -282,10 +275,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(
-        `Failed to get Call Forward setting: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get Call Forward setting: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -329,10 +320,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(
-        `Failed to set Call Forward setting: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to set Call Forward setting: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -374,8 +363,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to get Voicemail setting: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get Voicemail setting: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -419,9 +408,9 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to set Voicemail setting: ${err}`) as ExtendedError;
+      const error = new Error(`Failed to set Voicemail setting: ${err}`);
+      log.error(error, loggerContext);
 
-      log.error(extendedError, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -471,8 +471,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
         break;
       } catch (err: unknown) {
-        const error = new Error(`Failed to get client region info: ${err}`);
-        log.error(error, {
+        log.error(`Failed to get client region info: ${JSON.stringify(err)}`, {
           method: METHODS.GET_CLIENT_REGION_INFO,
           file: CALLING_CLIENT_FILE,
         });
@@ -606,8 +605,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
           }
         );
       } catch (err: unknown) {
-        const error = new Error(`Failed to get Mobius servers: ${err}`);
-        log.error(error, {
+        log.error(`Failed to get Mobius servers: ${JSON.stringify(err)}`, {
           method: METHODS.GET_MOBIUS_SERVERS,
           file: CALLING_CLIENT_FILE,
         });

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -3,7 +3,6 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import * as Media from '@webex/internal-media-core';
 import {Mutex} from 'async-mutex';
-import ExtendedError from 'Errors/catalog/ExtendedError';
 import {METHOD_START_MESSAGE} from '../common/constants';
 import {
   filterMobiusUris,
@@ -472,10 +471,8 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
         break;
       } catch (err: unknown) {
-        const extendedError = new Error(
-          `Failed to get client region info: ${err}`
-        ) as ExtendedError;
-        log.error(extendedError, {
+        const error = new Error(`Failed to get client region info: ${err}`);
+        log.error(error, {
           method: METHODS.GET_CLIENT_REGION_INFO,
           file: CALLING_CLIENT_FILE,
         });
@@ -609,8 +606,8 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
           }
         );
       } catch (err: unknown) {
-        const extendedError = new Error(`Failed to get Mobius servers: ${err}`) as ExtendedError;
-        log.error(extendedError, {
+        const error = new Error(`Failed to get Mobius servers: ${err}`);
+        log.error(error, {
           method: METHODS.GET_MOBIUS_SERVERS,
           file: CALLING_CLIENT_FILE,
         });

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -985,8 +985,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: this.handleOutgoingCallSetup.name,
       });
     } catch (e) {
-      const err = new Error(`Failed to setup the call: ${e}`);
-      log.error(err, {
+      log.error(`Failed to setup the call: ${JSON.stringify(e)}`, {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_SETUP,
       });
@@ -1061,8 +1060,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         }, SUPPLEMENTARY_SERVICES_TIMEOUT);
       }
     } catch (e) {
-      const err = new Error(`Failed to put the call on hold: ${e}`);
-      log.error(err, {
+      log.error(`Failed to put the call on hold: ${JSON.stringify(e)}`, {
         file: CALL_FILE,
         method: METHODS.HANDLE_CALL_HOLD,
       });
@@ -1137,8 +1135,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         }, SUPPLEMENTARY_SERVICES_TIMEOUT);
       }
     } catch (e) {
-      const err = new Error(`Failed to resume the call: ${e}`);
-      log.error(err, {
+      log.error(`Failed to resume the call: ${JSON.stringify(e)}`, {
         file: CALL_FILE,
         method: METHODS.HANDLE_CALL_RESUME,
       });
@@ -1262,8 +1259,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: METHODS.HANDLE_OUTGOING_CALL_ALERTING,
       });
     } catch (e) {
-      const err = new Error(`Failed to signal call progression: ${e}`);
-      log.error(err, {
+      log.error(`Failed to signal call progression: ${JSON.stringify(e)}`, {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_ALERTING,
       });
@@ -1348,8 +1344,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: METHODS.HANDLE_OUTGOING_CALL_CONNECT,
       });
     } catch (e) {
-      const err = new Error(`Failed to connect the call: ${e}`);
-      log.error(err, {
+      log.error(`Failed to connect the call: ${JSON.stringify(e)}`, {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_CONNECT,
       });
@@ -1400,7 +1395,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: METHODS.HANDLE_OUTGOING_CALL_DISCONNECT,
       });
     } catch (e) {
-      log.warn('Failed to delete the call', {
+      log.warn(`Failed to delete the call: ${JSON.stringify(e)}`, {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_DISCONNECT,
       });
@@ -2065,10 +2060,12 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       log.info(`callFrom: ${callFrom}`, loggerContext);
     } catch (error) {
       const errorInfo = error as WebexRequestPayload;
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
-      const err = new Error(`Failed to upload webrtc telemetry statistics. ${errorStatus}`);
+      const errorStatus = await serviceErrorCodeHandler(errorInfo, loggerContext);
 
-      log.error(err, loggerContext);
+      log.error(
+        `Failed to upload webrtc telemetry statistics. ${JSON.stringify(errorStatus)}`,
+        loggerContext
+      );
 
       await uploadLogs({
         correlationId: this.correlationId,

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -8,7 +8,6 @@ import {createMachine, interpret} from 'xstate';
 import {v4 as uuid} from 'uuid';
 import {EffectEvent, TrackEffect} from '@webex/web-media-effects';
 import {RtcMetrics} from '@webex/internal-plugin-metrics';
-import ExtendedError from '../../Errors/catalog/ExtendedError';
 import {ERROR_LAYER, ERROR_TYPE, ErrorContext} from '../../Errors/types';
 import {
   handleCallErrors,
@@ -986,8 +985,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         method: this.handleOutgoingCallSetup.name,
       });
     } catch (e) {
-      const extendedError = new Error(`Failed to setup the call: ${e}`) as ExtendedError;
-      log.error(extendedError, {
+      const err = new Error(`Failed to setup the call: ${e}`);
+      log.error(err, {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_SETUP,
       });
@@ -1062,8 +1061,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         }, SUPPLEMENTARY_SERVICES_TIMEOUT);
       }
     } catch (e) {
-      const extendedError = new Error(`Failed to put the call on hold: ${e}`) as ExtendedError;
-      log.error(extendedError, {
+      const err = new Error(`Failed to put the call on hold: ${e}`);
+      log.error(err, {
         file: CALL_FILE,
         method: METHODS.HANDLE_CALL_HOLD,
       });
@@ -1138,8 +1137,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         }, SUPPLEMENTARY_SERVICES_TIMEOUT);
       }
     } catch (e) {
-      const extendedError = new Error(`Failed to resume the call: ${e}`) as ExtendedError;
-      log.error(extendedError, {
+      const err = new Error(`Failed to resume the call: ${e}`);
+      log.error(err, {
         file: CALL_FILE,
         method: METHODS.HANDLE_CALL_RESUME,
       });
@@ -1262,13 +1261,13 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_ALERTING,
       });
-    } catch (err) {
-      const extendedError = new Error(`Failed to signal call progression: ${err}`) as ExtendedError;
-      log.error(extendedError, {
+    } catch (e) {
+      const err = new Error(`Failed to signal call progression: ${e}`);
+      log.error(err, {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_ALERTING,
       });
-      const errData = err as MobiusCallResponse;
+      const errData = e as MobiusCallResponse;
 
       handleCallErrors(
         (error: CallError) => {
@@ -1348,13 +1347,13 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_CONNECT,
       });
-    } catch (err) {
-      const extendedError = new Error(`Failed to connect the call: ${err}`) as ExtendedError;
-      log.error(extendedError, {
+    } catch (e) {
+      const err = new Error(`Failed to connect the call: ${e}`);
+      log.error(err, {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_CONNECT,
       });
-      const errData = err as MobiusCallResponse;
+      const errData = e as MobiusCallResponse;
 
       handleCallErrors(
         (error: CallError) => {
@@ -2067,11 +2066,9 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     } catch (error) {
       const errorInfo = error as WebexRequestPayload;
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
-      const errorLog = new Error(
-        `Failed to upload webrtc telemetry statistics. ${errorStatus}`
-      ) as ExtendedError;
+      const err = new Error(`Failed to upload webrtc telemetry statistics. ${errorStatus}`);
 
-      log.error(errorLog, loggerContext);
+      log.error(err, loggerContext);
 
       await uploadLogs({
         correlationId: this.correlationId,

--- a/packages/calling/src/CallingClient/calling/callManager.test.ts
+++ b/packages/calling/src/CallingClient/calling/callManager.test.ts
@@ -282,7 +282,7 @@ describe('Call Manager Tests with respect to calls', () => {
 
     expect(patchMock).toHaveBeenCalledWith(MobiusCallState.ALERTING);
     expect(errorSpy).toHaveBeenCalledWith(
-      Error(`Failed to signal call progression: ${dummyResponse}`),
+      `Failed to signal call progression: ${JSON.stringify(dummyResponse)}`,
       {
         file: 'call',
         method: 'handleOutgoingCallAlerting',

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -164,7 +164,7 @@ export class Registration implements IRegistration {
         },
       });
     } catch (error) {
-      log.warn(`Delete failed with Mobius ${error}`, {
+      log.warn(`Delete failed with Mobius: ${JSON.stringify(error)}`, {
         file: REGISTRATION_FILE,
         method: METHODS.DELETE_REGISTRATION,
       });
@@ -407,10 +407,13 @@ export class Registration implements IRegistration {
           break;
         }
       } catch (error) {
-        log.warn(`Ping failed for primary Mobius: ${mobiusUrl} with error: ${error}`, {
-          file: REGISTRATION_FILE,
-          method: FAILBACK_UTIL,
-        });
+        log.warn(
+          `Ping failed for primary Mobius: ${mobiusUrl} with error: ${JSON.stringify(error)}`,
+          {
+            file: REGISTRATION_FILE,
+            method: FAILBACK_UTIL,
+          }
+        );
         status = 'down';
       }
     }
@@ -918,7 +921,7 @@ export class Registration implements IRegistration {
         method: METHODS.DEREGISTER,
       });
     } catch (err) {
-      log.warn(`Delete failed with Mobius: ${err}`, {
+      log.warn(`Delete failed with Mobius: ${JSON.stringify(err)}`, {
         file: REGISTRATION_FILE,
         method: METHODS.DEREGISTER,
       });

--- a/packages/calling/src/CallingClient/registration/webWorker.ts
+++ b/packages/calling/src/CallingClient/registration/webWorker.ts
@@ -48,11 +48,11 @@ const messageHandler = (event: MessageEvent) => {
           keepAliveRetryCount = 0;
         } catch (err: any) {
           const headers = {} as Record<string, string>;
-          if (err.headers.has('Retry-After')) {
+          if (err.headers?.has('Retry-After')) {
             headers['retry-after'] = err.headers.get('Retry-After');
           }
 
-          if (err.headers.has('Trackingid')) {
+          if (err.headers?.has('Trackingid')) {
             // eslint-disable-next-line dot-notation
             headers['trackingid'] = err.headers.get('Trackingid');
           }

--- a/packages/calling/src/CallingClient/registration/webWorkerStr.ts
+++ b/packages/calling/src/CallingClient/registration/webWorkerStr.ts
@@ -75,11 +75,11 @@ const messageHandler = (event) => {
           keepAliveRetryCount = 0;
         } catch (err) {
           let headers = {};
-          if(err.headers.has('Retry-After')) {
+          if(err.headers?.has('Retry-After')) {
             headers['retry-after'] = err.headers.get('Retry-After');
           } 
 
-          if(err.headers.has('Trackingid')) {
+          if(err.headers?.has('Trackingid')) {
             headers['trackingid'] = err.headers.get('Trackingid');
           }   
 

--- a/packages/calling/src/Contacts/ContactsClient.test.ts
+++ b/packages/calling/src/Contacts/ContactsClient.test.ts
@@ -488,7 +488,7 @@ describe('ContactClient Tests', () => {
     expect(errorSpy).toBeCalledTimes(1);
     expect(errorSpy).toHaveBeenNthCalledWith(
       1,
-      Error(`Unable to create contact group: ${failureResponsePayload}`),
+      `Unable to create contact group: ${JSON.stringify(failureResponsePayload)}`,
       loggerContext
     );
 
@@ -528,9 +528,9 @@ describe('ContactClient Tests', () => {
     expect(uploadLogsSpy).toBeCalledTimes(1);
     expect(errorSpy).toHaveBeenNthCalledWith(
       1,
-      Error(
-        `Unable to delete contact group ${mockGroupResponse.groupId}: ${failureResponsePayload}`
-      ),
+      `Unable to delete contact group ${mockGroupResponse.groupId}: ${JSON.stringify(
+        failureResponsePayload
+      )}`,
       loggerContext
     );
     expect(warnSpy).toHaveBeenNthCalledWith(
@@ -842,10 +842,13 @@ describe('ContactClient Tests', () => {
       file: CONTACTS_CLIENT,
       method: METHODS.CREATE_CONTACT,
     });
-    expect(log.error).toBeCalledWith(Error(`Failed to create contact: ${failureResponsePayload}`), {
-      file: CONTACTS_CLIENT,
-      method: METHODS.CREATE_CONTACT,
-    });
+    expect(log.error).toBeCalledWith(
+      `Failed to create contact: ${JSON.stringify(failureResponsePayload)}`,
+      {
+        file: CONTACTS_CLIENT,
+        method: METHODS.CREATE_CONTACT,
+      }
+    );
   });
 
   it('successful deletion of contacts', async () => {

--- a/packages/calling/src/Contacts/ContactsClient.ts
+++ b/packages/calling/src/Contacts/ContactsClient.ts
@@ -431,10 +431,8 @@ export class ContactsClient implements IContacts {
 
       return contactResponse;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Error fetching contacts: ${err}`);
-      log.error(error, loggerContext);
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      log.error(`Error fetching contacts: ${JSON.stringify(err)}`, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
       await uploadLogs();
 
       return errorStatus;
@@ -651,10 +649,8 @@ export class ContactsClient implements IContacts {
 
       return contactResponse;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Unable to create contact group: ${err}`);
-      log.error(error, loggerContext);
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      log.error(`Unable to create contact group: ${JSON.stringify(err)}`, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
       await uploadLogs();
 
       return errorStatus;
@@ -703,10 +699,8 @@ export class ContactsClient implements IContacts {
 
       return contactResponse;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Unable to delete contact group ${groupId}: ${err}`);
-      log.error(error, loggerContext);
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      log.error(`Unable to delete contact group ${groupId}: ${JSON.stringify(err)}`, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
       await uploadLogs();
 
       return errorStatus;
@@ -813,10 +807,8 @@ export class ContactsClient implements IContacts {
 
       return contactResponse;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Failed to create contact: ${err}`);
-      log.error(error, loggerContext);
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      log.error(`Failed to create contact: ${JSON.stringify(err)}`, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
       await uploadLogs();
 
       return errorStatus;
@@ -861,10 +853,8 @@ export class ContactsClient implements IContacts {
 
       return contactResponse;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Unable to delete contact ${contactId}: ${err}`);
-      log.error(error, loggerContext);
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      log.error(`Unable to delete contact ${contactId}: ${JSON.stringify(err)}`, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
       await uploadLogs();
 
       return errorStatus;

--- a/packages/calling/src/Contacts/ContactsClient.ts
+++ b/packages/calling/src/Contacts/ContactsClient.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-await-in-loop */
-import ExtendedError from 'Errors/catalog/ExtendedError';
 import {
   FAILURE_MESSAGE,
   METHOD_START_MESSAGE,
@@ -433,8 +432,8 @@ export class ContactsClient implements IContacts {
       return contactResponse;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(`Error fetching contacts: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Error fetching contacts: ${err}`);
+      log.error(error, loggerContext);
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
       await uploadLogs();
 
@@ -653,8 +652,8 @@ export class ContactsClient implements IContacts {
       return contactResponse;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(`Unable to create contact group: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Unable to create contact group: ${err}`);
+      log.error(error, loggerContext);
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
       await uploadLogs();
 
@@ -705,10 +704,8 @@ export class ContactsClient implements IContacts {
       return contactResponse;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(
-        `Unable to delete contact group ${groupId}: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Unable to delete contact group ${groupId}: ${err}`);
+      log.error(error, loggerContext);
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
       await uploadLogs();
 
@@ -817,8 +814,8 @@ export class ContactsClient implements IContacts {
       return contactResponse;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(`Failed to create contact: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to create contact: ${err}`);
+      log.error(error, loggerContext);
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
       await uploadLogs();
 
@@ -865,10 +862,8 @@ export class ContactsClient implements IContacts {
       return contactResponse;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(
-        `Unable to delete contact ${contactId}: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Unable to delete contact ${contactId}: ${err}`);
+      log.error(error, loggerContext);
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
       await uploadLogs();
 

--- a/packages/calling/src/Events/impl/index.ts
+++ b/packages/calling/src/Events/impl/index.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import EventEmitter from 'events';
 import TypedEmitter, {EventMap} from 'typed-emitter'; // eslint-disable-line import/no-extraneous-dependencies
+import {stringify} from 'flatted';
 import Logger from '../../Logger';
 import {LOG_PREFIX} from '../../Logger/types';
 
@@ -23,7 +24,7 @@ export class Eventing<T extends EventMap> extends (EventEmitter as {
     Logger.info(
       `${timestamp} ${
         LOG_PREFIX.EVENT
-      }: ${event.toString()} - event emitted with parameters -> ${args} = `,
+      }: ${event.toString()} - event emitted with parameters -> ${stringify(args)}`,
       {
         file: 'Events/impl/index.ts',
         method: 'emit',

--- a/packages/calling/src/Logger/index.test.ts
+++ b/packages/calling/src/Logger/index.test.ts
@@ -49,7 +49,7 @@ describe('Coverage tests for logger', () => {
     log.trace(fakePrint, dummyContext);
     expect(traceSpy).not.toHaveBeenCalledTimes(1);
 
-    log.error(new Error(fakePrint), dummyContext);
+    log.error(fakePrint, dummyContext);
     expect(errorSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/calling/src/Logger/index.test.ts
+++ b/packages/calling/src/Logger/index.test.ts
@@ -1,4 +1,3 @@
-import ExtendedError from '../Errors/catalog/ExtendedError';
 import {LOGGER} from './types';
 import log from '.';
 
@@ -50,7 +49,7 @@ describe('Coverage tests for logger', () => {
     log.trace(fakePrint, dummyContext);
     expect(traceSpy).not.toHaveBeenCalledTimes(1);
 
-    log.error(new Error(fakePrint) as ExtendedError, dummyContext);
+    log.error(new Error(fakePrint), dummyContext);
     expect(errorSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/calling/src/Logger/index.ts
+++ b/packages/calling/src/Logger/index.ts
@@ -2,7 +2,6 @@
 import {Logger} from '../SDKConnector/types';
 import {REPO_NAME} from '../CallingClient/constants';
 import {IMetaContext} from '../common/types';
-import ExtendedError from '../Errors/catalog/ExtendedError';
 import {LOGGING_LEVEL, LogContext, LOGGER, LOG_PREFIX} from './types';
 
 /*
@@ -191,7 +190,7 @@ const logTrace = (message: string, context: LogContext) => {
  * @param error - Error string .
  * @param context - File and method which called.
  */
-const logError = (error: ExtendedError, context: LogContext) => {
+const logError = (error: Error, context: LogContext) => {
   if (currentLogLevel >= LOGGING_LEVEL.error) {
     writeToLogger(
       `${format(context, '[ERROR]')} - !${LOG_PREFIX.ERROR}!${LOG_PREFIX.MESSAGE}:${error.message}`,

--- a/packages/calling/src/Logger/index.ts
+++ b/packages/calling/src/Logger/index.ts
@@ -187,13 +187,13 @@ const logTrace = (message: string, context: LogContext) => {
 /**
  * Can be used to print only errors.
  *
- * @param error - Error string .
+ * @param errorMsg - Error string .
  * @param context - File and method which called.
  */
-const logError = (error: Error, context: LogContext) => {
+const logError = (errorMsg: string, context: LogContext) => {
   if (currentLogLevel >= LOGGING_LEVEL.error) {
     writeToLogger(
-      `${format(context, '[ERROR]')} - !${LOG_PREFIX.ERROR}!${LOG_PREFIX.MESSAGE}:${error.message}`,
+      `${format(context, '[ERROR]')} - !${LOG_PREFIX.ERROR}!${LOG_PREFIX.MESSAGE}:${errorMsg}`,
       LOGGER.ERROR
     );
   }

--- a/packages/calling/src/Voicemail/BroadworksBackendConnector.test.ts
+++ b/packages/calling/src/Voicemail/BroadworksBackendConnector.test.ts
@@ -218,6 +218,10 @@ describe('Voicemail Broadworks Backend Connector Test case', () => {
           method: 'getUserId',
         }
       );
+      expect(errorSpy).toHaveBeenCalledWith('Failed to get userId: {}', {
+        file: 'BroadworksBackendConnector',
+        method: 'getUserId',
+      });
     });
 
     it('verify failed case when token is invalid', async () => {
@@ -242,6 +246,10 @@ describe('Voicemail Broadworks Backend Connector Test case', () => {
           method: 'getUserId',
         }
       );
+      expect(errorSpy).toHaveBeenCalledWith('Failed to get userId: {}', {
+        file: 'BroadworksBackendConnector',
+        method: 'getUserId',
+      });
     });
 
     it('verify no response case when token have invalid userid', async () => {

--- a/packages/calling/src/Voicemail/BroadworksBackendConnector.ts
+++ b/packages/calling/src/Voicemail/BroadworksBackendConnector.ts
@@ -150,8 +150,7 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
         statusCode: err instanceof Error ? Number(err.message) : '',
       } as WebexRequestPayload;
 
-      const error = new Error(`Failed to get userId: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get userId: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       return serviceErrorCodeHandler(errorInfo, loggerContext);
@@ -179,11 +178,7 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
       this.bwtoken = response[TOKEN][BEARER];
       log.log('Successfully fetched Broadworks token', loggerContext);
     } catch (err: unknown) {
-      const error = new Error(`Broadworks token exception: ${err}`);
-      log.error(error, {
-        file: BROADWORKS_VOICEMAIL_FILE,
-        method: METHODS.GET_BW_TOKEN,
-      });
+      log.error(`Broadworks token exception: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
     }
   }
@@ -291,8 +286,7 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
           statusCode: err instanceof Error ? Number(err.message) : '',
         } as WebexRequestPayload;
 
-        const error = new Error(`Failed to get voicemail list: ${err}`);
-        log.error(error, loggerContext);
+        log.error(`Failed to get voicemail list: ${JSON.stringify(err)}`, loggerContext);
         await uploadLogs();
 
         const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
@@ -381,8 +375,7 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
         statusCode: err instanceof Error ? Number(err.message) : '',
       } as WebexRequestPayload;
 
-      const error = new Error(`Failed to get voicemail content: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get voicemail content: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
@@ -444,8 +437,7 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
         statusCode: err instanceof Error ? Number(err.message) : '',
       } as WebexRequestPayload;
 
-      const error = new Error(`Failed to mark voicemail as read: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to mark voicemail as read: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
@@ -498,8 +490,7 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
         statusCode: err instanceof Error ? Number(err.message) : '',
       } as WebexRequestPayload;
 
-      const error = new Error(`Failed to mark voicemail as unread: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to mark voicemail as unread: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
@@ -552,8 +543,7 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
         statusCode: err instanceof Error ? Number(err.message) : '',
       } as WebexRequestPayload;
 
-      const error = new Error(`Failed to delete voicemail: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to delete voicemail: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);

--- a/packages/calling/src/Voicemail/BroadworksBackendConnector.ts
+++ b/packages/calling/src/Voicemail/BroadworksBackendConnector.ts
@@ -1,6 +1,5 @@
 /* eslint-disable valid-jsdoc */
 /* eslint-disable no-underscore-dangle */
-import ExtendedError from '../Errors/catalog/ExtendedError';
 import {ERROR_CODE} from '../Errors/types';
 import SDKConnector from '../SDKConnector';
 import {
@@ -151,8 +150,8 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
         statusCode: err instanceof Error ? Number(err.message) : '',
       } as WebexRequestPayload;
 
-      const extendedError = new Error(`Failed to get userId: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get userId: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       return serviceErrorCodeHandler(errorInfo, loggerContext);
@@ -180,8 +179,8 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
       this.bwtoken = response[TOKEN][BEARER];
       log.log('Successfully fetched Broadworks token', loggerContext);
     } catch (err: unknown) {
-      const extendedError = new Error(`Broadworks token exception: ${err}`) as ExtendedError;
-      log.error(extendedError, {
+      const error = new Error(`Broadworks token exception: ${err}`);
+      log.error(error, {
         file: BROADWORKS_VOICEMAIL_FILE,
         method: METHODS.GET_BW_TOKEN,
       });
@@ -292,8 +291,8 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
           statusCode: err instanceof Error ? Number(err.message) : '',
         } as WebexRequestPayload;
 
-        const extendedError = new Error(`Failed to get voicemail list: ${err}`) as ExtendedError;
-        log.error(extendedError, loggerContext);
+        const error = new Error(`Failed to get voicemail list: ${err}`);
+        log.error(error, loggerContext);
         await uploadLogs();
 
         const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
@@ -382,8 +381,8 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
         statusCode: err instanceof Error ? Number(err.message) : '',
       } as WebexRequestPayload;
 
-      const extendedError = new Error(`Failed to get voicemail content: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get voicemail content: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
@@ -445,8 +444,8 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
         statusCode: err instanceof Error ? Number(err.message) : '',
       } as WebexRequestPayload;
 
-      const extendedError = new Error(`Failed to mark voicemail as read: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to mark voicemail as read: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
@@ -499,10 +498,8 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
         statusCode: err instanceof Error ? Number(err.message) : '',
       } as WebexRequestPayload;
 
-      const extendedError = new Error(
-        `Failed to mark voicemail as unread: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to mark voicemail as unread: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
@@ -555,8 +552,8 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
         statusCode: err instanceof Error ? Number(err.message) : '',
       } as WebexRequestPayload;
 
-      const extendedError = new Error(`Failed to delete voicemail: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to delete voicemail: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
 
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);

--- a/packages/calling/src/Voicemail/UcmBackendConnector.ts
+++ b/packages/calling/src/Voicemail/UcmBackendConnector.ts
@@ -185,9 +185,7 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to get voicemail list: ${err}`);
-      log.error(error, loggerContext);
-
+      log.error(`Failed to get voicemail list: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
 
       const errorInfo = err as WebexRequestPayload;
@@ -218,8 +216,7 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
       return response as VoicemailResponseEvent;
     } catch (err: unknown) {
-      const error = new Error(`Failed to get voicemail content: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get voicemail content: ${JSON.stringify(err)}`, loggerContext);
 
       await uploadLogs();
 
@@ -370,8 +367,7 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to mark voicemail as read: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to mark voicemail as read: ${JSON.stringify(err)}`, loggerContext);
 
       await uploadLogs();
 
@@ -418,8 +414,7 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to mark voicemail as unread: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to mark voicemail as unread: ${JSON.stringify(err)}`, loggerContext);
 
       await uploadLogs();
 
@@ -463,8 +458,7 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const error = new Error(`Failed to delete voicemail: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to delete voicemail: ${JSON.stringify(err)}`, loggerContext);
 
       await uploadLogs();
 

--- a/packages/calling/src/Voicemail/UcmBackendConnector.ts
+++ b/packages/calling/src/Voicemail/UcmBackendConnector.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable valid-jsdoc */
 /* eslint-disable @typescript-eslint/no-shadow */
-import ExtendedError from '../Errors/catalog/ExtendedError';
 import SDKConnector from '../SDKConnector';
 import {ISDKConnector, WebexSDK} from '../SDKConnector/types';
 import {
@@ -186,8 +185,8 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to get voicemail list: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get voicemail list: ${err}`);
+      log.error(error, loggerContext);
 
       await uploadLogs();
 
@@ -219,8 +218,8 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
       return response as VoicemailResponseEvent;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to get voicemail content: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get voicemail content: ${err}`);
+      log.error(error, loggerContext);
 
       await uploadLogs();
 
@@ -371,8 +370,8 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to mark voicemail as read: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to mark voicemail as read: ${err}`);
+      log.error(error, loggerContext);
 
       await uploadLogs();
 
@@ -419,10 +418,8 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(
-        `Failed to mark voicemail as unread: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to mark voicemail as unread: ${err}`);
+      log.error(error, loggerContext);
 
       await uploadLogs();
 
@@ -466,8 +463,8 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to delete voicemail: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to delete voicemail: ${err}`);
+      log.error(error, loggerContext);
 
       await uploadLogs();
 

--- a/packages/calling/src/Voicemail/Voicemail.ts
+++ b/packages/calling/src/Voicemail/Voicemail.ts
@@ -59,26 +59,21 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
    *
    */
   public async init() {
+    const loggerContext = {
+      file: VOICEMAIL_FILE,
+      method: METHODS.INIT,
+    };
+
     try {
-      log.info(METHOD_START_MESSAGE, {
-        file: VOICEMAIL_FILE,
-        method: METHODS.INIT,
-      });
+      log.info(METHOD_START_MESSAGE, loggerContext);
 
       const response = this.backendConnector.init();
 
-      log.log('Voicemail connector initialized successfully', {
-        file: VOICEMAIL_FILE,
-        method: METHODS.INIT,
-      });
+      log.log('Voicemail connector initialized successfully', loggerContext);
 
       return response;
     } catch (err: unknown) {
-      const error = new Error(`Failed to initialize voicemail: ${err}`);
-      log.error(error, {
-        file: VOICEMAIL_FILE,
-        method: METHODS.INIT,
-      });
+      log.error(`Failed to initialize voicemail: ${JSON.stringify(err)}`, loggerContext);
 
       await uploadLogs();
 
@@ -161,13 +156,15 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
     sort: SORT,
     refresh?: boolean
   ): Promise<VoicemailResponseEvent> {
+    const loggerContext = {
+      file: VOICEMAIL_FILE,
+      method: METHODS.GET_VOICEMAIL_LIST,
+    };
+
     try {
       log.info(
         `${METHOD_START_MESSAGE} with: offset=${offset}, limit=${offsetLimit}, sort=${sort}, refresh=${refresh}`,
-        {
-          file: VOICEMAIL_FILE,
-          method: METHODS.GET_VOICEMAIL_LIST,
-        }
+        loggerContext
       );
 
       const response = await this.backendConnector.getVoicemailList(
@@ -179,18 +176,14 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
 
       this.submitMetric(response, VOICEMAIL_ACTION.GET_VOICEMAILS);
 
-      log.log(`Successfully retrieved voicemail list: statusCode=${response.statusCode}`, {
-        file: VOICEMAIL_FILE,
-        method: METHODS.GET_VOICEMAIL_LIST,
-      });
+      log.log(
+        `Successfully retrieved voicemail list: statusCode=${response.statusCode}`,
+        loggerContext
+      );
 
       return response;
     } catch (err: unknown) {
-      const error = new Error(`Failed to get voicemail list: ${err}`);
-      log.error(error, {
-        file: VOICEMAIL_FILE,
-        method: METHODS.GET_VOICEMAIL_LIST,
-      });
+      log.error(`Failed to get voicemail list: ${JSON.stringify(err)}`, loggerContext);
 
       await uploadLogs();
 
@@ -204,10 +197,12 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
    * @param messageId - The identifier of the voicemail message.
    */
   public async getVoicemailContent(messageId: string): Promise<VoicemailResponseEvent> {
-    log.info(`${METHOD_START_MESSAGE} with: messageId=${messageId}`, {
+    const loggerContext = {
       file: VOICEMAIL_FILE,
       method: METHODS.GET_VOICEMAIL_CONTENT,
-    });
+    };
+
+    log.info(`${METHOD_START_MESSAGE} with: messageId=${messageId}`, loggerContext);
 
     const response = await this.backendConnector.getVoicemailContent(messageId);
 
@@ -215,10 +210,7 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
 
     log.log(
       `Successfully retrieved voicemail content for messageId=${messageId}, statusCode=${response.statusCode}`,
-      {
-        file: VOICEMAIL_FILE,
-        method: METHODS.GET_VOICEMAIL_CONTENT,
-      }
+      loggerContext
     );
 
     return response;
@@ -229,10 +221,12 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
    *
    */
   public async getVoicemailSummary(): Promise<VoicemailResponseEvent | null> {
-    log.info(METHOD_START_MESSAGE, {
+    const loggerContext = {
       file: VOICEMAIL_FILE,
       method: METHODS.GET_VOICEMAIL_SUMMARY,
-    });
+    };
+
+    log.info(METHOD_START_MESSAGE, loggerContext);
 
     const response = await this.backendConnector.getVoicemailSummary();
 
@@ -240,10 +234,10 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
     if (response !== null) {
       this.submitMetric(response, VOICEMAIL_ACTION.GET_VOICEMAIL_SUMMARY);
 
-      log.log(`Successfully retrieved voicemail summary: statusCode=${response.statusCode}`, {
-        file: VOICEMAIL_FILE,
-        method: METHODS.GET_VOICEMAIL_SUMMARY,
-      });
+      log.log(
+        `Successfully retrieved voicemail summary: statusCode=${response.statusCode}`,
+        loggerContext
+      );
     }
 
     return response;
@@ -255,10 +249,12 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
    * @param messageId -string result from the voicemail list.
    */
   public async voicemailMarkAsRead(messageId: string): Promise<VoicemailResponseEvent> {
-    log.info(`${METHOD_START_MESSAGE} with: messageId=${messageId}`, {
+    const loggerContext = {
       file: VOICEMAIL_FILE,
       method: METHODS.VOICEMAIL_MARK_AS_READ,
-    });
+    };
+
+    log.info(`${METHOD_START_MESSAGE} with: messageId=${messageId}`, loggerContext);
 
     const response = await this.backendConnector.voicemailMarkAsRead(messageId);
 
@@ -266,10 +262,7 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
 
     log.log(
       `Successfully marked voicemail as read: messageId=${messageId}, statusCode=${response.statusCode}`,
-      {
-        file: VOICEMAIL_FILE,
-        method: METHODS.VOICEMAIL_MARK_AS_READ,
-      }
+      loggerContext
     );
 
     return response;
@@ -281,10 +274,12 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
    * @param messageId -string result from the voicemail list.
    */
   public async voicemailMarkAsUnread(messageId: string): Promise<VoicemailResponseEvent> {
-    log.info(`${METHOD_START_MESSAGE} with: messageId=${messageId}`, {
+    const loggerContext = {
       file: VOICEMAIL_FILE,
       method: METHODS.VOICEMAIL_MARK_AS_UNREAD,
-    });
+    };
+
+    log.info(`${METHOD_START_MESSAGE} with: messageId=${messageId}`, loggerContext);
 
     const response = await this.backendConnector.voicemailMarkAsUnread(messageId);
 
@@ -292,10 +287,7 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
 
     log.log(
       `Successfully marked voicemail as unread: messageId=${messageId}, statusCode=${response.statusCode}`,
-      {
-        file: VOICEMAIL_FILE,
-        method: METHODS.VOICEMAIL_MARK_AS_UNREAD,
-      }
+      loggerContext
     );
 
     return response;
@@ -307,10 +299,12 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
    * @param messageId -string result from the voicemail list.
    */
   public async deleteVoicemail(messageId: string): Promise<VoicemailResponseEvent> {
-    log.info(`${METHOD_START_MESSAGE} with: messageId=${messageId}`, {
+    const loggerContext = {
       file: VOICEMAIL_FILE,
       method: METHODS.DELETE_VOICEMAIL,
-    });
+    };
+
+    log.info(`${METHOD_START_MESSAGE} with: messageId=${messageId}`, loggerContext);
 
     const response = await this.backendConnector.deleteVoicemail(messageId);
 
@@ -318,10 +312,7 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
 
     log.log(
       `Successfully deleted voicemail: messageId=${messageId}, statusCode=${response.statusCode}`,
-      {
-        file: VOICEMAIL_FILE,
-        method: METHODS.DELETE_VOICEMAIL,
-      }
+      loggerContext
     );
 
     return response;
@@ -333,10 +324,12 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
    * @param messageId - MessageId for which we need the transcript.
    */
   public async getVMTranscript(messageId: string): Promise<VoicemailResponseEvent | null> {
-    log.info(`${METHOD_START_MESSAGE} with: messageId=${messageId}`, {
+    const loggerContext = {
       file: VOICEMAIL_FILE,
       method: METHODS.GET_VM_TRANSCRIPT,
-    });
+    };
+
+    log.info(`${METHOD_START_MESSAGE} with: messageId=${messageId}`, loggerContext);
 
     const response = await this.backendConnector.getVMTranscript(messageId);
 
@@ -345,10 +338,7 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
 
       log.log(
         `Successfully retrieved voicemail transcript: messageId=${messageId}, statusCode=${response.statusCode}`,
-        {
-          file: VOICEMAIL_FILE,
-          method: METHODS.GET_VM_TRANSCRIPT,
-        }
+        loggerContext
       );
     }
 
@@ -361,17 +351,16 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
    * @param callingPartyInfo - Calling Party Info.
    */
   public resolveContact(callingPartyInfo: CallingPartyInfo): Promise<DisplayInformation | null> {
-    log.info(METHOD_START_MESSAGE, {
+    const loggerContext = {
       file: VOICEMAIL_FILE,
       method: METHODS.RESOLVE_CONTACT,
-    });
+    };
+
+    log.info(METHOD_START_MESSAGE, loggerContext);
 
     const response = this.backendConnector.resolveContact(callingPartyInfo);
 
-    log.log('Contact resolution completed successfully', {
-      file: VOICEMAIL_FILE,
-      method: METHODS.RESOLVE_CONTACT,
-    });
+    log.log('Contact resolution completed successfully', loggerContext);
 
     return response;
   }

--- a/packages/calling/src/Voicemail/Voicemail.ts
+++ b/packages/calling/src/Voicemail/Voicemail.ts
@@ -1,7 +1,6 @@
 /* eslint-disable dot-notation */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable valid-jsdoc */
-import ExtendedError from 'Errors/catalog/ExtendedError';
 import {METHOD_START_MESSAGE} from '../common/constants';
 import SDKConnector from '../SDKConnector';
 import {ISDKConnector, WebexSDK} from '../SDKConnector/types';
@@ -75,8 +74,8 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
 
       return response;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to initialize voicemail: ${err}`) as ExtendedError;
-      log.error(extendedError, {
+      const error = new Error(`Failed to initialize voicemail: ${err}`);
+      log.error(error, {
         file: VOICEMAIL_FILE,
         method: METHODS.INIT,
       });
@@ -187,8 +186,8 @@ export class Voicemail extends Eventing<VoicemailEventTypes> implements IVoicema
 
       return response;
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to get voicemail list: ${err}`) as ExtendedError;
-      log.error(extendedError, {
+      const error = new Error(`Failed to get voicemail list: ${err}`);
+      log.error(error, {
         file: VOICEMAIL_FILE,
         method: METHODS.GET_VOICEMAIL_LIST,
       });

--- a/packages/calling/src/Voicemail/WxCallBackendConnector.test.ts
+++ b/packages/calling/src/Voicemail/WxCallBackendConnector.test.ts
@@ -108,11 +108,11 @@ describe('Voicemail webex call Backend Connector Test case', () => {
         })
       );
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.any(Error),
-        expect.objectContaining({
+        `Failed to get voicemail list: ${JSON.stringify(failurePayload)}`,
+        {
           file: 'WxCallBackendConnector',
           method: 'getVoicemailList',
-        })
+        }
       );
     });
 
@@ -150,9 +150,7 @@ describe('Voicemail webex call Backend Connector Test case', () => {
       );
       expect(errorSpy).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({
-          message: expect.stringContaining('Failed to mark voicemail as read'),
-        }),
+        `Failed to mark voicemail as read: ${JSON.stringify(failurePayload)}`,
         {
           file: 'WxCallBackendConnector',
           method: 'voicemailMarkAsRead',
@@ -194,9 +192,7 @@ describe('Voicemail webex call Backend Connector Test case', () => {
       );
       expect(errorSpy).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({
-          message: expect.stringContaining('Failed to mark voicemail as unread'),
-        }),
+        `Failed to mark voicemail as unread: ${JSON.stringify(failurePayload)}`,
         {
           file: 'WxCallBackendConnector',
           method: 'voicemailMarkAsUnread',
@@ -238,9 +234,7 @@ describe('Voicemail webex call Backend Connector Test case', () => {
         }
       );
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('Failed to delete voicemail'),
-        }),
+        `Failed to delete voicemail: ${JSON.stringify(failurePayload)}`,
         {
           file: 'WxCallBackendConnector',
           method: 'deleteVoicemail',
@@ -447,12 +441,13 @@ describe('Voicemail webex call Backend Connector Test case', () => {
         file: 'WxCallBackendConnector',
         method: 'getVoicemailSummary',
       });
+
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.any(Error),
-        expect.objectContaining({
+        `Failed to get voicemail summary: ${JSON.stringify(failurePayload)}`,
+        {
           file: 'WxCallBackendConnector',
           method: 'getVoicemailSummary',
-        })
+        }
       );
     });
 

--- a/packages/calling/src/Voicemail/WxCallBackendConnector.test.ts
+++ b/packages/calling/src/Voicemail/WxCallBackendConnector.test.ts
@@ -570,6 +570,14 @@ describe('Voicemail webex call Backend Connector Test case', () => {
         headers: {},
       });
       expect(response).toStrictEqual(responseDetails);
+      expect(infoSpy).toHaveBeenCalledWith(METHOD_START_MESSAGE, {
+        file: 'WxCallBackendConnector',
+        method: 'getVoicemailSummary',
+      });
+      expect(logSpy).toHaveBeenCalledWith('Successfully fetched voicemail summary', {
+        file: 'WxCallBackendConnector',
+        method: 'getVoicemailSummary',
+      });
     });
 
     it('verify that PENDING transcription status is passed while transcribing is in progress in the backend', async () => {
@@ -879,6 +887,17 @@ describe('Voicemail webex call Backend Connector Test case', () => {
       const response = await wxCallBackendConnector.voicemailMarkAsRead(messageId.$);
 
       expect(response).toStrictEqual(EMPTY_SUCCESS_RESPONSE);
+      expect(infoSpy).toHaveBeenCalledWith(
+        `${METHOD_START_MESSAGE} with messageId: ${messageId.$}`,
+        {
+          file: 'WxCallBackendConnector',
+          method: 'voicemailMarkAsRead',
+        }
+      );
+      expect(logSpy).toHaveBeenCalledWith('Successfully marked voicemail as read', {
+        file: 'WxCallBackendConnector',
+        method: 'voicemailMarkAsRead',
+      });
     });
 
     it('verify successful voicemailMarkAsUnread', async () => {
@@ -889,6 +908,17 @@ describe('Voicemail webex call Backend Connector Test case', () => {
       const response = await wxCallBackendConnector.voicemailMarkAsUnread(messageId.$);
 
       expect(response).toStrictEqual(EMPTY_SUCCESS_RESPONSE);
+      expect(infoSpy).toHaveBeenCalledWith(
+        `${METHOD_START_MESSAGE} with messageId: ${messageId.$}`,
+        {
+          file: 'WxCallBackendConnector',
+          method: 'voicemailMarkAsUnread',
+        }
+      );
+      expect(logSpy).toHaveBeenCalledWith('Successfully marked voicemail as unread', {
+        file: 'WxCallBackendConnector',
+        method: 'voicemailMarkAsUnread',
+      });
     });
 
     it('verify successful deleteVoicemail', async () => {
@@ -898,6 +928,17 @@ describe('Voicemail webex call Backend Connector Test case', () => {
       const response = await wxCallBackendConnector.deleteVoicemail(messageId.$);
 
       expect(response).toStrictEqual(EMPTY_SUCCESS_RESPONSE);
+      expect(infoSpy).toHaveBeenCalledWith(
+        `${METHOD_START_MESSAGE} with messageId: ${messageId.$}`,
+        {
+          file: 'WxCallBackendConnector',
+          method: 'deleteVoicemail',
+        }
+      );
+      expect(logSpy).toHaveBeenCalledWith('Successfully deleted voicemail', {
+        file: 'WxCallBackendConnector',
+        method: 'deleteVoicemail',
+      });
     });
 
     it('verify resolveContact', async () => {

--- a/packages/calling/src/Voicemail/WxCallBackendConnector.ts
+++ b/packages/calling/src/Voicemail/WxCallBackendConnector.ts
@@ -210,11 +210,9 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
         storeVoicemailList(this.context, messageinfo);
       } catch (err: unknown) {
-        const errorInfo = err as WebexRequestPayload;
-        const error = new Error(`Failed to get voicemail list: ${err}`);
-        log.error(error, loggerContext);
+        log.error(`Failed to get voicemail list: ${JSON.stringify(err)}`, loggerContext);
         await uploadLogs();
-        const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+        const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
 
         return errorStatus;
       }
@@ -287,11 +285,9 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Failed to get voicemail content: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get voicemail content: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
 
       return errorStatus;
     }
@@ -346,11 +342,9 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Failed to get voicemail summary: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get voicemail summary: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
 
       return errorStatus;
     }
@@ -389,11 +383,9 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Failed to mark voicemail as read: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to mark voicemail as read: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
 
       return errorStatus;
     }
@@ -432,11 +424,9 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Failed to mark voicemail as unread: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to mark voicemail as unread: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
 
       return errorStatus;
     }
@@ -476,11 +466,9 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Failed to delete voicemail: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to delete voicemail: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
 
       return errorStatus;
     }
@@ -527,11 +515,9 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
       return responseDetails;
     } catch (err: unknown) {
-      const errorInfo = err as WebexRequestPayload;
-      const error = new Error(`Failed to get voicemail transcript: ${err}`);
-      log.error(error, loggerContext);
+      log.error(`Failed to get voicemail transcript: ${JSON.stringify(err)}`, loggerContext);
       await uploadLogs();
-      const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
+      const errorStatus = serviceErrorCodeHandler(err as WebexRequestPayload, loggerContext);
 
       return errorStatus;
     }

--- a/packages/calling/src/Voicemail/WxCallBackendConnector.ts
+++ b/packages/calling/src/Voicemail/WxCallBackendConnector.ts
@@ -1,6 +1,5 @@
 /* eslint-disable dot-notation */
 /* eslint-disable no-underscore-dangle */
-import ExtendedError from '../Errors/catalog/ExtendedError';
 import SDKConnector from '../SDKConnector';
 import {
   RAW_REQUEST,
@@ -212,8 +211,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
         storeVoicemailList(this.context, messageinfo);
       } catch (err: unknown) {
         const errorInfo = err as WebexRequestPayload;
-        const extendedError = new Error(`Failed to get voicemail list: ${err}`) as ExtendedError;
-        log.error(extendedError, loggerContext);
+        const error = new Error(`Failed to get voicemail list: ${err}`);
+        log.error(error, loggerContext);
         await uploadLogs();
         const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
 
@@ -289,8 +288,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
       return responseDetails;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(`Failed to get voicemail content: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get voicemail content: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
 
@@ -348,8 +347,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
       return responseDetails;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(`Failed to get voicemail summary: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get voicemail summary: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
 
@@ -391,8 +390,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
       return responseDetails;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(`Failed to mark voicemail as read: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to mark voicemail as read: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
 
@@ -434,10 +433,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
       return responseDetails;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(
-        `Failed to mark voicemail as unread: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to mark voicemail as unread: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
 
@@ -480,8 +477,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
       return responseDetails;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(`Failed to delete voicemail: ${err}`) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to delete voicemail: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
 
@@ -531,10 +528,8 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
       return responseDetails;
     } catch (err: unknown) {
       const errorInfo = err as WebexRequestPayload;
-      const extendedError = new Error(
-        `Failed to get voicemail transcript: ${err}`
-      ) as ExtendedError;
-      log.error(extendedError, loggerContext);
+      const error = new Error(`Failed to get voicemail transcript: ${err}`);
+      log.error(error, loggerContext);
       await uploadLogs();
       const errorStatus = serviceErrorCodeHandler(errorInfo, loggerContext);
 

--- a/packages/calling/src/common/Utils.test.ts
+++ b/packages/calling/src/common/Utils.test.ts
@@ -1807,15 +1807,10 @@ describe('uploadLogs', () => {
       expect(true).toBe(false); // This will fail the test if no exception is thrown
     } catch (error) {
       expect(error).toBe(mockError);
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('Failed to upload Logs'),
-        }),
-        {
-          file: UTILS_FILE,
-          method: 'uploadLogs',
-        }
-      );
+      expect(logSpy).toHaveBeenCalledWith(`Failed to upload Logs ${JSON.stringify(error)}`, {
+        file: UTILS_FILE,
+        method: 'uploadLogs',
+      });
       expect(mockSubmitRegistrationMetric).toHaveBeenCalledWith(
         'web-calling-sdk-upload-logs-failed',
         {
@@ -1828,7 +1823,7 @@ describe('uploadLogs', () => {
             tracking_id: undefined,
             feedback_id: 'mocked-uuid-12345',
             call_id: undefined,
-            error: 'Failed to upload Logs Error: Upload failed',
+            error: `Failed to upload Logs ${JSON.stringify(error)}`,
           },
           tags: {action: 'upload_logs', device_id: undefined, service_indicator: 'calling'},
           type: 'behavioral',
@@ -1852,15 +1847,10 @@ describe('uploadLogs', () => {
     const result = await uploadLogs(mockMetaData, false);
     expect(result).toBeUndefined();
 
-    expect(logSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining('Failed to upload Logs'),
-      }),
-      {
-        file: UTILS_FILE,
-        method: 'uploadLogs',
-      }
-    );
+    expect(logSpy).toHaveBeenCalledWith(`Failed to upload Logs ${JSON.stringify(mockError)}`, {
+      file: UTILS_FILE,
+      method: 'uploadLogs',
+    });
     expect(mockSubmitRegistrationMetric).toHaveBeenCalledWith(
       'web-calling-sdk-upload-logs-failed',
       {
@@ -1873,7 +1863,7 @@ describe('uploadLogs', () => {
           tracking_id: undefined,
           feedback_id: 'mocked-uuid-12345',
           call_id: undefined,
-          error: 'Failed to upload Logs Error: Upload failed',
+          error: `Failed to upload Logs ${JSON.stringify(mockError)}`,
         },
         tags: {action: 'upload_logs', device_id: undefined, service_indicator: 'calling'},
         type: 'behavioral',

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -1680,8 +1680,8 @@ export async function uploadLogs(
       feedbackId,
     };
   } catch (error) {
-    const errorLog = new Error(`Failed to upload Logs ${error}`);
-    log.error(errorLog, {
+    const errorLog = new Error(`Failed to upload Logs ${JSON.stringify(error)}`);
+    log.error(errorLog.message, {
       file: UTILS_FILE,
       method: 'uploadLogs',
     });

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -4,7 +4,6 @@
 import * as platform from 'platform';
 import {v4 as uuid} from 'uuid';
 import {METRIC_EVENT, METRIC_TYPE, UPLOAD_LOGS_ACTION} from '../Metrics/types';
-import ExtendedError from '../Errors/catalog/ExtendedError';
 import {getMetricManager} from '../Metrics';
 import {restoreRegistrationCallBack, retry429CallBack} from '../CallingClient/registration/types';
 import {CallingClientErrorEmitterCallback} from '../CallingClient/types';
@@ -1681,7 +1680,7 @@ export async function uploadLogs(
       feedbackId,
     };
   } catch (error) {
-    const errorLog = new Error(`Failed to upload Logs ${error}`) as ExtendedError;
+    const errorLog = new Error(`Failed to upload Logs ${error}`);
     log.error(errorLog, {
       file: UTILS_FILE,
       method: 'uploadLogs',


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [CAI-7234](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7234) >

## This pull request addresses

We were using the `ExtendedError` just for the typecasting to match the param type for `logger.error`. The logger.error was also accepting the 2nd param for context (file and method name) and we are passing that info everywhere so using the ExtendedError type was not required. From the first argument of `logger.error` as error object we were simply using the `error.message` to print the log so, now we are simply passing the error message and printing it directly. Keeping it consistent with all other logger methods and reducing the boilerplate.

Also stringifying the error object so that we **don't** get `[object Object]` in the logs.

## by making the following changes

Error logs are cleanly added now.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
