### PR TITLE
fix: webinar 5k error when events received before join response

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -815,8 +815,19 @@ export default class LocusInfo extends EventsScope {
         data.stateElementsMessage as HashTreeMessage
       );
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const {eventType} = data;
+
+      if (eventType === LOCUSEVENT.HASH_TREE_DATA_UPDATED) {
+        // this can happen when we get an event before join http response
+        // it's OK to just ignore it
+        LoggerProxy.logger.info(
+          `Locus-info:index#parse --> received locus hash tree event before hashTreeParser is created`
+        );
+
+        return;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-shadow
       const locus = this.getTheLocusToUpdate(data.locus);
       LoggerProxy.logger.info(`Locus-info:index#parse --> received locus data: ${eventType}`);
 
@@ -841,12 +852,6 @@ export default class LocusInfo extends EventsScope {
           break;
         case LOCUSEVENT.DIFFERENCE:
           this.handleLocusDelta(locus, meeting);
-          break;
-        case LOCUSEVENT.HASH_TREE_DATA_UPDATED:
-          this.sendClassicVsHashTreeMismatchMetric(
-            meeting,
-            `got ${eventType}, expected classic events`
-          );
           break;
 
         default:

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -29,7 +29,8 @@ import {
 } from '../../../../src/constants';
 
 import {self, selfWithInactivity} from './selfConstant';
-import { MEETING_REMOVED_REASON } from '@webex/plugin-meetings/src/constants';
+import {MEETING_REMOVED_REASON} from '@webex/plugin-meetings/src/constants';
+import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';
 
 describe('plugin-meetings', () => {
   describe('LocusInfo index', () => {
@@ -4212,6 +4213,30 @@ describe('plugin-meetings', () => {
         locusInfo.parse(mockMeeting, data);
 
         assert.calledOnceWithExactly(mockHashTreeParser.handleMessage, fakeHashTreeMessage);
+      });
+
+      it('ignores hash tree event when hashTreeParser is not created yet', () => {
+        const data = {
+          eventType: LOCUSEVENT.HASH_TREE_DATA_UPDATED,
+          stateElementsMessage: {
+            locusStateElements: [],
+            dataSets: [],
+          },
+        };
+
+        const loggerSpy = sinon.spy(LoggerProxy.logger, 'info');
+        const getTheLocusToUpdateStub = sinon.stub(locusInfo, 'getTheLocusToUpdate');
+
+        // Ensure we're not using hash trees
+        assert.isUndefined(locusInfo.hashTreeParser);
+
+        locusInfo.parse(mockMeeting, data);
+
+        assert.calledWith(
+          loggerSpy,
+          'Locus-info:index#parse --> received locus hash tree event before hashTreeParser is created'
+        );
+        assert.notCalled(getTheLocusToUpdateStub);
       });
     });
   });


### PR DESCRIPTION
# COMPLETES #[SPARK-770971](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-770971)

## This pull request addresses
Locus recently started sending us some hash tree events before we get the join http response. When we receive them, we throw  an error:
<img width="1276" height="323" alt="image" src="https://github.com/user-attachments/assets/58a28182-7025-4a0f-a028-9d6ac6c45e71" />


## by making the following changes
Explicitly checking for hash tree event before we try to access locus from the message (hash tree events will never have a locus object in them).
That message is triggered by our join request and it contains the same data as the HTTP response, so we can just ignore the event. Even in the extreme case if the event contains newer data than the http response, once we initialize our hash trees with the http response data the hash tree syncing mechanism will ensure that we eventually are up-to-date.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
