### PR TITLE
Esm build fix

### DIFF
--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -10,8 +10,8 @@
     "Shreyas Sharma (shreysh2@cisco.com)",
     "Sreekanth Narayanan (sreenara@cisco.com)"
   ],
-  "main": "dist/module/index.js",
-  "module": "dist/module/index.js",
+  "main": "dist/esm/index.js",
+  "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
   "license": "MIT",
   "author": "devsupport@webex.com",
@@ -25,8 +25,8 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "tsc",
-    "build:src": "tsc",
+    "build": "rollup -c rollup.config.mjs",
+    "build:src": "rollup -c rollup.config.mjs",
     "test:unit": "jest --config=jest.config.js --runInBand",
     "test:style": "eslint 'src/**/*.ts'",
     "fix:lint": "eslint 'src/**/*.ts' --fix",

--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -10,9 +10,16 @@
     "Shreyas Sharma (shreysh2@cisco.com)",
     "Sreekanth Narayanan (sreenara@cisco.com)"
   ],
-  "main": "dist/module/index.js",
-  "module": "dist/module/index.js",
-  "types": "dist/types/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/esm/types/index.d.ts"
+    }
+  },
   "license": "MIT",
   "author": "devsupport@webex.com",
   "repository": {

--- a/packages/calling/package.json
+++ b/packages/calling/package.json
@@ -10,8 +10,8 @@
     "Shreyas Sharma (shreysh2@cisco.com)",
     "Sreekanth Narayanan (sreenara@cisco.com)"
   ],
-  "main": "dist/esm/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/module/index.js",
+  "module": "dist/module/index.js",
   "types": "dist/types/index.d.ts",
   "license": "MIT",
   "author": "devsupport@webex.com",

--- a/packages/calling/rollup.config.mjs
+++ b/packages/calling/rollup.config.mjs
@@ -1,0 +1,45 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from 'rollup-plugin-typescript2';
+import json from '@rollup/plugin-json';
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    dir: 'dist/esm',
+    format: 'esm',
+    preserveModules: true,
+    preserveModulesRoot: 'src',
+    entryFileNames: '[name].js',
+  },
+  external: [
+    '@webex/internal-media-core',
+    '@webex/internal-plugin-metrics',
+    '@webex/media-helpers',
+    'events',
+    'uuid',
+    'buffer',
+    'platform',
+    'async-mutex',
+    'xstate',
+  ],
+  plugins: [
+    resolve({
+      extensions: ['.ts', '.js'],
+    }),
+    commonjs(),
+    json(),
+    typescript({
+      tsconfig: './tsconfig.json',
+      useTsconfigDeclarationDir: true,
+      tsconfigOverride: {
+        compilerOptions: {
+          declaration: true,
+          declarationDir: 'dist/types',
+          outDir: 'dist/esm',
+        },
+        exclude: ['**/*.test.ts', 'node_modules'],
+      },
+    }),
+  ],
+};

--- a/packages/calling/rollup.config.mjs
+++ b/packages/calling/rollup.config.mjs
@@ -3,43 +3,64 @@ import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import json from '@rollup/plugin-json';
 
-export default {
-  input: 'src/index.ts',
-  output: {
-    dir: 'dist/module',
-    format: 'esm',
-    preserveModules: true,
-    preserveModulesRoot: 'src',
-    entryFileNames: '[name].js',
-  },
-  external: [
-    '@webex/internal-media-core',
-    '@webex/internal-plugin-metrics',
-    '@webex/media-helpers',
-    'events',
-    'uuid',
-    'buffer',
-    'platform',
-    'async-mutex',
-    'xstate',
-  ],
-  plugins: [
-    resolve({
-      extensions: ['.ts', '.js'],
-    }),
-    commonjs(),
-    json(),
-    typescript({
-      tsconfig: './tsconfig.json',
-      useTsconfigDeclarationDir: true,
-      tsconfigOverride: {
-        compilerOptions: {
-          declaration: true,
-          declarationDir: 'dist/types',
-          outDir: 'dist/module',
-        },
-        exclude: ['**/*.test.ts', 'node_modules'],
+const external = [
+  '@webex/internal-media-core',
+  '@webex/internal-plugin-metrics',
+  '@webex/media-helpers',
+  'events',
+  'uuid',
+  'buffer',
+  'platform',
+  'async-mutex',
+  'xstate',
+];
+
+const plugins = [
+  resolve({
+    extensions: ['.ts', '.js'],
+  }),
+  commonjs(),
+  json(),
+];
+
+const tsPlugin = (declarationDir, outDir) =>
+  typescript({
+    tsconfig: './tsconfig.json',
+    useTsconfigDeclarationDir: true,
+    tsconfigOverride: {
+      compilerOptions: {
+        declaration: true,
+        declarationDir,
+        outDir,
       },
-    }),
-  ],
-};
+      exclude: ['**/*.test.ts', 'node_modules'],
+    },
+  });
+
+export default [
+  {
+    input: 'src/index.ts',
+    output: {
+      dir: 'dist/esm',
+      format: 'esm',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+      entryFileNames: '[name].js',
+    },
+    external,
+    plugins: [...plugins, tsPlugin('dist/esm/types', 'dist/esm')],
+  },
+  {
+    input: 'src/index.ts',
+    output: {
+      dir: 'dist/cjs',
+      format: 'cjs',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+      entryFileNames: '[name].js',
+      exports: 'auto',
+    },
+    external,
+    plugins: [...plugins, tsPlugin('dist/cjs/types', 'dist/cjs')],
+  },
+];

--- a/packages/calling/rollup.config.mjs
+++ b/packages/calling/rollup.config.mjs
@@ -6,7 +6,7 @@ import json from '@rollup/plugin-json';
 export default {
   input: 'src/index.ts',
   output: {
-    dir: 'dist/esm',
+    dir: 'dist/module',
     format: 'esm',
     preserveModules: true,
     preserveModulesRoot: 'src',
@@ -36,7 +36,7 @@ export default {
         compilerOptions: {
           declaration: true,
           declarationDir: 'dist/types',
-          outDir: 'dist/esm',
+          outDir: 'dist/module',
         },
         exclude: ['**/*.test.ts', 'node_modules'],
       },

--- a/packages/calling/tsconfig.json
+++ b/packages/calling/tsconfig.json
@@ -71,15 +71,27 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
   "typedocOptions": {
-    "entryPoints": ["./src/api.ts"],
-    "sort": ["source-order"],
+    "entryPoints": [
+      "./src/api.ts"
+    ],
+    "sort": [
+      "source-order"
+    ],
     "name": "Calling SDK (@webex/calling)",
     "disableSources": "true",
     "entryPointStrategy": "expand",
     "excludeExternals": "true",
     "excludePrivate": "true",
-    "hideGenerator": "true"
+    "hideGenerator": "true",
   },
-  "include": ["src/**/*.ts", "jest.global.d.ts"],
-  "exclude": ["./node_modules/**", "./test", "./docs/examples", "./src/**/*.test.ts"]
+  "include": [
+    "src/**/*.ts",
+    "jest.global.d.ts"
+  ],
+  "exclude": [
+    "./node_modules/**",
+    "./test",
+    "./docs/examples",
+    "./src/**/*.test.ts"
+  ]
 }

--- a/packages/calling/tsconfig.json
+++ b/packages/calling/tsconfig.json
@@ -71,27 +71,15 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
   "typedocOptions": {
-    "entryPoints": [
-      "./src/api.ts"
-    ],
-    "sort": [
-      "source-order"
-    ],
+    "entryPoints": ["./src/api.ts"],
+    "sort": ["source-order"],
     "name": "Calling SDK (@webex/calling)",
     "disableSources": "true",
     "entryPointStrategy": "expand",
     "excludeExternals": "true",
     "excludePrivate": "true",
-    "hideGenerator": "true",
+    "hideGenerator": "true"
   },
-  "include": [
-    "src/**/*.ts",
-    "jest.global.d.ts"
-  ],
-  "exclude": [
-    "./node_modules/**",
-    "./test",
-    "./docs/examples",
-    "./src/**/*.test.ts"
-  ]
+  "include": ["src/**/*.ts", "jest.global.d.ts"],
+  "exclude": ["./node_modules/**", "./test", "./docs/examples", "./src/**/*.test.ts"]
 }


### PR DESCRIPTION
# COMPLETES #4706

## This pull request addresses

The `@webex/calling` package outputs ESM files without `.js` extensions on relative imports, which breaks native ESM resolution in tools like Vite, Vitest, and Node.js ESM mode. This was causing build failures in downstream consumers attempting to use modern bundlers.

## by making the following changes

- Added a Rollup configuration ([rollup.config.mjs](cci:7://file:///Users/jnestor/dev/webex-js-sdk/packages/calling/rollup.config.mjs:0:0-0:0)) to build the package instead of using plain `tsc`
- Updated the build scripts in [package.json](cci:7://file:///Users/jnestor/dev/webex-js-sdk/packages/calling/package.json:0:0-0:0) to use Rollup
- Rollup automatically adds `.js` extensions to relative imports in the ESM output, making the package compatible with strict ESM resolvers

**No changes to source files required** - Rollup handles the extension addition during the build process.

**No breaking changes for consumers** - The output path (`dist/module/`) and package entry points remain unchanged.

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- `yarn build` in `packages/calling` - builds successfully, outputs ESM with `.js` extensions
- `yarn samples:build` from repo root - calling sample bundle builds successfully
- Verified `dist/module/index.js` contains proper `.js` extensions on all relative imports

## The GAI Coding Policy And Copyright Annotation Best Practices

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify: Windsurf Cascade
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly