### PR TITLE
feat(calling): fixed-double-media-request

### DIFF
--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -1703,30 +1703,66 @@ describe('State Machine handler tests', () => {
     expect(stateMachineSpy).toBeCalledOnceWith({data: {media: true}, type: 'E_UNKNOWN'});
   });
 
-  it("does not post media when ROAP error messageType isn't 'ERROR' and disconnects if not connected", async () => {
-    const postMediaSpy = jest.spyOn(call as any, 'postMedia');
-    const stateMachineSpy = jest.spyOn(call, 'sendCallStateMachineEvt');
+  it('incoming call: failing ROAP_ANSWER posts error path and tears down', async () => {
+    const statusPayload = <WebexRequestPayload>(<unknown>{
+      statusCode: 403,
+      body: mockStatusBody,
+    });
+
     const warnSpy = jest.spyOn(log, 'warn');
+    const postMediaSpy = jest.spyOn(call as any, 'postMedia').mockRejectedValueOnce(statusPayload);
 
-    call['connected'] = false;
-    call['mediaStateMachine'].state.value = 'S_SEND_ROAP_ANSWER';
+    // Simulate inbound call flow
+    call['direction'] = CallDirection.INBOUND;
 
-    const errorEvent = {
-      type: 'E_ROAP_ERROR',
+    const setupEvent = {
+      type: 'E_RECV_CALL_SETUP',
       data: {
-        seq: 3,
-        messageType: 'OK',
+        seq: 1,
+        messageType: 'OFFER',
       },
-    } as RoapEvent;
+    };
 
-    await call['handleRoapError']({} as MediaContext, errorEvent);
+    call.sendCallStateMachineEvt(setupEvent as CallEvent);
+    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
-    expect(postMediaSpy).not.toHaveBeenCalled();
+    const connectEvent = {type: 'E_SEND_CALL_CONNECT'};
+    call.sendCallStateMachineEvt(connectEvent as CallEvent);
+    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_CONNECT');
+
+    const offerEvent = {
+      type: 'E_RECV_ROAP_OFFER',
+      data: {
+        seq: 1,
+        messageType: 'OFFER',
+      },
+    };
+    call.sendMediaStateMachineEvt(offerEvent as RoapEvent);
+
+    const answerEvent = {
+      type: 'E_SEND_ROAP_ANSWER',
+      data: {
+        seq: 1,
+        messageType: 'ANSWER',
+      },
+    };
+
+    await call.sendMediaStateMachineEvt(answerEvent as RoapEvent);
+    await flushPromises(2);
+
+    expect(postMediaSpy).toBeCalledOnceWith(answerEvent.data as RoapMessage);
+    expect(warnSpy).toHaveBeenCalledWith('Failed to send MediaAnswer request', {
+      file: 'call',
+      method: 'handleOutgoingRoapAnswer',
+    });
     expect(warnSpy).toHaveBeenCalledWith('Call failed due to media issue', {
       file: 'call',
       method: 'handleRoapError',
     });
-    expect(stateMachineSpy).toBeCalledOnceWith({type: 'E_UNKNOWN', data: {media: true}});
+
+    // Final state should be torn down and cleared for unconnected call
+    expect(call['mediaStateMachine'].state.value).toBe('S_ROAP_TEARDOWN');
+    expect(call['callStateMachine'].state.value).toBe('S_CALL_CLEARED');
   });
 
   it('state changes during successful incoming call with out of order events', async () => {

--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -1400,15 +1400,15 @@ describe('State Machine handler tests', () => {
     await flushPromises(2);
     expect(call.isConnected()).toBe(false);
 
-    expect(call['mediaStateMachine'].state.value).toBe('S_ROAP_ERROR');
-    expect(call['callStateMachine'].state.value).toBe('S_UNKNOWN');
+    expect(call['mediaStateMachine'].state.value).toBe('S_ROAP_TEARDOWN');
+    expect(call['callStateMachine'].state.value).toBe('S_CALL_CLEARED');
     expect(warnSpy).toHaveBeenCalledWith('Failed to process MediaOk request', {
       file: 'call',
       method: 'handleRoapEstablished',
     });
-    expect(uploadLogsSpy).toHaveBeenCalledWith({
-      correlationId: call.getCorrelationId(),
-      callId: call.getCallId(),
+    expect(warnSpy).toHaveBeenCalledWith('Call failed due to media issue', {
+      file: 'call',
+      method: 'handleRoapError',
     });
   });
 
@@ -1701,6 +1701,32 @@ describe('State Machine handler tests', () => {
       method: 'handleRoapError',
     });
     expect(stateMachineSpy).toBeCalledOnceWith({data: {media: true}, type: 'E_UNKNOWN'});
+  });
+
+  it("does not post media when ROAP error messageType isn't 'ERROR' and disconnects if not connected", async () => {
+    const postMediaSpy = jest.spyOn(call as any, 'postMedia');
+    const stateMachineSpy = jest.spyOn(call, 'sendCallStateMachineEvt');
+    const warnSpy = jest.spyOn(log, 'warn');
+
+    call['connected'] = false;
+    call['mediaStateMachine'].state.value = 'S_SEND_ROAP_ANSWER';
+
+    const errorEvent = {
+      type: 'E_ROAP_ERROR',
+      data: {
+        seq: 3,
+        messageType: 'OK',
+      },
+    } as RoapEvent;
+
+    await call['handleRoapError']({} as MediaContext, errorEvent);
+
+    expect(postMediaSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith('Call failed due to media issue', {
+      file: 'call',
+      method: 'handleRoapError',
+    });
+    expect(stateMachineSpy).toBeCalledOnceWith({type: 'E_UNKNOWN', data: {media: true}});
   });
 
   it('state changes during successful incoming call with out of order events', async () => {

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -1814,7 +1814,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     const message = event.data as RoapMessage;
 
     /* istanbul ignore else */
-    if (message) {
+    if (message && message.messageType === 'ERROR') {
       try {
         const res = await this.postMedia(message);
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7272 >

## This pull request addresses

* During the mobius chaos testing, a small issue was found with the SDK during the answerOffer phase.
* The SDK was sending a media request ot mobius even after delete.
* The reason was because of a check we were not doing in our `handleRoapError`

## by making the following changes

* Added a minor `if` check in `handleRoapError` to only post actual ERRORS from media core to mobius

<img width="724" height="706" alt="Screenshot 2025-10-29 at 2 06 19 PM" src="https://github.com/user-attachments/assets/2a6b849a-d6d3-4031-a8bd-6f9ac3cca9a3" />

Vidcast - https://app.vidcast.io/share/d7377177-c7aa-4e64-a44a-694e71daf0d3


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested the same TC as mobius team did.
* Tested basic outgoing call.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
