### PR TITLE
feat(meetings): added rootHash query param to Locus hash tree sync requests

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -1011,7 +1011,8 @@ class HashTreeParser {
             try {
               // request hashes from sender
               const {hashes, dataSet: latestDataSetInfo} = await this.getHashesFromLocus(
-                dataSet.name
+                dataSet.name,
+                rootHash
               );
 
               receivedHashes = hashes;
@@ -1077,9 +1078,10 @@ class HashTreeParser {
   /**
    * Gets the current hashes from the locus for a specific data set.
    * @param {string} dataSetName
+   * @param {string} currentRootHash
    * @returns {string[]}
    */
-  private getHashesFromLocus(dataSetName: string) {
+  private getHashesFromLocus(dataSetName: string, currentRootHash: string) {
     LoggerProxy.logger.info(
       `HashTreeParser#getHashesFromLocus --> ${this.debugId} Requesting hashes for data set "${dataSetName}"`
     );
@@ -1091,6 +1093,9 @@ class HashTreeParser {
     return this.webexRequest({
       method: HTTP_VERBS.GET,
       uri: url,
+      qs: {
+        rootHash: currentRootHash,
+      },
     })
       .then((response) => {
         const hashes = response.body?.hashes as string[] | undefined;
@@ -1152,9 +1157,14 @@ class HashTreeParser {
       });
     });
 
+    const ourCurrentRootHash = dataSet.hashTree ? dataSet.hashTree.getRootHash() : EMPTY_HASH;
+
     return this.webexRequest({
       method: HTTP_VERBS.POST,
       uri: url,
+      qs: {
+        rootHash: ourCurrentRootHash,
+      },
       body,
     })
       .then((resp) => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -1180,6 +1180,9 @@ describe('HashTreeParser', () => {
           sinon.match({
             method: 'GET',
             uri: `${mainDataSetUrl}/hashtree`,
+            qs: {
+              rootHash: hashTree.getRootHash(),
+            },
           })
         );
 
@@ -1187,6 +1190,7 @@ describe('HashTreeParser', () => {
         assert.calledWith(webexRequest, {
           method: 'POST',
           uri: `${mainDataSetUrl}/sync`,
+          qs: {rootHash: hashTree.getRootHash()},
           body: {
             leafCount: 16,
             leafDataEntries: [
@@ -1240,6 +1244,7 @@ describe('HashTreeParser', () => {
         assert.calledWith(webexRequest, {
           method: 'POST',
           uri: `${parser.dataSets.self.url}/sync`,
+          qs: {rootHash: parser.dataSets.self.hashTree.getRootHash()},
           body: {
             leafCount: 1,
             leafDataEntries: [


### PR DESCRIPTION
# COMPLETES #[SPARK-755461](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-755461)

## This pull request addresses
Locus is changing their API, now a `rootHash` query param is required for /hashtree and /sync APIs
See this Locus PR that updates their docs:
https://sqbu-github.cisco.com/WebExSquared/locus/pull/17880/files

## by making the following changes
changed `HashTreeParser.getHashesFromLocus()` and `HashTreeParser.sendSyncRequestToLocus()` to send the new parameter

<img width="356" height="109" alt="image" src="https://github.com/user-attachments/assets/728ac4f2-ee99-4d5d-9aad-83a18b1c3de3" />

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

unit tests, manual test with web app

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
