### PR TITLE
fix(calling): moves fetching of mobius clusters to service layer

### DIFF
--- a/packages/@webex/webex-core/src/lib/services-v2/index.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/index.ts
@@ -1,7 +1,6 @@
 /*!
  * Copyright (c) 2015-2020 Cisco Systems, Inc. See LICENSE file.
  */
-
 export {default as ServicesV2} from './services-v2';
 export {default as ServiceCatalogV2} from './service-catalog';
 export {default as ServiceDetail} from './service-detail';

--- a/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
@@ -14,6 +14,7 @@ import {
   Service,
   ServiceHostmap,
   ServiceGroup,
+  ServiceHost,
 } from './types';
 
 const trailingSlashes = /(?:^\/)|(?:\/$)/;
@@ -104,40 +105,34 @@ const Services = WebexPlugin.extend({
     return catalog.markFailedServiceUrl(url);
   },
 
-  /*
-   *  Get all Mobius cluster host entries from the v2 services list.
+  /**
+   * Get all Mobius cluster host entries from the v2 services list.
+   * @returns {Array<ServiceHost>} - An array of `ServiceHost` objects.
    */
-  getMobiusClusters(): Array<{
-    host: string;
-    ttl: number;
-    priority: number;
-    id: string;
-    homeCluster?: boolean;
-  }> {
-    const clusters: Array<{
-      host: string;
-      ttl: number;
-      priority: number;
-      id: string;
-      homeCluster?: boolean;
-    }> = [];
+  getMobiusClusters(): Array<ServiceHost> {
+    const clusters: Array<ServiceHost> = [];
     const services: Array<Service> = this._services || [];
 
-    services.forEach((service) => {
-      if (service?.serviceName === 'mobius' && Array.isArray(service.serviceUrls)) {
+    services
+      .filter(
+        (service) =>
+          service?.serviceName === 'mobius' &&
+          Array.isArray(service.serviceUrls) &&
+          service.serviceUrls.length > 0
+      )
+      .forEach((service) => {
         service.serviceUrls.forEach((serviceUrl) => {
-          if (!clusters.find((c) => c && c.host === serviceUrl.baseUrl)) {
-            serviceUrl.baseUrl = serviceUrl.baseUrl.replace('https://', '').replace('/api/v1', '');
+          const modifiedHost = serviceUrl.baseUrl.replace('https://', '').replace('/api/v1', '');
+          if (!clusters.find((c) => c && c.host === modifiedHost)) {
             clusters.push({
-              host: serviceUrl.baseUrl,
+              host: modifiedHost,
               priority: serviceUrl.priority,
               id: service.id,
               ttl: 0,
             });
           }
         });
-      }
-    });
+      });
 
     return clusters;
   },

--- a/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
@@ -104,6 +104,41 @@ const Services = WebexPlugin.extend({
     return catalog.markFailedServiceUrl(url);
   },
 
+  /*
+   * Get all Mobius cluster host entries from the v2 services list
+   */
+  getMobiusClusters(): Array<{
+    host: string;
+    ttl: number;
+    priority: number;
+    id: string;
+    homeCluster?: boolean;
+  }> {
+    const clusters: Array<{
+      host: string;
+      ttl: number;
+      priority: number;
+      id: string;
+      homeCluster?: boolean;
+    }> = [];
+    const services: Array<Service> = this._services || [];
+
+    services.forEach((service) => {
+      if (service?.serviceName === 'mobius' && Array.isArray(service.serviceUrls)) {
+        service.serviceUrls.forEach((serviceUrl) => {
+          clusters.push({
+            host: serviceUrl.host,
+            priority: serviceUrl.priority,
+            id: service.id,
+            ttl: 0,
+          });
+        });
+      }
+    });
+
+    return clusters;
+  },
+
   /**
    * saves all the services from the pre and post catalog service
    * @param {ActiveServices} activeServices

--- a/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
@@ -105,7 +105,7 @@ const Services = WebexPlugin.extend({
   },
 
   /*
-   * Get all Mobius cluster host entries from the v2 services list
+   *  Get all Mobius cluster host entries from the v2 services list.
    */
   getMobiusClusters(): Array<{
     host: string;
@@ -126,12 +126,15 @@ const Services = WebexPlugin.extend({
     services.forEach((service) => {
       if (service?.serviceName === 'mobius' && Array.isArray(service.serviceUrls)) {
         service.serviceUrls.forEach((serviceUrl) => {
-          clusters.push({
-            host: serviceUrl.host,
-            priority: serviceUrl.priority,
-            id: service.id,
-            ttl: 0,
-          });
+          if (!clusters.find((c) => c && c.host === serviceUrl.baseUrl)) {
+            serviceUrl.baseUrl = serviceUrl.baseUrl.replace('https://', '').replace('/api/v1', '');
+            clusters.push({
+              host: serviceUrl.baseUrl,
+              priority: serviceUrl.priority,
+              id: service.id,
+              ttl: 0,
+            });
+          }
         });
       }
     });

--- a/packages/@webex/webex-core/src/lib/services-v2/types.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/types.ts
@@ -2,6 +2,14 @@ type ServiceName = string;
 type ClusterId = string;
 export type ServiceGroup = 'discovery' | 'override' | 'preauth' | 'postauth' | 'signin';
 
+export type ServiceHost = {
+  host: string;
+  ttl: number;
+  priority: number;
+  id: string;
+  homeCluster?: boolean;
+};
+
 export type ServiceUrl = {
   baseUrl: string;
   host: string;

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -61,6 +61,9 @@ const Services = WebexPlugin.extend({
 
   _hostCatalog: null,
 
+  // Map of active cluster ids per service, e.g. { wdm: 'urn:TEAM:ap-southeast-2_m:wdm' }
+  _activeServices: {},
+
   /**
    * Get the registry associated with this webex instance.
    *
@@ -103,6 +106,21 @@ const Services = WebexPlugin.extend({
    */
   get(name, priorityHost, serviceGroup) {
     const catalog = this._getCatalog();
+
+    // Prefer active cluster selection when available (e.g., in-region WDM)
+    const clusterId = this._activeServices && this._activeServices[name];
+
+    if (clusterId) {
+      const service = catalog.findServiceFromClusterId({
+        clusterId,
+        priorityHost,
+        serviceGroup,
+      });
+
+      if (service && service.url) {
+        return service.url;
+      }
+    }
 
     return catalog.get(name, priorityHost, serviceGroup);
   },
@@ -158,6 +176,39 @@ const Services = WebexPlugin.extend({
     const catalog = this._getCatalog();
 
     return catalog.markFailedUrl(url, noPriorityHosts);
+  },
+
+  /**
+   * Get all Mobius cluster host entries from the legacy host catalog.
+   * @returns {Array<Object>}
+   */
+  getMobiusClusters() {
+    const clusters = [];
+    const hostCatalog = this._hostCatalog || {};
+
+    Object.entries(hostCatalog).forEach(([host, entries]) => {
+      (entries || []).forEach((entry) => {
+        if (typeof entry?.id === 'string' && entry.id.endsWith(':mobius')) {
+          // Ensure host is included; prefer entry.host if present, else use the map key
+          const withHost = entry.host ? entry.host : host;
+          // Skip duplicates for the same host
+          if (!clusters.find((c) => c && c.host === withHost)) {
+            clusters.push({...entry, host: withHost});
+          }
+        }
+      });
+    });
+
+    return clusters;
+  },
+
+  /**
+   * Merge provided active cluster mappings into current state.
+   * @param {Record<string,string>} activeServices
+   * @returns {void}
+   */
+  _updateActiveServices(activeServices) {
+    this._activeServices = {...this._activeServices, ...activeServices};
   },
 
   /**
@@ -498,6 +549,30 @@ const Services = WebexPlugin.extend({
         // On failure, reject with error from **License**.
         .catch((error) => Promise.reject(error))
     );
+  },
+
+  /**
+   * Update cluster id via mercury/service update. Allows selecting in-region URLs (e.g., WDM).
+   * If a provided clusterId cannot be resolved to a service, it will be ignored.
+   * @param {Record<string,string>} newActiveClusters - e.g. { wdm: 'urn:TEAM:ap-southeast-2_m:wdm' }
+   * @returns {Promise<void>}
+   */
+  switchActiveClusterIds(newActiveClusters) {
+    this.logger.info('services: switching active cluster ids');
+
+    if (!newActiveClusters || typeof newActiveClusters !== 'object') {
+      this.logger.warn('services: invalid newActiveClusters provided to switchActiveClusterIds');
+
+      return Promise.resolve();
+    }
+
+    // Do not validate against current catalog readiness; persist desired mapping immediately.
+    // When catalogs are ready, `get()` will resolve URLs via clusterId.
+    this._updateActiveServices(newActiveClusters);
+
+    this.logger.info('services: active cluster ids updated successfully');
+
+    return Promise.resolve();
   },
 
   /**

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -107,20 +107,20 @@ const Services = WebexPlugin.extend({
   get(name, priorityHost, serviceGroup) {
     const catalog = this._getCatalog();
 
-    // Prefer active cluster selection when available (e.g., in-region WDM)
-    const clusterId = this._activeServices && this._activeServices[name];
+    // // Prefer active cluster selection when available (e.g., in-region WDM)
+    // const clusterId = this._activeServices && this._activeServices[name];
 
-    if (clusterId) {
-      const service = catalog.findServiceFromClusterId({
-        clusterId,
-        priorityHost,
-        serviceGroup,
-      });
+    // if (clusterId) {
+    //   const service = catalog.findServiceFromClusterId({
+    //     clusterId,
+    //     priorityHost,
+    //     serviceGroup,
+    //   });
 
-      if (service && service.url) {
-        return service.url;
-      }
-    }
+    //   if (service && service.url) {
+    //     return service.url;
+    //   }
+    // }
 
     return catalog.get(name, priorityHost, serviceGroup);
   },
@@ -551,29 +551,29 @@ const Services = WebexPlugin.extend({
     );
   },
 
-  /**
-   * Update cluster id via mercury/service update. Allows selecting in-region URLs (e.g., WDM).
-   * If a provided clusterId cannot be resolved to a service, it will be ignored.
-   * @param {Record<string,string>} newActiveClusters - e.g. { wdm: 'urn:TEAM:ap-southeast-2_m:wdm' }
-   * @returns {Promise<void>}
-   */
-  switchActiveClusterIds(newActiveClusters) {
-    this.logger.info('services: switching active cluster ids');
+  // /**
+  //  * Update cluster id via mercury/service update. Allows selecting in-region URLs (e.g., WDM).
+  //  * If a provided clusterId cannot be resolved to a service, it will be ignored.
+  //  * @param {Record<string,string>} newActiveClusters - e.g. { wdm: 'urn:TEAM:ap-southeast-2_m:wdm' }
+  //  * @returns {Promise<void>}
+  //  */
+  // switchActiveClusterIds(newActiveClusters) {
+  //   this.logger.info('services: switching active cluster ids');
 
-    if (!newActiveClusters || typeof newActiveClusters !== 'object') {
-      this.logger.warn('services: invalid newActiveClusters provided to switchActiveClusterIds');
+  //   if (!newActiveClusters || typeof newActiveClusters !== 'object') {
+  //     this.logger.warn('services: invalid newActiveClusters provided to switchActiveClusterIds');
 
-      return Promise.resolve();
-    }
+  //     return Promise.resolve();
+  //   }
 
-    // Do not validate against current catalog readiness; persist desired mapping immediately.
-    // When catalogs are ready, `get()` will resolve URLs via clusterId.
-    this._updateActiveServices(newActiveClusters);
+  //   // Do not validate against current catalog readiness; persist desired mapping immediately.
+  //   // When catalogs are ready, `get()` will resolve URLs via clusterId.
+  //   this._updateActiveServices(newActiveClusters);
 
-    this.logger.info('services: active cluster ids updated successfully');
+  //   this.logger.info('services: active cluster ids updated successfully');
 
-    return Promise.resolve();
-  },
+  //   return Promise.resolve();
+  // },
 
   /**
    * Updates a given service group i.e. preauth, signin, postauth with a new hostmap.

--- a/packages/@webex/webex-core/src/lib/services/services.js
+++ b/packages/@webex/webex-core/src/lib/services/services.js
@@ -107,21 +107,6 @@ const Services = WebexPlugin.extend({
   get(name, priorityHost, serviceGroup) {
     const catalog = this._getCatalog();
 
-    // // Prefer active cluster selection when available (e.g., in-region WDM)
-    // const clusterId = this._activeServices && this._activeServices[name];
-
-    // if (clusterId) {
-    //   const service = catalog.findServiceFromClusterId({
-    //     clusterId,
-    //     priorityHost,
-    //     serviceGroup,
-    //   });
-
-    //   if (service && service.url) {
-    //     return service.url;
-    //   }
-    // }
-
     return catalog.get(name, priorityHost, serviceGroup);
   },
 
@@ -550,30 +535,6 @@ const Services = WebexPlugin.extend({
         .catch((error) => Promise.reject(error))
     );
   },
-
-  // /**
-  //  * Update cluster id via mercury/service update. Allows selecting in-region URLs (e.g., WDM).
-  //  * If a provided clusterId cannot be resolved to a service, it will be ignored.
-  //  * @param {Record<string,string>} newActiveClusters - e.g. { wdm: 'urn:TEAM:ap-southeast-2_m:wdm' }
-  //  * @returns {Promise<void>}
-  //  */
-  // switchActiveClusterIds(newActiveClusters) {
-  //   this.logger.info('services: switching active cluster ids');
-
-  //   if (!newActiveClusters || typeof newActiveClusters !== 'object') {
-  //     this.logger.warn('services: invalid newActiveClusters provided to switchActiveClusterIds');
-
-  //     return Promise.resolve();
-  //   }
-
-  //   // Do not validate against current catalog readiness; persist desired mapping immediately.
-  //   // When catalogs are ready, `get()` will resolve URLs via clusterId.
-  //   this._updateActiveServices(newActiveClusters);
-
-  //   this.logger.info('services: active cluster ids updated successfully');
-
-  //   return Promise.resolve();
-  // },
 
   /**
    * Updates a given service group i.e. preauth, signin, postauth with a new hostmap.

--- a/packages/@webex/webex-core/test/unit/spec/services-v2/services-v2.ts
+++ b/packages/@webex/webex-core/test/unit/spec/services-v2/services-v2.ts
@@ -695,5 +695,60 @@ describe('webex-core', () => {
         assert.isUndefined(result);
       });
     });
+
+    describe('#getMobiusClusters', () => {
+      it('returns unique mobius entries derived from serviceUrls baseUrl', () => {
+        // Arrange: seed internal _services with mobius (including duplicate baseUrl)
+        services._services = [
+          {
+            "id": "urn:TEAM:us-east-2_a:mobius",
+            "serviceName": 'mobius',
+            "serviceUrls": [
+              {"baseUrl": 'https://mobius-us-east-2.prod.infra.webex.com/api/v1', "priority": 5},
+              {"baseUrl": 'https://mobius-eu-central-1.prod.infra.webex.com/api/v1', "priority": 10},
+              {"baseUrl": 'https://mobius-ap-southeast-2.prod.infra.webex.com/api/v1', "priority": 15}, // duplicate
+            ],
+          },
+          {
+            "id": "urn:TEAM:ap-southeast-2_m:mobius",
+            "serviceName": "mobius",
+            "serviceUrls": [
+                {
+                    "baseUrl": "https://mobius-me-central-1.prod.infra.webex.com/api/v1",
+                    "priority": 5
+                },
+                {
+                    "baseUrl": "https://mobius-eu-central-1.prod.infra.webex.com/api/v1",
+                    "priority": 10
+                },
+                {
+                    "baseUrl": "https://mobius-ap-southeast-2.prod.infra.webex.com/api/v1",
+                    "priority": 15
+                },
+            ],
+          },
+          // Non-mobius service should be ignored by getMobiusClusters
+          {
+            id: 'urn:TEAM:us-east-2_a:wdm',
+            serviceName: 'wdm',
+            serviceUrls: [{baseUrl: 'https://wdm-a.webex.com/api/v1', priority: 5}],
+          },
+        ];
+
+        // Act
+        const clusters = services.getMobiusClusters();
+
+        // Assert (v2 currently pushes baseUrl into host field and dedups by baseUrl)
+        assert.deepEqual(
+          clusters.map(({host, id, ttl, priority}) => ({host, id, ttl, priority})),
+          [
+            {host: 'mobius-us-east-2.prod.infra.webex.com', id: 'urn:TEAM:us-east-2_a:mobius', ttl: 0, priority: 5},
+            {host: 'mobius-eu-central-1.prod.infra.webex.com', id: 'urn:TEAM:us-east-2_a:mobius', ttl: 0, priority: 10},
+            {host: 'mobius-ap-southeast-2.prod.infra.webex.com', id: 'urn:TEAM:us-east-2_a:mobius', ttl: 0, priority: 15},
+            {host: 'mobius-me-central-1.prod.infra.webex.com', id: 'urn:TEAM:ap-southeast-2_m:mobius', ttl: 0, priority: 5},
+          ]
+        );
+      });
+    });
   });
 });

--- a/packages/@webex/webex-core/test/unit/spec/services/services.js
+++ b/packages/@webex/webex-core/test/unit/spec/services/services.js
@@ -839,6 +839,35 @@ describe('webex-core', () => {
         assert.equal(webex.config.credentials.authorizeUrl, authUrl);
       });
     });
+    
+    describe('#getMobiusClusters', () => {
+      it('returns unique mobius host entries from hostCatalog', () => {
+        // Arrange: two hostCatalog keys, with duplicate mobius host across keys
+        services._hostCatalog = {
+          'mobius-a.webex.com': [
+            {host: 'mobius-a.webex.com', ttl: -1, priority: 5, id: 'urn:TEAM:xyz:mobius'},
+            {host: 'mobius-b.webex.com', ttl: -1, priority: 10, id: 'urn:TEAM:xyz:mobius'},
+            {host: 'ignore.webex.com', ttl: -1, priority: 1, id: 'urn:TEAM:abc:wdm'}, // not mobius
+          ],
+          'dup-entry-key': [
+            {host: 'mobius-a.webex.com', ttl: -1, priority: 7, id: 'urn:TEAM:xyz:mobius'}, // duplicate host
+          ],
+        };
+    
+        // Act
+        const clusters = services.getMobiusClusters();
+    
+        // Assert
+        // deduped; only mobius entries; keeps first seen mobius-a, then mobius-b
+        assert.deepEqual(
+          clusters.map(({host, id, ttl, priority}) => ({host, id, ttl, priority})),
+          [
+            {host: 'mobius-a.webex.com', id: 'urn:TEAM:xyz:mobius', ttl: -1, priority: 5},
+            {host: 'mobius-b.webex.com', id: 'urn:TEAM:xyz:mobius', ttl: -1, priority: 10},
+          ]
+        );
+      });
+    });
   });
 });
 /* eslint-enable no-underscore-dangle */

--- a/packages/calling/src/CallHistory/CallHistory.ts
+++ b/packages/calling/src/CallHistory/CallHistory.ts
@@ -103,7 +103,7 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
     }
     this.webex = this.sdkConnector.getWebex();
     this.janusUrl =
-      this.webex.internal.services._serviceUrls.janus ||
+      this.webex.internal.services._serviceUrls?.janus ||
       this.webex.internal.services.get(this.webex.internal.services._activeServices.janus);
     this.registerSessionsListener();
     log.setLogger(logger.level, CALL_HISTORY_FILE);

--- a/packages/calling/src/CallHistory/CallHistory.ts
+++ b/packages/calling/src/CallHistory/CallHistory.ts
@@ -103,7 +103,9 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
       SDKConnector.setWebex(webex);
     }
     this.webex = this.sdkConnector.getWebex();
-    this.janusUrl = this.webex.internal.services._serviceUrls.janus;
+    this.janusUrl =
+      this.webex.internal.services._serviceUrls.janus ||
+      this.webex.internal.services.get(this.webex.internal.services._activeServices.janus);
     this.registerSessionsListener();
     log.setLogger(logger.level, CALL_HISTORY_FILE);
   }

--- a/packages/calling/src/CallSettings/WxCallBackendConnector.ts
+++ b/packages/calling/src/CallSettings/WxCallBackendConnector.ts
@@ -68,7 +68,7 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
     this.webex = this.sdkConnector.getWebex();
     /* eslint no-underscore-dangle: 0 */
     this.hydraEndpoint =
-      this.webex.internal.services._serviceUrls.hydra ||
+      this.webex.internal.services._serviceUrls?.hydra ||
       this.webex.internal.services.get(this.webex.internal.services._activeServices.hydra);
     log.setLogger(logger.level, WEBEX_CALLING_CONNECTOR_FILE);
 

--- a/packages/calling/src/CallSettings/WxCallBackendConnector.ts
+++ b/packages/calling/src/CallSettings/WxCallBackendConnector.ts
@@ -68,7 +68,9 @@ export class WxCallBackendConnector implements IWxCallBackendConnector {
 
     this.webex = this.sdkConnector.getWebex();
     /* eslint no-underscore-dangle: 0 */
-    this.hydraEndpoint = this.webex.internal.services._serviceUrls.hydra;
+    this.hydraEndpoint =
+      this.webex.internal.services._serviceUrls.hydra ||
+      this.webex.internal.services.get(this.webex.internal.services._activeServices.hydra);
     log.setLogger(logger.level, WEBEX_CALLING_CONNECTOR_FILE);
 
     this.userId = this.webex.internal.device.userId;

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -27,7 +27,6 @@ import {
   RegionInfo,
   ALLOWED_SERVICES,
   HTTP_METHODS,
-  IpInfo,
   MobiusServers,
   WebexRequestPayload,
   RegistrationStatus,
@@ -44,14 +43,9 @@ import {
   CISCO_DEVICE_URL,
   DISCOVERY_URL,
   GET_MOBIUS_SERVERS_UTIL,
-  IP_ENDPOINT,
   SPARK_USER_AGENT,
   URL_ENDPOINT,
   API_V1,
-  MOBIUS_US_PROD,
-  MOBIUS_EU_PROD,
-  MOBIUS_US_INT,
-  MOBIUS_EU_INT,
   METHODS,
   NETWORK_FLAP_TIMEOUT,
 } from './constants';
@@ -158,32 +152,11 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
     this.primaryMobiusUris = [];
     this.backupMobiusUris = [];
-    let mobiusServiceHost = '';
-    try {
-      mobiusServiceHost = new URL(this.webex.internal.services._serviceUrls.mobius).host;
-    } catch (error) {
-      log.warn(`Failed to parse mobius service URL`, {
-        file: CALLING_CLIENT_FILE,
-        method: this.constructor.name,
-      });
-    }
-
-    // TODO: This is a temp fix - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6809
-    if (this.webex.internal.services._hostCatalog) {
-      this.mobiusClusters =
-        (mobiusServiceHost && this.webex.internal.services._hostCatalog[mobiusServiceHost]) ||
-        this.webex.internal.services._hostCatalog[MOBIUS_US_PROD] ||
-        this.webex.internal.services._hostCatalog[MOBIUS_EU_PROD] ||
-        this.webex.internal.services._hostCatalog[MOBIUS_US_INT] ||
-        this.webex.internal.services._hostCatalog[MOBIUS_EU_INT];
-    } else {
-      // @ts-ignore
-      const mobiusObject = this.webex.internal.services._services.find(
-        // @ts-ignore
-        (item) => item.serviceName === 'mobius'
-      );
-      this.mobiusClusters = [mobiusObject.serviceUrls[0].baseUrl];
-    }
+    // Use unified helper to fetch all mobius hosts from catalog (legacy or v2)
+    // Returns an array of ServiceHost-like entries: {host, priority, id, ttl}
+    // @ts-ignore - services may be v1 or v2, both expose getMobiusClusters()
+    this.mobiusClusters = this.webex.internal.services.getMobiusClusters();
+    console.log('pkesari_mobiusClusters', this.mobiusClusters);
     this.mobiusHost = '';
 
     this.registerSessionsListener();
@@ -402,112 +375,85 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     });
     const regionInfo = {} as RegionInfo;
 
-    for (const mobius of this.mobiusClusters) {
-      if (mobius.host) {
-        this.mobiusHost = `https://${mobius.host}${API_V1}`;
-      } else {
-        this.mobiusHost = mobius as unknown as string;
-      }
+    // for (const mobius of this.mobiusClusters) {
+    // if (mobius.host) {
+    //   this.mobiusHost = `https://${mobius.host}${API_V1}`;
+    // } else {
+    //   this.mobiusHost = mobius as unknown as string;
+    // }
 
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const temp = <WebexRequestPayload>await this.webex.request({
-          uri: `${this.mobiusHost}${URL_ENDPOINT}${IP_ENDPOINT}`,
-          method: HTTP_METHODS.GET,
-          headers: {
-            [CISCO_DEVICE_URL]: this.webex.internal.device.url,
-            [SPARK_USER_AGENT]: CALLING_USER_AGENT,
-          },
-          service: ALLOWED_SERVICES.MOBIUS,
-        });
+    try {
+      const response = <WebexRequestPayload>await this.webex.request({
+        uri: `${DISCOVERY_URL}`,
+        method: HTTP_METHODS.GET,
+        addAuthHeader: false,
+        headers: {
+          [SPARK_USER_AGENT]: null,
+        },
+      });
 
-        log.log(`Response trackingId: ${temp?.headers?.trackingid}`, {
+      log.log(`Response trackingId: ${response?.headers?.trackingid}`, {
+        file: CALLING_CLIENT_FILE,
+        method: METHODS.GET_CLIENT_REGION_INFO,
+      });
+
+      const clientRegionInfo = response.body as ClientRegionInfo;
+
+      regionInfo.clientRegion = clientRegionInfo?.clientRegion ? clientRegionInfo.clientRegion : '';
+
+      regionInfo.countryCode = clientRegionInfo?.countryCode ? clientRegionInfo.countryCode : '';
+
+      log.log(
+        `Successfully fetched Client region info: ${regionInfo.clientRegion}, countryCode: ${regionInfo.countryCode}, and response trackingid: ${response?.headers?.trackingid}`,
+        {
           file: CALLING_CLIENT_FILE,
           method: METHODS.GET_CLIENT_REGION_INFO,
-        });
-
-        const myIP = (temp.body as IpInfo).ipv4;
-
-        // eslint-disable-next-line no-await-in-loop
-        const response = <WebexRequestPayload>await this.webex.request({
-          uri: `${DISCOVERY_URL}/${myIP}`,
-          method: HTTP_METHODS.GET,
-          addAuthHeader: false,
-          headers: {
-            [SPARK_USER_AGENT]: null,
-          },
-        });
-
-        log.log(`Response trackingId: ${response?.headers?.trackingid}`, {
-          file: CALLING_CLIENT_FILE,
-          method: METHODS.GET_CLIENT_REGION_INFO,
-        });
-
-        const clientRegionInfo = response.body as ClientRegionInfo;
-
-        regionInfo.clientRegion = clientRegionInfo?.clientRegion
-          ? clientRegionInfo.clientRegion
-          : '';
-
-        regionInfo.countryCode = clientRegionInfo?.countryCode ? clientRegionInfo.countryCode : '';
-
-        log.log(
-          `Successfully fetched Client region info: ${regionInfo.clientRegion}, countryCode: ${regionInfo.countryCode}, and response trackingid: ${response?.headers?.trackingid}`,
-          {
-            file: CALLING_CLIENT_FILE,
-            method: METHODS.GET_CLIENT_REGION_INFO,
-          }
-        );
-
-        // Metrics for region info - trying clusters in loop
-        this.metricManager.submitRegionInfoMetric(
-          METRIC_EVENT.MOBIUS_DISCOVERY,
-          MOBIUS_SERVER_ACTION.REGION_INFO,
-          METRIC_TYPE.BEHAVIORAL,
-          this.mobiusHost,
-          clientRegionInfo.clientRegion,
-          clientRegionInfo.countryCode,
-          response?.headers?.trackingid ?? ''
-        );
-
-        break;
-      } catch (err: unknown) {
-        const extendedError = new Error(
-          `Failed to get client region info: ${err}`
-        ) as ExtendedError;
-        log.error(extendedError, {
-          method: METHODS.GET_CLIENT_REGION_INFO,
-          file: CALLING_CLIENT_FILE,
-        });
-
-        // eslint-disable-next-line no-await-in-loop
-        abort = await handleCallingClientErrors(
-          err as WebexRequestPayload,
-          (clientError) => {
-            this.metricManager.submitRegistrationMetric(
-              METRIC_EVENT.REGISTRATION_ERROR,
-              REG_ACTION.REGISTER,
-              METRIC_TYPE.BEHAVIORAL,
-              GET_MOBIUS_SERVERS_UTIL,
-              'UNKNOWN',
-              (err as WebexRequestPayload).headers?.trackingId ?? '',
-              undefined,
-              clientError
-            );
-            this.emit(CALLING_CLIENT_EVENT_KEYS.ERROR, clientError);
-          },
-          {method: GET_MOBIUS_SERVERS_UTIL, file: CALLING_CLIENT_FILE}
-        );
-
-        regionInfo.clientRegion = '';
-        regionInfo.countryCode = '';
-
-        if (abort) {
-          // eslint-disable-next-line no-await-in-loop
-          await uploadLogs();
-
-          return regionInfo;
         }
+      );
+
+      // Metrics for region info - trying clusters in loop
+      this.metricManager.submitRegionInfoMetric(
+        METRIC_EVENT.MOBIUS_DISCOVERY,
+        MOBIUS_SERVER_ACTION.REGION_INFO,
+        METRIC_TYPE.BEHAVIORAL,
+        this.mobiusHost,
+        clientRegionInfo.clientRegion,
+        clientRegionInfo.countryCode,
+        response?.headers?.trackingid ?? ''
+      );
+    } catch (err: unknown) {
+      const extendedError = new Error(`Failed to get client region info: ${err}`) as ExtendedError;
+      log.error(extendedError, {
+        method: METHODS.GET_CLIENT_REGION_INFO,
+        file: CALLING_CLIENT_FILE,
+      });
+
+      // eslint-disable-next-line no-await-in-loop
+      abort = await handleCallingClientErrors(
+        err as WebexRequestPayload,
+        (clientError) => {
+          this.metricManager.submitRegistrationMetric(
+            METRIC_EVENT.REGISTRATION_ERROR,
+            REG_ACTION.REGISTER,
+            METRIC_TYPE.BEHAVIORAL,
+            GET_MOBIUS_SERVERS_UTIL,
+            'UNKNOWN',
+            (err as WebexRequestPayload).headers?.trackingId ?? '',
+            undefined,
+            clientError
+          );
+          this.emit(CALLING_CLIENT_EVENT_KEYS.ERROR, clientError);
+        },
+        {method: GET_MOBIUS_SERVERS_UTIL, file: CALLING_CLIENT_FILE}
+      );
+
+      regionInfo.clientRegion = '';
+      regionInfo.countryCode = '';
+
+      if (abort) {
+        await uploadLogs();
+
+        return regionInfo;
       }
     }
 
@@ -543,7 +489,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       });
       clientRegion = this.sdkConfig?.discovery?.region;
       countryCode = this.sdkConfig?.discovery?.country;
-      this.mobiusHost = this.webex.internal.services._serviceUrls.mobius;
+      this.mobiusHost = this.webex.internal.services._serviceUrls.mobius; // This needs to be fixed too as per services.v2 catalog
     } else {
       log.log('Updating region and country through Region discovery', {
         file: CALLING_CLIENT_FILE,
@@ -565,80 +511,90 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
         }
       );
 
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const response = <WebexRequestPayload>await this.webex.request({
-          uri: `${this.mobiusHost}${URL_ENDPOINT}?regionCode=${clientRegion}&countryCode=${countryCode}`,
-          method: HTTP_METHODS.GET,
-          headers: {
-            [CISCO_DEVICE_URL]: this.webex.internal.device.url,
-            [SPARK_USER_AGENT]: CALLING_USER_AGENT,
-          },
-          service: ALLOWED_SERVICES.MOBIUS,
-        });
-
-        log.log(
-          `Mobius Server found for the region. Response trackingId: ${response?.headers?.trackingid}`,
-          {
-            file: CALLING_CLIENT_FILE,
-            method: GET_MOBIUS_SERVERS_UTIL,
-          }
-        );
-
-        const mobiusServers = response.body as MobiusServers;
-
-        // Metrics for mobius servers
-        this.metricManager.submitMobiusServersMetric(
-          METRIC_EVENT.MOBIUS_DISCOVERY,
-          MOBIUS_SERVER_ACTION.MOBIUS_SERVERS,
-          METRIC_TYPE.BEHAVIORAL,
-          mobiusServers,
-          response?.headers?.trackingid ?? ''
-        );
-
-        /* update arrays of Mobius Uris. */
-        const mobiusUris = filterMobiusUris(mobiusServers, this.mobiusHost);
-        this.primaryMobiusUris = mobiusUris.primary;
-        this.backupMobiusUris = mobiusUris.backup;
-
-        log.log(
-          `Final list of Mobius Servers, primary: ${mobiusUris.primary} and backup: ${mobiusUris.backup}`,
-          {
-            file: CALLING_CLIENT_FILE,
-            method: GET_MOBIUS_SERVERS_UTIL,
-          }
-        );
-      } catch (err: unknown) {
-        const extendedError = new Error(`Failed to get Mobius servers: ${err}`) as ExtendedError;
-        log.error(extendedError, {
-          method: METHODS.GET_MOBIUS_SERVERS,
-          file: CALLING_CLIENT_FILE,
-        });
-
-        const abort = await handleCallingClientErrors(
-          err as WebexRequestPayload,
-          (clientError) => {
-            this.metricManager.submitRegistrationMetric(
-              METRIC_EVENT.REGISTRATION_ERROR,
-              REG_ACTION.REGISTER,
-              METRIC_TYPE.BEHAVIORAL,
-              GET_MOBIUS_SERVERS_UTIL,
-              'UNKNOWN',
-              (err as WebexRequestPayload).headers?.trackingId ?? '',
-              undefined,
-              clientError
-            );
-            this.emit(CALLING_CLIENT_EVENT_KEYS.ERROR, clientError);
-          },
-          {method: GET_MOBIUS_SERVERS_UTIL, file: CALLING_CLIENT_FILE}
-        );
-
-        if (abort) {
-          // Upload logs on final error
-          await uploadLogs();
+      for (const mobius of this.mobiusClusters) {
+        if (mobius.host) {
+          this.mobiusHost = `https://${mobius.host}${API_V1}`;
+        } else {
+          this.mobiusHost = mobius as unknown as string;
         }
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          const response = <WebexRequestPayload>await this.webex.request({
+            uri: `${this.mobiusHost}${URL_ENDPOINT}?regionCode=${clientRegion}&countryCode=${countryCode}`,
+            method: HTTP_METHODS.GET,
+            headers: {
+              [CISCO_DEVICE_URL]: this.webex.internal.device.url,
+              [SPARK_USER_AGENT]: CALLING_USER_AGENT,
+            },
+            service: ALLOWED_SERVICES.MOBIUS,
+          });
 
-        useDefault = true;
+          log.log(
+            `Mobius Server found for the region. Response trackingId: ${response?.headers?.trackingid}`,
+            {
+              file: CALLING_CLIENT_FILE,
+              method: GET_MOBIUS_SERVERS_UTIL,
+            }
+          );
+
+          const mobiusServers = response.body as MobiusServers;
+
+          // Metrics for mobius servers
+          this.metricManager.submitMobiusServersMetric(
+            METRIC_EVENT.MOBIUS_DISCOVERY,
+            MOBIUS_SERVER_ACTION.MOBIUS_SERVERS,
+            METRIC_TYPE.BEHAVIORAL,
+            mobiusServers,
+            response?.headers?.trackingid ?? ''
+          );
+
+          /* update arrays of Mobius Uris. */
+          const mobiusUris = filterMobiusUris(mobiusServers, this.mobiusHost);
+          this.primaryMobiusUris = mobiusUris.primary;
+          this.backupMobiusUris = mobiusUris.backup;
+
+          log.log(
+            `Final list of Mobius Servers, primary: ${mobiusUris.primary} and backup: ${mobiusUris.backup}`,
+            {
+              file: CALLING_CLIENT_FILE,
+              method: GET_MOBIUS_SERVERS_UTIL,
+            }
+          );
+          break;
+        } catch (err: unknown) {
+          const extendedError = new Error(`Failed to get Mobius servers: ${err}`) as ExtendedError;
+          log.error(extendedError, {
+            method: METHODS.GET_MOBIUS_SERVERS,
+            file: CALLING_CLIENT_FILE,
+          });
+
+          // eslint-disable-next-line no-await-in-loop
+          const abort = await handleCallingClientErrors(
+            err as WebexRequestPayload,
+            (clientError) => {
+              this.metricManager.submitRegistrationMetric(
+                METRIC_EVENT.REGISTRATION_ERROR,
+                REG_ACTION.REGISTER,
+                METRIC_TYPE.BEHAVIORAL,
+                GET_MOBIUS_SERVERS_UTIL,
+                'UNKNOWN',
+                (err as WebexRequestPayload).headers?.trackingId ?? '',
+                undefined,
+                clientError
+              );
+              this.emit(CALLING_CLIENT_EVENT_KEYS.ERROR, clientError);
+            },
+            {method: GET_MOBIUS_SERVERS_UTIL, file: CALLING_CLIENT_FILE}
+          );
+
+          if (abort) {
+            // Upload logs on final error
+            // eslint-disable-next-line no-await-in-loop
+            await uploadLogs();
+          }
+
+          useDefault = true;
+        }
       }
     } else {
       /* Setting this to true because region info is possibly undefined */
@@ -784,7 +740,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
    * Retrieves call objects for all the active calls present in the client
    */
   public getActiveCalls(): Record<string, ICall[]> {
-    const activeCalls = {};
+    const activeCalls: Record<string, ICall[]> = {};
     const calls = this.callManager.getActiveCalls();
     Object.keys(calls).forEach((correlationId) => {
       const call = calls[correlationId];

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -156,7 +156,6 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     // Returns an array of ServiceHost-like entries: {host, priority, id, ttl}
     // @ts-ignore - services may be v1 or v2, both expose getMobiusClusters()
     this.mobiusClusters = this.webex.internal.services.getMobiusClusters();
-    console.log('pkesari_mobiusClusters', this.mobiusClusters);
     this.mobiusHost = '';
 
     this.registerSessionsListener();
@@ -489,7 +488,9 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       });
       clientRegion = this.sdkConfig?.discovery?.region;
       countryCode = this.sdkConfig?.discovery?.country;
-      this.mobiusHost = this.webex.internal.services._serviceUrls.mobius; // This needs to be fixed too as per services.v2 catalog
+      this.mobiusHost =
+        this.webex.internal.services._serviceUrls.mobius ||
+        this.webex.internal.services.get(this.webex.internal.services._activeServices.mobius);
     } else {
       log.log('Updating region and country through Region discovery', {
         file: CALLING_CLIENT_FILE,

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -383,11 +383,6 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
         },
       });
 
-      log.log(`Response trackingId: ${response?.headers?.trackingid}`, {
-        file: CALLING_CLIENT_FILE,
-        method: METHODS.GET_CLIENT_REGION_INFO,
-      });
-
       const clientRegionInfo = response.body as ClientRegionInfo;
 
       regionInfo.clientRegion = clientRegionInfo?.clientRegion ? clientRegionInfo.clientRegion : '';
@@ -412,8 +407,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
         response?.headers?.trackingid ?? ''
       );
     } catch (err: unknown) {
-      const extendedError = new Error(`Failed to get client region info: ${err}`) as ExtendedError;
-      log.error(extendedError, {
+      log.error(`Failed to get client region info: ${JSON.stringify(err)}`, {
         method: METHODS.GET_CLIENT_REGION_INFO,
         file: CALLING_CLIENT_FILE,
       });
@@ -552,10 +546,10 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
               method: GET_MOBIUS_SERVERS_UTIL,
             }
           );
+
           break;
         } catch (err: unknown) {
-          const extendedError = new Error(`Failed to get Mobius servers: ${err}`) as ExtendedError;
-          log.error(extendedError, {
+          log.error(`Failed to get Mobius servers: ${JSON.stringify(err)}`, {
             method: METHODS.GET_MOBIUS_SERVERS,
             file: CALLING_CLIENT_FILE,
           });

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -374,13 +374,6 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     });
     const regionInfo = {} as RegionInfo;
 
-    // for (const mobius of this.mobiusClusters) {
-    // if (mobius.host) {
-    //   this.mobiusHost = `https://${mobius.host}${API_V1}`;
-    // } else {
-    //   this.mobiusHost = mobius as unknown as string;
-    // }
-
     try {
       const response = <WebexRequestPayload>await this.webex.request({
         uri: `${DISCOVERY_URL}`,
@@ -410,7 +403,6 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
         }
       );
 
-      // Metrics for region info - trying clusters in loop
       this.metricManager.submitRegionInfoMetric(
         METRIC_EVENT.MOBIUS_DISCOVERY,
         MOBIUS_SERVER_ACTION.REGION_INFO,
@@ -589,12 +581,11 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
           );
 
           if (abort) {
-            // Upload logs on final error
+            useDefault = true;
             // eslint-disable-next-line no-await-in-loop
             await uploadLogs();
+            break;
           }
-
-          useDefault = true;
         }
       }
     } else {

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -474,7 +474,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       clientRegion = this.sdkConfig?.discovery?.region;
       countryCode = this.sdkConfig?.discovery?.country;
       this.mobiusHost =
-        this.webex.internal.services._serviceUrls.mobius ||
+        this.webex.internal.services._serviceUrls?.mobius ||
         this.webex.internal.services.get(this.webex.internal.services._activeServices.mobius);
     } else {
       log.log('Updating region and country through Region discovery', {

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -151,9 +151,6 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
     this.primaryMobiusUris = [];
     this.backupMobiusUris = [];
-    // Use unified helper to fetch all mobius hosts from catalog (legacy or v2)
-    // Returns an array of ServiceHost-like entries: {host, priority, id, ttl}
-    // @ts-ignore - services may be v1 or v2, both expose getMobiusClusters()
     this.mobiusClusters = this.webex.internal.services.getMobiusClusters();
     this.mobiusHost = '';
 
@@ -385,9 +382,9 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
       const clientRegionInfo = response.body as ClientRegionInfo;
 
-      regionInfo.clientRegion = clientRegionInfo?.clientRegion ? clientRegionInfo.clientRegion : '';
+      regionInfo.clientRegion = clientRegionInfo?.clientRegion || '';
 
-      regionInfo.countryCode = clientRegionInfo?.countryCode ? clientRegionInfo.countryCode : '';
+      regionInfo.countryCode = clientRegionInfo?.clientRegion || '';
 
       log.log(
         `Successfully fetched Client region info: ${regionInfo.clientRegion}, countryCode: ${regionInfo.countryCode}, and response trackingid: ${response?.headers?.trackingid}`,

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -384,7 +384,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
       regionInfo.clientRegion = clientRegionInfo?.clientRegion || '';
 
-      regionInfo.countryCode = clientRegionInfo?.clientRegion || '';
+      regionInfo.countryCode = clientRegionInfo?.countryCode || '';
 
       log.log(
         `Successfully fetched Client region info: ${regionInfo.clientRegion}, countryCode: ${regionInfo.countryCode}, and response trackingid: ${response?.headers?.trackingid}`,

--- a/packages/calling/src/Contacts/ContactsClient.ts
+++ b/packages/calling/src/Contacts/ContactsClient.ts
@@ -81,7 +81,7 @@ export class ContactsClient implements IContacts {
     this.contacts = undefined;
     this.defaultGroupId = '';
     this.contactsServiceUrl =
-      this.webex.internal.services._serviceUrls.contactsService ||
+      this.webex.internal.services._serviceUrls?.contactsService ||
       this.webex.internal.services.get(
         this.webex.internal.services._activeServices.contactsService
       );

--- a/packages/calling/src/Contacts/ContactsClient.ts
+++ b/packages/calling/src/Contacts/ContactsClient.ts
@@ -63,6 +63,8 @@ export class ContactsClient implements IContacts {
 
   private defaultGroupId: string;
 
+  private contactsServiceUrl: string;
+
   /**
    * @ignore
    */
@@ -79,7 +81,11 @@ export class ContactsClient implements IContacts {
     this.groups = undefined;
     this.contacts = undefined;
     this.defaultGroupId = '';
-
+    this.contactsServiceUrl =
+      this.webex.internal.services._serviceUrls.contactsService ||
+      this.webex.internal.services.get(
+        this.webex.internal.services._activeServices.contactsService
+      );
     log.setLogger(logger.level, CONTACTS_CLIENT);
   }
 
@@ -346,7 +352,7 @@ export class ContactsClient implements IContacts {
     try {
       const response = <WebexRequestPayload>await this.webex.request({
         // eslint-disable-next-line no-underscore-dangle
-        uri: `${this.webex.internal.services._serviceUrls.contactsService}/${ENCRYPT_FILTER}/${USERS}/${CONTACT_FILTER}`,
+        uri: `${this.contactsServiceUrl}/${ENCRYPT_FILTER}/${USERS}/${CONTACT_FILTER}`,
         method: HTTP_METHODS.GET,
       });
 
@@ -628,7 +634,7 @@ export class ContactsClient implements IContacts {
     try {
       const response = <WebexRequestPayload>await this.webex.request({
         // eslint-disable-next-line no-underscore-dangle
-        uri: `${this.webex.internal.services._serviceUrls.contactsService}/${ENCRYPT_FILTER}/${USERS}/${GROUP_FILTER}`,
+        uri: `${this.contactsServiceUrl}/${ENCRYPT_FILTER}/${USERS}/${GROUP_FILTER}`,
         method: HTTP_METHODS.POST,
         body: groupInfo,
       });
@@ -678,7 +684,7 @@ export class ContactsClient implements IContacts {
       log.info(`Deleting contact group: ${groupId}`, loggerContext);
       const response = <WebexRequestPayload>await this.webex.request({
         // eslint-disable-next-line no-underscore-dangle
-        uri: `${this.webex.internal.services._serviceUrls.contactsService}/${ENCRYPT_FILTER}/${USERS}/${GROUP_FILTER}/${groupId}`,
+        uri: `${this.contactsServiceUrl}/${ENCRYPT_FILTER}/${USERS}/${GROUP_FILTER}/${groupId}`,
         method: HTTP_METHODS.DELETE,
       });
 
@@ -780,7 +786,7 @@ export class ContactsClient implements IContacts {
 
       const response = <WebexRequestPayload>await this.webex.request({
         // eslint-disable-next-line no-underscore-dangle
-        uri: `${this.webex.internal.services._serviceUrls.contactsService}/${ENCRYPT_FILTER}/${USERS}/${CONTACT_FILTER}`,
+        uri: `${this.contactsServiceUrl}/${ENCRYPT_FILTER}/${USERS}/${CONTACT_FILTER}`,
         method: HTTP_METHODS.POST,
         body: requestBody,
       });
@@ -842,7 +848,7 @@ export class ContactsClient implements IContacts {
       log.info(`Deleting contact : ${contactId}`, loggerContext);
       const response = <WebexRequestPayload>await this.webex.request({
         // eslint-disable-next-line no-underscore-dangle
-        uri: `${this.webex.internal.services._serviceUrls.contactsService}/${ENCRYPT_FILTER}/${USERS}/${CONTACT_FILTER}/${contactId}`,
+        uri: `${this.contactsServiceUrl}/${ENCRYPT_FILTER}/${USERS}/${CONTACT_FILTER}/${contactId}`,
         method: HTTP_METHODS.DELETE,
       });
 

--- a/packages/calling/src/SDKConnector/types.ts
+++ b/packages/calling/src/SDKConnector/types.ts
@@ -137,6 +137,7 @@ export interface WebexSDK {
         mobius: string;
       };
       get: (service: string) => string;
+      getMobiusClusters: () => ServiceHost[];
       fetchClientRegionInfo: () => Promise<ClientRegionInfo>;
     };
     metrics: {

--- a/packages/calling/src/SDKConnector/types.ts
+++ b/packages/calling/src/SDKConnector/types.ts
@@ -128,6 +128,10 @@ export interface WebexSDK {
         'ucmgmt-gateway': string;
         contactsService: string;
       };
+      _activeServices: {
+        mobius: string;
+      };
+      get: (service: string) => string;
       fetchClientRegionInfo: () => Promise<ClientRegionInfo>;
     };
     metrics: {

--- a/packages/calling/src/SDKConnector/types.ts
+++ b/packages/calling/src/SDKConnector/types.ts
@@ -129,6 +129,11 @@ export interface WebexSDK {
         contactsService: string;
       };
       _activeServices: {
+        broadworksIdpProxy: string;
+        contactsService: string;
+        hydra: string;
+        janus: string;
+        mercuryApi: string;
         mobius: string;
       };
       get: (service: string) => string;

--- a/packages/calling/src/Voicemail/BroadworksBackendConnector.ts
+++ b/packages/calling/src/Voicemail/BroadworksBackendConnector.ts
@@ -169,9 +169,14 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
     };
 
     log.info(METHOD_START_MESSAGE, loggerContext);
+    const broadworksIdpProxyUrl =
+      this.webex.internal.services._serviceUrls.broadworksIdpProxy ||
+      this.webex.internal.services.get(
+        this.webex.internal.services._activeServices.broadworksIdpProxy
+      );
     try {
       const bwTokenResponse = await (<WebexRequestPayload>this.webex.request({
-        uri: `${this.webex.internal.services._serviceUrls.broadworksIdpProxy}${BW_TOKEN_FETCH_ENDPOINT}`,
+        uri: `${broadworksIdpProxyUrl}${BW_TOKEN_FETCH_ENDPOINT}`,
         method: HTTP_METHODS.GET,
       }));
 

--- a/packages/calling/src/Voicemail/BroadworksBackendConnector.ts
+++ b/packages/calling/src/Voicemail/BroadworksBackendConnector.ts
@@ -168,7 +168,7 @@ export class BroadworksBackendConnector implements IBroadworksCallBackendConnect
 
     log.info(METHOD_START_MESSAGE, loggerContext);
     const broadworksIdpProxyUrl =
-      this.webex.internal.services._serviceUrls.broadworksIdpProxy ||
+      this.webex.internal.services._serviceUrls?.broadworksIdpProxy ||
       this.webex.internal.services.get(
         this.webex.internal.services._activeServices.broadworksIdpProxy
       );

--- a/packages/calling/src/Voicemail/UcmBackendConnector.ts
+++ b/packages/calling/src/Voicemail/UcmBackendConnector.ts
@@ -251,7 +251,7 @@ export class UcmBackendConnector implements IUcmBackendConnector {
     return new Promise((resolve, reject) => {
       const voicemailContentUrl = `${this.vgVoiceMessageURI}${VOICEMAILS}/${messageId}/${CONTENT}`;
       const mercuryUrl =
-        this.webex.internal.services._serviceUrls.mercuryApi ||
+        this.webex.internal.services._serviceUrls?.mercuryApi ||
         this.webex.internal.services.get(this.webex.internal.services._activeServices.mercuryApi);
       const mercuryApi = `${mercuryUrl}`;
 

--- a/packages/calling/src/Voicemail/UcmBackendConnector.ts
+++ b/packages/calling/src/Voicemail/UcmBackendConnector.ts
@@ -250,10 +250,9 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
     return new Promise((resolve, reject) => {
       const voicemailContentUrl = `${this.vgVoiceMessageURI}${VOICEMAILS}/${messageId}/${CONTENT}`;
-      const mercuryUrl =
+      const mercuryApi =
         this.webex.internal.services._serviceUrls?.mercuryApi ||
         this.webex.internal.services.get(this.webex.internal.services._activeServices.mercuryApi);
-      const mercuryApi = `${mercuryUrl}`;
 
       this.returnUcmPromise(voicemailContentUrl, mercuryApi)
         .then((response: VoicemailResponseEvent) => {

--- a/packages/calling/src/Voicemail/UcmBackendConnector.ts
+++ b/packages/calling/src/Voicemail/UcmBackendConnector.ts
@@ -254,7 +254,10 @@ export class UcmBackendConnector implements IUcmBackendConnector {
 
     return new Promise((resolve, reject) => {
       const voicemailContentUrl = `${this.vgVoiceMessageURI}${VOICEMAILS}/${messageId}/${CONTENT}`;
-      const mercuryApi = `${this.webex.internal.services._serviceUrls.mercuryApi}`;
+      const mercuryUrl =
+        this.webex.internal.services._serviceUrls.mercuryApi ||
+        this.webex.internal.services.get(this.webex.internal.services._activeServices.mercuryApi);
+      const mercuryApi = `${mercuryUrl}`;
 
       this.returnUcmPromise(voicemailContentUrl, mercuryApi)
         .then((response: VoicemailResponseEvent) => {

--- a/packages/calling/src/common/testUtil.ts
+++ b/packages/calling/src/common/testUtil.ts
@@ -81,6 +81,7 @@ export function getTestUtilsWebex() {
           contactsService: 'https://contacts-service-a.wbx2.com/contact/api/v1',
         },
         fetchClientRegionInfo: jest.fn(),
+        getMobiusClusters: jest.fn(),
       },
     },
     // public plugins


### PR DESCRIPTION
# COMPLETES #SPARK-700838 

## This pull request addresses
Accommodate fetching different services urls using V1Catalog as well as V2 catalog.

## by making the following changes
1. Fetching Mobius cluster information for V1Catalog and V2Catalog from services layer itself.
2. Removed /myIP request as it is not needed.
3. Updated other urls being fetched directly fro serviceUrl for V1 catalog to fetch entries from V2 catalog.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested
Logs for v1Catalog and v2Catalog are uploaded in Jira, please check.

<img width="967" height="511" alt="Screenshot 2025-11-06 at 3 59 15 PM" src="https://github.com/user-attachments/assets/9d0327b1-8542-4206-9a4b-1a542db6159e" />


## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
