### PR TITLE
fix(cc): fix task disconnect using click2dial api

### DIFF
--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -294,6 +294,10 @@ export default class TaskManager extends EventEmitter {
                   !isSecondaryEpDnAgent(payload.data.interaction),
               });
 
+              if (task.data.interaction.state === 'wrapUp') {
+                task = this.updateTaskData(task, {...payload.data, wrapUpRequired: false});
+              }
+
               // Handle cleanup based on whether task should be deleted
               this.handleTaskCleanup(task);
 
@@ -669,6 +673,10 @@ export default class TaskManager extends EventEmitter {
     // For non-OUTDIAL: remove if state is 'new'
     // Always remove if secondary EpDn agent
     if ((isNew && !(isOutdial && needsWrapUp)) || isSecondaryEpDnAgent(task.data.interaction)) {
+      this.removeTaskFromCollection(task);
+    }
+
+    if (task.data.interaction.state === 'wrapUp') {
       this.removeTaskFromCollection(task);
     }
   }

--- a/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
@@ -381,6 +381,50 @@ describe('TaskManager', () => {
     );
   });
 
+  it('should clear wrapUpRequired and remove task on CONTACT_ENDED when interaction is in wrapUp state', () => {
+    webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
+
+    const task = taskManager.getTask(taskId);
+    const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
+    task.updateTaskData = jest.fn().mockImplementation((newData) => {
+      task.data = {
+        ...(task.data || {}),
+        ...(newData || {}),
+        interaction: {
+          ...(task.data?.interaction || {}),
+          ...(newData?.interaction || {}),
+        },
+      };
+
+      return task;
+    });
+
+    const payload = {
+      data: {
+        type: CC_EVENTS.CONTACT_ENDED,
+        interactionId: taskId,
+        interaction: {
+          state: 'wrapUp',
+          mediaType: 'telephony',
+        },
+      },
+    };
+
+    webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+    // updateTaskData should ultimately be called with wrapUpRequired set to false
+    const lastCallArgs = (task.updateTaskData as jest.Mock).mock.calls.slice(-1)[0][0];
+    expect(lastCallArgs.wrapUpRequired).toBe(false);
+
+    // Final task data should also reflect wrapUpRequired cleared
+    expect(task.data.wrapUpRequired).toBe(false);
+
+    // Task should be removed from the collection when in wrapUp state
+    expect(removeTaskSpy).toHaveBeenCalledWith(task);
+    expect(taskManager.getTask(taskId)).toBeUndefined();
+  });
+
   it('should emit TASK_REJECT event on AGENT_INVITE_FAILED event', () => {
     webSocketManagerMock.emit('message', JSON.stringify(initalPayload));
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7508

## This pull request addresses

Using the Click2Dial APi, the call is initiated and disconnect before customer can join the task. In this scenario the wrap up was being shown when its not required. The root cause was that received task object with CONTACT_ENDED event was different, state = wrapup. So our condition was setting wrapupRequired as true- which was incorrect.

## by making the following changes

We use the state to set the wrap up as false when we get CONTACT_ENDED
https://app.vidcast.io/share/f33a8f72-78bd-40bd-bedf-0ce66d3e1633

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Linked the SDK with widgets and reproduced the issue 

1. Call is initiated and ended by the API - wrap up IS NOT shown
2. Call is initiated by the API, agent picks the call and customer ends the call - wrap up IS show
3. Call is initiated by the API, agent picks the call and ends the call - wrap up IS show


https://github.com/user-attachments/assets/e1ee8e56-fa29-4093-80c1-50b658dd9e7c

## The GAI Coding Policy And Copyright 

Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
