### PR TITLE
fix(webinar5k): route token

### DIFF
--- a/packages/@webex/plugin-meetings/src/interceptors/locusRouteToken.ts
+++ b/packages/@webex/plugin-meetings/src/interceptors/locusRouteToken.ts
@@ -66,7 +66,7 @@ export default class LocusRouteTokenInterceptor extends Interceptor {
    * @returns {void}
    */
   updateToken(locusId, token) {
-    if (token === 'null' || !token) {
+    if (token === 'null' || token === null) {
       delete ROUTE_TOKEN[locusId];
     } else {
       ROUTE_TOKEN[locusId] = token;

--- a/packages/@webex/plugin-meetings/src/interceptors/locusRouteToken.ts
+++ b/packages/@webex/plugin-meetings/src/interceptors/locusRouteToken.ts
@@ -6,7 +6,7 @@ import {Interceptor} from '@webex/http-core';
 import {has} from 'lodash';
 
 const LOCUS_ID_REGEX = /\/locus\/api\/v1\/loci\/([a-f0-9-]{36})/i;
-const X_CISCO_PART_ROUTE_TOKEN = 'X-Cisco-Part-Route-Token';
+const X_CISCO_PART_ROUTE_TOKEN = 'x-cisco-part-route-token';
 const ROUTE_TOKEN = {};
 
 /**
@@ -66,7 +66,11 @@ export default class LocusRouteTokenInterceptor extends Interceptor {
    * @returns {void}
    */
   updateToken(locusId, token) {
-    ROUTE_TOKEN[locusId] = token;
+    if (token === 'null' || !token) {
+      delete ROUTE_TOKEN[locusId];
+    } else {
+      ROUTE_TOKEN[locusId] = token;
+    }
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/interceptors/locusRouteToken.ts
+++ b/packages/@webex/plugin-meetings/src/interceptors/locusRouteToken.ts
@@ -3,10 +3,9 @@
  */
 
 import {Interceptor} from '@webex/http-core';
-import {has} from 'lodash';
 
 const LOCUS_ID_REGEX = /\/locus\/api\/v1\/loci\/([a-f0-9-]{36})/i;
-const X_CISCO_PART_ROUTE_TOKEN = 'x-cisco-part-route-token';
+const X_CISCO_PART_ROUTE_TOKEN = 'X-Cisco-Part-Route-Token';
 const ROUTE_TOKEN = {};
 
 /**
@@ -25,6 +24,13 @@ export default class LocusRouteTokenInterceptor extends Interceptor {
     return url?.match(LOCUS_ID_REGEX)?.[1];
   }
 
+  // Helper function to get header value case insensitively
+  getHeader(headers: Record<string, string>, name: string) {
+    const key = Object.keys(headers).find((k) => k.toLowerCase() === name.toLowerCase());
+
+    return key ? headers[key] : undefined;
+  }
+
   /**
    * @param {Object} options
    * @param {HttpResponse} response
@@ -33,8 +39,10 @@ export default class LocusRouteTokenInterceptor extends Interceptor {
   onResponse(options, response) {
     const locusId = this.getLocusIdByRequestUrl(options.uri);
     if (locusId) {
-      const hasRouteToken = has(response.headers, X_CISCO_PART_ROUTE_TOKEN);
-      const token = response.headers[X_CISCO_PART_ROUTE_TOKEN];
+      const hasRouteToken = Object.keys(response.headers).some(
+        (key) => key.toLowerCase() === X_CISCO_PART_ROUTE_TOKEN.toLowerCase()
+      );
+      const token = this.getHeader(response.headers, X_CISCO_PART_ROUTE_TOKEN);
       if (hasRouteToken) {
         this.updateToken(locusId, token);
       }

--- a/packages/@webex/plugin-meetings/test/unit/spec/interceptors/locusRouteToken.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/interceptors/locusRouteToken.ts
@@ -89,4 +89,9 @@ describe('LocusRouteTokenInterceptor', () => {
     interceptor.updateToken(TEST_LOCUS_ID, 'null');
     assert.isUndefined(interceptor.getToken(TEST_LOCUS_ID));
   });
+
+  it('should delete token when updateToken called with null', () => {
+    interceptor.updateToken(TEST_LOCUS_ID, null);
+    assert.isUndefined(interceptor.getToken(TEST_LOCUS_ID));
+  });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/interceptors/locusRouteToken.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/interceptors/locusRouteToken.ts
@@ -9,7 +9,7 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import {LocusRouteTokenInterceptor} from '@webex/plugin-meetings/src/interceptors';
 import Meetings from '@webex/plugin-meetings';
 
-const X_CISCO_PART_ROUTE_TOKEN = 'x-cisco-part-route-token';
+const X_CISCO_PART_ROUTE_TOKEN = 'X-Cisco-Part-Route-Token';
 
 describe('LocusRouteTokenInterceptor', () => {
   let interceptor, webex;
@@ -41,6 +41,23 @@ describe('LocusRouteTokenInterceptor', () => {
     const response = {
       headers: {
         [X_CISCO_PART_ROUTE_TOKEN]: 'test-token',
+      },
+    };
+
+    const result = await interceptor.onResponse(
+      {
+        uri: `https://locus-test.webex.com/locus/api/v1/loci/${TEST_LOCUS_ID}/foo`,
+      },
+      response
+    );
+    assert.equal(result, response);
+    assert.equal(interceptor.getToken(TEST_LOCUS_ID), 'test-token');
+  });
+
+  it('get route token case insensitively ', async () => {
+    const response = {
+      headers: {
+        ['x-cisco-part-route-token']: 'test-token',
       },
     };
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/interceptors/locusRouteToken.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/interceptors/locusRouteToken.ts
@@ -9,7 +9,7 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import {LocusRouteTokenInterceptor} from '@webex/plugin-meetings/src/interceptors';
 import Meetings from '@webex/plugin-meetings';
 
-const X_CISCO_PART_ROUTE_TOKEN = 'X-Cisco-Part-Route-Token';
+const X_CISCO_PART_ROUTE_TOKEN = 'x-cisco-part-route-token';
 
 describe('LocusRouteTokenInterceptor', () => {
   let interceptor, webex;
@@ -83,5 +83,10 @@ describe('LocusRouteTokenInterceptor', () => {
   it('updateToken & getToken should work as pair', () => {
     interceptor.updateToken(TEST_LOCUS_ID, 'abc456');
     assert.equal(interceptor.getToken(TEST_LOCUS_ID), 'abc456');
+  });
+
+  it('should delete token when updateToken called with "null"', () => {
+    interceptor.updateToken(TEST_LOCUS_ID, 'null');
+    assert.isUndefined(interceptor.getToken(TEST_LOCUS_ID));
   });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-759245

## This pull request addresses

Modify token values and support the string 'null'

## by making the following changes

'X-Cisco-Part-Route-Token' -> 'x-cisco-part-route-token'

<img width="578" height="833" alt="image" src="https://github.com/user-attachments/assets/4517c7b5-5142-4fc3-ba08-d195f097d6cf" />

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
