### PR TITLE
feat(plugin-meetings): add support for Metadata object in Locus Hash trees

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -5,7 +5,7 @@ import {Enum, HTTP_VERBS} from '../constants';
 import {DataSetNames, EMPTY_HASH} from './constants';
 import {ObjectType, HtMeta, HashTreeObject} from './types';
 import {LocusDTO} from '../locus-info/types';
-import {deleteNestedObjectsWithHtMeta, isSelf} from './utils';
+import {deleteNestedObjectsWithHtMeta, isMetadata, isSelf} from './utils';
 
 export interface DataSet {
   url: string;
@@ -31,6 +31,17 @@ export interface HashTreeMessage {
   locusUrl: string;
 }
 
+export interface VisibleDataSetInfo {
+  name: string;
+  url: string;
+  dataChannelUrl?: string;
+}
+
+export interface Metadata {
+  htMeta: HtMeta;
+  visibleDataSets: VisibleDataSetInfo[];
+}
+
 interface InternalDataSet extends DataSet {
   hashTree?: HashTree; // set only for visible data sets
   timer?: ReturnType<typeof setTimeout>;
@@ -49,11 +60,23 @@ export type LocusInfoUpdateCallback = (
   data?: {updatedObjects: HashTreeObject[]}
 ) => void;
 
+interface LeafInfo {
+  type: ObjectType;
+  id: number;
+  version: number;
+  data?: any;
+}
+
 /**
  * This error is thrown if we receive information that the meeting has ended while we're processing some hash messages.
  * It's handled internally by HashTreeParser and results in MEETING_ENDED being sent up.
  */
 class MeetingEndedError extends Error {}
+
+/* Currently Locus always sends Metadata objects only in the "self" dataset.
+ * If this ever changes, update all the code that relies on this constant.
+ */
+const MetadataDataSetName = DataSetNames.SELF;
 
 /**
  * Parses hash tree eventing locus data
@@ -63,7 +86,7 @@ class HashTreeParser {
   visibleDataSetsUrl: string; // url from which we can get info about all data sets
   webexRequest: WebexRequestMethod;
   locusInfoUpdateCallback: LocusInfoUpdateCallback;
-  visibleDataSets: string[];
+  visibleDataSets: VisibleDataSetInfo[];
   debugId: string;
 
   /**
@@ -76,6 +99,7 @@ class HashTreeParser {
       dataSets: Array<DataSet>;
       locus: any;
     };
+    metadata: Metadata | null;
     webexRequest: WebexRequestMethod;
     locusInfoUpdateCallback: LocusInfoUpdateCallback;
     debugId: string;
@@ -85,15 +109,21 @@ class HashTreeParser {
     this.debugId = options.debugId;
     this.webexRequest = options.webexRequest;
     this.locusInfoUpdateCallback = options.locusInfoUpdateCallback;
-    this.visibleDataSets = locus?.self?.visibleDataSets || [];
+    this.visibleDataSetsUrl = locus?.links?.resources?.visibleDataSets?.url;
+    this.visibleDataSets = cloneDeep(options.metadata?.visibleDataSets || []);
 
-    if (this.visibleDataSets.length === 0) {
+    if (options.metadata?.visibleDataSets?.length === 0) {
       LoggerProxy.logger.warn(
-        `HashTreeParser#constructor --> ${this.debugId} No visibleDataSets found in locus.self`
+        `HashTreeParser#constructor --> ${this.debugId} No visibleDataSets found in Metadata`
       );
     }
     // object mapping dataset names to arrays of leaf data
     const leafData = this.analyzeLocusHtMeta(locus);
+
+    if (options.metadata) {
+      // add also the metadata that's outside of locus object itself
+      this.analyzeMetadata(leafData, options.metadata);
+    }
 
     LoggerProxy.logger.info(
       `HashTreeParser#constructor --> creating HashTreeParser for datasets: ${JSON.stringify(
@@ -106,7 +136,7 @@ class HashTreeParser {
 
       this.dataSets[name] = {
         ...dataSet,
-        hashTree: this.visibleDataSets.includes(name)
+        hashTree: this.isVisibleDataSet(name)
           ? new HashTree(leafData[name] || [], leafCount)
           : undefined,
       };
@@ -114,38 +144,49 @@ class HashTreeParser {
   }
 
   /**
+   * Checks if the given data set name is in the list of visible data sets
+   * @param {string} dataSetName data set name to check
+   * @returns {Boolean} True if the data set is visible, false otherwise
+   */
+  private isVisibleDataSet(dataSetName: string): boolean {
+    return this.visibleDataSets.some((vds) => vds.name === dataSetName);
+  }
+
+  /**
    * Initializes a new visible data set by creating a hash tree for it, adding it to all the internal structures,
    * and sending an initial sync request to Locus with empty leaf data - that will trigger Locus to gives us all the data
    * from that dataset (in the response or via messages).
    *
-   * @param {DataSet} dataSet The new data set to be added
+   * @param {VisibleDataSetInfo} visibleDataSetInfo Information about the new visible data set
+   * @param {DataSet} dataSetInfo The new data set to be added
    * @returns {Promise}
    */
   private initializeNewVisibleDataSet(
-    dataSet: DataSet
+    visibleDataSetInfo: VisibleDataSetInfo,
+    dataSetInfo: DataSet
   ): Promise<{updateType: LocusInfoUpdateType; updatedObjects?: HashTreeObject[]}> {
-    if (this.visibleDataSets.includes(dataSet.name)) {
+    if (this.isVisibleDataSet(dataSetInfo.name)) {
       LoggerProxy.logger.info(
-        `HashTreeParser#initializeNewVisibleDataSet --> ${this.debugId} Data set "${dataSet.name}" already exists, skipping init`
+        `HashTreeParser#initializeNewVisibleDataSet --> ${this.debugId} Data set "${dataSetInfo.name}" already exists, skipping init`
       );
 
       return Promise.resolve({updateType: LocusInfoUpdateType.OBJECTS_UPDATED, updatedObjects: []});
     }
 
     LoggerProxy.logger.info(
-      `HashTreeParser#initializeNewVisibleDataSet --> ${this.debugId} Adding visible data set "${dataSet.name}"`
+      `HashTreeParser#initializeNewVisibleDataSet --> ${this.debugId} Adding visible data set "${dataSetInfo.name}"`
     );
 
-    this.visibleDataSets.push(dataSet.name);
+    this.visibleDataSets.push(visibleDataSetInfo);
 
-    const hashTree = new HashTree([], dataSet.leafCount);
+    const hashTree = new HashTree([], dataSetInfo.leafCount);
 
-    this.dataSets[dataSet.name] = {
-      ...dataSet,
+    this.dataSets[dataSetInfo.name] = {
+      ...dataSetInfo,
       hashTree,
     };
 
-    return this.sendInitializationSyncRequestToLocus(dataSet.name, 'new visible data set');
+    return this.sendInitializationSyncRequestToLocus(dataSetInfo.name, 'new visible data set');
   }
 
   /**
@@ -190,15 +231,22 @@ class HashTreeParser {
   }
 
   /**
-   * Queries Locus for information about all the data sets
+   * Queries Locus for all up-to-date information about all visible data sets
    *
-   * @param {string} url - url from which we can get info about all data sets
    * @returns {Promise}
    */
-  private getAllDataSetsMetadata(url) {
+  private getAllVisibleDataSetsFromLocus() {
+    if (!this.visibleDataSetsUrl) {
+      LoggerProxy.logger.warn(
+        `HashTreeParser#getAllVisibleDataSetsFromLocus --> ${this.debugId} No visibleDataSetsUrl, cannot get data sets information`
+      );
+
+      return Promise.resolve([]);
+    }
+
     return this.webexRequest({
       method: HTTP_VERBS.GET,
-      uri: url,
+      uri: this.visibleDataSetsUrl,
     }).then((response) => {
       return response.body.dataSets as Array<DataSet>;
     });
@@ -211,12 +259,14 @@ class HashTreeParser {
    * @returns {Promise}
    */
   async initializeFromMessage(message: HashTreeMessage) {
-    LoggerProxy.logger.info(
-      `HashTreeParser#initializeFromMessage --> ${this.debugId} visibleDataSetsUrl=${message.visibleDataSetsUrl}`
-    );
-    const dataSets = await this.getAllDataSetsMetadata(message.visibleDataSetsUrl);
+    this.visibleDataSetsUrl = message.visibleDataSetsUrl;
 
-    await this.initializeDataSets(dataSets, 'initialization from message');
+    LoggerProxy.logger.info(
+      `HashTreeParser#initializeFromMessage --> ${this.debugId} visibleDataSetsUrl=${this.visibleDataSetsUrl}`
+    );
+    const visibleDataSets = await this.getAllVisibleDataSetsFromLocus();
+
+    await this.initializeDataSets(visibleDataSets, 'initialization from message');
   }
 
   /**
@@ -236,28 +286,29 @@ class HashTreeParser {
 
       return;
     }
+    this.visibleDataSetsUrl = locus.links.resources.visibleDataSets.url;
 
     LoggerProxy.logger.info(
-      `HashTreeParser#initializeFromGetLociResponse --> ${this.debugId} visibleDataSets url: ${locus.links.resources.visibleDataSets.url}`
+      `HashTreeParser#initializeFromGetLociResponse --> ${this.debugId} visibleDataSets url: ${this.visibleDataSetsUrl}`
     );
 
-    const dataSets = await this.getAllDataSetsMetadata(locus.links.resources.visibleDataSets.url);
+    const visibleDataSets = await this.getAllVisibleDataSetsFromLocus();
 
-    await this.initializeDataSets(dataSets, 'initialization from GET /loci response');
+    await this.initializeDataSets(visibleDataSets, 'initialization from GET /loci response');
   }
 
   /**
    * Initializes data sets by doing an initialization sync on each visible data set that doesn't have a hash tree yet.
    *
-   * @param {DataSet[]} dataSets Array of DataSet objects to initialize
+   * @param {DataSet[]} visibleDataSets Array of visible DataSet objects to initialize
    * @param {string} debugText Text to include in logs for debugging purposes
    * @returns {Promise}
    */
-  private async initializeDataSets(dataSets: Array<DataSet>, debugText: string) {
+  private async initializeDataSets(visibleDataSets: Array<DataSet>, debugText: string) {
     const updatedObjects: HashTreeObject[] = [];
 
-    for (const dataSet of dataSets) {
-      const {name, leafCount} = dataSet;
+    for (const dataSet of visibleDataSets) {
+      const {name, leafCount, url} = dataSet;
 
       if (!this.dataSets[name]) {
         LoggerProxy.logger.info(
@@ -273,7 +324,14 @@ class HashTreeParser {
         );
       }
 
-      if (this.visibleDataSets.includes(name) && !this.dataSets[name].hashTree) {
+      if (!this.isVisibleDataSet(name)) {
+        this.visibleDataSets.push({
+          name,
+          url,
+        });
+      }
+
+      if (!this.dataSets[name].hashTree) {
         LoggerProxy.logger.info(
           `HashTreeParser#initializeDataSets --> ${this.debugId} creating hash tree for visible dataset "${name}" (${debugText})`
         );
@@ -316,10 +374,7 @@ class HashTreeParser {
   private analyzeLocusHtMeta(locus: any, options?: {copyData?: boolean}) {
     const {copyData = false} = options || {};
     // object mapping dataset names to arrays of leaf data
-    const leafInfo: Record<
-      string,
-      Array<{type: ObjectType; id: number; version: number; data?: any}>
-    > = {};
+    const leafInfo: Record<string, Array<LeafInfo>> = {};
 
     const findAndStoreMetaData = (currentLocusPart: any) => {
       if (typeof currentLocusPart !== 'object' || currentLocusPart === null) {
@@ -329,7 +384,7 @@ class HashTreeParser {
       if (currentLocusPart.htMeta && currentLocusPart.htMeta.dataSetNames) {
         const {type, id, version} = currentLocusPart.htMeta.elementId;
         const {dataSetNames} = currentLocusPart.htMeta;
-        const newLeafInfo: {type: ObjectType; id: number; version: number; data?: any} = {
+        const newLeafInfo: LeafInfo = {
           type,
           id,
           version,
@@ -366,6 +421,43 @@ class HashTreeParser {
     findAndStoreMetaData(locus);
 
     return leafInfo;
+  }
+
+  /**
+   * Analyzes the Metadata object that is sent outside of Locus object, and appends its data to passed in leafInfo
+   * structure.
+   *
+   * @param {Record<string, LeafInfo[]>} leafInfo the structure to which the Metadata info will be appended
+   * @param {Metadata} metadata Metadata object
+   * @returns {void}
+   */
+  private analyzeMetadata(leafInfo: Record<string, LeafInfo[]>, metadata: Metadata) {
+    const {htMeta} = metadata;
+
+    if (
+      htMeta?.dataSetNames?.length === 1 &&
+      htMeta.dataSetNames[0].toLowerCase() === MetadataDataSetName
+    ) {
+      const {type, id, version} = metadata.htMeta.elementId;
+
+      const dataSetName = htMeta.dataSetNames[0];
+
+      if (!leafInfo[dataSetName]) {
+        leafInfo[dataSetName] = [];
+      }
+
+      leafInfo[dataSetName].push({
+        type,
+        id,
+        version,
+      });
+    } else {
+      throw new Error(
+        `${this.debugId} Metadata htMeta has unexpected dataSetNames: ${
+          htMeta && htMeta.dataSetNames.join(',')
+        }`
+      );
+    }
   }
 
   /**
@@ -421,14 +513,66 @@ class HashTreeParser {
   }
 
   /**
+   * Handles updates to Metadata object that we receive from Locus via other means than messages. Right now
+   * that means only in the API response alongside locus object.
+   *
+   * @param {Metadata} metadata received in Locus update other than a message (for example in an API response)
+   * @param {HashTreeObject[]} updatedObjects a list of updated hash tree objects to which any updates resulting from new Metadata will be added
+   * @returns {void}
+   */
+  handleMetadataUpdate(metadata: Metadata, updatedObjects: HashTreeObject[]): void {
+    let dataSetsRequiringInitialization: VisibleDataSetInfo[] = [];
+
+    // current assumption based on Locus docs is that Metadata object lives always in "self" data set
+    const hashTree = this.dataSets[MetadataDataSetName]?.hashTree;
+
+    if (!hashTree) {
+      LoggerProxy.logger.warn(
+        `HashTreeParser#handleLocusUpdate --> ${this.debugId} received Metadata object but no hash tree for "${MetadataDataSetName}" data set exists`
+      );
+    } else {
+      const metadataUpdated = hashTree.putItem(metadata.htMeta.elementId);
+
+      if (metadataUpdated) {
+        // metadata in Locus API response is in a slightly different format than the objects in messages, so need to adapt it
+        const metadataObject: HashTreeObject = {
+          htMeta: metadata.htMeta,
+          data: metadata,
+        };
+
+        updatedObjects.push(metadataObject);
+
+        const {changeDetected, removedDataSets, addedDataSets} = this.checkForVisibleDataSetChanges(
+          [metadataObject]
+        );
+
+        if (changeDetected) {
+          dataSetsRequiringInitialization = this.processVisibleDataSetChanges(
+            removedDataSets,
+            addedDataSets,
+            updatedObjects
+          );
+        }
+
+        if (dataSetsRequiringInitialization.length > 0) {
+          // there are some data sets that we need to initialize asynchronously
+          queueMicrotask(() => {
+            this.initializeNewVisibleDataSets(dataSetsRequiringInitialization);
+          });
+        }
+      }
+    }
+  }
+
+  /**
    * This method should be called when we receive a partial locus DTO that contains dataSets and htMeta information
    * It updates the hash trees with the new leaf data based on the received Locus
    *
    * @param {Object} update - The locus update containing data sets and locus information
    * @returns {void}
    */
-  handleLocusUpdate(update: {dataSets?: Array<DataSet>; locus: any}): void {
-    const {dataSets, locus} = update;
+  handleLocusUpdate(update: {dataSets?: Array<DataSet>; locus: any; metadata?: Metadata}): void {
+    const {dataSets, locus, metadata} = update;
 
     if (!dataSets) {
       LoggerProxy.logger.warn(
@@ -442,6 +586,11 @@ class HashTreeParser {
 
     // first, analyze the locus object to extract the hash tree objects' htMeta and data from it
     const leafInfo = this.analyzeLocusHtMeta(locus, {copyData: true});
+
+    // if we got metadata, process it (currently that means only potential visible data set list changes)
+    if (metadata) {
+      this.handleMetadataUpdate(metadata, updatedObjects);
+    }
 
     // then process the data in hash trees, if it is a new version, then add it to updatedObjects
     Object.keys(leafInfo).forEach((dataSetName) => {
@@ -493,9 +642,6 @@ class HashTreeParser {
         updatedObjects,
       });
     }
-
-    // todo: once Locus design on how visible data sets will be communicated in subsequent API responses is confirmed,
-    // we'll need to check here if visible data sets have changed and update this.visibleDataSets, remove/create hash trees etc
   }
 
   /**
@@ -511,7 +657,7 @@ class HashTreeParser {
       };
 
       LoggerProxy.logger.info(
-        `HashTreeParser#handleMessage --> ${this.debugId} created entry for "${receivedDataSet.name}" dataset: version=${receivedDataSet.version}, root=${receivedDataSet.root}`
+        `HashTreeParser#updateDataSetInfo --> ${this.debugId} created entry for "${receivedDataSet.name}" dataset: version=${receivedDataSet.version}, root=${receivedDataSet.root}`
       );
 
       return;
@@ -526,7 +672,7 @@ class HashTreeParser {
         exponent: receivedDataSet.backoff.exponent,
       };
       LoggerProxy.logger.info(
-        `HashTreeParser#handleMessage --> ${this.debugId} updated "${receivedDataSet.name}" to version=${receivedDataSet.version}, root=${receivedDataSet.root}`
+        `HashTreeParser#updateDataSetInfo --> ${this.debugId} updated "${receivedDataSet.name}" dataset to version=${receivedDataSet.version}, root=${receivedDataSet.root}`
       );
     }
   }
@@ -537,25 +683,28 @@ class HashTreeParser {
    * @returns {Object} An object containing the removed and added visible data sets.
    */
   private checkForVisibleDataSetChanges(updatedObjects: HashTreeObject[]) {
-    let removedDataSets: string[] = [];
-    let addedDataSets: string[] = [];
+    let removedDataSets: VisibleDataSetInfo[] = [];
+    let addedDataSets: VisibleDataSetInfo[] = [];
 
-    // visibleDataSets can only be changed by self object updates
+    // visibleDataSets can only be changed by Metadata object updates
     updatedObjects.forEach((object) => {
-      // todo: in the future visibleDataSets will be in "Metadata" object, not in "self"
-      if (isSelf(object) && object.data?.visibleDataSets) {
+      if (isMetadata(object) && object.data?.visibleDataSets) {
         const newVisibleDataSets = object.data.visibleDataSets;
 
-        removedDataSets = this.visibleDataSets.filter((ds) => !newVisibleDataSets.includes(ds));
-        addedDataSets = newVisibleDataSets.filter((ds) => !this.visibleDataSets.includes(ds));
+        removedDataSets = this.visibleDataSets.filter(
+          (ds) => !newVisibleDataSets.some((nvs) => nvs.name === ds.name)
+        );
+        addedDataSets = newVisibleDataSets.filter((nvs) =>
+          this.visibleDataSets.every((ds) => ds.name !== nvs.name)
+        );
 
         if (removedDataSets.length > 0 || addedDataSets.length > 0) {
           LoggerProxy.logger.info(
             `HashTreeParser#checkForVisibleDataSetChanges --> ${
               this.debugId
-            } visible data sets change: removed: ${removedDataSets.join(
-              ', '
-            )}, added: ${addedDataSets.join(', ')}`
+            } visible data sets change: removed: ${removedDataSets
+              .map((ds) => ds.name)
+              .join(', ')}, added: ${addedDataSets.map((ds) => ds.name).join(', ')}`
           );
         }
       }
@@ -593,49 +742,51 @@ class HashTreeParser {
    * visible data sets and they require async initialization, the names of these data sets
    * are returned in an array.
    *
-   * @param {string[]} removedDataSets - The list of removed data sets.
-   * @param {string[]} addedDataSets - The list of added data sets.
+   * @param {VisibleDataSetInfo[]} removedDataSets - The list of removed data sets.
+   * @param {VisibleDataSetInfo[]} addedDataSets - The list of added data sets.
    * @param {HashTreeObject[]} updatedObjects - The list of updated hash tree objects to which changes will be added.
-   * @returns {string[]} names of data sets that couldn't be initialized synchronously
+   * @returns {VisibleDataSetInfo[]} list of data sets that couldn't be initialized synchronously
    */
   private processVisibleDataSetChanges(
-    removedDataSets: string[],
-    addedDataSets: string[],
+    removedDataSets: VisibleDataSetInfo[],
+    addedDataSets: VisibleDataSetInfo[],
     updatedObjects: HashTreeObject[]
-  ): string[] {
-    const dataSetsRequiringInitialization = [];
+  ): VisibleDataSetInfo[] {
+    const dataSetsRequiringInitialization: VisibleDataSetInfo[] = [];
 
     // if a visible data set was removed, we need to tell our client that all objects from it are removed
     const removedObjects: HashTreeObject[] = [];
 
     removedDataSets.forEach((ds) => {
-      if (this.dataSets[ds]?.hashTree) {
-        for (let i = 0; i < this.dataSets[ds].hashTree.numLeaves; i += 1) {
+      if (this.dataSets[ds.name]?.hashTree) {
+        for (let i = 0; i < this.dataSets[ds.name].hashTree.numLeaves; i += 1) {
           removedObjects.push(
-            ...this.dataSets[ds].hashTree.getLeafData(i).map((elementId) => ({
+            ...this.dataSets[ds.name].hashTree.getLeafData(i).map((elementId) => ({
               htMeta: {
                 elementId,
-                dataSetNames: [ds],
+                dataSetNames: [ds.name],
               },
               data: null,
             }))
           );
         }
 
-        this.deleteHashTree(ds);
+        this.deleteHashTree(ds.name);
       }
     });
-    this.visibleDataSets = this.visibleDataSets.filter((vds) => !removedDataSets.includes(vds));
+    this.visibleDataSets = this.visibleDataSets.filter(
+      (vds) => !removedDataSets.some((rds) => rds.name === vds.name)
+    );
     updatedObjects.push(...removedObjects);
 
     // now setup the new visible data sets
     for (const ds of addedDataSets) {
-      const dataSetInfo = this.dataSets[ds];
+      const dataSetInfo = this.dataSets[ds.name];
 
       if (dataSetInfo) {
-        if (this.visibleDataSets.includes(dataSetInfo.name)) {
+        if (this.isVisibleDataSet(dataSetInfo.name)) {
           LoggerProxy.logger.info(
-            `HashTreeParser#processVisibleDataSetChanges --> ${this.debugId} Data set "${ds}" is already visible, skipping`
+            `HashTreeParser#processVisibleDataSetChanges --> ${this.debugId} Data set "${ds.name}" is already visible, skipping`
           );
 
           // eslint-disable-next-line no-continue
@@ -643,7 +794,7 @@ class HashTreeParser {
         }
 
         LoggerProxy.logger.info(
-          `HashTreeParser#processVisibleDataSetChanges --> ${this.debugId} Adding visible data set "${ds}"`
+          `HashTreeParser#processVisibleDataSetChanges --> ${this.debugId} Adding visible data set "${ds.name}"`
         );
 
         this.visibleDataSets.push(ds);
@@ -656,7 +807,7 @@ class HashTreeParser {
         };
       } else {
         LoggerProxy.logger.info(
-          `HashTreeParser#processVisibleDataSetChanges --> ${this.debugId} visible data set "${ds}" added but no info about it in our dataSets structures`
+          `HashTreeParser#processVisibleDataSetChanges --> ${this.debugId} visible data set "${ds.name}" added but no info about it in our dataSets structures`
         );
         // todo: add a metric here
         dataSetsRequiringInitialization.push(ds);
@@ -670,32 +821,28 @@ class HashTreeParser {
    * Adds entries to the passed in updateObjects array
    * for the changes that result from adding and removing visible data sets.
    *
-   * @param {HashTreeMessage} message - The hash tree message that triggered the visible data set changes.
-   * @param {string[]} addedDataSets - The list of added data sets.
+   * @param {VisibleDataSetInfo[]} addedDataSets - The list of added data sets.
    * @returns {Promise<void>}
    */
-  private async initializeNewVisibleDataSets(
-    message: HashTreeMessage,
-    addedDataSets: string[]
-  ): Promise<void> {
-    const allDataSets = await this.getAllDataSetsMetadata(message.visibleDataSetsUrl);
+  private async initializeNewVisibleDataSets(addedDataSets: VisibleDataSetInfo[]): Promise<void> {
+    const allDataSets = await this.getAllVisibleDataSetsFromLocus();
 
     for (const ds of addedDataSets) {
-      const dataSetInfo = allDataSets.find((d) => d.name === ds);
+      const dataSetInfo = allDataSets.find((d) => d.name === ds.name);
 
       LoggerProxy.logger.info(
-        `HashTreeParser#initializeNewVisibleDataSets --> ${this.debugId} initializing data set "${ds}"`
+        `HashTreeParser#initializeNewVisibleDataSets --> ${this.debugId} initializing data set "${ds.name}"`
       );
 
       if (!dataSetInfo) {
         LoggerProxy.logger.warn(
-          `HashTreeParser#handleHashTreeMessage --> ${this.debugId} missing info about data set "${ds}" in Locus response from visibleDataSetsUrl`
+          `HashTreeParser#handleHashTreeMessage --> ${this.debugId} missing info about data set "${ds.name}" in Locus response from visibleDataSetsUrl`
         );
       } else {
         // we're awaiting in a loop, because in practice there will be only one new data set at a time,
         // so no point in trying to parallelize this
         // eslint-disable-next-line no-await-in-loop
-        const updates = await this.initializeNewVisibleDataSet(dataSetInfo);
+        const updates = await this.initializeNewVisibleDataSet(ds, dataSetInfo);
 
         this.callLocusInfoUpdateCallback(updates);
       }
@@ -746,32 +893,31 @@ class HashTreeParser {
     // available in the message, they will require separate async initialization
     let dataSetsRequiringInitialization = [];
 
-    // first find out if there are any visible data set changes - they're signalled in SELF object updates
-    const selfUpdates = (message.locusStateElements || []).filter((object) =>
-      // todo: SPARK-744859 once Locus supports it, we will filter for "Metadata" type here instead of "self"
-      isSelf(object)
+    // first find out if there are any visible data set changes - they're signalled in Metadata object updates
+    const metadataUpdates = (message.locusStateElements || []).filter((object) =>
+      isMetadata(object)
     );
 
-    if (selfUpdates.length > 0) {
-      const updatedSelfObjects = [];
+    if (metadataUpdates.length > 0) {
+      const updatedMetadataObjects = [];
 
-      selfUpdates.forEach((object) => {
+      metadataUpdates.forEach((object) => {
         // todo: once Locus supports it, we will use the "view" field here instead of dataSetNames
         for (const dataSetName of object.htMeta.dataSetNames) {
           const hashTree = this.dataSets[dataSetName]?.hashTree;
 
           if (hashTree && object.data) {
             if (hashTree.putItem(object.htMeta.elementId)) {
-              updatedSelfObjects.push(object);
+              updatedMetadataObjects.push(object);
             }
           }
         }
       });
 
-      updatedObjects.push(...updatedSelfObjects);
+      updatedObjects.push(...updatedMetadataObjects);
 
       const {changeDetected, removedDataSets, addedDataSets} =
-        this.checkForVisibleDataSetChanges(updatedSelfObjects);
+        this.checkForVisibleDataSetChanges(updatedMetadataObjects);
 
       if (changeDetected) {
         dataSetsRequiringInitialization = this.processVisibleDataSetChanges(
@@ -838,7 +984,7 @@ class HashTreeParser {
     if (dataSetsRequiringInitialization.length > 0) {
       // there are some data sets that we need to initialize asynchronously
       queueMicrotask(() => {
-        this.initializeNewVisibleDataSets(message, dataSetsRequiringInitialization);
+        this.initializeNewVisibleDataSets(dataSetsRequiringInitialization);
       });
     }
 

--- a/packages/@webex/plugin-meetings/src/hashTree/types.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/types.ts
@@ -10,6 +10,7 @@ export const ObjectType = {
   fullState: 'fullstate',
   links: 'links',
   control: 'controlentry',
+  metadata: 'metadata',
 } as const;
 
 export type ObjectType = Enum<typeof ObjectType>;

--- a/packages/@webex/plugin-meetings/src/hashTree/utils.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/utils.ts
@@ -12,6 +12,15 @@ export function isSelf(object: HashTreeObject) {
 }
 
 /**
+ * Checks if the given hash tree object is of type "Metadata"
+ * @param {HashTreeObject} object object to check
+ * @returns {boolean} True if the object is of type "Metadata", false otherwise
+ */
+export function isMetadata(object: HashTreeObject) {
+  return object.htMeta.elementId.type.toLowerCase() === ObjectType.metadata;
+}
+
+/**
  * Analyzes given part of Locus DTO recursively and delete any nested objects that have their own htMeta
  *
  * @param {Object} currentLocusPart part of locus DTO to analyze

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -35,10 +35,11 @@ import HashTreeParser, {
   DataSet,
   HashTreeMessage,
   LocusInfoUpdateType,
+  Metadata,
 } from '../hashTree/hashTreeParser';
 import {HashTreeObject, ObjectType, ObjectTypeToLocusKeyMap} from '../hashTree/types';
-import {isSelf} from '../hashTree/utils';
-import {Links, LocusDTO, LocusFullState} from './types';
+import {isMetadata} from '../hashTree/utils';
+import {Links, LocusDTO} from './types';
 
 export type LocusLLMEvent = {
   data: {
@@ -69,6 +70,7 @@ const LocusDtoTopLevelKeys = [
 export type LocusApiResponseBody = {
   dataSets?: DataSet[];
   locus: LocusDTO; // this LocusDTO here might not be the full one (for example it won't have all the participants, but it should have self)
+  metadata?: Metadata;
 };
 
 const LocusObjectStateAfterUpdates = {
@@ -239,7 +241,7 @@ export default class LocusInfo extends EventsScope {
             'Locus-info:index#doLocusSync --> got full DTO when we asked for delta'
           );
         }
-        meeting.locusInfo.onFullLocus(res.body);
+        meeting.locusInfo.onFullLocus('classic Locus sync', res.body);
       })
       .catch((e) => {
         LoggerProxy.logger.info(
@@ -362,14 +364,17 @@ export default class LocusInfo extends EventsScope {
    */
   private createHashTreeParser({
     initialLocus,
+    metadata,
   }: {
     initialLocus: {
       dataSets: Array<DataSet>;
       locus: any;
     };
+    metadata: Metadata;
   }) {
     return new HashTreeParser({
       initialLocus,
+      metadata,
       webexRequest: this.webex.request.bind(this.webex),
       locusInfoUpdateCallback: this.updateFromHashTree.bind(this),
       debugId: `HT-${this.meetingId.substring(0, 4)}`,
@@ -387,6 +392,7 @@ export default class LocusInfo extends EventsScope {
           trigger: 'join-response';
           locus: LocusDTO;
           dataSets?: DataSet[];
+          metadata?: Metadata;
         }
       | {
           trigger: 'locus-message';
@@ -401,27 +407,32 @@ export default class LocusInfo extends EventsScope {
     switch (data.trigger) {
       case 'locus-message':
         if (data.hashTreeMessage) {
-          // we need the SELF object to be in the received message, because it contains visibleDataSets
+          // we need the Metadata object to be in the received message, because it contains visibleDataSets
           // and these are needed to initialize all the hash trees
-          const selfObject = data.hashTreeMessage.locusStateElements?.find((el) => isSelf(el));
+          const metadataObject = data.hashTreeMessage.locusStateElements?.find((el) =>
+            isMetadata(el)
+          );
 
-          if (!selfObject?.data?.visibleDataSets) {
+          if (!metadataObject?.data?.visibleDataSets) {
             LoggerProxy.logger.warn(
-              `Locus-info:index#initialSetup --> cannot initialize HashTreeParser, SELF object with visibleDataSets is missing in the message`
+              `Locus-info:index#initialSetup --> cannot initialize HashTreeParser, Metadata object with visibleDataSets is missing in the message`
             );
 
-            throw new Error('SELF object with visibleDataSets is missing in the message');
+            throw new Error('Metadata object with visibleDataSets is missing in the message');
           }
 
           LoggerProxy.logger.info(
             'Locus-info:index#initialSetup --> creating HashTreeParser from message'
           );
           // first create the HashTreeParser, but don't initialize it with any data yet
-          // pass just a fake locus that contains only the visibleDataSets
           this.hashTreeParser = this.createHashTreeParser({
             initialLocus: {
-              locus: {self: {visibleDataSets: selfObject.data.visibleDataSets}},
+              locus: null,
               dataSets: [], // empty, because they will be populated in initializeFromMessage() call  // dataSets: data.hashTreeMessage.dataSets,
+            },
+            metadata: {
+              htMeta: metadataObject.htMeta,
+              visibleDataSets: metadataObject.data.visibleDataSets,
             },
           });
 
@@ -430,12 +441,12 @@ export default class LocusInfo extends EventsScope {
         } else {
           // "classic" Locus case, no hash trees involved
           this.updateLocusCache(data.locus);
-          this.onFullLocus(data.locus, undefined);
+          this.onFullLocus('classic locus message', data.locus, undefined);
         }
         break;
       case 'join-response':
         this.updateLocusCache(data.locus);
-        this.onFullLocus(data.locus, undefined, data.dataSets);
+        this.onFullLocus('join response', data.locus, undefined, data.dataSets, data.metadata);
         break;
       case 'get-loci-response':
         if (data.locus?.links?.resources?.visibleDataSets?.url) {
@@ -443,12 +454,12 @@ export default class LocusInfo extends EventsScope {
             'Locus-info:index#initialSetup --> creating HashTreeParser from get-loci-response'
           );
           // first create the HashTreeParser, but don't initialize it with any data yet
-          // pass just a fake locus that contains only the visibleDataSets
           this.hashTreeParser = this.createHashTreeParser({
             initialLocus: {
-              locus: {self: {visibleDataSets: data.locus?.self?.visibleDataSets}},
+              locus: null,
               dataSets: [], // empty, because we don't have them yet
             },
+            metadata: null, // get-loci-response doesn't contain Metadata object
           });
 
           // now initialize all the data
@@ -456,7 +467,7 @@ export default class LocusInfo extends EventsScope {
         } else {
           // "classic" Locus case, no hash trees involved
           this.updateLocusCache(data.locus);
-          this.onFullLocus(data.locus, undefined);
+          this.onFullLocus('classic get-loci-response', data.locus, undefined);
         }
     }
     // Change it to true after it receives it first locus object
@@ -643,6 +654,12 @@ export default class LocusInfo extends EventsScope {
           }
         }
         break;
+      case ObjectType.metadata:
+        LoggerProxy.logger.info(
+          `Locus-info:index#updateLocusFromHashTreeObject --> metadata object updated to version ${object.htMeta.elementId.version}`
+        );
+        // we don't use hash tree metadata right now for anything, it's mainly used internally by HashTreeParser
+        break;
       default:
         LoggerProxy.logger.warn(
           `Locus-info:index#updateLocusFromHashTreeObject --> received unsupported object type ${type}`
@@ -827,7 +844,6 @@ export default class LocusInfo extends EventsScope {
         return;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-shadow
       const locus = this.getTheLocusToUpdate(data.locus);
       LoggerProxy.logger.info(`Locus-info:index#parse --> received locus data: ${eventType}`);
 
@@ -848,7 +864,7 @@ export default class LocusInfo extends EventsScope {
         case LOCUSEVENT.PARTICIPANT_DECLINED:
         case LOCUSEVENT.FLOOR_GRANTED:
         case LOCUSEVENT.FLOOR_RELEASED:
-          this.onFullLocus(locus, eventType);
+          this.onFullLocus(`classic locus event ${eventType}`, locus, eventType);
           break;
         case LOCUSEVENT.DIFFERENCE:
           this.handleLocusDelta(locus, meeting);
@@ -876,22 +892,35 @@ export default class LocusInfo extends EventsScope {
   /**
    * Function for handling full locus when it's using hash trees (so not the "classic" one).
    *
+   * @param {string} debugText string explaining the trigger for this call, added to logs for debugging purposes
    * @param {object} locus locus object
+   * @param {object} metadata locus hash trees metadata
    * @param {string} eventType locus event
    * @param {DataSet[]} dataSets
    * @returns {void}
    */
-  private onFullLocusWithHashTrees(locus: any, eventType?: string, dataSets?: Array<DataSet>) {
+  private onFullLocusWithHashTrees(
+    debugText: string,
+    locus: any,
+    metadata: Metadata,
+    eventType?: string,
+    dataSets?: Array<DataSet>
+  ) {
     if (!this.hashTreeParser) {
-      LoggerProxy.logger.info(`Locus-info:index#onFullLocus --> creating hash tree parser`);
       LoggerProxy.logger.info(
-        'Locus-info:index#onFullLocus --> dataSets:',
+        `Locus-info:index#onFullLocus (${debugText}) --> creating hash tree parser`
+      );
+      LoggerProxy.logger.info(
+        `Locus-info:index#onFullLocus (${debugText}) --> dataSets:`,
         dataSets,
         ' and locus:',
-        locus
+        locus,
+        ' and metadata:',
+        metadata
       );
       this.hashTreeParser = this.createHashTreeParser({
         initialLocus: {locus, dataSets},
+        metadata,
       });
       this.onFullLocusCommon(locus, eventType);
     } else {
@@ -899,23 +928,24 @@ export default class LocusInfo extends EventsScope {
       // so treat it like if we just got it in any api response
 
       LoggerProxy.logger.info(
-        'Locus-info:index#onFullLocus --> hash tree parser already exists, handling it like a normal API response'
+        `Locus-info:index#onFullLocus (${debugText}) --> hash tree parser already exists, handling it like a normal API response`
       );
-      this.handleLocusAPIResponse(undefined, {dataSets, locus});
+      this.handleLocusAPIResponse(undefined, {dataSets, locus, metadata});
     }
   }
 
   /**
    * Function for handling full locus when it's the "classic" one (not hash trees)
    *
+   * @param {string} debugText string explaining the trigger for this call, added to logs for debugging purposes
    * @param {object} locus locus object
    * @param {string} eventType locus event
    * @returns {void}
    */
-  private onFullLocusClassic(locus: any, eventType?: string) {
+  private onFullLocusClassic(debugText: string, locus: any, eventType?: string) {
     if (!this.locusParser.isNewFullLocus(locus)) {
       LoggerProxy.logger.info(
-        `Locus-info:index#onFullLocus --> ignoring old full locus DTO, eventType=${eventType}`
+        `Locus-info:index#onFullLocus (${debugText}) --> ignoring old full locus DTO, eventType=${eventType}`
       );
 
       return;
@@ -925,24 +955,37 @@ export default class LocusInfo extends EventsScope {
 
   /**
    * updates the locus with full locus object
+   * @param {string} debugText string explaining the trigger for this call, added to logs for debugging purposes
    * @param {object} locus locus object
    * @param {string} eventType locus event
    * @param {DataSet[]} dataSets
+   * @param {object} metadata locus hash trees metadata
    * @returns {object} null
    * @memberof LocusInfo
    */
-  onFullLocus(locus: any, eventType?: string, dataSets?: Array<DataSet>) {
+  onFullLocus(
+    debugText: string,
+    locus: any,
+    eventType?: string,
+    dataSets?: Array<DataSet>,
+    metadata?: Metadata
+  ) {
     if (!locus) {
       LoggerProxy.logger.error(
-        'Locus-info:index#onFullLocus --> object passed as argument was invalid, continuing.'
+        `Locus-info:index#onFullLocus (${debugText}) --> object passed as argument was invalid, continuing.`
       );
     }
 
     if (dataSets) {
+      if (!metadata) {
+        throw new Error(
+          `Locus-info:index#onFullLocus (${debugText}) --> hash tree metadata is missing with full Locus`
+        );
+      }
       // this is the new hashmap Locus DTO format (only applicable to webinars for now)
-      this.onFullLocusWithHashTrees(locus, eventType, dataSets);
+      this.onFullLocusWithHashTrees(debugText, locus, metadata, eventType, dataSets);
     } else {
-      this.onFullLocusClassic(locus, eventType);
+      this.onFullLocusClassic(debugText, locus, eventType);
     }
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -179,7 +179,7 @@ import JoinForbiddenError from '../common/errors/join-forbidden-error';
 import {ReachabilityMetrics} from '../reachability/reachability.types';
 import {SetStageOptions, SetStageVideoLayout, UnsetStageVideoLayout} from './request.type';
 import {Invitee} from './type';
-import {DataSet} from '../hashTree/hashTreeParser';
+import {DataSet, Metadata} from '../hashTree/hashTreeParser';
 import {LocusDTO} from '../locus-info/types';
 
 // default callback so we don't call an undefined function, but in practice it should never be used
@@ -4598,7 +4598,8 @@ export default class Meeting extends StatelessWebexPlugin {
     mediaId: string;
     host: object;
     selfId: string;
-    dataSets: DataSet[];
+    dataSets: DataSet[]; // only sent by Locus when hash trees are used
+    metadata: Metadata; // only sent by Locus when hash trees are used
   }) {
     const mtgLocus: any = data.locus;
 
@@ -4614,6 +4615,7 @@ export default class Meeting extends StatelessWebexPlugin {
       trigger: 'join-response',
       locus: mtgLocus,
       dataSets: data.dataSets,
+      metadata: data.metadata,
     });
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -33,6 +33,7 @@ const MeetingUtil = {
     // First todo: add check for existance
     parsed.locus = response.body.locus;
     parsed.dataSets = response.body.dataSets;
+    parsed.metadata = response.body.metaData;
     parsed.mediaConnections = response.body.mediaConnections;
     parsed.locusUrl = parsed.locus.url;
     parsed.locusId = parsed.locus.url.split('/').pop();

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -6,6 +6,8 @@ import {expect} from '@webex/test-helper-chai';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
 
+const visibleDataSetsUrl = 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/visibleDataSets';
+
 const exampleInitialLocus = {
   dataSets: [
     {
@@ -46,6 +48,7 @@ const exampleInitialLocus = {
       },
       dataSetNames: ['main'],
     },
+    links: {resources: {visibleDataSets: {url: visibleDataSetsUrl}}},
     participants: [
       {
         url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/11941033',
@@ -62,7 +65,6 @@ const exampleInitialLocus = {
     ],
     self: {
       url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/11941033',
-      visibleDataSets: ['main', 'self', 'atd-unmuted'],
       person: {},
       htMeta: {
         elementId: {
@@ -74,6 +76,28 @@ const exampleInitialLocus = {
       },
     },
   },
+};
+
+const exampleMetadata = {
+  htMeta: {
+    elementId: {
+      type: 'metadata',
+      id: 5,
+      version: 50,
+    },
+    dataSetNames: ['self'],
+  },
+  visibleDataSets: [
+    {name: 'main', url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main'},
+    {
+      name: 'self',
+      url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+    },
+    {
+      name: 'atd-unmuted',
+      url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/atd-unmuted',
+    },
+  ],
 };
 
 function createDataSet(name: string, leafCount: number, version = 1) {
@@ -119,7 +143,6 @@ function mockSyncRequest(webexRequest: sinon.SinonStub, datasetUrl: string, resp
 }
 
 describe('HashTreeParser', () => {
-  const visibleDataSetsUrl = 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/visibleDataSets';
   const locusUrl = 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f';
 
   let clock;
@@ -139,9 +162,13 @@ describe('HashTreeParser', () => {
   });
 
   // Helper to create a HashTreeParser instance with common defaults
-  function createHashTreeParser(initialLocus: any = exampleInitialLocus) {
+  function createHashTreeParser(
+    initialLocus: any = exampleInitialLocus,
+    metadata: any = exampleMetadata
+  ) {
     return new HashTreeParser({
       initialLocus,
+      metadata,
       webexRequest,
       locusInfoUpdateCallback: callback,
       debugId: 'test',
@@ -197,8 +224,49 @@ describe('HashTreeParser', () => {
         body: response,
       });
   }
+
+  async function checkAsyncDatasetInitialization(
+    parser: HashTreeParser,
+    newDataSet: {name: string; leafCount: number; url: string}
+  ) {
+    // immediately we don't have the dataset yet, so it should not be in visibleDataSets
+    // and no hash tree should exist yet
+    expect(parser.visibleDataSets.some((vds) => vds.name === newDataSet.name)).to.be.false;
+    assert.isUndefined(parser.dataSets[newDataSet.name]);
+
+    // Wait for the async initialization to complete (queued as microtask)
+    await clock.tickAsync(0);
+
+    // The visibleDataSets is updated from the metadata object data
+    expect(parser.visibleDataSets.some((vds) => vds.name === newDataSet.name)).to.be.true;
+
+    // Verify that a hash tree was created for newDataSet
+    assert.exists(parser.dataSets[newDataSet.name].hashTree);
+    assert.equal(parser.dataSets[newDataSet.name].hashTree.numLeaves, newDataSet.leafCount);
+
+    // Verify getAllDataSetsMetadata was called for async initialization
+    assert.calledWith(
+      webexRequest,
+      sinon.match({
+        method: 'GET',
+        uri: visibleDataSetsUrl,
+      })
+    );
+
+    // Verify sync request was sent for the new dataset
+    assert.calledWith(
+      webexRequest,
+      sinon.match({
+        method: 'POST',
+        uri: `${newDataSet.url}/sync`,
+      })
+    );
+  }
   it('should correctly initialize trees from initialLocus data', () => {
     const parser = createHashTreeParser();
+
+    // verify that visibleDataSetsUrl is read out from inside locus
+    expect(parser.visibleDataSetsUrl).to.equal(visibleDataSetsUrl);
 
     // Check that the correct number of trees are created
     expect(Object.keys(parser.dataSets).length).to.equal(3);
@@ -215,7 +283,11 @@ describe('HashTreeParser', () => {
     const selfTree = parser.dataSets.self.hashTree;
     expect(selfTree).to.be.instanceOf(HashTree);
     const expectedSelfLeaves = new Array(1).fill(null).map(() => ({}));
-    expectedSelfLeaves[4 % 1] = {self: {4: {type: 'self', id: 4, version: 100}}};
+    // Both self (id=4) and metadata (id=5) map to the same leaf (4%1=0, 5%1=0)
+    expectedSelfLeaves[0] = {
+      self: {4: {type: 'self', id: 4, version: 100}},
+      metadata: {5: {type: 'metadata', id: 5, version: 50}},
+    };
     expect(selfTree.leaves).to.deep.equal(expectedSelfLeaves);
     expect(selfTree.numLeaves).to.equal(1);
 
@@ -247,7 +319,7 @@ describe('HashTreeParser', () => {
       name: 'empty-set',
     });
 
-    const parser = createHashTreeParser(modifiedLocus);
+    const parser = createHashTreeParser(modifiedLocus, exampleMetadata);
 
     expect(Object.keys(parser.dataSets).length).to.equal(4); // main, self, atd-unmuted (now empty), empty-set
 
@@ -260,7 +332,10 @@ describe('HashTreeParser', () => {
 
     const selfTree = parser.dataSets.self.hashTree;
     const expectedSelfLeaves = new Array(1).fill(null).map(() => ({}));
-    expectedSelfLeaves[4 % 1] = {self: {4: {type: 'self', id: 4, version: 100}}};
+    expectedSelfLeaves[4 % 1] = {
+      self: {4: {type: 'self', id: 4, version: 100}},
+      metadata: {5: exampleMetadata.htMeta.elementId},
+    };
     expect(selfTree.leaves).to.deep.equal(expectedSelfLeaves);
     expect(selfTree.numLeaves).to.equal(1);
 
@@ -283,25 +358,34 @@ describe('HashTreeParser', () => {
     // Create a parser with minimal initial data
     const minimalInitialLocus = {
       dataSets: [],
-      locus: {
-        self: {
-          visibleDataSets: ['main', 'self'],
-        },
-      },
+      locus: null,
     };
 
-    const hashTreeParser = createHashTreeParser(minimalInitialLocus);
+    const minimalMetadata = {
+      htMeta: {
+        elementId: {
+          type: 'metadata',
+          id: 5,
+          version: 50,
+        },
+        dataSetNames: ['self'],
+      },
+      visibleDataSets: [
+        {name: 'main', url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main'},
+        {
+          name: 'self',
+          url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+        },
+      ],
+    };
+
+    const hashTreeParser = createHashTreeParser(minimalInitialLocus, minimalMetadata);
 
     // Setup the datasets that will be returned from getAllDataSetsMetadata
     const mainDataSet = createDataSet('main', 16, 1100);
     const selfDataSet = createDataSet('self', 1, 2100);
-    const invisibleDataSet = createDataSet('invisible', 4, 4000);
 
-    mockGetAllDataSetsMetadata(webexRequest, visibleDataSetsUrl, [
-      mainDataSet,
-      selfDataSet,
-      invisibleDataSet,
-    ]);
+    mockGetAllDataSetsMetadata(webexRequest, visibleDataSetsUrl, [mainDataSet, selfDataSet]);
 
     // Mock sync requests for visible datasets with some updated objects
     const mainSyncResponse = {
@@ -357,15 +441,16 @@ describe('HashTreeParser', () => {
       })
     );
 
-    // Verify all datasets are added to dataSets
+    // verify that visibleDataSetsUrl is set on the parser
+    expect(hashTreeParser.visibleDataSetsUrl).to.equal(visibleDataSetsUrl);
+
+    // Verify all datasets returned from visibleDataSetsUrl are added to dataSets
     expect(hashTreeParser.dataSets.main).to.exist;
     expect(hashTreeParser.dataSets.self).to.exist;
-    expect(hashTreeParser.dataSets.invisible).to.exist;
 
     // Verify hash trees are created only for visible datasets
     expect(hashTreeParser.dataSets.main.hashTree).to.be.instanceOf(HashTree);
     expect(hashTreeParser.dataSets.self.hashTree).to.be.instanceOf(HashTree);
-    expect(hashTreeParser.dataSets.invisible.hashTree).to.be.undefined;
 
     // Verify hash trees have correct leaf counts
     expect(hashTreeParser.dataSets.main.hashTree.numLeaves).to.equal(16);
@@ -403,15 +488,6 @@ describe('HashTreeParser', () => {
       })
     );
 
-    // Verify sync request was NOT sent for invisible dataset
-    assert.neverCalledWith(
-      webexRequest,
-      sinon.match({
-        method: 'POST',
-        uri: `${invisibleDataSet.url}/sync`,
-      })
-    );
-
     // Verify callback was called with OBJECTS_UPDATED and correct updatedObjects list
     assert.calledWith(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
       updatedObjects: [
@@ -443,8 +519,6 @@ describe('HashTreeParser', () => {
     // verify that sync timers are set for visible datasets
     expect(hashTreeParser.dataSets.main.timer).to.not.be.undefined;
     expect(hashTreeParser.dataSets.self.timer).to.not.be.undefined;
-    // and not for invisible dataset
-    expect(hashTreeParser.dataSets.invisible.timer).to.be.undefined;
   };
 
   describe('#initializeFromMessage', () => {
@@ -461,7 +535,7 @@ describe('HashTreeParser', () => {
 
   describe('#initializeFromGetLociResponse', () => {
     it('does nothing if url for visibleDataSets is missing from locus', async () => {
-      const parser = createHashTreeParser({dataSets: [], locus: {}});
+      const parser = createHashTreeParser({dataSets: [], locus: {}}, null);
 
       await parser.initializeFromGetLociResponse({participants: []});
 
@@ -488,12 +562,9 @@ describe('HashTreeParser', () => {
     it('updates hash trees based on provided new locus', () => {
       const parser = createHashTreeParser();
 
-      const mainPutItemsSpy = sinon
-        .spy(parser.dataSets.main.hashTree, 'putItems');
-      const selfPutItemsSpy = sinon
-        .spy(parser.dataSets.self.hashTree, 'putItems');
-      const atdUnmutedPutItemsSpy = sinon
-        .spy(parser.dataSets['atd-unmuted'].hashTree, 'putItems');
+      const mainPutItemsSpy = sinon.spy(parser.dataSets.main.hashTree, 'putItems');
+      const selfPutItemsSpy = sinon.spy(parser.dataSets.self.hashTree, 'putItems');
+      const atdUnmutedPutItemsSpy = sinon.spy(parser.dataSets['atd-unmuted'].hashTree, 'putItems');
 
       // Create a locus update with new htMeta information for some things
       const locusUpdate = {
@@ -540,7 +611,6 @@ describe('HashTreeParser', () => {
           ],
           self: {
             url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/11941033',
-            visibleDataSets: ['main', 'self', 'atd-unmuted'],
             person: {},
             htMeta: {
               elementId: {
@@ -710,6 +780,211 @@ describe('HashTreeParser', () => {
           },
         ],
       });
+    });
+
+    it('handles metadata updates with new version', async () => {
+      const parser = createHashTreeParser();
+
+      const selfPutItemSpy = sinon.spy(parser.dataSets.self.hashTree, 'putItem');
+
+      // Create a locus update with updated metadata
+      const locusUpdate = {
+        dataSets: [createDataSet('self', 1, 2100), createDataSet('attendees', 8, 4000)],
+        locus: {
+          links: {resources: {visibleDataSets: {url: visibleDataSetsUrl}}},
+          participants: [
+            {
+              url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/15',
+              person: {},
+              htMeta: {
+                elementId: {
+                  type: 'participant',
+                  id: 15, // new participant
+                  version: 999,
+                },
+                dataSetNames: ['attendees'],
+              },
+            },
+          ],
+        },
+        metadata: {
+          htMeta: {
+            elementId: {
+              type: 'metadata',
+              id: 5,
+              version: 51, // incremented version
+            },
+            dataSetNames: ['self'],
+          },
+          // new visibleDataSets: atd-unmuted removed, "attendees" and "new-dataset" added
+          visibleDataSets: [
+            {
+              name: 'main',
+              url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main',
+            },
+            {
+              name: 'self',
+              url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+            },
+            {
+              name: 'new-dataset', // this one is not in dataSets, so will require async initialization
+              url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/new-dataset',
+            },
+            {
+              name: 'attendees', // this one is in dataSets, so should be processed immediately
+              url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/attendees',
+            },
+          ],
+        },
+      };
+
+      // Mock the async initialization of the new dataset
+      const newDataSet = createDataSet('new-dataset', 4, 5000);
+      mockGetAllDataSetsMetadata(webexRequest, visibleDataSetsUrl, [newDataSet]);
+      mockSyncRequest(webexRequest, newDataSet.url, {
+        dataSets: [newDataSet],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [],
+      });
+
+      // Call handleLocusUpdate
+      parser.handleLocusUpdate(locusUpdate);
+
+      // Verify putItem was called on self hash tree with metadata
+      assert.calledOnceWithExactly(selfPutItemSpy, {type: 'metadata', id: 5, version: 51});
+
+      console.log(
+        'callback calls',
+        callback.getCalls().map((call) => JSON.stringify(call.args, null, 2))
+      );
+      // Verify callback was called with metadata object and removed dataset objects
+      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+        updatedObjects: [
+          // updated metadata object:
+          {
+            htMeta: {
+              elementId: {
+                type: 'metadata',
+                id: 5,
+                version: 51,
+              },
+              dataSetNames: ['self'],
+            },
+            data: {
+              htMeta: {
+                elementId: {
+                  type: 'metadata',
+                  id: 5,
+                  version: 51,
+                },
+                dataSetNames: ['self'],
+              },
+              visibleDataSets: [
+                {
+                  name: 'main',
+                  url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main',
+                },
+                {
+                  name: 'self',
+                  url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+                },
+                {
+                  name: 'new-dataset',
+                  url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/new-dataset',
+                },
+                {
+                  name: 'attendees',
+                  url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/attendees',
+                },
+              ],
+            },
+          },
+          // removed participant from a removed dataset 'atd-unmuted':
+          {
+            htMeta: {
+              elementId: {
+                type: 'participant',
+                id: 14,
+                version: 300,
+              },
+              dataSetNames: ['atd-unmuted'],
+            },
+            data: null,
+          },
+          // new participant from a new data set 'attendees':
+          {
+            htMeta: {
+              elementId: {
+                type: 'participant',
+                id: 15,
+                version: 999,
+              },
+              dataSetNames: ['attendees'],
+            },
+            data: {
+              url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/15',
+              person: {},
+              htMeta: {
+                elementId: {
+                  type: 'participant',
+                  id: 15,
+                  version: 999,
+                },
+                dataSetNames: ['attendees'],
+              },
+            },
+          },
+        ],
+      });
+
+      // verify also that an async initialization was done for
+      await checkAsyncDatasetInitialization(parser, newDataSet);
+    });
+
+    it('handles metadata updates with same version (no callback)', () => {
+      const parser = createHashTreeParser();
+
+      const selfPutItemSpy = sinon.spy(parser.dataSets.self.hashTree, 'putItem');
+
+      // Create a locus update with metadata that has the same version and same visibleDataSets
+      const locusUpdate = {
+        dataSets: [createDataSet('self', 1, 2100)],
+        locus: {},
+        metadata: {
+          htMeta: {
+            elementId: {
+              type: 'metadata',
+              id: 5,
+              version: 50, // same version as initial
+            },
+            dataSetNames: ['self'],
+          },
+          visibleDataSets: [
+            {
+              name: 'main',
+              url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main',
+            },
+            {
+              name: 'self',
+              url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+            },
+            {
+              name: 'atd-unmuted',
+              url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/atd-unmuted',
+            },
+          ],
+        },
+      };
+
+      // Call handleLocusUpdate
+      parser.handleLocusUpdate(locusUpdate);
+
+      // Verify putItem was called on self hash tree
+      assert.calledOnceWithExactly(selfPutItemSpy, {type: 'metadata', id: 5, version: 50});
+
+      // Verify callback was NOT called because version didn't change
+      assert.notCalled(callback);
     });
   });
 
@@ -912,22 +1187,11 @@ describe('HashTreeParser', () => {
         updatedObjects: [
           {
             htMeta: {
-              elementId: {type: 'self', id: 4, version: 101},
-              dataSetNames: ['self'],
-            },
-            data: {person: {name: 'updated self name'}},
-          },
-          {
-            htMeta: {
               elementId: {type: 'locus', id: 0, version: 201},
               dataSetNames: ['main'],
             },
             data: {info: {id: 'updated-locus-info'}},
           },
-          // self updates appear twice, because they are processed twice in HashTreeParser.parseMessage()
-          // (first for checking for visibleDataSets changes and again with the rest of updates in the main part of parseMessage())
-          // this is only temporary until SPARK-744859 is done and having them twice here is not harmful
-          // so keeping it like this for now
           {
             htMeta: {
               elementId: {type: 'self', id: 4, version: 101},
@@ -1242,7 +1506,13 @@ describe('HashTreeParser', () => {
           body: {
             leafCount: 1,
             leafDataEntries: [
-              {leafIndex: 0, elementIds: [{type: 'self', id: 4, version: 102}]},
+              {
+                leafIndex: 0,
+                elementIds: [
+                  {type: 'self', id: 4, version: 102},
+                  {type: 'metadata', id: 5, version: 50},
+                ],
+              },
             ],
           },
         });
@@ -1257,7 +1527,7 @@ describe('HashTreeParser', () => {
         // Stub updateItems on self hash tree to return true
         sinon.stub(parser.dataSets.self.hashTree, 'updateItems').returns([true]);
 
-        // Send a message with SELF object that has a new visibleDataSets list
+        // Send a message with Metadata object that has a new visibleDataSets list
         const message = {
           dataSets: [createDataSet('self', 1, 2100), createDataSet('attendees', 8, 4000)],
           visibleDataSetsUrl,
@@ -1266,14 +1536,31 @@ describe('HashTreeParser', () => {
             {
               htMeta: {
                 elementId: {
-                  type: 'self' as const,
-                  id: 4,
-                  version: 101,
+                  type: 'metadata' as const,
+                  id: 5,
+                  version: 51,
                 },
                 dataSetNames: ['self'],
               },
               data: {
-                visibleDataSets: ['main', 'self', 'atd-unmuted', 'attendees'], // added 'attendees'
+                visibleDataSets: [
+                  {
+                    name: 'main',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main',
+                  },
+                  {
+                    name: 'self',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+                  },
+                  {
+                    name: 'atd-unmuted',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/atd-unmuted',
+                  },
+                  {
+                    name: 'attendees',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/attendees',
+                  },
+                ], // added 'attendees'
               },
             },
           ],
@@ -1282,31 +1569,65 @@ describe('HashTreeParser', () => {
         await parser.handleMessage(message, 'add visible dataset');
 
         // Verify that 'attendees' was added to visibleDataSets
-        assert.include(parser.visibleDataSets, 'attendees');
+        expect(parser.visibleDataSets.some((vds) => vds.name === 'attendees')).to.be.true;
 
         // Verify that a hash tree was created for 'attendees'
         assert.exists(parser.dataSets.attendees.hashTree);
         assert.equal(parser.dataSets.attendees.hashTree.numLeaves, 8);
 
-        // Verify callback was called with the self update (appears twice due to SPARK-744859)
+        // Verify callback was called with the metadata update (appears twice - processed once for visible dataset changes, once in main loop)
         assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
           updatedObjects: [
             {
               htMeta: {
-                elementId: {type: 'self', id: 4, version: 101},
+                elementId: {type: 'metadata', id: 5, version: 51},
                 dataSetNames: ['self'],
               },
               data: {
-                visibleDataSets: ['main', 'self', 'atd-unmuted', 'attendees'],
+                visibleDataSets: [
+                  {
+                    name: 'main',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main',
+                  },
+                  {
+                    name: 'self',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+                  },
+                  {
+                    name: 'atd-unmuted',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/atd-unmuted',
+                  },
+                  {
+                    name: 'attendees',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/attendees',
+                  },
+                ],
               },
             },
             {
               htMeta: {
-                elementId: {type: 'self', id: 4, version: 101},
+                elementId: {type: 'metadata', id: 5, version: 51},
                 dataSetNames: ['self'],
               },
               data: {
-                visibleDataSets: ['main', 'self', 'atd-unmuted', 'attendees'],
+                visibleDataSets: [
+                  {
+                    name: 'main',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main',
+                  },
+                  {
+                    name: 'self',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+                  },
+                  {
+                    name: 'atd-unmuted',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/atd-unmuted',
+                  },
+                  {
+                    name: 'attendees',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/attendees',
+                  },
+                ],
               },
             },
           ],
@@ -1320,7 +1641,7 @@ describe('HashTreeParser', () => {
         // Stub updateItems on self hash tree to return true
         sinon.stub(parser.dataSets.self.hashTree, 'updateItems').returns([true]);
 
-        // Send a message with SELF object that has a new visibleDataSets list (adding 'new-dataset')
+        // Send a message with Metadata object that has a new visibleDataSets list (adding 'new-dataset')
         // but WITHOUT providing info about the new dataset in dataSets array
         const message = {
           dataSets: [createDataSet('self', 1, 2100)],
@@ -1330,14 +1651,31 @@ describe('HashTreeParser', () => {
             {
               htMeta: {
                 elementId: {
-                  type: 'self' as const,
-                  id: 4,
-                  version: 101,
+                  type: 'metadata' as const,
+                  id: 5,
+                  version: 51,
                 },
                 dataSetNames: ['self'],
               },
               data: {
-                visibleDataSets: ['main', 'self', 'atd-unmuted', 'new-dataset'],
+                visibleDataSets: [
+                  {
+                    name: 'main',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main',
+                  },
+                  {
+                    name: 'self',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+                  },
+                  {
+                    name: 'atd-unmuted',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/atd-unmuted',
+                  },
+                  {
+                    name: 'new-dataset',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/new-dataset',
+                  },
+                ],
               },
             },
           ],
@@ -1355,38 +1693,7 @@ describe('HashTreeParser', () => {
 
         await parser.handleMessage(message, 'add new dataset requiring async init');
 
-        // immediately we don't have the dataset yet, so it should not be in visibleDataSets
-        // and no hash tree should exist yet
-        assert.isFalse(parser.visibleDataSets.includes('new-dataset'));
-        assert.isUndefined(parser.dataSets['new-dataset']);
-
-        // Wait for the async initialization to complete (queued as microtask)
-        await clock.tickAsync(0);
-
-        // The visibleDataSets is updated from the self object data
-        assert.include(parser.visibleDataSets, 'new-dataset');
-
-        // Verify that a hash tree was created for 'new-dataset'
-        assert.exists(parser.dataSets['new-dataset'].hashTree);
-        assert.equal(parser.dataSets['new-dataset'].hashTree.numLeaves, 4);
-
-        // Verify getAllDataSetsMetadata was called for async initialization
-        assert.calledWith(
-          webexRequest,
-          sinon.match({
-            method: 'GET',
-            uri: visibleDataSetsUrl,
-          })
-        );
-
-        // Verify sync request was sent for the new dataset
-        assert.calledWith(
-          webexRequest,
-          sinon.match({
-            method: 'POST',
-            uri: `${newDataSet.url}/sync`,
-          })
-        );
+        await checkAsyncDatasetInitialization(parser, newDataSet);
       });
 
       it('handles removal of visible data set', async () => {
@@ -1406,7 +1713,7 @@ describe('HashTreeParser', () => {
         // Stub updateItems on self hash tree to return true
         sinon.stub(parser.dataSets.self.hashTree, 'updateItems').returns([true]);
 
-        // Send a message with SELF object that has removed 'atd-unmuted' from visibleDataSets
+        // Send a message with Metadata object that has removed 'atd-unmuted' from visibleDataSets
         const message = {
           dataSets: [createDataSet('self', 1, 2100)],
           visibleDataSetsUrl,
@@ -1415,14 +1722,23 @@ describe('HashTreeParser', () => {
             {
               htMeta: {
                 elementId: {
-                  type: 'self' as const,
-                  id: 4,
-                  version: 101,
+                  type: 'metadata' as const,
+                  id: 5,
+                  version: 51,
                 },
                 dataSetNames: ['self'],
               },
               data: {
-                visibleDataSets: ['main', 'self'], // removed 'atd-unmuted'
+                visibleDataSets: [
+                  {
+                    name: 'main',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main',
+                  },
+                  {
+                    name: 'self',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+                  },
+                ], // removed 'atd-unmuted'
               },
             },
           ],
@@ -1431,7 +1747,7 @@ describe('HashTreeParser', () => {
         await parser.handleMessage(message, 'remove visible dataset');
 
         // Verify that 'atd-unmuted' was removed from visibleDataSets
-        assert.notInclude(parser.visibleDataSets, 'atd-unmuted');
+        expect(parser.visibleDataSets.some((vds) => vds.name === 'atd-unmuted')).to.be.false;
 
         // Verify that the hash tree for 'atd-unmuted' was deleted
         assert.isUndefined(parser.dataSets['atd-unmuted'].hashTree);
@@ -1439,16 +1755,25 @@ describe('HashTreeParser', () => {
         // Verify that the timer was cleared
         assert.isUndefined(parser.dataSets['atd-unmuted'].timer);
 
-        // Verify callback was called with both the self update and the removed objects
+        // Verify callback was called with the metadata update and the removed objects (metadata appears twice - processed once for dataset changes, once in main loop)
         assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
           updatedObjects: [
             {
               htMeta: {
-                elementId: {type: 'self', id: 4, version: 101},
+                elementId: {type: 'metadata', id: 5, version: 51},
                 dataSetNames: ['self'],
               },
               data: {
-                visibleDataSets: ['main', 'self'],
+                visibleDataSets: [
+                  {
+                    name: 'main',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main',
+                  },
+                  {
+                    name: 'self',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+                  },
+                ],
               },
             },
             {
@@ -1460,11 +1785,20 @@ describe('HashTreeParser', () => {
             },
             {
               htMeta: {
-                elementId: {type: 'self', id: 4, version: 101}, // 2nd self because of SPARK-744859
+                elementId: {type: 'metadata', id: 5, version: 51},
                 dataSetNames: ['self'],
               },
               data: {
-                visibleDataSets: ['main', 'self'],
+                visibleDataSets: [
+                  {
+                    name: 'main',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/main',
+                  },
+                  {
+                    name: 'self',
+                    url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+                  },
+                ],
               },
             },
           ],
@@ -1489,7 +1823,7 @@ describe('HashTreeParser', () => {
         });
 
         // Verify attendees is NOT in visibleDataSets
-        assert.notInclude(parser.visibleDataSets, 'attendees');
+        expect(parser.visibleDataSets.some((vds) => vds.name === 'attendees')).to.be.false;
 
         // Send a message with attendees data
         const message = {

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -107,7 +107,7 @@ describe('plugin-meetings', () => {
       const createHashTreeMessage = (visibleDataSets) => ({
         locusStateElements: [
           {
-            htMeta: {elementId: {type: 'self'}},
+            htMeta: {elementId: {type: 'metadata'}},
             data: {visibleDataSets},
           },
         ],
@@ -137,8 +137,12 @@ describe('plugin-meetings', () => {
           HashTreeParserStub,
           sinon.match({
             initialLocus: {
-              locus: {self: {visibleDataSets}},
+              locus: null,
               dataSets: [],
+            },
+            metadata: {
+              htMeta: hashTreeMessage.locusStateElements[0].htMeta,
+              visibleDataSets,
             },
             webexRequest: sinon.match.func,
             locusInfoUpdateCallback: sinon.match.func,
@@ -170,11 +174,16 @@ describe('plugin-meetings', () => {
         const visibleDataSets = ['dataset1', 'dataset2'];
         const locus = createLocusWithVisibleDataSets(visibleDataSets);
         const dataSets = [{name: 'dataset1', url: 'http://dataset-url.com'}];
+        const metadata = {
+          htMeta: {elementId: {type: 'metadata'}},
+          visibleDataSets,
+        };
 
         await locusInfo.initialSetup({
           trigger: 'join-response',
           locus,
           dataSets,
+          metadata,
         });
 
         assert.calledOnceWithExactly(
@@ -184,6 +193,7 @@ describe('plugin-meetings', () => {
               locus,
               dataSets,
             },
+            metadata,
             webexRequest: sinon.match.func,
             locusInfoUpdateCallback: sinon.match.func,
             debugId: sinon.match.string,
@@ -221,12 +231,13 @@ describe('plugin-meetings', () => {
           HashTreeParserStub,
           sinon.match({
             initialLocus: {
-              locus: {self: {visibleDataSets}},
+              locus: null,
               dataSets: [],
             },
             webexRequest: sinon.match.func,
             locusInfoUpdateCallback: sinon.match.func,
             debugId: sinon.match.string,
+            metadata: null,
           })
         );
         assert.calledOnceWithExactly(mockHashTreeParser.initializeFromGetLociResponse, locus);
@@ -250,6 +261,30 @@ describe('plugin-meetings', () => {
         assert.isTrue(locusInfo.emitChange);
       });
 
+      it('throws if called with "locus-message" and Metadata object without visibleDataSets', async () => {
+        const hashTreeMessage = {
+          locusStateElements: [
+            {
+              htMeta: {elementId: {type: 'Metadata'}},
+              data: {},
+            },
+          ],
+          dataSets: [{name: 'dataset1', url: 'test-url'}],
+        };
+        try {
+          await locusInfo.initialSetup({
+            trigger: 'locus-message',
+            hashTreeMessage,
+          });
+          assert.fail('should have thrown an error');
+        } catch (error) {
+          assert.equal(
+            error.message,
+            'Metadata object with visibleDataSets is missing in the message'
+          );
+        }
+      });
+
       describe('should setup correct locusInfoUpdateCallback when creating HashTreeParser', () => {
         const OBJECTS_UPDATED = HashTreeParserModule.LocusInfoUpdateType.OBJECTS_UPDATED;
         const MEETING_ENDED = HashTreeParserModule.LocusInfoUpdateType.MEETING_ENDED;
@@ -266,8 +301,8 @@ describe('plugin-meetings', () => {
             hashTreeMessage: {
               locusStateElements: [
                 {
-                  htMeta: {elementId: {type: 'self'}},
-                  data: {visibleDataSets: ['dataset1']},
+                  htMeta: {elementId: {type: 'Metadata'}},
+                  data: {visibleDataSets: [{name: 'dataset1', url: 'test-url'}]},
                 },
               ],
               dataSets: [{name: 'dataset1', url: 'test-url'}],
@@ -1077,7 +1112,7 @@ describe('plugin-meetings', () => {
       it('should trigger the CONTROLS_POLLING_QA_CHANGED event when necessary', () => {
         locusInfo.controls = {};
         locusInfo.emitScoped = sinon.stub();
-        newControls.pollingQAControl = { enabled: true };
+        newControls.pollingQAControl = {enabled: true};
         locusInfo.updateControls(newControls);
 
         assert.calledWith(
@@ -1632,7 +1667,6 @@ describe('plugin-meetings', () => {
         );
       });
 
-
       it('should call with participant display name', () => {
         const failureParticipant = [
           {
@@ -1657,7 +1691,7 @@ describe('plugin-meetings', () => {
             displayName: 'Test User',
           }
         );
-      })
+      });
     });
 
     describe('#updateSelf', () => {
@@ -2458,8 +2492,8 @@ describe('plugin-meetings', () => {
           {
             isInitializing: !self,
           }
-          );
-        });
+        );
+      });
 
       const checkMeetingInfoUpdatedCalled = (expected, payload) => {
         const expectedArgs = [
@@ -3040,7 +3074,7 @@ describe('plugin-meetings', () => {
         sandbox.stub(locusInfo, 'handleOneOnOneEvent');
         sandbox.stub(locusParser, 'isNewFullLocus').returns(true);
 
-        locusInfo.onFullLocus(fakeLocus, eventType);
+        locusInfo.onFullLocus('test', fakeLocus, eventType);
 
         assert.equal(fakeLocus, locusParser.workingCopy);
       });
@@ -3061,7 +3095,7 @@ describe('plugin-meetings', () => {
 
         sandbox.stub(locusParser, 'isNewFullLocus').returns(false);
 
-        locusInfo.onFullLocus(fakeLocus, eventType);
+        locusInfo.onFullLocus('test', fakeLocus, eventType);
 
         spies.forEach((spy) => {
           assert.notCalled(spy);
@@ -3211,7 +3245,11 @@ describe('plugin-meetings', () => {
         }).then(() => {
           assert.calledOnceWithExactly(meeting.meetingRequest.getLocusDTO, {url: 'oldLocusUrl'});
 
-          assert.calledOnceWithExactly(meeting.locusInfo.onFullLocus, fakeFullLocusDto);
+          assert.calledOnceWithExactly(
+            meeting.locusInfo.onFullLocus,
+            'classic Locus sync',
+            fakeFullLocusDto
+          );
           assert.calledOnce(locusInfo.locusParser.resume);
         });
       });
@@ -3309,7 +3347,11 @@ describe('plugin-meetings', () => {
             });
 
             assert.notCalled(meeting.locusInfo.handleLocusDelta);
-            assert.calledOnceWithExactly(meeting.locusInfo.onFullLocus, fakeFullLocusDto);
+            assert.calledOnceWithExactly(
+              meeting.locusInfo.onFullLocus,
+              'classic Locus sync',
+              fakeFullLocusDto
+            );
             assert.calledOnce(locusInfo.locusParser.resume);
           });
         });
@@ -3485,7 +3527,11 @@ describe('plugin-meetings', () => {
           url: 'fake locus DELTA url',
         });
         assert.notCalled(meeting.locusInfo.handleLocusDelta);
-        assert.calledOnceWithExactly(meeting.locusInfo.onFullLocus, fakeFullLocusDto);
+        assert.calledOnceWithExactly(
+          meeting.locusInfo.onFullLocus,
+          'classic Locus sync',
+          fakeFullLocusDto
+        );
         assert.calledOnce(locusInfo.locusParser.resume);
       });
     });
@@ -3951,7 +3997,7 @@ describe('plugin-meetings', () => {
           getLocusDTO: syncRequestStub,
         };
 
-        locusInfo.onFullLocus({
+        locusInfo.onFullLocus('test', {
           sequence: {
             rangeStart: 0,
             rangeEnd: 0,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -12783,6 +12783,7 @@ describe('plugin-meetings', () => {
 
         it('should read the locus object, set on the meeting and return null', () => {
           const dataSets = {someFakeStuff: 'dataSet'};
+          const metadata = {some: 'metadata'};
 
           meeting.setLocus({
             mediaConnections: [test1],
@@ -12792,12 +12793,14 @@ describe('plugin-meetings', () => {
             mediaId: uuid3,
             locus: {host: {id: uuid4}},
             dataSets,
+            metadata,
           });
           assert.calledOnce(meeting.locusInfo.initialSetup);
           assert.calledWith(meeting.locusInfo.initialSetup, {
             trigger: 'join-response',
             locus: {host: {id: uuid4}},
             dataSets,
+            metadata,
           });
           assert.equal(meeting.mediaConnections, test1);
           assert.equal(meeting.locusUrl, url1);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -1464,6 +1464,7 @@ describe('plugin-meetings', () => {
                 id: 'selfId123',
               },
             },
+            metaData: {id: 'some hash tree metadata'},
             dataSets: [{name: 'dataset1', url: 'http://dataset.com'}],
             mediaConnections: [{mediaId: 'mediaId456'}, {someOtherField: 'value'}],
           },
@@ -1481,6 +1482,7 @@ describe('plugin-meetings', () => {
           locusId: '12345',
           selfId: 'selfId123',
           mediaId: 'mediaId456',
+          metadata: {id: 'some hash tree metadata'},
         });
       });
 
@@ -1510,6 +1512,7 @@ describe('plugin-meetings', () => {
           locusUrl: 'https://locus-a.wbx2.com/locus/api/v1/loci/12345',
           locusId: '12345',
           selfId: 'selfId123',
+          metadata: {id: 'some hash tree metadata'},
         });
         assert.isUndefined(result.mediaId);
       });


### PR DESCRIPTION
# COMPLETES #[SPARK-744859](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-744859)

## This pull request addresses
Locus is now sending information about visible data sets in Metada object in "self" data set. The old way of sending it inside self object is deprecated and will be removed in the next week or 2.

The Metadata object data format is like this:
```
"visibleDataSets": [
            {
                "url": "...",
                "name": "self"
            },
            {
                "url": "...",
                "name": "atd-active",
                "dataChannelUrl": "..."
            },
            {
                "url": "...",
                "name": "main",
                "dataChannelUrl": "..."
            }
        ]
```
Data channel url is still being sent in the usual "old" way too and Locus team said there are no plans to remove it from there, so for now we're not using it from this new location from Metadata in this PR.

more info here (see design topic 2):
https://sqbu-github.cisco.com/gist/dangard2/d943bce073a381b1bc77ae0c93989c26

## by making the following changes
- added support for Metadata object.
- instead of storing just a list of names of visible datasets in `HashTreeParser.visibleDataSets` we are now storing the whole array of objects like they are sent by Locus in Metadata.
- added handling of Metadata to handleLocusUpdate() method (it's called when we get API responses for subsequent API calls to Locus)
- renamed private method getAllDataSetsMetadata() to getAllVisibleDataSetsFromLocus() - it better reflects what it's doing as we were always using it only with visible data sets url
- storing visibleDataSetsUrl in HashTreeParser.visibleDataSetsUrl in constructor, initializeFromMessage() and initializeFromGetLociResponse() - the fact that we didn't store it was a bug I realised while doing unit tests for this PR
- added a debugText argument to LocusInfo.onFullLocus() to help with debugging

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual testing with web app and Locus in integration co.dmz site

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
