### PR TITLE
fix(cc): task removal on disconnect using click2dial api

### DIFF
--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -660,13 +660,16 @@ export default class TaskManager extends EventEmitter {
 
     const isOutdial = task.data.interaction.outboundType === 'OUTDIAL';
     const isNew = task.data.interaction.state === 'new';
-    const needsWrapUp = task.data.agentsPendingWrapUp?.length > 0;
+    const needsWrapUp = task.data.agentsPendingWrapUp?.includes(this.agentId) ?? false;
 
     // For OUTDIAL: only remove if NOT terminated (user-declined, no wrap-up follows)
-    // If terminated, keep task for wrap-up flow (CONTACT_ENDED → AGENT_WRAPUP)
     // For non-OUTDIAL: remove if state is 'new'
     // Always remove if secondary EpDn agent
-    if ((isNew && !(isOutdial && needsWrapUp)) || isSecondaryEpDnAgent(task.data.interaction)) {
+    if (
+      (isNew && !(isOutdial && needsWrapUp)) ||
+      isSecondaryEpDnAgent(task.data.interaction) ||
+      (!needsWrapUp && isOutdial) // For outdial tasks, needs wrap-up is false and state is "WRAPUP". We need to just remove the task.
+    ) {
       this.removeTaskFromCollection(task);
     }
   }

--- a/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
@@ -896,6 +896,9 @@ describe('TaskManager', () => {
   });
 
   it('should NOT remove OUTDIAL task on CONTACT_ENDED when agentsPendingWrapUp exists', () => {
+    const agentId = '723a8ffb-a26e-496d-b14a-ff44fb83b64f';
+    taskManager.setAgentId(agentId);
+
     const task = taskManager.getTask(taskId);
     task.updateTaskData = jest.fn().mockImplementation((newData) => {
       task.data = {
@@ -907,7 +910,7 @@ describe('TaskManager', () => {
           state: 'new',
           mediaType: 'telephony',
         },
-        agentsPendingWrapUp: ['agent-123'],
+        agentsPendingWrapUp: [agentId],
       };
       return task;
     });
@@ -923,7 +926,7 @@ describe('TaskManager', () => {
           state: 'new',
           mediaType: 'telephony',
         },
-        agentsPendingWrapUp: ['agent-123'],
+        agentsPendingWrapUp: [agentId],
       },
     };
 
@@ -2527,6 +2530,318 @@ describe('TaskManager', () => {
       // Other task should not be affected
       expect(otherTask.data.isConferencing).toBeUndefined();
       expect(otherTask.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleTaskCleanup - stage changes', () => {
+    const agentId = '723a8ffb-a26e-496d-b14a-ff44fb83b64f';
+
+    beforeEach(() => {
+      taskManager.setAgentId(agentId);
+    });
+
+    it('should remove OUTDIAL task on CONTACT_ENDED when current agent is NOT in agentsPendingWrapUp', () => {
+      const task = taskManager.getTask(taskId);
+      task.updateTaskData = jest.fn().mockImplementation((newData) => {
+        task.data = {
+          ...task.data,
+          ...newData,
+          interaction: {
+            ...task.data.interaction,
+            outboundType: 'OUTDIAL',
+            state: 'new',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: ['different-agent-123'], // Current agent not in the list
+        };
+        return task;
+      });
+      task.unregisterWebCallListeners = jest.fn();
+      const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
+      const payload = {
+        data: {
+          type: CC_EVENTS.CONTACT_ENDED,
+          interactionId: taskId,
+          interaction: {
+            outboundType: 'OUTDIAL',
+            state: 'new',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: ['different-agent-123'], // Current agent not in the list
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+      expect(removeTaskSpy).toHaveBeenCalled();
+      expect(taskManager.getTask(taskId)).toBeUndefined();
+    });
+
+    it('should NOT remove OUTDIAL task on CONTACT_ENDED when current agent IS in agentsPendingWrapUp', () => {
+      const task = taskManager.getTask(taskId);
+      task.updateTaskData = jest.fn().mockImplementation((newData) => {
+        task.data = {
+          ...task.data,
+          ...newData,
+          interaction: {
+            ...task.data.interaction,
+            outboundType: 'OUTDIAL',
+            state: 'new',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: [agentId, 'other-agent-456'], // Current agent IS in the list
+        };
+        return task;
+      });
+      task.unregisterWebCallListeners = jest.fn();
+      const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
+      const payload = {
+        data: {
+          type: CC_EVENTS.CONTACT_ENDED,
+          interactionId: taskId,
+          interaction: {
+            outboundType: 'OUTDIAL',
+            state: 'new',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: [agentId, 'other-agent-456'], // Current agent IS in the list
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+      expect(removeTaskSpy).not.toHaveBeenCalled();
+      expect(taskManager.getTask(taskId)).toBeDefined();
+    });
+
+    it('should remove OUTDIAL task when needsWrapUp is false and task is outdial', () => {
+      const task = taskManager.getTask(taskId);
+      task.updateTaskData = jest.fn().mockImplementation((newData) => {
+        task.data = {
+          ...task.data,
+          ...newData,
+          interaction: {
+            ...task.data.interaction,
+            outboundType: 'OUTDIAL',
+            state: 'WRAPUP', // Not 'new' state
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: [], // No agents pending wrap-up
+        };
+        return task;
+      });
+      task.unregisterWebCallListeners = jest.fn();
+      const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
+      const payload = {
+        data: {
+          type: CC_EVENTS.CONTACT_ENDED,
+          interactionId: taskId,
+          interaction: {
+            outboundType: 'OUTDIAL',
+            state: 'WRAPUP', // Not 'new' state
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: [], // No agents pending wrap-up
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+      expect(removeTaskSpy).toHaveBeenCalled();
+      expect(taskManager.getTask(taskId)).toBeUndefined();
+    });
+
+    it('should remove OUTDIAL task when needsWrapUp is false (agentsPendingWrapUp is undefined)', () => {
+      const task = taskManager.getTask(taskId);
+      task.updateTaskData = jest.fn().mockImplementation((newData) => {
+        task.data = {
+          ...task.data,
+          ...newData,
+          interaction: {
+            ...task.data.interaction,
+            outboundType: 'OUTDIAL',
+            state: 'WRAPUP',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: undefined, // No agentsPendingWrapUp field
+        };
+        return task;
+      });
+      task.unregisterWebCallListeners = jest.fn();
+      const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
+      const payload = {
+        data: {
+          type: CC_EVENTS.CONTACT_ENDED,
+          interactionId: taskId,
+          interaction: {
+            outboundType: 'OUTDIAL',
+            state: 'WRAPUP',
+            mediaType: 'telephony',
+          },
+          // agentsPendingWrapUp not included
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+      expect(removeTaskSpy).toHaveBeenCalled();
+      expect(taskManager.getTask(taskId)).toBeUndefined();
+    });
+
+    it('should NOT remove OUTDIAL task when needsWrapUp is true (current agent in agentsPendingWrapUp) even if state is WRAPUP', () => {
+      const task = taskManager.getTask(taskId);
+      task.updateTaskData = jest.fn().mockImplementation((newData) => {
+        task.data = {
+          ...task.data,
+          ...newData,
+          interaction: {
+            ...task.data.interaction,
+            outboundType: 'OUTDIAL',
+            state: 'WRAPUP',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: [agentId], // Current agent needs wrap-up
+        };
+        return task;
+      });
+      task.unregisterWebCallListeners = jest.fn();
+      const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
+      const payload = {
+        data: {
+          type: CC_EVENTS.CONTACT_ENDED,
+          interactionId: taskId,
+          interaction: {
+            outboundType: 'OUTDIAL',
+            state: 'WRAPUP',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: [agentId], // Current agent needs wrap-up
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+      expect(removeTaskSpy).not.toHaveBeenCalled();
+      expect(taskManager.getTask(taskId)).toBeDefined();
+    });
+
+    it('should remove non-OUTDIAL task when state is new regardless of agentsPendingWrapUp', () => {
+      const task = taskManager.getTask(taskId);
+      task.updateTaskData = jest.fn().mockImplementation((newData) => {
+        task.data = {
+          ...task.data,
+          ...newData,
+          interaction: {
+            ...task.data.interaction,
+            outboundType: 'PREVIEW', // Not OUTDIAL
+            state: 'new',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: [agentId],
+        };
+        return task;
+      });
+      task.unregisterWebCallListeners = jest.fn();
+      const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
+      const payload = {
+        data: {
+          type: CC_EVENTS.CONTACT_ENDED,
+          interactionId: taskId,
+          interaction: {
+            outboundType: 'PREVIEW',
+            state: 'new',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: [agentId],
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+      expect(removeTaskSpy).toHaveBeenCalled();
+      expect(taskManager.getTask(taskId)).toBeUndefined();
+    });
+
+    it('should handle agentsPendingWrapUp with multiple agents correctly - remove if current agent not in list', () => {
+      const task = taskManager.getTask(taskId);
+      task.updateTaskData = jest.fn().mockImplementation((newData) => {
+        task.data = {
+          ...task.data,
+          ...newData,
+          interaction: {
+            ...task.data.interaction,
+            outboundType: 'OUTDIAL',
+            state: 'new',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: ['agent-1', 'agent-2', 'agent-3'], // Current agent not in the list
+        };
+        return task;
+      });
+      task.unregisterWebCallListeners = jest.fn();
+      const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
+      const payload = {
+        data: {
+          type: CC_EVENTS.CONTACT_ENDED,
+          interactionId: taskId,
+          interaction: {
+            outboundType: 'OUTDIAL',
+            state: 'new',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: ['agent-1', 'agent-2', 'agent-3'],
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+      expect(removeTaskSpy).toHaveBeenCalled();
+      expect(taskManager.getTask(taskId)).toBeUndefined();
+    });
+
+    it('should handle agentsPendingWrapUp with multiple agents correctly - keep if current agent is in list', () => {
+      const task = taskManager.getTask(taskId);
+      task.updateTaskData = jest.fn().mockImplementation((newData) => {
+        task.data = {
+          ...task.data,
+          ...newData,
+          interaction: {
+            ...task.data.interaction,
+            outboundType: 'OUTDIAL',
+            state: 'new',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: ['agent-1', agentId, 'agent-3'], // Current agent IS in the list
+        };
+        return task;
+      });
+      task.unregisterWebCallListeners = jest.fn();
+      const removeTaskSpy = jest.spyOn(taskManager, 'removeTaskFromCollection');
+
+      const payload = {
+        data: {
+          type: CC_EVENTS.CONTACT_ENDED,
+          interactionId: taskId,
+          interaction: {
+            outboundType: 'OUTDIAL',
+            state: 'new',
+            mediaType: 'telephony',
+          },
+          agentsPendingWrapUp: ['agent-1', agentId, 'agent-3'],
+        },
+      };
+
+      webSocketManagerMock.emit('message', JSON.stringify(payload));
+
+      expect(removeTaskSpy).not.toHaveBeenCalled();
+      expect(taskManager.getTask(taskId)).toBeDefined();
     });
   });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7508

## This pull request addresses

The task was not getting cleaned up in cases where click2dial api ends the call before agent can answer

## by making the following changes
Added a condition that checks for this before clearing the task

Vidcast: https://app.vidcast.io/share/7b21ef4e-9db4-4d52-bdb4-0f57c0c2c493

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

https://app.vidcast.io/share/7b21ef4e-9db4-4d52-bdb4-0f57c0c2c493

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Cursor
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
