### PR TITLE
fix: remove code for roster drop detection via self with null data

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -263,10 +263,13 @@ class HashTreeParser {
     return this.sendSyncRequestToLocus(this.dataSets[datasetName], emptyLeavesData).then(
       (syncResponse) => {
         if (syncResponse) {
-          return this.parseMessage(
-            syncResponse,
-            `via empty leaves /sync API call for ${debugText}`
-          );
+          return {
+            updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
+            updatedObjects: this.parseMessage(
+              syncResponse,
+              `via empty leaves /sync API call for ${debugText}`
+            ),
+          };
         }
 
         return {updateType: LocusInfoUpdateType.OBJECTS_UPDATED, updatedObjects: []};
@@ -395,15 +398,6 @@ class HashTreeParser {
 
         // eslint-disable-next-line no-await-in-loop
         const data = await this.sendInitializationSyncRequestToLocus(name, debugText);
-
-        if (data.updateType === LocusInfoUpdateType.MEETING_ENDED) {
-          LoggerProxy.logger.warn(
-            `HashTreeParser#initializeDataSets --> ${this.debugId} meeting ended while initializing new visible data set "${name}"`
-          );
-
-          // throw an error, it will be caught higher up and the meeting will be destroyed
-          throw new MeetingEndedError();
-        }
 
         if (data.updateType === LocusInfoUpdateType.OBJECTS_UPDATED) {
           updatedObjects.push(...(data.updatedObjects || []));
@@ -943,12 +937,9 @@ class HashTreeParser {
    *
    * @param {HashTreeMessage} message - The hash tree message containing data sets and objects to be processed
    * @param {string} [debugText] - Optional debug text to include in logs
-   * @returns {Promise}
+   * @returns {HashTreeObject[]} list of hash tree objects that were updated as a result of processing the message
    */
-  private async parseMessage(
-    message: HashTreeMessage,
-    debugText?: string
-  ): Promise<{updateType: LocusInfoUpdateType; updatedObjects?: HashTreeObject[]}> {
+  private parseMessage(message: HashTreeMessage, debugText?: string): HashTreeObject[] {
     const {dataSets, visibleDataSetsUrl} = message;
 
     LoggerProxy.logger.info(
@@ -966,7 +957,6 @@ class HashTreeParser {
     this.visibleDataSetsUrl = visibleDataSetsUrl;
     dataSets.forEach((dataSet) => this.updateDataSetInfo(dataSet));
 
-    let isRosterDropped = false;
     const updatedObjects: HashTreeObject[] = [];
 
     // when we detect new visible datasets, it may be that the metadata about them is not
@@ -1032,9 +1022,6 @@ class HashTreeParser {
             zip(appliedChangesList, locusStateElementsForThisSet).forEach(
               ([changeApplied, object]) => {
                 if (changeApplied) {
-                  if (isSelf(object) && !object.data) {
-                    isRosterDropped = true;
-                  }
                   // add to updatedObjects so that our locus DTO will get updated with the new object
                   updatedObjects.push(object);
                 }
@@ -1047,20 +1034,8 @@ class HashTreeParser {
           }
         }
 
-        if (!isRosterDropped) {
-          this.runSyncAlgorithm(dataSet);
-        }
+        this.runSyncAlgorithm(dataSet);
       });
-    }
-
-    if (isRosterDropped) {
-      LoggerProxy.logger.info(
-        `HashTreeParser#parseMessage --> ${this.debugId} detected roster drop`
-      );
-      this.stopAllTimers();
-
-      // in case of roster drop we don't care about other updates
-      return {updateType: LocusInfoUpdateType.MEETING_ENDED};
     }
 
     if (dataSetsRequiringInitialization.length > 0) {
@@ -1074,7 +1049,7 @@ class HashTreeParser {
       );
     }
 
-    return {updateType: LocusInfoUpdateType.OBJECTS_UPDATED, updatedObjects};
+    return updatedObjects;
   }
 
   /**
@@ -1084,7 +1059,7 @@ class HashTreeParser {
    * @param {string} [debugText] - Optional debug text to include in logs
    * @returns {void}
    */
-  async handleMessage(message: HashTreeMessage, debugText?: string): Promise<void> {
+  handleMessage(message: HashTreeMessage, debugText?: string) {
     if (message.heartbeatIntervalMs) {
       this.heartbeatIntervalMs = message.heartbeatIntervalMs;
     }
@@ -1099,14 +1074,13 @@ class HashTreeParser {
       this.handleRootHashHeartBeatMessage(message);
       this.resetHeartbeatWatchdogs(message.dataSets);
     } else {
-      const updates = await this.parseMessage(message, debugText);
+      const updatedObjects = this.parseMessage(message, debugText);
 
-      // Only reset watchdogs if the meeting hasn't ended
-      if (updates.updateType !== LocusInfoUpdateType.MEETING_ENDED) {
-        this.resetHeartbeatWatchdogs(message.dataSets);
-      }
-
-      this.callLocusInfoUpdateCallback(updates);
+      this.resetHeartbeatWatchdogs(message.dataSets);
+      this.callLocusInfoUpdateCallback({
+        updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
+        updatedObjects,
+      });
     }
   }
 

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -35,7 +35,6 @@ import HashTreeParser, {
   DataSet,
   HashTreeMessage,
   LocusInfoUpdateType,
-  MeetingEndedError,
   Metadata,
 } from '../hashTree/hashTreeParser';
 import {HashTreeObject, ObjectType, ObjectTypeToLocusKeyMap} from '../hashTree/types';
@@ -744,15 +743,8 @@ export default class LocusInfo extends EventsScope {
 
       return;
     }
-    try {
-      await this.hashTreeParser.handleMessage(message);
-    } catch (error) {
-      if (error instanceof MeetingEndedError) {
-        this.webex.meetings.destroy(meeting, MEETING_REMOVED_REASON.SELF_REMOVED);
-      } else {
-        throw error;
-      }
-    }
+
+    this.hashTreeParser.handleMessage(message);
   }
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -1222,7 +1222,7 @@ describe('HashTreeParser', () => {
         ],
       };
 
-      await parser.handleMessage(normalMessage, 'initial message');
+      parser.handleMessage(normalMessage, 'initial message');
 
       // Verify the timer was set (the sync algorithm should have started)
       expect(parser.dataSets.main.timer).to.not.be.undefined;
@@ -1242,7 +1242,7 @@ describe('HashTreeParser', () => {
         'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' // still different from our hash
       );
 
-      await parser.handleMessage(heartbeatMessage, 'heartbeat message');
+      parser.handleMessage(heartbeatMessage, 'heartbeat message');
 
       // Verify the timer was restarted (should still exist)
       expect(parser.dataSets.main.timer).to.not.be.undefined;
@@ -1369,7 +1369,7 @@ describe('HashTreeParser', () => {
         ],
       };
 
-      await parser.handleMessage(message, 'normal update');
+      parser.handleMessage(message, 'normal update');
 
       // Verify updateItems was called on main hash tree
       assert.calledOnceWithExactly(mainUpdateItemsStub, [
@@ -1422,45 +1422,6 @@ describe('HashTreeParser', () => {
       });
     });
 
-    it('detects roster drop correctly', async () => {
-      const parser = createHashTreeParser();
-
-      // Stub updateItems to return true (indicating the change was applied)
-      sinon.stub(parser.dataSets.self.hashTree, 'updateItems').returns([true]);
-
-      // Send a roster drop message (SELF object with no data)
-      const rosterDropMessage = {
-        dataSets: [createDataSet('self', 1, 2101)],
-        visibleDataSetsUrl,
-        locusUrl,
-        locusStateElements: [
-          {
-            htMeta: {
-              elementId: {
-                type: 'self' as const,
-                id: 4,
-                version: 102,
-              },
-              dataSetNames: ['self'],
-            },
-            data: undefined, // No data - this indicates roster drop
-          },
-        ],
-      };
-
-      await parser.handleMessage(rosterDropMessage, 'roster drop message');
-
-      // Verify callback was called with MEETING_ENDED
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {
-        updatedObjects: undefined,
-      });
-
-      // Verify that all timers were stopped (timer should be undefined after roster drop)
-      assert.equal(parser.dataSets.self.timer, undefined);
-      assert.equal(parser.dataSets.main.timer, undefined);
-      assert.equal(parser.dataSets['atd-unmuted'].timer, undefined);
-    });
-
     describe('handles sentinel messages correctly', () => {
       ['main', 'self', 'unjoined'].forEach((dataSetName) => {
         it('emits MEETING_ENDED for sentinel message with dataset ' + dataSetName, async () => {
@@ -1489,7 +1450,7 @@ describe('HashTreeParser', () => {
             } as any;
           }
 
-          await parser.handleMessage(sentinelMessage, 'sentinel message');
+          parser.handleMessage(sentinelMessage, 'sentinel message');
 
           // Verify callback was called with MEETING_ENDED
           assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {
@@ -1513,7 +1474,7 @@ describe('HashTreeParser', () => {
         // Create a sentinel message for 'unjoined' dataset which the parser has never seen
         const sentinelMessage = createHeartbeatMessage('unjoined', 1, 10000, EMPTY_HASH);
 
-        await parser.handleMessage(sentinelMessage, 'sentinel message');
+        parser.handleMessage(sentinelMessage, 'sentinel message');
 
         // Verify callback was called with MEETING_ENDED
         assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {
@@ -1556,7 +1517,7 @@ describe('HashTreeParser', () => {
           ],
         };
 
-        await parser.handleMessage(message, 'initial message');
+        parser.handleMessage(message, 'initial message');
 
         // Verify callback was called with initial updates
         assert.calledOnce(callback);
@@ -1652,7 +1613,7 @@ describe('HashTreeParser', () => {
               ],
             };
 
-            await parser.handleMessage(message, 'initial message');
+            parser.handleMessage(message, 'initial message');
             callback.resetHistory();
 
             const mainDataSetUrl = parser.dataSets.main.url;
@@ -1710,7 +1671,7 @@ describe('HashTreeParser', () => {
               ],
             };
 
-            await parser.handleMessage(message, 'initial message');
+            parser.handleMessage(message, 'initial message');
             callback.resetHistory();
 
             const mainDataSetUrl = parser.dataSets.main.url;
@@ -1799,7 +1760,7 @@ describe('HashTreeParser', () => {
           ],
         };
 
-        await parser.handleMessage(message, 'initial message');
+        parser.handleMessage(message, 'initial message');
 
         callback.resetHistory();
 
@@ -1887,7 +1848,7 @@ describe('HashTreeParser', () => {
           ],
         };
 
-        await parser.handleMessage(message, 'message with self update');
+        parser.handleMessage(message, 'message with self update');
 
         callback.resetHistory();
 
@@ -1971,7 +1932,7 @@ describe('HashTreeParser', () => {
           ],
         };
 
-        await parser.handleMessage(message, 'add visible dataset');
+        parser.handleMessage(message, 'add visible dataset');
 
         // Verify that 'attendees' was added to visibleDataSets
         expect(parser.visibleDataSets.some((vds) => vds.name === 'attendees')).to.be.true;
@@ -2096,7 +2057,7 @@ describe('HashTreeParser', () => {
           locusStateElements: [],
         });
 
-        await parser.handleMessage(message, 'add new dataset requiring async init');
+        parser.handleMessage(message, 'add new dataset requiring async init');
 
         await checkAsyncDatasetInitialization(parser, newDataSet);
       });
@@ -2158,7 +2119,7 @@ describe('HashTreeParser', () => {
           )
           .rejects(error);
 
-        await parser.handleMessage(message, 'add new dataset triggering 404');
+        parser.handleMessage(message, 'add new dataset triggering 404');
 
         // The first callback call is from parseMessage with the metadata update
         callback.resetHistory();
@@ -2220,7 +2181,7 @@ describe('HashTreeParser', () => {
           ],
         };
 
-        await parser.handleMessage(message, 'remove visible dataset');
+        parser.handleMessage(message, 'remove visible dataset');
 
         // Verify that 'atd-unmuted' was removed from visibleDataSets
         expect(parser.visibleDataSets.some((vds) => vds.name === 'atd-unmuted')).to.be.false;
@@ -2321,7 +2282,7 @@ describe('HashTreeParser', () => {
           ],
         };
 
-        await parser.handleMessage(message, 'message with non-visible dataset');
+        parser.handleMessage(message, 'message with non-visible dataset');
 
         // Verify that no hash tree was created for attendees
         assert.isUndefined(parser.dataSets.attendees.hashTree);
@@ -2349,7 +2310,7 @@ describe('HashTreeParser', () => {
           heartbeatIntervalMs,
         };
 
-        await parser.handleMessage(heartbeatMessage, 'initial heartbeat');
+        parser.handleMessage(heartbeatMessage, 'initial heartbeat');
 
         // Verify only 'main' watchdog timer is set
         expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
@@ -2413,7 +2374,7 @@ describe('HashTreeParser', () => {
           heartbeatIntervalMs,
         };
 
-        await parser.handleMessage(heartbeatMessage, 'self heartbeat');
+        parser.handleMessage(heartbeatMessage, 'self heartbeat');
 
         // Mock sync response for self
         mockSendSyncRequestResponse(parser.dataSets.self.url, null);
@@ -2460,7 +2421,7 @@ describe('HashTreeParser', () => {
           heartbeatIntervalMs,
         };
 
-        await parser.handleMessage(heartbeatMessage, 'multi-dataset heartbeat');
+        parser.handleMessage(heartbeatMessage, 'multi-dataset heartbeat');
 
         // Watchdog timers should be set for both datasets in the message
         expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
@@ -2486,7 +2447,7 @@ describe('HashTreeParser', () => {
           heartbeatIntervalMs,
         };
 
-        await parser.handleMessage(heartbeat1, 'first heartbeat');
+        parser.handleMessage(heartbeat1, 'first heartbeat');
 
         const firstTimer = parser.dataSets.main.heartbeatWatchdogTimer;
         expect(firstTimer).to.not.be.undefined;
@@ -2507,7 +2468,7 @@ describe('HashTreeParser', () => {
           heartbeatIntervalMs,
         };
 
-        await parser.handleMessage(heartbeat2, 'second heartbeat');
+        parser.handleMessage(heartbeat2, 'second heartbeat');
 
         const secondTimer = parser.dataSets.main.heartbeatWatchdogTimer;
         expect(secondTimer).to.not.be.undefined;
@@ -2538,7 +2499,7 @@ describe('HashTreeParser', () => {
           heartbeatIntervalMs,
         };
 
-        await parser.handleMessage(heartbeat, 'initial heartbeat');
+        parser.handleMessage(heartbeat, 'initial heartbeat');
 
         const firstTimer = parser.dataSets.main.heartbeatWatchdogTimer;
         expect(firstTimer).to.not.be.undefined;
@@ -2566,7 +2527,7 @@ describe('HashTreeParser', () => {
           heartbeatIntervalMs,
         };
 
-        await parser.handleMessage(normalMessage, 'normal message');
+        parser.handleMessage(normalMessage, 'normal message');
 
         const secondTimer = parser.dataSets.main.heartbeatWatchdogTimer;
         expect(secondTimer).to.not.be.undefined;
@@ -2584,12 +2545,12 @@ describe('HashTreeParser', () => {
           parser.dataSets.main.hashTree.getRootHash()
         );
 
-        await parser.handleMessage(heartbeatMessage, 'heartbeat without interval');
+        parser.handleMessage(heartbeatMessage, 'heartbeat without interval');
 
         expect(parser.dataSets.main.heartbeatWatchdogTimer).to.be.undefined;
       });
 
-      it('stops all watchdog timers when meeting ends', async () => {
+      it('stops all watchdog timers when meeting ends via sentinel message', async () => {
         const parser = createHashTreeParser();
         const heartbeatIntervalMs = 5000;
 
@@ -2611,34 +2572,22 @@ describe('HashTreeParser', () => {
           heartbeatIntervalMs,
         };
 
-        await parser.handleMessage(heartbeat, 'initial heartbeat');
+        parser.handleMessage(heartbeat, 'initial heartbeat');
 
         expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
         expect(parser.dataSets.self.heartbeatWatchdogTimer).to.not.be.undefined;
 
-        // Stub updateItems to return true for the roster drop detection
-        sinon.stub(parser.dataSets.self.hashTree, 'updateItems').returns([true]);
+        // Send a sentinel END MEETING message
+        const sentinelMessage = createHeartbeatMessage(
+          'main',
+          1,
+          parser.dataSets.main.version + 1,
+          EMPTY_HASH
+        );
 
-        // Send a roster drop message that triggers MEETING_ENDED
-        const rosterDropMessage = {
-          dataSets: [createDataSet('self', 1, 2101)],
-          visibleDataSetsUrl,
-          locusUrl,
-          locusStateElements: [
-            {
-              htMeta: {
-                elementId: {type: 'self' as const, id: 4, version: 102},
-                dataSetNames: ['self'],
-              },
-              data: undefined,
-            },
-          ],
-          heartbeatIntervalMs,
-        };
+        parser.handleMessage(sentinelMessage as any, 'sentinel message');
 
-        await parser.handleMessage(rosterDropMessage, 'roster drop');
-
-        // All watchdog timers should have been stopped and NOT restarted
+        // All watchdog timers should have been stopped
         expect(parser.dataSets.main.heartbeatWatchdogTimer).to.be.undefined;
         expect(parser.dataSets.self.heartbeatWatchdogTimer).to.be.undefined;
       });
@@ -2696,7 +2645,7 @@ describe('HashTreeParser', () => {
           heartbeatIntervalMs,
         };
 
-        await parser.handleMessage(heartbeat, 'heartbeat');
+        parser.handleMessage(heartbeat, 'heartbeat');
 
         // 'main' watchdog delay = 5000 + 1^2 * 500 = 5500ms
         // 'self' watchdog delay = 5000 + 1^3 * 2000 = 7000ms
@@ -2760,7 +2709,7 @@ describe('HashTreeParser', () => {
           heartbeatIntervalMs,
         };
 
-        await parser.handleMessage(heartbeatMessage, 'heartbeat with non-visible dataset');
+        parser.handleMessage(heartbeatMessage, 'heartbeat with non-visible dataset');
 
         // Watchdog set for main (visible) but not for atd-active (no hash tree)
         expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
@@ -2771,7 +2720,7 @@ describe('HashTreeParser', () => {
 
   describe('#callLocusInfoUpdateCallback filtering', () => {
     // Helper to setup parser with initial objects and reset callback history
-    async function setupParserWithObjects(locusStateElements: any[]) {
+    function setupParserWithObjects(locusStateElements: any[]) {
       const parser = createHashTreeParser();
 
       if (locusStateElements.length > 0) {
@@ -2793,15 +2742,15 @@ describe('HashTreeParser', () => {
           locusStateElements,
         };
 
-        await parser.handleMessage(setupMessage, 'setup');
+        parser.handleMessage(setupMessage, 'setup');
       }
 
       callback.resetHistory();
       return parser;
     }
 
-    it('filters out updates when a dataset has a higher version', async () => {
-      const parser = await setupParserWithObjects([
+    it('filters out updates when a dataset has a higher version', () => {
+      const parser = setupParserWithObjects([
         {
           htMeta: {
             elementId: {type: 'locus' as const, id: 5, version: 100},
@@ -2827,14 +2776,14 @@ describe('HashTreeParser', () => {
         ],
       };
 
-      await parser.handleMessage(updateMessage, 'update with older version');
+      parser.handleMessage(updateMessage, 'update with older version');
 
       // Callback should not be called because the update was filtered out
       assert.notCalled(callback);
     });
 
-    it('allows updates when version is newer than existing', async () => {
-      const parser = await setupParserWithObjects([
+    it('allows updates when version is newer than existing', () => {
+      const parser = setupParserWithObjects([
         {
           htMeta: {
             elementId: {type: 'locus' as const, id: 5, version: 100},
@@ -2860,7 +2809,7 @@ describe('HashTreeParser', () => {
         ],
       };
 
-      await parser.handleMessage(updateMessage, 'update with newer version');
+      parser.handleMessage(updateMessage, 'update with newer version');
 
       // Callback should be called with the update
       assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
@@ -2876,8 +2825,8 @@ describe('HashTreeParser', () => {
       });
     });
 
-    it('filters out removal when object still exists in any dataset', async () => {
-      const parser = await setupParserWithObjects([
+    it('filters out removal when object still exists in any dataset', () => {
+      const parser = setupParserWithObjects([
         {
           htMeta: {
             elementId: {type: 'participant' as const, id: 10, version: 50},
@@ -2903,14 +2852,14 @@ describe('HashTreeParser', () => {
         ],
       };
 
-      await parser.handleMessage(removalMessage, 'removal from one dataset');
+      parser.handleMessage(removalMessage, 'removal from one dataset');
 
       // Callback should not be called because object still exists in atd-unmuted
       assert.notCalled(callback);
     });
 
-    it('allows removal when object does not exist in any dataset', async () => {
-      const parser = await setupParserWithObjects([]);
+    it('allows removal when object does not exist in any dataset', () => {
+      const parser = setupParserWithObjects([]);
 
       // Stub updateItems to return true (simulating that the removal was "applied")
       sinon.stub(parser.dataSets.main.hashTree, 'updateItems').returns([true]);
@@ -2931,7 +2880,7 @@ describe('HashTreeParser', () => {
         ],
       };
 
-      await parser.handleMessage(removalMessage, 'removal of non-existent object');
+      parser.handleMessage(removalMessage, 'removal of non-existent object');
 
       // Callback should be called with the removal
       assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
@@ -2947,11 +2896,11 @@ describe('HashTreeParser', () => {
       });
     });
 
-    it('filters out removal when object exists in another dataset with newer version', async () => {
+    it('filters out removal when object exists in another dataset with newer version', () => {
       const parser = createHashTreeParser();
 
       // Setup: Add object to main with version 40
-      await parser.handleMessage(
+      parser.handleMessage(
         {
           dataSets: [createDataSet('main', 16, 1100)],
           visibleDataSetsUrl,
@@ -2970,7 +2919,7 @@ describe('HashTreeParser', () => {
       );
 
       // Add object to atd-unmuted with version 50
-      await parser.handleMessage(
+      parser.handleMessage(
         {
           dataSets: [createDataSet('atd-unmuted', 16, 3100)],
           visibleDataSetsUrl,
@@ -3005,14 +2954,14 @@ describe('HashTreeParser', () => {
         ],
       };
 
-      await parser.handleMessage(removalMessage, 'removal with older version');
+      parser.handleMessage(removalMessage, 'removal with older version');
 
       // Callback should not be called because object still exists with newer version
       assert.notCalled(callback);
     });
 
-    it('filters mixed updates correctly - some pass, some filtered', async () => {
-      const parser = await setupParserWithObjects([
+    it('filters mixed updates correctly - some pass, some filtered', () => {
+      const parser = setupParserWithObjects([
         {
           htMeta: {
             elementId: {type: 'participant' as const, id: 1, version: 100},
@@ -3066,7 +3015,7 @@ describe('HashTreeParser', () => {
         ],
       };
 
-      await parser.handleMessage(mixedMessage, 'mixed updates');
+      parser.handleMessage(mixedMessage, 'mixed updates');
 
       // Callback should be called with only the valid updates (participant 1 v110 and participant 3 v10)
       assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
@@ -3089,8 +3038,8 @@ describe('HashTreeParser', () => {
       });
     });
 
-    it('does not call callback when all updates are filtered out', async () => {
-      const parser = await setupParserWithObjects([
+    it('does not call callback when all updates are filtered out', () => {
+      const parser = setupParserWithObjects([
         {
           htMeta: {
             elementId: {type: 'locus' as const, id: 5, version: 100},
@@ -3123,17 +3072,17 @@ describe('HashTreeParser', () => {
         ],
       };
 
-      await parser.handleMessage(updateMessage, 'all filtered updates');
+      parser.handleMessage(updateMessage, 'all filtered updates');
 
       // Callback should not be called at all
       assert.notCalled(callback);
     });
 
-    it('checks all visible datasets when filtering', async () => {
+    it('checks all visible datasets when filtering', () => {
       const parser = createHashTreeParser();
 
       // Setup: Add same object to multiple datasets with different versions
-      await parser.handleMessage(
+      parser.handleMessage(
         {
           dataSets: [createDataSet('main', 16, 1100)],
           visibleDataSetsUrl,
@@ -3151,7 +3100,7 @@ describe('HashTreeParser', () => {
         'setup main'
       );
 
-      await parser.handleMessage(
+      parser.handleMessage(
         {
           dataSets: [createDataSet('self', 1, 2100)],
           visibleDataSetsUrl,
@@ -3169,7 +3118,7 @@ describe('HashTreeParser', () => {
         'setup self'
       );
 
-      await parser.handleMessage(
+      parser.handleMessage(
         {
           dataSets: [createDataSet('atd-unmuted', 16, 3100)],
           visibleDataSetsUrl,
@@ -3204,14 +3153,14 @@ describe('HashTreeParser', () => {
         ],
       };
 
-      await parser.handleMessage(updateMessage, 'update with v115');
+      parser.handleMessage(updateMessage, 'update with v115');
 
       // Should be filtered out because self dataset has version 120
       assert.notCalled(callback);
     });
 
-    it('does not call callback for empty locusStateElements', async () => {
-      const parser = await setupParserWithObjects([]);
+    it('does not call callback for empty locusStateElements', () => {
+      const parser = setupParserWithObjects([]);
 
       const emptyMessage = {
         dataSets: [createDataSet('main', 16, 1100)],
@@ -3220,13 +3169,13 @@ describe('HashTreeParser', () => {
         locusStateElements: [],
       };
 
-      await parser.handleMessage(emptyMessage, 'empty elements');
+      parser.handleMessage(emptyMessage, 'empty elements');
 
       assert.notCalled(callback);
     });
 
-    it('always calls callback for MEETING_ENDED regardless of filtering', async () => {
-      const parser = await setupParserWithObjects([
+    it('always calls callback for MEETING_ENDED regardless of filtering', () => {
+      const parser = setupParserWithObjects([
         {
           htMeta: {
             elementId: {type: 'locus' as const, id: 0, version: 100},
@@ -3236,23 +3185,15 @@ describe('HashTreeParser', () => {
         },
       ]);
 
-      // Send roster drop message (SELF object with no data) to trigger MEETING_ENDED
-      const rosterDropMessage = {
-        dataSets: [createDataSet('self', 1, 2101)],
-        visibleDataSetsUrl,
-        locusUrl,
-        locusStateElements: [
-          {
-            htMeta: {
-              elementId: {type: 'self' as const, id: 4, version: 102},
-              dataSetNames: ['self'],
-            },
-            data: undefined, // roster drop triggers MEETING_ENDED
-          },
-        ],
-      };
+      // Send a sentinel END MEETING message
+      const sentinelMessage = createHeartbeatMessage(
+        'main',
+        1,
+        parser.dataSets.main.version + 1,
+        EMPTY_HASH
+      );
 
-      await parser.handleMessage(rosterDropMessage, 'roster drop message');
+      parser.handleMessage(sentinelMessage as any, 'sentinel message');
 
       // Callback should be called with MEETING_ENDED
       assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -4318,37 +4318,6 @@ describe('plugin-meetings', () => {
         assert.calledOnceWithExactly(mockHashTreeParser.handleMessage, fakeHashTreeMessage);
       });
 
-      it('destroys the meeting if HashTreeParser.handleMessage throws MeetingEndedError', async () => {
-        const fakeHashTreeMessage = {
-          locusStateElements: [],
-          dataSets: [{name: 'dataset1', url: 'http://test.com'}],
-        };
-
-        const data = {
-          eventType: LOCUSEVENT.HASH_TREE_DATA_UPDATED,
-          stateElementsMessage: fakeHashTreeMessage,
-        };
-
-        // Create a mock hash tree parser that rejects with MeetingEndedError
-        const mockHashTreeParser = {
-          handleMessage: sinon.stub().rejects(new HashTreeParserModule.MeetingEndedError()),
-        };
-        locusInfo.hashTreeParser = mockHashTreeParser;
-
-        sinon.stub(webex.meetings, 'destroy');
-
-        locusInfo.parse(mockMeeting, data);
-
-        await testUtils.flushPromises();
-
-        assert.calledOnceWithExactly(mockHashTreeParser.handleMessage, fakeHashTreeMessage);
-        assert.calledOnceWithExactly(
-          webex.meetings.destroy,
-          mockMeeting,
-          MEETING_REMOVED_REASON.SELF_REMOVED
-        );
-      });
-
       it('ignores hash tree event when hashTreeParser is not created yet', () => {
         const data = {
           eventType: LOCUSEVENT.HASH_TREE_DATA_UPDATED,


### PR DESCRIPTION
# COMPLETES #[SPARK-755474](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-755474)

## This pull request addresses
This is a kind of continuation of https://github.com/webex/webex-js-sdk/pull/4746

Locus team have confirmed that the old way of detecting roster drop is not needed anymore, so I've removed the code that detects SELF object with NULL data and treats is as an "end meeting" signal - this allows some further simplifications of code.

<img width="1404" height="238" alt="image" src="https://github.com/user-attachments/assets/d7af411b-9418-4ca9-b22f-ab82327018e1" />


## by making the following changes
Removed code for handling SELF with data=null as an indication of end of meeting

As a result I also realised that HashTreeParser.parseMessage() doesn't need to be async and because it will never return LocusInfoUpdateType.MEETING_ENDED update type, I've changed it to just return the array of updated objects

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
