### PR TITLE
fix: trigger auto detect spoken language event

### DIFF
--- a/packages/@webex/internal-plugin-voicea/src/constants.ts
+++ b/packages/@webex/internal-plugin-voicea/src/constants.ts
@@ -10,6 +10,8 @@ export const EVENT_TRIGGERS = {
   EVA_COMMAND: 'voicea:wxa',
   HIGHLIGHT_CREATED: 'voicea:highlightCreated',
   NEW_MANUAL_CAPTION: 'aibridge:newManualCaption',
+
+  LANGUAGE_DETECTED: 'voicea:languageDetected',
 };
 
 export const AIBRIDGE_RELAY_TYPES = {

--- a/packages/@webex/internal-plugin-voicea/src/voicea.ts
+++ b/packages/@webex/internal-plugin-voicea/src/voicea.ts
@@ -202,9 +202,12 @@ export class VoiceaChannel extends WebexPlugin implements IVoiceaChannel {
 
       case TRANSCRIPTION_TYPE.LANGUAGE_DETECTED:
         // @ts-ignore
-        if (this.spokenLanguages.includes(voiceaPayload.language)) {
-          this.setSpokenLanguage(voiceaPayload.language, LANGUAGE_ASSIGNMENT.AUTO);
-        }
+        this.trigger(EVENT_TRIGGERS.LANGUAGE_DETECTED, {
+          languageCode: voiceaPayload.language,
+          languageAssignment: LANGUAGE_ASSIGNMENT.AUTO,
+          isInSpokenLanguages: this.spokenLanguages.includes(voiceaPayload.language),
+        });
+
         break;
 
       default:

--- a/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
+++ b/packages/@webex/internal-plugin-voicea/test/unit/spec/voicea.js
@@ -884,13 +884,13 @@ describe('plugin-voicea', () => {
       });
 
       it('processes a language detected if language is in spoken languages', async () => {
-        voiceaService.on(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, triggerSpy);
+        voiceaService.on(EVENT_TRIGGERS.LANGUAGE_DETECTED, triggerSpy);
 
         const voiceaPayload = {
           id: '9bc51440-1a22-7c81-6add-4b6ff7b59f7c',
           meeting: 'fd5bd0fc-06fb-4fd1-982b-554c4368f101',
           type: 'language_detected',
-          language: 'pl',
+          language: 'en',
           translation: {
             allowed_languages: ['af', 'am'],
             max_languages: 5,
@@ -902,58 +902,24 @@ describe('plugin-voicea', () => {
           version: 'v2',
         };
 
-         const spy = sinon.spy();
+          const spy = sinon.spy();
 
         voiceaService.on(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, spy);
         voiceaService.listenToEvents();
         voiceaService.processAnnouncementMessage(voiceaPayload);
 
-        // eslint-disable-next-line no-underscore-dangle
+          // eslint-disable-next-line no-underscore-dangle
         await voiceaService.webex.internal.llm._emit('event:relay.event', {
           headers: {from: 'ws'},
           data: {relayType: 'voicea.transcription', voiceaPayload},
         });
 
         assert.calledOnceWithExactly(functionSpy, voiceaPayload);
-
-        assert.calledOnceWithExactly(triggerSpy, {languageCode: 'pl'});
-      });
-
-      it('processes a language detected if language is not in spoken languages', async () => {
-        voiceaService.on(EVENT_TRIGGERS.SPOKEN_LANGUAGE_UPDATE, triggerSpy);
-
-        const voiceaPayload = {
-          id: '9bc51440-1a22-7c81-6add-4b6ff7b59f7c',
-          meeting: 'fd5bd0fc-06fb-4fd1-982b-554c4368f101',
-          type: 'language_detected',
-          language: 'zh',
-
-          translation: {
-            allowed_languages: ['af', 'am'],
-            max_languages: 5,
-          },
-          ASR: {
-            spoken_languages: ['en'],
-          },
-
-          version: 'v2',
-        };
-
-        const spy = sinon.spy();
-
-        voiceaService.on(EVENT_TRIGGERS.VOICEA_ANNOUNCEMENT, spy);
-        voiceaService.listenToEvents();
-        voiceaService.processAnnouncementMessage(voiceaPayload);
-
-        // eslint-disable-next-line no-underscore-dangle
-        await voiceaService.webex.internal.llm._emit('event:relay.event', {
-          headers: {from: 'ws'},
-          data: {relayType: 'voicea.transcription', voiceaPayload},
+        assert.calledOnceWithExactly(triggerSpy, {
+            languageCode: 'en',
+            languageAssignment: 'AUTO',
+            isInSpokenLanguages: true
         });
-
-        assert.calledOnceWithExactly(functionSpy, voiceaPayload);
-
-        assert.notCalled(triggerSpy);
       });
 
     });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses
attendee will trigger auto-detect spokenlanguage, and it will call setSpokenLanguage, return a 403 error, ONLY host can setSpokenLanguage, so move the implementation to cantina.

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
