### PR TITLE
fix: for the prejoin api authorization need set as false

### DIFF
--- a/packages/@webex/webex-core/src/interceptors/redirect.js
+++ b/packages/@webex/webex-core/src/interceptors/redirect.js
@@ -119,6 +119,10 @@ export default class RedirectInterceptor extends Interceptor {
         options.uri = options.uri.replace(/(?<=https:\/\/)[^/]+/, response.body.data.siteFullUrl);
       }
 
+      if (options.resource === 'preJoin' && options.service === 'webex-appapi-service') {
+        options.headers.authorization = false;
+      }
+
       this.webex.logger.warn('redirect: url redirects needed to', options.uri);
       options.$redirectCount += 1;
       if (options.$redirectCount > this.webex.config.maxLocusRedirects) {

--- a/packages/@webex/webex-core/test/unit/spec/interceptors/redirect.js
+++ b/packages/@webex/webex-core/test/unit/spec/interceptors/redirect.js
@@ -168,6 +168,104 @@ describe('webex-core', () => {
             uri: 'http://newlocus.example.com',
           });
         });
+
+        it('removes authorization header when redirecting preJoin request to webex-appapi-service', () => {
+          const response = {
+            statusCode: 404,
+            headers: {},
+            body: {
+              code: 404100,
+              data: {
+                siteFullUrl: 'newlocus.example.com'
+              },
+            },
+          };
+
+          const options = {
+            $redirectCount: 0,
+            uri: 'https://test.webex.com/meet/v1/preJoin',
+            resource: 'preJoin',
+            service: 'webex-appapi-service',
+            headers: {
+              authorization: 'Bearer token123',
+            },
+          };
+
+          interceptor.onResponse(options, response);
+          sinon.assert.calledWith(webex.request, sinon.match({
+            $redirectCount: 1,
+            uri: 'https://newlocus.example.com/meet/v1/preJoin',
+            resource: 'preJoin',
+            service: 'webex-appapi-service',
+            headers: {
+              authorization: false,
+            },
+          }));
+        });
+
+        it('keeps authorization header for non-preJoin requests on appapi redirect', () => {
+          const response = {
+            statusCode: 404,
+            headers: {},
+            body: {
+              code: 404100,
+              data: {
+                siteFullUrl: 'newlocus.example.com'
+              },
+            },
+          };
+
+          const options = {
+            $redirectCount: 0,
+            uri: 'https://test.webex.com/meet/v1/join',
+            resource: 'join',
+            service: 'webex-appapi-service',
+            headers: {
+              authorization: 'Bearer token123',
+            },
+          };
+
+          interceptor.onResponse(options, response);
+          sinon.assert.calledWith(webex.request, sinon.match({
+            $redirectCount: 1,
+            uri: 'https://newlocus.example.com/meet/v1/join',
+            headers: {
+              authorization: 'Bearer token123',
+            },
+          }));
+        });
+
+        it('keeps authorization header for preJoin requests to non-webex-appapi-service', () => {
+          const response = {
+            statusCode: 404,
+            headers: {},
+            body: {
+              code: 404100,
+              data: {
+                siteFullUrl: 'newlocus.example.com'
+              },
+            },
+          };
+
+          const options = {
+            $redirectCount: 0,
+            uri: 'https://test.webex.com/meet/v1/preJoin',
+            resource: 'preJoin',
+            service: 'other-service',
+            headers: {
+              authorization: 'Bearer token123',
+            },
+          };
+
+          interceptor.onResponse(options, response);
+          sinon.assert.calledWith(webex.request, sinon.match({
+            $redirectCount: 1,
+            uri: 'https://newlocus.example.com/meet/v1/preJoin',
+            headers: {
+              authorization: 'Bearer token123',
+            },
+          }));
+        });
       });
     });
   });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-744646

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >
For the preJoin API, headers authorization is false, 
set disableWebRedirect=true when call preJoin API,
server return 404100, means need redirect, sdk will redirect to new server
<img width="728" height="269" alt="image" src="https://github.com/user-attachments/assets/49f4b81c-704f-469c-9229-908877393c58" />

<img width="350" height="140" alt="image" src="https://github.com/user-attachments/assets/d4c2df6a-575d-485c-b0f9-4f10891d11b4" />

<img width="883" height="160" alt="image" src="https://github.com/user-attachments/assets/3026b482-2833-4e3e-85cb-56e213027804" />


## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [X] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [X] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
