### PR TITLE
feat: added allowPublishMediaInLobby to AddMediaOptions

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -250,6 +250,7 @@ export type AddMediaOptions = {
   remoteMediaManagerConfig?: RemoteMediaManagerConfiguration; // applies only to multistream meetings
   bundlePolicy?: BundlePolicy; // applies only to multistream meetings
   allowMediaInLobby?: boolean; // allows adding media when in the lobby
+  allowPublishMediaInLobby?: boolean; // allows publishing media when in the lobby, if not specified, default value false is used
   additionalMediaOptions?: AdditionalMediaOptions; // allows adding additional options like send/receive audio/video
 };
 
@@ -623,6 +624,13 @@ export default class Meeting extends StatelessWebexPlugin {
   keepAliveTimerId: NodeJS.Timeout;
   lastVideoLayoutInfo: any;
   locusInfo: any;
+  // this group of properties is populated via updateMeetingObject() that's registered as a callback with LocusInfo
+  isUserUnadmitted?: boolean;
+  joinedWith?: any;
+  selfId?: string;
+  roles: any[];
+  // ... there is more ... see SelfUtils.parse()
+  // end of the group
   locusMediaRequest?: LocusMediaRequest;
   mediaProperties: MediaProperties;
   mediaRequestManagers: {
@@ -657,7 +665,6 @@ export default class Meeting extends StatelessWebexPlugin {
   endCallInitJoinReq: any;
   endJoinReqResp: any;
   endLocalSDPGenRemoteSDPRecvDelay: any;
-  joinedWith: any;
   locusId: any;
   startCallInitJoinReq: any;
   startJoinReqResp: any;
@@ -672,12 +679,10 @@ export default class Meeting extends StatelessWebexPlugin {
   permissionTokenReceivedLocalTime: number;
   resourceId: any;
   resourceUrl: string;
-  selfId: string;
   state: any;
   localAudioStreamMuteStateHandler: () => void;
   localVideoStreamMuteStateHandler: () => void;
   localOutputTrackChangeHandler: () => void;
-  roles: any[];
   environment: string;
   namespace = MEETINGS;
   allowMediaInLobby: boolean;
@@ -8026,6 +8031,7 @@ export default class Meeting extends StatelessWebexPlugin {
       remoteMediaManagerConfig,
       bundlePolicy = 'max-bundle',
       additionalMediaOptions = {},
+      allowPublishMediaInLobby = false,
     } = options;
 
     const {
@@ -8046,7 +8052,6 @@ export default class Meeting extends StatelessWebexPlugin {
     const ipver = MeetingUtil.getIpVersion(this.webex); // used just for metrics
 
     // If the user is unjoined or guest waiting in lobby dont allow the user to addMedia
-    // @ts-ignore - isUserUnadmitted coming from SelfUtil
     if (this.isUserUnadmitted && !this.wirelessShare && !this.allowMediaInLobby) {
       throw new UserInLobbyError();
     }
@@ -8091,7 +8096,13 @@ export default class Meeting extends StatelessWebexPlugin {
     this.brbState = createBrbState(this, false);
 
     try {
-      await this.setUpLocalStreamReferences(localStreams);
+      // if we're in a lobby and allowPublishMediaInLobby==false, we don't want to
+      // setup local streams for publishing, because if we ever end up admitted to the meeting
+      // but Locus event about it for us is delayed or missed, others could see/hear our user's video/audio
+      // while the user would still think they're in the lobby
+      if (allowPublishMediaInLobby || !this.isUserUnadmitted) {
+        await this.setUpLocalStreamReferences(localStreams);
+      }
 
       this.setMercuryListener();
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -3028,6 +3028,111 @@ describe('plugin-meetings', () => {
           checkWorking({allowMediaInLobby: true});
         });
 
+        const setupLobbyTest = () => {
+          meeting.roap.doTurnDiscovery = sinon
+            .stub()
+            .resolves({turnServerInfo: undefined, turnDiscoverySkippedReason: undefined});
+
+          meeting.meetingState = 'ACTIVE';
+          meeting.locusInfo.parsedLocus = {self: {state: 'IDLE'}};
+          meeting.isUserUnadmitted = true;
+
+          // Mock locusMediaRequest
+          meeting.locusMediaRequest = {
+            send: sinon.stub().resolves(),
+            isConfluenceCreated: sinon.stub().returns(false),
+          };
+
+          sinon.stub(RemoteMediaManagerModule, 'RemoteMediaManager').returns({
+            start: sinon.stub().resolves(),
+            on: sinon.stub(),
+            logAllReceiveSlots: sinon.stub(),
+          });
+
+          meeting.isMultistream = true;
+
+          const createFakeStream = (id) => ({
+            on: sinon.stub(),
+            off: sinon.stub(),
+            userMuted: false,
+            systemMuted: false,
+            get muted() {
+              return this.userMuted || this.systemMuted;
+            },
+            setUnmuteAllowed: sinon.stub(),
+            setUserMuted: sinon.stub(),
+            outputStream: {
+              getTracks: () => [{id}],
+            },
+            getSettings: sinon.stub().returns({}),
+          });
+
+          return {
+            fakeMicrophoneStream: createFakeStream('fake mic'),
+            fakeCameraStream: createFakeStream('fake camera'),
+          };
+        };
+
+        it('should not publish any local streams when in the lobby and allowPublishMediaInLobby is false', async () => {
+          const {fakeMicrophoneStream, fakeCameraStream} = setupLobbyTest();
+
+          const publishStreamStub = sinon.stub();
+          fakeMediaConnection.createSendSlot = sinon.stub().returns({
+            publishStream: publishStreamStub,
+            unpublishStream: sinon.stub(),
+            setNamedMediaGroups: sinon.stub(),
+          });
+
+          await meeting.addMedia({
+            allowMediaInLobby: true,
+            allowPublishMediaInLobby: false,
+            audioEnabled: true,
+            videoEnabled: true,
+            localStreams: {
+              microphone: fakeMicrophoneStream,
+              camera: fakeCameraStream,
+            },
+          });
+
+          assert.notCalled(publishStreamStub);
+        });
+
+        it('should publish local streams when in the lobby and allowPublishMediaInLobby is true', async () => {
+          const {fakeMicrophoneStream, fakeCameraStream} = setupLobbyTest();
+
+          const audioSlot = {
+            publishStream: sinon.stub(),
+            unpublishStream: sinon.stub(),
+            setNamedMediaGroups: sinon.stub(),
+          };
+          const videoSlot = {
+            publishStream: sinon.stub(),
+            unpublishStream: sinon.stub(),
+            setNamedMediaGroups: sinon.stub(),
+          };
+
+          fakeMediaConnection.createSendSlot = sinon.stub().callsFake((mediaType) => {
+            if (mediaType === 'AUDIO-MAIN') {
+              return audioSlot;
+            }
+            return videoSlot;
+          });
+
+          await meeting.addMedia({
+            allowMediaInLobby: true,
+            allowPublishMediaInLobby: true,
+            audioEnabled: true,
+            videoEnabled: true,
+            localStreams: {
+              microphone: fakeMicrophoneStream,
+              camera: fakeCameraStream,
+            },
+          });
+
+          assert.calledOnceWithExactly(audioSlot.publishStream, fakeMicrophoneStream);
+          assert.calledOnceWithExactly(videoSlot.publishStream, fakeCameraStream);
+        });
+
         it('should create rtcMetrics and pass them to Media.createMediaConnection()', async () => {
           const setIntervalOriginal = window.setInterval;
           window.setInterval = sinon.stub().returns(1);


### PR DESCRIPTION
# COMPLETES #[SPARK-681282](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-681282)

## This pull request addresses
There is a possible race condition:
When the app calls Meeting.joinWithMedia() and passes some local streams, it is possible that SDK is notified about user being placed in the lobby before the media connection is actually established. This means that when SDK forwards the "entered lobby" event to the app, the app doesn't do anything about local streams, because there is no media connection yet created so it thinks that there is nothing to unpublish. However, the media creation triggered by joinWithMedia() call continues in parallel to all this and eventually will publish the streams that were given in the arguments. So we end up with local streams published while we are in a lobby. This is not the end of the world, as backend does remote mute on us anyway while in lobby, but when the user is admitted to the meeting, sometimes we have big delays in getting Locus event about it (or even the event is missed completely) and then if we have published streams, remote participants will see our video while our app thinks we're still in the lobby.

Sequence of things:
1. Meeting.joinWithMedia() called with some local streams - at this point we don't know if we'll be in the lobby or not
3. Locus tells SDK that we're in lobby
4. SDK tells the app that we're in the lobby -> app ignores it, because there is no media connection yet, so nothing to do with local streams
5. Meeting.addMediaInternal() is called from Meeting.joinWithMedia()
6. local streams from point 1 are published

Result: we're in the lobby with published local streams

## by making the following changes
Added a new parameter to AddMediaOptions to indicate that the client app doesn't want to have streams published in a lobby - this allows SDK to have logic to just not do anything with passed in local streams if we are in the lobby at the point of media connection creation.

To test the fix manually with the web app:
- you need to hack joinWithMedia() and add a delay before calling addMediaInternal()
- hack SDK or web app to ignore or delay the event about being admitted from lobby into the meeting

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual testing with web app

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
