### PR TITLE
fix(contact-center): error handling for websocket register method

### DIFF
--- a/packages/@webex/contact-center/src/services/core/websocket/WebSocketManager.ts
+++ b/packages/@webex/contact-center/src/services/core/websocket/WebSocketManager.ts
@@ -46,7 +46,15 @@ export class WebSocketManager extends EventEmitter {
 
   async initWebSocket(options: {body: SubscribeRequest}): Promise<WelcomeResponse> {
     const connectionConfig = options.body;
-    await this.register(connectionConfig);
+    try {
+      await this.register(connectionConfig);
+    } catch (error) {
+      LoggerProxy.error(`[WebSocketStatus] | Error in registering Websocket ${error}`, {
+        module: WEB_SOCKET_MANAGER_FILE,
+        method: METHODS.INIT_WEB_SOCKET,
+      });
+      throw error;
+    }
 
     return new Promise((resolve, reject) => {
       this.welcomePromiseResolve = resolve;
@@ -90,6 +98,7 @@ export class WebSocketManager extends EventEmitter {
         `Register API Failed, Request to RoutingNotifs websocket registration API failed ${e}`,
         {module: WEB_SOCKET_MANAGER_FILE, method: METHODS.REGISTER}
       );
+      throw e;
     }
   }
 

--- a/packages/@webex/contact-center/test/unit/spec/services/core/websocket/WebSocketManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/core/websocket/WebSocketManager.ts
@@ -126,6 +126,26 @@ describe('WebSocketManager', () => {
     });
   });
 
+  it('should log error and throw when register API fails in initWebSocket', async () => {
+    const error = new Error('Register API failed');
+
+    (mockWebex.request as jest.Mock).mockRejectedValueOnce(error);
+
+    await expect(
+      webSocketManager.initWebSocket({ body: fakeSubscribeRequest })
+    ).rejects.toThrow(error);
+
+    expect(LoggerProxy.error).toHaveBeenCalledWith(
+      `Register API Failed, Request to RoutingNotifs websocket registration API failed ${error}`,
+      { module: WEB_SOCKET_MANAGER_FILE, method: 'register' }
+    );
+
+    expect(LoggerProxy.error).toHaveBeenCalledWith(
+      `[WebSocketStatus] | Error in registering Websocket ${error}`,
+      { module: WEB_SOCKET_MANAGER_FILE, method: 'initWebSocket' }
+    );
+  });
+
   it('should close WebSocket connection', async () => {
     const subscribeResponse = {
       body: {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7498

## This pull request addresses

We are not error handling the register method in WebSocketManager and the error is also not thrown for the register method.

## by making the following changes

Now the error is caught and thrown for the widgets to catch
<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Locally linked widgets and caught the error 

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
