### PR TITLE
fix(contact-center): fixed-outdial-fail-issue

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -1013,6 +1013,12 @@ function registerTaskListeners(task) {
     showAgentStatePopup(reason);
   });
 
+  task.on('task:outdialFailed', (reason) => {
+    updateTaskList();
+    console.info('Outdial failed with reason:', reason);
+    showOutdialFailedPopup(reason);
+  });
+
   task.on('task:wrappedup', updateTaskList); // Update the task list UI to have latest tasks
 
   // Conference event listeners - Simplified approach
@@ -1817,6 +1823,31 @@ function showAgentStatePopup(reason) {
   }
 
   popup.classList.remove('hidden');
+}
+
+function showOutdialFailedPopup(reason) {
+  const outdialFailedReasonText = document.getElementById('outdialFailedReasonText');
+  
+  // Set the reason text based on the reason
+  if (reason === 'CUSTOMER_BUSY') {
+    outdialFailedReasonText.innerText = 'Customer is busy';
+  } else if (reason === 'NO_ANSWER') {
+    outdialFailedReasonText.innerText = 'No answer from customer';
+  } else if (reason === 'CALL_FAILED') {
+    outdialFailedReasonText.innerText = 'Call failed';
+  } else if (reason === 'INVALID_NUMBER') {
+    outdialFailedReasonText.innerText = 'Invalid phone number';
+  } else {
+    outdialFailedReasonText.innerText = `Outdial failed: ${reason}`;
+  }
+
+  const outdialFailedPopup = document.getElementById('outdialFailedPopup');
+  outdialFailedPopup.classList.remove('hidden');
+}
+
+function closeOutdialFailedPopup() {
+  const outdialFailedPopup = document.getElementById('outdialFailedPopup');
+  outdialFailedPopup.classList.add('hidden');
 }
 
 async function renderBuddyAgents() {

--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -311,6 +311,15 @@
     </div>
   </div>
 
+  <!-- Popup for outdial failed -->
+  <div id="outdialFailedPopup" class="modal hidden">
+    <div class="modal-content">
+      <h2>Outdial Failed</h2>
+      <p id="outdialFailedReasonText"></p>
+      <button id="closeOutdialFailedPopup" class="btn btn-primary my-3" onclick="closeOutdialFailedPopup()">Close</button>
+    </div>
+  </div>
+
   <style>
     .modal {
       position: fixed;

--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -214,9 +214,9 @@ export default class TaskManager extends EventEmitter {
             LoggerProxy.log(`Agent outbound failed for task`, {
               module: TASK_MANAGER_FILE,
               method: METHODS.REGISTER_TASK_LISTENERS,
-              interactionId: payload.data?.interactionId,
+              interactionId: payload.data.interactionId,
             });
-            task.emit(TASK_EVENTS.TASK_REJECT, payload?.data?.reason);
+            task.emit(TASK_EVENTS.TASK_REJECT, payload.data.reason ?? 'UNKNOWN_REASON');
             break;
           case CC_EVENTS.AGENT_CONTACT_ASSIGNED:
             task = this.updateTaskData(task, payload.data);
@@ -560,9 +560,9 @@ export default class TaskManager extends EventEmitter {
       this.webCallingService.cleanUpCall();
     }
 
-    const isOutdial = task?.data?.interaction?.outboundType === 'OUTDIAL';
-    const isNew = task?.data?.interaction?.state === 'new';
-    const isTerminated = task?.data?.interaction?.isTerminated;
+    const isOutdial = task.data.interaction.outboundType === 'OUTDIAL';
+    const isNew = task.data.interaction.state === 'new';
+    const isTerminated = task.data.interaction.isTerminated;
 
     // For OUTDIAL: only remove if NOT terminated (user-declined, no wrap-up follows)
     // If terminated, keep task for wrap-up flow (CONTACT_ENDED → AGENT_WRAPUP)

--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -201,15 +201,22 @@ export default class TaskManager extends EventEmitter {
             this.emit(TASK_EVENTS.TASK_OFFER_CONTACT, task);
             break;
           case CC_EVENTS.AGENT_OUTBOUND_FAILED:
-            // We don't have to emit any event here since this will be result of promise.
-            if (task.data) {
-              this.removeTaskFromCollection(task);
-            }
+            task = this.updateTaskData(task, payload.data);
+            this.metricsManager.trackEvent(
+              METRIC_EVENT_NAMES.TASK_OUTDIAL_FAILED,
+              {
+                ...MetricsManager.getCommonTrackingFieldForAQMResponse(payload.data),
+                taskId: payload.data.interactionId,
+                reason: payload.data.reasonCode || payload.data.reason,
+              },
+              ['behavioral', 'operational']
+            );
             LoggerProxy.log(`Agent outbound failed for task`, {
               module: TASK_MANAGER_FILE,
               method: METHODS.REGISTER_TASK_LISTENERS,
               interactionId: payload.data?.interactionId,
             });
+            task.emit(TASK_EVENTS.TASK_REJECT, payload?.data?.reason);
             break;
           case CC_EVENTS.AGENT_CONTACT_ASSIGNED:
             task = this.updateTaskData(task, payload.data);
@@ -553,9 +560,15 @@ export default class TaskManager extends EventEmitter {
       this.webCallingService.cleanUpCall();
     }
 
-    if (task.data.interaction.state === 'new' || isSecondaryEpDnAgent(task.data.interaction)) {
-      // Only remove tasks in 'new' state or isSecondaryEpDnAgent immediately. For other states,
-      // retain tasks until they complete wrap-up, unless the task disconnected before being answered.
+    const isOutdial = task?.data?.interaction?.outboundType === 'OUTDIAL';
+    const isNew = task?.data?.interaction?.state === 'new';
+    const isTerminated = task?.data?.interaction?.isTerminated;
+
+    // For OUTDIAL: only remove if NOT terminated (user-declined, no wrap-up follows)
+    // If terminated, keep task for wrap-up flow (CONTACT_ENDED → AGENT_WRAPUP)
+    // For non-OUTDIAL: remove if state is 'new'
+    // Always remove if secondary EpDn agent
+    if ((isNew && !(isOutdial && isTerminated)) || isSecondaryEpDnAgent(task.data.interaction)) {
       this.removeTaskFromCollection(task);
     }
   }

--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -216,7 +216,7 @@ export default class TaskManager extends EventEmitter {
               method: METHODS.REGISTER_TASK_LISTENERS,
               interactionId: payload.data.interactionId,
             });
-            task.emit(TASK_EVENTS.TASK_REJECT, payload.data.reason ?? 'UNKNOWN_REASON');
+            task.emit(TASK_EVENTS.TASK_OUTDIAL_FAILED, payload.data.reason ?? 'UNKNOWN_REASON');
             break;
           case CC_EVENTS.AGENT_CONTACT_ASSIGNED:
             task = this.updateTaskData(task, payload.data);

--- a/packages/@webex/contact-center/src/services/task/types.ts
+++ b/packages/@webex/contact-center/src/services/task/types.ts
@@ -348,6 +348,18 @@ export enum TASK_EVENTS {
   TASK_REJECT = 'task:rejected',
 
   /**
+   * Triggered when an outdial call fails
+   * @example
+   * ```typescript
+   * task.on(TASK_EVENTS.TASK_OUTDIAL_FAILED, (reason: string) => {
+   *   console.log('Outdial failed:', reason);
+   *   // Handle outdial failure
+   * });
+   * ```
+   */
+  TASK_OUTDIAL_FAILED = 'task:outdialFailed',
+
+  /**
    * Triggered when a task is populated with data
    * @example
    * ```typescript

--- a/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
@@ -673,14 +673,36 @@ describe('TaskManager', () => {
     expect(taskUpdateTaskDataSpy).toHaveBeenCalledWith(payload.data);
   });
 
-  it('should remove currentTask from taskCollection on AGENT_OUTBOUND_FAILED event', () => {
+  it('should NOT remove OUTDIAL task from taskCollection on AGENT_OUTBOUND_FAILED when terminated (wrap-up flow)', () => {
+    const task = taskManager.getTask(taskId);
+    task.updateTaskData = jest.fn().mockImplementation((newData) => {
+      task.data = {
+        ...task.data,
+        ...newData,
+        interaction: {
+          ...task.data.interaction,
+          ...newData.interaction,
+          outboundType: 'OUTDIAL',
+          state: 'new',
+          isTerminated: true,
+        },
+      };
+      return task;
+    });
+    task.unregisterWebCallListeners = jest.fn();
+    const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
     const payload = {
       data: {
         type: CC_EVENTS.AGENT_OUTBOUND_FAILED,
         agentId: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
         eventTime: 1733211616959,
         eventType: 'RoutingMessage',
-        interaction: {},
+        interaction: {
+          outboundType: 'OUTDIAL',
+          state: 'new',
+          isTerminated: true,
+        },
         interactionId: taskId,
         orgId: '6ecef209-9a34-4ed1-a07a-7ddd1dbe925a',
         trackingId: '575c0ec2-618c-42af-a61c-53aeb0a221ee',
@@ -688,14 +710,63 @@ describe('TaskManager', () => {
         destAgentId: 'ebeb893b-ba67-4f36-8418-95c7492b28c2',
         owner: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
         queueMgr: 'aqm',
+        reason: 'CUSTOMER_BUSY',
+        reasonCode: 1022,
       },
     };
 
-    taskManager.taskCollection[taskId] = taskManager.getTask(taskId);
+    webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+    expect(taskManager.getTask(taskId)).toBeDefined();
+    expect(removeTaskSpy).not.toHaveBeenCalled();
+  });
+
+  it('should remove OUTDIAL task from taskCollection on AGENT_CONTACT_ASSIGN_FAILED when NOT terminated (user-declined)', () => {
+    const task = taskManager.getTask(taskId);
+    task.updateTaskData = jest.fn().mockImplementation((newData) => {
+      task.data = {
+        ...task.data,
+        ...newData,
+        interaction: {
+          ...task.data.interaction,
+          ...newData.interaction,
+          outboundType: 'OUTDIAL',
+          state: 'new',
+          isTerminated: false,
+        },
+      };
+      return task;
+    });
+    task.unregisterWebCallListeners = jest.fn();
+    const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
+    const payload = {
+      data: {
+        type: CC_EVENTS.AGENT_CONTACT_ASSIGN_FAILED,
+        agentId: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
+        eventTime: 1733211616959,
+        eventType: 'RoutingMessage',
+        interaction: {
+          outboundType: 'OUTDIAL',
+          state: 'new',
+          isTerminated: false,
+        },
+        interactionId: taskId,
+        orgId: '6ecef209-9a34-4ed1-a07a-7ddd1dbe925a',
+        trackingId: '575c0ec2-618c-42af-a61c-53aeb0a221ee',
+        mediaResourceId: '0ae913a4-c857-4705-8d49-76dd3dde75e4',
+        destAgentId: 'ebeb893b-ba67-4f36-8418-95c7492b28c2',
+        owner: '723a8ffb-a26e-496d-b14a-ff44fb83b64f',
+        queueMgr: 'aqm',
+        reason: 'USER_DECLINED',
+        reasonCode: 156,
+      },
+    };
 
     webSocketManagerMock.emit('message', JSON.stringify(payload));
 
     expect(taskManager.getTask(taskId)).toBeUndefined();
+    expect(removeTaskSpy).toHaveBeenCalled();
   });
 
   it('handle AGENT_OFFER_CONSULT event', () => {

--- a/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
@@ -721,6 +721,21 @@ describe('TaskManager', () => {
     expect(removeTaskSpy).not.toHaveBeenCalled();
   });
 
+  it('should emit TASK_OUTDIAL_FAILED event on AGENT_OUTBOUND_FAILED', () => {
+    const task = taskManager.getTask(taskId);
+    task.updateTaskData = jest.fn().mockReturnValue(task);
+    const taskEmitSpy = jest.spyOn(task, 'emit');
+    const payload = {
+      data: {
+        type: CC_EVENTS.AGENT_OUTBOUND_FAILED,
+        interactionId: taskId,
+        reason: 'CUSTOMER_BUSY',
+      },
+    };
+    webSocketManagerMock.emit('message', JSON.stringify(payload));
+    expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_OUTDIAL_FAILED, 'CUSTOMER_BUSY');
+  });
+
   it('should remove OUTDIAL task from taskCollection on AGENT_CONTACT_ASSIGN_FAILED when NOT terminated (user-declined)', () => {
     const task = taskManager.getTask(taskId);
     task.updateTaskData = jest.fn().mockImplementation((newData) => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< AD-HOC >

## This pull request addresses

* EPIC team reported an issue that was happening with the widgets.
* Whenever a user got the `AgentOutboundFailed` event, the widgets was not properly cleaning up the call and so the user was not able to do further outdials.
* Further triaging found that this was because the SDK was clearing the `task` object on receiving this event and hence subsequent wrapup was not being shown.

## by making the following changes

* Now we simply emit TASK_REJECT on receiving the AgentOutboundFailed event and on subsequent events from the backend, we end task and show wrapup.
* Code was also added to ensure that rejecting the outdial event clears up the task and older flows remain unaffected.
* Other task clear ups also work.

Vidcast (EXTENSION) - https://app.vidcast.io/share/604f2f25-55ea-4446-950b-68777ce8f6a3
Vidcast (BROWSER) - https://app.vidcast.io/share/25857bee-9aa8-4539-b411-5b4c4808d1d3

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested outdial on both EXTENSION and BROWSER
* Tested for both working outdial and failing.
* Tested user rejecting outdial call.
* Tested basic call to see all flows worked.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
