### PR TITLE
fix(contact-center): allow profile update for all fields

### DIFF
--- a/packages/@webex/contact-center/src/cc.ts
+++ b/packages/@webex/contact-center/src/cc.ts
@@ -1656,6 +1656,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   /**
    * Updates the agent device type and login configuration.
    * Use this method to change how an agent connects to the contact center system (e.g., switching from browser-based calling to a desk phone extension).
+   * Change to any field of the profile is allowed;
    *
    * @param {AgentDeviceUpdate} data Configuration containing:
    *   - loginOption: New device type ('BROWSER', 'EXTENSION', 'AGENT_DN')
@@ -1695,29 +1696,8 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     });
 
     try {
-      // Only block if both loginOption AND teamId remain unchanged
-      if (
-        this.webCallingService?.loginOption === data.loginOption &&
-        data.teamId === this.agentConfig.currentTeamId
-      ) {
-        const message =
-          'Will not proceed with device update as new Device type is same as current device type and teamId is same as current teamId';
-        const err = new Error(message) as GenericError;
-        err.details = {
-          type: 'Identical Device Change Failure',
-          orgId: this.$webex.credentials.getOrgId(),
-          trackingId,
-          data: {
-            agentId: this.agentConfig.agentId,
-            reasonCode: 'R002',
-            reason: message,
-          },
-        };
-        throw err;
-      }
-
       await this.stationLogout({
-        logoutReason: 'User requested agent device change',
+        logoutReason: 'User requested agent profile update',
       });
 
       const loginPayload: AgentLogin = {

--- a/packages/@webex/contact-center/src/services/agent/types.ts
+++ b/packages/@webex/contact-center/src/services/agent/types.ts
@@ -259,7 +259,7 @@ export type Logout = {
   logoutReason?:
     | 'User requested logout'
     | 'Inactivity Logout'
-    | 'User requested agent device change';
+    | 'User requested agent profile update';
 };
 
 /**

--- a/packages/@webex/contact-center/test/unit/spec/cc.ts
+++ b/packages/@webex/contact-center/test/unit/spec/cc.ts
@@ -1850,7 +1850,7 @@ describe('webex.cc', () => {
       );
 
       expect(webex.cc.stationLogout).toHaveBeenCalledWith({
-        logoutReason: 'User requested agent device change',
+        logoutReason: 'User requested agent profile update',
       });
       expect(webex.cc.stationLogin).toHaveBeenCalledWith({
         teamId: 'teamId',
@@ -1934,24 +1934,26 @@ describe('webex.cc', () => {
       });
     });
 
-    it('should throw with detailed error when loginOption equals current device type', async () => {
-      webex.cc.webCallingService.loginOption = LoginOption.BROWSER;
+    it('should allow update when loginOption and teamId are unchanged (e.g. dialNumber or profile refresh)', async () => {
+      webex.cc.webCallingService.loginOption = LoginOption.AGENT_DN;
       const data = {
         teamId: 'teamId',
-        loginOption: LoginOption.BROWSER,
-        dialNumber: '',
+        loginOption: LoginOption.AGENT_DN,
+        dialNumber: '1234',
       };
-      const expectedMessage =
-        'Will not proceed with device update as new Device type is same as current device type and teamId is same as current teamId';
+      const logoutSpy = jest.spyOn(webex.cc, 'stationLogout').mockResolvedValue({});
+      const loginSpy = jest.spyOn(webex.cc, 'stationLogin').mockResolvedValue({
+        type: 'AgentDeviceTypeUpdateSuccess',
+      } as any);
 
-      await expect(webex.cc.updateAgentProfile(data)).rejects.toMatchObject({
-        message: expectedMessage,
-        details: expect.objectContaining({
-          data: expect.objectContaining({
-            agentId: webex.cc.agentConfig.agentId,
-            reason: expectedMessage,
-          }),
-        }),
+      await expect(webex.cc.updateAgentProfile(data)).resolves.toBeDefined();
+      expect(logoutSpy).toHaveBeenCalledWith({
+        logoutReason: 'User requested agent profile update',
+      });
+      expect(loginSpy).toHaveBeenCalledWith({
+        teamId: data.teamId,
+        loginOption: data.loginOption,
+        dialNumber: data.dialNumber,
       });
     });
 
@@ -2104,7 +2106,9 @@ describe('webex.cc', () => {
       const detailedError = new Error('Detailed service error');
       getErrorDetailsSpy.mockReturnValue({error: detailedError});
 
-      await expect(webex.cc.getOutdialAniEntries(mockParams)).rejects.toThrow('Detailed service error');
+      await expect(webex.cc.getOutdialAniEntries(mockParams)).rejects.toThrow(
+        'Detailed service error'
+      );
 
       // Verify failure metrics are tracked
       expect(mockMetricsManager.trackEvent).toHaveBeenCalledWith(
@@ -2128,11 +2132,7 @@ describe('webex.cc', () => {
       );
 
       // Verify getErrorDetails was called
-      expect(getErrorDetailsSpy).toHaveBeenCalledWith(
-        mockError,
-        'getOutdialAniEntries',
-        CC_FILE
-      );
+      expect(getErrorDetailsSpy).toHaveBeenCalledWith(mockError, 'getOutdialAniEntries', CC_FILE);
     });
 
     it('should throw error when orgId is not found', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [CAI-7460](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7460)

## This pull request addresses

The WxCC SDK was blocking update profile if the device type or team remained un changed. This is not in parity with agent desktop.

## by making the following changes

* Removed the condition that checks if the change was not in device type or team
* Updated the test case as well
* Changed the error message

## Vidcast

https://app.vidcast.io/share/63f743f3-ee0c-49ea-928b-bce5bd015043

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
* Tested the SDK and existing widgets side by side to see whatever was changed in the SDK is affected in the Widgets
* Locally linked the SDK to Widgets repo and tested that Widgets is able to update the Dial Number or Extension

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
