### PR TITLE
fix(plugin-mercury): fix closing a unopen websocket with a custom code

### DIFF
--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -223,7 +223,7 @@ const Mercury = WebexPlugin.extend({
     this.logger.info(
       `${this.namespace}#disconnect: connecting state: ${this.connecting}, connected state: ${
         this.connected
-      }, sockert exists: ${!!this.socket}, options: ${JSON.stringify(options)}`
+      }, socket exists: ${!!this.socket}, options: ${JSON.stringify(options)}`
     );
 
     return new Promise((resolve) => {

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -220,6 +220,12 @@ const Mercury = WebexPlugin.extend({
 
   @oneFlight
   disconnect(options) {
+    this.logger.info(
+      `${this.namespace}#disconnect: connecting state: ${this.connecting}, connected state: ${
+        this.connected
+      }, sockert exists: ${!!this.socket}, options: ${JSON.stringify(options)}`
+    );
+
     return new Promise((resolve) => {
       if (this.backoffCall) {
         this.logger.info(`${this.namespace}: aborting connection`);

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -161,7 +161,27 @@ export default class Socket extends EventEmitter {
         resolve(event);
       };
 
-      socket.close(options.code, options.reason);
+      // If socket is still connecting, manually trigger close handler with desired code
+      // because calling close() on a CONNECTING socket may not preserve custom codes
+      if (socket.readyState === 0) {
+        this.logger.info(
+          `socket,${this._domain}: socket still connecting, triggering close manually`
+        );
+        clearTimeout(closeTimer);
+        const closeEvent = {code: options.code, reason: options.reason};
+        this.onclose(closeEvent);
+        resolve(closeEvent);
+        try {
+          socket.close(options.code, options.reason);
+        } catch (error) {
+          this.logger.info(
+            `socket,${this._domain}: error while closing CONNECTING socket, likely due to browser incompatibility with custom close codes`,
+            error
+          );
+        }
+      } else {
+        socket.close(options.code, options.reason);
+      }
     });
   }
 

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
@@ -654,94 +654,65 @@ describe('plugin-mercury', () => {
         assert.calledOnce(socket._ping);
       });
 
-      it('manually triggers close handler when socket is still connecting', async () => {
-        const s = new Socket();
-        let socketInstance;
+      [
+        {
+          description: 'manually triggers close handler when socket is still connecting',
+          closeOptions: {code: 3001, reason: 'Custom close while connecting'},
+          expectedCode: 3001,
+          expectedReason: 'Custom close while connecting',
+        },
+        {
+          description:
+            'manually triggers close handler with default code when socket is connecting',
+          closeOptions: undefined,
+          expectedCode: 1000,
+          expectedReason: 'Done',
+        },
+      ].forEach(({description, closeOptions, expectedCode, expectedReason}) => {
+        it(description, async () => {
+          const s = new Socket();
+          let socketInstance;
 
-        // Save the current stub and replace it
-        const previousStub = Socket.getWebSocketConstructor;
-        Socket.getWebSocketConstructor = sinon.stub().callsFake(
-          () =>
-            function (...args) {
-              socketInstance = new MockWebSocket(...args);
-              return socketInstance;
-            }
-        );
+          // Save the current stub and replace it
+          const previousStub = Socket.getWebSocketConstructor;
+          Socket.getWebSocketConstructor = sinon.stub().callsFake(
+            () =>
+              function (...args) {
+                socketInstance = new MockWebSocket(...args);
+                return socketInstance;
+              }
+          );
 
-        // open the socket
-        s.open('ws://example.com', mockoptions);
+          // open the socket
+          s.open('ws://example.com', mockoptions);
 
-        // Keep socket in CONNECTING state (readyState 0)
-        socketInstance.readyState = 0;
+          // Keep socket in CONNECTING state (readyState 0)
+          socketInstance.readyState = 0;
 
-        const onCloseHandler = sinon.spy();
-        s.on('close', onCloseHandler);
+          const closeSpy = sinon.spy();
+          s.on('close', closeSpy);
 
-        // Call close and await the result
-        const result = await s.close({code: 3001, reason: 'Custom close while connecting'});
+          // Call close and await the result
+          const result = await s.close(closeOptions);
 
-        // Verify the promise resolved with the correct close event
-        assert.equal(result.code, 3001);
-        assert.equal(result.reason, 'Custom close while connecting');
+          // Verify the promise resolved with the correct close event
+          assert.equal(result.code, expectedCode);
+          assert.equal(result.reason, expectedReason);
 
-        // Verify close handler was called with custom code/reason
-        assert.calledOnce(onCloseHandler);
-        assert.calledWith(onCloseHandler, {
-          code: 3001,
-          reason: 'Custom close while connecting',
+          // Verify close handler was called with expected code/reason
+          assert.calledOnce(closeSpy);
+          assert.calledWith(closeSpy, {
+            code: expectedCode,
+            reason: expectedReason,
+          });
+
+          // Verify the underlying socket.close was called with the correct params
+          assert.calledOnce(socketInstance.close);
+          assert.calledWith(socketInstance.close, expectedCode, expectedReason);
+
+          // Restore the previous stub
+          Socket.getWebSocketConstructor = previousStub;
         });
-
-        // Verify the underlying socket.close was called with the correct params
-        assert.calledOnce(socketInstance.close);
-        assert.calledWith(socketInstance.close, 3001, 'Custom close while connecting');
-
-        // Restore the previous stub
-        Socket.getWebSocketConstructor = previousStub;
-      });
-
-      it('manually triggers close handler with default code when socket is connecting', async () => {
-        const s = new Socket();
-        let socketInstance;
-
-        // Save the current stub and replace it
-        const previousStub = Socket.getWebSocketConstructor;
-        Socket.getWebSocketConstructor = sinon.stub().callsFake(
-          () =>
-            function (...args) {
-              socketInstance = new MockWebSocket(...args);
-              return socketInstance;
-            }
-        );
-
-        // open the socket
-        s.open('ws://example.com', mockoptions);
-
-        // Keep socket in CONNECTING state (readyState 0)
-        socketInstance.readyState = 0;
-
-        const closeSpy = sinon.spy();
-        s.on('close', closeSpy);
-
-        // Call close and await the result
-        const result = await s.close();
-
-        // Verify the promise resolved with the default close event
-        assert.equal(result.code, 1000);
-        assert.equal(result.reason, 'Done');
-
-        // Verify close handler was called with default code/reason
-        assert.calledOnce(closeSpy);
-        assert.calledWith(closeSpy, {
-          code: 1000,
-          reason: 'Done',
-        });
-
-        // Verify the underlying socket.close was called with the correct params
-        assert.calledOnce(socketInstance.close);
-        assert.calledWith(socketInstance.close, 1000, 'Done');
-
-        // Restore the previous stub
-        Socket.getWebSocketConstructor = previousStub;
       });
     });
 

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/socket.js
@@ -653,6 +653,96 @@ describe('plugin-mercury', () => {
         });
         assert.calledOnce(socket._ping);
       });
+
+      it('manually triggers close handler when socket is still connecting', async () => {
+        const s = new Socket();
+        let socketInstance;
+
+        // Save the current stub and replace it
+        const previousStub = Socket.getWebSocketConstructor;
+        Socket.getWebSocketConstructor = sinon.stub().callsFake(
+          () =>
+            function (...args) {
+              socketInstance = new MockWebSocket(...args);
+              return socketInstance;
+            }
+        );
+
+        // open the socket
+        s.open('ws://example.com', mockoptions);
+
+        // Keep socket in CONNECTING state (readyState 0)
+        socketInstance.readyState = 0;
+
+        const onCloseHandler = sinon.spy();
+        s.on('close', onCloseHandler);
+
+        // Call close and await the result
+        const result = await s.close({code: 3001, reason: 'Custom close while connecting'});
+
+        // Verify the promise resolved with the correct close event
+        assert.equal(result.code, 3001);
+        assert.equal(result.reason, 'Custom close while connecting');
+
+        // Verify close handler was called with custom code/reason
+        assert.calledOnce(onCloseHandler);
+        assert.calledWith(onCloseHandler, {
+          code: 3001,
+          reason: 'Custom close while connecting',
+        });
+
+        // Verify the underlying socket.close was called with the correct params
+        assert.calledOnce(socketInstance.close);
+        assert.calledWith(socketInstance.close, 3001, 'Custom close while connecting');
+
+        // Restore the previous stub
+        Socket.getWebSocketConstructor = previousStub;
+      });
+
+      it('manually triggers close handler with default code when socket is connecting', async () => {
+        const s = new Socket();
+        let socketInstance;
+
+        // Save the current stub and replace it
+        const previousStub = Socket.getWebSocketConstructor;
+        Socket.getWebSocketConstructor = sinon.stub().callsFake(
+          () =>
+            function (...args) {
+              socketInstance = new MockWebSocket(...args);
+              return socketInstance;
+            }
+        );
+
+        // open the socket
+        s.open('ws://example.com', mockoptions);
+
+        // Keep socket in CONNECTING state (readyState 0)
+        socketInstance.readyState = 0;
+
+        const closeSpy = sinon.spy();
+        s.on('close', closeSpy);
+
+        // Call close and await the result
+        const result = await s.close();
+
+        // Verify the promise resolved with the default close event
+        assert.equal(result.code, 1000);
+        assert.equal(result.reason, 'Done');
+
+        // Verify close handler was called with default code/reason
+        assert.calledOnce(closeSpy);
+        assert.calledWith(closeSpy, {
+          code: 1000,
+          reason: 'Done',
+        });
+
+        // Verify the underlying socket.close was called with the correct params
+        assert.calledOnce(socketInstance.close);
+        assert.calledWith(socketInstance.close, 1000, 'Done');
+
+        // Restore the previous stub
+        Socket.getWebSocketConstructor = previousStub;
+      });
     });
 
     describe('#send()', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Closing a socket before it has opened using a custom code doesn't work on Chrome. It errors and closes the socket with the normal 1006 code. This causes our retry logic to kick in when it shouldn't e.g. code 3050.

## by making the following changes

When the readyState is zero, call the handlers manually and then close the socket. That way the consuming code gets the correct effect and the socket is still closed.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
