### PR TITLE
feat(meetings): added support for heartbeatIntervalMs in webinars

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -29,6 +29,7 @@ export interface HashTreeMessage {
   locusStateElements?: Array<HashTreeObject>;
   locusSessionId?: string;
   locusUrl: string;
+  heartbeatIntervalMs?: number;
 }
 
 export interface VisibleDataSetInfo {
@@ -45,6 +46,7 @@ export interface Metadata {
 interface InternalDataSet extends DataSet {
   hashTree?: HashTree; // set only for visible data sets
   timer?: ReturnType<typeof setTimeout>;
+  heartbeatWatchdogTimer?: ReturnType<typeof setTimeout>;
 }
 
 type WebexRequestMethod = (options: Record<string, any>) => Promise<any>;
@@ -88,6 +90,7 @@ class HashTreeParser {
   locusInfoUpdateCallback: LocusInfoUpdateCallback;
   visibleDataSets: VisibleDataSetInfo[];
   debugId: string;
+  heartbeatIntervalMs?: number;
 
   /**
    * Constructor for HashTreeParser
@@ -726,10 +729,14 @@ class HashTreeParser {
   private deleteHashTree(dataSetName: string) {
     this.dataSets[dataSetName].hashTree = undefined;
 
-    // we also need to stop the timer as there is no hash tree anymore to sync
+    // we also need to stop the timers as there is no hash tree anymore to sync
     if (this.dataSets[dataSetName].timer) {
       clearTimeout(this.dataSets[dataSetName].timer);
       this.dataSets[dataSetName].timer = undefined;
+    }
+    if (this.dataSets[dataSetName].heartbeatWatchdogTimer) {
+      clearTimeout(this.dataSets[dataSetName].heartbeatWatchdogTimer);
+      this.dataSets[dataSetName].heartbeatWatchdogTimer = undefined;
     }
   }
 
@@ -1005,10 +1012,19 @@ class HashTreeParser {
    * @returns {void}
    */
   async handleMessage(message: HashTreeMessage, debugText?: string): Promise<void> {
+    if (message.heartbeatIntervalMs) {
+      this.heartbeatIntervalMs = message.heartbeatIntervalMs;
+    }
     if (message.locusStateElements === undefined) {
       this.handleRootHashHeartBeatMessage(message);
+      this.resetHeartbeatWatchdogs(message.dataSets);
     } else {
       const updates = await this.parseMessage(message, debugText);
+
+      // Only reset watchdogs if the meeting hasn't ended
+      if (updates.updateType !== LocusInfoUpdateType.MEETING_ENDED) {
+        this.resetHeartbeatWatchdogs(message.dataSets);
+      }
 
       this.callLocusInfoUpdateCallback(updates);
     }
@@ -1088,6 +1104,75 @@ class HashTreeParser {
   }
 
   /**
+   * Performs a sync for the given data set.
+   *
+   * @param {InternalDataSet} dataSet - The data set to sync
+   * @param {string} rootHash - Our current root hash for this data set
+   * @param {string} reason - The reason for the sync (used for logging)
+   * @returns {Promise<void>}
+   */
+  private async performSync(
+    dataSet: InternalDataSet,
+    rootHash: string,
+    reason: string
+  ): Promise<void> {
+    if (!dataSet.hashTree) {
+      return;
+    }
+
+    LoggerProxy.logger.info(
+      `HashTreeParser#performSync --> ${this.debugId} ${reason}, syncing data set "${dataSet.name}"`
+    );
+
+    const mismatchedLeavesData: Record<number, LeafDataItem[]> = {};
+
+    if (dataSet.leafCount !== 1) {
+      let receivedHashes;
+
+      try {
+        // request hashes from sender
+        const {hashes, dataSet: latestDataSetInfo} = await this.getHashesFromLocus(
+          dataSet.name,
+          rootHash
+        );
+
+        receivedHashes = hashes;
+
+        dataSet.hashTree.resize(latestDataSetInfo.leafCount);
+      } catch (error) {
+        if (error.statusCode === 409) {
+          // this is a leaf count mismatch, we should do nothing, just wait for another heartbeat message from Locus
+          LoggerProxy.logger.info(
+            `HashTreeParser#getHashesFromLocus --> ${this.debugId} Got 409 when fetching hashes for data set "${dataSet.name}": ${error.message}`
+          );
+
+          return;
+        }
+        throw error;
+      }
+
+      // identify mismatched leaves
+      const mismatchedLeaveIndexes = dataSet.hashTree.diffHashes(receivedHashes);
+
+      mismatchedLeaveIndexes.forEach((index) => {
+        mismatchedLeavesData[index] = dataSet.hashTree.getLeafData(index);
+      });
+    } else {
+      mismatchedLeavesData[0] = dataSet.hashTree.getLeafData(0);
+    }
+    // request sync for mismatched leaves
+    if (Object.keys(mismatchedLeavesData).length > 0) {
+      const syncResponse = await this.sendSyncRequestToLocus(dataSet, mismatchedLeavesData);
+
+      // sync API may return nothing (in that case data will arrive via messages)
+      // or it may return a response in the same format as messages
+      if (syncResponse) {
+        this.handleMessage(syncResponse, 'via sync API');
+      }
+    }
+  }
+
+  /**
    * Runs the sync algorithm for the given data set.
    *
    * @param {DataSet} receivedDataSet - The data set to run the sync algorithm for.
@@ -1145,56 +1230,11 @@ class HashTreeParser {
         const rootHash = dataSet.hashTree.getRootHash();
 
         if (dataSet.root !== rootHash) {
-          LoggerProxy.logger.info(
-            `HashTreeParser#runSyncAlgorithm --> ${this.debugId} Root hash mismatch: received=${dataSet.root}, ours=${rootHash}, syncing data set "${dataSet.name}"`
+          await this.performSync(
+            dataSet,
+            rootHash,
+            `Root hash mismatch: received=${dataSet.root}, ours=${rootHash}`
           );
-
-          const mismatchedLeavesData: Record<number, LeafDataItem[]> = {};
-
-          if (dataSet.leafCount !== 1) {
-            let receivedHashes;
-
-            try {
-              // request hashes from sender
-              const {hashes, dataSet: latestDataSetInfo} = await this.getHashesFromLocus(
-                dataSet.name,
-                rootHash
-              );
-
-              receivedHashes = hashes;
-
-              dataSet.hashTree.resize(latestDataSetInfo.leafCount);
-            } catch (error) {
-              if (error.statusCode === 409) {
-                // this is a leaf count mismatch, we should do nothing, just wait for another heartbeat message from Locus
-                LoggerProxy.logger.info(
-                  `HashTreeParser#getHashesFromLocus --> ${this.debugId} Got 409 when fetching hashes for data set "${dataSet.name}": ${error.message}`
-                );
-
-                return;
-              }
-              throw error;
-            }
-
-            // identify mismatched leaves
-            const mismatchedLeaveIndexes = dataSet.hashTree.diffHashes(receivedHashes);
-
-            mismatchedLeaveIndexes.forEach((index) => {
-              mismatchedLeavesData[index] = dataSet.hashTree.getLeafData(index);
-            });
-          } else {
-            mismatchedLeavesData[0] = dataSet.hashTree.getLeafData(0);
-          }
-          // request sync for mismatched leaves
-          if (Object.keys(mismatchedLeavesData).length > 0) {
-            const syncResponse = await this.sendSyncRequestToLocus(dataSet, mismatchedLeavesData);
-
-            // sync API may return nothing (in that case data will arrive via messages)
-            // or it may return a response in the same format as messages
-            if (syncResponse) {
-              this.handleMessage(syncResponse, 'via sync API');
-            }
-          }
         } else {
           LoggerProxy.logger.info(
             `HashTreeParser#runSyncAlgorithm --> ${this.debugId} "${dataSet.name}" root hash matching: ${rootHash}, version=${dataSet.version}`
@@ -1209,6 +1249,52 @@ class HashTreeParser {
   }
 
   /**
+   * Resets the heartbeat watchdog timers for the specified data sets. Each data set has its own
+   * watchdog timer that monitors whether heartbeats are being received within the expected interval.
+   * If a heartbeat is not received for a specific data set within heartbeatIntervalMs plus
+   * a backoff-calculated time, the sync algorithm is initiated for that data set
+   *
+   * @param {Array<DataSet>} receivedDataSets - The data sets from the received message for which watchdog timers should be reset
+   * @returns {void}
+   */
+  private resetHeartbeatWatchdogs(receivedDataSets: Array<DataSet>): void {
+    if (!this.heartbeatIntervalMs) {
+      return;
+    }
+
+    for (const receivedDataSet of receivedDataSets) {
+      const dataSet = this.dataSets[receivedDataSet.name];
+
+      if (!dataSet?.hashTree) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      if (dataSet.heartbeatWatchdogTimer) {
+        clearTimeout(dataSet.heartbeatWatchdogTimer);
+        dataSet.heartbeatWatchdogTimer = undefined;
+      }
+
+      const backoffTime = this.getWeightedBackoffTime(dataSet.backoff);
+      const delay = this.heartbeatIntervalMs + backoffTime;
+
+      dataSet.heartbeatWatchdogTimer = setTimeout(async () => {
+        dataSet.heartbeatWatchdogTimer = undefined;
+
+        LoggerProxy.logger.warn(
+          `HashTreeParser#resetHeartbeatWatchdogs --> ${this.debugId} Heartbeat watchdog fired for data set "${dataSet.name}" - no heartbeat received within expected interval, initiating sync`
+        );
+
+        await this.performSync(
+          dataSet,
+          dataSet.hashTree.getRootHash(),
+          `heartbeat watchdog expired`
+        );
+      }, delay);
+    }
+  }
+
+  /**
    * Stops all timers for the data sets to prevent any further sync attempts.
    * @returns {void}
    */
@@ -1217,6 +1303,10 @@ class HashTreeParser {
       if (dataSet.timer) {
         clearTimeout(dataSet.timer);
         dataSet.timer = undefined;
+      }
+      if (dataSet.heartbeatWatchdogTimer) {
+        clearTimeout(dataSet.heartbeatWatchdogTimer);
+        dataSet.heartbeatWatchdogTimer = undefined;
       }
     });
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -1860,6 +1860,443 @@ describe('HashTreeParser', () => {
         assert.notCalled(callback);
       });
     });
+
+    describe('heartbeat watchdog', () => {
+      it('initiates sync immediately only for the specific data set whose heartbeat watchdog fires', async () => {
+        const parser = createHashTreeParser();
+        const heartbeatIntervalMs = 5000;
+
+        // Send initial heartbeat message for 'main' only
+        const heartbeatMessage = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1100),
+              root: parser.dataSets.main.hashTree.getRootHash(),
+            },
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(heartbeatMessage, 'initial heartbeat');
+
+        // Verify only 'main' watchdog timer is set
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
+        expect(parser.dataSets.self.heartbeatWatchdogTimer).to.be.undefined;
+        expect(parser.dataSets['atd-unmuted'].heartbeatWatchdogTimer).to.be.undefined;
+
+        // Mock responses for performSync (GET hashtree then POST sync for leafCount > 1)
+        const mainDataSetUrl = parser.dataSets.main.url;
+        mockGetHashesFromLocusResponse(
+          mainDataSetUrl,
+          new Array(16).fill('00000000000000000000000000000000'),
+          createDataSet('main', 16, 1101)
+        );
+        mockSendSyncRequestResponse(mainDataSetUrl, null);
+
+        // Advance time past heartbeatIntervalMs + backoff (Math.random returns 0, so backoff = 0)
+        // performSync is called immediately when the watchdog fires - no additional delay
+        await clock.tickAsync(heartbeatIntervalMs);
+
+        // Verify sync request was sent immediately for 'main' (GET hashtree + POST sync)
+        assert.calledWith(
+          webexRequest,
+          sinon.match({
+            method: 'GET',
+            uri: `${mainDataSetUrl}/hashtree`,
+          })
+        );
+
+        // Verify no sync requests were sent for other datasets
+        assert.neverCalledWith(
+          webexRequest,
+          sinon.match({
+            method: 'POST',
+            uri: `${parser.dataSets.self.url}/sync`,
+          })
+        );
+        assert.neverCalledWith(
+          webexRequest,
+          sinon.match({
+            method: 'GET',
+            uri: `${parser.dataSets['atd-unmuted'].url}/hashtree`,
+          })
+        );
+      });
+
+      it('calls POST sync directly for leafCount === 1 data sets', async () => {
+        const parser = createHashTreeParser();
+        const heartbeatIntervalMs = 5000;
+
+        // Send heartbeat for 'self' (leafCount === 1)
+        const heartbeatMessage = {
+          dataSets: [
+            {
+              ...createDataSet('self', 1, 2100),
+              url: parser.dataSets.self.url,
+              root: parser.dataSets.self.hashTree.getRootHash(),
+            },
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(heartbeatMessage, 'self heartbeat');
+
+        // Mock sync response for self
+        mockSendSyncRequestResponse(parser.dataSets.self.url, null);
+
+        // Advance time past watchdog delay
+        await clock.tickAsync(heartbeatIntervalMs);
+
+        // For leafCount === 1, performSync skips GET hashtree and goes straight to POST sync
+        assert.neverCalledWith(
+          webexRequest,
+          sinon.match({
+            method: 'GET',
+            uri: `${parser.dataSets.self.url}/hashtree`,
+          })
+        );
+        assert.calledWith(
+          webexRequest,
+          sinon.match({
+            method: 'POST',
+            uri: `${parser.dataSets.self.url}/sync`,
+          })
+        );
+      });
+
+      it('sets watchdog timers for each data set in the message', async () => {
+        const parser = createHashTreeParser();
+        const heartbeatIntervalMs = 5000;
+
+        // Send heartbeat with multiple datasets
+        const heartbeatMessage = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1100),
+              root: parser.dataSets.main.hashTree.getRootHash(),
+            },
+            {
+              ...createDataSet('self', 1, 2100),
+              url: parser.dataSets.self.url,
+              root: parser.dataSets.self.hashTree.getRootHash(),
+            },
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(heartbeatMessage, 'multi-dataset heartbeat');
+
+        // Watchdog timers should be set for both datasets in the message
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
+        expect(parser.dataSets.self.heartbeatWatchdogTimer).to.not.be.undefined;
+        // But not for datasets not in the message
+        expect(parser.dataSets['atd-unmuted'].heartbeatWatchdogTimer).to.be.undefined;
+      });
+
+      it('resets the watchdog timer for a specific data set when a new heartbeat for it is received', async () => {
+        const parser = createHashTreeParser();
+        const heartbeatIntervalMs = 5000;
+
+        // Send first heartbeat for 'main'
+        const heartbeat1 = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1100),
+              root: parser.dataSets.main.hashTree.getRootHash(),
+            },
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(heartbeat1, 'first heartbeat');
+
+        const firstTimer = parser.dataSets.main.heartbeatWatchdogTimer;
+        expect(firstTimer).to.not.be.undefined;
+
+        // Advance time to just before the watchdog would fire
+        clock.tick(4000);
+
+        // Send second heartbeat for 'main' - this should reset the watchdog
+        const heartbeat2 = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1101),
+              root: parser.dataSets.main.hashTree.getRootHash(),
+            },
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(heartbeat2, 'second heartbeat');
+
+        const secondTimer = parser.dataSets.main.heartbeatWatchdogTimer;
+        expect(secondTimer).to.not.be.undefined;
+        expect(secondTimer).to.not.equal(firstTimer);
+
+        // Advance another 4000ms (total 8000ms from start, but only 4000ms since last heartbeat)
+        // The watchdog should NOT fire yet
+        await clock.tickAsync(4000);
+
+        // No sync requests should have been sent
+        assert.notCalled(webexRequest);
+      });
+
+      it('resets the watchdog timer when a normal message (with locusStateElements) is received', async () => {
+        const parser = createHashTreeParser();
+        const heartbeatIntervalMs = 5000;
+
+        // Send initial heartbeat to start the watchdog for 'main'
+        const heartbeat = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1100),
+              root: parser.dataSets.main.hashTree.getRootHash(),
+            },
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(heartbeat, 'initial heartbeat');
+
+        const firstTimer = parser.dataSets.main.heartbeatWatchdogTimer;
+        expect(firstTimer).to.not.be.undefined;
+
+        // Advance time partially
+        clock.tick(3000);
+
+        // Stub updateItems so the normal message is processed
+        sinon.stub(parser.dataSets.main.hashTree, 'updateItems').returns([true]);
+
+        // Send a normal message (with locusStateElements) for 'main' - should also reset watchdog
+        const normalMessage = {
+          dataSets: [createDataSet('main', 16, 1101)],
+          visibleDataSetsUrl,
+          locusUrl,
+          locusStateElements: [
+            {
+              htMeta: {
+                elementId: {type: 'locus' as const, id: 0, version: 201},
+                dataSetNames: ['main'],
+              },
+              data: {someData: 'value'},
+            },
+          ],
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(normalMessage, 'normal message');
+
+        const secondTimer = parser.dataSets.main.heartbeatWatchdogTimer;
+        expect(secondTimer).to.not.be.undefined;
+        expect(secondTimer).to.not.equal(firstTimer);
+      });
+
+      it('does not set the watchdog timer when heartbeatIntervalMs is not set', async () => {
+        const parser = createHashTreeParser();
+
+        // Send a heartbeat message without heartbeatIntervalMs
+        const heartbeatMessage = createHeartbeatMessage(
+          'main',
+          16,
+          1100,
+          parser.dataSets.main.hashTree.getRootHash()
+        );
+
+        await parser.handleMessage(heartbeatMessage, 'heartbeat without interval');
+
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.be.undefined;
+      });
+
+      it('stops all watchdog timers when meeting ends', async () => {
+        const parser = createHashTreeParser();
+        const heartbeatIntervalMs = 5000;
+
+        // Send heartbeat for multiple datasets
+        const heartbeat = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1100),
+              root: parser.dataSets.main.hashTree.getRootHash(),
+            },
+            {
+              ...createDataSet('self', 1, 2100),
+              url: parser.dataSets.self.url,
+              root: parser.dataSets.self.hashTree.getRootHash(),
+            },
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(heartbeat, 'initial heartbeat');
+
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
+        expect(parser.dataSets.self.heartbeatWatchdogTimer).to.not.be.undefined;
+
+        // Stub updateItems to return true for the roster drop detection
+        sinon.stub(parser.dataSets.self.hashTree, 'updateItems').returns([true]);
+
+        // Send a roster drop message that triggers MEETING_ENDED
+        const rosterDropMessage = {
+          dataSets: [createDataSet('self', 1, 2101)],
+          visibleDataSetsUrl,
+          locusUrl,
+          locusStateElements: [
+            {
+              htMeta: {
+                elementId: {type: 'self' as const, id: 4, version: 102},
+                dataSetNames: ['self'],
+              },
+              data: undefined,
+            },
+          ],
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(rosterDropMessage, 'roster drop');
+
+        // All watchdog timers should have been stopped and NOT restarted
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.be.undefined;
+        expect(parser.dataSets.self.heartbeatWatchdogTimer).to.be.undefined;
+      });
+
+      it("uses each data set's own backoff for its watchdog delay", async () => {
+        // Create a parser where datasets have different backoff configs
+        const initialLocus = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1000),
+              backoff: {maxMs: 500, exponent: 2},
+            },
+            {
+              ...createDataSet('self', 1, 2000),
+              url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/participant/713e9f99/datasets/self',
+              backoff: {maxMs: 2000, exponent: 3},
+            },
+          ],
+          locus: {
+            ...exampleInitialLocus.locus,
+          },
+        };
+
+        const metadata = {
+          ...exampleMetadata,
+          visibleDataSets: [
+            {name: 'main', url: initialLocus.dataSets[0].url},
+            {name: 'self', url: initialLocus.dataSets[1].url},
+          ],
+        };
+
+        const parser = createHashTreeParser(initialLocus, metadata);
+        const heartbeatIntervalMs = 5000;
+
+        // Set Math.random to return 1 so that backoff = 1^exponent * maxMs = maxMs
+        mathRandomStub.returns(1);
+
+        // Send heartbeat for both datasets
+        const heartbeat = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1100),
+              backoff: {maxMs: 500, exponent: 2},
+              root: parser.dataSets.main.hashTree.getRootHash(),
+            },
+            {
+              ...createDataSet('self', 1, 2100),
+              url: parser.dataSets.self.url,
+              backoff: {maxMs: 2000, exponent: 3},
+              root: parser.dataSets.self.hashTree.getRootHash(),
+            },
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(heartbeat, 'heartbeat');
+
+        // 'main' watchdog delay = 5000 + 1^2 * 500 = 5500ms
+        // 'self' watchdog delay = 5000 + 1^3 * 2000 = 7000ms
+
+        // Mock sync responses
+        mockGetHashesFromLocusResponse(
+          parser.dataSets.main.url,
+          new Array(16).fill('00000000000000000000000000000000'),
+          createDataSet('main', 16, 1101)
+        );
+        mockSendSyncRequestResponse(parser.dataSets.main.url, null);
+        mockSendSyncRequestResponse(parser.dataSets.self.url, null);
+
+        // At 5499ms, neither watchdog should have fired
+        await clock.tickAsync(5499);
+        assert.notCalled(webexRequest);
+
+        // At 5500ms, 'main' watchdog fires and performSync runs immediately
+        await clock.tickAsync(1);
+
+        // main sync should have triggered immediately (GET hashtree + POST sync)
+        assert.calledWith(
+          webexRequest,
+          sinon.match({
+            method: 'GET',
+            uri: `${parser.dataSets.main.url}/hashtree`,
+          })
+        );
+
+        webexRequest.resetHistory();
+
+        // At 7000ms, 'self' watchdog fires and performSync runs immediately
+        await clock.tickAsync(1500);
+
+        // self sync should have also triggered (POST sync only, leafCount === 1)
+        assert.calledWith(
+          webexRequest,
+          sinon.match({
+            method: 'POST',
+            uri: `${parser.dataSets.self.url}/sync`,
+          })
+        );
+      });
+
+      it('does not set watchdog for data sets without a hash tree', async () => {
+        const parser = createHashTreeParser();
+        const heartbeatIntervalMs = 5000;
+
+        // 'atd-active' is in the initial locus but is not visible (no hash tree)
+        // Send heartbeat mentioning a non-visible dataset
+        const heartbeatMessage = {
+          dataSets: [
+            {
+              ...createDataSet('main', 16, 1100),
+              root: parser.dataSets.main.hashTree.getRootHash(),
+            },
+            createDataSet('atd-active', 16, 4000),
+          ],
+          visibleDataSetsUrl,
+          locusUrl,
+          heartbeatIntervalMs,
+        };
+
+        await parser.handleMessage(heartbeatMessage, 'heartbeat with non-visible dataset');
+
+        // Watchdog set for main (visible) but not for atd-active (no hash tree)
+        expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
+        expect(parser.dataSets['atd-active']?.heartbeatWatchdogTimer).to.be.undefined;
+      });
+    });
   });
 
   describe('#callLocusInfoUpdateCallback filtering', () => {


### PR DESCRIPTION
# COMPLETES #[SPARK-755460](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-755460)

## This pull request addresses
Locus has added a property called heartbeatIntervalMs, more details here:
1. https://sqbu-github.cisco.com/gist/dangard2/261adf94fb306fd8a74d23b7ae5d6aeb - see point 5
2. https://sqbu-github.cisco.com/pages/WebExSquared/locus/guides/convergedWebinar5k/hashTreeMessaging.html#hashtreemessaging - search for "heartbeatIntervalMs"

## by making the following changes
Starting a separate timer for each data set that has a hash hash tree, if we don't get any message within that timer, we do a sync.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests, manual testing with web app and Locus

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
