### PR TITLE
fix(callhistory): add wxc backend support for shared sessions in CH

### DIFF
--- a/packages/calling/src/CallHistory/CallHistory.ts
+++ b/packages/calling/src/CallHistory/CallHistory.ts
@@ -139,12 +139,9 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
     log.info(`Janus API URL: ${this.janusUrl}`, this.loggerContext);
     log.info(`Call history from date : ${this.fromDate}`, this.loggerContext);
 
-    let url: string;
-    if (callingBackend === CALLING_BACKEND.WXC) {
-      url = `${this.janusUrl}/${HISTORY}/${USER_SESSIONS}${FROM_DATE}=${this.fromDate}&limit=${limit}&includeNewSessionTypes=true&sort=${sortParam}&includeSharedSessions=true`;
-    } else {
-      url = `${this.janusUrl}/${HISTORY}/${USER_SESSIONS}${FROM_DATE}=${this.fromDate}&limit=${limit}&includeNewSessionTypes=true&sort=${sortParam}`;
-    }
+    const sharedSessionsParam =
+      callingBackend === CALLING_BACKEND.WXC ? '&includeSharedSessions=true' : '';
+    const url = `${this.janusUrl}/${HISTORY}/${USER_SESSIONS}${FROM_DATE}=${this.fromDate}&limit=${limit}&includeNewSessionTypes=true&sort=${sortParam}${sharedSessionsParam}`;
 
     try {
       const janusResponse = <WebexRequestPayload>await this.webex.request({

--- a/packages/calling/src/CallHistory/CallHistory.ts
+++ b/packages/calling/src/CallHistory/CallHistory.ts
@@ -125,7 +125,7 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
       2. Calculating the fromDate by deducting the NUMBER_OF_DAYS with the current date
      */
     const date = new Date();
-
+    const callingBackend = getCallingBackEnd(this.webex);
     date.setDate(date.getDate() - days);
     this.fromDate = date.toISOString();
     const sortByParam = Object.values(SORT_BY).includes(sortBy) ? sortBy : SORT_BY.DEFAULT;
@@ -138,7 +138,13 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
 
     log.info(`Janus API URL: ${this.janusUrl}`, this.loggerContext);
     log.info(`Call history from date : ${this.fromDate}`, this.loggerContext);
-    const url = `${this.janusUrl}/${HISTORY}/${USER_SESSIONS}${FROM_DATE}=${this.fromDate}&limit=${limit}&includeNewSessionTypes=true&sort=${sortParam}`;
+
+    let url: string;
+    if (callingBackend === CALLING_BACKEND.WXC) {
+      url = `${this.janusUrl}/${HISTORY}/${USER_SESSIONS}${FROM_DATE}=${this.fromDate}&limit=${limit}&includeNewSessionTypes=true&sort=${sortParam}&includeSharedSessions=true`;
+    } else {
+      url = `${this.janusUrl}/${HISTORY}/${USER_SESSIONS}${FROM_DATE}=${this.fromDate}&limit=${limit}&includeNewSessionTypes=true&sort=${sortParam}`;
+    }
 
     try {
       const janusResponse = <WebexRequestPayload>await this.webex.request({
@@ -166,7 +172,6 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
         }
       }
       // Check the calling backend
-      const callingBackend = getCallingBackEnd(this.webex);
       if (callingBackend === CALLING_BACKEND.UCM) {
         // Check if userSessions exist and the length is greater than 0
         if (this.userSessions[USER_SESSIONS] && this.userSessions[USER_SESSIONS].length > 0) {

--- a/packages/calling/src/CallHistory/CallHistory.ts
+++ b/packages/calling/src/CallHistory/CallHistory.ts
@@ -139,8 +139,17 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
     log.info(`Janus API URL: ${this.janusUrl}`, this.loggerContext);
     log.info(`Call history from date : ${this.fromDate}`, this.loggerContext);
 
+    /* For MS Teams Cisco call app multiline support, WXC backend needs includeSharedSessions=true
+    to fetch calls with sessionType "WEBEXCALLING_SHARED" */
     const sharedSessionsParam =
       callingBackend === CALLING_BACKEND.WXC ? '&includeSharedSessions=true' : '';
+    // Log backend and whether shared sessions are included
+    log.info(
+      `Fetching call history for ${callingBackend} backend${
+        callingBackend === CALLING_BACKEND.WXC ? ' with shared sessions' : ''
+      }`,
+      this.loggerContext
+    );
     const url = `${this.janusUrl}/${HISTORY}/${USER_SESSIONS}${FROM_DATE}=${this.fromDate}&limit=${limit}&includeNewSessionTypes=true&sort=${sortParam}${sharedSessionsParam}`;
 
     try {

--- a/packages/calling/src/CallHistory/CallHistory.ts
+++ b/packages/calling/src/CallHistory/CallHistory.ts
@@ -141,11 +141,9 @@ export class CallHistory extends Eventing<CallHistoryEventTypes> implements ICal
     log.info(`Janus API URL: ${this.janusUrl}`, this.loggerContext);
     log.info(`Call history from date : ${this.fromDate}`, this.loggerContext);
 
-    /* For MS Teams Cisco call app multiline support, WXC backend needs includeSharedSessions=true
-    to fetch calls with sessionType "WEBEXCALLING_SHARED" */
+    // Add includeSharedSessions=true parameter for WXC backend to fetch calls with sessionType "WEBEXCALLING_SHARED"
     const sharedSessionsParam =
       callingBackend === CALLING_BACKEND.WXC ? '&includeSharedSessions=true' : '';
-    // Log backend and whether shared sessions are included
     log.info(
       `Fetching call history for ${callingBackend} backend${
         callingBackend === CALLING_BACKEND.WXC ? ' with shared sessions' : ''


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-713061 >

## This pull request addresses
To support multilines for call history within MS Teams Cisco call app we need to introduce an additional parameter "includeSharedSessions=true" to fetch the calls related to "sessionType": "WEBEXCALLING_SHARED".

Implemented conditional URL construction - Different URLs for WXC vs other backends:
WXC backend: Includes &includeSharedSessions=true parameter
Other backends: Standard URL without shared sessions parameter

## by making the following changes

callhistory response 
[multiline_Vijay_response.txt](https://github.com/user-attachments/files/23575103/multiline_Vijay_response.txt)
<img width="1148" height="1041" alt="Screenshot 2025-11-17 at 12 26 33 PM" src="https://github.com/user-attachments/assets/7f4af35f-c2e9-488b-856c-7d30d6da75d4" />


POC multiline 
<img width="1317" height="874" alt="PoC_multilines" src="https://github.com/user-attachments/assets/8c63d72d-9861-4aec-ab25-443478b01f47" />

Webex Calling User
<img width="1728" height="1117" alt="Screenshot 2025-11-12 at 5 34 52 PM" src="https://github.com/user-attachments/assets/6bb39321-90f7-4cc1-ab3f-959a8702120d" />

UCMC User
<img width="1728" height="1117" alt="Screenshot 2025-11-12 at 5 19 56 PM" src="https://github.com/user-attachments/assets/2ee73c64-0c58-4571-8c54-95132d690d7f" />


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
