### PR TITLE
feat(contact-center): add Playwright E2E ai-docs framework for migration

### DIFF
--- a/packages/@webex/contact-center/AGENTS.md
+++ b/packages/@webex/contact-center/AGENTS.md
@@ -12,7 +12,7 @@ This is the main orchestrator for AI assistants working with the package `@webex
 
 When a developer provides a task, follow this workflow **in order**:
 
-1. **Classify the task** - Use the Task Classification Decision Tree below to identify the task type (A-F). If you cannot confidently classify, ask the developer.
+1. **Classify the task** - Use the Task Classification Decision Tree below to identify the task type (A-G). If you cannot confidently classify, ask the developer.
 2. **STOP — Ask the developer questions** - Open the routed template's pre-questions file. Present every MANDATORY question to the developer. Wait for their answers. **Do NOT proceed until all MANDATORY fields have explicit answers from the developer.** Do not infer, assume, or fill in answers yourself.
 3. **Present Spec Summary for approval** - After gathering answers, present a structured summary of what you will build (see Spec Summary Gate below). Wait for the developer to confirm.
 4. **Load context** - Use the [Service Routing Table](#service-routing-table) to find and read the target service's `AGENTS.md` and `ARCHITECTURE.md`, then load relevant patterns.
@@ -29,26 +29,29 @@ When a developer provides a task, follow this workflow **in order**:
 Use these questions **in order** to classify the developer's request. Follow the first matching path.
 
 ```
-Q1: Is the task read-only (understanding, explaining, or analyzing code)?
-├── YES → Type E: Understand Architecture
+Q0: Is this about Playwright E2E tests (add/update/fix/stabilize)?
+├── YES → Type G: E2E Test Work (Playwright)
 │
-└── NO → Q2: Is something broken or behaving incorrectly?
-    ├── YES → Type C: Fix Bug
+└── NO → Q1: Is the task read-only (understanding, explaining, or analyzing code)?
+    ├── YES → Type E: Understand Architecture
     │
-    └── NO → Q3: Does this involve creating a new file, class, or module?
-        ├── YES → Type A: Create New Service
+    └── NO → Q2: Is something broken or behaving incorrectly?
+        ├── YES → Type C: Fix Bug
         │
-        └── NO → Q4: Does this involve adding a brand-new method that does not exist yet?
-            │   NOTE: If the developer describes a "capability" or "feature" that
-            │   happens to require a new method, check signal keywords — if the
-            │   request matches Type D signals ("add capability", "enhance", "enable"),
-            │   use the Disambiguation Rule to confirm with the developer.
-            ├── YES → Type B: Add New Method
+        └── NO → Q3: Does this involve creating a new file, class, or module?
+            ├── YES → Type A: Create New Service
             │
-            └── NO → Q5: Does this involve changing an existing method's signature, behavior, parameters, or return type?
-                ├── YES → Type F: Modify Existing Method
+            └── NO → Q4: Does this involve adding a brand-new method that does not exist yet?
+                │   NOTE: If the developer describes a "capability" or "feature" that
+                │   happens to require a new method, check signal keywords — if the
+                │   request matches Type D signals ("add capability", "enhance", "enable"),
+                │   use the Disambiguation Rule to confirm with the developer.
+                ├── YES → Type B: Add New Method
                 │
-                └── NO → Type D: Add Feature / Enhance Existing Service
+                └── NO → Q5: Does this involve changing an existing method's signature, behavior, parameters, or return type?
+                    ├── YES → Type F: Modify Existing Method
+                    │
+                    └── NO → Type D: Add Feature / Enhance Existing Service
 ```
 
 ### Signal Keywords by Task Type
@@ -63,6 +66,7 @@ Use these keyword patterns to help confirm your classification:
 | **D. Add Feature** | "enhance", "add feature", "add capability", "improve", "extend", "support for", "enable" |
 | **E. Understand Architecture** | "explain", "how does", "understand", "architecture", "what is", "walk me through", "show me" |
 | **F. Modify Existing Method** | "change", "modify", "update", "add parameter to", "change return type", "rename", "refactor [methodName]" |
+| **G. E2E Test Work** | "e2e", "playwright", "end-to-end", "integration test", "flaky test", "test suite", "test set", "stabilize test" |
 
 ### Disambiguation Rule
 
@@ -75,6 +79,7 @@ Use these keyword patterns to help confirm your classification:
 > - D. Add a feature or enhance an existing service
 > - E. Understand/explain the architecture (no code changes)
 > - F. Modify an existing method (change signature, behavior, parameters)
+> - G. Add/update/fix/stabilize Playwright E2E tests
 
 **Do not guess. Do not default to the most common type. Ask.**
 
@@ -123,6 +128,13 @@ Use these keyword patterns to help confirm your classification:
 - **Route to:** [`ai-docs/templates/existing-service/feature-enhancement.md`](ai-docs/templates/existing-service/feature-enhancement.md) (follow the same workflow, but skip placement triage — the method already exists).
 - **Pre-questions:** Feature-enhancement template Pre-Enhancement Questions (skip Step 0 triage) — STOP and ask these first.
 - **Follow:** Gather requirements -> Design change -> Implement -> Test -> Validate backward compatibility.
+
+**G. E2E Test Work (Playwright)**
+- Use when adding, updating, fixing, or stabilizing Playwright end-to-end tests.
+- **Route to:** [`ai-docs/templates/e2e/00-master.md`](ai-docs/templates/e2e/00-master.md)
+- **Pre-questions:** [`ai-docs/templates/e2e/01-pre-questions.md`](ai-docs/templates/e2e/01-pre-questions.md) — STOP and ask these first.
+- **Follow:** Full E2E workflow including test factory pattern, console log verification, framework/doc updates, and validation.
+- **Context:** Load [`playwright/ai-docs/AGENTS.md`](playwright/ai-docs/AGENTS.md) and [`playwright/ai-docs/ARCHITECTURE.md`](playwright/ai-docs/ARCHITECTURE.md) for framework-specific guidance.
 
 If a developer request includes multiple task types, split into ordered subtasks and execute each through the full classify -> question -> spec-summary -> implement sequence.
 
@@ -279,6 +291,12 @@ Mandatory behavior:
 2. Read [`ai-docs/patterns/typescript-patterns.md`](ai-docs/patterns/typescript-patterns.md)
 3. Read related existing implementation
 
+### For E2E Test Work (Playwright):
+1. Load [`playwright/ai-docs/AGENTS.md`](playwright/ai-docs/AGENTS.md) — workflow and commands
+2. Load [`playwright/ai-docs/ARCHITECTURE.md`](playwright/ai-docs/ARCHITECTURE.md) — TestManager, Utils, Constants, Console Log Verification
+3. Read [`ai-docs/patterns/e2e-patterns.md`](ai-docs/patterns/e2e-patterns.md) — test factory, multi-agent coordination, timeout selection
+4. Read existing test files in the same SET for naming and structure conventions
+
 ---
 
 ## Repository Structure
@@ -338,11 +356,30 @@ packages/@webex/contact-center/
 │   └── unit/
 │       └── spec/
 │           └── cc.ts                  # Main test file (reference)
+├── playwright/                        # E2E test framework (Playwright)
+│   ├── ai-docs/                       # Playwright-specific AI documentation
+│   │   ├── AGENTS.md                  # Playwright usage guide & commands
+│   │   └── ARCHITECTURE.md            # TestManager, Utils, Constants, patterns
+│   ├── test-manager/                  # TestManager class (browser context orchestration)
+│   ├── utils/                         # Shared test utilities
+│   ├── constants/                     # Test constants, timeouts, enums
+│   ├── test-data/                     # Fixture data for tests
+│   ├── tests/                         # Test files organized by SET
+│   ├── suites/                        # Suite registries that compose tests
+│   ├── global-setup.ts                # One-time setup (auth tokens, env validation)
+│   └── playwright.config.ts           # Playwright config (projects from USER_SETS)
 └── ai-docs/                           # AI documentation
     ├── README.md                      # AI-docs overview
     ├── RULES.md                       # Coding standards
     ├── patterns/                      # Pattern documentation
+    │   └── e2e-patterns.md            # E2E test patterns (test factory, console log, etc.)
     └── templates/                     # Code generation templates
+        └── e2e/                       # E2E test templates (task type G)
+            ├── 00-master.md           # E2E orchestrator
+            ├── 01-pre-questions.md    # Mandatory questions before E2E work
+            ├── 02-test-implementation.md  # Implementation paths A-D
+            ├── 03-framework-and-doc-updates.md  # MANDATORY doc updates
+            └── 04-validation.md       # Validation & doc sync checklist
 ```
 
 ---
@@ -393,6 +430,9 @@ After code changes, verify whether docs must be updated:
 - Service-level docs (use [Service Routing Table](#service-routing-table) to locate):
   - Service `AGENTS.md` — if usage/workflow changed
   - Service `ARCHITECTURE.md` — if data flow/architecture changed
+- Playwright docs (use [Service Routing Table](#service-routing-table) to locate):
+  - [`playwright/ai-docs/AGENTS.md`](playwright/ai-docs/AGENTS.md) — if E2E workflow or commands changed
+  - [`playwright/ai-docs/ARCHITECTURE.md`](playwright/ai-docs/ARCHITECTURE.md) — if TestManager, Utils, Constants, or test topology changed
 - Root-level docs:
   - This file ([`AGENTS.md`](AGENTS.md)) — if task routing or rules changed
   - [`ai-docs/templates/`](ai-docs/templates/) — if a new reusable template is needed
@@ -424,6 +464,7 @@ Use this table to identify which service's ai-docs to load based on the develope
 | **Task** | task, hold, transfer, conference, wrapup, outdial, consult | [`src/services/task/ai-docs/AGENTS.md`](src/services/task/ai-docs/AGENTS.md) | [`src/services/task/ai-docs/ARCHITECTURE.md`](src/services/task/ai-docs/ARCHITECTURE.md) |
 | **Config** | profile, register, teams, aux codes, desktop profile, settings | [`src/services/config/ai-docs/AGENTS.md`](src/services/config/ai-docs/AGENTS.md) | [`src/services/config/ai-docs/ARCHITECTURE.md`](src/services/config/ai-docs/ARCHITECTURE.md) |
 | **Core** | websocket, HTTP, connection, reconnect, aqm, utils, errors | [`src/services/core/ai-docs/AGENTS.md`](src/services/core/ai-docs/AGENTS.md) | [`src/services/core/ai-docs/ARCHITECTURE.md`](src/services/core/ai-docs/ARCHITECTURE.md) |
+| **Playwright E2E** | e2e, playwright, end-to-end, test suite, test set, flaky test, stabilize | [`playwright/ai-docs/AGENTS.md`](playwright/ai-docs/AGENTS.md) | [`playwright/ai-docs/ARCHITECTURE.md`](playwright/ai-docs/ARCHITECTURE.md) |
 
 **Routing rule:** If the developer's task mentions keywords in the "Scope / Keywords" column, load that service's ai-docs. If multiple services are involved, load all relevant ones. If unsure which service is affected, ask the developer.
 
@@ -434,3 +475,4 @@ Use this table to identify which service's ai-docs to load based on the develope
 - **TypeScript patterns**: [`ai-docs/patterns/typescript-patterns.md`](ai-docs/patterns/typescript-patterns.md)
 - **Testing patterns**: [`ai-docs/patterns/testing-patterns.md`](ai-docs/patterns/testing-patterns.md)
 - **Event patterns**: [`ai-docs/patterns/event-driven-patterns.md`](ai-docs/patterns/event-driven-patterns.md)
+- **E2E test patterns**: [`ai-docs/patterns/e2e-patterns.md`](ai-docs/patterns/e2e-patterns.md)

--- a/packages/@webex/contact-center/ai-docs/patterns/e2e-patterns.md
+++ b/packages/@webex/contact-center/ai-docs/patterns/e2e-patterns.md
@@ -1,0 +1,297 @@
+# E2E Test Patterns
+
+## Purpose
+
+Reusable patterns for Playwright E2E tests in `@webex/contact-center`. These patterns are adapted from the established ccWidgets Playwright framework for SDK-level testing.
+
+---
+
+## Pattern 1: Test Factory
+
+**What**: Every test file exports a default function (factory) that returns a closure. Suites compose tests by calling these factories inside `test.describe`.
+
+**Why**: Decouples test logic from suite registration. A single test file can be included in multiple suites without duplication.
+
+```typescript
+// playwright/tests/station-login-test.spec.ts
+import {test, expect} from '@playwright/test';
+import {TestManager} from '../test-manager';
+
+export default function createStationLoginTests() {
+  let tm: TestManager;
+
+  test.beforeAll(async ({browser}, testInfo) => {
+    tm = new TestManager(testInfo.project.name);
+    await tm.setup(browser, {needsAgent1: true});
+  });
+
+  test.afterAll(async () => {
+    await tm.cleanup();
+  });
+
+  test('agent can login via desktop mode', async () => {
+    // Test logic here
+  });
+}
+```
+
+```typescript
+// playwright/suites/basic-tests.spec.ts
+import {test} from '@playwright/test';
+import createStationLoginTests from '../tests/station-login-test.spec';
+
+test.describe('Basic Tests', () => {
+  test.describe('Station Login', createStationLoginTests);
+});
+```
+
+**Rules**:
+- Test files MUST export a `default function` (not a named export, not inline tests)
+- Suite files MUST use `test.describe('Name', createXTests)` — pass the factory, don't call it with `()`
+- `testInfo.project.name` provides the SET name for env var prefix lookup
+
+---
+
+## Pattern 2: Console Log Verification
+
+**What**: Capture browser console output and assert that expected SDK events were logged.
+
+**Why**: SDK E2E tests don't have UI widgets to inspect. The sample app logs SDK events to console, making console output the primary verification channel.
+
+```typescript
+// Setup: capture console messages
+test.beforeAll(async ({browser}, testInfo) => {
+  tm = new TestManager(testInfo.project.name);
+  await tm.setup(browser, {enableConsoleLogging: true});
+});
+
+// Verify: check for expected console output
+test('state change emits success event', async () => {
+  // Action
+  await tm.agent1Page.click('#setAgentStatus');
+
+  // Verify SDK event was logged
+  await expect.poll(() =>
+    tm.consoleMessages.some(msg =>
+      msg.includes(CONSOLE_PATTERNS.SDK_STATE_CHANGE_SUCCESS)
+    ),
+    {timeout: AWAIT_TIMEOUT}
+  ).toBeTruthy();
+});
+```
+
+**Rules**:
+- Always use `expect.poll()` — console messages arrive asynchronously
+- Use `CONSOLE_PATTERNS` constants, never hardcode pattern strings
+- Clear `tm.consoleMessages` between independent assertions if needed
+- Use exact string matching (`includes` for substring, regex for structured data)
+
+---
+
+## Pattern 3: Multi-Agent Coordination
+
+**What**: Tests that require two agents (e.g., consult transfer, conference) provision both via `SetupConfig`.
+
+**Why**: Some SDK operations require interaction between two agents. TestManager handles parallel setup.
+
+```typescript
+export default function createConsultTransferTests() {
+  let tm: TestManager;
+
+  test.beforeAll(async ({browser}, testInfo) => {
+    tm = new TestManager(testInfo.project.name);
+    await tm.setup(browser, {
+      needsAgent1: true,
+      needsAgent2: true,
+      needsCaller: true,
+      enableConsoleLogging: true,
+    });
+  });
+
+  test('agent1 can consult transfer to agent2', async () => {
+    // Use tm.agent1Page for agent 1 actions
+    // Use tm.agent2Page for agent 2 actions
+    // Use tm.callerPage to initiate the incoming call
+  });
+}
+```
+
+**Rules**:
+- Each agent gets its own `BrowserContext` (isolated cookies/storage)
+- Env vars use SET-prefixed names: `${projectName}_AGENT1_ACCESS_TOKEN`, `${projectName}_AGENT2_ACCESS_TOKEN`
+- Never share pages between agents — use the correct `tm.agentXPage`
+
+---
+
+## Pattern 4: Setup and Cleanup Lifecycle
+
+**What**: TestManager setup in `beforeAll`, cleanup in `afterAll`, with stray task handling.
+
+**Why**: Browser contexts are expensive. Create once per test file, not per test case.
+
+```typescript
+test.beforeAll(async ({browser}, testInfo) => {
+  tm = new TestManager(testInfo.project.name);
+  await tm.setup(browser, config);
+});
+
+test.afterAll(async () => {
+  await tm.cleanup();
+});
+```
+
+**Rules**:
+- `beforeAll` / `afterAll`, not `beforeEach` / `afterEach` — context creation is too slow per test
+- Always call `cleanup()` — leaked browser processes cause CI failures
+- Use `handleStrayTasks()` before test execution if previous tests may have left orphaned tasks
+
+---
+
+## Pattern 5: Timeout Selection
+
+**What**: Choose timeouts from the constant hierarchy based on what you're waiting for.
+
+**Why**: Arbitrary timeout values cause flaky tests (too short) or slow suites (too long).
+
+| Waiting For | Use This Timeout |
+|-------------|-----------------|
+| Dropdown animation | `DROPDOWN_SETTLE_TIMEOUT` (200ms) |
+| UI element to appear | `UI_SETTLE_TIMEOUT` (2000ms) |
+| Default operation | `DEFAULT_TIMEOUT` (5000ms) |
+| Async SDK response | `AWAIT_TIMEOUT` (10000ms) |
+| Wrapup completion | `WRAPUP_TIMEOUT` (15000ms) |
+| Form population from API | `FORM_FIELD_TIMEOUT` (20000ms) |
+| Long SDK operation | `OPERATION_TIMEOUT` (30000ms) |
+| Extension registration | `EXTENSION_REGISTRATION_TIMEOUT` (40000ms) |
+| Widget initialization | `WIDGET_INIT_TIMEOUT` (50000ms) |
+| Incoming task acceptance | `ACCEPT_TASK_TIMEOUT` (60000ms) |
+
+**Rules**:
+- Never use `page.waitForTimeout(N)` with a magic number — always reference a named constant
+- Pick the smallest timeout that fits the operation
+- If you need a new timeout value, add it to `constants.ts` at the correct hierarchy level and document it in `ARCHITECTURE.md`
+
+---
+
+## Pattern 6: State Verification
+
+**What**: Verify agent state transitions through console log patterns.
+
+**Why**: Agent state changes are the most common assertion in contact center E2E tests.
+
+```typescript
+test('agent transitions to Available after login', async () => {
+  // Trigger state change
+  await tm.agent1Page.selectOption('#idleCodesDropdown', 'Available');
+  await tm.agent1Page.click('#setAgentStatus');
+
+  // Verify via console output
+  await expect.poll(() =>
+    tm.consoleMessages.some(msg => {
+      const match = msg.match(CONSOLE_PATTERNS.ON_STATE_CHANGE_REGEX);
+      return match && match[1] === 'Available';
+    }),
+    {timeout: AWAIT_TIMEOUT}
+  ).toBeTruthy();
+});
+```
+
+---
+
+## Pattern 7: Network Resilience
+
+**What**: Use retry wrappers for operations that depend on network calls.
+
+**Why**: SDK operations make HTTP/WebSocket calls that may fail transiently in CI.
+
+```typescript
+// TestManager has built-in retry with exponential backoff
+await tm.retryOperation(
+  () => someNetworkOperation(),
+  'network operation name',
+  3  // max retries
+);
+```
+
+**Rules**:
+- Use `retryOperation()` for setup operations, not for test assertions
+- Test assertions should use `expect.poll()` with appropriate timeouts
+- If a test needs more than 3 retries to pass, investigate the root cause
+
+---
+
+## Pattern 8: RONA Handling
+
+**What**: Handle RONA (Redirection on No Answer) state when an agent doesn't answer in time.
+
+**Why**: RONA is a common state in contact center tests that must be handled explicitly.
+
+```typescript
+test('agent recovers from RONA to Available', async () => {
+  // After RONA, agent must explicitly set state
+  const ronaMsg = await expect.poll(() =>
+    tm.consoleMessages.find(msg =>
+      msg.includes('RONA')
+    ),
+    {timeout: ACCEPT_TASK_TIMEOUT}
+  );
+
+  // Select recovery option
+  await tm.agent1Page.selectOption('#agentStateSelect', RONA_OPTIONS.AVAILABLE);
+  await tm.agent1Page.click('#setAgentState');
+});
+```
+
+---
+
+## Anti-Patterns
+
+### Do NOT use arbitrary waits
+```typescript
+// BAD
+await page.waitForTimeout(5000);
+
+// GOOD
+await expect.poll(() => condition, {timeout: AWAIT_TIMEOUT}).toBeTruthy();
+```
+
+### Do NOT hardcode console patterns
+```typescript
+// BAD
+const found = messages.some(m => m.includes('WXCC_SDK_AGENT_STATE_CHANGE_SUCCESS'));
+
+// GOOD
+const found = messages.some(m => m.includes(CONSOLE_PATTERNS.SDK_STATE_CHANGE_SUCCESS));
+```
+
+### Do NOT share mutable state between test files
+```typescript
+// BAD — global variable shared across tests
+let sharedAgent: Page;
+
+// GOOD — TestManager scoped to factory function
+export default function createTests() {
+  let tm: TestManager;
+  // tm is local to this factory
+}
+```
+
+### Do NOT use anonymous callbacks for event listeners
+```typescript
+// BAD — can't unsubscribe
+page.on('console', (msg) => messages.push(msg.text()));
+
+// GOOD — named function can be unsubscribed
+const handleConsole = (msg: ConsoleMessage) => messages.push(msg.text());
+page.on('console', handleConsole);
+// Later: page.off('console', handleConsole);
+```
+
+### Do NOT skip documentation updates
+```typescript
+// BAD — add test file but don't update ARCHITECTURE.md
+// "I'll update docs later" → docs never get updated
+
+// GOOD — every PR includes both code AND doc updates
+// Follow 03-framework-and-doc-updates.md checklist
+```

--- a/packages/@webex/contact-center/ai-docs/templates/e2e/00-master.md
+++ b/packages/@webex/contact-center/ai-docs/templates/e2e/00-master.md
@@ -1,0 +1,46 @@
+# E2E Test Work — Master Template
+
+## Purpose
+
+Orchestrator for all Playwright E2E test work in `@webex/contact-center`. This template routes you through the correct workflow based on the E2E task type.
+
+---
+
+## E2E Task Types
+
+| Code | Task | Description |
+|------|------|-------------|
+| G1 | New test file | Add a new `.spec.ts` test file to an existing SET |
+| G2 | New test suite | Create a new suite that composes test files |
+| G3 | New SET | Create a new SET (project) with tests and suites |
+| G4 | Fix flaky test | Stabilize an unreliable test |
+| G5 | Fix broken test | Fix a test that consistently fails |
+| G6 | Update test for SDK change | Modify tests after SDK method/event changes |
+| G7 | Add utility | Add a new shared utility to `playwright/utils/` |
+| G8 | Update TestManager | Modify TestManager setup/cleanup/convenience methods |
+| G9 | Update constants | Add/modify timeout constants, enums, or patterns |
+| G10 | Framework config | Modify `playwright.config.ts` or `global-setup.ts` |
+| G11 | Understand E2E architecture | Read-only exploration of E2E framework |
+
+---
+
+## Workflow
+
+1. **Ask pre-questions** — Open [`01-pre-questions.md`](01-pre-questions.md). Present every MANDATORY question. Wait for answers.
+2. **Implement** — Follow [`02-test-implementation.md`](02-test-implementation.md) for the appropriate implementation path.
+3. **Update documentation (MANDATORY)** — Follow [`03-framework-and-doc-updates.md`](03-framework-and-doc-updates.md). This step is NOT optional.
+4. **Validate** — Follow [`04-validation.md`](04-validation.md) to confirm tests pass and docs are in sync.
+
+---
+
+## SUT (System Under Test) Reference
+
+The SDK sample app at `docs/samples/contact-center/` is the SUT for E2E tests. It exposes SDK methods via DOM elements that Playwright interacts with. Before writing any test, read the sample app's `app.js` to understand what DOM elements and SDK methods are available.
+
+---
+
+## Key References
+
+- **Framework guide**: [`playwright/ai-docs/AGENTS.md`](../../../playwright/ai-docs/AGENTS.md)
+- **Technical reference**: [`playwright/ai-docs/ARCHITECTURE.md`](../../../playwright/ai-docs/ARCHITECTURE.md)
+- **E2E patterns**: [`ai-docs/patterns/e2e-patterns.md`](../../patterns/e2e-patterns.md)

--- a/packages/@webex/contact-center/ai-docs/templates/e2e/01-pre-questions.md
+++ b/packages/@webex/contact-center/ai-docs/templates/e2e/01-pre-questions.md
@@ -1,0 +1,73 @@
+# E2E Pre-Questions — MANDATORY Before Implementation
+
+## Purpose
+
+These questions MUST be answered by the developer before any E2E implementation begins. Do not infer or assume answers.
+
+---
+
+## Section 1: Task Identification (MANDATORY)
+
+1. **What is the E2E task type?** (G1–G11 from `00-master.md`)
+2. **Which SET does this belong to?** (existing SET name, or "new SET" if G3)
+3. **What is the test/suite name?** (descriptive name for the new/modified test)
+
+---
+
+## Section 2: SDK Methods Under Test (MANDATORY for G1, G2, G3, G6)
+
+4. **Which SDK methods will this test exercise?**
+   - List the exact method names from `cc.ts` or service files (e.g., `cc.stationLogin()`, `task.hold()`)
+   - These methods must exist in the sample app's `app.js` as callable DOM actions
+
+5. **What SDK events should be verified?**
+   - List events the test should capture via console log verification (e.g., `WXCC_SDK_AGENT_STATE_CHANGE_SUCCESS`)
+   - These must match the patterns in `constants.ts` → `CONSOLE_PATTERNS`
+
+6. **What is the expected state flow?**
+   - Describe the sequence: initial state → action → expected state (e.g., `Available → incoming task → Engaged → end task → Available`)
+
+---
+
+## Section 3: Test Environment (MANDATORY for G1, G2, G3)
+
+7. **How many agents are needed?**
+   - Single agent (agent1 only) or multi-agent (agent1 + agent2)?
+   - Does the test need a caller page? Extension page? Chat page?
+   - Map to `SetupConfig` options: `needsAgent1`, `needsAgent2`, `needsCaller`, `needsExtension`, `needsChat`
+
+8. **What login mode?**
+   - Desktop (default), Extension, or Dial Number?
+   - Map to `SetupConfig.agent1LoginMode`
+
+---
+
+## Section 4: Stability Context (MANDATORY for G4, G5)
+
+9. **What is the failure symptom?**
+   - Exact error message or screenshot
+   - Frequency: always fails, fails ~X% of runs, fails only in CI
+
+10. **What has been tried already?**
+    - Timeout increases? (If so, which timeouts and to what values?)
+    - Retry additions? Selector changes?
+
+---
+
+## Section 5: Framework Changes (MANDATORY for G7, G8, G9, G10)
+
+11. **What is the change?**
+    - Exact description of what to add/modify in the utility, TestManager, constants, or config
+
+12. **Which existing tests will be affected?**
+    - List tests/suites that use the component being modified
+    - Confirm: should existing tests continue to work unchanged (backward compatible)?
+
+---
+
+## Core Principles (apply to all answers)
+
+- **Root cause over timeout increase**: If a test is flaky, find the root cause. Increasing timeouts is a last resort, not a fix.
+- **No lazy reasoning**: "It probably works" is not acceptable. Verify with actual code references.
+- **Timeout justification required**: If a timeout value is chosen, explain why that specific duration (reference `ARCHITECTURE.md` timeout hierarchy).
+- **Console log verification is primary**: SDK E2E tests verify behavior via console output, not UI state. Design tests around `CONSOLE_PATTERNS`.

--- a/packages/@webex/contact-center/ai-docs/templates/e2e/02-test-implementation.md
+++ b/packages/@webex/contact-center/ai-docs/templates/e2e/02-test-implementation.md
@@ -1,0 +1,98 @@
+# E2E Test Implementation
+
+## Purpose
+
+Implementation guide for Playwright E2E tasks. Choose the path matching your task type.
+
+---
+
+## Path A: New Test File (G1)
+
+1. **Create test file** in `playwright/tests/` following the test factory pattern:
+   ```typescript
+   import {test, expect} from '@playwright/test';
+   import {TestManager} from '../test-manager';
+
+   export default function createYourTests() {
+     let tm: TestManager;
+
+     test.beforeAll(async ({browser}, testInfo) => {
+       tm = new TestManager(testInfo.project.name);
+       await tm.setup(browser, {
+         needsAgent1: true,
+         // ... SetupConfig options from pre-questions
+       });
+     });
+
+     test.afterAll(async () => {
+       await tm.cleanup();
+     });
+
+     test('descriptive test name', async () => {
+       // 1. Action: interact with SUT via page
+       // 2. Verify: check console messages or page state
+     });
+   }
+   ```
+
+2. **Register in suite** — Import and call the factory in the appropriate suite file:
+   ```typescript
+   import createYourTests from '../tests/your-test.spec';
+   test.describe('Your Test Suite', createYourTests);
+   ```
+
+3. **Follow patterns** from [`e2e-patterns.md`](../../patterns/e2e-patterns.md) — especially console log verification and timeout selection.
+
+---
+
+## Path B: New Suite / New SET (G2, G3)
+
+1. **Create suite file** in `playwright/suites/` that imports and composes test factories:
+   ```typescript
+   import {test} from '@playwright/test';
+   import createTestA from '../tests/test-a.spec';
+   import createTestB from '../tests/test-b.spec';
+
+   test.describe('Suite Name', () => {
+     test.describe('Test A', createTestA);
+     test.describe('Test B', createTestB);
+   });
+   ```
+
+2. **For new SET (G3)**: Add a project entry to `playwright.config.ts` that maps `USER_SETS` env var to the new SET name and suite.
+
+3. **Update ARCHITECTURE.md** — Add the new SET/suite to the Set→Suite→Test mapping table.
+
+---
+
+## Path C: Fix Flaky/Broken Test (G4, G5)
+
+1. **Reproduce** — Run the specific test in isolation: `npx playwright test <file> --project=<SET>`
+2. **Investigate root cause** — Check:
+   - Race condition (missing `waitFor` or event)
+   - Selector instability (dynamic IDs vs. `data-testid`)
+   - Timeout too short (reference timeout hierarchy in ARCHITECTURE.md)
+   - State leakage from previous test (cleanup issue)
+3. **Fix** — Address root cause. Do NOT just increase timeouts unless justified.
+4. **Verify** — Run 5+ times to confirm stability: `npx playwright test <file> --project=<SET> --repeat-each=5`
+
+---
+
+## Path D: Update for SDK Change (G6)
+
+1. **Identify affected tests** — Grep for the changed SDK method/event across `playwright/tests/` and `playwright/utils/`
+2. **Update test logic** — Modify assertions, setup, or teardown to match new SDK behavior
+3. **Update SUT if needed** — If the SDK method signature changed, update `docs/samples/contact-center/app.js`
+4. **Run full regression** — `npx playwright test` to verify no other tests broke
+
+---
+
+## Done Criteria
+
+- [ ] Tests pass locally: `npx playwright test <file> --project=<SET>`
+- [ ] No hardcoded timeouts without justification (use constants from `constants.ts`)
+- [ ] Console log verification pattern used for SDK event assertions
+- [ ] Test factory pattern followed (exported default function, not inline)
+- [ ] **AGENTS.md baseline updated** — suite/SET counts match actual files
+- [ ] **ARCHITECTURE.md file topology updated** — new files appear in mapping tables
+- [ ] Proceed to [`03-framework-and-doc-updates.md`](03-framework-and-doc-updates.md)

--- a/packages/@webex/contact-center/ai-docs/templates/e2e/03-framework-and-doc-updates.md
+++ b/packages/@webex/contact-center/ai-docs/templates/e2e/03-framework-and-doc-updates.md
@@ -1,0 +1,44 @@
+# Framework and Documentation Updates — MANDATORY
+
+## Purpose
+
+This step is **MANDATORY**, not optional. Every E2E task that modifies files must verify and update the Playwright ai-docs to stay in sync.
+
+---
+
+## When to Update What
+
+| Change Type | Files to Update |
+|---|---|
+| New test file added | ARCHITECTURE.md (file topology, Set→Suite→Test mapping) |
+| New suite added | ARCHITECTURE.md (file topology, Set→Suite→Test mapping), AGENTS.md (baseline counts) |
+| New SET added | ARCHITECTURE.md (file topology, Set→Suite→Test mapping), AGENTS.md (baseline counts), `playwright.config.ts` |
+| New utility added | ARCHITECTURE.md (Utils reference table) |
+| New constant/timeout added | ARCHITECTURE.md (Constants section, timeout hierarchy) |
+| TestManager changed | ARCHITECTURE.md (TestManager section — SetupConfig, convenience methods, or cleanup) |
+| Console pattern changed | ARCHITECTURE.md (Console Log Verification Pattern section) |
+| Flaky test fixed | AGENTS.md (if stability pattern is reusable, add to known patterns) |
+| SDK change updated tests | ARCHITECTURE.md (if SUT interface changed) |
+
+---
+
+## Update Checklist
+
+### ARCHITECTURE.md (`playwright/ai-docs/ARCHITECTURE.md`)
+
+- [ ] **File Topology**: All new/renamed/deleted files reflected in the tree
+- [ ] **Set→Suite→Test Mapping**: Table matches actual suite registrations
+- [ ] **TestManager Section**: SetupConfig options, page properties, convenience methods are current
+- [ ] **Utils Reference Table**: All utility files listed with method signatures
+- [ ] **Constants Section**: All enums, timeout values, and console patterns are current
+- [ ] **Timeout Hierarchy**: New timeouts placed at correct level
+
+### AGENTS.md (`playwright/ai-docs/AGENTS.md`)
+
+- [ ] **Baseline Counts**: SET count, suite count, test count match actual files
+- [ ] **Common Commands**: Any new run configurations documented
+
+### e2e-patterns.md (`ai-docs/patterns/e2e-patterns.md`)
+
+- [ ] **New reusable pattern**: If the task introduced a pattern other tests should follow, add it
+- [ ] **Anti-patterns**: If the task fixed a bad pattern, add it to anti-patterns section

--- a/packages/@webex/contact-center/ai-docs/templates/e2e/04-validation.md
+++ b/packages/@webex/contact-center/ai-docs/templates/e2e/04-validation.md
@@ -1,0 +1,53 @@
+# E2E Validation Checklist
+
+## Purpose
+
+Final validation before marking an E2E task complete. Covers both test execution and documentation sync.
+
+---
+
+## Test Execution
+
+### Run specific test
+```bash
+npx playwright test playwright/tests/<test-file>.spec.ts --project=<SET_NAME>
+```
+
+### Run specific suite
+```bash
+npx playwright test playwright/suites/<suite-file>.spec.ts --project=<SET_NAME>
+```
+
+### Run all tests for a project/SET
+```bash
+npx playwright test --project=<SET_NAME>
+```
+
+### Stability check (run 5+ times)
+```bash
+npx playwright test <path> --project=<SET_NAME> --repeat-each=5
+```
+
+### List all available projects
+```bash
+npx playwright test --list
+```
+
+---
+
+## Documentation Sync Checklist (MANDATORY)
+
+- [ ] `playwright/ai-docs/ARCHITECTURE.md` file topology matches actual `playwright/` directory
+- [ ] `playwright/ai-docs/ARCHITECTURE.md` Set→Suite→Test mapping matches actual suite registrations
+- [ ] `playwright/ai-docs/AGENTS.md` baseline counts (SETs, suites, tests) match actual files
+- [ ] `ai-docs/patterns/e2e-patterns.md` reflects any new patterns introduced
+- [ ] Root `AGENTS.md` service routing table still accurate (Playwright E2E row present)
+
+---
+
+## Final Gate
+
+- [ ] All targeted tests pass
+- [ ] No regressions in other tests (run full suite if changes affect shared code)
+- [ ] Documentation updated per [`03-framework-and-doc-updates.md`](03-framework-and-doc-updates.md)
+- [ ] PR includes both test changes AND doc updates in the same commit

--- a/packages/@webex/contact-center/playwright/ai-docs/AGENTS.md
+++ b/packages/@webex/contact-center/playwright/ai-docs/AGENTS.md
@@ -1,0 +1,92 @@
+# Playwright E2E — AI Agent Guide
+
+## Purpose
+
+Usage and workflow guide for AI assistants working on Playwright E2E tests in `@webex/contact-center`. This is the entry point for all E2E test work.
+
+---
+
+## When to Use This Guide
+
+You were routed here because the developer's task was classified as **Type G: E2E Test Work** by the root [`AGENTS.md`](../../AGENTS.md). Follow the templates for implementation.
+
+---
+
+## Quick Reference
+
+### Templates (follow in order)
+
+1. [`ai-docs/templates/e2e/00-master.md`](../../ai-docs/templates/e2e/00-master.md) — Task routing and E2E task types
+2. [`ai-docs/templates/e2e/01-pre-questions.md`](../../ai-docs/templates/e2e/01-pre-questions.md) — MANDATORY pre-questions
+3. [`ai-docs/templates/e2e/02-test-implementation.md`](../../ai-docs/templates/e2e/02-test-implementation.md) — Implementation paths A-D
+4. [`ai-docs/templates/e2e/03-framework-and-doc-updates.md`](../../ai-docs/templates/e2e/03-framework-and-doc-updates.md) — MANDATORY doc updates
+5. [`ai-docs/templates/e2e/04-validation.md`](../../ai-docs/templates/e2e/04-validation.md) — Validation & doc sync checklist
+
+### Patterns
+
+- [`ai-docs/patterns/e2e-patterns.md`](../../ai-docs/patterns/e2e-patterns.md) — Test factory, console log verification, multi-agent coordination, timeout selection
+
+### Technical Reference
+
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — TestManager, Utils, Constants, Console Log Verification, file topology
+
+---
+
+## Common Commands
+
+### Run all E2E tests
+```bash
+cd packages/@webex/contact-center
+npx playwright test
+```
+
+### Run a specific test file
+```bash
+npx playwright test playwright/tests/<test-file>.spec.ts --project=<SET_NAME>
+```
+
+### Run a specific suite
+```bash
+npx playwright test playwright/suites/<suite-file>.spec.ts --project=<SET_NAME>
+```
+
+### List all projects/SETs
+```bash
+npx playwright test --list
+```
+
+### Run with repeat for stability check
+```bash
+npx playwright test <path> --project=<SET_NAME> --repeat-each=5
+```
+
+### Run in headed mode for debugging
+```bash
+npx playwright test <path> --headed
+```
+
+### Show Playwright report
+```bash
+npx playwright show-report
+```
+
+---
+
+## Baseline Counts
+
+> Update these counts whenever tests/suites/SETs are added or removed.
+
+| Metric | Count | Last Updated |
+|--------|-------|--------------|
+| SETs (projects) | 0 | Initial — no tests exist yet |
+| Suites | 0 | Initial — no tests exist yet |
+| Test files | 0 | Initial — no tests exist yet |
+| Utility files | 0 | Initial — no tests exist yet |
+
+---
+
+## Context for New Contributors
+
+This package (`@webex/contact-center`) currently has **zero E2E tests**. The existing browser testing uses WebdriverIO (`wdio.conf.js` at repo root) for the `browser-plugin-meetings` package, not for contact-center.
+
+The Playwright framework documented here is being built as a **migration target**. The ccWidgets repository (`webex/widgets`) has an established Playwright framework with TestManager, Utils, and console log verification patterns. This ccSDK framework mirrors those patterns adapted for SDK-level testing (no UI widgets — the SUT is the vanilla JS sample app at `docs/samples/contact-center/`).

--- a/packages/@webex/contact-center/playwright/ai-docs/ARCHITECTURE.md
+++ b/packages/@webex/contact-center/playwright/ai-docs/ARCHITECTURE.md
@@ -1,0 +1,260 @@
+# Playwright E2E — Architecture Reference
+
+## Purpose
+
+Complete technical reference for the Playwright E2E framework in `@webex/contact-center`. This document covers the SUT, TestManager, utilities, constants, patterns, and file topology.
+
+---
+
+## System Under Test (SUT)
+
+The SUT is the **SDK sample app** at `docs/samples/contact-center/`. Unlike ccWidgets (which tests UI widgets), ccSDK E2E tests exercise the raw SDK through a vanilla JavaScript sample app.
+
+### SUT Structure
+
+| File | Purpose |
+|------|---------|
+| `docs/samples/contact-center/app.js` | Main app — exposes SDK methods via DOM elements |
+| `docs/samples/contact-center/index.html` | HTML with buttons, dropdowns, and status elements |
+| `docs/samples/contact-center/style.css` | Styling |
+
+### Key DOM Elements (from `app.js`)
+
+| Element ID | SDK Method / Purpose |
+|------------|---------------------|
+| `#access-token-save` | Store auth token |
+| `#webexcc-register` | `cc.register()` — WebSocket registration |
+| `#webexcc-deregister` | `cc.deregister()` — WebSocket disconnect |
+| `#loginAgent` | `agent.stationLogin()` — Station login |
+| `#logoutAgent` | `agent.logout()` — Agent logout |
+| `#setAgentStatus` | `agent.stateChange()` — Set agent state |
+| `#answer` | `task.answer()` — Answer incoming task |
+| `#decline` | `task.decline()` — Decline incoming task |
+| `#hold-resume` | `task.hold()` / `task.resume()` — Hold/resume |
+| `#end` | `task.end()` — End active task |
+| `#wrapup` | `task.wrapup()` — Submit wrapup |
+| `#initiate-consult` | `task.consult()` — Start consultation |
+| `#consult-transfer` | `task.consultTransfer()` — Consult transfer |
+| `#initiate-transfer` | `task.blindTransfer()` — Blind transfer |
+| `#merge-conference` | `task.conference()` — Merge to conference |
+
+### Console Output Pattern
+
+The sample app logs SDK events and state changes to the browser console. E2E tests capture these via `page.on('console', ...)` — this is the **primary assertion mechanism** for SDK behavior verification.
+
+Key console output patterns from `app.js`:
+- `WXCC_SDK_*` events logged on SDK callbacks
+- `onStateChange invoked with state name: <state>` on agent state transitions
+- `onHoldResume` callbacks on hold/resume actions
+
+---
+
+## TestManager
+
+The `TestManager` class orchestrates browser context creation, page provisioning, login flows, and cleanup for each test.
+
+### Constructor
+
+```typescript
+class TestManager {
+  constructor(projectName: string, maxRetries: number = DEFAULT_MAX_RETRIES)
+}
+```
+
+- `projectName`: Maps to environment variable prefix for per-SET credentials (`${projectName}_AGENT1_ACCESS_TOKEN`, etc.)
+- `maxRetries`: Retry count for flaky operations (default: 3)
+
+### SetupConfig Options
+
+| Option | Type | Default | Purpose |
+|--------|------|---------|---------|
+| `needsAgent1` | `boolean` | `true` | Provision agent 1 browser context + login |
+| `needsAgent2` | `boolean` | `false` | Provision agent 2 for multi-agent tests |
+| `needsCaller` | `boolean` | `false` | Provision caller page for incoming task tests |
+| `needsExtension` | `boolean` | `false` | Provision extension login page |
+| `needsChat` | `boolean` | `false` | Provision chat page for digital channel tests |
+| `needsMultiSession` | `boolean` | `false` | Provision second session for same agent |
+| `agent1LoginMode` | `LoginMode` | `'Desktop'` | Login mode: Desktop, Extension, or Dial Number |
+| `enableConsoleLogging` | `boolean` | `true` | Capture console messages for verification |
+| `enableAdvancedLogging` | `boolean` | `false` | Capture advanced task control console events |
+| `needDialNumberLogin` | `boolean` | `false` | Provision dial number login flow |
+
+### Page Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `agent1Page` | `Page` | Main agent 1 page (always available) |
+| `agent2Page` | `Page` | Agent 2 page (when `needsAgent2: true`) |
+| `callerPage` | `Page` | Caller extension page (when `needsCaller: true`) |
+| `agent1ExtensionPage` | `Page` | Extension login page (when `needsExtension: true`) |
+| `chatPage` | `Page` | Chat page (when `needsChat: true`) |
+| `multiSessionAgent1Page` | `Page` | Second session page (when `needsMultiSession: true`) |
+| `dialNumberPage` | `Page` | Dial number page (when `needDialNumberLogin: true`) |
+
+### Convenience Methods
+
+| Method | Purpose |
+|--------|---------|
+| `setup(browser, config)` | 3-phase parallel setup: contexts → login + init → console logging |
+| `cleanup()` | Close all browser contexts in parallel |
+| `retryOperation(operation, name, maxRetries)` | Retry with exponential backoff |
+| `isLogoutButtonVisible(page, timeout)` | Check if logout button is visible |
+
+### 3-Phase Parallel Setup
+
+The `setup()` method executes in three parallelized phases:
+
+1. **Create browser contexts** — `Promise.all` creates all required `BrowserContext` + `Page` pairs
+2. **Login + widget init** — `Promise.all` runs login flows for each provisioned page independently
+3. **Console logging** — Attaches `page.on('console', ...)` handlers after pages are ready
+
+### Cleanup
+
+`cleanup()` closes all open browser contexts in parallel. Tests MUST call `cleanup()` in `test.afterAll` to avoid leaked browser processes.
+
+---
+
+## Utils Reference
+
+Shared utilities in `playwright/utils/`. Each file provides focused helper functions.
+
+| File | Key Functions | Purpose |
+|------|--------------|---------|
+| `initUtils.ts` | `enableAllWidgets()`, `initialiseWidgets()`, `loginViaAccessToken()`, `enableMultiLogin()` | Page initialization, widget loading, token-based auth |
+| `stationLoginUtils.ts` | `telephonyLogin()`, `stationLogout()` | Station login/logout flows with team and DN selection |
+| `incomingTaskUtils.ts` | `loginExtension()` | Extension login for caller agent |
+| `taskControlUtils.ts` | `setupConsoleLogging()` | Basic console log capture setup |
+| `advancedTaskControlUtils.ts` | `setupAdvancedConsoleLogging()` | Advanced console log capture for task controls |
+| `helperUtils.ts` | `pageSetup()`, `handleStrayTasks()` | Page navigation, stray task cleanup |
+| `userStateUtils.ts` | State change utilities | Agent state transition helpers |
+| `wrapupUtils.ts` | Wrapup utilities | Wrapup code selection and submission |
+
+---
+
+## Constants
+
+### Enums (const object + type pattern)
+
+| Constant | Values | Purpose |
+|----------|--------|---------|
+| `USER_STATES` | Meeting, Available, Lunch Break, RONA, Engaged, Agent_Declined | Agent state values |
+| `THEME_COLORS` | RGB values for Available, Meeting, Engaged, RONA | Visual state indicators |
+| `LOGIN_MODE` | Desktop, Extension, Dial Number | Station login modes |
+| `PAGE_TYPES` | agent1, agent2, caller, extension, chat, multiSession, dialNumber | TestManager page identifiers |
+| `TASK_TYPES` | Call, Chat, Email, Social | Task channel types |
+| `WRAPUP_REASONS` | Sale, Resolved | Wrapup completion reasons |
+| `RONA_OPTIONS` | Available, Idle | RONA recovery options |
+
+### Timeout Hierarchy
+
+Timeouts are organized from shortest to longest. Always pick the smallest timeout that satisfies the operation — never use a longer timeout "just in case."
+
+| Timeout | Value | Use For |
+|---------|-------|---------|
+| `DROPDOWN_SETTLE_TIMEOUT` | 200ms | UI micro-interactions (dropdown animation) |
+| `UI_SETTLE_TIMEOUT` | 2000ms | UI state settling after action |
+| `DEFAULT_TIMEOUT` | 5000ms | Default TestManager operation timeout |
+| `AWAIT_TIMEOUT` | 10000ms | Universal await for async operations |
+| `WRAPUP_TIMEOUT` | 15000ms | Wrapup submission + confirmation |
+| `FORM_FIELD_TIMEOUT` | 20000ms | Form field population after API response |
+| `OPERATION_TIMEOUT` | 30000ms | Long-running SDK operations |
+| `EXTENSION_REGISTRATION_TIMEOUT` | 40000ms | Extension registration + WebSocket setup |
+| `NETWORK_OPERATION_TIMEOUT` | 40000ms | Network-dependent operations |
+| `WIDGET_INIT_TIMEOUT` | 50000ms | Full widget initialization |
+| `ACCEPT_TASK_TIMEOUT` | 60000ms | Incoming task acceptance (includes routing delay) |
+| `CHAT_LAUNCHER_TIMEOUT` | 60000ms | Chat widget launcher initialization |
+
+### Console Patterns
+
+| Pattern | Value | Purpose |
+|---------|-------|---------|
+| `SDK_STATE_CHANGE_SUCCESS` | `'WXCC_SDK_AGENT_STATE_CHANGE_SUCCESS'` | Detect successful agent state change |
+| `ON_STATE_CHANGE_REGEX` | `/onStateChange invoked with state name:\s*(.+)/i` | Extract state name from callback log |
+| `ON_STATE_CHANGE_KEYWORDS` | `['onstatechange', 'invoked']` | Quick-match keywords before regex |
+
+---
+
+## Console Log Verification Pattern
+
+This is the **primary assertion mechanism** for SDK E2E tests. Instead of checking UI elements (which don't exist in SDK-only tests), tests verify SDK behavior by capturing browser console output.
+
+### How It Works
+
+1. **Setup**: `page.on('console', (msg) => tm.consoleMessages.push(msg.text()))` captures all console output
+2. **Action**: Test triggers SDK method via DOM element click (e.g., `page.click('#answer')`)
+3. **Verify**: Test asserts that expected console patterns appeared:
+   ```typescript
+   // Wait for state change event
+   await expect.poll(() =>
+     tm.consoleMessages.some(msg =>
+       msg.includes(CONSOLE_PATTERNS.SDK_STATE_CHANGE_SUCCESS)
+     )
+   ).toBeTruthy();
+
+   // Extract state name from callback
+   const stateMsg = tm.consoleMessages.find(msg =>
+     CONSOLE_PATTERNS.ON_STATE_CHANGE_REGEX.test(msg)
+   );
+   const match = stateMsg?.match(CONSOLE_PATTERNS.ON_STATE_CHANGE_REGEX);
+   expect(match?.[1]).toBe('Available');
+   ```
+
+### Key Rules
+
+- **Always use `expect.poll()`** for console message checks — messages arrive asynchronously
+- **Use exact matches** where possible — avoid `expect.objectContaining` or partial matches
+- **Clear `consoleMessages` between assertions** if the same pattern appears multiple times
+- **Reference `CONSOLE_PATTERNS`** from constants — never hardcode pattern strings in tests
+
+---
+
+## Set → Suite → Test Mapping
+
+> This table is empty because no tests exist yet. Update this table as tests are added.
+
+| SET (Project) | Suite File | Test Files | Description |
+|--------------|------------|------------|-------------|
+| _(none yet)_ | — | — | No E2E tests exist yet |
+
+---
+
+## File Topology
+
+> Update this tree as files are added.
+
+```
+packages/@webex/contact-center/playwright/
+├── ai-docs/
+│   ├── AGENTS.md                      # This usage guide
+│   └── ARCHITECTURE.md                # This file
+├── test-manager.ts                    # TestManager class (to be created)
+├── constants.ts                       # Timeouts, enums, console patterns (to be created)
+├── playwright.config.ts               # Playwright config (to be created)
+├── global-setup.ts                    # One-time auth/env setup (to be created)
+├── test-data.ts                       # Fixture data (to be created)
+├── utils/                             # Shared utilities (to be created)
+├── tests/                             # Test files organized by SET (to be created)
+└── suites/                            # Suite registries (to be created)
+```
+
+---
+
+## Extension Points
+
+When adding new capabilities to the framework:
+
+1. **New page type**: Add to `PAGE_TYPES` constant, add property to TestManager, add context creation in `createContextsForConfig()`, add setup in `createSetupPromises()`
+2. **New SetupConfig option**: Add to `SetupConfig` interface with default in `setup()`, document in this file's SetupConfig table
+3. **New timeout**: Add to constants file at correct hierarchy level, document in this file's Timeout Hierarchy table
+4. **New console pattern**: Add to `CONSOLE_PATTERNS` constant, document in this file's Console Patterns table
+5. **New utility file**: Create in `utils/`, export functions, document in this file's Utils Reference table
+
+---
+
+## Stability Principles
+
+1. **Root cause over timeout increase** — If a test fails intermittently, investigate why, don't just bump timeouts
+2. **Explicit waits over implicit** — Use `expect.poll()`, `page.waitForSelector()`, or `page.waitForEvent()` instead of `page.waitForTimeout()`
+3. **Isolated tests** — Each test file exports a factory function. Tests share no mutable state outside TestManager
+4. **Deterministic cleanup** — `cleanup()` in `afterAll` closes all contexts. `handleStrayTasks()` cleans orphaned tasks
+5. **Named callbacks** — Use named functions for `.on()`/`.off()` handlers so they can be unsubscribed


### PR DESCRIPTION
## This pull request addresses

The `@webex/contact-center` package currently has zero E2E tests. The existing browser testing uses WebdriverIO (`wdio.conf.js`) for `browser-plugin-meetings` only. This PR establishes the complete AI-docs framework for a Playwright E2E migration, mirroring the patterns established in ccWidgets' Playwright framework but adapted for SDK-level testing (SUT is the vanilla JS sample app at `docs/samples/contact-center/`).

This PR adds **task type G (E2E Test Work)** to the root AGENTS.md orchestrator so AI agents can properly route, classify, and implement Playwright E2E tasks.

## by making the following changes

### Root AGENTS.md updates (1 file modified)
- Added task type G to Quick Start Workflow (A-F → A-G)
- Added Q0 (Playwright E2E) as first question in Task Classification Decision Tree
- Added G row to Signal Keywords table
- Added G option to Disambiguation Rule
- Added G routing block to Task Type Routing section
- Added "For E2E Test Work" to Context Loading section
- Added `playwright/` tree to Repository Structure
- Added Playwright E2E row to Service Routing Table
- Added Playwright docs to Documentation Update Gate
- Added E2E patterns link to Need More Context section

### E2E templates (5 new files)
- `ai-docs/templates/e2e/00-master.md` — Orchestrator with 11 E2E task types (G1-G11)
- `ai-docs/templates/e2e/01-pre-questions.md` — 12 mandatory questions across 5 sections, including SDK Methods Under Test
- `ai-docs/templates/e2e/02-test-implementation.md` — 4 implementation paths (A: new test, B: new suite/SET, C: fix flaky/broken, D: update for SDK change)
- `ai-docs/templates/e2e/03-framework-and-doc-updates.md` — MANDATORY doc update checklist (not optional)
- `ai-docs/templates/e2e/04-validation.md` — Test execution commands and documentation sync checklist

### Playwright ai-docs (2 new files)
- `playwright/ai-docs/AGENTS.md` — Usage guide, common commands, baseline counts, context for new contributors
- `playwright/ai-docs/ARCHITECTURE.md` — Full technical reference: SUT (sample app DOM elements → SDK methods), TestManager (constructor, SetupConfig with 10 options, 7 page properties, 3-phase parallel setup, cleanup), Utils reference (8 files), Constants (7 enums, 12-level timeout hierarchy, console patterns), Console Log Verification Pattern, Set→Suite→Test mapping, file topology, extension points, stability principles

### E2E patterns (1 new file)
- `ai-docs/patterns/e2e-patterns.md` — 8 reusable patterns (test factory, console log verification, multi-agent coordination, setup/cleanup lifecycle, timeout selection, state verification, network resilience, RONA handling) + anti-patterns section

### Change Type

- [x] Documentation update
- [x] New feature (non-breaking change which adds functionality)

## The following scenarios were tested

- Verified all internal markdown links resolve correctly
- Verified AGENTS.md decision tree routes Task Type G before other types (Q0 position)
- Verified Service Routing Table includes Playwright E2E row with correct paths
- Verified Repository Structure tree matches actual new file locations
- Verified ARCHITECTURE.md DOM element table matches actual `docs/samples/contact-center/app.js` selectors
- Verified timeout hierarchy values match ccWidgets constants.ts reference
- Verified all 9 files have no conflicts with `upstream/task-refactor` base

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [x] GAI was used to create a draft that was subsequently customized or modified
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Other - Claude Code (Anthropic)
- [x] This PR is related to
  - [x] Feature
  - [x] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly