### PR TITLE
fix(calling): fix the timer issue for call keepalive

### DIFF
--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -948,7 +948,7 @@ describe('State Machine handler tests', () => {
     call['callStateMachine'].state.value = 'S_SEND_CALL_CONNECT';
 
     webex.request.mockReturnValue(statusPayload);
-    jest.spyOn(global, 'setTimeout');
+    jest.spyOn(global, 'setInterval');
 
     const funcSpy = jest.spyOn(call, 'postStatus').mockResolvedValue(statusPayload);
     const logSpy = jest.spyOn(log, 'info');
@@ -962,12 +962,12 @@ describe('State Machine handler tests', () => {
      */
     await flushPromises(3);
 
-    expect(setTimeout).toHaveBeenCalledTimes(2);
-    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), DEFAULT_SESSION_TIMER);
+    expect(setInterval).toHaveBeenCalledTimes(1);
+    expect(setInterval).toHaveBeenCalledWith(expect.any(Function), DEFAULT_SESSION_TIMER);
     expect(funcSpy).toBeCalledTimes(1);
     expect(logSpy).toBeCalledWith('Session refresh successful', {
       file: 'call',
-      method: 'handleCallEstablished',
+      method: 'scheduleCallKeepaliveInterval',
     });
     expect(logSpy).toHaveBeenCalledWith(
       `${METHOD_START_MESSAGE} with: ${call.getCorrelationId()}`,
@@ -985,7 +985,7 @@ describe('State Machine handler tests', () => {
     });
 
     webex.request.mockReturnValue(statusPayload);
-    jest.spyOn(global, 'clearTimeout');
+    jest.spyOn(global, 'clearInterval');
 
     const emitSpy = jest.spyOn(call, 'emit');
 
@@ -1001,7 +1001,7 @@ describe('State Machine handler tests', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(clearTimeout).toHaveBeenCalledTimes(1);
+    expect(clearInterval).toHaveBeenCalledTimes(1);
     expect(funcSpy).toBeCalledTimes(1);
     expect(emitSpy).toHaveBeenCalledWith(CALL_EVENT_KEYS.DISCONNECT, call.getCorrelationId());
   });
@@ -1013,7 +1013,7 @@ describe('State Machine handler tests', () => {
     });
 
     webex.request.mockReturnValue(statusPayload);
-    jest.spyOn(global, 'clearTimeout');
+    jest.spyOn(global, 'clearInterval');
 
     call.on(CALL_EVENT_KEYS.CALL_ERROR, (errObj) => {
       expect(errObj.type).toStrictEqual(ERROR_TYPE.FORBIDDEN_ERROR);
@@ -1040,7 +1040,7 @@ describe('State Machine handler tests', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(clearTimeout).toHaveBeenCalledTimes(2);
+    expect(clearInterval).toHaveBeenCalledTimes(1);
     expect(funcSpy).toBeCalledTimes(1);
   });
 
@@ -1054,7 +1054,7 @@ describe('State Machine handler tests', () => {
 
     const okPayload = <WebexRequestPayload>(<unknown>{statusCode: 200, body: {}});
 
-    const sendEvtSpy = jest.spyOn(call as any, 'sendCallStateMachineEvt');
+    const scheduleKeepaliveSpy = jest.spyOn(call as any, 'scheduleCallKeepaliveInterval');
     const postStatusSpy = jest
       .spyOn(call as any, 'postStatus')
       .mockRejectedValueOnce(errorPayload)
@@ -1069,7 +1069,14 @@ describe('State Machine handler tests', () => {
     await Promise.resolve();
 
     expect(postStatusSpy).toHaveBeenCalledTimes(1);
-    expect(sendEvtSpy).toHaveBeenCalledWith({type: 'E_CALL_ESTABLISHED'});
+
+    // Now advance by 1 second for the retry-after interval
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(postStatusSpy).toHaveBeenCalledTimes(2);
+    expect(scheduleKeepaliveSpy).toHaveBeenCalled();
   });
 
   it('keepalive ends after reaching max retry count', async () => {
@@ -1100,8 +1107,11 @@ describe('State Machine handler tests', () => {
     jest.advanceTimersByTime(DEFAULT_SESSION_TIMER);
     await resolvePromise();
 
-    // Now advance by 1 second for each of the 3 more retry attempts (retry-after: 1 second each)
+    // Now advance by 1 second for each of the 4 retry attempts (retry-after: 1 second each)
     // Need to do this separately to allow state machine to process and create new intervals
+    jest.advanceTimersByTime(1000);
+    await resolvePromise();
+
     jest.advanceTimersByTime(1000);
     await resolvePromise();
 
@@ -1113,15 +1123,14 @@ describe('State Machine handler tests', () => {
 
     // The error handler should detect we're at max retry count and stop
     expect(warnSpy).toHaveBeenCalledWith(
-      `Max call keepalive retry attempts reached for call: ${call.getCorrelationId()}`,
+      `Max keepalive retry attempts reached. Aborting call keepalive for callId: ${call.getCallId()}`,
       {
         file: 'call',
-        method: 'handleCallEstablished',
+        method: 'keepaliveRetryCallback',
       }
     );
-    expect(postStatusSpy).toHaveBeenCalledTimes(4);
-    expect(call['callKeepaliveRetryCount']).toBe(0);
-    expect(call['sessionTimer']).toBeUndefined();
+    expect(postStatusSpy).toHaveBeenCalledTimes(5);
+    expect(call['callKeepaliveRetryCount']).toBe(4);
   });
 
   it('state changes during successful incoming call', async () => {

--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -948,7 +948,7 @@ describe('State Machine handler tests', () => {
     call['callStateMachine'].state.value = 'S_SEND_CALL_CONNECT';
 
     webex.request.mockReturnValue(statusPayload);
-    jest.spyOn(global, 'setInterval');
+    jest.spyOn(global, 'setTimeout');
 
     const funcSpy = jest.spyOn(call, 'postStatus').mockResolvedValue(statusPayload);
     const logSpy = jest.spyOn(log, 'info');
@@ -962,7 +962,8 @@ describe('State Machine handler tests', () => {
      */
     await flushPromises(3);
 
-    expect(setInterval).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledTimes(2);
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), DEFAULT_SESSION_TIMER);
     expect(funcSpy).toBeCalledTimes(1);
     expect(logSpy).toBeCalledWith('Session refresh successful', {
       file: 'call',
@@ -984,7 +985,7 @@ describe('State Machine handler tests', () => {
     });
 
     webex.request.mockReturnValue(statusPayload);
-    jest.spyOn(global, 'clearInterval');
+    jest.spyOn(global, 'clearTimeout');
 
     const emitSpy = jest.spyOn(call, 'emit');
 
@@ -1000,7 +1001,7 @@ describe('State Machine handler tests', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(clearInterval).toHaveBeenCalledTimes(1);
+    expect(clearTimeout).toHaveBeenCalledTimes(1);
     expect(funcSpy).toBeCalledTimes(1);
     expect(emitSpy).toHaveBeenCalledWith(CALL_EVENT_KEYS.DISCONNECT, call.getCorrelationId());
   });
@@ -1012,7 +1013,7 @@ describe('State Machine handler tests', () => {
     });
 
     webex.request.mockReturnValue(statusPayload);
-    jest.spyOn(global, 'clearInterval');
+    jest.spyOn(global, 'clearTimeout');
 
     call.on(CALL_EVENT_KEYS.CALL_ERROR, (errObj) => {
       expect(errObj.type).toStrictEqual(ERROR_TYPE.FORBIDDEN_ERROR);
@@ -1039,7 +1040,7 @@ describe('State Machine handler tests', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(clearInterval).toHaveBeenCalledTimes(2); // check this
+    expect(clearTimeout).toHaveBeenCalledTimes(2);
     expect(funcSpy).toBeCalledTimes(1);
   });
 

--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -1024,11 +1024,6 @@ describe('State Machine handler tests', () => {
 
     const funcSpy = jest.spyOn(call, 'postStatus').mockRejectedValue(statusPayload);
 
-    if (call['sessionTimer'] === undefined) {
-      /* In cases where this test is run independently/alone, there is no sessionTimer initiated
-      Thus we will check and initialize the timer when not present by calling handleCallEstablish() */
-      call['handleCallEstablished']({} as CallEvent);
-    }
     call['handleCallEstablished']({} as CallEvent);
 
     jest.advanceTimersByTime(DEFAULT_SESSION_TIMER);
@@ -1036,9 +1031,7 @@ describe('State Machine handler tests', () => {
     /* This is to flush all the promises from the Promise queue so that
      * Jest.fakeTimers can advance time and also clear the promise Queue
      */
-
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises(2);
 
     expect(clearInterval).toHaveBeenCalledTimes(1);
     expect(funcSpy).toBeCalledTimes(1);
@@ -1065,26 +1058,19 @@ describe('State Machine handler tests', () => {
     }
 
     jest.advanceTimersByTime(DEFAULT_SESSION_TIMER);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises(2);
 
     expect(postStatusSpy).toHaveBeenCalledTimes(1);
 
     // Now advance by 1 second for the retry-after interval
     jest.advanceTimersByTime(1000);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises(2);
 
     expect(postStatusSpy).toHaveBeenCalledTimes(2);
-    expect(scheduleKeepaliveSpy).toHaveBeenCalled();
+    expect(scheduleKeepaliveSpy).toHaveBeenCalledTimes(2);
   });
 
   it('keepalive ends after reaching max retry count', async () => {
-    const resolvePromise = async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    };
-
     const errorPayload = <WebexRequestPayload>(<unknown>{
       statusCode: 500,
       headers: {
@@ -1105,21 +1091,21 @@ describe('State Machine handler tests', () => {
 
     // Advance timer to trigger the first failure (uses DEFAULT_SESSION_TIMER)
     jest.advanceTimersByTime(DEFAULT_SESSION_TIMER);
-    await resolvePromise();
+    await flushPromises(2);
 
     // Now advance by 1 second for each of the 4 retry attempts (retry-after: 1 second each)
     // Need to do this separately to allow state machine to process and create new intervals
     jest.advanceTimersByTime(1000);
-    await resolvePromise();
+    await flushPromises(2);
 
     jest.advanceTimersByTime(1000);
-    await resolvePromise();
+    await flushPromises(2);
 
     jest.advanceTimersByTime(1000);
-    await resolvePromise();
+    await flushPromises(2);
 
     jest.advanceTimersByTime(1000);
-    await resolvePromise();
+    await flushPromises(2);
 
     // The error handler should detect we're at max retry count and stop
     expect(warnSpy).toHaveBeenCalledWith(

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -172,8 +172,6 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
 
   private callKeepaliveRetryCount = 0;
 
-  private callKeepaliveInterval?: number;
-
   /**
    * Getter to check if the call is muted or not.
    *
@@ -1499,6 +1497,88 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     this.sendCallStateMachineEvt({type: 'E_CALL_CLEARED'});
   }
 
+  private callKeepaliveRetryCallback = (interval: number) => {
+    if (this.callKeepaliveRetryCount === MAX_CALL_KEEPALIVE_RETRY_COUNT) {
+      log.warn(
+        `Max keepalive retry attempts reached. Aborting call keepalive for callId: ${this.callId}`,
+        {
+          file: CALL_FILE,
+          method: 'keepaliveRetryCallback',
+        }
+      );
+
+      return;
+    }
+
+    this.callKeepaliveRetryCount += 1;
+
+    setTimeout(async () => {
+      try {
+        await this.postStatus();
+        this.scheduleCallKeepaliveInterval();
+      } catch (err: unknown) {
+        await this.handleCallKeepaliveError(err);
+      }
+    }, interval * 1000);
+  };
+
+  private handleCallKeepaliveError = async (err: unknown) => {
+    const error = <WebexRequestPayload>err;
+
+    /* We are clearing the timer here as all are error scenarios. Only scenario where
+     * timer reset won't be required is 503 with retry after. But that case will
+     * be handled automatically as Mobius will also reset timer when we post status
+     * in retry-after scenario.
+     */
+    /* istanbul ignore next */
+    if (this.sessionTimer) {
+      clearInterval(this.sessionTimer);
+    }
+
+    const abort = await handleCallErrors(
+      (callError: CallError) => {
+        this.emit(CALL_EVENT_KEYS.CALL_ERROR, callError);
+        this.submitCallErrorMetric(callError);
+      },
+      ERROR_LAYER.CALL_CONTROL,
+      this.callKeepaliveRetryCallback,
+      this.getCorrelationId(),
+      error,
+      'handleCallEstablished',
+      CALL_FILE
+    );
+
+    if (abort) {
+      this.sendCallStateMachineEvt({type: 'E_SEND_CALL_DISCONNECT'});
+      this.emit(CALL_EVENT_KEYS.DISCONNECT, this.getCorrelationId());
+      this.callKeepaliveRetryCount = 0;
+    }
+
+    await uploadLogs({
+      correlationId: this.correlationId,
+      callId: this.callId,
+      broadworksCorrelationInfo: this.broadworksCorrelationInfo,
+    });
+  };
+
+  private scheduleCallKeepaliveInterval = () => {
+    const loggerContext = {
+      file: CALL_FILE,
+      method: 'scheduleCallKeepaliveInterval',
+    };
+
+    this.sessionTimer = setInterval(async () => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const res = await this.postStatus();
+
+        log.info(`Session refresh successful`, loggerContext);
+      } catch (err: unknown) {
+        await this.handleCallKeepaliveError(err);
+      }
+    }, DEFAULT_SESSION_TIMER);
+  };
+
   /**
    * Handle Call Established - Roap related negotiations.
    *
@@ -1527,83 +1607,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       clearTimeout(this.sessionTimer);
     }
 
-    const handleTimer = () => {
-      this.sessionTimer = setTimeout(async () => {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const res = await this.postStatus();
-
-          // Starting the interval again with the DEFAULT_SESSION_TIMER
-          clearTimeout(this.sessionTimer);
-          this.callKeepaliveRetryCount = 0;
-          this.callKeepaliveInterval = undefined;
-          handleTimer();
-
-          log.info(`Session refresh successful`, loggerContext);
-        } catch (err: unknown) {
-          const error = <WebexRequestPayload>err;
-
-          /* We are clearing the timer here as all are error scenarios. Only scenario where
-           * timer reset won't be required is 503 with retry after. But that case will
-           * be handled automatically as Mobius will also reset timer when we post status
-           * in retry-after scenario.
-           */
-          /* istanbul ignore next */
-          if (this.sessionTimer) {
-            clearTimeout(this.sessionTimer);
-          }
-
-          const abort = await handleCallErrors(
-            (callError: CallError) => {
-              this.emit(CALL_EVENT_KEYS.CALL_ERROR, callError);
-              this.submitCallErrorMetric(callError);
-            },
-            ERROR_LAYER.CALL_CONTROL,
-            (interval: number) => {
-              this.callKeepaliveRetryCount += 1;
-              this.callKeepaliveInterval = interval * 1000;
-
-              // If we have reached the max retry count, do not attempt to refresh the session
-              if (this.callKeepaliveRetryCount === MAX_CALL_KEEPALIVE_RETRY_COUNT) {
-                this.callKeepaliveRetryCount = 0;
-                clearTimeout(this.sessionTimer);
-                this.sessionTimer = undefined;
-                this.callKeepaliveInterval = undefined;
-
-                log.warn(
-                  `Max call keepalive retry attempts reached for call: ${this.getCorrelationId()}`,
-                  loggerContext
-                );
-
-                return;
-              }
-
-              // Scheduling next keepalive attempt - calling handleCallEstablished
-              this.sendCallStateMachineEvt({type: 'E_CALL_ESTABLISHED'});
-            },
-            this.getCorrelationId(),
-            error,
-            'handleCallEstablished',
-            CALL_FILE
-          );
-
-          if (abort) {
-            this.sendCallStateMachineEvt({type: 'E_SEND_CALL_DISCONNECT'});
-            this.emit(CALL_EVENT_KEYS.DISCONNECT, this.getCorrelationId());
-            this.callKeepaliveRetryCount = 0;
-            this.callKeepaliveInterval = undefined;
-          }
-
-          await uploadLogs({
-            correlationId: this.correlationId,
-            callId: this.callId,
-            broadworksCorrelationInfo: this.broadworksCorrelationInfo,
-          });
-        }
-      }, this.callKeepaliveInterval || DEFAULT_SESSION_TIMER);
-    };
-
-    handleTimer();
+    this.scheduleCallKeepaliveInterval();
   }
 
   /**

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -1527,79 +1527,83 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       clearTimeout(this.sessionTimer);
     }
 
-    this.sessionTimer = setTimeout(async () => {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const res = await this.postStatus();
+    const handleTimer = () => {
+      this.sessionTimer = setTimeout(async () => {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const res = await this.postStatus();
 
-        // Starting the interval again with the DEFAULT_SESSION_TIMER
-        clearTimeout(this.sessionTimer);
-        this.callKeepaliveRetryCount = 0;
-        this.callKeepaliveInterval = undefined;
-        this.sendCallStateMachineEvt({type: 'E_CALL_ESTABLISHED'});
-
-        log.info(`Session refresh successful`, loggerContext);
-      } catch (err: unknown) {
-        const error = <WebexRequestPayload>err;
-
-        /* We are clearing the timer here as all are error scenarios. Only scenario where
-         * timer reset won't be required is 503 with retry after. But that case will
-         * be handled automatically as Mobius will also reset timer when we post status
-         * in retry-after scenario.
-         */
-        /* istanbul ignore next */
-        if (this.sessionTimer) {
+          // Starting the interval again with the DEFAULT_SESSION_TIMER
           clearTimeout(this.sessionTimer);
-        }
-
-        const abort = await handleCallErrors(
-          (callError: CallError) => {
-            this.emit(CALL_EVENT_KEYS.CALL_ERROR, callError);
-            this.submitCallErrorMetric(callError);
-          },
-          ERROR_LAYER.CALL_CONTROL,
-          (interval: number) => {
-            this.callKeepaliveRetryCount += 1;
-            this.callKeepaliveInterval = interval * 1000;
-
-            // If we have reached the max retry count, do not attempt to refresh the session
-            if (this.callKeepaliveRetryCount === MAX_CALL_KEEPALIVE_RETRY_COUNT) {
-              this.callKeepaliveRetryCount = 0;
-              clearTimeout(this.sessionTimer);
-              this.sessionTimer = undefined;
-              this.callKeepaliveInterval = undefined;
-
-              log.warn(
-                `Max call keepalive retry attempts reached for call: ${this.getCorrelationId()}`,
-                loggerContext
-              );
-
-              return;
-            }
-
-            // Scheduling next keepalive attempt - calling handleCallEstablished
-            this.sendCallStateMachineEvt({type: 'E_CALL_ESTABLISHED'});
-          },
-          this.getCorrelationId(),
-          error,
-          'handleCallEstablished',
-          CALL_FILE
-        );
-
-        if (abort) {
-          this.sendCallStateMachineEvt({type: 'E_SEND_CALL_DISCONNECT'});
-          this.emit(CALL_EVENT_KEYS.DISCONNECT, this.getCorrelationId());
           this.callKeepaliveRetryCount = 0;
           this.callKeepaliveInterval = undefined;
-        }
+          handleTimer();
 
-        await uploadLogs({
-          correlationId: this.correlationId,
-          callId: this.callId,
-          broadworksCorrelationInfo: this.broadworksCorrelationInfo,
-        });
-      }
-    }, this.callKeepaliveInterval || DEFAULT_SESSION_TIMER);
+          log.info(`Session refresh successful`, loggerContext);
+        } catch (err: unknown) {
+          const error = <WebexRequestPayload>err;
+
+          /* We are clearing the timer here as all are error scenarios. Only scenario where
+           * timer reset won't be required is 503 with retry after. But that case will
+           * be handled automatically as Mobius will also reset timer when we post status
+           * in retry-after scenario.
+           */
+          /* istanbul ignore next */
+          if (this.sessionTimer) {
+            clearTimeout(this.sessionTimer);
+          }
+
+          const abort = await handleCallErrors(
+            (callError: CallError) => {
+              this.emit(CALL_EVENT_KEYS.CALL_ERROR, callError);
+              this.submitCallErrorMetric(callError);
+            },
+            ERROR_LAYER.CALL_CONTROL,
+            (interval: number) => {
+              this.callKeepaliveRetryCount += 1;
+              this.callKeepaliveInterval = interval * 1000;
+
+              // If we have reached the max retry count, do not attempt to refresh the session
+              if (this.callKeepaliveRetryCount === MAX_CALL_KEEPALIVE_RETRY_COUNT) {
+                this.callKeepaliveRetryCount = 0;
+                clearTimeout(this.sessionTimer);
+                this.sessionTimer = undefined;
+                this.callKeepaliveInterval = undefined;
+
+                log.warn(
+                  `Max call keepalive retry attempts reached for call: ${this.getCorrelationId()}`,
+                  loggerContext
+                );
+
+                return;
+              }
+
+              // Scheduling next keepalive attempt - calling handleCallEstablished
+              this.sendCallStateMachineEvt({type: 'E_CALL_ESTABLISHED'});
+            },
+            this.getCorrelationId(),
+            error,
+            'handleCallEstablished',
+            CALL_FILE
+          );
+
+          if (abort) {
+            this.sendCallStateMachineEvt({type: 'E_SEND_CALL_DISCONNECT'});
+            this.emit(CALL_EVENT_KEYS.DISCONNECT, this.getCorrelationId());
+            this.callKeepaliveRetryCount = 0;
+            this.callKeepaliveInterval = undefined;
+          }
+
+          await uploadLogs({
+            correlationId: this.correlationId,
+            callId: this.callId,
+            broadworksCorrelationInfo: this.broadworksCorrelationInfo,
+          });
+        }
+      }, this.callKeepaliveInterval || DEFAULT_SESSION_TIMER);
+    };
+
+    handleTimer();
   }
 
   /**

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -1600,13 +1600,6 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
 
     this.connected = true;
 
-    /* Session timers need to be reset at all offer/answer exchanges */
-    if (this.sessionTimer) {
-      log.log('Resetting session timer', loggerContext);
-
-      clearTimeout(this.sessionTimer);
-    }
-
     this.scheduleCallKeepaliveInterval();
   }
 

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -1524,15 +1524,19 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     if (this.sessionTimer) {
       log.log('Resetting session timer', loggerContext);
 
-      clearInterval(this.sessionTimer);
+      clearTimeout(this.sessionTimer);
     }
 
-    this.sessionTimer = setInterval(async () => {
+    this.sessionTimer = setTimeout(async () => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const res = await this.postStatus();
+
+        // Starting the interval again with the DEFAULT_SESSION_TIMER
+        clearTimeout(this.sessionTimer);
         this.callKeepaliveRetryCount = 0;
         this.callKeepaliveInterval = undefined;
+        this.sendCallStateMachineEvt({type: 'E_CALL_ESTABLISHED'});
 
         log.info(`Session refresh successful`, loggerContext);
       } catch (err: unknown) {
@@ -1545,7 +1549,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
          */
         /* istanbul ignore next */
         if (this.sessionTimer) {
-          clearInterval(this.sessionTimer);
+          clearTimeout(this.sessionTimer);
         }
 
         const abort = await handleCallErrors(
@@ -1561,7 +1565,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
             // If we have reached the max retry count, do not attempt to refresh the session
             if (this.callKeepaliveRetryCount === MAX_CALL_KEEPALIVE_RETRY_COUNT) {
               this.callKeepaliveRetryCount = 0;
-              clearInterval(this.sessionTimer);
+              clearTimeout(this.sessionTimer);
               this.sessionTimer = undefined;
               this.callKeepaliveInterval = undefined;
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< Ad-hoc >

## This pull request addresses

Fixes the timer issue for the handleCallEstablished function. 

This is continuation of the PR - #4557 

## by making the following changes

Clearing the interval in success case and rescheduling a new interval. Logic is bit altered to use `setTimeout` instead of `setInterval` now.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

Tested the following with the burp suite (to update the response header)

- For 4xx cases the call was being cleaned up
- For 5xx cases with retry-after, it honors the value if provided else fallback to 30 sec retry interval
- Tries max of 4 retries after first failure and if all fails it stops the retries
- Failed 3 keepalives and then let 1 pass which did reset the counter and again letting the keepalive fail for 4 times stops sending further keepalive request


## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
