### PR TITLE
fix: make sure wdm registrtion happens before silent relogin

### DIFF
--- a/packages/@webex/contact-center/src/cc.ts
+++ b/packages/@webex/contact-center/src/cc.ts
@@ -715,20 +715,18 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
             this.agentConfig.webRtcEnabled &&
             this.agentConfig.loginVoiceOptions.includes(LoginOption.BROWSER)
           ) {
-            this.$webex.internal.mercury
-              .connect()
-              .then(() => {
-                LoggerProxy.log('Authentication: webex.internal.mercury.connect successful', {
-                  module: CC_FILE,
-                  method: METHODS.CONNECT_WEBSOCKET,
-                });
-              })
-              .catch((error) => {
-                LoggerProxy.error(`Error occurred during mercury.connect() ${error}`, {
-                  module: CC_FILE,
-                  method: METHODS.CONNECT_WEBSOCKET,
-                });
+            try {
+              await this.$webex.internal.mercury.connect();
+              LoggerProxy.log('Authentication: webex.internal.mercury.connect successful', {
+                module: CC_FILE,
+                method: METHODS.CONNECT_WEBSOCKET,
               });
+            } catch (error) {
+              LoggerProxy.error(`Error occurred during mercury.connect() ${error}`, {
+                module: CC_FILE,
+                method: METHODS.CONNECT_WEBSOCKET,
+              });
+            }
           }
           if (this.$config && this.$config.allowAutomatedRelogin) {
             await this.silentRelogin();

--- a/packages/@webex/contact-center/src/cc.ts
+++ b/packages/@webex/contact-center/src/cc.ts
@@ -693,50 +693,49 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       module: CC_FILE,
       method: METHODS.CONNECT_WEBSOCKET,
     });
+
     try {
-      return this.services.webSocketManager
-        .initWebSocket({
-          body: this.getConnectionConfig(),
-        })
-        .then(async (data: WelcomeEvent) => {
-          const agentId = data.agentId;
-          const orgId = this.$webex.credentials.getOrgId();
-          this.agentConfig = await this.services.config.getAgentConfig(orgId, agentId);
-          LoggerProxy.log(`Agent config is fetched successfully`, {
+      const data = (await this.services.webSocketManager.initWebSocket({
+        body: this.getConnectionConfig(),
+      })) as WelcomeEvent;
+
+      const agentId = data.agentId;
+      const orgId = this.$webex.credentials.getOrgId();
+      this.agentConfig = await this.services.config.getAgentConfig(orgId, agentId);
+
+      LoggerProxy.log(`Agent config is fetched successfully`, {
+        module: CC_FILE,
+        method: METHODS.CONNECT_WEBSOCKET,
+      });
+
+      // TODO: Make profile a singleton to make it available throughout app/sdk so we dont need to inject info everywhere
+      this.taskManager.setWrapupData(this.agentConfig.wrapUpData);
+      this.taskManager.setAgentId(this.agentConfig.agentId);
+      this.taskManager.setWebRtcEnabled(this.agentConfig.webRtcEnabled);
+
+      if (
+        this.agentConfig.webRtcEnabled &&
+        this.agentConfig.loginVoiceOptions.includes(LoginOption.BROWSER)
+      ) {
+        try {
+          await this.$webex.internal.mercury.connect();
+          LoggerProxy.log('Authentication: webex.internal.mercury.connect successful', {
             module: CC_FILE,
             method: METHODS.CONNECT_WEBSOCKET,
           });
-          // TODO: Make profile a singleton to make it available throughout app/sdk so we dont need to inject info everywhere
-          this.taskManager.setWrapupData(this.agentConfig.wrapUpData);
-          this.taskManager.setAgentId(this.agentConfig.agentId);
-          this.taskManager.setWebRtcEnabled(this.agentConfig.webRtcEnabled);
+        } catch (error) {
+          LoggerProxy.error(`Error occurred during mercury.connect() ${error}`, {
+            module: CC_FILE,
+            method: METHODS.CONNECT_WEBSOCKET,
+          });
+        }
+      }
 
-          if (
-            this.agentConfig.webRtcEnabled &&
-            this.agentConfig.loginVoiceOptions.includes(LoginOption.BROWSER)
-          ) {
-            try {
-              await this.$webex.internal.mercury.connect();
-              LoggerProxy.log('Authentication: webex.internal.mercury.connect successful', {
-                module: CC_FILE,
-                method: METHODS.CONNECT_WEBSOCKET,
-              });
-            } catch (error) {
-              LoggerProxy.error(`Error occurred during mercury.connect() ${error}`, {
-                module: CC_FILE,
-                method: METHODS.CONNECT_WEBSOCKET,
-              });
-            }
-          }
-          if (this.$config && this.$config.allowAutomatedRelogin) {
-            await this.silentRelogin();
-          }
+      if (this.$config && this.$config.allowAutomatedRelogin) {
+        await this.silentRelogin();
+      }
 
-          return this.agentConfig;
-        })
-        .catch((error) => {
-          throw error;
-        });
+      return this.agentConfig;
     } catch (error) {
       LoggerProxy.error(`Error during register: ${error}`, {
         module: CC_FILE,


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7496

## This pull request addresses

Changed Mercury websocket connection to use await pattern to ensure sequential execution before silent relogin


## by making the following changes

Modified webex.internal.mercury.connect() to use await instead of allowing it to execute in .then() callback context
Wrapped Mercury connection in try-catch block for proper error handling
Added success and error logging for Mercury connection status
<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
