### PR TITLE
fix(plugin-meetings): Meetings registration fixes

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -962,15 +962,17 @@ export default class Meetings extends WebexPlugin {
         'Meetings:index#register --> INFO, Meetings plugin unregistration in progress, waiting to register'
       );
 
-      this.registrationPromise = this.unregistrationPromise.finally(() => {
-        LoggerProxy.logger.info(
-          'Meetings:index#register --> INFO, Meetings plugin unregistration completed, proceeding to register'
-        );
+      this.registrationPromise = this.unregistrationPromise
+        .catch(() => {}) // It doesn't matter what happened during unregistration
+        .finally(() => {
+          LoggerProxy.logger.info(
+            'Meetings:index#register --> INFO, Meetings plugin unregistration completed, proceeding to register'
+          );
 
-        this.registrationPromise = null;
+          this.registrationPromise = null;
 
-        return this.register(deviceRegistrationOptions);
-      });
+          return this.register(deviceRegistrationOptions);
+        });
 
       return this.registrationPromise;
     }
@@ -1094,15 +1096,17 @@ export default class Meetings extends WebexPlugin {
       );
 
       // Wait for registration to complete (success or failure), then call unregister again
-      this.unregistrationPromise = this.registrationPromise.finally(() => {
-        LoggerProxy.logger.info(
-          'Meetings:index#unregister --> INFO, Meetings plugin registration completed, proceeding to unregister'
-        );
+      this.unregistrationPromise = this.registrationPromise
+        .catch(() => {}) // It doesn't matter what happened during registration
+        .finally(() => {
+          LoggerProxy.logger.info(
+            'Meetings:index#unregister --> INFO, Meetings plugin registration completed, proceeding to unregister'
+          );
 
-        this.unregistrationPromise = null;
+          this.unregistrationPromise = null;
 
-        return this.unregister();
-      });
+          return this.unregister();
+        });
 
       return this.unregistrationPromise;
     }

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -195,6 +195,8 @@ export default class Meetings extends WebexPlugin {
   preferredWebexSite: any;
   reachability: Reachability;
   registered: any;
+  registrationPromise: Promise<void>;
+  unregistrationPromise: Promise<void>;
   request: any;
   geoHintInfo: any;
   meetingInfo: any;
@@ -929,9 +931,20 @@ export default class Meetings extends WebexPlugin {
    * @returns {Promise} A promise that resolves when the step is completed.
    */
   executeRegistrationStep(step: () => Promise<any>, stepName: string) {
-    return step().then(() => {
-      this.registrationStatus[stepName] = true;
-    });
+    return step()
+      .then(() => {
+        LoggerProxy.logger.info(
+          `Meetings:index#executeRegistrationStep --> INFO, ${stepName} completed`
+        );
+        this.registrationStatus[stepName] = true;
+      })
+      .catch((error) => {
+        LoggerProxy.logger.error(
+          `Meetings:index#executeRegistrationStep --> ERROR, ${stepName} failed: ${error.message}`
+        );
+
+        return Promise.reject(error);
+      });
   }
 
   /**
@@ -944,7 +957,31 @@ export default class Meetings extends WebexPlugin {
    * @memberof Meetings
    */
   public register(deviceRegistrationOptions?: DeviceRegistrationOptions): Promise<any> {
-    this.registrationStatus = clone(INITIAL_REGISTRATION_STATUS);
+    if (this.unregistrationPromise) {
+      LoggerProxy.logger.info(
+        'Meetings:index#register --> INFO, Meetings plugin unregistration in progress, waiting to register'
+      );
+
+      this.registrationPromise = this.unregistrationPromise.finally(() => {
+        LoggerProxy.logger.info(
+          'Meetings:index#register --> INFO, Meetings plugin unregistration completed, proceeding to register'
+        );
+
+        this.registrationPromise = null;
+
+        return this.register(deviceRegistrationOptions);
+      });
+
+      return this.registrationPromise;
+    }
+
+    if (this.registrationPromise) {
+      LoggerProxy.logger.info(
+        'Meetings:index#register --> INFO, Meetings plugin registration in progress, returning existing promise'
+      );
+
+      return this.registrationPromise;
+    }
 
     // @ts-ignore
     if (!this.webex.canAuthorize) {
@@ -963,7 +1000,11 @@ export default class Meetings extends WebexPlugin {
       return Promise.resolve();
     }
 
-    return Promise.all([
+    LoggerProxy.logger.info('Meetings:index#register --> INFO, Registering Meetings plugin');
+
+    this.registrationStatus = clone(INITIAL_REGISTRATION_STATUS);
+
+    this.registrationPromise = Promise.all([
       this.executeRegistrationStep(() => this.fetchUserPreferredWebexSite(), 'fetchWebexSite'),
       this.executeRegistrationStep(() => this.getGeoHint(), 'getGeoHint'),
       this.executeRegistrationStep(
@@ -1022,7 +1063,12 @@ export default class Meetings extends WebexPlugin {
         });
 
         return Promise.reject(error);
+      })
+      .finally(() => {
+        this.registrationPromise = null;
       });
+
+    return this.registrationPromise;
   }
 
   /**
@@ -1034,6 +1080,33 @@ export default class Meetings extends WebexPlugin {
    * @memberof Meetings
    */
   unregister() {
+    if (this.unregistrationPromise) {
+      LoggerProxy.logger.info(
+        'Meetings:index#unregister --> INFO, Meetings plugin unregistration in progress, returning existing promise'
+      );
+
+      return this.unregistrationPromise;
+    }
+
+    if (this.registrationPromise) {
+      LoggerProxy.logger.info(
+        'Meetings:index#unregister --> INFO, Meetings plugin registration in progress, waiting to unregister'
+      );
+
+      // Wait for registration to complete (success or failure), then call unregister again
+      this.unregistrationPromise = this.registrationPromise.finally(() => {
+        LoggerProxy.logger.info(
+          'Meetings:index#unregister --> INFO, Meetings plugin registration completed, proceeding to unregister'
+        );
+
+        this.unregistrationPromise = null;
+
+        return this.unregister();
+      });
+
+      return this.unregistrationPromise;
+    }
+
     if (!this.registered) {
       LoggerProxy.logger.info(
         'Meetings:index#unregister --> INFO, Meetings plugin already unregistered'
@@ -1044,7 +1117,7 @@ export default class Meetings extends WebexPlugin {
 
     this.stopListeningForEvents();
 
-    return (
+    this.unregistrationPromise =
       // @ts-ignore
       this.webex.internal.mercury
         .disconnect()
@@ -1077,7 +1150,11 @@ export default class Meetings extends WebexPlugin {
           this.registered = false;
           this.registrationStatus = clone(INITIAL_REGISTRATION_STATUS);
         })
-    );
+        .finally(() => {
+          this.unregistrationPromise = null;
+        });
+
+    return this.unregistrationPromise;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -903,13 +903,9 @@ describe('plugin-meetings', () => {
           assert.calledOnce(webex.internal.mercury.disconnect);
         });
 
-        it.only('handles unregister called during registration that fails', async () => {
+        it('handles unregister called during registration that fails', async () => {
           webex.canAuthorize = true;
           webex.meetings.registered = false;
-
-          LoggerProxy.logger.info = (msg) => {
-            console.error(msg);
-          };
 
           const registrationError = new Error('registration failed');
           let rejectRegistration;
@@ -930,8 +926,6 @@ describe('plugin-meetings', () => {
 
           // Registration should fail
           await assert.isRejected(registerPromise, 'registration failed');
-
-          console.log('HERE');
 
           // // Unregister should resolve immediately since registration failed
           await unregisterPromise;
@@ -1048,6 +1042,153 @@ describe('plugin-meetings', () => {
           resolveRegistration();
           await registerPromise;
           await unregisterPromise;
+
+          loggerSpy.restore();
+        });
+
+        it('returns the same promise when unregister is called multiple times concurrently', async () => {
+          webex.meetings.registered = true;
+
+          // Make unregistration take some time
+          let resolveUnregistration;
+          const unregistrationDelay = new Promise((resolve) => {
+            resolveUnregistration = resolve;
+          });
+
+          webex.internal.mercury.disconnect.returns(unregistrationDelay);
+          webex.internal.device.unregister.returns(Promise.resolve());
+
+          // Start first unregistration
+          const firstUnregisterPromise = webex.meetings.unregister();
+
+          // Immediately start second unregistration while first is in progress
+          const secondUnregisterPromise = webex.meetings.unregister();
+
+          // Start third unregistration
+          const thirdUnregisterPromise = webex.meetings.unregister();
+
+          // All should return the same promise
+          assert.strictEqual(firstUnregisterPromise, secondUnregisterPromise);
+          assert.strictEqual(secondUnregisterPromise, thirdUnregisterPromise);
+
+          // Complete the unregistration
+          resolveUnregistration();
+
+          await firstUnregisterPromise;
+          await secondUnregisterPromise;
+          await thirdUnregisterPromise;
+
+          // Mercury disconnect and device unregister should only be called once
+          assert.calledOnce(webex.internal.mercury.disconnect);
+          assert.calledOnce(webex.internal.device.unregister);
+          assert.isFalse(webex.meetings.registered);
+        });
+
+        it('clears unregistrationPromise after successful unregistration', async () => {
+          webex.meetings.registered = true;
+
+          await webex.meetings.unregister();
+
+          assert.isFalse(webex.meetings.registered);
+          assert.isNull(webex.meetings.unregistrationPromise);
+        });
+
+        it('clears unregistrationPromise after failed unregistration', async () => {
+          webex.meetings.registered = true;
+
+          webex.internal.mercury.disconnect.rejects(new Error('disconnect failed'));
+
+          await assert.isRejected(webex.meetings.unregister());
+
+          assert.isTrue(webex.meetings.registered);
+          assert.isNull(webex.meetings.unregistrationPromise);
+        });
+
+        it('allows new unregistration after previous unregistration completes', async () => {
+          webex.meetings.registered = true;
+
+          // First unregistration
+          await webex.meetings.unregister();
+          assert.isFalse(webex.meetings.registered);
+
+          // Register again
+          webex.canAuthorize = true;
+          await webex.meetings.register();
+          assert.isTrue(webex.meetings.registered);
+
+          // Reset history
+          webex.internal.mercury.disconnect.resetHistory();
+          webex.internal.device.unregister.resetHistory();
+
+          // Second unregistration should work normally
+          await webex.meetings.unregister();
+          assert.calledOnce(webex.internal.mercury.disconnect);
+          assert.calledOnce(webex.internal.device.unregister);
+          assert.isFalse(webex.meetings.registered);
+        });
+
+        it('handles register called during unregistration that fails', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = true;
+
+          const unregistrationError = new Error('unregistration failed');
+          let rejectUnregistration;
+          const unregistrationDelay = new Promise((resolve, reject) => {
+            rejectUnregistration = reject;
+          });
+
+          webex.internal.mercury.disconnect.returns(unregistrationDelay);
+
+          // Start unregistration (don't await)
+          const unregisterPromise = webex.meetings.unregister();
+
+          // Call register while unregistration is in progress
+          const registerPromise = webex.meetings.register();
+
+          // Fail the unregistration
+          rejectUnregistration(unregistrationError);
+
+          // Unregistration should fail
+          await assert.isRejected(unregisterPromise, 'unregistration failed');
+
+          // Register should still succeed (retry after unregister failure)
+          await registerPromise;
+
+          // Verify final state - should be registered
+          assert.isTrue(webex.meetings.registered);
+          assert.isNull(webex.meetings.unregistrationPromise);
+        });
+
+        it('logs appropriate message when register is called during unregistration', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = true;
+
+          const loggerSpy = sinon.spy(LoggerProxy.logger, 'info');
+
+          let resolveUnregistration;
+          const unregistrationDelay = new Promise((resolve) => {
+            resolveUnregistration = resolve;
+          });
+
+          webex.internal.mercury.disconnect.returns(unregistrationDelay);
+          webex.internal.device.unregister.returns(Promise.resolve());
+
+          // Start unregistration
+          const unregisterPromise = webex.meetings.unregister();
+
+          // Call register during unregistration
+          const registerPromise = webex.meetings.register();
+
+          // Should log that it's waiting
+          assert.calledWith(
+            loggerSpy,
+            'Meetings:index#register --> INFO, Meetings plugin unregistration in progress, waiting to register'
+          );
+
+          // Complete unregistration and registration
+          resolveUnregistration();
+          await unregisterPromise;
+          await registerPromise;
 
           loggerSpy.restore();
         });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -425,7 +425,10 @@ describe('plugin-meetings', () => {
 
     describe('#_toggleStopIceGatheringAfterFirstRelayCandidate', () => {
       it('should have _toggleStopIceGatheringAfterFirstRelayCandidate', () => {
-        assert.equal(typeof webex.meetings._toggleStopIceGatheringAfterFirstRelayCandidate, 'function');
+        assert.equal(
+          typeof webex.meetings._toggleStopIceGatheringAfterFirstRelayCandidate,
+          'function'
+        );
       });
 
       describe('success', () => {
@@ -602,6 +605,196 @@ describe('plugin-meetings', () => {
 
           clock.restore();
         });
+
+        it('returns the same promise when register is called multiple times concurrently', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          // Make registration take some time
+          let resolveRegistration;
+          const registrationDelay = new Promise((resolve) => {
+            resolveRegistration = resolve;
+          });
+
+          webex.internal.device.register.returns(registrationDelay);
+          webex.internal.mercury.connect.returns(Promise.resolve());
+
+          // Start first registration
+          const firstRegisterPromise = webex.meetings.register();
+
+          // Immediately start second registration while first is in progress
+          const secondRegisterPromise = webex.meetings.register();
+
+          // Start third registration
+          const thirdRegisterPromise = webex.meetings.register();
+
+          // All should return the same promise
+          assert.strictEqual(firstRegisterPromise, secondRegisterPromise);
+          assert.strictEqual(secondRegisterPromise, thirdRegisterPromise);
+
+          // Complete the registration
+          resolveRegistration();
+
+          await firstRegisterPromise;
+          await secondRegisterPromise;
+          await thirdRegisterPromise;
+
+          // Device registration and mercury connect should only be called once
+          assert.calledOnce(webex.internal.device.register);
+          assert.calledOnce(webex.internal.mercury.connect);
+          assert.isTrue(webex.meetings.registered);
+        });
+
+        it('prevents duplicate registrations when register is called during in-flight registration', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          let deviceRegisterCallCount = 0;
+          let mercuryConnectCallCount = 0;
+
+          // Track actual calls
+          webex.internal.device.register = sinon.stub().callsFake(() => {
+            deviceRegisterCallCount++;
+            return Promise.resolve();
+          });
+          webex.internal.mercury.connect = sinon.stub().callsFake(() => {
+            mercuryConnectCallCount++;
+            return Promise.resolve();
+          });
+
+          // Start registration without awaiting
+          const promise1 = webex.meetings.register();
+
+          // Call register again while first is in progress
+          const promise2 = webex.meetings.register();
+
+          // Wait for both
+          await Promise.all([promise1, promise2]);
+
+          // Should only register once
+          assert.equal(deviceRegisterCallCount, 1, 'device.register should only be called once');
+          assert.equal(mercuryConnectCallCount, 1, 'mercury.connect should only be called once');
+          assert.isTrue(webex.meetings.registered);
+        });
+
+        it('handles concurrent register calls when first registration fails', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          const registrationError = new Error('registration failed');
+          webex.internal.device.register.rejects(registrationError);
+
+          // Start first registration
+          const firstRegisterPromise = webex.meetings.register();
+
+          // Start second registration while first is in progress
+          const secondRegisterPromise = webex.meetings.register();
+
+          // Both should reject with the same error
+          await assert.isRejected(firstRegisterPromise, 'registration failed');
+          await assert.isRejected(secondRegisterPromise, 'registration failed');
+
+          // Should still only attempt registration once
+          assert.calledOnce(webex.internal.device.register);
+          assert.isFalse(webex.meetings.registered);
+        });
+
+        it('allows new registration after previous registration completes', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          // First registration
+          await webex.meetings.register();
+          assert.isTrue(webex.meetings.registered);
+
+          // Reset for second registration
+          webex.meetings.registered = false;
+          webex.internal.device.register.resetHistory();
+          webex.internal.mercury.connect.resetHistory();
+
+          // Second registration should work normally
+          await webex.meetings.register();
+          assert.calledOnce(webex.internal.device.register);
+          assert.calledOnce(webex.internal.mercury.connect);
+          assert.isTrue(webex.meetings.registered);
+        });
+
+        it('clears registrationPromise after successful registration', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          await webex.meetings.register();
+
+          assert.isTrue(webex.meetings.registered);
+          assert.isNull(webex.meetings.registrationPromise);
+        });
+
+        it('clears registrationPromise after failed registration', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          webex.internal.device.register.rejects(new Error('registration failed'));
+
+          await assert.isRejected(webex.meetings.register());
+
+          assert.isFalse(webex.meetings.registered);
+          assert.isNull(webex.meetings.registrationPromise);
+        });
+
+        it('waits for unregistration to complete before registering', async () => {
+          webex.canAuthorize = true;
+
+          assert.isFalse(webex.meetings.registered);
+
+          // First, register successfully
+          await webex.meetings.register();
+          assert.isTrue(webex.meetings.registered);
+
+          // Start unregistration (but don't await it)
+          const unregisterPromise = webex.meetings.unregister();
+          assert.isDefined(webex.meetings.unregistrationPromise);
+
+          // Immediately try to register while unregister is in progress
+          const registerPromise = webex.meetings.register();
+
+          // Wait for register to complete
+          await registerPromise;
+
+          // Should have completed registration
+          assert.isTrue(webex.meetings.registered);
+
+          // Now await the original unregister promise - this should have already completed
+          // and should NOT affect the registered state since register() took over
+          await unregisterPromise;
+
+          // Should STILL be registered because register() took over
+          assert.isTrue(webex.meetings.registered);
+        });
+
+        it('handles multiple register calls during unregistration', async () => {
+          webex.canAuthorize = true;
+
+          // First, register successfully
+          await webex.meetings.register();
+          assert.isTrue(webex.meetings.registered);
+
+          // Start unregistration
+          const unregistrationPromise = webex.meetings.unregister();
+
+          // Try to register once while unregister is in progress
+          await webex.meetings.register();
+
+          // Should be registered again
+          assert.isTrue(
+            webex.meetings.registered,
+            'Expected meetings to be registered after unregister and register cycle'
+          );
+
+          await unregistrationPromise;
+
+          // Should STILL be registered because register() took over
+          assert.isTrue(webex.meetings.registered);
+        });
       });
 
       describe('#unregister', () => {
@@ -669,6 +862,194 @@ describe('plugin-meetings', () => {
             assert.deepEqual(webex.meetings.registrationStatus, INITIAL_REGISTRATION_STATUS);
             done();
           });
+        });
+
+        it('waits for registration to complete before unregistering when called during registration', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          let resolveRegistration;
+          const registrationDelay = new Promise((resolve) => {
+            resolveRegistration = resolve;
+          });
+
+          webex.internal.device.register.returns(registrationDelay);
+          webex.internal.mercury.connect.returns(Promise.resolve());
+
+          // Start registration (don't await)
+          const registerPromise = webex.meetings.register();
+
+          // Verify registration is in progress
+          assert.exists(webex.meetings.registrationPromise);
+          assert.isFalse(webex.meetings.registered);
+
+          // Call unregister while registration is in progress
+          const unregisterPromise = webex.meetings.unregister();
+
+          // Registration should still be in progress
+          assert.exists(webex.meetings.registrationPromise);
+
+          // Complete the registration
+          resolveRegistration();
+          await registerPromise;
+
+          // Now unregister should proceed
+          await unregisterPromise;
+
+          // Verify final state
+          assert.isFalse(webex.meetings.registered);
+          assert.isNull(webex.meetings.registrationPromise);
+          assert.calledOnce(webex.internal.device.unregister);
+          assert.calledOnce(webex.internal.mercury.disconnect);
+        });
+
+        it.only('handles unregister called during registration that fails', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          LoggerProxy.logger.info = (msg) => {
+            console.error(msg);
+          };
+
+          const registrationError = new Error('registration failed');
+          let rejectRegistration;
+          const registrationDelay = new Promise((resolve, reject) => {
+            rejectRegistration = reject;
+          });
+
+          webex.internal.device.register.returns(registrationDelay);
+
+          // Start registration (don't await)
+          const registerPromise = webex.meetings.register();
+
+          // Call unregister while registration is in progress
+          const unregisterPromise = webex.meetings.unregister();
+
+          // Fail the registration
+          rejectRegistration(registrationError);
+
+          // Registration should fail
+          await assert.isRejected(registerPromise, 'registration failed');
+
+          console.log('HERE');
+
+          // // Unregister should resolve immediately since registration failed
+          await unregisterPromise;
+
+          // Verify final state - not registered
+          assert.isFalse(webex.meetings.registered);
+          assert.isNull(webex.meetings.registrationPromise);
+          // Device unregister should not be called because registration never completed
+          assert.notCalled(webex.internal.device.unregister);
+        });
+
+        it('handles multiple unregister calls during registration', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          let resolveRegistration;
+          const registrationDelay = new Promise((resolve) => {
+            resolveRegistration = resolve;
+          });
+
+          webex.internal.device.register.returns(registrationDelay);
+          webex.internal.mercury.connect.returns(Promise.resolve());
+
+          // Start registration
+          const registerPromise = webex.meetings.register();
+
+          // Call unregister multiple times while registration is in progress
+          const unregisterPromise1 = webex.meetings.unregister();
+          const unregisterPromise2 = webex.meetings.unregister();
+          const unregisterPromise3 = webex.meetings.unregister();
+
+          // Complete registration
+          resolveRegistration();
+          await registerPromise;
+
+          // All unregister calls should complete
+          await Promise.all([unregisterPromise1, unregisterPromise2, unregisterPromise3]);
+
+          // Verify final state
+          assert.isFalse(webex.meetings.registered);
+          // Disconnect and unregister should be called, but not multiple times
+          assert.calledOnce(webex.internal.mercury.disconnect);
+          assert.calledOnce(webex.internal.device.unregister);
+        });
+
+        it('completes unregister correctly after waiting for registration', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          const stopListeningForEventsSpy = sinon.spy(webex.meetings, 'stopListeningForEvents');
+
+          let resolveRegistration;
+          const registrationDelay = new Promise((resolve) => {
+            resolveRegistration = resolve;
+          });
+
+          webex.internal.device.register.returns(registrationDelay);
+          webex.internal.mercury.connect.returns(Promise.resolve());
+
+          // Start registration
+          const registerPromise = webex.meetings.register();
+
+          // Call unregister during registration
+          const unregisterPromise = webex.meetings.unregister();
+
+          // stopListeningForEvents should not be called yet
+          assert.notCalled(stopListeningForEventsSpy);
+
+          // Complete registration
+          resolveRegistration();
+          await registerPromise;
+
+          // After registration completes, the meetings plugin should be registered
+          assert.isTrue(webex.meetings.registered);
+
+          // Now unregister should proceed
+          await unregisterPromise;
+
+          // Verify unregister completed properly
+          assert.calledOnce(stopListeningForEventsSpy);
+          assert.calledOnce(webex.internal.mercury.disconnect);
+          assert.calledOnce(webex.internal.device.unregister);
+          assert.isFalse(webex.meetings.registered);
+          assert.deepEqual(webex.meetings.registrationStatus, INITIAL_REGISTRATION_STATUS);
+        });
+
+        it('logs appropriate message when unregister is called during registration', async () => {
+          webex.canAuthorize = true;
+          webex.meetings.registered = false;
+
+          const loggerSpy = sinon.spy(LoggerProxy.logger, 'info');
+
+          let resolveRegistration;
+          const registrationDelay = new Promise((resolve) => {
+            resolveRegistration = resolve;
+          });
+
+          webex.internal.device.register.returns(registrationDelay);
+          webex.internal.mercury.connect.returns(Promise.resolve());
+
+          // Start registration
+          const registerPromise = webex.meetings.register();
+
+          // Call unregister during registration
+          const unregisterPromise = webex.meetings.unregister();
+
+          // Should log that it's waiting
+          assert.calledWith(
+            loggerSpy,
+            'Meetings:index#unregister --> INFO, Meetings plugin registration in progress, waiting to unregister'
+          );
+
+          // Complete registration and unregistration
+          resolveRegistration();
+          await registerPromise;
+          await unregisterPromise;
+
+          loggerSpy.restore();
         });
       });
 
@@ -918,7 +1299,7 @@ describe('plugin-meetings', () => {
                 locus: {
                   url: url1,
                 },
-                hashTreeMessage: undefined
+                hashTreeMessage: undefined,
               });
             });
           });
@@ -1203,8 +1584,30 @@ describe('plugin-meetings', () => {
 
         it('calls createMeeting with classificationId and returns its promise', async () => {
           await checkCallCreateMeeting(
-            [test1, test2, FAKE_USE_RANDOM_DELAY, {}, undefined, true, callStateForMetrics, undefined, undefined, undefined, classificationId],
-            [test1, test2, FAKE_USE_RANDOM_DELAY, {}, callStateForMetrics, true, undefined, undefined, classificationId],
+            [
+              test1,
+              test2,
+              FAKE_USE_RANDOM_DELAY,
+              {},
+              undefined,
+              true,
+              callStateForMetrics,
+              undefined,
+              undefined,
+              undefined,
+              classificationId,
+            ],
+            [
+              test1,
+              test2,
+              FAKE_USE_RANDOM_DELAY,
+              {},
+              callStateForMetrics,
+              true,
+              undefined,
+              undefined,
+              classificationId,
+            ]
           );
         });
 
@@ -1437,7 +1840,7 @@ describe('plugin-meetings', () => {
                   webExMeetingId,
                 },
               },
-              hashTreeMessage: undefined
+              hashTreeMessage: undefined,
             });
           });
           it('should setup the meeting from a hash tree event', async () => {
@@ -1507,7 +1910,7 @@ describe('plugin-meetings', () => {
                   webExMeetingId,
                 },
               },
-              hashTreeMessage: undefined
+              hashTreeMessage: undefined,
             });
           });
 
@@ -1583,7 +1986,7 @@ describe('plugin-meetings', () => {
                   webExMeetingId,
                 },
               },
-              hashTreeMessage: undefined
+              hashTreeMessage: undefined,
             });
           });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

The meetings plugin registration/unregistration was not handling the case where either could be called while either are in progress.

## by making the following changes

Added both a registration and an unregistration promise to the plugin and logic such that the in progress action (either registration or unregistration) finishes before the other one starts.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
