### PR TITLE
fix(ai-assistant): remove mercury disconnect on deregister

### DIFF
--- a/packages/@webex/internal-plugin-ai-assistant/src/ai-assistant.ts
+++ b/packages/@webex/internal-plugin-ai-assistant/src/ai-assistant.ts
@@ -105,10 +105,10 @@ const AIAssistant = WebexPlugin.extend({
 
     this.stopListeningForEvents();
 
-    return this.webex.internal.mercury.disconnect().then(() => {
-      this.trigger(AI_ASSISTANT_UNREGISTERED);
-      this.registered = false;
-    });
+    this.trigger(AI_ASSISTANT_UNREGISTERED);
+    this.registered = false;
+
+    return Promise.resolve();
   },
 
   /**

--- a/packages/@webex/internal-plugin-ai-assistant/test/unit/spec/ai-assistant.ts
+++ b/packages/@webex/internal-plugin-ai-assistant/test/unit/spec/ai-assistant.ts
@@ -16,7 +16,12 @@ import {
   AI_ASSISTANT_ERROR_CODES,
   AI_ASSISTANT_ERRORS,
 } from '@webex/internal-plugin-ai-assistant/src/constants';
-import {jsonResponse, messageResponse, workspaceResponse, scheduleMeetingResponse} from '../data/messages';
+import {
+  jsonResponse,
+  messageResponse,
+  workspaceResponse,
+  scheduleMeetingResponse,
+} from '../data/messages';
 
 const waitForAsync = () =>
   new Promise<void>((resolve) =>
@@ -130,7 +135,6 @@ describe('plugin-ai-assistant', () => {
         const result = await webex.internal.aiAssistant.unregister();
 
         expect(result).to.be.undefined;
-        assert.callCount(webex.internal.mercury.disconnect, 0);
         assert.equal(webex.internal.aiAssistant.registered, false);
       });
     });
@@ -332,9 +336,7 @@ describe('plugin-ai-assistant', () => {
           responseType: 'thought',
         };
         expect(triggerSpy.getCall(1).args[0]).to.deep.equal('aiassistant:stream:test-request-id');
-        expect(triggerSpy.getCall(1).args[1]).to.deep.equal(
-          expectedResult
-        );
+        expect(triggerSpy.getCall(1).args[1]).to.deep.equal(expectedResult);
 
         triggerSpy.resetHistory();
 
@@ -443,7 +445,8 @@ describe('plugin-ai-assistant', () => {
             type: 'json',
             encryptionKeyUrl: 'kms://kms-us.wbx2.com/keys/9565506d-78b1-4742-b0fd-63719748282e',
             value: {
-              value: 'decrypted-with-kms://kms-us.wbx2.com/keys/9565506d-78b1-4742-b0fd-63719748282e-json_3_encrypted_value',
+              value:
+                'decrypted-with-kms://kms-us.wbx2.com/keys/9565506d-78b1-4742-b0fd-63719748282e-json_3_encrypted_value',
               type: 'markdown',
             },
           },
@@ -574,12 +577,10 @@ describe('plugin-ai-assistant', () => {
         // Update the clientRequestId to match the test setup
         const firstEvent = cloneDeep(workspaceResponse[0]);
         firstEvent.clientRequestId = 'test-request-id';
-        
+
         await webex.internal.aiAssistant._handleEvent(firstEvent);
 
-        expect(triggerSpy.getCall(0).args[0]).to.equal(
-          `aiassistant:result:test-request-id`
-        );
+        expect(triggerSpy.getCall(0).args[0]).to.equal(`aiassistant:result:test-request-id`);
 
         await waitForAsync();
 
@@ -594,7 +595,7 @@ describe('plugin-ai-assistant', () => {
         // second event is another workspace chunk with an encrypted value
         const secondEvent = cloneDeep(workspaceResponse[1]);
         secondEvent.clientRequestId = 'test-request-id';
-        
+
         await webex.internal.aiAssistant._handleEvent(secondEvent);
 
         expectedResult = set(
@@ -604,7 +605,7 @@ describe('plugin-ai-assistant', () => {
         );
 
         expect(triggerSpy.getCall(2).args[1]).to.deep.equal(expectedResult);
-      });      
+      });
 
       it('handles a schedule meeting response', async () => {
         const triggerSpy = sinon.spy(webex.internal.aiAssistant, 'trigger');
@@ -620,30 +621,28 @@ describe('plugin-ai-assistant', () => {
         // Handle schedule meeting event with encrypted fields
         const event = cloneDeep(scheduleMeetingResponse[0]);
         event.clientRequestId = 'test-request-id';
-        
+
         await webex.internal.aiAssistant._handleEvent(event);
 
-        expect(triggerSpy.getCall(0).args[0]).to.equal(
-          `aiassistant:result:test-request-id`
-        );
+        expect(triggerSpy.getCall(0).args[0]).to.equal(`aiassistant:result:test-request-id`);
 
         await waitForAsync();
 
         // Verify all encrypted fields were decrypted
         const expectedResult = cloneDeep(event);
-        expectedResult.response.content.parameters.commentary = 
+        expectedResult.response.content.parameters.commentary =
           'decrypted-with-kms://kms-cisco.wbx2.com/keys/dd6053f0-a1b3-428d-8104-317527d73630-schedule_meeting_encrypted_commentary';
-        expectedResult.response.content.value.results.data.attendees[0].email = 
+        expectedResult.response.content.value.results.data.attendees[0].email =
           'decrypted-with-kms://kms-cisco.wbx2.com/keys/dd6053f0-a1b3-428d-8104-317527d73630-schedule_meeting_encrypted_email_0';
-        expectedResult.response.content.value.results.data.attendees[1].email = 
+        expectedResult.response.content.value.results.data.attendees[1].email =
           'decrypted-with-kms://kms-cisco.wbx2.com/keys/dd6053f0-a1b3-428d-8104-317527d73630-schedule_meeting_encrypted_email_1';
-        expectedResult.response.content.value.results.data.title = 
+        expectedResult.response.content.value.results.data.title =
           'decrypted-with-kms://kms-cisco.wbx2.com/keys/dd6053f0-a1b3-428d-8104-317527d73630-schedule_meeting_encrypted_title';
-        expectedResult.response.content.value.results.data.description = 
+        expectedResult.response.content.value.results.data.description =
           'decrypted-with-kms://kms-cisco.wbx2.com/keys/dd6053f0-a1b3-428d-8104-317527d73630-schedule_meeting_encrypted_description';
-        expectedResult.response.content.value.results.data.inScopeReply = 
+        expectedResult.response.content.value.results.data.inScopeReply =
           'decrypted-with-kms://kms-cisco.wbx2.com/keys/dd6053f0-a1b3-428d-8104-317527d73630-schedule_meeting_encrypted_inScopeReply';
-        expectedResult.response.content.value.results.data.meetingLink = 
+        expectedResult.response.content.value.results.data.meetingLink =
           'decrypted-with-kms://kms-cisco.wbx2.com/keys/dd6053f0-a1b3-428d-8104-317527d73630-schedule_meeting_encrypted_meetingLink';
 
         expect(triggerSpy.getCall(0).args[1]).to.deep.equal(expectedResult);
@@ -830,7 +829,8 @@ describe('plugin-ai-assistant', () => {
             id: 'test-message-id',
             url: 'https://assistant-api-a.wbx2.com:443/assistant-api/api/v1/sessions/test-session-id/messages/test-message-id',
             sessionId: 'test-session-id',
-            sessionUrl: 'https://assistant-api-a.wbx2.com:443/assistant-api/api/v1/sessions/test-session-id',
+            sessionUrl:
+              'https://assistant-api-a.wbx2.com:443/assistant-api/api/v1/sessions/test-session-id',
             creatorId: 'test-creator-id',
             createdAt: '2025-08-05T02:11:12.361Z',
           },
@@ -867,7 +867,7 @@ describe('plugin-ai-assistant', () => {
         // Verify the request was made correctly
         expect(webex.request.calledOnce).to.be.true;
         const requestArgs = webex.request.getCall(0).args[0];
-        
+
         expect(requestArgs.service).to.equal('assistant-api');
         expect(requestArgs.resource).to.equal('sessions/test-session-id/messages');
         expect(requestArgs.method).to.equal('POST');
@@ -901,7 +901,8 @@ describe('plugin-ai-assistant', () => {
           id: 'test-message-id',
           url: 'https://assistant-api-a.wbx2.com:443/assistant-api/api/v1/sessions/test-session-id/messages/test-message-id',
           sessionId: 'test-session-id',
-          sessionUrl: 'https://assistant-api-a.wbx2.com:443/assistant-api/api/v1/sessions/test-session-id',
+          sessionUrl:
+            'https://assistant-api-a.wbx2.com:443/assistant-api/api/v1/sessions/test-session-id',
           creatorId: 'test-creator-id',
           createdAt: '2025-08-05T02:11:12.361Z',
           requestId: 'custom-request-id',
@@ -1003,7 +1004,7 @@ describe('plugin-ai-assistant', () => {
         // Should use the UUID stub
         expect(result.requestId).to.equal('test-request-id');
         expect(result.streamEventName).to.equal('aiassistant:stream:test-request-id');
-        
+
         const requestArgs = webex.request.getCall(0).args[0];
         expect(requestArgs.body.clientRequestId).to.equal('test-request-id');
       });
@@ -1065,9 +1066,9 @@ describe('plugin-ai-assistant', () => {
           contentValue: 'test_action',
         };
 
-        await expect(
-          webex.internal.aiAssistant.makeAiAssistantRequest(options)
-        ).to.be.rejectedWith('Network error');
+        await expect(webex.internal.aiAssistant.makeAiAssistantRequest(options)).to.be.rejectedWith(
+          'Network error'
+        );
       });
 
       it('starts timer when making a request', async () => {
@@ -1087,7 +1088,7 @@ describe('plugin-ai-assistant', () => {
 
       it('handles timeout when no streaming response comes back', async () => {
         const triggerSpy = sinon.spy(webex.internal.aiAssistant, 'trigger');
-        
+
         const options = {
           sessionId: 'test-session-id',
           encryptionKeyUrl: 'test-key-url',
@@ -1105,10 +1106,13 @@ describe('plugin-ai-assistant', () => {
 
         // Should trigger timeout event on the stream
         expect(triggerSpy.calledWith('aiassistant:stream:test-request-id')).to.be.true;
-        const timeoutCall = triggerSpy.getCalls().find(call => 
-          call.args[0] === 'aiassistant:stream:test-request-id' &&
-          call.args[1].errorMessage === AI_ASSISTANT_ERRORS.AI_ASSISTANT_TIMEOUT
-        );
+        const timeoutCall = triggerSpy
+          .getCalls()
+          .find(
+            (call) =>
+              call.args[0] === 'aiassistant:stream:test-request-id' &&
+              call.args[1].errorMessage === AI_ASSISTANT_ERRORS.AI_ASSISTANT_TIMEOUT
+          );
         expect(timeoutCall).to.exist;
         expect(timeoutCall.args[1]).to.deep.include({
           requestId: 'test-request-id',
@@ -1121,7 +1125,7 @@ describe('plugin-ai-assistant', () => {
       it('resets timer when streaming responses are received', async () => {
         const timerResetSpy = sinon.spy(Timer.prototype, 'reset');
         const timerCancelSpy = sinon.spy(Timer.prototype, 'cancel');
-        
+
         const options = {
           sessionId: 'test-session-id',
           encryptionKeyUrl: 'test-key-url',

--- a/packages/@webex/internal-plugin-dss/src/dss.ts
+++ b/packages/@webex/internal-plugin-dss/src/dss.ts
@@ -105,10 +105,10 @@ const DSS = WebexPlugin.extend({
 
     this.stopListeningForEvents();
 
-    return this.webex.internal.mercury.disconnect().then(() => {
-      this.trigger(DSS_UNREGISTERED);
-      this.registered = false;
-    });
+    this.trigger(DSS_UNREGISTERED);
+    this.registered = false;
+
+    return Promise.resolve();
   },
 
   /**

--- a/packages/@webex/internal-plugin-dss/test/unit/spec/dss.ts
+++ b/packages/@webex/internal-plugin-dss/test/unit/spec/dss.ts
@@ -764,12 +764,18 @@ describe('plugin-dss', () => {
       const PHONE_1 = '+15551234567';
       const PHONE_2 = '+442012345678';
       const PHONE_3 = '+33123456789';
-      const PHONE_BATCH = ['+15551111111', '+15552222222', '+15553333333', '+15554444444', '+15555555555'];
-      
+      const PHONE_BATCH = [
+        '+15551111111',
+        '+15552222222',
+        '+15553333333',
+        '+15554444444',
+        '+15555555555',
+      ];
+
       const ENTITY_1 = {id: 'user1', displayName: 'John Doe', phoneNumbers: [PHONE_1]};
       const ENTITY_2 = {id: 'user2', displayName: 'Jane Smith', phoneNumbers: [PHONE_2]};
       const ENTITY_3 = {id: 'user3', phoneNumbers: [PHONE_3]};
-      
+
       const EMPTY_RESULT = {
         resultArray: [],
         foundArray: [],
@@ -818,7 +824,7 @@ describe('plugin-dss', () => {
 
       it('works correctly with multiple phone numbers, some found', async () => {
         const phoneNumbers = [PHONE_1, PHONE_2, PHONE_3];
-        
+
         const {requestId, promise} = await testMakeRequest({
           method: 'lookupByPhoneNumbers',
           resource: '/lookup/orgid/userOrgId/phonenumbers',
@@ -844,7 +850,7 @@ describe('plugin-dss', () => {
 
       it('works correctly with all phone numbers not found', async () => {
         const phoneNumbers = [PHONE_1, PHONE_2];
-        
+
         const {requestId, promise} = await testMakeRequest({
           method: 'lookupByPhoneNumbers',
           resource: '/lookup/orgid/userOrgId/phonenumbers',
@@ -977,7 +983,7 @@ describe('plugin-dss', () => {
 
       it('fails with timeout when request only partially resolved', async () => {
         const phoneNumbers = [PHONE_1, PHONE_2];
-        
+
         const {requestId, promise} = await testMakeRequest({
           method: 'lookupByPhoneNumbers',
           resource: '/lookup/orgid/userOrgId/phonenumbers',


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Both the dss plugin and the ai-assistant plugin unregister functions disconnect mercury. Calling .disconnect without the code 3050 will cause an immediate reconnection.

## by making the following changes

Remove the mercury disconnection. It is generally not what we want. A plugin might bring up mercury because mercury is a prerequisite, but that doesn't mean it should disconnect mercury if the plugin is unregistered as many other plugins may be using it.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
