### PR TITLE
fix(meetings): webex-455994 browser-media-block return error message

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -179,6 +179,18 @@ export const isSdpOfferCreationError = (rawError: any) => {
   return false;
 };
 
+export const isBrowserMediaError = (rawError) => {
+  if (isBrowserMediaErrorName(rawError.name)) {
+    return true;
+  }
+
+  return false;
+};
+
+export const getBrowserMediaErrorCode = (rawError) => {
+  return BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP[rawError.name];
+};
+
 /**
  * MDN Media Devices getUserMedia() method returns a name if it errs
  * Documentation can be found here: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -179,7 +179,15 @@ export const isSdpOfferCreationError = (rawError: any) => {
   return false;
 };
 
+/**
+ * Checks if the given error is a browser media error by its name.
+ * Returns true if the error name matches any known browser media error name in the mapping.
+ *
+ * @param {Object} rawError - The error object to check.
+ * @returns {boolean} True if the error is a browser media error, false otherwise.
+ */
 export const isBrowserMediaError = (rawError) => {
+  // eslint-disable-next-line no-use-before-define
   if (isBrowserMediaErrorName(rawError.name)) {
     return true;
   }
@@ -187,6 +195,13 @@ export const isBrowserMediaError = (rawError) => {
   return false;
 };
 
+/**
+ * Returns the client error code mapped to the given browser media error name.
+ * If the error name is not found in the mapping, returns undefined.
+ *
+ * @param {Object} rawError - The error object containing the error name.
+ * @returns {string|undefined} The mapped client error code, or undefined if not found.
+ */
 export const getBrowserMediaErrorCode = (rawError) => {
   return BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP[rawError.name];
 };

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -10,6 +10,7 @@ import {
   ICE_AND_REACHABILITY_FAILED_CLIENT_CODE,
   ICE_FAILED_WITH_TURN_TLS_CLIENT_CODE,
   MISSING_ROAP_ANSWER_CLIENT_CODE,
+  BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP,
 } from '../../../../src/call-diagnostic/config';
 import Logger from '@webex/plugin-logger';
 
@@ -688,14 +689,15 @@ describe('internal-plugin-metrics', () => {
 
   describe('isBrowserMediaError', () => {
     it('should return true if error name is in BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP', () => {
+      // Use a known browser media error name from the config map
       const errorName = Object.keys(BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP)[0];
       const error = {name: errorName};
-      expect(isBrowserMediaError(error)).toBe(true);
+      assert.isTrue(CallDiagnosticUtils.isBrowserMediaError(error));
     });
 
     it('should return false if error name is not in BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP', () => {
       const error = {name: 'SomeOtherError'};
-      expect(isBrowserMediaError(error)).toBe(false);
+      assert.isFalse(CallDiagnosticUtils.isBrowserMediaError(error));
     });
   });
 
@@ -703,12 +705,15 @@ describe('internal-plugin-metrics', () => {
     it('should return correct error code for known error name', () => {
       const errorName = Object.keys(BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP)[0];
       const error = {name: errorName};
-      expect(getBrowserMediaErrorCode(error)).toBe(BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP[errorName]);
+      assert.strictEqual(
+        CallDiagnosticUtils.getBrowserMediaErrorCode(error),
+        BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP[errorName]
+      );
     });
 
     it('should return undefined for unknown error name', () => {
       const error = {name: 'UnknownError'};
-      expect(getBrowserMediaErrorCode(error)).toBeUndefined();
+      assert.isUndefined(CallDiagnosticUtils.getBrowserMediaErrorCode(error));
     });
   });
 });

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -685,4 +685,30 @@ describe('internal-plugin-metrics', () => {
       });
     });
   });
+
+  describe('isBrowserMediaError', () => {
+    it('should return true if error name is in BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP', () => {
+      const errorName = Object.keys(BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP)[0];
+      const error = {name: errorName};
+      expect(isBrowserMediaError(error)).toBe(true);
+    });
+
+    it('should return false if error name is not in BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP', () => {
+      const error = {name: 'SomeOtherError'};
+      expect(isBrowserMediaError(error)).toBe(false);
+    });
+  });
+
+  describe('getBrowserMediaErrorCode', () => {
+    it('should return correct error code for known error name', () => {
+      const errorName = Object.keys(BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP)[0];
+      const error = {name: errorName};
+      expect(getBrowserMediaErrorCode(error)).toBe(BROWSER_MEDIA_ERROR_NAME_TO_CLIENT_ERROR_CODES_MAP[errorName]);
+    });
+
+    it('should return undefined for unknown error name', () => {
+      const error = {name: 'UnknownError'};
+      expect(getBrowserMediaErrorCode(error)).toBeUndefined();
+    });
+  });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1316,6 +1316,27 @@ describe('plugin-meetings', () => {
             })
           );
         });
+
+        it('should not handle non-browser media error', () => {
+          let shouldRetry = true;
+          let error = {name: 'OtherError', message: 'other'};
+
+          if (CallDiagnosticUtils.isBrowserMediaError(error)) {
+            shouldRetry = false;
+            error = merge({
+              error: {
+                body: {
+                  errorCode: CallDiagnosticUtils.getBrowserMediaErrorCode(error),
+                  message: error?.message,
+                  name: error?.name,
+                },
+              },
+            });
+          }
+
+          expect(shouldRetry).toBe(true);
+          expect(error).toEqual({name: 'OtherError', message: 'other'});
+        });
       });
       describe('#isTranscriptionSupported', () => {
         it('should return false if the feature is not supported for the meeting', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1334,8 +1334,8 @@ describe('plugin-meetings', () => {
             });
           }
 
-          expect(shouldRetry).toBe(true);
-          expect(error).toEqual({name: 'OtherError', message: 'other'});
+          assert.equal(shouldRetry, true);
+          assert.equal(error.name, 'OtherError');
         });
       });
       describe('#isTranscriptionSupported', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -714,7 +714,7 @@ describe('plugin-meetings', () => {
         });
       });
 
-      describe('#joinWithMedia', () => {
+      describe.only('#joinWithMedia', () => {
         it('should have #joinWithMedia', () => {
           assert.exists(meeting.joinWithMedia);
         });
@@ -1001,6 +1001,35 @@ describe('plugin-meetings', () => {
               type: addMediaError.name,
             }
           );
+        });
+
+        it('should call leave() if addMediaInternal() fails ', async () => {
+          const addMediaError = new Error('fake addMedia error');
+          addMediaError.name = 'TypeError';
+
+          const rejectError = {
+            error: {
+              body: {
+                errorCode: 2729,
+                message: 'fake addMedia error',
+                name: 'TypeError'
+              }
+            }
+          };
+          meeting.addMediaInternal.rejects(addMediaError);
+          sinon.stub(meeting, 'leave').resolves();
+
+          await assert.isRejected(
+            meeting.joinWithMedia({
+              joinOptions,
+              mediaOptions,
+            }),
+            rejectError
+          );
+
+          assert.calledOnce(meeting.join);
+          assert.calledOnce(meeting.addMediaInternal);
+          assert.calledOnce(Metrics.sendBehavioralMetric);
         });
 
         it('should not call leave() if addMediaInternal() fails the first time and succeeds the second time and should only call join() once', async () => {
@@ -1315,27 +1344,6 @@ describe('plugin-meetings', () => {
               receiveAudio: true,
             })
           );
-        });
-
-        it('should not handle non-browser media error', () => {
-          let shouldRetry = true;
-          let error = {name: 'OtherError', message: 'other'};
-
-          if (CallDiagnosticUtils.isBrowserMediaError(error)) {
-            shouldRetry = false;
-            error = merge({
-              error: {
-                body: {
-                  errorCode: CallDiagnosticUtils.getBrowserMediaErrorCode(error),
-                  message: error?.message,
-                  name: error?.name,
-                },
-              },
-            });
-          }
-
-          assert.equal(shouldRetry, true);
-          assert.equal(error.name, 'OtherError');
         });
       });
       describe('#isTranscriptionSupported', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -714,7 +714,7 @@ describe('plugin-meetings', () => {
         });
       });
 
-      describe.only('#joinWithMedia', () => {
+      describe('#joinWithMedia', () => {
         it('should have #joinWithMedia', () => {
           assert.exists(meeting.joinWithMedia);
         });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >
https://jira-eng-gpk2.cisco.com/jira/browse/WEBEX-455994

## This pull request addresses

< DESCRIBE THE CONTEXT OF THE ISSUE >
Web client wants display the following error message when received "TypeError: RTCPeerConnection is not a constructor" 
<img width="713" height="334" alt="image" src="https://github.com/user-attachments/assets/9c26152e-6412-4842-b76b-2e2cb4cb1d8a" />

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
