### PR TITLE
feat(tools): fix missed stable tags

### DIFF
--- a/packages/tools/package/src/commands/increment/increment.ts
+++ b/packages/tools/package/src/commands/increment/increment.ts
@@ -1,13 +1,13 @@
 import path from 'path';
 
-import type { CommandsCommand } from '@webex/cli-tools';
+import type {CommandsCommand} from '@webex/cli-tools';
 
-import { Package } from '../../models';
-import { Yarn } from '../../utils';
-import type { PackageConfig, PackageVersion } from '../../models';
+import {Package} from '../../models';
+import {Yarn} from '../../utils';
+import type {PackageConfig, PackageVersion} from '../../models';
 
 import CONSTANTS from './increment.constants';
-import type { Options } from './increment.types';
+import type {Options} from './increment.types';
 
 /**
  * The increment Command configuration Object. This Command is used to increment
@@ -48,17 +48,38 @@ const increment: CommandsCommand<Options> = {
 
     const tag = options.tag?.split('/').pop();
 
-    return Yarn.list({ since: options.since })
-      .then((packageDetails) => packageDetails.map(({ location, name }: PackageConfig) => new Package({
-        location: path.join(rootDir, location),
-        name,
-        tag,
-      })))
-      .then((packs: Array<Package>) => packs.filter((pack) => (options.packages
-        ? options.packages.includes(pack.name)
-        : true)))
-      .then((packs) => Promise.all(packs.map((pack) => pack.inspect())))
-      .then((packs) => Promise.all(packs.map((pack) => pack.syncVersion())))
+    // First, get the reference version from the 'webex' package
+    // This is used for packages that don't have a proper stable version yet
+    const referencePackage = new Package({
+      location: path.join(rootDir, 'packages/webex'),
+      name: 'webex',
+      tag,
+    });
+
+    return referencePackage
+      .inspect()
+      .then(() => {
+        const referenceVersion = Package.parseVersionStringToObject(
+          referencePackage.packageInfo['dist-tags'].latest
+        );
+
+        return Yarn.list({since: options.since})
+          .then((packageDetails) =>
+            packageDetails.map(
+              ({location, name}: PackageConfig) =>
+                new Package({
+                  location: path.join(rootDir, location),
+                  name,
+                  tag,
+                })
+            )
+          )
+          .then((packs: Array<Package>) =>
+            packs.filter((pack) => (options.packages ? options.packages.includes(pack.name) : true))
+          )
+          .then((packs) => Promise.all(packs.map((pack) => pack.inspect())))
+          .then((packs) => Promise.all(packs.map((pack) => pack.syncVersion(referenceVersion))));
+      })
       .then((packs) => {
         const incrementBy: Partial<PackageVersion> = {
           major: options.major ? parseInt(options.major, 10) : undefined,

--- a/packages/tools/package/src/models/package/package.ts
+++ b/packages/tools/package/src/models/package/package.ts
@@ -1,17 +1,10 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-import { Yarn } from '../../utils';
+import {Yarn} from '../../utils';
 
 import CONSTANTS from './package.constants';
-import type {
-  Config,
-  Data,
-  Definition,
-  InspectOptions,
-  PackageInfo,
-  Version,
-} from './package.types';
+import type {Config, Data, Definition, InspectOptions, PackageInfo, Version} from './package.types';
 
 /**
  * The Package class.
@@ -67,6 +60,13 @@ class Package {
     return this.data.name;
   }
 
+  /**
+   * The package info from the npm registry for this package.
+   */
+  public get packageInfo(): PackageInfo {
+    return this.data.packageInfo;
+  }
+
   public get version(): string {
     return Package.parseVersionObjectToString(this.data.version);
   }
@@ -80,7 +80,7 @@ class Package {
   public apply(): Promise<this> {
     const packageDefinitionPath = path.join(this.data.location, CONSTANTS.PACKAGE_DEFINITION_FILE);
 
-    return Package.readDefinition({ definitionPath: packageDefinitionPath })
+    return Package.readDefinition({definitionPath: packageDefinitionPath})
       .then((definition) => ({
         ...definition,
         version: Package.parseVersionObjectToString(this.data.version),
@@ -102,14 +102,13 @@ class Package {
   public hasScript(scriptName: string): Promise<boolean> {
     const packageDefinitionPath = path.join(this.data.location, CONSTANTS.PACKAGE_DEFINITION_FILE);
 
-    return Package.readDefinition({ definitionPath: packageDefinitionPath })
-      .then((definition) => {
-        if (!definition.scripts || !definition.scripts[scriptName]) {
-          return false;
-        }
+    return Package.readDefinition({definitionPath: packageDefinitionPath}).then((definition) => {
+      if (!definition.scripts || !definition.scripts[scriptName]) {
+        return false;
+      }
 
-        return true;
-      });
+      return true;
+    });
   }
 
   /**
@@ -125,7 +124,7 @@ class Package {
    * @returns - This Package instance.
    */
   public incrementVersion(version: Partial<Version> = {}): this {
-    const processedVersion: Version = { ...this.data.version };
+    const processedVersion: Version = {...this.data.version};
 
     if (version.major) {
       processedVersion.major += version.major;
@@ -160,24 +159,23 @@ class Package {
    * @returns - Promise resolving with this Package instance.
    */
   public inspect(): Promise<this> {
-    const { tag } = this.data.version;
+    const {tag} = this.data.version;
 
-    return Package.inspect({ package: this.data.name })
-      .then((packageInfo) => {
-        this.data.packageInfo = packageInfo;
+    return Package.inspect({package: this.data.name}).then((packageInfo) => {
+      this.data.packageInfo = packageInfo;
 
-        const tagVersion = packageInfo['dist-tags'][tag];
+      const tagVersion = packageInfo['dist-tags'][tag];
 
-        if (tagVersion) {
-          this.data.version = Package.parseVersionStringToObject(tagVersion);
-
-          return this;
-        }
-
-        this.data.version = Package.parseVersionStringToObject(`${packageInfo.version}-${tag}.0`);
+      if (tagVersion) {
+        this.data.version = Package.parseVersionStringToObject(tagVersion);
 
         return this;
-      });
+      }
+
+      this.data.version = Package.parseVersionStringToObject(`${packageInfo.version}-${tag}.0`);
+
+      return this;
+    });
   }
 
   /**
@@ -188,10 +186,12 @@ class Package {
    */
   public setVersion(version: Partial<Version> = {}): this {
     this.data.version = {
-      major: Number.isInteger(version.major) ? version.major as number : this.data.version.major,
-      minor: Number.isInteger(version.minor) ? version.minor as number : this.data.version.minor,
-      patch: Number.isInteger(version.patch) ? version.patch as number : this.data.version.patch,
-      release: Number.isInteger(version.release) ? version.release as number : this.data.version.release,
+      major: Number.isInteger(version.major) ? (version.major as number) : this.data.version.major,
+      minor: Number.isInteger(version.minor) ? (version.minor as number) : this.data.version.minor,
+      patch: Number.isInteger(version.patch) ? (version.patch as number) : this.data.version.patch,
+      release: Number.isInteger(version.release)
+        ? (version.release as number)
+        : this.data.version.release,
       tag: version.tag || this.data.version.tag,
     };
 
@@ -203,18 +203,27 @@ class Package {
    *
    * @remarks
    * This method will skip any modifications if the current version tag is
-   * stable.
+   * stable. If the package has no proper stable version (0.0.0), it will use
+   * the provided reference version instead.
    *
+   * @param referenceVersion - Optional reference version to use when the package
+   *   has no proper stable version. This should be the parsed version object from
+   *   a reference package like 'webex'.
    * @returns - This Package instance.
    */
-  public syncVersion(): this {
-    const { version } = this.data;
+  public syncVersion(referenceVersion?: Version): this {
+    const {version} = this.data;
 
     if (version.tag === Package.CONSTANTS.STABLE_TAG) {
       return this;
     }
 
-    const stable = Package.parseVersionStringToObject(this.data.packageInfo['dist-tags'].latest);
+    let stable = Package.parseVersionStringToObject(this.data.packageInfo['dist-tags'].latest);
+
+    // If this package has no proper stable version (0.0.0), use the reference version
+    if (stable.major === 0 && stable.minor === 0 && stable.patch === 0 && referenceVersion) {
+      stable = referenceVersion;
+    }
 
     let hasVersionChanged = false;
 
@@ -254,13 +263,12 @@ class Package {
    * @returns - Package Info for the provided package.
    */
   public static inspect(options: InspectOptions): Promise<PackageInfo> {
-    return Yarn.view({ distTags: true, package: options.package, version: true })
-      .catch(() => ({
-        version: Package.CONSTANTS.DEFAULT_VERSION,
-        'dist-tags': {
-          [Package.CONSTANTS.STABLE_TAG]: Package.CONSTANTS.DEFAULT_VERSION,
-        },
-      }));
+    return Yarn.view({distTags: true, package: options.package, version: true}).catch(() => ({
+      version: Package.CONSTANTS.DEFAULT_VERSION,
+      'dist-tags': {
+        [Package.CONSTANTS.STABLE_TAG]: Package.CONSTANTS.DEFAULT_VERSION,
+      },
+    }));
   }
 
   /**
@@ -313,7 +321,9 @@ class Package {
 
     return [
       semanticVersion,
-      version.tag && version.tag !== CONSTANTS.STABLE_TAG ? `-${version.tag}.${version.release}` : '',
+      version.tag && version.tag !== CONSTANTS.STABLE_TAG
+        ? `-${version.tag}.${version.release}`
+        : '',
     ].join('');
   }
 
@@ -329,8 +339,9 @@ class Package {
    * @param options - Options to use when reading a file definition.
    * @returns - Promise resolving to the package definition.
    */
-  public static readDefinition({ definitionPath }: { definitionPath: string }): Promise<Definition> {
-    return fs.readFile(definitionPath)
+  public static readDefinition({definitionPath}: {definitionPath: string}): Promise<Definition> {
+    return fs
+      .readFile(definitionPath)
       .then((buffer) => buffer.toString())
       .then((data) => JSON.parse(data))
       .then((definition: Definition) => definition);

--- a/packages/tools/package/test/module/increment/increment.test.js
+++ b/packages/tools/package/test/module/increment/increment.test.js
@@ -1,14 +1,10 @@
 const path = require('path');
-const { increment, Package, Yarn } = require('@webex/package-tools');
+const {increment, Package, Yarn} = require('@webex/package-tools');
 
 describe('increment', () => {
   describe('config', () => {
     it('should include all expected top-level keys', () => {
-      expect(Object.keys(increment.config)).toEqual([
-        'name',
-        'description',
-        'options',
-      ]);
+      expect(Object.keys(increment.config)).toEqual(['name', 'description', 'options']);
     });
 
     it('should include the fully qualified "major" option', () => {
@@ -72,9 +68,9 @@ describe('increment', () => {
     const rootDir = '/path/to/project';
     const spies = {};
     const listResolve = [
-      { location: 'packages/scope/example-a', name: '@scope/example-a' },
-      { location: 'packages/scope/example-b', name: '@scope/example-b' },
-      { location: 'packages/scope/example-c', name: '@scope/example-c' },
+      {location: 'packages/scope/example-a', name: '@scope/example-a'},
+      {location: 'packages/scope/example-b', name: '@scope/example-b'},
+      {location: 'packages/scope/example-c', name: '@scope/example-c'},
     ];
     const options = {
       major: 1,
@@ -92,10 +88,14 @@ describe('increment', () => {
       };
 
       spies.package = {
-        inspect: jest.spyOn(Package.prototype, 'inspect')
-          .mockImplementation(function func() { return Promise.resolve(this); }),
-        syncVersion: jest.spyOn(Package.prototype, 'syncVersion')
-          .mockImplementation(function func() { return Promise.resolve(this); }),
+        inspect: jest.spyOn(Package.prototype, 'inspect').mockImplementation(function func() {
+          return Promise.resolve(this);
+        }),
+        syncVersion: jest
+          .spyOn(Package.prototype, 'syncVersion')
+          .mockImplementation(function func() {
+            return Promise.resolve(this);
+          }),
         incrementVersion: jest.spyOn(Package.prototype, 'incrementVersion').mockReturnThis(),
         apply: jest.spyOn(Package.prototype, 'apply').mockReturnThis(),
       };
@@ -112,33 +112,36 @@ describe('increment', () => {
       };
     });
 
-    it('should call "Yarn.list()" with the since option', () => increment.handler(options)
-      .then(() => {
+    it('should call "Yarn.list()" with the since option', () =>
+      increment.handler(options).then(() => {
         expect(spies.Yarn.list).toHaveBeenCalledTimes(1);
-        expect(spies.Yarn.list).toHaveBeenCalledWith(expect.objectContaining({
-          since: options.since,
-        }));
+        expect(spies.Yarn.list).toHaveBeenCalledWith(
+          expect.objectContaining({
+            since: options.since,
+          })
+        );
       }));
 
-    it('should return a Promise that resolves to the Package class Objects', () => increment.handler(options)
-      .then((results) => {
+    it('should return a Promise that resolves to the Package class Objects', () =>
+      increment.handler(options).then((results) => {
         results.forEach((result) => {
           expect(result instanceof Package).toBeTruthy();
         });
       }));
 
-    it('should call "package.inspect()" for each located package', () => increment.handler(options)
-      .then(() => {
-        expect(spies.package.inspect).toHaveBeenCalledTimes(listResolve.length);
+    it('should call "package.inspect()" for each located package plus the reference package', () =>
+      increment.handler(options).then(() => {
+        // +1 for the reference 'webex' package that is inspected first
+        expect(spies.package.inspect).toHaveBeenCalledTimes(listResolve.length + 1);
       }));
 
-    it('should call "package.syncVersion()" for each located package', () => increment.handler(options)
-      .then(() => {
+    it('should call "package.syncVersion()" for each located package', () =>
+      increment.handler(options).then(() => {
         expect(spies.package.syncVersion).toHaveBeenCalledTimes(listResolve.length);
       }));
 
-    it('should not increment any packages when the version details provided are undefined', () => increment.handler({})
-      .then((results) => {
+    it('should not increment any packages when the version details provided are undefined', () =>
+      increment.handler({}).then((results) => {
         const expected = {
           major: undefined,
           minor: undefined,
@@ -156,33 +159,26 @@ describe('increment', () => {
     it('should only resolve with Package objects included in the packages option', () => {
       const targetPackages = [options.packages[0], options.packages[1]];
 
-      return increment.handler({ ...options, packages: targetPackages })
-        .then((results) => {
-          expect(results).toHaveLength(2);
-          expect(results[0].name).toBe(targetPackages[0]);
-          expect(results[1].name).toBe(targetPackages[1]);
-        });
+      return increment.handler({...options, packages: targetPackages}).then((results) => {
+        expect(results).toHaveLength(2);
+        expect(results[0].name).toBe(targetPackages[0]);
+        expect(results[1].name).toBe(targetPackages[1]);
+      });
     });
 
-    it(
-      'should write the list of packages updated and their corresponding new versions',
-      () => increment.handler({ ...options })
-        .then(() => {
-          const generatedString = options.packages.map(
-            (pack) => `${pack} => 0.0.0-${options.tag.split('/').pop()}.0`,
-          ).join('\n');
+    it('should write the list of packages updated and their corresponding new versions', () =>
+      increment.handler({...options}).then(() => {
+        const generatedString = options.packages
+          .map((pack) => `${pack} => 0.0.0-${options.tag.split('/').pop()}.0`)
+          .join('\n');
 
-          expect(spies.process.stdout.write).toHaveBeenCalledTimes(1);
-          expect(spies.process.stdout.write).toHaveBeenCalledWith(generatedString);
-        }),
-    );
+        expect(spies.process.stdout.write).toHaveBeenCalledTimes(1);
+        expect(spies.process.stdout.write).toHaveBeenCalledWith(generatedString);
+      }));
 
-    it(
-      'should return all packages when packages is not provided',
-      () => increment.handler({ ...options, packages: undefined })
-        .then((results) => {
-          expect(results).toHaveLength(3);
-        }),
-    );
+    it('should return all packages when packages is not provided', () =>
+      increment.handler({...options, packages: undefined}).then((results) => {
+        expect(results).toHaveLength(3);
+      }));
   });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# This pull request addresses #
Packages added to the monorepo after a stable release (like @webex/internal-plugin-ai-assistant) get stuck publishing pre-release versions like 0.0.0-next.42 instead of properly versioned ones like 3.10.0-next.X. This happens because the syncVersion() method uses the package's latest npm dist-tag to determine the base version, and newly added packages have latest pointing to 0.0.0-next.1.

# by making the following changes #
Modified Package.syncVersion() to accept an optional referenceVersion parameter that serves as a fallback when the package's latest dist-tag is 0.0.0
Updated increment command to fetch the webex package's latest version first and pass it as the reference version to all packages during synchronization
Added packageInfo getter to expose npm registry data from Package instances
Updated tests to account for the additional inspect() call on the reference package
After merging, packages with 0.0.0 as their latest tag will automatically use the webex package's stable version (3.10.0) as their base, ensuring consistent versioning across the SDK. The next time these packages are published to the next branch, they will use the correct version (e.g., 3.10.0-next.1 instead of 0.0.0-next.43).

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
