### PR TITLE
fix(u2cv2): js error when update catalog with empty hostmap

### DIFF
--- a/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
@@ -119,7 +119,7 @@ const ServiceCatalog = AmpState.extend({
     // declare namespaces outside of loop
     let existingService: IServiceDetail | undefined;
 
-    serviceDetails.forEach((service) => {
+    serviceDetails?.forEach((service) => {
       existingService = this._getServiceDetail(service.id, serviceGroup);
 
       if (existingService) {

--- a/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/service-catalog.ts
@@ -311,13 +311,13 @@ const ServiceCatalog = AmpState.extend({
   ) {
     const currentServiceDetails = this.serviceGroups[serviceGroup];
 
-    const unusedServicesDetails = currentServiceDetails.filter((serviceDetail) =>
-      serviceDetails.every(({id}) => id !== serviceDetail.id)
+    const unusedServicesDetails = currentServiceDetails?.filter((serviceDetail) =>
+      serviceDetails?.every(({id}) => id !== serviceDetail.id)
     );
 
     this._unloadServiceDetails(serviceGroup, unusedServicesDetails);
 
-    serviceDetails.forEach((serviceObj) => {
+    serviceDetails?.forEach((serviceObj) => {
       const serviceDetail = this._getServiceDetail(serviceObj.id, serviceGroup);
       serviceObj?.serviceUrls?.sort((a, b) => {
         if (a.priority < 0 && b.priority < 0) return 0;

--- a/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
@@ -790,7 +790,7 @@ const Services = WebexPlugin.extend({
   _formatReceivedHostmap({services, activeServices, timestamp, orgId, format}) {
     const formattedHostmap: ServiceHostmap = {
       activeServices,
-      services: services.map((service) => this._formatHostMapEntry(service)),
+      services: services?.map((service) => this._formatHostMapEntry(service)),
       timestamp,
       orgId,
       format,

--- a/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
+++ b/packages/@webex/webex-core/src/lib/services-v2/services-v2.ts
@@ -545,7 +545,7 @@ const Services = WebexPlugin.extend({
   updateCatalog(serviceGroup: ServiceGroup, hostMap: ServiceHostmap): Promise<void> {
     const catalog = this._getCatalog();
 
-    const serviceHostMap = this._formatReceivedHostmap(hostMap);
+    const serviceHostMap = this._formatReceivedHostmap(hostMap || {});
 
     return catalog.updateServiceGroups(
       serviceGroup,
@@ -957,7 +957,7 @@ const Services = WebexPlugin.extend({
 
     return this.webex.internal.newMetrics.callDiagnosticLatencies
       .measureLatency(() => this.request(requestObject), 'internal.get.u2c.time')
-      .then(({body}) => this._formatReceivedHostmap(body));
+      .then(({body}) => this._formatReceivedHostmap(body || {}));
   },
 
   /**

--- a/packages/@webex/webex-core/test/fixtures/host-catalog-v2.ts
+++ b/packages/@webex/webex-core/test/fixtures/host-catalog-v2.ts
@@ -153,5 +153,5 @@ export const serviceHostmapV2 = {
   services: formattedServiceHostmapV2,
   orgId: '3e0e410f-f83f-4ee4-ac32-12692e99355c',
   timestamp: '1745533341',
-  format: 'U2Cv2',
+  format: 'U2CV2',
 };

--- a/packages/@webex/webex-core/test/integration/spec/services-v2/service-catalog.js
+++ b/packages/@webex/webex-core/test/integration/spec/services-v2/service-catalog.js
@@ -599,7 +599,7 @@ describe('webex-core', () => {
           ],
           orgId: '3e0e410f-f83f-4ee4-ac32-12692e99355c',
           timestamp: '1745533341',
-          format: 'U2Cv2',
+          format: 'U2CV2',
         };
 
         catalog.updateServiceGroups('preauth', formattedHM.services);
@@ -686,7 +686,7 @@ describe('webex-core', () => {
           ],
           orgId: '3e0e410f-f83f-4ee4-ac32-12692e99355c',
           timestamp: '1745533341',
-          format: 'U2Cv2',
+          format: 'U2CV2',
         };
         const notInOrderFormattedHM = services._formatReceivedHostmap(notInOrderServiceHM);
         const checkFormattedHM = cloneDeep(notInOrderFormattedHM);

--- a/packages/@webex/webex-core/test/unit/spec/services-v2/services-v2.ts
+++ b/packages/@webex/webex-core/test/unit/spec/services-v2/services-v2.ts
@@ -331,6 +331,20 @@ describe('webex-core', () => {
 
         assert.deepEqual(result, [{some: 'value'}]);
       });
+      it('updates the catalog with empty hostmap', async () => {
+        const serviceGroup = 'postauth';
+        const hostmap = {};
+
+        services._formatReceivedHostmap = sinon.stub().returns({services : undefined});
+
+        catalog.updateServiceGroups = sinon.stub().returns(Promise.resolve([{some: 'value'}]));
+
+        const result = await services.updateCatalog(serviceGroup, hostmap);
+
+        assert.calledWith(services._formatReceivedHostmap, hostmap);
+
+        assert.calledWith(catalog.updateServiceGroups, serviceGroup, undefined);
+      });
     });
 
     describe('#_fetchNewServiceHostmap()', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-740806

## This pull request addresses
When user click sign in as host, will call updateCatalog with empty hostmap, just add the protection for it to escape the js error.

## by making the following changes
Add protection to escape js error

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
