### PR TITLE
fix(meetings): added support for links Locus hash tree objects

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/types.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/types.ts
@@ -8,12 +8,14 @@ export const ObjectType = {
   mediaShare: 'mediashare',
   info: 'info',
   fullState: 'fullstate',
+  links: 'links',
 } as const;
 
 export type ObjectType = Enum<typeof ObjectType>;
 
 // mapping from ObjectType to top level LocusDTO keys
 export const ObjectTypeToLocusKeyMap = {
+  [ObjectType.links]: 'links',
   [ObjectType.info]: 'info',
   [ObjectType.fullState]: 'fullState',
   [ObjectType.self]: 'self',

--- a/packages/@webex/plugin-meetings/src/locus-info/types.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/types.ts
@@ -12,6 +12,11 @@ export type LocusFullState = {
   type: string;
 };
 
+export type Links = {
+  services: Record<'breakout' | 'record', {url: string}>; // there exist also other services, but these are the ones we currently use
+  resources: Record<'webcastInstance' | 'visibleDataSets', {url: string}>; // there exist also other resources, but these are the ones we currently use
+};
+
 export type LocusDTO = {
   controls?: any;
   fullState?: LocusFullState;
@@ -27,7 +32,7 @@ export type LocusDTO = {
   jsSdkMeta?: {
     removedParticipantIds: string[]; // list of ids of participants that are removed in the last update
   };
-  links?: any;
+  links?: Links;
   mediaShares?: any[];
   meetings?: any[];
   participants: any[];


### PR DESCRIPTION
# COMPLETES #[SPARK-746275](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-746275)

## This pull request addresses
Locus has taken out links out of Locus object and into a separate "links" object.

## by making the following changes
Existing code was taking services and resources out of links and copying them onto LocusInfo class, so you would end up with `Meeting.locusInfo.services` and `Meeting.locusInfo.resources`, but no `Meeting.locusInfo.links`. This is inconsistent with how other Locus DTO fiels are handled (like `info`, `fullState`, etc) and also would complicate code for hash trees handling, so I've changed it to just copy `links` from DTO into `Meeting.locusInfo.links`.

BTW, there is also a piece of code [here](https://github.com/webex/webex-js-sdk/blob/0e03f3bb9ddf392b9559c28a9fa64f0e4347ba17/packages/%40webex/plugin-meetings/src/meeting/index.ts#L1492) in Meeting constructor that expects `locusInfo.links` to exist, but before this PR this would never happen and RecordingController has been working fine only by luck, because we always get at least one Locus update during meeting join, so then it gets the serviceUrl correctly from the `LOCUSINFO.EVENTS.LINKS_SERVICES` event.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual e2e test with web app and Locus in integration

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
