### PR TITLE
fix(meetings): checking audio level from RTP header before emitting DECODE_RESULTS_IN_ZERO_AUDIO_LEVEL

### DIFF
--- a/packages/@webex/media-helpers/package.json
+++ b/packages/@webex/media-helpers/package.json
@@ -22,9 +22,9 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/internal-media-core": "2.20.0",
+    "@webex/internal-media-core": "2.20.1",
     "@webex/ts-events": "^1.1.0",
-    "@webex/web-media-effects": "2.27.1"
+    "@webex/web-media-effects": "2.32.1"
   },
   "browserify": {
     "transform": [

--- a/packages/@webex/media-helpers/src/webrtc-core.ts
+++ b/packages/@webex/media-helpers/src/webrtc-core.ts
@@ -29,6 +29,8 @@ export {
   RemoteStreamEventNames,
   type VideoContentHint,
   type StreamState,
+  type InboundAudioIssueEvent,
+  InboundAudioIssueSubTypes,
 } from '@webex/internal-media-core';
 
 export type ServerMuteReason =

--- a/packages/@webex/plugin-meetings/package.json
+++ b/packages/@webex/plugin-meetings/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@webex/common": "workspace:*",
     "@webex/event-dictionary-ts": "^1.0.1930",
-    "@webex/internal-media-core": "2.20.0",
+    "@webex/internal-media-core": "2.20.1",
     "@webex/internal-plugin-conversation": "workspace:*",
     "@webex/internal-plugin-device": "workspace:*",
     "@webex/internal-plugin-llm": "workspace:*",
@@ -75,7 +75,7 @@
     "@webex/plugin-people": "workspace:*",
     "@webex/plugin-rooms": "workspace:*",
     "@webex/ts-sdp": "^1.8.1",
-    "@webex/web-capabilities": "^1.6.0",
+    "@webex/web-capabilities": "^1.7.1",
     "@webex/webex-core": "workspace:*",
     "ampersand-collection": "^2.0.2",
     "bowser": "^2.11.0",

--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -347,7 +347,7 @@ export const EVENT_TRIGGERS = {
   MEETING_SELF_LEFT: 'meeting:self:left',
   NETWORK_QUALITY: 'network:quality',
   MEDIA_NEGOTIATED: 'media:negotiated',
-  MEDIA_INBOUND_AUDIO_ISSUE_DETECTED: 'media:inboundAudio:issueDetected',
+  MEDIA_INBOUND_AUDIO_ISSUE_DETECTED: 'media:inboundAudio:issueDetected', // event.data: InboundAudioIssueEvent
   // the following events apply only to multistream media connections
   ACTIVE_SPEAKER_CHANGED: 'media:activeSpeakerChanged',
   REMOTE_VIDEO_SOURCE_COUNT_CHANGED: 'media:remoteVideoSourceCountChanged',

--- a/packages/@webex/plugin-meetings/src/media/index.ts
+++ b/packages/@webex/plugin-meetings/src/media/index.ts
@@ -194,6 +194,12 @@ Media.createMediaConnection = (
       config.stopIceGatheringAfterFirstRelayCandidate = stopIceGatheringAfterFirstRelayCandidate;
     }
 
+    if (BrowserInfo.isEdge() || BrowserInfo.isChrome()) {
+      // we need this for getting inbound audio metadata
+      // but the audioLevel that we use is only available on Chromium based browsers
+      config.enableInboundAudioLevelMonitoring = true;
+    }
+
     return new MultistreamRoapMediaConnection(
       config,
       meetingId,

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -30,6 +30,7 @@ import {
   NetworkQualityMonitor,
   StatsMonitor,
   StatsMonitorEventNames,
+  InboundAudioIssueSubTypes,
 } from '@webex/internal-media-core';
 
 import {

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
@@ -141,12 +141,12 @@ describe('createMediaConnection', () => {
     const roapMediaConnectionConstructorStub = sinon
       .stub(InternalMediaCoreModule, 'RoapMediaConnection')
       .returns(fakeRoapMediaConnection);
-  
+
     StaticConfig.set({bandwidth: {audio: 123, video: 456, startBitrate: 999}});
-  
+
     const ENABLE_EXTMAP = false;
     const ENABLE_RTX = true;
-  
+
     Media.createMediaConnection(false, 'sendonly-debug-id', 'meetingId', {
       mediaProperties: {
         mediaDirection: {
@@ -168,7 +168,7 @@ describe('createMediaConnection', () => {
       turnServerInfo: undefined,
       iceCandidatesTimeout: undefined,
     });
-  
+
     assert.calledWith(
       roapMediaConnectionConstructorStub,
       sinon.match.any,
@@ -194,12 +194,12 @@ describe('createMediaConnection', () => {
     const roapMediaConnectionConstructorStub = sinon
       .stub(InternalMediaCoreModule, 'RoapMediaConnection')
       .returns(fakeRoapMediaConnection);
-  
+
     StaticConfig.set({bandwidth: {audio: 123, video: 456, startBitrate: 999}});
-  
+
     const ENABLE_EXTMAP = true;
     const ENABLE_RTX = false;
-  
+
     Media.createMediaConnection(false, 'recvonly-debug-id', 'meetingId', {
       mediaProperties: {
         mediaDirection: {
@@ -221,7 +221,7 @@ describe('createMediaConnection', () => {
       turnServerInfo: undefined,
       iceCandidatesTimeout: undefined,
     });
-  
+
     assert.calledWith(
       roapMediaConnectionConstructorStub,
       sinon.match.any,
@@ -242,7 +242,6 @@ describe('createMediaConnection', () => {
       'recvonly-debug-id'
     );
   });
-  
 
   it('creates a MultistreamRoapMediaConnection when multistream is enabled', () => {
     const multistreamRoapMediaConnectionConstructorStub = sinon
@@ -510,6 +509,138 @@ describe('createMediaConnection', () => {
       'meeting id'
     );
   });
+
+  const testEnableInboundAudioLevelMonitoring = (
+    testName: string,
+    browserStubs: {isChrome?: boolean; isEdge?: boolean; isFirefox?: boolean},
+    isMultistream: boolean,
+    expectedConfig: object,
+    additionalOptions = {}
+  ) => {
+    it(testName, () => {
+      const connectionConstructorStub = isMultistream
+        ? sinon.stub(InternalMediaCoreModule, 'MultistreamRoapMediaConnection')
+        : sinon.stub(InternalMediaCoreModule, 'RoapMediaConnection');
+
+      connectionConstructorStub.returns(fakeRoapMediaConnection);
+
+      // Set up browser stubs
+      sinon.stub(BrowserInfo, 'isChrome').returns(browserStubs.isChrome || false);
+      sinon.stub(BrowserInfo, 'isEdge').returns(browserStubs.isEdge || false);
+      sinon.stub(BrowserInfo, 'isFirefox').returns(browserStubs.isFirefox || false);
+
+      const baseOptions = {
+        mediaProperties: {
+          mediaDirection: {
+            sendAudio: true,
+            sendVideo: true,
+            sendShare: false,
+            receiveAudio: true,
+            receiveVideo: true,
+            receiveShare: true,
+          },
+          ...(isMultistream
+            ? {}
+            : {
+                audioStream: fakeAudioStream,
+                videoStream: fakeVideoStream,
+                shareVideoTrack: null,
+                shareAudioTrack: null,
+              }),
+        },
+        ...(isMultistream
+          ? {}
+          : {
+              remoteQualityLevel: 'HIGH',
+              enableRtx: true,
+              enableExtmap: true,
+            }),
+        ...additionalOptions,
+      };
+
+      if (!isMultistream) {
+        StaticConfig.set({bandwidth: {audio: 123, video: 456, startBitrate: 999}});
+      }
+
+      Media.createMediaConnection(isMultistream, 'debug string', 'meeting id', baseOptions);
+
+      if (isMultistream) {
+        assert.calledOnceWithExactly(
+          connectionConstructorStub,
+          expectedConfig,
+          'meeting id',
+          sinon.match.func,
+          sinon.match.func,
+          sinon.match.func
+        );
+      } else {
+        assert.calledOnceWithExactly(
+          connectionConstructorStub,
+          expectedConfig,
+          sinon.match.object,
+          'debug string'
+        );
+      }
+    });
+  };
+
+  testEnableInboundAudioLevelMonitoring(
+    'enables enableInboundAudioLevelMonitoring for multistream when browser is Chrome',
+    {isChrome: true, isEdge: false},
+    true,
+    {
+      iceServers: [],
+      disableAudioTwcc: true,
+      enableInboundAudioLevelMonitoring: true,
+    }
+  );
+
+  testEnableInboundAudioLevelMonitoring(
+    'enables enableInboundAudioLevelMonitoring for multistream when browser is Edge',
+    {isChrome: false, isEdge: true},
+    true,
+    {
+      iceServers: [],
+      disableAudioTwcc: true,
+      enableInboundAudioLevelMonitoring: true,
+    }
+  );
+
+  testEnableInboundAudioLevelMonitoring(
+    'does not enable enableInboundAudioLevelMonitoring for multistream when browser is Firefox',
+    {isChrome: false, isEdge: false, isFirefox: true},
+    true,
+    {
+      iceServers: [],
+      disableAudioTwcc: true,
+      doFullIce: true,
+      stopIceGatheringAfterFirstRelayCandidate: undefined,
+    }
+  );
+
+  testEnableInboundAudioLevelMonitoring(
+    'does not enable enableInboundAudioLevelMonitoring for non-multistream connections even when browser is Chrome',
+    {isChrome: true, isEdge: false},
+    false,
+    {
+      iceServers: [],
+      iceCandidatesTimeout: undefined,
+      skipInactiveTransceivers: false,
+      requireH264: true,
+      sdpMunging: {
+        convertPort9to0: false,
+        addContentSlides: true,
+        bandwidthLimits: {
+          audio: 123,
+          video: 456,
+        },
+        startBitrate: 999,
+        periodicKeyframes: 20,
+        disableExtmap: false,
+        disableRtx: false,
+      },
+    }
+  );
 
   [
     {testCase: 'turnServerInfo is undefined', turnServerInfo: undefined},

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/index.ts
@@ -586,7 +586,7 @@ describe('createMediaConnection', () => {
 
   testEnableInboundAudioLevelMonitoring(
     'enables enableInboundAudioLevelMonitoring for multistream when browser is Chrome',
-    {isChrome: true, isEdge: false},
+    {isChrome: true},
     true,
     {
       iceServers: [],
@@ -597,7 +597,7 @@ describe('createMediaConnection', () => {
 
   testEnableInboundAudioLevelMonitoring(
     'enables enableInboundAudioLevelMonitoring for multistream when browser is Edge',
-    {isChrome: false, isEdge: true},
+    {isEdge: true},
     true,
     {
       iceServers: [],
@@ -608,7 +608,7 @@ describe('createMediaConnection', () => {
 
   testEnableInboundAudioLevelMonitoring(
     'does not enable enableInboundAudioLevelMonitoring for multistream when browser is Firefox',
-    {isChrome: false, isEdge: false, isFirefox: true},
+    {isFirefox: true},
     true,
     {
       iceServers: [],
@@ -620,7 +620,7 @@ describe('createMediaConnection', () => {
 
   testEnableInboundAudioLevelMonitoring(
     'does not enable enableInboundAudioLevelMonitoring for non-multistream connections even when browser is Chrome',
-    {isChrome: true, isEdge: false},
+    {isChrome: true},
     false,
     {
       iceServers: [],

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -690,11 +690,9 @@ describe('plugin-meetings', () => {
           assert.deepEqual(result.options, {
             mode: 'BLUR',
             blurStrength: 'STRONG',
-            generator: 'worker',
             quality: 'LOW',
             authToken: 'fake_token',
             mirror: false,
-            canvasResolutionScaling: 1,
           });
           assert.exists(result.enable);
           assert.exists(result.disable);

--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@types/platform": "1.3.4",
-    "@webex/internal-media-core": "2.20.0",
+    "@webex/internal-media-core": "2.20.1",
     "@webex/internal-plugin-metrics": "workspace:*",
     "@webex/media-helpers": "workspace:*",
     "async-mutex": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,15 +3109,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.25.6":
-  version: 7.25.6
-  resolution: "@babel/runtime@npm:7.25.6"
-  dependencies:
-    regenerator-runtime: ^0.14.0
-  checksum: ee1a69d3ac7802803f5ee6a96e652b78b8addc28c6a38c725a4ad7d61a059d9e6cb9f6550ed2f63cce67a1bd82e0b1ef66a1079d895be6bfb536a5cfbd9ccc32
-  languageName: node
-  linkType: hard
-
 "@babel/runtime@npm:^7.8.4":
   version: 7.20.7
   resolution: "@babel/runtime@npm:7.20.7"
@@ -8894,7 +8885,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.38.1
     "@typescript-eslint/parser": 5.38.1
     "@web/dev-server": 0.4.5
-    "@webex/internal-media-core": 2.20.0
+    "@webex/internal-media-core": 2.20.1
     "@webex/internal-plugin-metrics": "workspace:*"
     "@webex/media-helpers": "workspace:*"
     async-mutex: 0.4.0
@@ -9223,23 +9214,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/internal-media-core@npm:2.20.0":
-  version: 2.20.0
-  resolution: "@webex/internal-media-core@npm:2.20.0"
+"@webex/internal-media-core@npm:2.20.1":
+  version: 2.20.1
+  resolution: "@webex/internal-media-core@npm:2.20.1"
   dependencies:
     "@babel/runtime": ^7.18.9
     "@babel/runtime-corejs2": ^7.25.0
     "@webex/rtcstats": ^1.5.5
     "@webex/ts-sdp": 1.8.2
-    "@webex/web-capabilities": ^1.6.1
-    "@webex/web-client-media-engine": 3.34.0
+    "@webex/web-capabilities": ^1.7.1
+    "@webex/web-client-media-engine": 3.35.0
     events: ^3.3.0
     ip-anonymize: ^0.1.0
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
     webrtc-adapter: ^8.1.2
     xstate: ^4.30.6
-  checksum: 1b1a5a5d78048a4c234549776cedf17752ad1376c9cdd85a8bf274be1b0c54a8df5ee869e1ae52f3bf40a3407d9c0016ddeec6f658c554859a39e2f5661d2d5b
+  checksum: 780f238cefe248f807988d827220ea0c351bf4567ebd7ec9f5023b175bfbbea2f697c68799b9c8def81f4d1c204d788bcb5c8a10c61e3fe366be2c86f6148aa8
   languageName: node
   linkType: hard
 
@@ -9936,19 +9927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/ladon-ts@npm:^5.5.1":
-  version: 5.5.1
-  resolution: "@webex/ladon-ts@npm:5.5.1"
-  dependencies:
-    "@rollup/rollup-linux-x64-gnu": 4.36.0
-  dependenciesMeta:
-    "@rollup/rollup-linux-x64-gnu":
-      optional: true
-  checksum: 2dbe15cce061f66dc6fa79f8d64156f379f3f6b6503d2690ea4d046db8933475abb21319b55c3f6ee2c3299ece4a292355cf8ecbdc0bfc37d2a832a458508a93
-  languageName: node
-  linkType: hard
-
-"@webex/ladon-ts@npm:^5.7.1":
+"@webex/ladon-ts@npm:^5.10.0":
   version: 5.10.0
   resolution: "@webex/ladon-ts@npm:5.10.0"
   dependencies:
@@ -10038,13 +10017,13 @@ __metadata:
     "@babel/preset-typescript": 7.22.11
     "@webex/babel-config-legacy": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
-    "@webex/internal-media-core": 2.20.0
+    "@webex/internal-media-core": 2.20.1
     "@webex/jest-config-legacy": "workspace:*"
     "@webex/legacy-tools": "workspace:*"
     "@webex/test-helper-chai": "workspace:*"
     "@webex/test-helper-mock-webex": "workspace:*"
     "@webex/ts-events": ^1.1.0
-    "@webex/web-media-effects": 2.27.1
+    "@webex/web-media-effects": 2.32.1
     eslint: ^8.24.0
     jsdom-global: 3.0.2
     prettier: ^2.7.1
@@ -10306,7 +10285,7 @@ __metadata:
     "@webex/common": "workspace:*"
     "@webex/eslint-config-legacy": "workspace:*"
     "@webex/event-dictionary-ts": ^1.0.1930
-    "@webex/internal-media-core": 2.20.0
+    "@webex/internal-media-core": 2.20.1
     "@webex/internal-plugin-conversation": "workspace:*"
     "@webex/internal-plugin-device": "workspace:*"
     "@webex/internal-plugin-llm": "workspace:*"
@@ -10326,7 +10305,7 @@ __metadata:
     "@webex/test-helper-retry": "workspace:*"
     "@webex/test-helper-test-users": "workspace:*"
     "@webex/ts-sdp": ^1.8.1
-    "@webex/web-capabilities": ^1.6.0
+    "@webex/web-capabilities": ^1.7.1
     "@webex/webex-core": "workspace:*"
     ampersand-collection: ^2.0.2
     bowser: ^2.11.0
@@ -11032,15 +11011,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/web-capabilities@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@webex/web-capabilities@npm:1.6.0"
-  dependencies:
-    bowser: ^2.11.0
-  checksum: 18473b9f63cd12b13534f69aadee26d737401025a6e8de1485eee778c6f6a87fd7d1fab60d66f8ae3c15bcd7b3db0ffe614994bdaef5dc199261175448980330
-  languageName: node
-  linkType: hard
-
 "@webex/web-capabilities@npm:^1.6.1":
   version: 1.6.1
   resolution: "@webex/web-capabilities@npm:1.6.1"
@@ -11050,52 +11020,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:3.34.0":
-  version: 3.34.0
-  resolution: "@webex/web-client-media-engine@npm:3.34.0"
+"@webex/web-capabilities@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "@webex/web-capabilities@npm:1.7.1"
+  dependencies:
+    bowser: ^2.11.0
+  checksum: d61efb296bc30478b7fb0242ce0b17963f2f6b53d7d6dad6e7f48f8074097e0306d817a82f2f13e4c15242300b58b667e3063863834030e98a1e67d182df4c64
+  languageName: node
+  linkType: hard
+
+"@webex/web-client-media-engine@npm:3.35.0":
+  version: 3.35.0
+  resolution: "@webex/web-client-media-engine@npm:3.35.0"
   dependencies:
     "@webex/json-multistream": ^2.3.1
     "@webex/rtcstats": ^1.5.5
     "@webex/ts-events": ^1.2.1
     "@webex/ts-sdp": 1.8.2
-    "@webex/web-capabilities": ^1.6.1
-    "@webex/web-media-effects": 2.28.2
-    "@webex/webrtc-core": 2.13.3
+    "@webex/web-capabilities": ^1.7.1
+    "@webex/web-media-effects": 2.32.1
+    "@webex/webrtc-core": 2.13.4
     async: ^3.2.4
     js-logger: ^1.6.1
     typed-emitter: ^2.1.0
     uuid: ^8.3.2
-  checksum: aae84de432aa875d242712fabb169664636cd403c8a83fc69ee854acc6282e7afbc88b0cbca0dfb49eb4af1c0c9ab0a4b7b2a3bfc24d340c5bb4ac4cc62b4027
+  checksum: b81394b8bae2d1ea6212ca8ee5ced790558ff1504ba98c17752b2b1b09a415ae9266498f8d6d063bf08e05366903f9f6ca3c5de4a388ab05d544fa83fc7c6a72
   languageName: node
   linkType: hard
 
-"@webex/web-media-effects@npm:2.27.1":
-  version: 2.27.1
-  resolution: "@webex/web-media-effects@npm:2.27.1"
+"@webex/web-media-effects@npm:2.32.1":
+  version: 2.32.1
+  resolution: "@webex/web-media-effects@npm:2.32.1"
   dependencies:
-    "@webex/ladon-ts": ^5.5.1
-    events: ^3.3.0
-    js-logger: ^1.6.1
-    typed-emitter: ^1.4.0
-    uuid: ^9.0.1
-    worker-timers: ^8.0.2
-    yarn: ^1.22.22
-  checksum: e8bfb73860bfc25fa730d13b713a5cf3851d861cf6616343f4ce84d68cb085f2d2251e6788735f4671499324bee6e35b9d708fe1fdb0770695c116e2b55227e6
-  languageName: node
-  linkType: hard
-
-"@webex/web-media-effects@npm:2.28.2":
-  version: 2.28.2
-  resolution: "@webex/web-media-effects@npm:2.28.2"
-  dependencies:
-    "@webex/ladon-ts": ^5.7.1
+    "@webex/ladon-ts": ^5.10.0
     events: ^3.3.0
     js-logger: ^1.6.1
     typed-emitter: ^1.4.0
     uuid: ^9.0.1
     worker-timers: ^8.0.21
     yarn: ^1.22.22
-  checksum: bc16791b2c3eb0937d8d4f25c0e22673f45bb2e6580a829f43d04ad34095e71b7983e3fb5a5c5e4454f04256cc46e3fcd4816aab6bfb493e5a39ee303ebd89f5
+  checksum: d7ccbea8080c7a085a2808b8826b9573daaf060fcbecdd83ba2f0e347a395169f4f5cdcd21bb87571d460a60a7ee3655cf977126cda44d8c461658e7019289e0
   languageName: node
   linkType: hard
 
@@ -11189,18 +11153,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webex/webrtc-core@npm:2.13.3":
-  version: 2.13.3
-  resolution: "@webex/webrtc-core@npm:2.13.3"
+"@webex/webrtc-core@npm:2.13.4":
+  version: 2.13.4
+  resolution: "@webex/webrtc-core@npm:2.13.4"
   dependencies:
     "@webex/ts-events": ^1.2.1
     "@webex/web-capabilities": ^1.6.1
-    "@webex/web-media-effects": 2.28.2
+    "@webex/web-media-effects": 2.32.1
     events: ^3.3.0
     js-logger: ^1.6.1
     typed-emitter: ^2.1.0
     webrtc-adapter: ^8.1.2
-  checksum: 9b78656d0f14e961343b98f2338fae12dc2da39c8bbb973c648deeb012f7c0d9c49a58fbf24183d8ba71ea9ef36e2a858ecb9d217aed140dd70cdc03c07bf902
+  checksum: ee5e7b1896b1c976756975e834913d6b169c8ac634cb42982de560fd215e1a111dc06ce08bed3f19cdc4a4c315d2476266da322095469c3fd91d49957ad6a50d
   languageName: node
   linkType: hard
 
@@ -19110,16 +19074,6 @@ __metadata:
     "@babel/runtime": ^7.28.4
     tslib: ^2.8.1
   checksum: 0f5718ed8e4d60371e45ddb8746065d9c5beea2211a104bdee818f99f4f0e0881df790113d995f950c101be63d40c7632f7e789e4cf646a3b7c31401bbfce848
-  languageName: node
-  linkType: hard
-
-"fast-unique-numbers@npm:^9.0.9":
-  version: 9.0.9
-  resolution: "fast-unique-numbers@npm:9.0.9"
-  dependencies:
-    "@babel/runtime": ^7.25.6
-    tslib: ^2.7.0
-  checksum: 58481531260a91d57859a631378609368a5c3828a36da2e833f1b82f205eec7fe698df76151af84a4bbb1bf911ed9659b79e646d418462d7981e0e24e48f6394
   languageName: node
   linkType: hard
 
@@ -33796,13 +33750,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "tslib@npm:2.7.0"
-  checksum: 1606d5c89f88d466889def78653f3aab0f88692e80bb2066d090ca6112ae250ec1cfa9dbfaab0d17b60da15a4186e8ec4d893801c67896b277c17374e36e1d28
-  languageName: node
-  linkType: hard
-
 "tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
@@ -36099,18 +36046,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"worker-timers-broker@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "worker-timers-broker@npm:7.1.2"
-  dependencies:
-    "@babel/runtime": ^7.25.6
-    fast-unique-numbers: ^9.0.9
-    tslib: ^2.7.0
-    worker-timers-worker: ^8.0.4
-  checksum: ec2deb097662ef2331cdf4681023fe970504cd30b58cbf13ceab0741d05fd21a49e518c73f03b20a01e2684d9b8d6d59787aed82d05e615be99c8dc0229623c4
-  languageName: node
-  linkType: hard
-
 "worker-timers-broker@npm:^8.0.11":
   version: 8.0.11
   resolution: "worker-timers-broker@npm:8.0.11"
@@ -36124,16 +36059,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"worker-timers-worker@npm:^8.0.4":
-  version: 8.0.4
-  resolution: "worker-timers-worker@npm:8.0.4"
-  dependencies:
-    "@babel/runtime": ^7.25.6
-    tslib: ^2.7.0
-  checksum: fd59d4c947895efd036e46cd8d4c288b228256f7bac24ff5b83c682ef44e53584ce8bc4f0525eee469be00dbf1f89e9266682d0297df7478704996087a7553b2
-  languageName: node
-  linkType: hard
-
 "worker-timers-worker@npm:^9.0.11":
   version: 9.0.11
   resolution: "worker-timers-worker@npm:9.0.11"
@@ -36142,18 +36067,6 @@ __metadata:
     tslib: ^2.8.1
     worker-factory: ^7.0.46
   checksum: e49b9f3ee023cb83e1ae05862154bdab8a56809b4a43a67840467df26f1dbaf943a0589c3680f528bb211b0dfdece938ae1a4c8d7880346efc19a9b2b8c91637
-  languageName: node
-  linkType: hard
-
-"worker-timers@npm:^8.0.2":
-  version: 8.0.5
-  resolution: "worker-timers@npm:8.0.5"
-  dependencies:
-    "@babel/runtime": ^7.25.6
-    tslib: ^2.7.0
-    worker-timers-broker: ^7.1.2
-    worker-timers-worker: ^8.0.4
-  checksum: e8c00e33e5af252a37472c0fc1bc3c3b26cdd174e179ab1b301364b880db7e560f6f3eb82a4438970fe113c1e9a4855569df0ef61edc6d5de613a51789587ef4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES #[SPARK-728621](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-728621)

## This pull request addresses
We incorrectly detect issues with remote audio level being zero when remote participants are unmuted but silent.

## by making the following changes
Updating to latest internal-media-core (which includes new WCME) that only emits the INBOUND_AUDIO_ISSUE event with sub type DECODE_RESULTS_IN_ZERO_AUDIO_LEVEL when decoded audio level is zero while audio level in rtp header extension is not zero - this should minimize the false positives for these audio issue events we're seeing from our metrics.

This PR depends on:
- internal-media-core: https://sqbu-github.cisco.com/WebExSquared/webrtc-media-core/pull/353
- WCME: https://sqbu-github.cisco.com/CPaaS/web-client-media-engine/pull/492
- web-capabilities: https://github.com/webex/web-capabilities/pull/13


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual testing with WCME and web app

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
