### PR TITLE
fix: send a metric when we timeout waiting for media connection

### DIFF
--- a/packages/@webex/plugin-meetings/src/media/MediaConnectionAwaiter.ts
+++ b/packages/@webex/plugin-meetings/src/media/MediaConnectionAwaiter.ts
@@ -2,9 +2,12 @@ import {Defer} from '@webex/common';
 import {ConnectionState, MediaConnectionEventNames} from '@webex/internal-media-core';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {ICE_AND_DTLS_CONNECTION_TIMEOUT} from '../constants';
+import BEHAVIORAL_METRICS from '../metrics/constants';
+import Metrics from '../metrics';
 
 export interface MediaConnectionAwaiterProps {
   webrtcMediaConnection: any;
+  correlationId: string;
 }
 
 /**
@@ -16,6 +19,7 @@ export default class MediaConnectionAwaiter {
   private defer: Defer;
   private retried: boolean;
   private iceConnected: boolean;
+  private correlationId: string;
   private onTimeoutCallback: () => void;
   private peerConnectionStateCallback: () => void;
   private iceConnectionStateCallback: () => void;
@@ -24,11 +28,12 @@ export default class MediaConnectionAwaiter {
   /**
    * @param {MediaConnectionAwaiterProps} mediaConnectionAwaiterProps
    */
-  constructor({webrtcMediaConnection}: MediaConnectionAwaiterProps) {
+  constructor({webrtcMediaConnection, correlationId}: MediaConnectionAwaiterProps) {
     this.webrtcMediaConnection = webrtcMediaConnection;
     this.defer = new Defer();
     this.retried = false;
     this.iceConnected = false;
+    this.correlationId = correlationId;
     this.onTimeoutCallback = this.onTimeout.bind(this);
     this.peerConnectionStateCallback = this.peerConnectionStateHandler.bind(this);
     this.iceConnectionStateCallback = this.iceConnectionStateHandler.bind(this);
@@ -176,6 +181,32 @@ export default class MediaConnectionAwaiter {
   }
 
   /**
+   * sends a metric with some additional info that might help debugging
+   * issues where browser doesn't update the RTCPeerConnection's iceConnectionState or connectionState
+   *
+   * @returns {void}
+   */
+  async sendMetric() {
+    const stats = await this.webrtcMediaConnection.getStats();
+
+    // in theory we can end up with more than one transport report in the stats,
+    // but for the purpose of this metric it's fine to just use the first one
+    const transportReports = Array.from(
+      stats.values().filter((report) => report.type === 'transport')
+    ) as Record<string, number | string>[];
+
+    Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.MEDIA_STILL_NOT_CONNECTED, {
+      correlation_id: this.correlationId,
+      numTransports: transportReports.length,
+      dtlsState: transportReports[0]?.dtlsState,
+      iceState: transportReports[0]?.iceState,
+      packetsSent: transportReports[0]?.packetsSent,
+      packetsReceived: transportReports[0]?.packetsReceived,
+      dataChannelState: this.webrtcMediaConnection.multistreamConnection?.dataChannel?.readyState,
+    });
+  }
+
+  /**
    * Function called when the timeout is reached.
    *
    * @returns {void}
@@ -188,6 +219,8 @@ export default class MediaConnectionAwaiter {
 
       return;
     }
+
+    this.sendMetric();
 
     if (!this.isIceGatheringCompleted()) {
       if (!this.retried) {
@@ -226,8 +259,15 @@ export default class MediaConnectionAwaiter {
    */
   waitForMediaConnectionConnected(): Promise<void> {
     if (this.isConnected()) {
+      LoggerProxy.logger.log(
+        'Media:MediaConnectionAwaiter#waitForMediaConnectionConnected --> Already connected'
+      );
+
       return Promise.resolve();
     }
+    LoggerProxy.logger.log(
+      'Media:MediaConnectionAwaiter#waitForMediaConnectionConnected --> Waiting for media connection to be connected'
+    );
 
     this.webrtcMediaConnection.on(
       MediaConnectionEventNames.PEER_CONNECTION_STATE_CHANGED,

--- a/packages/@webex/plugin-meetings/src/media/properties.ts
+++ b/packages/@webex/plugin-meetings/src/media/properties.ts
@@ -196,11 +196,13 @@ export default class MediaProperties {
   /**
    * Waits for the webrtc media connection to be connected.
    *
+   * @param {string} correlationId
    * @returns {Promise<void>}
    */
-  waitForMediaConnectionConnected(): Promise<void> {
+  waitForMediaConnectionConnected(correlationId: string): Promise<void> {
     const mediaConnectionAwaiter = new MediaConnectionAwaiter({
       webrtcMediaConnection: this.webrtcMediaConnection,
+      correlationId,
     });
 
     return mediaConnectionAwaiter.waitForMediaConnectionConnected();

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -7433,7 +7433,7 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   private async waitForMediaConnectionConnected(): Promise<void> {
     try {
-      await this.mediaProperties.waitForMediaConnectionConnected();
+      await this.mediaProperties.waitForMediaConnectionConnected(this.correlationId);
     } catch (error) {
       const {iceConnected} = error;
 

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -90,6 +90,7 @@ const BEHAVIORAL_METRICS = {
   MEDIA_ISSUE_DETECTED: 'js_sdk_media_issue_detected',
   LOCUS_CLASSIC_VS_HASH_TREE_MISMATCH: 'js_sdk_locus_classic_vs_hash_tree_mismatch',
   LOCUS_HASH_TREE_UNSUPPORTED_OPERATION: 'js_sdk_locus_hash_tree_unsupported_operation',
+  MEDIA_STILL_NOT_CONNECTED: 'js_sdk_media_still_not_connected',
 };
 
 export {BEHAVIORAL_METRICS as default};

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/MediaConnectionAwaiter.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/MediaConnectionAwaiter.ts
@@ -5,6 +5,8 @@ import {ConnectionState, MediaConnectionEventNames} from '@webex/internal-media-
 import testUtils from '../../../utils/testUtils';
 import {ICE_AND_DTLS_CONNECTION_TIMEOUT} from '@webex/plugin-meetings/src/constants';
 import MediaConnectionAwaiter from '../../../../src/media/MediaConnectionAwaiter';
+import Metrics from '../../../../src/metrics';
+import BEHAVIORAL_METRICS from '../../../../src/metrics/constants';
 
 describe('MediaConnectionAwaiter', () => {
   let mediaConnectionAwaiter;
@@ -14,18 +16,34 @@ describe('MediaConnectionAwaiter', () => {
   beforeEach(() => {
     clock = sinon.useFakeTimers();
 
+    const mockTransportReport = {
+      type: 'transport',
+      dtlsState: 'connecting',
+      iceState: 'checking',
+      packetsSent: 10,
+      packetsReceived: 5,
+    };
+
     mockMC = {
-      getStats: sinon.stub().resolves([]),
+      getStats: sinon.stub().resolves({
+        values: () => [mockTransportReport],
+      }),
       on: sinon.stub(),
       off: sinon.stub(),
       getConnectionState: sinon.stub().returns(ConnectionState.New),
       getIceGatheringState: sinon.stub().returns('new'),
       getIceConnectionState: sinon.stub().returns('new'),
       getPeerConnectionState: sinon.stub().returns('new'),
+      multistreamConnection: {
+        dataChannel: {
+          readyState: 'open',
+        },
+      },
     };
 
     mediaConnectionAwaiter = new MediaConnectionAwaiter({
       webrtcMediaConnection: mockMC,
+      correlationId: 'test-correlation-id',
     });
   });
 
@@ -44,6 +62,8 @@ describe('MediaConnectionAwaiter', () => {
     });
 
     it('rejects after timeout if ice state is not connected', async () => {
+      const sendMetricSpy = sinon.spy(Metrics, 'sendBehavioralMetric');
+
       mockMC.getConnectionState.returns(ConnectionState.Connecting);
       mockMC.getIceGatheringState.returns('gathering');
 
@@ -83,6 +103,18 @@ describe('MediaConnectionAwaiter', () => {
       assert.equal(promiseRejected, true);
 
       assert.calledThrice(mockMC.off);
+
+      assert.calledOnceWithExactly(sendMetricSpy, BEHAVIORAL_METRICS.MEDIA_STILL_NOT_CONNECTED, {
+        correlation_id: 'test-correlation-id',
+        numTransports: 1,
+        dtlsState: 'connecting',
+        iceState: 'checking',
+        packetsSent: 10,
+        packetsReceived: 5,
+        dataChannelState: 'open',
+      });
+
+      sendMetricSpy.restore();
     });
 
     it('rejects immediately if ice state is FAILED', async () => {
@@ -351,6 +383,8 @@ describe('MediaConnectionAwaiter', () => {
     });
 
     it(`reject with restart timer once if gathering state is not complete`, async () => {
+      const sendMetricSpy = sinon.spy(Metrics, 'sendBehavioralMetric');
+
       mockMC.getConnectionState.returns(ConnectionState.Connecting);
       mockMC.getIceGatheringState.returns('new');
 
@@ -390,6 +424,12 @@ describe('MediaConnectionAwaiter', () => {
 
       assert.calledOnce(clearTimeoutSpy);
       assert.calledTwice(setTimeoutSpy);
+
+      // verify sendMetric was called twice (once for each timeout)
+      assert.calledTwice(sendMetricSpy);
+      assert.calledWith(sendMetricSpy, BEHAVIORAL_METRICS.MEDIA_STILL_NOT_CONNECTED);
+
+      sendMetricSpy.restore();
     });
 
     it(`resolves gathering and connection state complete right after`, async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
@@ -41,14 +41,23 @@ describe('MediaProperties', () => {
   describe('waitForMediaConnectionConnected', () => {
     it('resolves if media connection is connected', async () => {
       const waitForMediaConnectionConnectedResult = new Defer();
+      const correlationId = 'aaaa-bbbb-cccc-dddd';
 
-      sinon
+      let capturedInstance;
+      const stub = sinon
         .stub(MediaConnectionAwaiter.prototype, 'waitForMediaConnectionConnected')
-        .returns(waitForMediaConnectionConnectedResult.promise);
+        .callsFake(function () {
+          capturedInstance = this;
+          return waitForMediaConnectionConnectedResult.promise;
+        });
 
       waitForMediaConnectionConnectedResult.resolve();
 
-      await mediaProperties.waitForMediaConnectionConnected();
+      await mediaProperties.waitForMediaConnectionConnected(correlationId);
+
+      assert.calledOnce(stub);
+      assert.equal(capturedInstance.correlationId, correlationId);
+      assert.equal(capturedInstance.webrtcMediaConnection, mockMC);
     });
     it('rejects if media connection is not connected', async () => {
       const waitForMediaConnectionConnectedResult = new Defer();

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -9149,7 +9149,10 @@ describe('plugin-meetings', () => {
 
             // check that the right things were called by the callback
             assert.calledOnceWithExactly(meeting.waitForRemoteSDPAnswer);
-            assert.calledOnceWithExactly(meeting.mediaProperties.waitForMediaConnectionConnected);
+            assert.calledOnceWithExactly(
+              meeting.mediaProperties.waitForMediaConnectionConnected,
+              meeting.correlationId
+            );
           });
         });
 


### PR DESCRIPTION
# COMPLETES #[SPARK-768475](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-768475)

## This pull request addresses
We suspect Chrome has an issue where sometimes (very rarely) we successfully connect, but RTCPeerConnection doesn't emit the "connected" events and doesn't even report the iceConnectionState or connectionState correctly. We've seen a few cases like this from 1 user - there were other stats in webrtc dump indicating that a connection was made, also Homer thought connection was successful, but we were stuck in MediaConnectionAwaiter still waiting, eventually timed out.

## by making the following changes
Added a temporary metric to see how many cases we get for this and then decide if it's worth doing some workarounds or reporting to Chrome as a bug.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, tested manually with web app and faking MediaConnectionAwaiter.isConnected() to always return false 

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
