### PR TITLE
fix(calling): fix 429 re-try logic

### DIFF
--- a/packages/calling/src/CallingClient/constants.ts
+++ b/packages/calling/src/CallingClient/constants.ts
@@ -112,6 +112,7 @@ export const REGISTRATION_UTIL = 'triggerRegistration';
 export const REGISTER_UTIL = 'attemptRegistrationWithServers';
 export const GET_MOBIUS_SERVERS_UTIL = 'getMobiusServers';
 export const KEEPALIVE_UTIL = 'startKeepaliveTimer';
+export const RECONNECT_ON_FAILURE_UTIL = 'reconnectOnFailure';
 export const FAILBACK_UTIL = 'executeFailback';
 export const REG_429_RETRY_UTIL = 'handle429Retry';
 export const FAILOVER_UTIL = 'startFailoverTimer';

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -752,8 +752,6 @@ describe('Registration Tests', () => {
       });
       webex.request
         .mockRejectedValueOnce(failurePayload429Small)
-        .mockResolvedValueOnce(successPayload)
-        .mockRejectedValueOnce(failurePayload429Small)
         .mockResolvedValueOnce(successPayload);
 
       await reg.reconnectOnFailure(RECONNECT_ON_FAILURE_UTIL); // This call is being used to set the retry-after value
@@ -782,8 +780,6 @@ describe('Registration Tests', () => {
       });
       webex.request
         .mockRejectedValueOnce(failurePayload429Small)
-        .mockResolvedValueOnce(successPayload)
-        .mockRejectedValueOnce(failurePayload429Small)
         .mockResolvedValueOnce(successPayload);
 
       await reg.reconnectOnFailure(RECONNECT_ON_FAILURE_UTIL); // This call is being used to trigger the retry
@@ -807,6 +803,7 @@ describe('Registration Tests', () => {
       );
       expect(restartSpy).not.toHaveBeenCalledTimes(1);
       expect(restartSpy).not.toHaveBeenCalledWith(RECONNECT_ON_FAILURE_UTIL);
+      expect(reg.retryAfter).toEqual(undefined); // Clear retryAfter after 429 retry
     });
     it('should restart registration with primary if we get 429 while on backup', async () => {
       // Setup: Register successfully with primary first

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -31,6 +31,7 @@ import {
   REG_429_RETRY_UTIL,
   REG_TRY_BACKUP_TIMER_VAL_IN_SEC,
   SEC_TO_MSEC_MFACTOR,
+  RECONNECT_ON_FAILURE_UTIL,
 } from '../constants';
 import {ICall} from '../calling/types';
 import {LINE_EVENTS} from '../line/types';
@@ -1277,9 +1278,9 @@ describe('Registration Tests', () => {
 
       expect(reg.getStatus()).toEqual(RegistrationStatus.INACTIVE);
       expect(lineEmitter).toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
-      expect(reconnectSpy).toBeCalledOnceWith(KEEPALIVE_UTIL);
-      expect(restoreSpy).toBeCalledOnceWith(KEEPALIVE_UTIL);
-      expect(restartRegSpy).toBeCalledOnceWith(KEEPALIVE_UTIL);
+      expect(reconnectSpy).toBeCalledOnceWith(RECONNECT_ON_FAILURE_UTIL);
+      expect(restoreSpy).toBeCalledOnceWith(RECONNECT_ON_FAILURE_UTIL);
+      expect(restartRegSpy).toBeCalledOnceWith(RECONNECT_ON_FAILURE_UTIL);
 
       jest.useRealTimers();
 
@@ -1311,7 +1312,7 @@ describe('Registration Tests', () => {
       await flushPromises();
 
       expect(reg.webWorker).toBeUndefined();
-      expect(reconnectSpy).toBeCalledOnceWith(reg.startKeepaliveTimer.name);
+      expect(reconnectSpy).toBeCalledOnceWith(RECONNECT_ON_FAILURE_UTIL);
 
       webex.request.mockResolvedValueOnce(successPayload);
       await reg.triggerRegistration();
@@ -1329,8 +1330,8 @@ describe('Registration Tests', () => {
       expect(reg.getStatus()).toEqual(RegistrationStatus.ACTIVE);
       // reconnectSpy should have been called only once.
       expect(reconnectSpy).toBeCalledTimes(1);
-      expect(restoreSpy).toBeCalledOnceWith(reg.startKeepaliveTimer.name);
-      expect(restartSpy).toBeCalledOnceWith(reg.startKeepaliveTimer.name);
+      expect(restoreSpy).toBeCalledOnceWith(RECONNECT_ON_FAILURE_UTIL);
+      expect(restartSpy).toBeCalledOnceWith(RECONNECT_ON_FAILURE_UTIL);
       // Active Mobius URL should remain unchanged.
       expect(reg.getActiveMobiusUrl()).toStrictEqual(url);
     });
@@ -1422,7 +1423,7 @@ describe('Registration Tests', () => {
 
       // Verify that the keepalive timer was cleared and reconnectOnFailure was triggered
       expect(clearKeepaliveSpy).toHaveBeenCalled();
-      expect(reconnectSpy).toHaveBeenCalledWith(reg.startKeepaliveTimer.name);
+      expect(reconnectSpy).toHaveBeenCalledWith(RECONNECT_ON_FAILURE_UTIL);
 
       // Verify that the active Mobius URL has been updated to the backup server and registration is active
       expect(reg.getActiveMobiusUrl()).toEqual(mobiusUris.backup[0]);
@@ -1462,7 +1463,7 @@ describe('Registration Tests', () => {
       expect(lineEmitter).lastCalledWith(LINE_EVENTS.UNREGISTERED);
       expect(reg.keepaliveTimer).toStrictEqual(undefined);
       expect(reg.failbackTimer).toStrictEqual(undefined);
-      expect(reconnectSpy).toBeCalledOnceWith(KEEPALIVE_UTIL);
+      expect(reconnectSpy).toBeCalledOnceWith(RECONNECT_ON_FAILURE_UTIL);
       expect(restoreSpy).not.toBeCalled();
       expect(restartRegSpy).not.toBeCalled();
       expect(reg.reconnectPending).toStrictEqual(true);
@@ -1601,6 +1602,58 @@ describe('Registration Tests', () => {
           url: expect.any(String),
         })
       );
+    });
+
+    it('ensure retryAfter is set (line 291) when 429 occurs during failover retry', async () => {
+      await beforeEachSetupForKeepalive();
+      // Simulate loss of registration so failover path attempts a new registration
+      reg.clearKeepaliveTimer();
+      reg.setStatus(RegistrationStatus.INACTIVE);
+      const retry429Spy = jest.spyOn(reg, 'handle429Retry');
+      // Make the failover interval deterministic and simulate 429 on the failover attempt
+      jest.spyOn(reg as any, 'getRegRetryInterval').mockReturnValueOnce(33);
+      webex.request.mockRejectedValueOnce(failurePayload429One);
+
+      // Directly schedule the failover attempt
+      await (reg as any).startFailoverTimer();
+
+      jest.advanceTimersByTime(33 * SEC_TO_MSEC_MFACTOR);
+      await flushPromises();
+
+      expect(retry429Spy).toBeCalledWith(
+        failurePayload429One.headers['retry-after'],
+        'startFailoverTimer'
+      );
+      expect((reg as any).retryAfter).toEqual(failurePayload429One.headers['retry-after']);
+
+      jest.useRealTimers();
+    });
+
+    it('sets retryAfter when reconnectOnFailure caller receives 429 after keepalive threshold miss', async () => {
+      await beforeEachSetupForKeepalive();
+      const retry429Spy = jest.spyOn(reg, 'handle429Retry');
+      // On reconnectOnFailure(RECONNECT_ON_FAILURE_UTIL) first restore attempt, make registration respond with 429 (retry-after: 20)
+      webex.request.mockRejectedValueOnce({
+        statusCode: 429,
+        body: mockPostResponse,
+        headers: {'retry-after': 20},
+      });
+
+      // Trigger the keepalive failure at threshold to route to reconnectOnFailure(RECONNECT_ON_FAILURE_UTIL)
+      const threshold = reg.isCCFlow ? 4 : 5;
+      reg.webWorker.onmessage({
+        data: {
+          type: WorkerMessageType.KEEPALIVE_FAILURE,
+          err: {statusCode: 503},
+          keepAliveRetryCount: threshold,
+        },
+      } as MessageEvent);
+
+      await flushPromises();
+
+      // handle429Retry is called with caller 'reconnectOnFailure' → else branch executes and sets retryAfter
+      expect(retry429Spy).toBeCalledOnceWith(20, RECONNECT_ON_FAILURE_UTIL);
+      expect(reg.retryAfter).toEqual(20);
     });
   });
 

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -1604,7 +1604,7 @@ describe('Registration Tests', () => {
       );
     });
 
-    it('ensure retryAfter is set (line 291) when 429 occurs during failover retry', async () => {
+    it('ensure retryAfter is set when 429 occurs during failover retry', async () => {
       await beforeEachSetupForKeepalive();
       // Simulate loss of registration so failover path attempts a new registration
       reg.clearKeepaliveTimer();

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -727,6 +727,110 @@ describe('Registration Tests', () => {
     });
   });
 
+  describe('restorePreviousRegistration 429 handling tests', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.clearAllMocks();
+      jest.useRealTimers();
+    });
+
+    it('should schedule retry when 429 with retry-after < 60 seconds during reconnect', async () => {
+      restartSpy = jest.spyOn(reg, 'restartRegistration');
+      reg.setActiveMobiusUrl(mobiusUris.primary[0]);
+      const failurePayload429Small = <WebexRequestPayload>(<unknown>{
+        statusCode: 429,
+        body: 'SOMETHING RANDOM',
+        headers: {
+          'retry-after': 30,
+        },
+      });
+      webex.request
+        .mockRejectedValueOnce(failurePayload429Small)
+        .mockResolvedValueOnce(successPayload)
+        .mockRejectedValueOnce(failurePayload429Small)
+        .mockResolvedValueOnce(successPayload);
+
+      await reg.reconnectOnFailure('SOMETHING RANDOM'); // This call is being used to set the retry-after value
+
+      await reg.reconnectOnFailure('SOMETHING RANDOM'); // This call is being used to trigger the retry
+      jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
+      await flushPromises();
+
+      expect(restartSpy).toHaveBeenCalledTimes(1);
+      expect(restartSpy).toHaveBeenCalledWith('SOMETHING RANDOM');
+    });
+
+    it('should try backup servers when 429 with retry-after >= 60 seconds on primary during reconnect', async () => {
+      // Setup: Register successfully with primary first
+      const attemptRegistrationWithServersSpy = jest.spyOn(reg, 'attemptRegistrationWithServers');
+      reg.setActiveMobiusUrl(mobiusUris.primary[0]);
+      const failurePayload429Small = <WebexRequestPayload>(<unknown>{
+        statusCode: 429,
+        body: 'SOMETHING RANDOM',
+        headers: {
+          'retry-after': 100,
+        },
+      });
+      webex.request
+        .mockRejectedValueOnce(failurePayload429Small)
+        .mockResolvedValueOnce(successPayload)
+        .mockRejectedValueOnce(failurePayload429Small)
+        .mockResolvedValueOnce(successPayload);
+
+      await reg.reconnectOnFailure('SOMETHING RANDOM'); // This call is being used to trigger the retry
+      jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
+      await flushPromises();
+
+      expect(attemptRegistrationWithServersSpy).toHaveBeenCalledTimes(2);
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(1, 'SOMETHING RANDOM', [
+        mobiusUris.primary[0],
+      ]);
+      // Immediately try backup servers when retry-after >= 60 seconds on primary
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(
+        2,
+        'SOMETHING RANDOM',
+        mobiusUris.backup
+      );
+    });
+    it('should restart registration with primary if we get 429 while on backup', async () => {
+      // Setup: Register successfully with primary first
+      restartSpy = jest.spyOn(reg, 'restartRegistration');
+      const attemptRegistrationWithServersSpy = jest.spyOn(reg, 'attemptRegistrationWithServers');
+      reg.setActiveMobiusUrl(mobiusUris.backup[0]);
+      const failurePayload429Small = <WebexRequestPayload>(<unknown>{
+        statusCode: 429,
+        body: 'SOMETHING RANDOM',
+        headers: {
+          'retry-after': 100,
+        },
+      });
+      webex.request
+        .mockRejectedValueOnce(failurePayload429Small)
+        .mockResolvedValueOnce(successPayload)
+        .mockRejectedValueOnce(failurePayload429Small)
+        .mockResolvedValueOnce(successPayload);
+
+      await reg.reconnectOnFailure('SOMETHING RANDOM'); // This call is being used to trigger the retry
+      jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
+      await flushPromises();
+
+      expect(attemptRegistrationWithServersSpy).toHaveBeenCalledTimes(2);
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(1, 'SOMETHING RANDOM', [
+        mobiusUris.backup[0],
+      ]);
+      // Immediately try primary servers when retry-after >= 60 seconds on backup
+      expect(restartSpy).toHaveBeenCalledTimes(1);
+      expect(restartSpy).toHaveBeenCalledWith('SOMETHING RANDOM');
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(2, 'SOMETHING RANDOM', [
+        mobiusUris.primary[0],
+      ]);
+    });
+  });
+
   describe('Registration failover tests', () => {
     it('verify unreachable primary with reachable backup servers', async () => {
       jest.useFakeTimers();
@@ -872,7 +976,10 @@ describe('Registration Tests', () => {
       // delete should be successful
       global.fetch = jest.fn(() => Promise.resolve({json: () => mockDeleteResponse})) as jest.Mock;
 
-      postRegistrationSpy.mockRejectedValue(failurePayload429Two);
+      // Mock to fail twice with 429 (once for executeFailback, once for restorePreviousRegistration)
+      postRegistrationSpy
+        .mockRejectedValueOnce(failurePayload429Two)
+        .mockRejectedValueOnce(failurePayload429Two);
 
       /* Wait for failback to be triggered. */
       jest.advanceTimersByTime(
@@ -892,11 +999,14 @@ describe('Registration Tests', () => {
         failurePayload429Two.headers['retry-after'],
         'executeFailback'
       );
-      expect(reg.failback429RetryAttempts).toBe(0);
+      // After handling 429 during failback, the counter is incremented to 1
+      expect(reg.failback429RetryAttempts).toBe(1);
       expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
       expect(restoreSpy).toBeCalledOnceWith(REG_429_RETRY_UTIL);
-      expect(restartSpy).toBeCalledOnceWith(REG_429_RETRY_UTIL);
-      expect(reg.failbackTimer).toBe(undefined);
+      // restartRegistration is not called immediately because 429 with retry-after < 60
+      // schedules a delayed retry instead
+      expect(restartSpy).not.toBeCalled();
+      expect(reg.failbackTimer).not.toBe(undefined); // Timer is set in handle429Retry
       expect(reg.rehomingIntervalMin).toBe(DEFAULT_REHOMING_INTERVAL_MIN);
       expect(reg.rehomingIntervalMax).toBe(DEFAULT_REHOMING_INTERVAL_MAX);
     });

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -43,6 +43,7 @@ const MockServiceData = {
   indicator: ServiceIndicator.CALLING,
   domain: '',
 };
+const TEST_RECONNECT_CALLER = 'TEST_RECONNECT_CALLER';
 const logSpy = jest.spyOn(log, 'log');
 const infoSpy = jest.spyOn(log, 'info');
 const warnSpy = jest.spyOn(log, 'warn');
@@ -743,7 +744,7 @@ describe('Registration Tests', () => {
       reg.setActiveMobiusUrl(mobiusUris.primary[0]);
       const failurePayload429Small = <WebexRequestPayload>(<unknown>{
         statusCode: 429,
-        body: 'SOMETHING RANDOM',
+        body: TEST_RECONNECT_CALLER,
         headers: {
           'retry-after': 30,
         },
@@ -754,14 +755,18 @@ describe('Registration Tests', () => {
         .mockRejectedValueOnce(failurePayload429Small)
         .mockResolvedValueOnce(successPayload);
 
-      await reg.reconnectOnFailure('SOMETHING RANDOM'); // This call is being used to set the retry-after value
+      await reg.reconnectOnFailure(TEST_RECONNECT_CALLER); // This call is being used to set the retry-after value
+      // Verify restore is invoked first and retry-after captured before scheduling
+      expect(restoreSpy).toBeCalledOnceWith(TEST_RECONNECT_CALLER);
+      expect(restartSpy).not.toBeCalled();
+      expect(reg.retryAfter).toEqual(30);
 
-      await reg.reconnectOnFailure('SOMETHING RANDOM'); // This call is being used to trigger the retry
+      await reg.reconnectOnFailure(TEST_RECONNECT_CALLER); // This call is being used to trigger the retry
       jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
       await flushPromises();
 
       expect(restartSpy).toHaveBeenCalledTimes(1);
-      expect(restartSpy).toHaveBeenCalledWith('SOMETHING RANDOM');
+      expect(restartSpy).toHaveBeenCalledWith(TEST_RECONNECT_CALLER);
     });
 
     it('should try backup servers when 429 with retry-after >= 60 seconds on primary during reconnect', async () => {
@@ -770,7 +775,7 @@ describe('Registration Tests', () => {
       reg.setActiveMobiusUrl(mobiusUris.primary[0]);
       const failurePayload429Small = <WebexRequestPayload>(<unknown>{
         statusCode: 429,
-        body: 'SOMETHING RANDOM',
+        body: TEST_RECONNECT_CALLER,
         headers: {
           'retry-after': 100,
         },
@@ -781,18 +786,21 @@ describe('Registration Tests', () => {
         .mockRejectedValueOnce(failurePayload429Small)
         .mockResolvedValueOnce(successPayload);
 
-      await reg.reconnectOnFailure('SOMETHING RANDOM'); // This call is being used to trigger the retry
+      await reg.reconnectOnFailure(TEST_RECONNECT_CALLER); // This call is being used to trigger the retry
+      // Verify restore gets invoked, 429 with retry-after is observed and captured
+      expect(restoreSpy).toBeCalledOnceWith(TEST_RECONNECT_CALLER);
+      expect(retry429Spy).toBeCalledOnceWith(100, TEST_RECONNECT_CALLER);
       jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
       await flushPromises();
 
       expect(attemptRegistrationWithServersSpy).toHaveBeenCalledTimes(2);
-      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(1, 'SOMETHING RANDOM', [
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(1, TEST_RECONNECT_CALLER, [
         mobiusUris.primary[0],
       ]);
       // Immediately try backup servers when retry-after >= 60 seconds on primary
       expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(
         2,
-        'SOMETHING RANDOM',
+        TEST_RECONNECT_CALLER,
         mobiusUris.backup
       );
     });
@@ -803,7 +811,7 @@ describe('Registration Tests', () => {
       reg.setActiveMobiusUrl(mobiusUris.backup[0]);
       const failurePayload429Small = <WebexRequestPayload>(<unknown>{
         statusCode: 429,
-        body: 'SOMETHING RANDOM',
+        body: TEST_RECONNECT_CALLER,
         headers: {
           'retry-after': 100,
         },
@@ -814,18 +822,23 @@ describe('Registration Tests', () => {
         .mockRejectedValueOnce(failurePayload429Small)
         .mockResolvedValueOnce(successPayload);
 
-      await reg.reconnectOnFailure('SOMETHING RANDOM'); // This call is being used to trigger the retry
+      await reg.reconnectOnFailure(TEST_RECONNECT_CALLER); // This call is being used to trigger the retry
+      // Verify restore path taken first and 429 handling captured
+      expect(restoreSpy).toBeCalledOnceWith(TEST_RECONNECT_CALLER);
+      expect(retry429Spy).toBeCalledOnceWith(100, TEST_RECONNECT_CALLER);
+      // No failover scheduling expected in this path
+      expect(failoverSpy).not.toBeCalled();
       jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
       await flushPromises();
 
       expect(attemptRegistrationWithServersSpy).toHaveBeenCalledTimes(2);
-      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(1, 'SOMETHING RANDOM', [
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(1, TEST_RECONNECT_CALLER, [
         mobiusUris.backup[0],
       ]);
       // Immediately try primary servers when retry-after >= 60 seconds on backup
       expect(restartSpy).toHaveBeenCalledTimes(1);
-      expect(restartSpy).toHaveBeenCalledWith('SOMETHING RANDOM');
-      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(2, 'SOMETHING RANDOM', [
+      expect(restartSpy).toHaveBeenCalledWith(TEST_RECONNECT_CALLER);
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(2, TEST_RECONNECT_CALLER, [
         mobiusUris.primary[0],
       ]);
     });

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -44,7 +44,6 @@ const MockServiceData = {
   indicator: ServiceIndicator.CALLING,
   domain: '',
 };
-const TEST_RECONNECT_CALLER = 'TEST_RECONNECT_CALLER';
 const logSpy = jest.spyOn(log, 'log');
 const infoSpy = jest.spyOn(log, 'info');
 const warnSpy = jest.spyOn(log, 'warn');
@@ -745,7 +744,7 @@ describe('Registration Tests', () => {
       reg.setActiveMobiusUrl(mobiusUris.primary[0]);
       const failurePayload429Small = <WebexRequestPayload>(<unknown>{
         statusCode: 429,
-        body: TEST_RECONNECT_CALLER,
+        body: RECONNECT_ON_FAILURE_UTIL,
         headers: {
           'retry-after': 30,
         },
@@ -756,18 +755,17 @@ describe('Registration Tests', () => {
         .mockRejectedValueOnce(failurePayload429Small)
         .mockResolvedValueOnce(successPayload);
 
-      await reg.reconnectOnFailure(TEST_RECONNECT_CALLER); // This call is being used to set the retry-after value
+      await reg.reconnectOnFailure(RECONNECT_ON_FAILURE_UTIL); // This call is being used to set the retry-after value
       // Verify restore is invoked first and retry-after captured before scheduling
-      expect(restoreSpy).toBeCalledOnceWith(TEST_RECONNECT_CALLER);
+      expect(restoreSpy).toBeCalledOnceWith(RECONNECT_ON_FAILURE_UTIL);
       expect(restartSpy).not.toBeCalled();
-      expect(reg.retryAfter).toEqual(30);
+      expect(reg.retryAfter).toEqual(undefined); // Clear retryAfter after 429 retry
 
-      await reg.reconnectOnFailure(TEST_RECONNECT_CALLER); // This call is being used to trigger the retry
       jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
       await flushPromises();
 
       expect(restartSpy).toHaveBeenCalledTimes(1);
-      expect(restartSpy).toHaveBeenCalledWith(TEST_RECONNECT_CALLER);
+      expect(restartSpy).toHaveBeenCalledWith(RECONNECT_ON_FAILURE_UTIL);
     });
 
     it('should try backup servers when 429 with retry-after >= 60 seconds on primary during reconnect', async () => {
@@ -776,7 +774,7 @@ describe('Registration Tests', () => {
       reg.setActiveMobiusUrl(mobiusUris.primary[0]);
       const failurePayload429Small = <WebexRequestPayload>(<unknown>{
         statusCode: 429,
-        body: TEST_RECONNECT_CALLER,
+        body: RECONNECT_ON_FAILURE_UTIL,
         headers: {
           'retry-after': 100,
         },
@@ -787,21 +785,23 @@ describe('Registration Tests', () => {
         .mockRejectedValueOnce(failurePayload429Small)
         .mockResolvedValueOnce(successPayload);
 
-      await reg.reconnectOnFailure(TEST_RECONNECT_CALLER); // This call is being used to trigger the retry
+      await reg.reconnectOnFailure(RECONNECT_ON_FAILURE_UTIL); // This call is being used to trigger the retry
       // Verify restore gets invoked, 429 with retry-after is observed and captured
-      expect(restoreSpy).toBeCalledOnceWith(TEST_RECONNECT_CALLER);
-      expect(retry429Spy).toBeCalledOnceWith(100, TEST_RECONNECT_CALLER);
+      expect(restoreSpy).toBeCalledOnceWith(RECONNECT_ON_FAILURE_UTIL);
+      expect(retry429Spy).toBeCalledOnceWith(100, RECONNECT_ON_FAILURE_UTIL);
       jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
       await flushPromises();
 
       expect(attemptRegistrationWithServersSpy).toHaveBeenCalledTimes(2);
-      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(1, TEST_RECONNECT_CALLER, [
-        mobiusUris.primary[0],
-      ]);
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(
+        1,
+        RECONNECT_ON_FAILURE_UTIL,
+        [mobiusUris.primary[0]]
+      );
       // Immediately try backup servers when retry-after >= 60 seconds on primary
       expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(
         2,
-        TEST_RECONNECT_CALLER,
+        RECONNECT_ON_FAILURE_UTIL,
         mobiusUris.backup
       );
     });
@@ -812,7 +812,7 @@ describe('Registration Tests', () => {
       reg.setActiveMobiusUrl(mobiusUris.backup[0]);
       const failurePayload429Small = <WebexRequestPayload>(<unknown>{
         statusCode: 429,
-        body: TEST_RECONNECT_CALLER,
+        body: RECONNECT_ON_FAILURE_UTIL,
         headers: {
           'retry-after': 100,
         },
@@ -823,25 +823,29 @@ describe('Registration Tests', () => {
         .mockRejectedValueOnce(failurePayload429Small)
         .mockResolvedValueOnce(successPayload);
 
-      await reg.reconnectOnFailure(TEST_RECONNECT_CALLER); // This call is being used to trigger the retry
+      await reg.reconnectOnFailure(RECONNECT_ON_FAILURE_UTIL); // This call is being used to trigger the retry
       // Verify restore path taken first and 429 handling captured
-      expect(restoreSpy).toBeCalledOnceWith(TEST_RECONNECT_CALLER);
-      expect(retry429Spy).toBeCalledOnceWith(100, TEST_RECONNECT_CALLER);
+      expect(restoreSpy).toBeCalledOnceWith(RECONNECT_ON_FAILURE_UTIL);
+      expect(retry429Spy).toBeCalledOnceWith(100, RECONNECT_ON_FAILURE_UTIL);
       // No failover scheduling expected in this path
       expect(failoverSpy).not.toBeCalled();
       jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
       await flushPromises();
 
       expect(attemptRegistrationWithServersSpy).toHaveBeenCalledTimes(2);
-      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(1, TEST_RECONNECT_CALLER, [
-        mobiusUris.backup[0],
-      ]);
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(
+        1,
+        RECONNECT_ON_FAILURE_UTIL,
+        [mobiusUris.backup[0]]
+      );
       // Immediately try primary servers when retry-after >= 60 seconds on backup
       expect(restartSpy).toHaveBeenCalledTimes(1);
-      expect(restartSpy).toHaveBeenCalledWith(TEST_RECONNECT_CALLER);
-      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(2, TEST_RECONNECT_CALLER, [
-        mobiusUris.primary[0],
-      ]);
+      expect(restartSpy).toHaveBeenCalledWith(RECONNECT_ON_FAILURE_UTIL);
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(
+        2,
+        RECONNECT_ON_FAILURE_UTIL,
+        [mobiusUris.primary[0]]
+      );
     });
   });
 
@@ -1653,7 +1657,7 @@ describe('Registration Tests', () => {
 
       // handle429Retry is called with caller 'reconnectOnFailure' → else branch executes and sets retryAfter
       expect(retry429Spy).toBeCalledOnceWith(20, RECONNECT_ON_FAILURE_UTIL);
-      expect(reg.retryAfter).toEqual(20);
+      expect(reg.retryAfter).toEqual(undefined); // Clear retryAfter after 429 retry
     });
   });
 

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -32,6 +32,7 @@ import {
   REG_TRY_BACKUP_TIMER_VAL_IN_SEC,
   SEC_TO_MSEC_MFACTOR,
   RECONNECT_ON_FAILURE_UTIL,
+  METHODS,
 } from '../constants';
 import {ICall} from '../calling/types';
 import {LINE_EVENTS} from '../line/types';
@@ -804,6 +805,8 @@ describe('Registration Tests', () => {
         RECONNECT_ON_FAILURE_UTIL,
         mobiusUris.backup
       );
+      expect(restartSpy).not.toHaveBeenCalledTimes(1);
+      expect(restartSpy).not.toHaveBeenCalledWith(RECONNECT_ON_FAILURE_UTIL);
     });
     it('should restart registration with primary if we get 429 while on backup', async () => {
       // Setup: Register successfully with primary first
@@ -846,6 +849,83 @@ describe('Registration Tests', () => {
         RECONNECT_ON_FAILURE_UTIL,
         [mobiusUris.primary[0]]
       );
+    });
+  });
+
+  describe('handleConnectionRestoration 429 handling tests', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.clearAllMocks();
+      jest.useRealTimers();
+    });
+
+    it('should schedule retry when 429 with retry-after < 60 seconds during handleConnectionRestoration', async () => {
+      reg.setActiveMobiusUrl(mobiusUris.primary[0]);
+      const failurePayload429Small = <WebexRequestPayload>(<unknown>{
+        statusCode: 429,
+        body: RECONNECT_ON_FAILURE_UTIL,
+        headers: {
+          'retry-after': 30,
+        },
+      });
+      webex.request
+        .mockRejectedValueOnce(failurePayload429Small)
+        .mockResolvedValueOnce(successPayload)
+        .mockRejectedValueOnce(failurePayload429Small)
+        .mockResolvedValueOnce(successPayload);
+
+      await reg.handleConnectionRestoration(true);
+      expect(restoreSpy).toBeCalledOnceWith(METHODS.HANDLE_CONNECTION_RESTORATION);
+      expect(restartSpy).not.toBeCalled();
+      expect(reg.retryAfter).toEqual(undefined); // Clear retryAfter after 429 retry
+
+      jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
+      await flushPromises();
+
+      expect(restartSpy).toHaveBeenCalledTimes(1);
+      expect(restartSpy).toHaveBeenCalledWith(METHODS.HANDLE_CONNECTION_RESTORATION);
+    });
+
+    it('should try backup servers when 429 with retry-after >= 60 seconds on primary during handleConnectionRestoration', async () => {
+      const attemptRegistrationWithServersSpy = jest.spyOn(reg, 'attemptRegistrationWithServers');
+      reg.setActiveMobiusUrl(mobiusUris.primary[0]);
+      const failurePayload429Small = <WebexRequestPayload>(<unknown>{
+        statusCode: 429,
+        body: RECONNECT_ON_FAILURE_UTIL,
+        headers: {
+          'retry-after': 100,
+        },
+      });
+      webex.request
+        .mockRejectedValueOnce(failurePayload429Small)
+        .mockResolvedValueOnce(successPayload)
+        .mockRejectedValueOnce(failurePayload429Small)
+        .mockResolvedValueOnce(successPayload);
+
+      await reg.handleConnectionRestoration(true);
+      expect(restoreSpy).toBeCalledOnceWith(METHODS.HANDLE_CONNECTION_RESTORATION);
+      expect(retry429Spy).toBeCalledOnceWith(100, METHODS.HANDLE_CONNECTION_RESTORATION);
+      jest.advanceTimersByTime(40 * SEC_TO_MSEC_MFACTOR);
+      await flushPromises();
+
+      expect(attemptRegistrationWithServersSpy).toHaveBeenCalledTimes(2);
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(
+        1,
+        METHODS.HANDLE_CONNECTION_RESTORATION,
+        [mobiusUris.primary[0]]
+      );
+      // Immediately try backup servers when retry-after >= 60 seconds on primary
+      expect(attemptRegistrationWithServersSpy).toHaveBeenNthCalledWith(
+        2,
+        METHODS.HANDLE_CONNECTION_RESTORATION,
+        mobiusUris.backup
+      );
+      expect(restartSpy).not.toHaveBeenCalledTimes(1);
+      expect(restartSpy).not.toHaveBeenCalledWith(METHODS.HANDLE_CONNECTION_RESTORATION);
     });
   });
 

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -207,9 +207,32 @@ export class Registration implements IRegistration {
    */
   private async restorePreviousRegistration(caller: string): Promise<boolean> {
     let abort = false;
-
+    // Testing:
+    // 4XX
+    // 429 big n small value
+    // 404
+    // 500
     if (this.activeMobiusUrl) {
       abort = await this.attemptRegistrationWithServers(caller, [this.activeMobiusUrl]);
+      if (this.retryAfter) {
+        if (this.retryAfter < RETRY_TIMER_UPPER_LIMIT) {
+          // If retry-after is less than threshold, honor it and schedule retry
+          setTimeout(async () => {
+            await this.restartRegistration(caller);
+          }, this.retryAfter * 1000);
+        } else if (
+          this.primaryMobiusUris.includes(this.activeMobiusUrl) &&
+          this.backupMobiusUris.length > 0
+        ) {
+          // If we are using primary and got 429, switch to backup
+          abort = await this.attemptRegistrationWithServers(caller, this.backupMobiusUris);
+        } else {
+          // If we are using backup and got 429, restart registration
+          this.restartRegistration(caller);
+        }
+
+        return true;
+      }
     }
 
     return abort;

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -207,11 +207,7 @@ export class Registration implements IRegistration {
    */
   private async restorePreviousRegistration(caller: string): Promise<boolean> {
     let abort = false;
-    // Testing:
-    // 4XX
-    // 429 big n small value
-    // 404
-    // 500
+
     if (this.activeMobiusUrl) {
       abort = await this.attemptRegistrationWithServers(caller, [this.activeMobiusUrl]);
       if (this.retryAfter) {

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -55,6 +55,7 @@ import {
   REGISTRATION_UTIL,
   METHODS,
   URL_ENDPOINT,
+  RECONNECT_ON_FAILURE_UTIL,
 } from '../constants';
 import {LINE_EVENTS, LineEmitterCallback} from '../line/types';
 import {LineError} from '../../Errors/catalog/LineError';
@@ -899,7 +900,7 @@ export class Registration implements IRegistration {
 
                 if (!abort) {
                   /* In case of non-final error, re-attempt registration */
-                  await this.reconnectOnFailure(KEEPALIVE_UTIL);
+                  await this.reconnectOnFailure(RECONNECT_ON_FAILURE_UTIL);
                 } else if (error.statusCode === 404) {
                   this.handle404KeepaliveFailure(KEEPALIVE_UTIL);
                 }

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -227,6 +227,7 @@ export class Registration implements IRegistration {
           // If we are using backup and got 429, restart registration
           this.restartRegistration(caller);
         }
+        this.retryAfter = undefined;
 
         return true;
       }


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # [JIRA](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-715146)

## This pull request addresses

- When a 429 fails we dont honor the retry-after values
- If the retry-after value is huge then we shouldnt wait and connect to the secondary (if connected to primary)
- If we get 429 with secondary then we should just unregister

## by making the following changes

- When 429 happens we honor the retry-after value and connect to secondary

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Unit tests
- Failed with 404, 403, 429
- Failed Primary with 429 ensured it conects to backup immediately
- Failed Primary with 429 with small retyr-after value - connects to Primary
- Failed Backup with 429 ensured it connects to backup -2 immediately

### 429- on primary and backup - moved to 2nd backup
<img width="1199" height="153" alt="429- on primary and backup - moved to 2nd backup" src="https://github.com/user-attachments/assets/3ba7670a-7560-47fe-8d59-f7ab0836da72" />

### 403-101 handling
<img width="726" height="213" alt="403-101 handling" src="https://github.com/user-attachments/assets/a74aa0f0-c8e7-4cd2-97f2-e0dcf6975d16" />

### 429-small interval - connect to primary
<img width="770" height="273" alt="429-small interval" src="https://github.com/user-attachments/assets/944a5a28-9829-42ab-b1a4-00b63d7452e4" />

### 429-big internal- fallback
<img width="1116" height="119" alt="429-big internal- fallback" src="https://github.com/user-attachments/assets/6c4476a2-d707-4273-b275-269f5478bc5f" />

### 429-big internal fallback
<img width="1396" height="363" alt="429-big internal fallback" src="https://github.com/user-attachments/assets/e88b9d6b-7b9c-441b-96e3-e53b25afb303" />

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
