### PR TITLE
fix: updated /sync request body

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -1113,11 +1113,7 @@ class HashTreeParser {
 
     const url = `${dataSet.url}/sync`;
     const body = {
-      dataSet: {
-        name: dataSet.name,
-        leafCount: dataSet.leafCount,
-        root: dataSet.hashTree?.getRootHash(),
-      },
+      leafCount: dataSet.leafCount,
       leafDataEntries: [],
     };
 

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -980,8 +980,8 @@ export default class LocusInfo extends EventsScope {
   // eslint-disable-next-line @typescript-eslint/no-shadow
   handleOneOnOneEvent(eventType: string) {
     if (
-      this.parsedLocus.fullState.type === _CALL_ ||
-      this.parsedLocus.fullState.type === _SIP_BRIDGE_
+      this.parsedLocus.fullState?.type === _CALL_ ||
+      this.parsedLocus.fullState?.type === _SIP_BRIDGE_
     ) {
       // for 1:1 bob calls alice and alice declines, notify the meeting state
       if (eventType === LOCUSEVENT.PARTICIPANT_DECLINED) {
@@ -1094,9 +1094,9 @@ export default class LocusInfo extends EventsScope {
    */
   isMeetingActive() {
     if (
-      this.parsedLocus.fullState.type === _CALL_ ||
-      this.parsedLocus.fullState.type === _SIP_BRIDGE_ ||
-      this.parsedLocus.fullState.type === _SPACE_SHARE_
+      this.parsedLocus.fullState?.type === _CALL_ ||
+      this.parsedLocus.fullState?.type === _SIP_BRIDGE_ ||
+      this.parsedLocus.fullState?.type === _SPACE_SHARE_
     ) {
       // @ts-ignore
       const partner = this.getLocusPartner(this.participants, this.self);
@@ -1189,7 +1189,7 @@ export default class LocusInfo extends EventsScope {
           }
         );
       }
-    } else if (this.parsedLocus.fullState.type === _MEETING_) {
+    } else if (this.parsedLocus.fullState?.type === _MEETING_) {
       if (
         this.fullState &&
         (this.fullState.state === LOCUS.STATE.INACTIVE ||
@@ -1286,6 +1286,7 @@ export default class LocusInfo extends EventsScope {
   compareSelfAndHost() {
     // In some cases the host info is not present but the moderator values changes from null to false so it triggers an update
     if (
+      this.parsedLocus.self &&
       this.parsedLocus.self.selfIdentity === this.parsedLocus.host?.hostId &&
       this.parsedLocus.self.moderator
     ) {
@@ -1970,14 +1971,14 @@ export default class LocusInfo extends EventsScope {
       }
 
       // TODO: check if we need to save the sipUri here as well
-      // this.emit(LOCUSINFO.EVENTS.MEETING_UPDATE, SelfUtils.getSipUrl(this.getLocusPartner(participants, self), this.parsedLocus.fullState.type, this.parsedLocus.info.sipUri));
+      // this.emit(LOCUSINFO.EVENTS.MEETING_UPDATE, SelfUtils.getSipUrl(this.getLocusPartner(participants, self), this.parsedLocus.fullState?.type, this.parsedLocus.info?.sipUri));
       const result = SelfUtils.getSipUrl(
         this.getLocusPartner(this.participants, self),
-        this.parsedLocus.fullState.type,
-        this.parsedLocus.info.sipUri
+        this.parsedLocus.fullState?.type,
+        this.parsedLocus.info?.sipUri
       );
 
-      if (result.sipUri) {
+      if (result?.sipUri) {
         this.updateMeeting(result);
       }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -1187,11 +1187,7 @@ describe('HashTreeParser', () => {
           method: 'POST',
           uri: `${mainDataSetUrl}/sync`,
           body: {
-            dataSet: {
-              name: 'main',
-              leafCount: 16,
-              root: '472801612a448c4e0ab74975ed9d7a2e'
-            },
+            leafCount: 16,
             leafDataEntries: [
               {leafIndex: 0, elementIds: [{type: 'locus', id: 0, version: 201}]},
               {leafIndex: 4, elementIds: [{type: 'participant', id: 4, version: 301}]},
@@ -1244,11 +1240,7 @@ describe('HashTreeParser', () => {
           method: 'POST',
           uri: `${parser.dataSets.self.url}/sync`,
           body: {
-            dataSet: {
-              name: 'self',
-              leafCount: 1,
-              root: '483ba32a5db954720b4c43ed528d8075'
-            },
+            leafCount: 1,
             leafDataEntries: [
               {leafIndex: 0, elementIds: [{type: 'self', id: 4, version: 102}]},
             ],


### PR DESCRIPTION
# COMPLETES #[SPARK-759852](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-759852)

## This pull request addresses
Locus has changed the /sync API request body, now they expect `leafCount` at top level in the body instead of being inside `dataSet` object

## by making the following changes
updated code that sends the /sync request

also added checks for undefined in a bunch of places where this.parsedLocus is used, because during testing I've noticed that in some edge cases (mainly if you have 2 browsers open with same user logged in and join a webinar from one of them) we end up with a short period of time where we might have only data from MAIN dataset or only from SELF and then some parts of this.parsedLocus like fullState or info can be missing.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual testing with webapp and Locus in integration

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
