### PR TITLE
fix: added support for controls hash tree object types

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/types.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/types.ts
@@ -1,6 +1,6 @@
 import {Enum} from '../constants';
 
-// todo: Locus docs have now more types like CONTROL_ENTRY, EMBEDDED_APP - need to add support for them once Locus implements them
+// todo: Locus docs have now more types like EMBEDDED_APP - need to add support for them once Locus implements them
 export const ObjectType = {
   participant: 'participant',
   self: 'self',
@@ -9,6 +9,7 @@ export const ObjectType = {
   info: 'info',
   fullState: 'fullstate',
   links: 'links',
+  control: 'controlentry',
 } as const;
 
 export type ObjectType = Enum<typeof ObjectType>;
@@ -21,6 +22,7 @@ export const ObjectTypeToLocusKeyMap = {
   [ObjectType.self]: 'self',
   [ObjectType.participant]: 'participants', // note: each object is a single participant in participants array
   [ObjectType.mediaShare]: 'mediaShares', // note: each object is a single mediaShare in mediaShares array
+  [ObjectType.control]: 'controls', // note: each object is a single control entry in controls object
 };
 export interface HtMeta {
   elementId: {

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -590,6 +590,24 @@ export default class LocusInfo extends EventsScope {
           this.hashTreeObjectId2ParticipantId.delete(object.htMeta.elementId.id);
         }
         break;
+      case ObjectType.control:
+        if (object.data) {
+          Object.keys(object.data).forEach((controlKey) => {
+            LoggerProxy.logger.info(
+              `Locus-info:index#updateLocusFromHashTreeObject --> control ${controlKey} updated:`,
+              object.data[controlKey]
+            );
+            if (!locus.controls) {
+              locus.controls = {};
+            }
+            locus.controls[controlKey] = object.data[controlKey];
+          });
+        } else {
+          LoggerProxy.logger.warn(
+            `Locus-info:index#updateLocusFromHashTreeObject --> control object update without data - this is not expected!`
+          );
+        }
+        break;
       case ObjectType.links:
       case ObjectType.info:
       case ObjectType.fullState:

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -486,7 +486,6 @@ describe('plugin-meetings', () => {
           // setup new updated locus that has many things missing
           const newLocusHtMeta = {elementId: {type: 'locus', version: 42}};
           const newLocus = {
-            controls: 'new-controls',
             host: 'new-host',
             htMeta: newLocusHtMeta,
           };
@@ -499,10 +498,11 @@ describe('plugin-meetings', () => {
           // check onDeltaLocus() was called with correctly updated locus info
           assert.calledOnceWithExactly(onDeltaLocusStub, {
             // these fields are not part of Locus object, so should keep their old values:
+            controls: {id: 'fake-controls'},
             info: {id: 'fake-info'},
             fullState: {id: 'fake-full-state'},
             self: {id: 'fake-self'},
-            links: { id: 'fake-links' },
+            links: {id: 'fake-links'},
             mediaShares: expectedLocusInfo.mediaShares,
             // and now the new fields
             ...newLocus,
@@ -518,7 +518,6 @@ describe('plugin-meetings', () => {
           // setup new updated locus that has many things missing
           const newLocusHtMeta = {elementId: {type: 'locus', version: 42}};
           const newLocus = {
-            controls: 'new-controls',
             host: 'new-host',
             htMeta: newLocusHtMeta,
           };
@@ -531,6 +530,7 @@ describe('plugin-meetings', () => {
                 data: {
                   ...newLocus,
                   // all these fields below should be ignored and not override the existing ones in our "old" Locus
+                  controls: {id: 'new-controls'},
                   info: 'new-info',
                   fullState: 'new-fullState',
                   self: 'new-self',
@@ -545,10 +545,11 @@ describe('plugin-meetings', () => {
           // with old values for the fields that should be ignored (like "info" or "fullState")
           assert.calledOnceWithExactly(onDeltaLocusStub, {
             // these fields have the "old" values:
+            controls: {id: 'fake-controls'},
             info: {id: 'fake-info'},
             fullState: {id: 'fake-full-state'},
             self: {id: 'fake-self'},
-            links: { id: 'fake-links' },
+            links: {id: 'fake-links'},
             mediaShares: expectedLocusInfo.mediaShares,
             participants: [], // empty means there were no participant updates
             jsSdkMeta: {removedParticipantIds: []}, // no participants were removed
@@ -579,6 +580,7 @@ describe('plugin-meetings', () => {
           // check onDeltaLocus() was called with correctly updated locus info
           assert.calledOnceWithExactly(onDeltaLocusStub, {
             // these fields are not part of Locus object, so should keep their old values:
+            controls: {id: 'fake-controls'},
             info: {id: 'fake-info'},
             fullState: {id: 'fake-full-state'},
             self: {id: 'fake-self'},
@@ -765,6 +767,60 @@ describe('plugin-meetings', () => {
             ],
             participants: [updatedParticipant2],
             self: newSelf,
+          });
+        });
+
+        it('should process locus update correctly when called with multiple CONTROL object updates', () => {
+          const firstControl = {
+            muteOnEntry: {enabled: true},
+            lock: {locked: true, meta: {lastModified: 'YESTERDAY', modifiedBy: 'John Doe'}},
+          };
+          const secondControl = {
+            reactions: {enabled: true},
+          };
+
+          // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
+          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+            updatedObjects: [
+              {
+                htMeta: {elementId: {type: 'controlentry', id: 'control-1'}},
+                data: firstControl,
+              },
+              {
+                htMeta: {elementId: {type: 'controlentry', id: 'control-2'}},
+                data: secondControl,
+              },
+            ],
+          });
+
+          // check onDeltaLocus() was called with correctly updated locus info
+          // all keys from both controls should be merged into the controls object
+          assert.calledOnceWithExactly(onDeltaLocusStub, {
+            ...expectedLocusInfo,
+            controls: {
+              id: 'fake-controls',
+              muteOnEntry: {enabled: true},
+              lock: {locked: true, meta: {lastModified: 'YESTERDAY', modifiedBy: 'John Doe'}},
+              reactions: {enabled: true},
+            },
+          });
+        });
+
+        it('should process locus update correctly when CONTROL object is received with no data', () => {
+          // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
+          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+            updatedObjects: [
+              {
+                htMeta: {elementId: {type: 'controlentry', id: 'some-control-id'}},
+                data: null,
+              },
+            ],
+          });
+
+          // check onDeltaLocus() was called with correctly updated locus info
+          // when data is null, it should be ignored and not change the controls
+          assert.calledOnceWithExactly(onDeltaLocusStub, {
+            ...expectedLocusInfo,
           });
         });
 


### PR DESCRIPTION
# COMPLETES #[SPARK-759383](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-759383)

## This pull request addresses
Locus has moved controls out of Locus main object type into a separate ControlEntry object type

## by making the following changes
updated SDK code to handle controls as separate hash tree object type

Locus docs explaining how the different object types should be handled can be seen in the table here:
https://sqbu-github.cisco.com/pages/WebExSquared/locus/guides/convergedWebinar5k/datasetsAndHashtreeSequencing.html#hash-tree-messages

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual e2e testing with web app and Locus in integration env

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
