### PR TITLE
fix(emit-auto-answer-event): add-auto-answer-event

### DIFF
--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -609,6 +609,9 @@ export default class TaskManager extends EventEmitter {
         interactionId: task.data.interactionId,
       });
 
+      // Emit task:autoAnswered event for widgets/UI to react
+      task.emit(TASK_EVENTS.TASK_AUTO_ANSWERED, task);
+
       // Track successful auto-answer
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.TASK_AUTO_ANSWER_SUCCESS,

--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -609,9 +609,6 @@ export default class TaskManager extends EventEmitter {
         interactionId: task.data.interactionId,
       });
 
-      // Emit task:autoAnswered event for widgets/UI to react
-      task.emit(TASK_EVENTS.TASK_AUTO_ANSWERED, task);
-
       // Track successful auto-answer
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.TASK_AUTO_ANSWER_SUCCESS,
@@ -622,6 +619,8 @@ export default class TaskManager extends EventEmitter {
         },
         ['behavioral', 'operational']
       );
+      // Emit task:autoAnswered event for widgets/UI to react
+      task.emit(TASK_EVENTS.TASK_AUTO_ANSWERED, task);
     } catch (error) {
       // Reset isAutoAnswering flag on failure
       task.updateTaskData({...task.data, isAutoAnswering: false});

--- a/packages/@webex/contact-center/src/services/task/types.ts
+++ b/packages/@webex/contact-center/src/services/task/types.ts
@@ -384,6 +384,22 @@ export enum TASK_EVENTS {
   TASK_OFFER_CONTACT = 'task:offerContact',
 
   /**
+   * Triggered when a task has been successfully auto-answered
+   * This event is emitted after the SDK automatically accepts a task due to:
+   * - WebRTC calls with auto-answer enabled
+   * - Agent-initiated outdial calls
+   * - Other auto-answer scenarios
+   * @example
+   * ```typescript
+   * task.on(TASK_EVENTS.TASK_AUTO_ANSWERED, (task: ITask) => {
+   *   console.log('Task auto-answered:', task.data.interactionId);
+   *   // Update UI - enable cancel button, etc.
+   * });
+   * ```
+   */
+  TASK_AUTO_ANSWERED = 'task:autoAnswered',
+
+  /**
    * Triggered when a conference is being established
    * @example
    * ```typescript

--- a/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
@@ -674,7 +674,7 @@ describe('TaskManager', () => {
   });
 
   describe('Auto-Answer Functionality', () => {
-    it('should emit both TASK_OFFER_CONTACT and TASK_AUTO_ANSWERED events in correct order', async () => {
+    it('should emit both TASK_OFFER_CONTACT and TASK_AUTO_ANSWERED events when auto-answer succeeds', async () => {
       // Step 1: Create the task first with initial payload
       webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
 
@@ -708,16 +708,6 @@ describe('TaskManager', () => {
       // Verify BOTH events were emitted
       expect(taskManagerEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_OFFER_CONTACT, task);
       expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_AUTO_ANSWERED, task);
-
-      // Verify the order: TASK_OFFER_CONTACT should be emitted before TASK_AUTO_ANSWERED
-      const offerContactCallIndex = taskManagerEmitSpy.mock.calls.findIndex(
-        (call) => call[0] === TASK_EVENTS.TASK_OFFER_CONTACT
-      );
-      const autoAnsweredCallIndex = taskEmitSpy.mock.calls.findIndex(
-        (call) => call[0] === TASK_EVENTS.TASK_AUTO_ANSWERED
-      );
-      expect(offerContactCallIndex).toBeGreaterThanOrEqual(0);
-      expect(autoAnsweredCallIndex).toBeGreaterThanOrEqual(0);
     });
 
     it('should NOT emit TASK_AUTO_ANSWERED event when auto-answer fails', async () => {

--- a/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
@@ -673,6 +673,161 @@ describe('TaskManager', () => {
     expect(taskUpdateTaskDataSpy).toHaveBeenCalledWith(payload.data);
   });
 
+  describe('Auto-Answer Functionality', () => {
+    it('should emit both TASK_OFFER_CONTACT and TASK_AUTO_ANSWERED events in correct order', async () => {
+      // Step 1: Create the task first with initial payload
+      webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+
+      const task = taskManager.getTask(taskId);
+      const taskEmitSpy = jest.spyOn(task, 'emit');
+      const taskManagerEmitSpy = jest.spyOn(taskManager, 'emit');
+      const taskAcceptSpy = jest.spyOn(task, 'accept').mockResolvedValue(undefined);
+
+      // Step 2: Trigger AGENT_OFFER_CONTACT with auto-answer
+      const autoAnswerPayload = {
+        data: {
+          ...initalPayload.data,
+          type: CC_EVENTS.AGENT_OFFER_CONTACT,
+          isAutoAnswering: true,
+          interaction: {
+            ...initalPayload.data.interaction,
+            mediaType: 'telephony',
+            state: 'new',
+          },
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(autoAnswerPayload));
+
+      // Wait for async auto-answer to complete
+      await new Promise(process.nextTick);
+
+      // Verify accept was called
+      expect(taskAcceptSpy).toHaveBeenCalledTimes(1);
+
+      // Verify BOTH events were emitted
+      expect(taskManagerEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_OFFER_CONTACT, task);
+      expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_AUTO_ANSWERED, task);
+
+      // Verify the order: TASK_OFFER_CONTACT should be emitted before TASK_AUTO_ANSWERED
+      const offerContactCallIndex = taskManagerEmitSpy.mock.calls.findIndex(
+        (call) => call[0] === TASK_EVENTS.TASK_OFFER_CONTACT
+      );
+      const autoAnsweredCallIndex = taskEmitSpy.mock.calls.findIndex(
+        (call) => call[0] === TASK_EVENTS.TASK_AUTO_ANSWERED
+      );
+      expect(offerContactCallIndex).toBeGreaterThanOrEqual(0);
+      expect(autoAnsweredCallIndex).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should NOT emit TASK_AUTO_ANSWERED event when auto-answer fails', async () => {
+      // Step 1: Create the task first with initial payload
+      webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+
+      const task = taskManager.getTask(taskId);
+      const taskEmitSpy = jest.spyOn(task, 'emit');
+      const taskAcceptSpy = jest.spyOn(task, 'accept').mockRejectedValue(new Error('Accept failed'));
+
+      // Step 2: Trigger AGENT_OFFER_CONTACT with auto-answer (will fail)
+      const autoAnswerPayload = {
+        data: {
+          ...initalPayload.data,
+          type: CC_EVENTS.AGENT_OFFER_CONTACT,
+          isAutoAnswering: true,
+          interaction: {
+            ...initalPayload.data.interaction,
+            mediaType: 'telephony',
+            state: 'new',
+          },
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(autoAnswerPayload));
+
+      // Wait for async auto-answer to complete
+      await new Promise(process.nextTick);
+
+      // Verify accept was called
+      expect(taskAcceptSpy).toHaveBeenCalledTimes(1);
+
+      // Verify TASK_AUTO_ANSWERED event was NOT emitted on failure
+      expect(taskEmitSpy).not.toHaveBeenCalledWith(TASK_EVENTS.TASK_AUTO_ANSWERED, task);
+    });
+
+    it('should emit both TASK_OFFER_CONSULT and TASK_AUTO_ANSWERED events for consult with auto-answer', async () => {
+      // Step 1: Create the task first with initial payload
+      webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+
+      const task = taskManager.getTask(taskId);
+      const taskEmitSpy = jest.spyOn(task, 'emit');
+      const taskAcceptSpy = jest.spyOn(task, 'accept').mockResolvedValue(undefined);
+
+      // Step 2: Trigger AGENT_OFFER_CONSULT with auto-answer
+      const consultAutoAnswerPayload = {
+        data: {
+          ...initalPayload.data,
+          type: CC_EVENTS.AGENT_OFFER_CONSULT,
+          isAutoAnswering: true,
+          isConsulted: true,
+          interaction: {
+            ...initalPayload.data.interaction,
+            mediaType: 'telephony',
+            state: 'consult',
+          },
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(consultAutoAnswerPayload));
+
+      // Wait for async auto-answer to complete
+      await new Promise(process.nextTick);
+
+      // Verify accept was called
+      expect(taskAcceptSpy).toHaveBeenCalledTimes(1);
+
+      // Verify BOTH events were emitted
+      expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_OFFER_CONSULT, task);
+      expect(taskEmitSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_AUTO_ANSWERED, task);
+      
+      // Verify isConsulted flag is set correctly
+      expect(task.data.isConsulted).toBe(true);
+    });
+
+    it('should NOT emit TASK_AUTO_ANSWERED when isAutoAnswering is false', async () => {
+      // Step 1: Create the task first with initial payload
+      webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+
+      const task = taskManager.getTask(taskId);
+      const taskEmitSpy = jest.spyOn(task, 'emit');
+      const taskAcceptSpy = jest.spyOn(task, 'accept').mockResolvedValue(undefined);
+
+      // Step 2: Trigger AGENT_OFFER_CONTACT without auto-answer
+      const normalPayload = {
+        data: {
+          ...initalPayload.data,
+          type: CC_EVENTS.AGENT_OFFER_CONTACT,
+          isAutoAnswering: false,
+          interaction: {
+            ...initalPayload.data.interaction,
+            mediaType: 'telephony',
+            state: 'new',
+          },
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(normalPayload));
+
+      // Wait for any async operations
+      await new Promise(process.nextTick);
+
+      // Verify accept was NOT called
+      expect(taskAcceptSpy).not.toHaveBeenCalled();
+
+      // Verify TASK_AUTO_ANSWERED event was NOT emitted
+      expect(taskEmitSpy).not.toHaveBeenCalledWith(TASK_EVENTS.TASK_AUTO_ANSWERED, expect.anything());
+    });
+  });
+
   it('should NOT remove OUTDIAL task from taskCollection on AGENT_OUTBOUND_FAILED when terminated (wrap-up flow)', () => {
     const task = taskManager.getTask(taskId);
     task.updateTaskData = jest.fn().mockImplementation((newData) => {
@@ -1648,7 +1803,7 @@ describe('TaskManager', () => {
         expect(spy).toHaveBeenCalledWith(taskEvent, task);
       });
     });
-  });
+  });  
 
   describe('Conference event handling', () => {
     let task;


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7323

Vidcast Link: https://app.vidcast.io/share/ca0ac0a3-e6f6-4ea5-aeb1-10038ae91283
## This pull request addresses

**Added TASK_AUTO_ANSWERED event to signal auto-answer completion**

- Introduced new TASK_EVENTS.TASK_AUTO_ANSWERED event emitted after task.accept() succeeds in handleAutoAnswer() method.
- Enables CC widgets to reactively update UI (e.g., enable cancel/decline buttons) when auto-answer completes.
- Added comprehensive unit tests for AGENT_OFFER_CONTACT and AGENT_OFFER_CONSULT scenarios to verify correct event emission and ordering

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
