### PR TITLE
feat(mcp): add-is-conference-in-progress-to-agent-contact-event

### DIFF
--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -112,7 +112,7 @@ export default class TaskManager extends EventEmitter {
           interactionId: payload.data?.interactionId,
         });
         switch (payload.data.type) {
-          case CC_EVENTS.AGENT_CONTACT:
+          case CC_EVENTS.AGENT_CONTACT: {
             // Case1 : Task is already present in taskCollection
             if (this.taskCollection[payload.data.interactionId]) {
               LoggerProxy.log(`Got AGENT_CONTACT: Task already exists in collection`, {
@@ -128,6 +128,12 @@ export default class TaskManager extends EventEmitter {
                 method: METHODS.REGISTER_TASK_LISTENERS,
                 interactionId: payload.data.interactionId,
               });
+
+              // Pre-calculate isConferenceInProgress for the initial task data
+              const simulatedTaskForAgentContact = {
+                data: {...payload.data},
+              } as ITask;
+
               task = new Task(
                 this.contact,
                 this.webCallingService,
@@ -135,6 +141,7 @@ export default class TaskManager extends EventEmitter {
                   ...payload.data,
                   wrapUpRequired:
                     payload.data.interaction?.participants?.[this.agentId]?.isWrapUp || false,
+                  isConferenceInProgress: getIsConferenceInProgress(simulatedTaskForAgentContact),
                 },
                 this.wrapupData,
                 this.agentId
@@ -165,6 +172,7 @@ export default class TaskManager extends EventEmitter {
               }
             }
             break;
+          }
           case CC_EVENTS.AGENT_CONTACT_RESERVED:
             task = new Task(
               this.contact,

--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -112,7 +112,7 @@ export default class TaskManager extends EventEmitter {
           interactionId: payload.data?.interactionId,
         });
         switch (payload.data.type) {
-          case CC_EVENTS.AGENT_CONTACT: {
+          case CC_EVENTS.AGENT_CONTACT:
             // Case1 : Task is already present in taskCollection
             if (this.taskCollection[payload.data.interactionId]) {
               LoggerProxy.log(`Got AGENT_CONTACT: Task already exists in collection`, {
@@ -172,7 +172,7 @@ export default class TaskManager extends EventEmitter {
               }
             }
             break;
-          }
+
           case CC_EVENTS.AGENT_CONTACT_RESERVED:
             task = new Task(
               this.contact,


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

**Fixed two issues:**

When an agent performs a switch call during a consult or conference, and then adds another agent to the conference, the "add agent to conference" operation was failing because the ToAddress parameter was being sent as null.

When refreshing one window during multi-login via extension mode, if the agent is in conference mode, the conference-related call controls were not being retained.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
