### PR TITLE
Revert "fix(calling): add .js extensions to ESM output for Node.js co…

### DIFF
--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -25,8 +25,8 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "tsc && tsc-alias --resolve-full-paths",
-    "build:src": "tsc && tsc-alias --resolve-full-paths",
+    "build": "tsc",
+    "build:src": "tsc",
     "test:unit": "jest --config=jest.config.js --runInBand",
     "test:style": "eslint 'src/**/*.ts'",
     "fix:lint": "eslint 'src/**/*.ts' --fix",
@@ -99,7 +99,6 @@
     "rollup-plugin-typescript2": "0.31.2",
     "sinon": "12.0.1",
     "ts-jest": "27.1.4",
-    "tsc-alias": "^1.8.16",
     "typed-emitter": "2.1.0",
     "typedoc": "0.23.26",
     "typescript": "4.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7438,7 +7438,6 @@ __metadata:
     rollup-plugin-typescript2: 0.31.2
     sinon: 12.0.1
     ts-jest: 27.1.4
-    tsc-alias: ^1.8.16
     typed-emitter: 2.1.0
     typedoc: 0.23.26
     typescript: 4.9.5
@@ -18676,15 +18675,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.10.0":
-  version: 4.13.6
-  resolution: "get-tsconfig@npm:4.13.6"
-  dependencies:
-    resolve-pkg-maps: ^1.0.0
-  checksum: 946575897a75b3de39905a8e95fe761b1ae9a595c8608c3982fa3a5748ed0d6441c799197a99fee27876cd8c5a2158418ad6e88d8008ec1244639c0f5ee2a2d8
-  languageName: node
-  linkType: hard
-
 "get-tsconfig@npm:^4.8.1":
   version: 4.13.0
   resolution: "get-tsconfig@npm:4.13.0"
@@ -19061,7 +19051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.4, globby@npm:^11.1.0":
+"globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -25801,13 +25791,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mylas@npm:^2.1.9":
-  version: 2.1.14
-  resolution: "mylas@npm:2.1.14"
-  checksum: 25616a33d6bfa332937b5dff3949d1fa6b57bd4c532870d47332982c3e19c1c249973f1d47b048506922a0ea8bbbd7023b8bff27088d3e7982145448a5dacb6a
-  languageName: node
-  linkType: hard
-
 "mz@npm:^2.7.0":
   version: 2.7.0
   resolution: "mz@npm:2.7.0"
@@ -27546,15 +27529,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"plimit-lit@npm:^1.2.6":
-  version: 1.6.1
-  resolution: "plimit-lit@npm:1.6.1"
-  dependencies:
-    queue-lit: ^1.5.1
-  checksum: 5f18f1ea7254832bdc663c303420c804b5bc8070c670c88161171f0ebacaf46ce7ca12147ddf52bc22d927bb37bfbac6ed6fa478c93cb4be16b62c5fad16dd5f
-  languageName: node
-  linkType: hard
-
 "plist@npm:3.1.0":
   version: 3.1.0
   resolution: "plist@npm:3.1.0"
@@ -28168,13 +28142,6 @@ __metadata:
   version: 2.2.0
   resolution: "querystringify@npm:2.2.0"
   checksum: 5641ea231bad7ef6d64d9998faca95611ed4b11c2591a8cae741e178a974f6a8e0ebde008475259abe1621cb15e692404e6b6626e927f7b849d5c09392604b15
-  languageName: node
-  linkType: hard
-
-"queue-lit@npm:^1.5.1":
-  version: 1.5.2
-  resolution: "queue-lit@npm:1.5.2"
-  checksum: 8dd45c79bd25b33b0c7d587391eb0b4acc4deb797bf92fef62b2d8e7c03b64083f5304f09d52a18267d34d020cc67ccde97a88185b67590eeccb194938ff1f98
   languageName: node
   linkType: hard
 
@@ -32226,23 +32193,6 @@ __metadata:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: 96d633774e13eb90ad49d644f397e99f5da72818e36040bf5b6bd66d0ab369dbb4348e499193c0fa45071f8e9559bb7724174139389e56bb562db36a3842484e
-  languageName: node
-  linkType: hard
-
-"tsc-alias@npm:^1.8.16":
-  version: 1.8.16
-  resolution: "tsc-alias@npm:1.8.16"
-  dependencies:
-    chokidar: ^3.5.3
-    commander: ^9.0.0
-    get-tsconfig: ^4.10.0
-    globby: ^11.0.4
-    mylas: ^2.1.9
-    normalize-path: ^3.0.0
-    plimit-lit: ^1.2.6
-  bin:
-    tsc-alias: dist/bin/index.js
-  checksum: 7bae356371fbd110768d0865d6740f670128f192a409901b698ea4d6787bb942282148faed4bb753c420cb94df016ac0d9da63b8bb28d7c83fcf83d658150616
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
TypeScript's tsc compiler does not add file extensions to relative imports when outputting ESM. Node.js native ESM resolution requires explicit .js extensions, causing failures in tools like Vite and Vitest that rely on native ESM.

Added tsc-alias with --resolve-full-paths as a post-build step to automatically append .js extensions to all relative imports and resolve bare directory imports to explicit index.js paths.

This unblocks downstream consumers that use ESM-native tooling.

# COMPLETES #N/A (no existing issue)

## This pull request addresses

The `@webex/calling` package outputs ESM via `tsc` (TypeScript compiler) with `"module": "es2020"` in [tsconfig.json](cci:7://file:///Users/jnestor/dev/webex-js-sdk/packages/calling/tsconfig.json:0:0-0:0). However, `tsc` does not add `.js` file extensions to relative imports in the compiled output. Node.js native ESM resolution **requires** explicit `.js` extensions on relative imports, causing resolution failures in downstream consumers that use ESM-native tooling such as Vite, Vitest, or Node.js with `--experimental-vm-modules`.

For example, the compiled `dist/module/index.js` contained:
```javascript
import { createClient } from './CallingClient/CallingClient';  // ❌ Missing .js
```

This causes `ERR_MODULE_NOT_FOUND` errors when consumed by any tool using native ESM resolution.

## by making the following changes

Added `tsc-alias` as a devDependency and appended `tsc-alias --resolve-full-paths` as a post-build step to the `build` and `build:src` scripts. This automatically:

1. Appends `.js` extensions to all relative import paths (e.g., `'./CallingClient/CallingClient'` → `'./CallingClient/CallingClient.js'`)
2. Resolves bare directory imports to explicit [index.js](cci:7://file:///Users/jnestor/dev/wxcc-desktop2/packages/agentx-services/dist/index.js:0:0-0:0) paths (e.g., `'./Logger'` → `'./Logger/index.js'`)

No source files are modified. External package imports (e.g., [@webex/media-helpers](cci:9://file:///Users/jnestor/dev/webex-js-sdk/packages/@webex/media-helpers:0:0-0:0)) are left untouched.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

1. **Clean build verification**: Ran `rimraf dist && tsc && tsc-alias --resolve-full-paths` and confirmed all `.js` files in `dist/module/` have correct `.js` extensions on relative imports.
2. **Diff verification**: Compared `tsc` output before and after `tsc-alias` — the only difference is the addition of `.js` extensions and resolution of directory imports to [index.js](cci:7://file:///Users/jnestor/dev/wxcc-desktop2/packages/agentx-services/dist/index.js:0:0-0:0).

## The GAI Coding Policy And Copyright Annotation Best Practices

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Windsurf Cascade
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly