### PR TITLE
fix(contact-center): add environment variable to OrgInfo type

### DIFF
--- a/packages/@webex/contact-center/src/services/config/Util.ts
+++ b/packages/@webex/contact-center/src/services/config/Util.ts
@@ -204,6 +204,7 @@ function parseAgentConfigs(profileData: {
     siteId: userData.siteId,
     enterpriseId: orgInfoData.tenantId,
     tenantTimezone: orgInfoData.timezone,
+    environment: orgInfoData.environment,
     privacyShieldVisible: tenantData.privacyShieldVisible,
     organizationIdleCodes: [], // TODO: for supervisor, getOrgFilteredIdleCodes(auxCodes, false),
     idleCodesAccess: agentProfileData.accessIdleCode as 'ALL' | 'SPECIFIC',

--- a/packages/@webex/contact-center/src/services/config/types.ts
+++ b/packages/@webex/contact-center/src/services/config/types.ts
@@ -580,6 +580,8 @@ export type OrgInfo = {
   tenantId: string;
   /** Organization timezone */
   timezone: string;
+  /** Current environment (e.g., 'produs1', 'intgus1') */
+  environment: string;
 };
 
 /**
@@ -1031,6 +1033,8 @@ export type Profile = {
   isAnalyzerEnabled?: boolean;
   /** Tenant timezone */
   tenantTimezone?: string;
+  /** Current environment (e.g., 'produs1', 'intgus1') */
+  environment?: string;
   /** Available voice login options */
   loginVoiceOptions?: LoginOption[];
   /** Current login device type */

--- a/packages/@webex/contact-center/test/unit/spec/services/config/index.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/config/index.ts
@@ -718,6 +718,7 @@ describe('AgentConfigService', () => {
       const mockOrgInfo = {
         tenantId: 'tenant123',
         timezone: 'GMT',
+        environment: 'produs1',
       };
 
       const mockOrgSettings = {
@@ -857,6 +858,7 @@ describe('AgentConfigService', () => {
       const mockOrgInfo = {
         tenantId: 'tenant123',
         timezone: 'GMT',
+        environment: 'produs1',
       };
 
       const mockOrgSettings = {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7419

## This pull request addresses

Adding support for the environment property in the organization info to identify the current deployment environment (e.g., 'produs1', 'intgus1') for contact center agents.

## by making the following changes

- Added environment field to OrgInfo type in types.ts and extracted it in Util.ts to include in the agent profile.
- Updated unit tests in test/unit/spec/services/config/index.ts to include environment: 'produs1' in mockOrgInfo objects

<!-- You may include screenshots -->
<img width="723" height="689" alt="Screenshot 2026-01-29 at 4 55 42 PM" src="https://github.com/user-attachments/assets/316d87eb-75d7-42c6-9741-d29b1c3cbbc8" />


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
