### PR TITLE
fix: add protection against empty sync responses

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -928,48 +928,50 @@ class HashTreeParser {
       }
     }
 
-    // by this point we now have this.dataSets setup for data sets from this message
-    // and hash trees created for the new visible data sets,
-    // so we can now process all the updates from the message
-    dataSets.forEach((dataSet) => {
-      if (this.dataSets[dataSet.name]) {
-        const {hashTree} = this.dataSets[dataSet.name];
+    if (message.locusStateElements?.length > 0) {
+      // by this point we now have this.dataSets setup for data sets from this message
+      // and hash trees created for the new visible data sets,
+      // so we can now process all the updates from the message
+      dataSets.forEach((dataSet) => {
+        if (this.dataSets[dataSet.name]) {
+          const {hashTree} = this.dataSets[dataSet.name];
 
-        if (hashTree) {
-          const locusStateElementsForThisSet = message.locusStateElements.filter((object) =>
-            object.htMeta.dataSetNames.includes(dataSet.name)
-          );
+          if (hashTree) {
+            const locusStateElementsForThisSet = message.locusStateElements.filter((object) =>
+              object.htMeta.dataSetNames.includes(dataSet.name)
+            );
 
-          const appliedChangesList = hashTree.updateItems(
-            locusStateElementsForThisSet.map((object) =>
-              object.data
-                ? {operation: 'update', item: object.htMeta.elementId}
-                : {operation: 'remove', item: object.htMeta.elementId}
-            )
-          );
+            const appliedChangesList = hashTree.updateItems(
+              locusStateElementsForThisSet.map((object) =>
+                object.data
+                  ? {operation: 'update', item: object.htMeta.elementId}
+                  : {operation: 'remove', item: object.htMeta.elementId}
+              )
+            );
 
-          zip(appliedChangesList, locusStateElementsForThisSet).forEach(
-            ([changeApplied, object]) => {
-              if (changeApplied) {
-                if (isSelf(object) && !object.data) {
-                  isRosterDropped = true;
+            zip(appliedChangesList, locusStateElementsForThisSet).forEach(
+              ([changeApplied, object]) => {
+                if (changeApplied) {
+                  if (isSelf(object) && !object.data) {
+                    isRosterDropped = true;
+                  }
+                  // add to updatedObjects so that our locus DTO will get updated with the new object
+                  updatedObjects.push(object);
                 }
-                // add to updatedObjects so that our locus DTO will get updated with the new object
-                updatedObjects.push(object);
               }
-            }
-          );
-        } else {
-          LoggerProxy.logger.info(
-            `Locus-info:index#parseMessage --> ${this.debugId} unexpected (not visible) dataSet ${dataSet.name} received in hash tree message`
-          );
+            );
+          } else {
+            LoggerProxy.logger.info(
+              `Locus-info:index#parseMessage --> ${this.debugId} unexpected (not visible) dataSet ${dataSet.name} received in hash tree message`
+            );
+          }
         }
-      }
 
-      if (!isRosterDropped) {
-        this.runSyncAlgorithm(dataSet);
-      }
-    });
+        if (!isRosterDropped) {
+          this.runSyncAlgorithm(dataSet);
+        }
+      });
+    }
 
     if (isRosterDropped) {
       LoggerProxy.logger.info(

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -532,6 +532,46 @@ describe('HashTreeParser', () => {
         });
       });
     });
+
+    it('handles sync response that has locusStateElements undefined', async () => {
+      const minimalInitialLocus = {
+        dataSets: [],
+        locus: null,
+      };
+
+      const parser = createHashTreeParser(minimalInitialLocus, null);
+
+      const mainDataSet = createDataSet('main', 16, 1100);
+
+      // Mock getAllVisibleDataSetsFromLocus to return the main dataset
+      mockGetAllDataSetsMetadata(webexRequest, visibleDataSetsUrl, [mainDataSet]);
+
+      // Mock the sync response to have locusStateElements: undefined
+      // This is what sendInitializationSyncRequestToLocus will receive and pass to parseMessage
+      mockSyncRequest(webexRequest, mainDataSet.url, {
+        dataSets: [mainDataSet],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: undefined,
+      });
+
+      // Trigger sendInitializationSyncRequestToLocus via initializeFromMessage
+      await parser.initializeFromMessage({
+        dataSets: [],
+        visibleDataSetsUrl,
+        locusUrl,
+      });
+
+      // Verify the hash tree was created for main dataset
+      expect(parser.dataSets.main.hashTree).to.be.instanceOf(HashTree);
+
+      // updateItems should NOT have been called because locusStateElements is undefined
+      const mainUpdateItemsStub = sinon.spy(parser.dataSets.main.hashTree, 'updateItems');
+      assert.notCalled(mainUpdateItemsStub);
+
+      // callback should not be called, because there are no updates
+      assert.notCalled(callback);
+    });
   });
 
   describe('#initializeFromGetLociResponse', () => {
@@ -855,10 +895,6 @@ describe('HashTreeParser', () => {
       // Verify putItem was called on self hash tree with metadata
       assert.calledOnceWithExactly(selfPutItemSpy, {type: 'metadata', id: 5, version: 51});
 
-      console.log(
-        'callback calls',
-        callback.getCalls().map((call) => JSON.stringify(call.args, null, 2))
-      );
       // Verify callback was called with metadata object and removed dataset objects
       assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
         updatedObjects: [


### PR DESCRIPTION
# COMPLETES #[SPARK-778058](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-778058)

## This pull request addresses
HashTreeParser.parseMessage() might get called with a message that has locusStateElements undefined - see more details in the jira.

## by making the following changes
Added protection against undefined locusStateElements

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests, warhol team confirmed the fix worked for them

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
