### PR TITLE
fix(meetings): added support for "info" and "fullState" Locus hash tree objects

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -958,10 +958,6 @@ class HashTreeParser {
       );
 
       dataSet.timer = setTimeout(async () => {
-        LoggerProxy.logger.info(
-          `HashTreeParser#runSyncAlgorithm --> ${this.debugId} Sync timer fired for "${dataSet.name}" data set`
-        );
-
         dataSet.timer = undefined;
 
         if (!dataSet.hashTree) {

--- a/packages/@webex/plugin-meetings/src/hashTree/types.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/types.ts
@@ -1,15 +1,25 @@
 import {Enum} from '../constants';
 
-// todo: Locus docs have now more types like CONTROL_ENTRY, EMBEDDED_APP, FULL_STATE, INFO, MEDIA_SHARE - need to add support for them once Locus implements them
+// todo: Locus docs have now more types like CONTROL_ENTRY, EMBEDDED_APP - need to add support for them once Locus implements them
 export const ObjectType = {
   participant: 'participant',
   self: 'self',
   locus: 'locus',
   mediaShare: 'mediashare',
+  info: 'info',
+  fullState: 'fullstate',
 } as const;
 
 export type ObjectType = Enum<typeof ObjectType>;
 
+// mapping from ObjectType to top level LocusDTO keys
+export const ObjectTypeToLocusKeyMap = {
+  [ObjectType.info]: 'info',
+  [ObjectType.fullState]: 'fullState',
+  [ObjectType.self]: 'self',
+  [ObjectType.participant]: 'participants', // note: each object is a single participant in participants array
+  [ObjectType.mediaShare]: 'mediaShares', // note: each object is a single mediaShare in mediaShares array
+};
 export interface HtMeta {
   elementId: {
     type: ObjectType;

--- a/packages/@webex/plugin-meetings/src/locus-info/types.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/types.ts
@@ -1,18 +1,20 @@
 import {HtMeta} from '../hashTree/types';
 
+export type LocusFullState = {
+  active: boolean;
+  count: number;
+  lastActive: string;
+  locked: boolean;
+  sessionId: string;
+  seessionIds: string[];
+  startTime: number;
+  state: string;
+  type: string;
+};
+
 export type LocusDTO = {
   controls?: any;
-  fullState?: {
-    active: boolean;
-    count: number;
-    lastActive: string;
-    locked: boolean;
-    sessionId: string;
-    seessionIds: string[];
-    startTime: number;
-    state: string;
-    type: string;
-  };
+  fullState?: LocusFullState;
   host?: {
     id: string;
     incomingCallProtocols: any[];


### PR DESCRIPTION
# COMPLETES #[SPARK-754131](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-754131)

## This pull request addresses
Locus has implemented "info" and "fullState" as separate hash tree objects - so no longer part of "Locus" object

## by making the following changes
Added handling of "info" and "fullState" hash tree objects

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual e2e testing on co.dmz.webex.com integration site with Locus

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
