### PR TITLE
fix: sample app reject and answer disable issues

### DIFF
--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -391,6 +391,7 @@ const callNotifyEvent = new CustomEvent('line:incoming_call', {
 callListener.addEventListener('line:incoming_call', (myEvent) => {
   console.log('Received incoming call');
   answerElm.disabled = false;
+  endElm.disabled = false;
   const callerDisplay = myEvent.detail.callObject.getCallerInfo();
 
   incomingDetailsElm.innerText = `Call from ${callerDisplay.name}, Ph: ${callerDisplay.num}`;
@@ -467,6 +468,7 @@ function endCall() {
   outboundEndElm.disabled = true;
   makeCallBtn.disabled = false;
   endElm.disabled = true;
+  answerElm.disabled = true;
   muteElm.value = 'Mute';
   holdResumeElm.value = 'Hold'
   imageElm.removeChild(img);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

UI button state issues in the calling sample app where:
The reject/end button was not enabled when receiving an incoming call, preventing users from rejecting the call
The answer button remained enabled after ending a call, which could cause confusion or unintended behavior

## by making the following changes

Modified docs/samples/calling/app.js:
Line 394: Added endElm.disabled = false; in the line:incoming_call event handler
Enables the reject/end button when an incoming call is received
Allows users to reject incoming calls through the UI
Line 471: Added answerElm.disabled = true; in the endCall() function
Disables the answer button after a call is ended
Ensures proper button state cleanup when call terminates


<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
