### PR TITLE
fix: better handling of undefined dataSets in HashTreeParser.handleLocusUpdate

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -578,12 +578,13 @@ class HashTreeParser {
     const {dataSets, locus, metadata} = update;
 
     if (!dataSets) {
-      LoggerProxy.logger.warn(
+      LoggerProxy.logger.info(
         `HashTreeParser#handleLocusUpdate --> ${this.debugId} received hash tree update without dataSets`
       );
-    }
-    for (const dataSet of dataSets) {
-      this.updateDataSetInfo(dataSet);
+    } else {
+      for (const dataSet of dataSets) {
+        this.updateDataSetInfo(dataSet);
+      }
     }
     const updatedObjects: HashTreeObject[] = [];
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -1023,6 +1023,71 @@ describe('HashTreeParser', () => {
       // Verify callback was NOT called because version didn't change
       assert.notCalled(callback);
     });
+
+    it('handles updates with no dataSets and metadata fields gracefully', () => {
+      const parser = createHashTreeParser();
+
+      const mainPutItemsSpy = sinon.spy(parser.dataSets.main.hashTree, 'putItems');
+      const selfPutItemsSpy = sinon.spy(parser.dataSets.self.hashTree, 'putItems');
+      const atdUnmutedPutItemsSpy = sinon.spy(parser.dataSets['atd-unmuted'].hashTree, 'putItems');
+
+      // Create a locus update with no dataSets and no metadata
+      const locusUpdate = {
+        locus: {
+          htMeta: {
+            elementId: {
+              type: 'locus',
+              id: 0,
+              version: 201,
+            },
+            dataSetNames: ['main'],
+          },
+          someData: 'value',
+        },
+      };
+
+      // Call handleLocusUpdate - should not throw
+      parser.handleLocusUpdate(locusUpdate);
+
+      // Verify putItems was still called for the dataset referenced in locus
+      assert.calledOnceWithExactly(mainPutItemsSpy, [{type: 'locus', id: 0, version: 201}]);
+
+      // Verify putItems was not called on other hash trees
+      assert.notCalled(selfPutItemsSpy);
+      assert.notCalled(atdUnmutedPutItemsSpy);
+
+      // Verify callback was called with the updated object
+      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+        updatedObjects: [
+          {
+            htMeta: {
+              elementId: {
+                type: 'locus',
+                id: 0,
+                version: 201,
+              },
+              dataSetNames: ['main'],
+            },
+            data: {
+              someData: 'value',
+              htMeta: {
+                elementId: {
+                  type: 'locus',
+                  id: 0,
+                  version: 201,
+                },
+                dataSetNames: ['main'],
+              },
+            },
+          },
+        ],
+      });
+
+      // Verify that dataset versions were NOT updated (no dataSets in the update)
+      expect(parser.dataSets.main.version).to.equal(1000);
+      expect(parser.dataSets.self.version).to.equal(2000);
+      expect(parser.dataSets['atd-unmuted'].version).to.equal(3000);
+    });
   });
 
   describe('#handleMessage', () => {


### PR DESCRIPTION
# COMPLETES #[SPARK-755437](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-755437)

## This pull request addresses
[Here]() Locus says that they may send API responses without dataSets or metedata

## by making the following changes
Made sure to not access dataSets if undefined

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests, manual test e2e by hacking the code to remove dataSets and metadata from API response

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
