### PR TITLE
fix(calling): moved-disconnect-event

### DIFF
--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -2222,6 +2222,19 @@ describe('State Machine handler tests', () => {
     );
   });
 
+  it('emits DISCONNECT before mobius delete request is invoked', async () => {
+    const emitSpy = jest.spyOn(call, 'emit');
+    const deleteSpy = jest.spyOn(call as any, 'delete').mockResolvedValue({statusCode: 200});
+
+    call.sendCallStateMachineEvt({type: 'E_RECV_CALL_DISCONNECT'} as CallEvent);
+
+    await flushPromises(1);
+
+    expect(emitSpy).toHaveBeenCalledWith(CALL_EVENT_KEYS.DISCONNECT, call.getCorrelationId());
+    expect(deleteSpy).toHaveBeenCalled();
+    expect(emitSpy.mock.invocationCallOrder[0]).toBeLessThan(deleteSpy.mock.invocationCallOrder[0]);
+  });
+
   describe('Call event timers tests', () => {
     let callManager;
     beforeEach(() => {

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -1385,6 +1385,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       method: METHODS.HANDLE_OUTGOING_CALL_DISCONNECT,
     });
 
+    this.emit(CALL_EVENT_KEYS.DISCONNECT, this.correlationId);
+
     this.setDisconnectReason();
 
     try {
@@ -1428,8 +1430,6 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
 
     this.sendMediaStateMachineEvt({type: 'E_ROAP_TEARDOWN'});
     this.sendCallStateMachineEvt({type: 'E_CALL_CLEARED'});
-
-    this.emit(CALL_EVENT_KEYS.DISCONNECT, this.correlationId);
   }
 
   /**

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -1382,7 +1382,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
   private async handleIncomingCallDisconnect(event: CallEvent) {
     log.info(`${METHOD_START_MESSAGE} with: ${this.getCorrelationId()}`, {
       file: CALL_FILE,
-      method: METHODS.HANDLE_OUTGOING_CALL_DISCONNECT,
+      method: METHODS.HANDLE_INCOMING_CALL_DISCONNECT,
     });
 
     this.emit(CALL_EVENT_KEYS.DISCONNECT, this.correlationId);
@@ -1394,12 +1394,12 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
 
       log.log(`Response code: ${response.statusCode}`, {
         file: CALL_FILE,
-        method: METHODS.HANDLE_OUTGOING_CALL_DISCONNECT,
+        method: METHODS.HANDLE_INCOMING_CALL_DISCONNECT,
       });
     } catch (e) {
       log.warn(`Failed to delete the call: ${JSON.stringify(e)}`, {
         file: CALL_FILE,
-        method: METHODS.HANDLE_OUTGOING_CALL_DISCONNECT,
+        method: METHODS.HANDLE_INCOMING_CALL_DISCONNECT,
       });
 
       uploadLogs({


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< AD-HOC (CC LSAC Issue) >

## This pull request addresses

* Currently in the calling SDK, whenever we get a DISCONNECT from mobius, state machine calls `handleIncomingCallDisconnect()`.
* Now here, we were sending a DELETE request to mobius and then emitting DISCONNECT event from the SDK.
* On agent desktop, they were listening to this event and clearing their call.
* However, for some customers it was observed that the DELETE was taking long time (around 4-5 seconds) due to network delays and hence this messed up agent desktop cleanup and flow of events.

## by making the following changes

* Changes were made to emit DISCONNECT as soon as we get the event from mobius, i.e as soon as method fires.
* Unit test was added to enforce this change

Vidcast (Tetsing Sample App) - https://app.vidcast.io/share/e93f41f0-9a4f-464c-9dba-ba01413811a3

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested basic incoming call disconnect on sample.
* Tests with web client and agent desktop are a WIP

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
