### PR TITLE
Add prelogin metrics

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -259,7 +259,17 @@ class Metrics extends WebexPlugin {
    * Call Analyzer: Pre-Login Event
    * @param args
    */
-  submitPreLoginEvent(preLoginId: string, name: string, payload: EventPayload): Promise<any> {
+  SubmitPreLoginEvent({
+    name,
+    preLoginId,
+    payload,
+    metadata,
+  }: {
+    name: string;
+    preLoginId: string;
+    payload: EventPayload;
+    metadata?: EventPayload;
+  }): Promise<void> {
     if (!this.isReady) {
       // @ts-ignore
       this.webex.logger.log(
@@ -269,7 +279,12 @@ class Metrics extends WebexPlugin {
       return Promise.resolve();
     }
 
-    return this.preLoginMetrics.submitPreLoginEvent(preLoginId, name, payload);
+    return this.preLoginMetrics.submitPreLoginEvent({
+      name,
+      preLoginId,
+      payload,
+      metadata,
+    });
   }
 
   /**

--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -9,6 +9,7 @@ import CallDiagnosticMetrics from './call-diagnostic/call-diagnostic-metrics';
 import BehavioralMetrics from './behavioral-metrics';
 import OperationalMetrics from './operational-metrics';
 import BusinessMetrics from './business-metrics';
+import PreLoginMetrics from './prelogin-metrics';
 import {
   RecursivePartial,
   MetricEventProduct,
@@ -45,6 +46,7 @@ class Metrics extends WebexPlugin {
   behavioralMetrics: BehavioralMetrics;
   operationalMetrics: OperationalMetrics;
   businessMetrics: BusinessMetrics;
+  preLoginMetrics: PreLoginMetrics;
   isReady = false;
 
   /**
@@ -87,6 +89,8 @@ class Metrics extends WebexPlugin {
     this.webex.once('ready', () => {
       // @ts-ignore
       this.callDiagnosticMetrics = new CallDiagnosticMetrics({}, {parent: this.webex});
+      // @ts-ignore
+      this.preLoginMetrics = new PreLoginMetrics({}, {parent: this.webex});
       this.isReady = true;
       this.setDelaySubmitClientEvents({
         shouldDelay: this.delaySubmitClientEvents,
@@ -249,6 +253,23 @@ class Metrics extends WebexPlugin {
     this.lazyBuildBusinessMetrics();
 
     return this.businessMetrics.submitBusinessEvent({name, payload, table, metadata});
+  }
+
+  /**
+   * Call Analyzer: Pre-Login Event
+   * @param args
+   */
+  submitPreLoginEvent(preLoginId: string, name: string, payload: EventPayload): Promise<any> {
+    if (!this.isReady) {
+      // @ts-ignore
+      this.webex.logger.log(
+        `NewMetrics: @submitPreLoginEvent. Attempted to submit before webex.ready: ${name}`
+      );
+
+      return Promise.resolve();
+    }
+
+    return this.preLoginMetrics.submitPreLoginEvent(preLoginId, name, payload);
   }
 
   /**

--- a/packages/@webex/internal-plugin-metrics/src/prelogin-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/prelogin-metrics.ts
@@ -1,0 +1,62 @@
+import GenericMetrics from './generic-metrics';
+import {EventPayload} from './metrics.types';
+import PreLoginMetricsBatcher from './prelogin-metrics-batcher';
+
+/**
+ * @param {string} name - Metric name
+ * @param {EventPayload} payload - Metric payload
+ * @returns {object} Metrics Payload
+ */
+function buildEvent(name: string, payload: EventPayload) {
+  return {
+    type: ['business'],
+    eventPayload: {
+      key: name,
+      client_timestamp: new Date().toISOString(),
+      // ...metadata,
+      value: payload,
+    },
+  };
+}
+
+/**
+ * @description Util class to handle PreLogin Metrics
+ * @export
+ * @class PreLoginMetrics
+ */
+export default class PreLoginMetrics extends GenericMetrics {
+  // @ts-ignore
+  private preLoginMetricsBatcher: PreLoginMetricsBatcher;
+
+  /**
+   * Constructor
+   * @param {any[]} args - Constructor arguments
+   * @constructor
+   */
+  constructor(...args) {
+    super(...args);
+    // @ts-ignore
+    this.logger = this.webex.logger;
+    // @ts-ignore
+    this.preLoginMetricsBatcher = new PreLoginMetricsBatcher({}, {parent: this.webex});
+  }
+
+  /**
+   * @param {string} preLoginId - A string representing the pre-login user ID
+   * @param {string} name - Metric name
+   * @param {EventPayload} payload - Metric payload
+   * @returns {Promise<any>} Metrics Payload
+   */
+  public submitPreLoginEvent(
+    preLoginId: string,
+    name: string,
+    payload: EventPayload
+  ): Promise<any> {
+    // build metrics-a event type
+    const finalEvent = buildEvent(name, payload);
+
+    this.preLoginMetricsBatcher.savePreLoginId(preLoginId);
+
+    return this.preLoginMetricsBatcher.request(finalEvent);
+  }
+}

--- a/packages/@webex/internal-plugin-metrics/src/prelogin-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/prelogin-metrics.ts
@@ -1,20 +1,31 @@
 import GenericMetrics from './generic-metrics';
-import {EventPayload} from './metrics.types';
+import {EventPayload, Table} from './metrics.types';
 import PreLoginMetricsBatcher from './prelogin-metrics-batcher';
 
 /**
+ * Builds a formatted event object for metrics submission.
  * @param {string} name - Metric name
- * @param {EventPayload} payload - Metric payload
- * @returns {object} Metrics Payload
+ * @param {string} preLoginId - Pre-login user identifier
+ * @param {EventPayload} payload - Metric payload data
+ * @param {EventPayload} metadata - Additional metadata to include in the event
+ * @returns {object} Formatted metrics event object with type, eventPayload, and timestamp
  */
-function buildEvent(name: string, payload: EventPayload) {
+function buildEvent(
+  name: string,
+  preLoginId: string,
+  payload: EventPayload,
+  metadata: EventPayload
+) {
+  const payloadWithPreLoginId = {...payload, preLoginId};
+
   return {
     type: ['business'],
     eventPayload: {
       key: name,
       client_timestamp: new Date().toISOString(),
-      // ...metadata,
-      value: payload,
+      preLoginId,
+      ...metadata,
+      value: payloadWithPreLoginId,
     },
   };
 }
@@ -42,18 +53,35 @@ export default class PreLoginMetrics extends GenericMetrics {
   }
 
   /**
-   * @param {string} preLoginId - A string representing the pre-login user ID
-   * @param {string} name - Metric name
-   * @param {EventPayload} payload - Metric payload
-   * @returns {Promise<any>} Metrics Payload
+   * Submit a business metric to our metrics endpoint.
+   * Routes to the correct table with the correct schema payload by table.
+   * @see https://confluence-eng-gpk2.cisco.com/conf/display/WAP/Business+metrics++-%3E+ROMA
+   * @param {Object} options - The options object
+   * @param {string} options.name - Name of the metric
+   * @param {string} options.preLoginId - ID to identify pre-login user
+   * @param {EventPayload} options.payload - User payload of the metric
+   * @param {EventPayload} [options.metadata] - Optional metadata to include outside of eventPayload.value
+   * @returns {Promise<void>} Promise that resolves when the metric is submitted
    */
-  public submitPreLoginEvent(
-    preLoginId: string,
-    name: string,
-    payload: EventPayload
-  ): Promise<any> {
-    // build metrics-a event type
-    const finalEvent = buildEvent(name, payload);
+  public submitPreLoginEvent({
+    name,
+    preLoginId,
+    payload,
+    metadata,
+  }: {
+    name: string;
+    preLoginId: string;
+    payload: EventPayload;
+    metadata?: EventPayload;
+  }): Promise<void> {
+    if (!metadata) {
+      metadata = {};
+    }
+    if (!metadata.appType) {
+      metadata.appType = 'Web Client';
+    }
+
+    const finalEvent = buildEvent(name, preLoginId, payload, metadata);
 
     this.preLoginMetricsBatcher.savePreLoginId(preLoginId);
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

We would like to send pre-login metrics i.e. add a new  API to the new-metrics plugin to support sending metrics before the user is authenticated. 

Much of the code for this already existed and was used by calling, however this uses cases are very much calling specific, so we added a non calling specific API to send pre login metics

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
