### PR TITLE
fix(plugin-meetings): only partially match the ws url for the metric

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -51,6 +51,7 @@ const MeetingUtil = {
   /**
    * Sanitizes a WebSocket URL by extracting only protocol, host, and pathname
    * Returns concatenated protocol + host + pathname for safe logging
+   * Note: This is used for logging only; URL matching uses partial matching via _urlsPartiallyMatch
    * @param {string} urlString - The URL to sanitize
    * @returns {string} Sanitized URL or empty string if parsing fails
    */
@@ -85,29 +86,40 @@ const MeetingUtil = {
   },
 
   /**
-   * Compares two URLs by protocol, host, and pathname (ignoring query params and hash)
-   * Uses sanitizeWebSocketUrl to ensure comparison matches what gets reported
+   * Checks if two URLs partially match using an endsWith approach
+   * Combines host and pathname, then checks if one ends with the other
+   * This handles cases where one URL goes through a proxy (e.g., /webproxy/) while the other is direct
    * @param {string} url1 - First URL to compare
    * @param {string} url2 - Second URL to compare
-   * @returns {boolean} True if URLs match, false otherwise
+   * @returns {boolean} True if one URL path ends with the other (partial match), false otherwise
    */
-  _urlsMatch: (url1: string, url2: string): boolean => {
+  _urlsPartiallyMatch: (url1: string, url2: string): boolean => {
     if (!url1 || !url2) {
       return false;
     }
 
     try {
-      const sanitized1 = MeetingUtil.sanitizeWebSocketUrl(url1);
-      const sanitized2 = MeetingUtil.sanitizeWebSocketUrl(url2);
+      const parsedUrl1 = url.parse(url1);
+      const parsedUrl2 = url.parse(url2);
 
-      // If either failed to parse (empty string), they don't match
-      if (!sanitized1 || !sanitized2) {
+      const host1 = parsedUrl1.host || '';
+      const host2 = parsedUrl2.host || '';
+      const pathname1 = parsedUrl1.pathname || '';
+      const pathname2 = parsedUrl2.pathname || '';
+
+      // If either failed to parse, they don't match
+      if (!host1 || !host2 || !pathname1 || !pathname2) {
         return false;
       }
 
-      return sanitized1 === sanitized2;
+      // Combine host and pathname for comparison
+      const combined1 = host1 + pathname1;
+      const combined2 = host2 + pathname2;
+
+      // Check if one combined path ends with the other (handles proxy URLs)
+      return combined1.endsWith(combined2) || combined2.endsWith(combined1);
     } catch (e) {
-      LoggerProxy.logger.warn('Meeting:util#_urlsMatch --> error comparing URLs', e);
+      LoggerProxy.logger.warn('Meeting:util#_urlsPartiallyMatch --> error comparing URLs', e);
 
       return false;
     }
@@ -115,6 +127,7 @@ const MeetingUtil = {
 
   /**
    * Gets socket URL information for metrics, including whether the socket URLs match
+   * Uses partial matching to handle proxy URLs (e.g., URLs with /webproxy/ prefix)
    * @param {Object} webex - The webex instance
    * @returns {Object} Object with hasMismatchedSocket, mercurySocketUrl, and deviceSocketUrl properties
    */
@@ -132,7 +145,7 @@ const MeetingUtil = {
       // If either URL is missing, we can't determine if there's a mismatch, so return false
       let hasMismatchedSocket = false;
       if (sanitizedMercuryUrl && sanitizedDeviceUrl) {
-        hasMismatchedSocket = !MeetingUtil._urlsMatch(mercuryUrl, deviceUrl);
+        hasMismatchedSocket = !MeetingUtil._urlsPartiallyMatch(mercuryUrl, deviceUrl);
       }
 
       return {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -1569,68 +1569,69 @@ describe('plugin-meetings', () => {
       });
     });
 
-    describe('#_urlsMatch', () => {
-      it('returns true when URLs match (ignoring query and hash)', () => {
+    describe('#_urlsPartiallyMatch', () => {
+      it('returns true when URLs match exactly (ignoring query and hash)', () => {
         const url1 = 'wss://example.com:443/path?token=abc#fragment1';
         const url2 = 'wss://example.com:443/path?token=xyz#fragment2';
 
-        assert.isTrue(MeetingUtil._urlsMatch(url1, url2));
+        assert.isTrue(MeetingUtil._urlsPartiallyMatch(url1, url2));
       });
 
-      it('returns false when protocols differ', () => {
-        const url1 = 'wss://example.com/path';
-        const url2 = 'ws://example.com/path';
+      it('returns true when one URL is proxied and ends with the other', () => {
+        const url1 = 'wss://other.example.com/somepath/mercury.example.com/v1/path';
+        const url2 = 'wss://mercury.example.com/v1/path';
 
-        assert.isFalse(MeetingUtil._urlsMatch(url1, url2));
+        assert.isTrue(MeetingUtil._urlsPartiallyMatch(url1, url2));
       });
 
-      it('returns false when hosts differ', () => {
+      it('returns true when the second URL is proxied', () => {
+        const url1 = 'wss://mercury.example.com/v1/path';
+        const url2 = 'wss://other.example.com/somepath/mercury.example.com/v1/path';
+
+        assert.isTrue(MeetingUtil._urlsPartiallyMatch(url1, url2));
+      });
+
+      it('returns false when hosts differ and no partial match', () => {
         const url1 = 'wss://example1.com/path';
         const url2 = 'wss://example2.com/path';
 
-        assert.isFalse(MeetingUtil._urlsMatch(url1, url2));
+        assert.isFalse(MeetingUtil._urlsPartiallyMatch(url1, url2));
       });
 
-      it('returns false when ports differ', () => {
-        const url1 = 'wss://example.com:443/path';
-        const url2 = 'wss://example.com:8443/path';
-
-        assert.isFalse(MeetingUtil._urlsMatch(url1, url2));
-      });
-
-      it('returns false when pathnames differ', () => {
+      it('returns false when pathnames differ and no partial match', () => {
         const url1 = 'wss://example.com/path1';
         const url2 = 'wss://example.com/path2';
 
-        assert.isFalse(MeetingUtil._urlsMatch(url1, url2));
+        assert.isFalse(MeetingUtil._urlsPartiallyMatch(url1, url2));
       });
 
       it('returns false when either URL is null or undefined', () => {
         const url = 'wss://example.com/path';
 
-        assert.isFalse(MeetingUtil._urlsMatch(null, url));
-        assert.isFalse(MeetingUtil._urlsMatch(url, null));
-        assert.isFalse(MeetingUtil._urlsMatch(undefined, url));
-        assert.isFalse(MeetingUtil._urlsMatch(url, undefined));
+        assert.isFalse(MeetingUtil._urlsPartiallyMatch(null, url));
+        assert.isFalse(MeetingUtil._urlsPartiallyMatch(url, null));
+        assert.isFalse(MeetingUtil._urlsPartiallyMatch(undefined, url));
+        assert.isFalse(MeetingUtil._urlsPartiallyMatch(url, undefined));
       });
 
       it('returns false when both URLs are null', () => {
-        assert.isFalse(MeetingUtil._urlsMatch(null, null));
+        assert.isFalse(MeetingUtil._urlsPartiallyMatch(null, null));
       });
 
       it('returns false when URL parsing fails', () => {
         const url1 = 'invalid url';
         const url2 = 'wss://example.com/path';
 
-        assert.isFalse(MeetingUtil._urlsMatch(url1, url2));
+        assert.isFalse(MeetingUtil._urlsPartiallyMatch(url1, url2));
       });
 
-      it('compares URLs case-sensitively', () => {
-        const url1 = 'wss://Example.com/path';
-        const url2 = 'wss://example.com/path';
+      it('handles real proxy scenario from production', () => {
+        const url1 =
+          'wss://other.example.com/somepath/mercury.example.com/v1/apps/wx2/registrations/00000000-0000-0000-0000-000000000000/messages';
+        const url2 =
+          'wss://mercury.example.com/v1/apps/wx2/registrations/00000000-0000-0000-0000-000000000000/messages';
 
-        // URL parsing should handle host case-sensitivity
-        assert.isTrue(MeetingUtil._urlsMatch(url1, url2));
+        assert.isTrue(MeetingUtil._urlsPartiallyMatch(url1, url2));
       });
     });
 
@@ -1675,6 +1676,34 @@ describe('plugin-meetings', () => {
         assert.isFalse(result.hasMismatchedSocket);
         assert.equal(result.mercurySocketUrl, 'wss://example.com:443/path');
         assert.equal(result.deviceSocketUrl, 'wss://example.com:443/path');
+      });
+
+      it('returns hasMismatchedSocket as false when one URL is proxied (partial match)', () => {
+        const testWebex = {
+          internal: {
+            mercury: {
+              socket: {
+                url: 'wss://other.example.com/somepath/mercury.example.com/v1/apps/wx2/registrations/00000000-0000-0000-0000-000000000000/messages',
+              },
+            },
+            device: {
+              webSocketUrl:
+                'wss://mercury.example.com/v1/apps/wx2/registrations/00000000-0000-0000-0000-000000000000/messages',
+            },
+          },
+        };
+
+        const result = MeetingUtil.getSocketUrlInfo(testWebex);
+
+        assert.isFalse(result.hasMismatchedSocket);
+        assert.equal(
+          result.mercurySocketUrl,
+          'wss://other.example.com/somepath/mercury.example.com/v1/apps/wx2/registrations/00000000-0000-0000-0000-000000000000/messages'
+        );
+        assert.equal(
+          result.deviceSocketUrl,
+          'wss://mercury.example.com/v1/apps/wx2/registrations/00000000-0000-0000-0000-000000000000/messages'
+        );
       });
 
       it('returns false for hasMismatchedSocket when mercury socket URL is missing', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -1624,15 +1624,6 @@ describe('plugin-meetings', () => {
 
         assert.isFalse(MeetingUtil._urlsPartiallyMatch(url1, url2));
       });
-
-      it('handles real proxy scenario from production', () => {
-        const url1 =
-          'wss://other.example.com/somepath/mercury.example.com/v1/apps/wx2/registrations/00000000-0000-0000-0000-000000000000/messages';
-        const url2 =
-          'wss://mercury.example.com/v1/apps/wx2/registrations/00000000-0000-0000-0000-000000000000/messages';
-
-        assert.isTrue(MeetingUtil._urlsPartiallyMatch(url1, url2));
-      });
     });
 
     describe('#getSocketUrlInfo', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

the mismatched websocket metric was incorrect in cases where requests are routed via another host. What matters for this debug is whether the registration is correct so I've simplified the logic to a partial match

## by making the following changes

< DESCRIBE YOUR CHANGES >

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
