### PR TITLE
fix(calling): clears a call keepalive interval before creating one

### DIFF
--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -1002,7 +1002,9 @@ describe('State Machine handler tests', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(clearInterval).toHaveBeenCalledTimes(1);
+    // clearInterval is called twice: once in scheduleCallKeepaliveInterval (at start)
+    // and once in handleCallKeepaliveError when clearing timer due to error
+    expect(clearInterval).toHaveBeenCalledTimes(2);
     expect(funcSpy).toBeCalledTimes(1);
     expect(emitSpy).toHaveBeenCalledWith(CALL_EVENT_KEYS.DISCONNECT, call.getCorrelationId());
   });
@@ -1034,7 +1036,9 @@ describe('State Machine handler tests', () => {
      */
     await flushPromises(2);
 
-    expect(clearInterval).toHaveBeenCalledTimes(1);
+    // clearInterval is called twice: once in scheduleCallKeepaliveInterval (at start)
+    // and once in handleCallKeepaliveError when clearing timer due to error
+    expect(clearInterval).toHaveBeenCalledTimes(2);
     expect(funcSpy).toBeCalledTimes(1);
   });
 
@@ -1069,6 +1073,34 @@ describe('State Machine handler tests', () => {
 
     expect(postStatusSpy).toHaveBeenCalledTimes(2);
     expect(scheduleKeepaliveSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('scheduleCallKeepaliveInterval clears existing interval before creating new one', async () => {
+    jest.spyOn(global, 'setInterval');
+    jest.spyOn(global, 'clearInterval');
+
+    // Setup the first keepalive interval
+    call['handleCallEstablished']({} as CallEvent);
+
+    // At this point, scheduleCallKeepaliveInterval was called once
+    // It should have called clearInterval once (at the start) and setInterval once
+    expect(clearInterval).toHaveBeenCalledTimes(1);
+    expect(setInterval).toHaveBeenCalledTimes(1);
+
+    const firstTimer = call['sessionTimer'];
+    expect(firstTimer).toBeDefined();
+
+    // Manually call scheduleCallKeepaliveInterval again to simulate a retry scenario
+    call['scheduleCallKeepaliveInterval']();
+
+    // clearInterval should have been called again to clear the previous timer
+    expect(clearInterval).toHaveBeenCalledTimes(2);
+    // A new interval should have been created
+    expect(setInterval).toHaveBeenCalledTimes(2);
+
+    // The sessionTimer should be different (new timer)
+    const secondTimer = call['sessionTimer'];
+    expect(secondTimer).toBeDefined();
   });
 
   it('keepalive ends after reaching max retry count', async () => {

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -1428,7 +1428,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       this.mediaConnection.close();
       log.info('Closing media channel', {
         file: CALL_FILE,
-        method: METHODS.HANDLE_OUTGOING_CALL_DISCONNECT,
+        method: METHODS.HANDLE_INCOMING_CALL_DISCONNECT,
       });
     }
 
@@ -1567,6 +1567,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       file: CALL_FILE,
       method: 'scheduleCallKeepaliveInterval',
     };
+
+    clearInterval(this.sessionTimer);
 
     this.sessionTimer = setInterval(async () => {
       try {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< Ad-hoc >

## This pull request addresses

After the investigation throughout the SDK and backend services we have found out that during the optimization of SDK we removed the extra interval clearing logic which was being invoked every time a re-invite was being sent from the backend with or without the change in the OFFER sdp. This caused to create an extra call keepalive interval running every 10 mins and for a longer call going beyond 30 mins where SDK receives a re-invite every 30 mins from the backend services so it started having multiple keepalives with the same callId. Now once the current call is ended and a new call gets established sdk has previous call keepalives with the old callId along with the new keepalive interval running. While the current call is still ongoing, the old keepalive request goes to the backend and receives a 404 response and as a result sdk clears the current call, causing it to unexpectedly drop the ongoing call.

Here Mobius is receiving RE_INVITE from SSE every 30 mins which it is forwarding to the SDK.

## by making the following changes

Clearing the existing call keepalive interval before create a new one. This fixes any unexpected invite/re-invite causing to create a new call keepalive intervals.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
