### PR TITLE
feat(meetings): added ability to ignore data sets

### DIFF
--- a/packages/@webex/plugin-meetings/src/config.ts
+++ b/packages/@webex/plugin-meetings/src/config.ts
@@ -101,5 +101,8 @@ export default {
     stopIceGatheringAfterFirstRelayCandidate: false,
     enableAudioTwccForMultistream: false,
     enablePerUdpUrlReachability: false, // true: separate peer connection per each UDP URL; false: single peer connection for all URLs
+    locus: {
+      excludedDataSets: ['attendees'], // attendees data set only applies to webinar attendees and we never really need that
+    },
   },
 };

--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -91,6 +91,7 @@ class HashTreeParser {
   visibleDataSets: VisibleDataSetInfo[];
   debugId: string;
   heartbeatIntervalMs?: number;
+  private excludedDataSets: string[];
 
   /**
    * Constructor for HashTreeParser
@@ -106,14 +107,18 @@ class HashTreeParser {
     webexRequest: WebexRequestMethod;
     locusInfoUpdateCallback: LocusInfoUpdateCallback;
     debugId: string;
+    excludedDataSets?: string[];
   }) {
     const {dataSets, locus} = options.initialLocus; // extract dataSets from initialLocus
 
     this.debugId = options.debugId;
     this.webexRequest = options.webexRequest;
     this.locusInfoUpdateCallback = options.locusInfoUpdateCallback;
+    this.excludedDataSets = options.excludedDataSets || [];
     this.visibleDataSetsUrl = locus?.links?.resources?.visibleDataSets?.url;
-    this.visibleDataSets = cloneDeep(options.metadata?.visibleDataSets || []);
+    this.visibleDataSets = (
+      cloneDeep(options.metadata?.visibleDataSets || []) as VisibleDataSetInfo[]
+    ).filter((vds) => !this.isExcludedDataSet(vds.name));
 
     if (options.metadata?.visibleDataSets?.length === 0) {
       LoggerProxy.logger.warn(
@@ -156,6 +161,34 @@ class HashTreeParser {
   }
 
   /**
+   * Checks if the given data set name is in the excluded list
+   * @param {string} dataSetName data set name to check
+   * @returns {boolean} True if the data set is excluded, false otherwise
+   */
+  private isExcludedDataSet(dataSetName: string): boolean {
+    return this.excludedDataSets.some((name) => name === dataSetName);
+  }
+
+  /**
+   * Adds a data set to the visible data sets list, unless it is in the excluded list.
+   * @param {VisibleDataSetInfo} dataSetInfo data set info to add
+   * @returns {boolean} True if the data set was added, false if it was excluded
+   */
+  private addToVisibleDataSetsList(dataSetInfo: VisibleDataSetInfo): boolean {
+    if (this.isExcludedDataSet(dataSetInfo.name)) {
+      LoggerProxy.logger.info(
+        `HashTreeParser#addToVisibleDataSetsList --> ${this.debugId} Data set "${dataSetInfo.name}" is in the excluded list, ignoring`
+      );
+
+      return false;
+    }
+
+    this.visibleDataSets.push(dataSetInfo);
+
+    return true;
+  }
+
+  /**
    * Initializes a new visible data set by creating a hash tree for it, adding it to all the internal structures,
    * and sending an initial sync request to Locus with empty leaf data - that will trigger Locus to gives us all the data
    * from that dataset (in the response or via messages).
@@ -180,7 +213,9 @@ class HashTreeParser {
       `HashTreeParser#initializeNewVisibleDataSet --> ${this.debugId} Adding visible data set "${dataSetInfo.name}"`
     );
 
-    this.visibleDataSets.push(visibleDataSetInfo);
+    if (!this.addToVisibleDataSetsList(visibleDataSetInfo)) {
+      return Promise.resolve({updateType: LocusInfoUpdateType.OBJECTS_UPDATED, updatedObjects: []});
+    }
 
     const hashTree = new HashTree([], dataSetInfo.leafCount);
 
@@ -328,10 +363,16 @@ class HashTreeParser {
       }
 
       if (!this.isVisibleDataSet(name)) {
-        this.visibleDataSets.push({
-          name,
-          url,
-        });
+        if (
+          !this.addToVisibleDataSetsList({
+            name,
+            url,
+          })
+        ) {
+          // dataset is excluded, skip it
+          // eslint-disable-next-line no-continue
+          continue;
+        }
       }
 
       if (!this.dataSets[name].hashTree) {
@@ -692,7 +733,9 @@ class HashTreeParser {
     // visibleDataSets can only be changed by Metadata object updates
     updatedObjects.forEach((object) => {
       if (isMetadata(object) && object.data?.visibleDataSets) {
-        const newVisibleDataSets = object.data.visibleDataSets;
+        const newVisibleDataSets = object.data.visibleDataSets.filter(
+          (vds) => !this.isExcludedDataSet(vds.name)
+        );
 
         removedDataSets = this.visibleDataSets.filter(
           (ds) => !newVisibleDataSets.some((nvs) => nvs.name === ds.name)
@@ -804,7 +847,10 @@ class HashTreeParser {
           `HashTreeParser#processVisibleDataSetChanges --> ${this.debugId} Adding visible data set "${ds.name}"`
         );
 
-        this.visibleDataSets.push(ds);
+        if (!this.addToVisibleDataSetsList(ds)) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
 
         const hashTree = new HashTree([], dataSetInfo.leafCount);
 

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -379,6 +379,7 @@ export default class LocusInfo extends EventsScope {
       webexRequest: this.webex.request.bind(this.webex),
       locusInfoUpdateCallback: this.updateFromHashTree.bind(this),
       debugId: `HT-${this.meetingId.substring(0, 4)}`,
+      excludedDataSets: this.webex.config.meetings.locus?.excludedDataSets,
     });
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -165,7 +165,8 @@ describe('HashTreeParser', () => {
   // Helper to create a HashTreeParser instance with common defaults
   function createHashTreeParser(
     initialLocus: any = exampleInitialLocus,
-    metadata: any = exampleMetadata
+    metadata: any = exampleMetadata,
+    excludedDataSets?: string[]
   ) {
     return new HashTreeParser({
       initialLocus,
@@ -173,6 +174,7 @@ describe('HashTreeParser', () => {
       webexRequest,
       locusInfoUpdateCallback: callback,
       debugId: 'test',
+      excludedDataSets,
     });
   }
 
@@ -351,6 +353,66 @@ describe('HashTreeParser', () => {
     // so an entry for it should exist, but hashTree shouldn't be created
     const emptySet = parser.dataSets['empty-set'];
     expect(emptySet.hashTree).to.be.undefined;
+  });
+
+  it('should exclude datasets listed in excludedDataSets during initialization', () => {
+    const parser = createHashTreeParser(exampleInitialLocus, exampleMetadata, ['atd-unmuted']);
+
+    // 'atd-unmuted' should be excluded from visibleDataSets
+    expect(parser.visibleDataSets.some((vds) => vds.name === 'atd-unmuted')).to.be.false;
+
+    // 'main' and 'self' should still be visible
+    expect(parser.visibleDataSets.some((vds) => vds.name === 'main')).to.be.true;
+    expect(parser.visibleDataSets.some((vds) => vds.name === 'self')).to.be.true;
+
+    // 'atd-unmuted' dataset entry should exist but without a hash tree (because it's not visible)
+    expect(parser.dataSets['atd-unmuted']).to.exist;
+    expect(parser.dataSets['atd-unmuted'].hashTree).to.be.undefined;
+
+    // 'main' and 'self' should have hash trees
+    expect(parser.dataSets.main.hashTree).to.be.instanceOf(HashTree);
+    expect(parser.dataSets.self.hashTree).to.be.instanceOf(HashTree);
+  });
+
+  it('should exclude datasets listed in excludedDataSets when adding new visible datasets', async () => {
+    // Create parser without 'atd-unmuted' in initial metadata visibleDataSets
+    const metadataWithoutAtdUnmuted = {
+      ...exampleMetadata,
+      visibleDataSets: exampleMetadata.visibleDataSets.filter((vds) => vds.name !== 'atd-unmuted'),
+    };
+    const parser = createHashTreeParser(exampleInitialLocus, metadataWithoutAtdUnmuted, [
+      'atd-unmuted',
+    ]);
+
+    // 'atd-unmuted' should not be in visibleDataSets initially
+    expect(parser.visibleDataSets.some((vds) => vds.name === 'atd-unmuted')).to.be.false;
+
+    // Now simulate initializeDataSets which calls addToVisibleDataSetsList
+    const atdUnmutedDataSet = createDataSet('atd-unmuted', 16, 3000);
+
+    mockGetAllDataSetsMetadata(webexRequest, visibleDataSetsUrl, [
+      createDataSet('main', 16, 1000),
+      createDataSet('self', 1, 2000),
+      atdUnmutedDataSet,
+    ]);
+
+    mockSyncRequest(
+      webexRequest,
+      'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f/datasets/atd-unmuted'
+    );
+
+    const message = {
+      dataSets: [createDataSet('main', 16, 1000)],
+      visibleDataSetsUrl,
+      locusUrl,
+    };
+    await parser.initializeFromMessage(message);
+
+    // 'atd-unmuted' should still not be in visibleDataSets because it is excluded
+    expect(parser.visibleDataSets.some((vds) => vds.name === 'atd-unmuted')).to.be.false;
+    // but 'main' and 'self' should be there
+    expect(parser.visibleDataSets.some((vds) => vds.name === 'main')).to.be.true;
+    expect(parser.visibleDataSets.some((vds) => vds.name === 'self')).to.be.true;
   });
 
   // helper method, needed because both initializeFromMessage and initializeFromGetLociResponse


### PR DESCRIPTION
# COMPLETES #[SPARK-779187](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-779187)

## This pull request addresses
Warhol client is using SDK and a machine account access token. This causes Locus to tell it that "attendees" is a visible data set for it, but when we try to sync on attendees, Locus fails with 403.

## by making the following changes
Added a config entry so that clients can configure datasets they want to ignore, setting it to ['attendees'] by default. This should unblock the Warhol team for now until Locus sorts out their handling of machine account access tokens.
SDK clients should never really be interested in attendees data set anyway, so might be worth keeping this functionality long term.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
