### PR TITLE
fix: removal of objects from a dataset when they stay in other dataset

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTree.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTree.ts
@@ -372,6 +372,23 @@ class HashTree {
   }
 
   /**
+   * Retrieves the version of a specific item by its id and type.
+   * @param {number} id The ID of the item.
+   * @param {ObjectType} type The type of the item.
+   * @returns {number | undefined} The version of the item if found, undefined otherwise.
+   */
+  getItemVersion(id: number, type: ObjectType): number | undefined {
+    if (this.numLeaves === 0) {
+      return undefined;
+    }
+
+    const index = id % this.numLeaves;
+    const item = this.leaves[index]?.[type]?.[id];
+
+    return item?.version;
+  }
+
+  /**
    * Resizes the HashTree to have a new number of leaf nodes, redistributing all existing items.
    * @param {number} newNumLeaves The new number of leaf nodes (must be 0 or a power of 2).
    * @returns {boolean} true if the tree was resized, false if the size didn't change.

--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -880,7 +880,49 @@ class HashTreeParser {
   }) {
     const {updateType, updatedObjects} = updates;
 
-    if (updateType !== LocusInfoUpdateType.OBJECTS_UPDATED || updatedObjects?.length > 0) {
+    if (updateType === LocusInfoUpdateType.OBJECTS_UPDATED && updatedObjects?.length > 0) {
+      // Filter out updates for objects that already have a higher version in their datasets,
+      // or removals for objects that still exist in any of their datasets
+      const filteredUpdates = updatedObjects.filter((object) => {
+        const {elementId} = object.htMeta;
+        const {type, id, version} = elementId;
+
+        // Check all datasets
+        for (const dataSetName of Object.keys(this.dataSets)) {
+          const dataSet = this.dataSets[dataSetName];
+
+          // only visible datasets have hash trees set
+          if (dataSet?.hashTree) {
+            const existingVersion = dataSet.hashTree.getItemVersion(id, type);
+            if (existingVersion !== undefined) {
+              if (object.data) {
+                // For updates: filter out if any dataset has a higher version
+                if (existingVersion > version) {
+                  LoggerProxy.logger.info(
+                    `HashTreeParser#callLocusInfoUpdateCallback --> ${this.debugId} Filtering out update for ${type}:${id} v${version} because dataset "${dataSetName}" has v${existingVersion}`
+                  );
+
+                  return false;
+                }
+              } else if (existingVersion >= version) {
+                // For removals: filter out if the object still exists in any dataset
+                LoggerProxy.logger.info(
+                  `HashTreeParser#callLocusInfoUpdateCallback --> ${this.debugId} Filtering out removal for ${type}:${id} v${version} because dataset "${dataSetName}" still has v${existingVersion}`
+                );
+
+                return false;
+              }
+            }
+          }
+        }
+
+        return true;
+      });
+
+      if (filteredUpdates.length > 0) {
+        this.locusInfoUpdateCallback(updateType, {updatedObjects: filteredUpdates});
+      }
+    } else if (updateType !== LocusInfoUpdateType.OBJECTS_UPDATED) {
       this.locusInfoUpdateCallback(updateType, {updatedObjects});
     }
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTree.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTree.ts
@@ -652,4 +652,70 @@ describe('HashTree', () => {
       expect(() => hashTree.computeLeafHash(2)).to.not.throw();
     });
   });
+
+  describe('getItemVersion', () => {
+    it('should return version when item exists', () => {
+      const items: LeafDataItem[] = [
+        {type: 'participant', id: 1, version: 5},
+        {type: 'self', id: 2, version: 10},
+      ];
+      const hashTree = new HashTree(items, 4);
+
+      expect(hashTree.getItemVersion(1, 'participant')).to.equal(5);
+      expect(hashTree.getItemVersion(2, 'self')).to.equal(10);
+    });
+
+    it('should return undefined when item does not exist', () => {
+      const items: LeafDataItem[] = [{type: 'participant', id: 1, version: 5}];
+      const hashTree = new HashTree(items, 4);
+
+      expect(hashTree.getItemVersion(999, 'participant')).to.be.undefined;
+    });
+
+    it('should return undefined when type does not match', () => {
+      const items: LeafDataItem[] = [{type: 'participant', id: 1, version: 5}];
+      const hashTree = new HashTree(items, 4);
+
+      expect(hashTree.getItemVersion(1, 'self')).to.be.undefined;
+    });
+
+    it('should return undefined for tree with 0 leaves', () => {
+      const hashTree = new HashTree([], 0);
+
+      expect(hashTree.getItemVersion(1, 'participant')).to.be.undefined;
+    });
+
+    it('should return correct version when multiple items exist in same leaf', () => {
+      const items: LeafDataItem[] = [
+        {type: 'participant', id: 1, version: 3}, // leaf 1 (1 % 2 = 1)
+        {type: 'self', id: 3, version: 7}, // leaf 1 (3 % 2 = 1)
+        {type: 'locus', id: 5, version: 12}, // leaf 1 (5 % 2 = 1)
+      ];
+      const hashTree = new HashTree(items, 2);
+
+      expect(hashTree.getItemVersion(1, 'participant')).to.equal(3);
+      expect(hashTree.getItemVersion(3, 'self')).to.equal(7);
+      expect(hashTree.getItemVersion(5, 'locus')).to.equal(12);
+    });
+
+    it('should return updated version after item is updated', () => {
+      const hashTree = new HashTree([{type: 'participant', id: 1, version: 5}], 4);
+
+      expect(hashTree.getItemVersion(1, 'participant')).to.equal(5);
+
+      hashTree.putItem({type: 'participant', id: 1, version: 10});
+
+      expect(hashTree.getItemVersion(1, 'participant')).to.equal(10);
+    });
+
+    it('should return undefined after item is removed', () => {
+      const hashTree = new HashTree([{type: 'participant', id: 1, version: 5}], 4);
+
+      expect(hashTree.getItemVersion(1, 'participant')).to.equal(5);
+
+      hashTree.removeItem({type: 'participant', id: 1, version: 5});
+
+      expect(hashTree.getItemVersion(1, 'participant')).to.be.undefined;
+    });
+  });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -5,6 +5,7 @@ import HashTree from '@webex/plugin-meetings/src/hashTree/hashTree';
 import {expect} from '@webex/test-helper-chai';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
+import {EMPTY_HASH} from '@webex/plugin-meetings/src/hashTree/constants';
 
 const exampleInitialLocus = {
   dataSets: [
@@ -1518,6 +1519,498 @@ describe('HashTreeParser', () => {
 
         // Verify callback was NOT called (no updates for non-visible datasets)
         assert.notCalled(callback);
+      });
+    });
+  });
+
+  describe('#callLocusInfoUpdateCallback filtering', () => {
+    // Helper to setup parser with initial objects and reset callback history
+    async function setupParserWithObjects(locusStateElements: any[]) {
+      const parser = createHashTreeParser();
+
+      if (locusStateElements.length > 0) {
+        // Determine which datasets to include based on the objects' dataSetNames
+        const dataSetNames = new Set<string>();
+        locusStateElements.forEach((element) => {
+          element.htMeta?.dataSetNames?.forEach((name) => dataSetNames.add(name));
+        });
+
+        const dataSets = [];
+        if (dataSetNames.has('main')) dataSets.push(createDataSet('main', 16, 1100));
+        if (dataSetNames.has('self')) dataSets.push(createDataSet('self', 1, 2100));
+        if (dataSetNames.has('atd-unmuted')) dataSets.push(createDataSet('atd-unmuted', 16, 3100));
+
+        const setupMessage = {
+          dataSets,
+          visibleDataSetsUrl,
+          locusUrl,
+          locusStateElements,
+        };
+
+        await parser.handleMessage(setupMessage, 'setup');
+      }
+
+      callback.resetHistory();
+      return parser;
+    }
+
+    it('filters out updates when a dataset has a higher version', async () => {
+      const parser = await setupParserWithObjects([
+        {
+          htMeta: {
+            elementId: {type: 'locus' as const, id: 5, version: 100},
+            dataSetNames: ['main'],
+          },
+          data: {existingField: 'existing'},
+        },
+      ]);
+
+      // Try to update with an older version (90)
+      const updateMessage = {
+        dataSets: [createDataSet('main', 16, 1101)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'locus' as const, id: 5, version: 90},
+              dataSetNames: ['main'],
+            },
+            data: {someField: 'value'},
+          },
+        ],
+      };
+
+      await parser.handleMessage(updateMessage, 'update with older version');
+
+      // Callback should not be called because the update was filtered out
+      assert.notCalled(callback);
+    });
+
+    it('allows updates when version is newer than existing', async () => {
+      const parser = await setupParserWithObjects([
+        {
+          htMeta: {
+            elementId: {type: 'locus' as const, id: 5, version: 100},
+            dataSetNames: ['main'],
+          },
+          data: {existingField: 'existing'},
+        },
+      ]);
+
+      // Try to update with a newer version (110)
+      const updateMessage = {
+        dataSets: [createDataSet('main', 16, 1101)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'locus' as const, id: 5, version: 110},
+              dataSetNames: ['main'],
+            },
+            data: {someField: 'new value'},
+          },
+        ],
+      };
+
+      await parser.handleMessage(updateMessage, 'update with newer version');
+
+      // Callback should be called with the update
+      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+        updatedObjects: [
+          {
+            htMeta: {
+              elementId: {type: 'locus', id: 5, version: 110},
+              dataSetNames: ['main'],
+            },
+            data: {someField: 'new value'},
+          },
+        ],
+      });
+    });
+
+    it('filters out removal when object still exists in any dataset', async () => {
+      const parser = await setupParserWithObjects([
+        {
+          htMeta: {
+            elementId: {type: 'participant' as const, id: 10, version: 50},
+            dataSetNames: ['main', 'atd-unmuted'],
+          },
+          data: {name: 'participant'},
+        },
+      ]);
+
+      // Try to remove the object from main only (it still exists in atd-unmuted)
+      const removalMessage = {
+        dataSets: [createDataSet('main', 16, 1101)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'participant' as const, id: 10, version: 50},
+              dataSetNames: ['main'],
+            },
+            data: null, // removal
+          },
+        ],
+      };
+
+      await parser.handleMessage(removalMessage, 'removal from one dataset');
+
+      // Callback should not be called because object still exists in atd-unmuted
+      assert.notCalled(callback);
+    });
+
+    it('allows removal when object does not exist in any dataset', async () => {
+      const parser = await setupParserWithObjects([]);
+
+      // Stub updateItems to return true (simulating that the removal was "applied")
+      sinon.stub(parser.dataSets.main.hashTree, 'updateItems').returns([true]);
+
+      // Try to remove an object that doesn't exist anywhere
+      const removalMessage = {
+        dataSets: [createDataSet('main', 16, 1100)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'participant' as const, id: 99, version: 10},
+              dataSetNames: ['main'],
+            },
+            data: null, // removal
+          },
+        ],
+      };
+
+      await parser.handleMessage(removalMessage, 'removal of non-existent object');
+
+      // Callback should be called with the removal
+      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+        updatedObjects: [
+          {
+            htMeta: {
+              elementId: {type: 'participant', id: 99, version: 10},
+              dataSetNames: ['main'],
+            },
+            data: null,
+          },
+        ],
+      });
+    });
+
+    it('filters out removal when object exists in another dataset with newer version', async () => {
+      const parser = createHashTreeParser();
+
+      // Setup: Add object to main with version 40
+      await parser.handleMessage(
+        {
+          dataSets: [createDataSet('main', 16, 1100)],
+          visibleDataSetsUrl,
+          locusUrl,
+          locusStateElements: [
+            {
+              htMeta: {
+                elementId: {type: 'participant' as const, id: 10, version: 40},
+                dataSetNames: ['main'],
+              },
+              data: {name: 'participant v40'},
+            },
+          ],
+        },
+        'setup main'
+      );
+
+      // Add object to atd-unmuted with version 50
+      await parser.handleMessage(
+        {
+          dataSets: [createDataSet('atd-unmuted', 16, 3100)],
+          visibleDataSetsUrl,
+          locusUrl,
+          locusStateElements: [
+            {
+              htMeta: {
+                elementId: {type: 'participant' as const, id: 10, version: 50},
+                dataSetNames: ['atd-unmuted'],
+              },
+              data: {name: 'participant v50'},
+            },
+          ],
+        },
+        'setup atd-unmuted'
+      );
+      callback.resetHistory();
+
+      // Try to remove with version 40 from main
+      const removalMessage = {
+        dataSets: [createDataSet('main', 16, 1101)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'participant' as const, id: 10, version: 40},
+              dataSetNames: ['main'],
+            },
+            data: null, // removal
+          },
+        ],
+      };
+
+      await parser.handleMessage(removalMessage, 'removal with older version');
+
+      // Callback should not be called because object still exists with newer version
+      assert.notCalled(callback);
+    });
+
+    it('filters mixed updates correctly - some pass, some filtered', async () => {
+      const parser = await setupParserWithObjects([
+        {
+          htMeta: {
+            elementId: {type: 'participant' as const, id: 1, version: 100},
+            dataSetNames: ['main'],
+          },
+          data: {name: 'participant 1'},
+        },
+        {
+          htMeta: {
+            elementId: {type: 'participant' as const, id: 2, version: 50},
+            dataSetNames: ['atd-unmuted'],
+          },
+          data: {name: 'participant 2'},
+        },
+      ]);
+
+      // Send mixed updates
+      const mixedMessage = {
+        dataSets: [createDataSet('main', 16, 1101)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'participant' as const, id: 1, version: 110}, // newer version - should pass
+              dataSetNames: ['main'],
+            },
+            data: {name: 'updated'},
+          },
+          {
+            htMeta: {
+              elementId: {type: 'participant' as const, id: 1, version: 90}, // older version - should be filtered
+              dataSetNames: ['main'],
+            },
+            data: {name: 'old'},
+          },
+          {
+            htMeta: {
+              elementId: {type: 'participant' as const, id: 3, version: 10}, // new object - should pass
+              dataSetNames: ['main'],
+            },
+            data: {name: 'new'},
+          },
+          {
+            htMeta: {
+              elementId: {type: 'participant' as const, id: 2, version: 50}, // removal but exists in atd-unmuted - should be filtered
+              dataSetNames: ['main'],
+            },
+            data: null,
+          },
+        ],
+      };
+
+      await parser.handleMessage(mixedMessage, 'mixed updates');
+
+      // Callback should be called with only the valid updates (participant 1 v110 and participant 3 v10)
+      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+        updatedObjects: [
+          {
+            htMeta: {
+              elementId: {type: 'participant', id: 1, version: 110},
+              dataSetNames: ['main'],
+            },
+            data: {name: 'updated'},
+          },
+          {
+            htMeta: {
+              elementId: {type: 'participant', id: 3, version: 10},
+              dataSetNames: ['main'],
+            },
+            data: {name: 'new'},
+          },
+        ],
+      });
+    });
+
+    it('does not call callback when all updates are filtered out', async () => {
+      const parser = await setupParserWithObjects([
+        {
+          htMeta: {
+            elementId: {type: 'locus' as const, id: 5, version: 100},
+            dataSetNames: ['main'],
+          },
+          data: {existingField: 'existing'},
+        },
+      ]);
+
+      // Try to update with older versions (all should be filtered)
+      const updateMessage = {
+        dataSets: [createDataSet('main', 16, 1101)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'locus' as const, id: 5, version: 80},
+              dataSetNames: ['main'],
+            },
+            data: {someField: 'value'},
+          },
+          {
+            htMeta: {
+              elementId: {type: 'locus' as const, id: 5, version: 90},
+              dataSetNames: ['main'],
+            },
+            data: {someField: 'another value'},
+          },
+        ],
+      };
+
+      await parser.handleMessage(updateMessage, 'all filtered updates');
+
+      // Callback should not be called at all
+      assert.notCalled(callback);
+    });
+
+    it('checks all visible datasets when filtering', async () => {
+      const parser = createHashTreeParser();
+
+      // Setup: Add same object to multiple datasets with different versions
+      await parser.handleMessage(
+        {
+          dataSets: [createDataSet('main', 16, 1100)],
+          visibleDataSetsUrl,
+          locusUrl,
+          locusStateElements: [
+            {
+              htMeta: {
+                elementId: {type: 'participant' as const, id: 10, version: 100},
+                dataSetNames: ['main'],
+              },
+              data: {name: 'v100'},
+            },
+          ],
+        },
+        'setup main'
+      );
+
+      await parser.handleMessage(
+        {
+          dataSets: [createDataSet('self', 1, 2100)],
+          visibleDataSetsUrl,
+          locusUrl,
+          locusStateElements: [
+            {
+              htMeta: {
+                elementId: {type: 'participant' as const, id: 10, version: 120}, // highest
+                dataSetNames: ['self'],
+              },
+              data: {name: 'v120'},
+            },
+          ],
+        },
+        'setup self'
+      );
+
+      await parser.handleMessage(
+        {
+          dataSets: [createDataSet('atd-unmuted', 16, 3100)],
+          visibleDataSetsUrl,
+          locusUrl,
+          locusStateElements: [
+            {
+              htMeta: {
+                elementId: {type: 'participant' as const, id: 10, version: 110},
+                dataSetNames: ['atd-unmuted'],
+              },
+              data: {name: 'v110'},
+            },
+          ],
+        },
+        'setup atd-unmuted'
+      );
+      callback.resetHistory();
+
+      // Try to update with version 115 (newer than main and atd-unmuted, but older than self)
+      const updateMessage = {
+        dataSets: [createDataSet('main', 16, 1101)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'participant' as const, id: 10, version: 115},
+              dataSetNames: ['main'],
+            },
+            data: {name: 'update'},
+          },
+        ],
+      };
+
+      await parser.handleMessage(updateMessage, 'update with v115');
+
+      // Should be filtered out because self dataset has version 120
+      assert.notCalled(callback);
+    });
+
+    it('does not call callback for empty locusStateElements', async () => {
+      const parser = await setupParserWithObjects([]);
+
+      const emptyMessage = {
+        dataSets: [createDataSet('main', 16, 1100)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [],
+      };
+
+      await parser.handleMessage(emptyMessage, 'empty elements');
+
+      assert.notCalled(callback);
+    });
+
+    it('always calls callback for MEETING_ENDED regardless of filtering', async () => {
+      const parser = await setupParserWithObjects([
+        {
+          htMeta: {
+            elementId: {type: 'locus' as const, id: 0, version: 100},
+            dataSetNames: ['main'],
+          },
+          data: {info: 'data'},
+        },
+      ]);
+
+      // Send roster drop message (SELF object with no data) to trigger MEETING_ENDED
+      const rosterDropMessage = {
+        dataSets: [createDataSet('self', 1, 2101)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'self' as const, id: 4, version: 102},
+              dataSetNames: ['self'],
+            },
+            data: undefined, // roster drop triggers MEETING_ENDED
+          },
+        ],
+      };
+
+      await parser.handleMessage(rosterDropMessage, 'roster drop message');
+
+      // Callback should be called with MEETING_ENDED
+      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {
+        updatedObjects: undefined,
       });
     });
   });


### PR DESCRIPTION
# COMPLETES #[SPARK-769895](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-769895)

## This pull request addresses
In some cases (for example when an attendee is elaveted to a panelist), an object (participant in this example) is removed from a dataset, but it is still existing in another dataset. In such case we don't want HashTreeParser to tell LocusInfo that the participant was removed, because it still exists in some dataset.

Detailed flow for attendee X becoming panelist:
1. we have participant X in atd-active data set
2. we receive a message from Locus that participant X is now also in main dataset
3. we receive a message from Locus that participant X is removed from atd-active

in current code, point 3 triggers a notification to LocusInfo that participant X is removed - this is wrong.

## by making the following changes
Filter out the notifications we are about to send from HashTreeParser:
- when a notification is about a removal of an object, check if that object still exists in another dataset
- for all other notifications also check the existence of that object in other datasets as we don't really want to send updates if there is another data set that has already a newer version of that object - it means that we must have already sent an update about it earlier
- 
### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual e2e tests with web app and Locus in integration site co.dmz

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
