### PR TITLE
 feat(internal-plugin-metrics): add prelogin metrics interface to new-metrics

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/generic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/generic-metrics.ts
@@ -79,7 +79,7 @@ export default abstract class GenericMetrics extends StatelessWebexPlugin {
       device: {
         id: this.getDeviceId(),
       },
-      locale: window.navigator.language,
+      locale: window?.navigator.language,
       os: {
         name: getOSNameInternal(),
         version: getOSVersion(),
@@ -94,12 +94,12 @@ export default abstract class GenericMetrics extends StatelessWebexPlugin {
   protected getBrowserDetails(): object {
     return {
       browser: getBrowserName(),
-      browserHeight: window.innerHeight,
+      browserHeight: window?.innerHeight,
       browserVersion: getBrowserVersion(),
-      browserWidth: window.innerWidth,
-      domain: window.location.hostname,
-      inIframe: window.self !== window.top,
-      locale: window.navigator.language,
+      browserWidth: window?.innerWidth,
+      domain: window?.location.hostname,
+      inIframe: window?.self !== window?.top,
+      locale: window?.navigator.language,
       os: getOSNameInternal(),
     };
   }

--- a/packages/@webex/internal-plugin-metrics/src/index.ts
+++ b/packages/@webex/internal-plugin-metrics/src/index.ts
@@ -28,6 +28,7 @@ import BehavioralMetrics from './behavioral-metrics';
 import OperationalMetrics from './operational-metrics';
 import BusinessMetrics from './business-metrics';
 import RtcMetrics from './rtcMetrics';
+import PreLoginMetrics from './prelogin-metrics';
 
 registerInternalPlugin('metrics', Metrics, {
   config,
@@ -51,6 +52,7 @@ export {
   OperationalMetrics,
   BusinessMetrics,
   RtcMetrics,
+  PreLoginMetrics,
 };
 export type {
   ClientEvent,

--- a/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
+++ b/packages/@webex/internal-plugin-metrics/src/metrics.types.ts
@@ -197,7 +197,7 @@ export interface BusinessEventPayload {
   metricName: string;
   timestamp: number;
   context: DeviceContext;
-  browserDetails: EventPayload;
+  browserDetails: object;
   value: EventPayload;
 }
 

--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -10,6 +10,7 @@ import BehavioralMetrics from './behavioral-metrics';
 import OperationalMetrics from './operational-metrics';
 import BusinessMetrics from './business-metrics';
 import PreLoginMetrics from './prelogin-metrics';
+import PreLoginMetricsBatcher from './prelogin-metrics-batcher';
 import {
   RecursivePartial,
   MetricEventProduct,
@@ -89,8 +90,13 @@ class Metrics extends WebexPlugin {
     this.webex.once('ready', () => {
       // @ts-ignore
       this.callDiagnosticMetrics = new CallDiagnosticMetrics({}, {parent: this.webex});
-      // @ts-ignore
-      this.preLoginMetrics = new PreLoginMetrics({}, {parent: this.webex});
+      this.preLoginMetrics = new PreLoginMetrics(
+        // @ts-ignore
+        new PreLoginMetricsBatcher({}, {parent: this.webex}),
+        {},
+        // @ts-ignore
+        {parent: this.webex}
+      );
       this.isReady = true;
       this.setDelaySubmitClientEvents({
         shouldDelay: this.delaySubmitClientEvents,
@@ -259,7 +265,7 @@ class Metrics extends WebexPlugin {
    * Call Analyzer: Pre-Login Event
    * @param args
    */
-  SubmitPreLoginEvent({
+  submitPreLoginEvent({
     name,
     preLoginId,
     payload,

--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -259,7 +259,17 @@ class Metrics extends WebexPlugin {
    * Call Analyzer: Pre-Login Event
    * @param args
    */
-  submitPreLoginEvent(preLoginId: string, name: string, payload: EventPayload): Promise<any> {
+  SubmitPreLoginEvent({
+    name,
+    preLoginId,
+    payload,
+    metadata,
+  }: {
+    name: string;
+    preLoginId: string;
+    payload: EventPayload;
+    metadata?: EventPayload;
+  }): Promise<void> {
     if (!this.isReady) {
       // @ts-ignore
       this.webex.logger.log(
@@ -269,7 +279,12 @@ class Metrics extends WebexPlugin {
       return Promise.resolve();
     }
 
-    return this.preLoginMetrics.submitPreLoginEvent(preLoginId, name, payload);
+    return this.preLoginMetrics.submitPreLoginEvent({
+      name,
+      preLoginId,
+      payload,
+      metadata,
+    });
   }
 
   /**

--- a/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/new-metrics.ts
@@ -9,6 +9,7 @@ import CallDiagnosticMetrics from './call-diagnostic/call-diagnostic-metrics';
 import BehavioralMetrics from './behavioral-metrics';
 import OperationalMetrics from './operational-metrics';
 import BusinessMetrics from './business-metrics';
+import PreLoginMetrics from './prelogin-metrics';
 import {
   RecursivePartial,
   MetricEventProduct,
@@ -45,6 +46,7 @@ class Metrics extends WebexPlugin {
   behavioralMetrics: BehavioralMetrics;
   operationalMetrics: OperationalMetrics;
   businessMetrics: BusinessMetrics;
+  preLoginMetrics: PreLoginMetrics;
   isReady = false;
 
   /**
@@ -87,6 +89,8 @@ class Metrics extends WebexPlugin {
     this.webex.once('ready', () => {
       // @ts-ignore
       this.callDiagnosticMetrics = new CallDiagnosticMetrics({}, {parent: this.webex});
+      // @ts-ignore
+      this.preLoginMetrics = new PreLoginMetrics({}, {parent: this.webex});
       this.isReady = true;
       this.setDelaySubmitClientEvents({
         shouldDelay: this.delaySubmitClientEvents,
@@ -249,6 +253,23 @@ class Metrics extends WebexPlugin {
     this.lazyBuildBusinessMetrics();
 
     return this.businessMetrics.submitBusinessEvent({name, payload, table, metadata});
+  }
+
+  /**
+   * Call Analyzer: Pre-Login Event
+   * @param args
+   */
+  submitPreLoginEvent(preLoginId: string, name: string, payload: EventPayload): Promise<any> {
+    if (!this.isReady) {
+      // @ts-ignore
+      this.webex.logger.log(
+        `NewMetrics: @submitPreLoginEvent. Attempted to submit before webex.ready: ${name}`
+      );
+
+      return Promise.resolve();
+    }
+
+    return this.preLoginMetrics.submitPreLoginEvent(preLoginId, name, payload);
   }
 
   /**

--- a/packages/@webex/internal-plugin-metrics/src/prelogin-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/prelogin-metrics.ts
@@ -1,34 +1,6 @@
 import GenericMetrics from './generic-metrics';
-import {EventPayload, Table} from './metrics.types';
+import {BusinessEvent, EventPayload} from './metrics.types';
 import PreLoginMetricsBatcher from './prelogin-metrics-batcher';
-
-/**
- * Builds a formatted event object for metrics submission.
- * @param {string} name - Metric name
- * @param {string} preLoginId - Pre-login user identifier
- * @param {EventPayload} payload - Metric payload data
- * @param {EventPayload} metadata - Additional metadata to include in the event
- * @returns {object} Formatted metrics event object with type, eventPayload, and timestamp
- */
-function buildEvent(
-  name: string,
-  preLoginId: string,
-  payload: EventPayload,
-  metadata: EventPayload
-) {
-  const payloadWithPreLoginId = {...payload, preLoginId};
-
-  return {
-    type: ['business'],
-    eventPayload: {
-      key: name,
-      client_timestamp: new Date().toISOString(),
-      preLoginId,
-      ...metadata,
-      value: payloadWithPreLoginId,
-    },
-  };
-}
 
 /**
  * @description Util class to handle PreLogin Metrics
@@ -36,20 +8,22 @@ function buildEvent(
  * @class PreLoginMetrics
  */
 export default class PreLoginMetrics extends GenericMetrics {
-  // @ts-ignore
-  private preLoginMetricsBatcher: PreLoginMetricsBatcher;
+  private preLoginMetricsBatcher: typeof PreLoginMetricsBatcher;
 
   /**
    * Constructor
-   * @param {any[]} args - Constructor arguments
+   * @param {PreLoginMetricsBatcher} preLoginMetricsBatcher - Pre-login metrics batcher
+   * @param {any} attrs - Attributes
+   * @param {any} options - Options
    * @constructor
    */
-  constructor(...args) {
-    super(...args);
-    // @ts-ignore
-    this.logger = this.webex.logger;
-    // @ts-ignore
-    this.preLoginMetricsBatcher = new PreLoginMetricsBatcher({}, {parent: this.webex});
+  constructor(
+    preLoginMetricsBatcher: typeof PreLoginMetricsBatcher,
+    attrs: any = {},
+    options: {parent?: any} = {}
+  ) {
+    super(attrs, options);
+    this.preLoginMetricsBatcher = preLoginMetricsBatcher;
   }
 
   /**
@@ -81,10 +55,40 @@ export default class PreLoginMetrics extends GenericMetrics {
       metadata.appType = 'Web Client';
     }
 
-    const finalEvent = buildEvent(name, preLoginId, payload, metadata);
+    const finalEvent = this.buildEvent(name, preLoginId, payload, metadata);
 
     this.preLoginMetricsBatcher.savePreLoginId(preLoginId);
 
     return this.preLoginMetricsBatcher.request(finalEvent);
+  }
+
+  /**
+   * Builds a formatted event object for metrics submission.
+   * @param {string} metricName - Metric name
+   * @param {string} preLoginId - Pre-login user identifier
+   * @param {EventPayload} payload - Metric payload data
+   * @param {EventPayload} metadata - Additional metadata to include in the event
+   * @returns {object} Formatted metrics event object with type, eventPayload, and timestamp
+   */
+  private buildEvent(
+    metricName: string,
+    preLoginId: string,
+    payload: EventPayload,
+    metadata: EventPayload
+  ): BusinessEvent {
+    return {
+      type: ['business'],
+      eventPayload: {
+        metricName,
+        browserDetails: this.getBrowserDetails(),
+        context: this.getContext(),
+        timestamp: new Date().getTime(),
+        value: {
+          preLoginId,
+          ...metadata,
+          ...payload,
+        },
+      },
+    };
   }
 }

--- a/packages/@webex/internal-plugin-metrics/src/prelogin-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/prelogin-metrics.ts
@@ -1,0 +1,62 @@
+import GenericMetrics from './generic-metrics';
+import {EventPayload} from './metrics.types';
+import PreLoginMetricsBatcher from './prelogin-metrics-batcher';
+
+/**
+ * @param {string} name - Metric name
+ * @param {EventPayload} payload - Metric payload
+ * @returns {object} Metrics Payload
+ */
+function buildEvent(name: string, payload: EventPayload) {
+  return {
+    type: ['business'],
+    eventPayload: {
+      key: name,
+      client_timestamp: new Date().toISOString(),
+      // ...metadata,
+      value: payload,
+    },
+  };
+}
+
+/**
+ * @description Util class to handle PreLogin Metrics
+ * @export
+ * @class PreLoginMetrics
+ */
+export default class PreLoginMetrics extends GenericMetrics {
+  // @ts-ignore
+  private preLoginMetricsBatcher: PreLoginMetricsBatcher;
+
+  /**
+   * Constructor
+   * @param {any[]} args - Constructor arguments
+   * @constructor
+   */
+  constructor(...args) {
+    super(...args);
+    // @ts-ignore
+    this.logger = this.webex.logger;
+    // @ts-ignore
+    this.preLoginMetricsBatcher = new PreLoginMetricsBatcher({}, {parent: this.webex});
+  }
+
+  /**
+   * @param {string} preLoginId - A string representing the pre-login user ID
+   * @param {string} name - Metric name
+   * @param {EventPayload} payload - Metric payload
+   * @returns {Promise<any>} Metrics Payload
+   */
+  public submitPreLoginEvent(
+    preLoginId: string,
+    name: string,
+    payload: EventPayload
+  ): Promise<any> {
+    // build metrics-a event type
+    const finalEvent = buildEvent(name, payload);
+
+    this.preLoginMetricsBatcher.savePreLoginId(preLoginId);
+
+    return this.preLoginMetricsBatcher.request(finalEvent);
+  }
+}

--- a/packages/@webex/internal-plugin-metrics/src/prelogin-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/prelogin-metrics.ts
@@ -1,20 +1,31 @@
 import GenericMetrics from './generic-metrics';
-import {EventPayload} from './metrics.types';
+import {EventPayload, Table} from './metrics.types';
 import PreLoginMetricsBatcher from './prelogin-metrics-batcher';
 
 /**
+ * Builds a formatted event object for metrics submission.
  * @param {string} name - Metric name
- * @param {EventPayload} payload - Metric payload
- * @returns {object} Metrics Payload
+ * @param {string} preLoginId - Pre-login user identifier
+ * @param {EventPayload} payload - Metric payload data
+ * @param {EventPayload} metadata - Additional metadata to include in the event
+ * @returns {object} Formatted metrics event object with type, eventPayload, and timestamp
  */
-function buildEvent(name: string, payload: EventPayload) {
+function buildEvent(
+  name: string,
+  preLoginId: string,
+  payload: EventPayload,
+  metadata: EventPayload
+) {
+  const payloadWithPreLoginId = {...payload, preLoginId};
+
   return {
     type: ['business'],
     eventPayload: {
       key: name,
       client_timestamp: new Date().toISOString(),
-      // ...metadata,
-      value: payload,
+      preLoginId,
+      ...metadata,
+      value: payloadWithPreLoginId,
     },
   };
 }
@@ -42,18 +53,35 @@ export default class PreLoginMetrics extends GenericMetrics {
   }
 
   /**
-   * @param {string} preLoginId - A string representing the pre-login user ID
-   * @param {string} name - Metric name
-   * @param {EventPayload} payload - Metric payload
-   * @returns {Promise<any>} Metrics Payload
+   * Submit a business metric to our metrics endpoint.
+   * Routes to the correct table with the correct schema payload by table.
+   * @see https://confluence-eng-gpk2.cisco.com/conf/display/WAP/Business+metrics++-%3E+ROMA
+   * @param {Object} options - The options object
+   * @param {string} options.name - Name of the metric
+   * @param {string} options.preLoginId - ID to identify pre-login user
+   * @param {EventPayload} options.payload - User payload of the metric
+   * @param {EventPayload} [options.metadata] - Optional metadata to include outside of eventPayload.value
+   * @returns {Promise<void>} Promise that resolves when the metric is submitted
    */
-  public submitPreLoginEvent(
-    preLoginId: string,
-    name: string,
-    payload: EventPayload
-  ): Promise<any> {
-    // build metrics-a event type
-    const finalEvent = buildEvent(name, payload);
+  public submitPreLoginEvent({
+    name,
+    preLoginId,
+    payload,
+    metadata,
+  }: {
+    name: string;
+    preLoginId: string;
+    payload: EventPayload;
+    metadata?: EventPayload;
+  }): Promise<void> {
+    if (!metadata) {
+      metadata = {};
+    }
+    if (!metadata.appType) {
+      metadata.appType = 'Web Client';
+    }
+
+    const finalEvent = buildEvent(name, preLoginId, payload, metadata);
 
     this.preLoginMetricsBatcher.savePreLoginId(preLoginId);
 

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/prelogin-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/prelogin-metrics.ts
@@ -1,0 +1,132 @@
+import PreLoginMetricsBatcher from '../../../src/prelogin-metrics-batcher';
+import {PreLoginMetrics} from '@webex/internal-plugin-metrics';
+import {assert} from '@webex/test-helper-chai';
+import MockWebex from '@webex/test-helper-mock-webex';
+import sinon from 'sinon';
+
+describe('internal-plugin-metrics', () => {
+  const mockedWebex: MockWebex = new MockWebex();
+  const fakedPreLoginMetricsBatcher: typeof PreLoginMetricsBatcher = new PreLoginMetricsBatcher({}, {parent: mockedWebex});
+
+  describe('prelogin-metrics', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('Should send metrics to preloginMetricsBatcher', async () => {
+      const testEvent = 'test';
+      const testId = 'abc123';
+      const preLoginMetrics = new PreLoginMetrics(fakedPreLoginMetricsBatcher, {}, {parent: mockedWebex});
+
+      sinon.stub(fakedPreLoginMetricsBatcher, 'savePreLoginId');
+      const requestSpy = sinon.stub(fakedPreLoginMetricsBatcher, 'request');
+
+      await preLoginMetrics.submitPreLoginEvent({name: testEvent, preLoginId: testId, payload: {}});
+
+      assert.calledOnceWithMatch(requestSpy, {
+        type: ['business'],
+        eventPayload: {metricName: testEvent, value: {preLoginId: testId}},
+      });
+    });
+
+    it('Should send metadata to preloginMetricsBatcher', async () => {
+      const testEvent = 'test';
+      const testId = 'abc123';
+      const testMetadata = { 'testKey': 'test-value' };
+      const preLoginMetrics = new PreLoginMetrics(fakedPreLoginMetricsBatcher, {}, {parent: mockedWebex});
+
+      sinon.stub(fakedPreLoginMetricsBatcher, 'savePreLoginId');
+      const requestSpy = sinon.stub(fakedPreLoginMetricsBatcher, 'request');
+
+      await preLoginMetrics.submitPreLoginEvent({name: testEvent, preLoginId: testId, payload: {}, metadata: testMetadata});
+
+      assert.calledOnceWithMatch(requestSpy, {
+        type: ['business'],
+        eventPayload: {metricName: testEvent, value: {preLoginId: testId, ...testMetadata}},
+      });
+    });
+
+    it('Should send payload to preloginMetricsBatcher', async () => {
+      const testEvent = 'test';
+      const testId = 'abc123';
+      const testPayload = { 'testKey': 'test-value' };
+      const preLoginMetrics = new PreLoginMetrics(fakedPreLoginMetricsBatcher, {}, {parent: mockedWebex});
+
+      sinon.stub(fakedPreLoginMetricsBatcher, 'savePreLoginId');
+      const requestSpy = sinon.stub(fakedPreLoginMetricsBatcher, 'request');
+
+      await preLoginMetrics.submitPreLoginEvent({name: testEvent, preLoginId: testId, payload: testPayload});
+
+      assert.calledOnceWithMatch(requestSpy, {
+        type: ['business'],
+        eventPayload: {metricName: testEvent, value: {preLoginId: testId, ...testPayload}},
+      });
+    });
+
+    it('Should fill appType if not defined', async () => {
+      const testEvent = 'test';
+      const preLoginMetrics = new PreLoginMetrics(fakedPreLoginMetricsBatcher, {}, {parent: mockedWebex});
+
+      sinon.stub(fakedPreLoginMetricsBatcher, 'savePreLoginId');
+      const requestSpy = sinon.stub(fakedPreLoginMetricsBatcher, 'request');
+
+      await preLoginMetrics.submitPreLoginEvent({name: testEvent, preLoginId: 'abc123', payload: {}});
+
+      assert.calledOnceWithMatch(requestSpy, {
+        type: ['business'],
+        eventPayload: {metricName: testEvent, value: {appType: 'Web Client'}},
+      });
+    });
+
+    it('Should add browser details', async () => {
+      const testEvent = 'test';
+      const testBrowserDetails = { browser: 'Firefox', domain: 'test.example.com' };
+      const preLoginMetrics = new PreLoginMetrics(fakedPreLoginMetricsBatcher, {}, {parent: mockedWebex});
+
+      sinon.stub(preLoginMetrics, 'getBrowserDetails').returns(testBrowserDetails);
+      sinon.stub(fakedPreLoginMetricsBatcher, 'savePreLoginId');
+      const requestSpy = sinon.stub(fakedPreLoginMetricsBatcher, 'request');
+
+      await preLoginMetrics.submitPreLoginEvent({name: testEvent, preLoginId: 'abc123', payload: {}});
+
+      assert.calledOnceWithMatch(requestSpy, {
+        type: ['business'],
+        eventPayload: {browserDetails: testBrowserDetails, metricName: testEvent},
+      });
+    });
+
+    it('Should add context', async () => {
+      const testEvent = 'test';
+      const testContext = { device: { id: 'abc123' }};
+      const preLoginMetrics = new PreLoginMetrics(fakedPreLoginMetricsBatcher, {}, {parent: mockedWebex});
+
+      sinon.stub(preLoginMetrics, 'getContext').returns(testContext);
+      sinon.stub(fakedPreLoginMetricsBatcher, 'savePreLoginId');
+      const requestSpy = sinon.stub(fakedPreLoginMetricsBatcher, 'request');
+
+      await preLoginMetrics.submitPreLoginEvent({name: testEvent, preLoginId: 'abc123', payload: {}});
+
+      assert.calledOnceWithMatch(requestSpy, {
+        type: ['business'],
+        eventPayload: {context: testContext, metricName: testEvent},
+      });
+    });
+
+    it('Should add timestamp', async () => {
+      const testEvent = 'test';
+      const testTime = 1234;
+      const preLoginMetrics = new PreLoginMetrics(fakedPreLoginMetricsBatcher, {}, {parent: mockedWebex});
+
+      sinon.useFakeTimers(testTime);
+      sinon.stub(fakedPreLoginMetricsBatcher, 'savePreLoginId');
+      const requestSpy = sinon.stub(fakedPreLoginMetricsBatcher, 'request');
+
+      await preLoginMetrics.submitPreLoginEvent({name: testEvent, preLoginId: 'abc123', payload: {}});
+
+      assert.calledOnceWithMatch(requestSpy, {
+        type: ['business'],
+        eventPayload: {metricName: testEvent, timestamp: testTime},
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[CX-22317](https://jira-eng-sjc12.cisco.com/jira/browse/CX-22317)

## This pull request addresses

We want to have the ability to send pre-login metrics from `wxcc-desktop`

## by making the following changes

Exposing an API in the SDK

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

This PR also adds unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
