### PR TITLE
fix: sometimes SDK leaves webinar5k right after joining it

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -3,9 +3,9 @@ import HashTree, {LeafDataItem} from './hashTree';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {Enum, HTTP_VERBS} from '../constants';
 import {DataSetNames, EMPTY_HASH} from './constants';
-import {ObjectType, HtMeta} from './types';
+import {ObjectType, HtMeta, HashTreeObject} from './types';
 import {LocusDTO} from '../locus-info/types';
-import {deleteNestedObjectsWithHtMeta} from './utils';
+import {deleteNestedObjectsWithHtMeta, isSelf} from './utils';
 
 export interface DataSet {
   url: string;
@@ -18,11 +18,6 @@ export interface DataSet {
     maxMs: number;
     exponent: number;
   };
-}
-
-export interface HashTreeObject {
-  htMeta: HtMeta;
-  data: Record<string, any>;
 }
 
 export interface RootHashMessage {
@@ -59,15 +54,6 @@ export type LocusInfoUpdateCallback = (
  * It's handled internally by HashTreeParser and results in MEETING_ENDED being sent up.
  */
 class MeetingEndedError extends Error {}
-
-/**
- * Checks if the given hash tree object is of type "self"
- * @param {HashTreeObject} object object to check
- * @returns {boolean} True if the object is of type "self", false otherwise
- */
-export function isSelf(object: HashTreeObject) {
-  return object.htMeta.elementId.type.toLowerCase() === ObjectType.self;
-}
 
 /**
  * Parses hash tree eventing locus data

--- a/packages/@webex/plugin-meetings/src/hashTree/types.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/types.ts
@@ -32,3 +32,8 @@ export interface HtMeta {
   };
   dataSetNames: string[];
 }
+
+export interface HashTreeObject {
+  htMeta: HtMeta;
+  data: Record<string, any>;
+}

--- a/packages/@webex/plugin-meetings/src/hashTree/utils.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/utils.ts
@@ -1,5 +1,16 @@
 /* eslint-disable import/prefer-default-export */
 
+import {ObjectType, HashTreeObject} from './types';
+
+/**
+ * Checks if the given hash tree object is of type "self"
+ * @param {HashTreeObject} object object to check
+ * @returns {boolean} True if the object is of type "self", false otherwise
+ */
+export function isSelf(object: HashTreeObject) {
+  return object.htMeta.elementId.type.toLowerCase() === ObjectType.self;
+}
+
 /**
  * Analyzes given part of Locus DTO recursively and delete any nested objects that have their own htMeta
  *

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -34,11 +34,10 @@ import BEHAVIORAL_METRICS from '../metrics/constants';
 import HashTreeParser, {
   DataSet,
   HashTreeMessage,
-  HashTreeObject,
-  isSelf,
   LocusInfoUpdateType,
 } from '../hashTree/hashTreeParser';
-import {ObjectType, ObjectTypeToLocusKeyMap} from '../hashTree/types';
+import {HashTreeObject, ObjectType, ObjectTypeToLocusKeyMap} from '../hashTree/types';
+import {isSelf} from '../hashTree/utils';
 import {Links, LocusDTO, LocusFullState} from './types';
 
 export type LocusLLMEvent = {

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -67,6 +67,8 @@ import {SpaceIDDeprecatedError} from '../common/errors/webex-errors';
 import NoMeetingInfoError from '../common/errors/no-meeting-info';
 import JoinForbiddenError from '../common/errors/join-forbidden-error';
 import {HashTreeMessage} from '../hashTree/hashTreeParser';
+import {HashTreeObject} from '../hashTree/types';
+import {isSelf} from '../hashTree/utils';
 
 let mediaLogger;
 
@@ -420,31 +422,36 @@ export default class Meetings extends WebexPlugin {
    * @memberof Meetings
    */
   getCorrespondingMeetingByLocus(data: LocusEvent) {
-    if (
-      data.eventType === LOCUSEVENT.HASH_TREE_DATA_UPDATED &&
-      data.stateElementsMessage?.locusUrl
-    ) {
-      return this.meetingCollection.getByKey(
-        MEETING_KEY.LOCUS_URL,
-        data.stateElementsMessage.locusUrl
-      );
+    const locusUrl =
+      data.stateElementsMessage?.locusUrl || // hash tree event
+      data.locusUrl; // classic event
+
+    // first try to find by locusUrl - that's the simplest and quickest way
+    const existingMeeting = this.meetingCollection.getByKey(MEETING_KEY.LOCUS_URL, locusUrl);
+
+    if (existingMeeting) {
+      return existingMeeting;
     }
 
-    // getting meeting by correlationId. This will happen for the new event
-    // Either the locus
-    // TODO : Add check for the callBack Address
+    // if that didn't work, fallback to other fields like correlationId, sipUri, etc
+
+    // If the event is a hash tree event, we need to extract "self" object from it
+    // We don't care about the version, just need to find the meeting this event is for,
+    // so any hash tree object of type "self" will do
+    const hashTreeEventSelf = data.stateElementsMessage?.locusStateElements?.find(
+      (obj: HashTreeObject) => isSelf(obj)
+    )?.data;
+
+    const self = hashTreeEventSelf || data.locus?.self;
+
     return (
-      this.meetingCollection.getByKey(MEETING_KEY.LOCUS_URL, data.locusUrl) ||
       // @ts-ignore
       this.meetingCollection.getByKey(
         MEETING_KEY.CORRELATION_ID,
         // @ts-ignore
-        MeetingsUtil.checkForCorrelationId(this.webex.internal.device.url, data.locus)
+        MeetingsUtil.getCorrelationIdForDevice(this.webex.internal.device.url, self)
       ) ||
-      this.meetingCollection.getByKey(
-        MEETING_KEY.SIP_URI,
-        data.locus?.self?.callbackInfo?.callbackAddress
-      ) ||
+      this.meetingCollection.getByKey(MEETING_KEY.SIP_URI, self?.callbackInfo?.callbackAddress) ||
       (data.locus?.info?.isUnifiedSpaceMeeting
         ? undefined
         : this.meetingCollection.getByKey(

--- a/packages/@webex/plugin-meetings/src/meetings/util.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/util.ts
@@ -117,15 +117,16 @@ MeetingsUtil.getMediaServerIp = (sdp) => {
   return mediaServerIp;
 };
 
-MeetingsUtil.checkForCorrelationId = (deviceUrl, locus) => {
-  let devices = [];
-
-  if (locus) {
-    if (locus && locus.self && locus.self.devices) {
-      devices = locus.self.devices;
-    }
-
-    const foundDevice = devices.find((device) => device.url === deviceUrl);
+/**
+ * Finds correlationId of a device from locus self devices array
+ * that matches the given deviceUrl
+ * @param {string} deviceUrl
+ * @param {object} locusSelf
+ * @returns {string|false} correlationId or false if not found
+ */
+MeetingsUtil.getCorrelationIdForDevice = (deviceUrl: string, locusSelf: any) => {
+  if (locusSelf?.devices) {
+    const foundDevice = locusSelf?.devices.find((device) => device.url === deviceUrl);
 
     if (foundDevice && foundDevice.correlationId) {
       return foundDevice.correlationId;

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/utils.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/utils.ts
@@ -1,4 +1,5 @@
-import {deleteNestedObjectsWithHtMeta} from '../../../../src/hashTree/utils';
+import {HashTreeObject, ObjectType} from '../../../../src/hashTree/types';
+import {deleteNestedObjectsWithHtMeta, isSelf} from '../../../../src/hashTree/utils';
 
 import {assert} from '@webex/test-helper-chai';
 
@@ -98,6 +99,42 @@ describe('Hash Tree Utils', () => {
         },
         participants: [],
       });
+    });
+  });
+
+  describe('#isSelf', () => {
+    ['self', 'SELF', 'Self'].forEach((type) => {
+      it(`should return true for object with type="${type}"`, () => {
+        const selfObject = {
+          htMeta: {
+            elementId: {
+              type,
+              id: 1,
+              version: 1,
+            },
+            dataSetNames: [],
+          },
+          data: {},
+        };
+
+        assert.isTrue(isSelf(selfObject as HashTreeObject));
+      });
+    });
+
+    it('should return false for non-self object', () => {
+      const participantObject = {
+        htMeta: {
+          elementId: {
+            type: ObjectType.participant,
+            id: 2,
+            version: 1,
+          },
+          dataSetNames: [],
+        },
+        data: {},
+      };
+
+      assert.isFalse(isSelf(participantObject));
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -2911,7 +2911,7 @@ describe('plugin-meetings', () => {
           conversationUrl: 'conversationUrl1',
         };
 
-        sinon.stub(MeetingsUtil, 'checkForCorrelationId').returns('correlationId1');
+        sinon.stub(MeetingsUtil, 'getCorrelationIdForDevice').returns('correlationId1');
       });
       afterEach(() => {
         sinon.restore();
@@ -3016,6 +3016,197 @@ describe('plugin-meetings', () => {
           'conversationUrl1'
         );
         assert.calledWith(webex.meetings.meetingCollection.getByKey, 'meetingNumber', '123456');
+      });
+
+      describe('when receiving hash tree events', () => {
+        let hashTreeEvent;
+
+        beforeEach(() => {
+          MeetingsUtil.getCorrelationIdForDevice.restore();
+          sinon.spy(MeetingsUtil, 'getCorrelationIdForDevice');
+
+          hashTreeEvent = {
+            eventType: 'locus.state_message',
+            stateElementsMessage: {
+              locusUrl: url1,
+              locusStateElements: [
+                {
+                  htMeta: {
+                    elementId: {
+                      type: 'participant',
+                      id: 2,
+                      version: 1,
+                    },
+                    dataSetNames: ['main'],
+                  },
+                  data: {
+                    id: 'participant1',
+                  },
+                },
+                {
+                  htMeta: {
+                    elementId: {
+                      type: 'Self',
+                      id: 1,
+                      version: 1,
+                    },
+                    dataSetNames: ['self'],
+                  },
+                  data: {
+                    callbackInfo: {
+                      callbackAddress: 'address1',
+                    },
+                    devices: [
+                      {
+                        url: 'deviceUrl',
+                        correlationId: 'correlationId1',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          };
+
+          webex.internal.device.url = 'deviceUrl';
+        });
+
+        it('should find meeting by locusUrl from stateElementsMessage', () => {
+          mockGetByKey('locusUrl');
+          const result = webex.meetings.getCorrespondingMeetingByLocus(hashTreeEvent);
+          assert.deepEqual(result, mockReturnMeeting);
+          assert.calledOnceWithExactly(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
+        });
+
+        it('should extract self data from locusStateElements and try correlationId when locusUrl not found', () => {
+          mockGetByKey('correlationId');
+          const result = webex.meetings.getCorrespondingMeetingByLocus(hashTreeEvent);
+          assert.deepEqual(result, mockReturnMeeting);
+          assert.callCount(webex.meetings.meetingCollection.getByKey, 2);
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
+          assert.calledWith(
+            webex.meetings.meetingCollection.getByKey,
+            'correlationId',
+            'correlationId1'
+          );
+          assert.calledOnceWithExactly(
+            MeetingsUtil.getCorrelationIdForDevice,
+            'deviceUrl',
+            hashTreeEvent.stateElementsMessage.locusStateElements[1].data
+          );
+        });
+
+        it('should extract self data from locusStateElements and try sipUri when locusUrl and correlationId not found', () => {
+          mockGetByKey('sipUri');
+          const result = webex.meetings.getCorrespondingMeetingByLocus(hashTreeEvent);
+          assert.deepEqual(result, mockReturnMeeting);
+          assert.callCount(webex.meetings.meetingCollection.getByKey, 3);
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
+          assert.calledWith(
+            webex.meetings.meetingCollection.getByKey,
+            'correlationId',
+            'correlationId1'
+          );
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'sipUri', 'address1');
+        });
+
+        it('should try all keys when no meeting found', () => {
+          mockGetByKey();
+          const result = webex.meetings.getCorrespondingMeetingByLocus(hashTreeEvent);
+          assert.isNull(result);
+          assert.callCount(webex.meetings.meetingCollection.getByKey, 5);
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
+          assert.calledWith(
+            webex.meetings.meetingCollection.getByKey,
+            'correlationId',
+            'correlationId1'
+          );
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'sipUri', 'address1');
+          // these remaining 2 will never work for hash trees, but just checking that
+          // the calls are made and we don't crash
+          assert.calledWith(
+            webex.meetings.meetingCollection.getByKey,
+            'conversationUrl',
+            undefined
+          );
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'meetingNumber', undefined);
+        });
+
+        it('should handle hash tree event with no self object', () => {
+          mockGetByKey();
+          hashTreeEvent.stateElementsMessage.locusStateElements = [
+            {
+              htMeta: {
+                elementId: {
+                  type: 'participant',
+                  id: 2,
+                  version: 1,
+                },
+                dataSetNames: ['dataset1'],
+              },
+              data: {
+                id: 'participant1',
+              },
+            },
+          ];
+
+          const result = webex.meetings.getCorrespondingMeetingByLocus(hashTreeEvent);
+          assert.isNull(result);
+          assert.callCount(webex.meetings.meetingCollection.getByKey, 5);
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'correlationId', false);
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'sipUri', undefined);
+          // these remaining 2 will never work for hash trees, but just checking that
+          // the calls are made and we don't crash
+          assert.calledWith(
+            webex.meetings.meetingCollection.getByKey,
+            'conversationUrl',
+            undefined
+          );
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'meetingNumber', undefined);
+        });
+
+        it('should handle hash tree event with empty locusStateElements', () => {
+          mockGetByKey();
+          hashTreeEvent.stateElementsMessage.locusStateElements = [];
+          const result = webex.meetings.getCorrespondingMeetingByLocus(hashTreeEvent);
+          assert.isNull(result);
+          assert.callCount(webex.meetings.meetingCollection.getByKey, 5);
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'correlationId', false);
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'sipUri', undefined);
+          // these remaining 2 will never work for hash trees, but just checking that
+          // the calls are made and we don't crash
+          assert.calledWith(
+            webex.meetings.meetingCollection.getByKey,
+            'conversationUrl',
+            undefined
+          );
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'meetingNumber', undefined);
+        });
+
+        it('should handle hash tree event with self object but no callbackAddress', () => {
+          mockGetByKey('meetingNumber');
+          delete hashTreeEvent.stateElementsMessage.locusStateElements[1].data.callbackInfo;
+          const result = webex.meetings.getCorrespondingMeetingByLocus(hashTreeEvent);
+          assert.deepEqual(result, mockReturnMeeting);
+          assert.callCount(webex.meetings.meetingCollection.getByKey, 5);
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
+          assert.calledWith(
+            webex.meetings.meetingCollection.getByKey,
+            'correlationId',
+            'correlationId1'
+          );
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'sipUri', undefined);
+          // these remaining 2 will never work for hash trees, but just checking that
+          // the calls are made and we don't crash
+          assert.calledWith(
+            webex.meetings.meetingCollection.getByKey,
+            'conversationUrl',
+            undefined
+          );
+          assert.calledWith(webex.meetings.meetingCollection.getByKey, 'meetingNumber', undefined);
+        });
       });
     });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
@@ -299,5 +299,55 @@ describe('plugin-meetings', () => {
       const sdp2 = 'v=0\r\no=HOMER 0 1 IN IP4 23.89.67.81\r\ns=-\r\nc=IN IP4 23.89.67.81\r\nb=TIAS:128000\r\nt=0 0\r\na=ice-lite\r\n'
       assert.equal(MeetingsUtil.getMediaServer(sdp2), 'homer');
     });
-  })
+  });
+
+  describe('#getCorrelationIdForDevice', () => {
+    it('should return correlationId if device with matching url is found', () => {
+      const locusSelf = {
+        devices: [
+          {url: 'deviceUrl1', correlationId: 'correlationId1'},
+          {url: 'deviceUrl2', correlationId: 'correlationId2'},
+        ],
+      };
+
+      const correlationId = MeetingsUtil.getCorrelationIdForDevice('deviceUrl1', locusSelf);
+      assert.equal(correlationId, 'correlationId1');
+    });
+
+    it('should return false if no device with matching url is found', () => {
+      const locusSelf = {
+        devices: [
+          {url: 'deviceUrl1', correlationId: 'correlationId1'},
+          {url: 'deviceUrl2', correlationId: 'correlationId2'},
+        ],
+      };
+
+      const correlationId = MeetingsUtil.getCorrelationIdForDevice('deviceUrl3', locusSelf);
+      assert.equal(correlationId, false);
+    });
+
+    it('should return false if device with matching url has no correlationId', () => {
+      const locusSelf = {
+        devices: [{url: 'deviceUrl1'}, {url: 'deviceUrl2', correlationId: 'correlationId2'}],
+      };
+
+      const correlationId = MeetingsUtil.getCorrelationIdForDevice('deviceUrl1', locusSelf);
+      assert.equal(correlationId, false);
+    });
+
+    it('should return false if locusSelf has no devices', () => {
+      const locusSelf = {};
+
+      const correlationId = MeetingsUtil.getCorrelationIdForDevice('deviceUrl1', locusSelf);
+      assert.equal(correlationId, false);
+    });
+
+    it('should return false if locusSelf is null or undefined', () => {
+      let correlationId = MeetingsUtil.getCorrelationIdForDevice('deviceUrl1', null);
+      assert.equal(correlationId, false);
+
+      correlationId = MeetingsUtil.getCorrelationIdForDevice('deviceUrl1', undefined);
+      assert.equal(correlationId, false);
+    });
+  });
 });


### PR DESCRIPTION
# COMPLETES #[SPARK-755993](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-755993)

## This pull request addresses
When a webinar is about to start, web app knows about it from the calendar service, Locus doesn't send us any OBTP for it. So,  only at the point when user clicks OBTP and tries to join the webinar, then web app creates the meeting object in SDK and that meeting object is initially mostly empty without any Locus information. All Locus data (including Locus URL) comes only in the http response for the join request.
The problem is that sometimes we might receive an event from Locus before we receive the HTTP response for join. Such event will have a locusUrl, but we won't be able to match it with our existing meeting object, because that object doesn't yet have any Locus related information. When we fail to match it, SDK creates a new meeting, so we end up with 2 meeting objects for the same webinar. This is not good. Furthermore when the app is notified about that 2nd meeting object, it actually calls leave() on it - see the code [here](https://sqbu-github.cisco.com/WebExSquared/webex-web-client/blob/65fe0e587075ff873f05507d674fc9b2848dd264/src/components/MeetingManager/index.js#L472), which causes us to leave the webinar.

The solution to this is to use other ways of looking up the meeting object when we receive the event before we got Locus join http response - these have been implemented already for classic events in getCorrespondingMeetingByLocus() but currently were not being used when a hash tree event was received.

## by making the following changes
Changed getCorrespondingMeetingByLocus() so that when we get a hash tree event, it doesn't just try only locus url lookup but tries all the other fallbacks too, mainly the correlation id and sip url. The last 2 fallbacks (conversation url and meeting number) are unlikely to ever work with hash tree events, because with hash trees we normally don't receive main locus object that contains locus.info over mercury, instead we receive it over LLM and LLM event handler goes through a different code path and is already tied to the meeting object so main dataset events don't have this issue.

I've also moved a util function isSelf from hashTreeParser.ts to utils file, because I needed to call it from meetings/index and HashTreeObject type definition to types.ts

I've also renamed checkForCorrelationId(), because I felt the existing name was not really matching what the function did

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manually tested with web app

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
