### PR TITLE
refactor(meetings): reorganize media request types and constants

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -148,7 +148,7 @@ import {
 } from '../meeting-info/meeting-info-v2';
 import {CSI, ReceiveSlotManager} from '../multistream/receiveSlotManager';
 import SendSlotManager from '../multistream/sendSlotManager';
-import {MediaRequestManager} from '../multistream/mediaRequestManager';
+import MediaRequestManager from '../multistream/mediaRequestManager';
 import {
   Configuration as RemoteMediaManagerConfiguration,
   RemoteMediaManager,

--- a/packages/@webex/plugin-meetings/src/members/index.ts
+++ b/packages/@webex/plugin-meetings/src/members/index.ts
@@ -28,7 +28,7 @@ import MembersCollection from './collection';
 import MembersRequest from './request';
 import MembersUtil from './util';
 import {ReceiveSlotManager} from '../multistream/receiveSlotManager';
-import {MediaRequestManager} from '../multistream/mediaRequestManager';
+import MediaRequestManager from '../multistream/mediaRequestManager';
 import {ServerRoleShape} from './types';
 import {Invitee} from '../meeting/type';
 

--- a/packages/@webex/plugin-meetings/src/multistream/codec/constants.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/codec/constants.ts
@@ -1,0 +1,40 @@
+import {H264EncodingParams, SupportedResolution} from '@webex/internal-media-core';
+import {RemoteVideoResolution} from '../types';
+
+export const H264_CODEC_PARAMETERS = {
+  '90p': {
+    maxFs: 60,
+  },
+  '180p': {
+    maxFs: 240,
+  },
+  '360p': {
+    maxFs: 920,
+  },
+  '540p': {
+    maxFs: 2040,
+  },
+  '720p': {
+    maxFs: 3600,
+  },
+  '1080p': {
+    maxFs: 8192,
+  },
+} satisfies Record<SupportedResolution, H264EncodingParams>;
+
+export const CODEC_DEFAULTS = {
+  h264: {
+    ...H264_CODEC_PARAMETERS['1080p'],
+    maxFps: 3000,
+    maxMbps: 245760,
+  },
+};
+
+export const PANE_SIZE_TO_RESOLUTION = {
+  thumbnail: '90p',
+  'very small': '180p',
+  small: '360p',
+  medium: '720p',
+  large: '1080p',
+  best: '1080p',
+} satisfies Record<RemoteVideoResolution, SupportedResolution>;

--- a/packages/@webex/plugin-meetings/src/multistream/codec/constants.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/codec/constants.ts
@@ -1,5 +1,4 @@
 import {H264EncodingParams, SupportedResolution} from '@webex/internal-media-core';
-import {RemoteVideoResolution} from '../types';
 
 export const H264_CODEC_PARAMETERS = {
   '90p': {
@@ -29,12 +28,3 @@ export const CODEC_DEFAULTS = {
     maxMbps: 245760,
   },
 };
-
-export const PANE_SIZE_TO_RESOLUTION = {
-  thumbnail: '90p',
-  'very small': '180p',
-  small: '360p',
-  medium: '720p',
-  large: '1080p',
-  best: '1080p',
-} satisfies Record<RemoteVideoResolution, SupportedResolution>;

--- a/packages/@webex/plugin-meetings/src/multistream/codec/types.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/codec/types.ts
@@ -1,22 +1,7 @@
-import {
-  CodecInfo as WcmeCodecInfo,
-  SupportedResolution,
-  H264EncodingParams,
-} from '@webex/internal-media-core';
-import type {MediaRequest} from '../types';
+import {H264EncodingParams} from '@webex/internal-media-core';
 
 export type H264CodecInfo = H264EncodingParams & {
   codec: 'h264';
 };
 
 export type CodecInfo = H264CodecInfo;
-
-export interface MediaCodecHelper {
-  getCodecInfo(options: {
-    getMaxFs?: () => number;
-    getMaxPicSize?: () => number;
-  }): CodecInfo | undefined;
-  getWCMECodecInfos(mediaRequest: MediaRequest): WcmeCodecInfo[];
-  degradeMediaRequest(mediaRequest: MediaRequest, resolution: SupportedResolution): number;
-  getMaxPayloadBitsPerSecond(mediaRequest: MediaRequest): number;
-}

--- a/packages/@webex/plugin-meetings/src/multistream/codec/types.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/codec/types.ts
@@ -1,0 +1,22 @@
+import {
+  CodecInfo as WcmeCodecInfo,
+  SupportedResolution,
+  H264EncodingParams,
+} from '@webex/internal-media-core';
+import type {MediaRequest} from '../types';
+
+export type H264CodecInfo = H264EncodingParams & {
+  codec: 'h264';
+};
+
+export type CodecInfo = H264CodecInfo;
+
+export interface MediaCodecHelper {
+  getCodecInfo(options: {
+    getMaxFs?: () => number;
+    getMaxPicSize?: () => number;
+  }): CodecInfo | undefined;
+  getWCMECodecInfos(mediaRequest: MediaRequest): WcmeCodecInfo[];
+  degradeMediaRequest(mediaRequest: MediaRequest, resolution: SupportedResolution): number;
+  getMaxPayloadBitsPerSecond(mediaRequest: MediaRequest): number;
+}

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -8,59 +8,31 @@ import {
   H264Codec,
   getRecommendedMaxBitrateForFrameSize,
   RecommendedOpusBitrates,
-  NamedMediaGroup,
 } from '@webex/internal-media-core';
 import {cloneDeepWith, debounce, isEmpty} from 'lodash';
 
 import LoggerProxy from '../common/logs/logger-proxy';
 
-import {ReceiveSlot, ReceiveSlotEvents} from './receiveSlot';
-import {MAX_FS_VALUES} from './remoteMedia';
+import {ReceiveSlotEvents} from './receiveSlot';
+import {MediaRequest, MediaRequestId} from './types';
+import {CODEC_DEFAULTS, H264_CODEC_PARAMETERS} from './codec/constants';
 
-export interface ActiveSpeakerPolicyInfo {
-  policy: 'active-speaker';
-  priority: number;
-  crossPriorityDuplication: boolean;
-  crossPolicyDuplication: boolean;
-  preferLiveVideo: boolean;
-  namedMediaGroups?: NamedMediaGroup[];
-}
-
-export interface ReceiverSelectedPolicyInfo {
-  policy: 'receiver-selected';
-  csi: number;
-}
-
-export type PolicyInfo = ActiveSpeakerPolicyInfo | ReceiverSelectedPolicyInfo;
-
-export interface H264CodecInfo {
-  codec: 'h264';
-  maxFs?: number;
-  maxFps?: number;
-  maxMbps?: number;
-  maxWidth?: number;
-  maxHeight?: number;
-}
-
-export type CodecInfo = H264CodecInfo; // we'll add AV1 here in the future when it's available
-
-export interface MediaRequest {
-  policyInfo: PolicyInfo;
-  receiveSlots: Array<ReceiveSlot>;
-  codecInfo?: CodecInfo;
-  preferredMaxFs?: number;
-  handleMaxFs?: ({maxFs}: {maxFs: number}) => void;
-}
-
-export type MediaRequestId = string;
-
-const CODEC_DEFAULTS = {
-  h264: {
-    maxFs: 8192,
-    maxFps: 3000,
-    maxMbps: 245760,
-  },
-};
+export type {
+  /** @deprecated use ActiveSpeakerPolicyInfo from @webex/plugin-meetings/src/types instead */
+  ActiveSpeakerPolicyInfo,
+  /** @deprecated use ReceiverSelectedPolicyInfo from @webex/plugin-meetings/src/types instead */
+  ReceiverSelectedPolicyInfo,
+  /** @deprecated use PolicyInfo from @webex/plugin-meetings/src/types instead */
+  PolicyInfo,
+  /** @deprecated use MediaRequest from @webex/plugin-meetings/src/types instead */
+  MediaRequest,
+  /** @deprecated use MediaRequestId from @webex/plugin-meetings/src/types instead */
+  MediaRequestId,
+} from './types';
+export type {
+  /** @deprecated use CodecInfo from @webex/plugin-meetings/src/codec/types instead */
+  CodecInfo,
+} from './codec/types';
 
 const DEBOUNCED_SOURCE_UPDATE_TIME = 1000;
 
@@ -123,19 +95,19 @@ export class MediaRequestManager {
 
   private getDegradedClientRequests(clientRequests: ClientRequestsMap) {
     const maxFsLimits = [
-      MAX_FS_VALUES['1080p'],
-      MAX_FS_VALUES['720p'],
-      MAX_FS_VALUES['540p'],
-      MAX_FS_VALUES['360p'],
-      MAX_FS_VALUES['180p'],
-      MAX_FS_VALUES['90p'],
+      H264_CODEC_PARAMETERS['1080p'].maxFs,
+      H264_CODEC_PARAMETERS['720p'].maxFs,
+      H264_CODEC_PARAMETERS['540p'].maxFs,
+      H264_CODEC_PARAMETERS['360p'].maxFs,
+      H264_CODEC_PARAMETERS['180p'].maxFs,
+      H264_CODEC_PARAMETERS['90p'].maxFs,
     ];
 
-    // reduce max-fs until total macroblocks is below limit
+    // reduce max-fs until total macroblocks is below limit (H264 only)
     for (let i = 0; i < maxFsLimits.length; i += 1) {
       let totalMacroblocksRequested = 0;
       Object.values(clientRequests).forEach((mr) => {
-        if (mr.codecInfo) {
+        if (mr.codecInfo && mr.codecInfo.codec === 'h264') {
           mr.codecInfo.maxFs = Math.min(
             mr.preferredMaxFs || CODEC_DEFAULTS.h264.maxFs,
             mr.codecInfo.maxFs || CODEC_DEFAULTS.h264.maxFs,
@@ -207,9 +179,12 @@ export class MediaRequestManager {
       return RecommendedOpusBitrates.FB_MONO_MUSIC;
     }
 
-    return getRecommendedMaxBitrateForFrameSize(
-      mediaRequest.codecInfo.maxFs || CODEC_DEFAULTS.h264.maxFs
-    );
+    const maxFs =
+      mediaRequest.codecInfo?.codec === 'h264'
+        ? mediaRequest.codecInfo.maxFs || CODEC_DEFAULTS.h264.maxFs
+        : CODEC_DEFAULTS.h264.maxFs;
+
+    return getRecommendedMaxBitrateForFrameSize(maxFs);
   }
 
   /**
@@ -223,6 +198,9 @@ export class MediaRequestManager {
    */
   // eslint-disable-next-line class-methods-use-this
   private getH264MaxMbps(mediaRequest: MediaRequest): number {
+    if (!mediaRequest.codecInfo || mediaRequest.codecInfo.codec !== 'h264') {
+      return (CODEC_DEFAULTS.h264.maxFs * CODEC_DEFAULTS.h264.maxFps) / 100;
+    }
     // fallback for maxFps (not needed for maxFs, since there is a fallback already in getDegradedClientRequests)
     const maxFps = mediaRequest.codecInfo.maxFps || CODEC_DEFAULTS.h264.maxFps;
 
@@ -355,18 +333,19 @@ export class MediaRequestManager {
               : new ReceiverSelectedInfo(mr.policyInfo.csi),
             mr.receiveSlots.map((receiveSlot) => receiveSlot.wcmeReceiveSlot),
             this.getMaxPayloadBitsPerSecond(mr),
-            mr.codecInfo && [
-              WcmeCodecInfo.fromH264(
-                0x80,
-                new H264Codec(
-                  mr.codecInfo.maxFs,
-                  mr.codecInfo.maxFps || CODEC_DEFAULTS.h264.maxFps,
-                  this.getH264MaxMbps(mr),
-                  mr.codecInfo.maxWidth,
-                  mr.codecInfo.maxHeight
-                )
-              ),
-            ]
+            mr.codecInfo &&
+              mr.codecInfo.codec === 'h264' && [
+                WcmeCodecInfo.fromH264(
+                  0x80,
+                  new H264Codec(
+                    mr.codecInfo.maxFs,
+                    mr.codecInfo.maxFps || CODEC_DEFAULTS.h264.maxFps,
+                    this.getH264MaxMbps(mr),
+                    mr.codecInfo.maxWidth,
+                    mr.codecInfo.maxHeight
+                  )
+                ),
+              ]
           )
         );
       }

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -103,11 +103,11 @@ export class MediaRequestManager {
       H264_CODEC_PARAMETERS['90p'].maxFs,
     ];
 
-    // reduce max-fs until total macroblocks is below limit (H264 only)
+    // reduce max-fs until total macroblocks is below limit
     for (let i = 0; i < maxFsLimits.length; i += 1) {
       let totalMacroblocksRequested = 0;
       Object.values(clientRequests).forEach((mr) => {
-        if (mr.codecInfo && mr.codecInfo.codec === 'h264') {
+        if (mr.codecInfo) {
           mr.codecInfo.maxFs = Math.min(
             mr.preferredMaxFs || CODEC_DEFAULTS.h264.maxFs,
             mr.codecInfo.maxFs || CODEC_DEFAULTS.h264.maxFs,
@@ -179,12 +179,9 @@ export class MediaRequestManager {
       return RecommendedOpusBitrates.FB_MONO_MUSIC;
     }
 
-    const maxFs =
-      mediaRequest.codecInfo?.codec === 'h264'
-        ? mediaRequest.codecInfo.maxFs || CODEC_DEFAULTS.h264.maxFs
-        : CODEC_DEFAULTS.h264.maxFs;
-
-    return getRecommendedMaxBitrateForFrameSize(maxFs);
+    return getRecommendedMaxBitrateForFrameSize(
+      mediaRequest.codecInfo.maxFs || CODEC_DEFAULTS.h264.maxFs
+    );
   }
 
   /**
@@ -198,9 +195,6 @@ export class MediaRequestManager {
    */
   // eslint-disable-next-line class-methods-use-this
   private getH264MaxMbps(mediaRequest: MediaRequest): number {
-    if (!mediaRequest.codecInfo || mediaRequest.codecInfo.codec !== 'h264') {
-      return (CODEC_DEFAULTS.h264.maxFs * CODEC_DEFAULTS.h264.maxFps) / 100;
-    }
     // fallback for maxFps (not needed for maxFs, since there is a fallback already in getDegradedClientRequests)
     const maxFps = mediaRequest.codecInfo.maxFps || CODEC_DEFAULTS.h264.maxFps;
 
@@ -333,19 +327,18 @@ export class MediaRequestManager {
               : new ReceiverSelectedInfo(mr.policyInfo.csi),
             mr.receiveSlots.map((receiveSlot) => receiveSlot.wcmeReceiveSlot),
             this.getMaxPayloadBitsPerSecond(mr),
-            mr.codecInfo &&
-              mr.codecInfo.codec === 'h264' && [
-                WcmeCodecInfo.fromH264(
-                  0x80,
-                  new H264Codec(
-                    mr.codecInfo.maxFs,
-                    mr.codecInfo.maxFps || CODEC_DEFAULTS.h264.maxFps,
-                    this.getH264MaxMbps(mr),
-                    mr.codecInfo.maxWidth,
-                    mr.codecInfo.maxHeight
-                  )
-                ),
-              ]
+            mr.codecInfo && [
+              WcmeCodecInfo.fromH264(
+                0x80,
+                new H264Codec(
+                  mr.codecInfo.maxFs,
+                  mr.codecInfo.maxFps || CODEC_DEFAULTS.h264.maxFps,
+                  this.getH264MaxMbps(mr),
+                  mr.codecInfo.maxWidth,
+                  mr.codecInfo.maxHeight
+                )
+              ),
+            ]
           )
         );
       }

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -17,23 +17,6 @@ import {ReceiveSlotEvents} from './receiveSlot';
 import {MediaRequest, MediaRequestId} from './types';
 import {CODEC_DEFAULTS, H264_CODEC_PARAMETERS} from './codec/constants';
 
-export type {
-  /** @deprecated use ActiveSpeakerPolicyInfo from @webex/plugin-meetings/src/types instead */
-  ActiveSpeakerPolicyInfo,
-  /** @deprecated use ReceiverSelectedPolicyInfo from @webex/plugin-meetings/src/types instead */
-  ReceiverSelectedPolicyInfo,
-  /** @deprecated use PolicyInfo from @webex/plugin-meetings/src/types instead */
-  PolicyInfo,
-  /** @deprecated use MediaRequest from @webex/plugin-meetings/src/types instead */
-  MediaRequest,
-  /** @deprecated use MediaRequestId from @webex/plugin-meetings/src/types instead */
-  MediaRequestId,
-} from './types';
-export type {
-  /** @deprecated use CodecInfo from @webex/plugin-meetings/src/codec/types instead */
-  CodecInfo,
-} from './codec/types';
-
 const DEBOUNCED_SOURCE_UPDATE_TIME = 1000;
 
 type DegradationPreferences = {
@@ -51,7 +34,7 @@ type Options = {
 
 type ClientRequestsMap = {[key: MediaRequestId]: MediaRequest};
 
-export class MediaRequestManager {
+export default class MediaRequestManager {
   private sendMediaRequestsCallback: SendMediaRequestsCallback;
 
   private kind: Kind;

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -1,32 +1,32 @@
 /* eslint-disable valid-jsdoc */
-import {MediaType, StreamState} from '@webex/internal-media-core';
+import {MediaType, StreamState, SupportedResolution} from '@webex/internal-media-core';
 import LoggerProxy from '../common/logs/logger-proxy';
 import EventsScope from '../common/events/events-scope';
 
 import {MediaRequestId, MediaRequestManager} from './mediaRequestManager';
 import {CSI, ReceiveSlot, ReceiveSlotEvents} from './receiveSlot';
+import type {RemoteVideoResolution} from './types';
+import {H264_CODEC_PARAMETERS} from './codec/constants';
+
+export type {
+  /** @deprecated use RemoteVideoResolution from @webex/plugin-meetings/src/types instead */
+  RemoteVideoResolution,
+} from './types';
 
 export const RemoteMediaEvents = {
   SourceUpdate: ReceiveSlotEvents.SourceUpdate,
   Stopped: 'stopped',
 };
 
-export type RemoteVideoResolution =
-  | 'thumbnail' // the smallest possible resolution, 90p or less
-  | 'very small' // 180p or less
-  | 'small' // 360p or less
-  | 'medium' // 720p or less
-  | 'large' // 1080p or less
-  | 'best'; // highest possible resolution
-
+/** @deprecated use H264_CODEC_PARAMETERS from @webex/plugin-meetings/src/codec/constants instead */
 export const MAX_FS_VALUES = {
-  '90p': 60,
-  '180p': 240,
-  '360p': 920,
-  '540p': 2040,
-  '720p': 3600,
-  '1080p': 8192,
-};
+  '90p': H264_CODEC_PARAMETERS['90p'].maxFs,
+  '180p': H264_CODEC_PARAMETERS['180p'].maxFs,
+  '360p': H264_CODEC_PARAMETERS['360p'].maxFs,
+  '540p': H264_CODEC_PARAMETERS['540p'].maxFs,
+  '720p': H264_CODEC_PARAMETERS['720p'].maxFs,
+  '1080p': H264_CODEC_PARAMETERS['1080p'].maxFs,
+} satisfies Record<SupportedResolution, number>;
 
 /**
  * Converts pane size into h264 maxFs

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts
@@ -1,32 +1,17 @@
 /* eslint-disable valid-jsdoc */
-import {MediaType, StreamState, SupportedResolution} from '@webex/internal-media-core';
+import {MediaType, StreamState} from '@webex/internal-media-core';
 import LoggerProxy from '../common/logs/logger-proxy';
 import EventsScope from '../common/events/events-scope';
 
-import {MediaRequestId, MediaRequestManager} from './mediaRequestManager';
+import MediaRequestManager from './mediaRequestManager';
 import {CSI, ReceiveSlot, ReceiveSlotEvents} from './receiveSlot';
-import type {RemoteVideoResolution} from './types';
+import type {MediaRequestId, RemoteVideoResolution} from './types';
 import {H264_CODEC_PARAMETERS} from './codec/constants';
-
-export type {
-  /** @deprecated use RemoteVideoResolution from @webex/plugin-meetings/src/types instead */
-  RemoteVideoResolution,
-} from './types';
 
 export const RemoteMediaEvents = {
   SourceUpdate: ReceiveSlotEvents.SourceUpdate,
   Stopped: 'stopped',
 };
-
-/** @deprecated use H264_CODEC_PARAMETERS from @webex/plugin-meetings/src/codec/constants instead */
-export const MAX_FS_VALUES = {
-  '90p': H264_CODEC_PARAMETERS['90p'].maxFs,
-  '180p': H264_CODEC_PARAMETERS['180p'].maxFs,
-  '360p': H264_CODEC_PARAMETERS['360p'].maxFs,
-  '540p': H264_CODEC_PARAMETERS['540p'].maxFs,
-  '720p': H264_CODEC_PARAMETERS['720p'].maxFs,
-  '1080p': H264_CODEC_PARAMETERS['1080p'].maxFs,
-} satisfies Record<SupportedResolution, number>;
 
 /**
  * Converts pane size into h264 maxFs
@@ -38,28 +23,28 @@ export function getMaxFs(paneSize: RemoteVideoResolution): number {
 
   switch (paneSize) {
     case 'thumbnail':
-      maxFs = MAX_FS_VALUES['90p'];
+      maxFs = H264_CODEC_PARAMETERS['90p'].maxFs;
       break;
     case 'very small':
-      maxFs = MAX_FS_VALUES['180p'];
+      maxFs = H264_CODEC_PARAMETERS['180p'].maxFs;
       break;
     case 'small':
-      maxFs = MAX_FS_VALUES['360p'];
+      maxFs = H264_CODEC_PARAMETERS['360p'].maxFs;
       break;
     case 'medium':
-      maxFs = MAX_FS_VALUES['720p'];
+      maxFs = H264_CODEC_PARAMETERS['720p'].maxFs;
       break;
     case 'large':
-      maxFs = MAX_FS_VALUES['1080p'];
+      maxFs = H264_CODEC_PARAMETERS['1080p'].maxFs;
       break;
     case 'best':
-      maxFs = MAX_FS_VALUES['1080p']; // for now 'best' is 1080p, so same as 'large'
+      maxFs = H264_CODEC_PARAMETERS['1080p'].maxFs; // for now 'best' is 1080p, so same as 'large'
       break;
     default:
       LoggerProxy.logger.warn(
         `RemoteMedia#getMaxFs --> unsupported paneSize: ${paneSize}, using "medium" instead`
       );
-      maxFs = MAX_FS_VALUES['720p'];
+      maxFs = H264_CODEC_PARAMETERS['720p'].maxFs;
   }
 
   return maxFs;
@@ -139,17 +124,17 @@ export class RemoteMedia extends EventsScope {
     const getThresholdHeight = (h: number) => Math.round(h * threshold);
 
     if (height < getThresholdHeight(90)) {
-      fs = MAX_FS_VALUES['90p'];
+      fs = H264_CODEC_PARAMETERS['90p'].maxFs;
     } else if (height < getThresholdHeight(180)) {
-      fs = MAX_FS_VALUES['180p'];
+      fs = H264_CODEC_PARAMETERS['180p'].maxFs;
     } else if (height < getThresholdHeight(360)) {
-      fs = MAX_FS_VALUES['360p'];
+      fs = H264_CODEC_PARAMETERS['360p'].maxFs;
     } else if (height < getThresholdHeight(540)) {
-      fs = MAX_FS_VALUES['540p'];
+      fs = H264_CODEC_PARAMETERS['540p'].maxFs;
     } else if (height <= 720) {
-      fs = MAX_FS_VALUES['720p'];
+      fs = H264_CODEC_PARAMETERS['720p'].maxFs;
     } else {
-      fs = MAX_FS_VALUES['1080p'];
+      fs = H264_CODEC_PARAMETERS['1080p'].maxFs;
     }
 
     this.maxFrameSize = fs;

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts
@@ -5,8 +5,9 @@ import {forEach} from 'lodash';
 import {NamedMediaGroup} from '@webex/internal-media-core';
 import LoggerProxy from '../common/logs/logger-proxy';
 
-import {getMaxFs, RemoteMedia, RemoteVideoResolution} from './remoteMedia';
-import {MediaRequestId, MediaRequestManager} from './mediaRequestManager';
+import {getMaxFs, RemoteMedia} from './remoteMedia';
+import MediaRequestManager from './mediaRequestManager';
+import type {MediaRequestId, RemoteVideoResolution} from './types';
 import {CSI, ReceiveSlot} from './receiveSlot';
 
 type Options = {

--- a/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts
@@ -6,11 +6,12 @@ import {MediaType, NamedMediaGroup} from '@webex/internal-media-core';
 import LoggerProxy from '../common/logs/logger-proxy';
 import EventsScope from '../common/events/events-scope';
 
-import {RemoteMedia, RemoteVideoResolution} from './remoteMedia';
+import {RemoteMedia} from './remoteMedia';
+import type {RemoteVideoResolution} from './types';
 import {ReceiveSlot, CSI} from './receiveSlot';
 import {ReceiveSlotManager} from './receiveSlotManager';
 import {RemoteMediaGroup} from './remoteMediaGroup';
-import {MediaRequestManager} from './mediaRequestManager';
+import MediaRequestManager from './mediaRequestManager';
 import {NAMED_MEDIA_GROUP_TYPE_AUDIO} from '../constants';
 
 export type PaneSize = RemoteVideoResolution;

--- a/packages/@webex/plugin-meetings/src/multistream/types.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/types.ts
@@ -1,0 +1,45 @@
+import {NamedMediaGroup} from '@webex/internal-media-core';
+import type {CodecInfo} from './codec/types';
+import {ReceiveSlot} from './receiveSlot';
+
+export interface ActiveSpeakerPolicyInfo {
+  policy: 'active-speaker';
+  priority: number;
+  crossPriorityDuplication: boolean;
+  crossPolicyDuplication: boolean;
+  preferLiveVideo: boolean;
+  namedMediaGroups?: NamedMediaGroup[];
+}
+
+export interface ReceiverSelectedPolicyInfo {
+  policy: 'receiver-selected';
+  csi: number;
+}
+
+export type PolicyInfo = ActiveSpeakerPolicyInfo | ReceiverSelectedPolicyInfo;
+
+export interface MediaRequest {
+  policyInfo: PolicyInfo;
+  receiveSlots: Array<ReceiveSlot>;
+  codecInfo?: CodecInfo;
+  preferredMaxFs?: number;
+  preferredMaxPicSize?: number;
+  handleMaxFs?: ({maxFs}: {maxFs: number}) => void;
+  handleMaxPicSize?: ({maxPicSize}: {maxPicSize: number}) => void;
+}
+
+export type MediaRequestId = string;
+
+export type RemoteVideoResolution =
+  /** the smallest possible resolution, 90p or less */
+  | 'thumbnail'
+  /** 180p or less */
+  | 'very small'
+  /** 360p or less */
+  | 'small'
+  /** 720p or less */
+  | 'medium'
+  /** 1080p or less */
+  | 'large'
+  /** highest possible resolution */
+  | 'best';

--- a/packages/@webex/plugin-meetings/src/multistream/types.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/types.ts
@@ -18,16 +18,6 @@ export interface ReceiverSelectedPolicyInfo {
 
 export type PolicyInfo = ActiveSpeakerPolicyInfo | ReceiverSelectedPolicyInfo;
 
-export interface MediaRequest {
-  policyInfo: PolicyInfo;
-  receiveSlots: Array<ReceiveSlot>;
-  codecInfo?: CodecInfo;
-  preferredMaxFs?: number;
-  handleMaxFs?: ({maxFs}: {maxFs: number}) => void;
-}
-
-export type MediaRequestId = string;
-
 export type RemoteVideoResolution =
   /** the smallest possible resolution, 90p or less */
   | 'thumbnail'
@@ -41,3 +31,13 @@ export type RemoteVideoResolution =
   | 'large'
   /** highest possible resolution */
   | 'best';
+
+export interface MediaRequest {
+  policyInfo: PolicyInfo;
+  receiveSlots: Array<ReceiveSlot>;
+  codecInfos?: CodecInfo[];
+  preferredMaxFs?: number;
+  handleMaxFs?: ({maxFs}: {maxFs: number}) => void;
+}
+
+export type MediaRequestId = string;

--- a/packages/@webex/plugin-meetings/src/multistream/types.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/types.ts
@@ -23,9 +23,7 @@ export interface MediaRequest {
   receiveSlots: Array<ReceiveSlot>;
   codecInfo?: CodecInfo;
   preferredMaxFs?: number;
-  preferredMaxPicSize?: number;
   handleMaxFs?: ({maxFs}: {maxFs: number}) => void;
-  handleMaxPicSize?: ({maxPicSize}: {maxPicSize: number}) => void;
 }
 
 export type MediaRequestId = string;

--- a/packages/@webex/plugin-meetings/src/multistream/types.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/types.ts
@@ -35,7 +35,7 @@ export type RemoteVideoResolution =
 export interface MediaRequest {
   policyInfo: PolicyInfo;
   receiveSlots: Array<ReceiveSlot>;
-  codecInfos?: CodecInfo[];
+  codecInfo?: CodecInfo;
   preferredMaxFs?: number;
   handleMaxFs?: ({maxFs}: {maxFs: number}) => void;
 }

--- a/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/reconnection-manager/index.ts
@@ -21,7 +21,7 @@ import ReconnectionError from '../common/errors/reconnection';
 import ReconnectionNotStartedError from '../common/errors/reconnection-not-started';
 import Metrics from '../metrics';
 import Meeting from '../meeting';
-import {MediaRequestManager} from '../multistream/mediaRequestManager';
+import MediaRequestManager from '../multistream/mediaRequestManager';
 
 /**
  * Used to indicate that the reconnect logic needs to be retried.

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -70,7 +70,7 @@ import LoggerConfig from '@webex/plugin-meetings/src/common/logs/logger-config';
 import TriggerProxy from '@webex/plugin-meetings/src/common/events/trigger-proxy';
 import Metrics from '@webex/plugin-meetings/src/metrics';
 import BEHAVIORAL_METRICS from '@webex/plugin-meetings/src/metrics/constants';
-import {MediaRequestManager} from '@webex/plugin-meetings/src/multistream/mediaRequestManager';
+import MediaRequestManager from '@webex/plugin-meetings/src/multistream/mediaRequestManager';
 import * as ReceiveSlotManagerModule from '@webex/plugin-meetings/src/multistream/receiveSlotManager';
 import * as SendSlotManagerModule from '@webex/plugin-meetings/src/multistream/sendSlotManager';
 import {CallDiagnosticUtils} from '@webex/internal-plugin-metrics';

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -7,7 +7,6 @@ import {getMaxFs} from '@webex/plugin-meetings/src/multistream/remoteMedia';
 import FakeTimers from '@sinonjs/fake-timers';
 import * as InternalMediaCoreModule from '@webex/internal-media-core';
 import { expect } from 'chai';
-import { H264_CODEC_PARAMETERS } from '../../../../src/multistream/codec/constants';
 
 type ExpectedActiveSpeaker = {
   policy: 'active-speaker';
@@ -913,7 +912,7 @@ describe('MediaRequestManager', () => {
         priority: 255,
         receiveSlots: fakeWcmeSlots.slice(0, 10),
         maxPayloadBitsPerSecond: MAX_PAYLOADBITSPS_540p,
-        maxFs:  H264_CODEC_PARAMETERS['540p'].maxFs,
+        maxFs: MAX_FS_540p,
         maxMbps: MAX_MBPS_540p,
       },
     ]);

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -1,12 +1,13 @@
 import 'jsdom-global/register';
-import {MediaRequestManager} from '@webex/plugin-meetings/src/multistream/mediaRequestManager';
+import MediaRequestManager from '@webex/plugin-meetings/src/multistream/mediaRequestManager';
 import {ReceiveSlot} from '@webex/plugin-meetings/src/multistream/receiveSlot';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
-import {getMaxFs, MAX_FS_VALUES} from '@webex/plugin-meetings/src/multistream/remoteMedia';
+import {getMaxFs} from '@webex/plugin-meetings/src/multistream/remoteMedia';
 import FakeTimers from '@sinonjs/fake-timers';
 import * as InternalMediaCoreModule from '@webex/internal-media-core';
 import { expect } from 'chai';
+import { H264_CODEC_PARAMETERS } from '../../../../src/multistream/codec/constants';
 
 type ExpectedActiveSpeaker = {
   policy: 'active-speaker';
@@ -912,7 +913,7 @@ describe('MediaRequestManager', () => {
         priority: 255,
         receiveSlots: fakeWcmeSlots.slice(0, 10),
         maxPayloadBitsPerSecond: MAX_PAYLOADBITSPS_540p,
-        maxFs:  MAX_FS_VALUES['540p'],
+        maxFs:  H264_CODEC_PARAMETERS['540p'].maxFs,
         maxMbps: MAX_MBPS_540p,
       },
     ]);

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMedia.ts
@@ -3,7 +3,8 @@ import 'jsdom-global/register';
 import EventEmitter from 'events';
 
 import {MediaType} from '@webex/internal-media-core';
-import {RemoteMedia, RemoteMediaEvents, RemoteVideoResolution} from '@webex/plugin-meetings/src/multistream/remoteMedia';
+import {RemoteMedia, RemoteMediaEvents} from '@webex/plugin-meetings/src/multistream/remoteMedia';
+import {RemoteVideoResolution} from '@webex/plugin-meetings/src/multistream/types';
 import {ReceiveSlotEvents} from '@webex/plugin-meetings/src/multistream/receiveSlot';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
@@ -289,7 +290,7 @@ describe('RemoteMedia', () => {
       // remoteMedia was created with {resolution: 'medium'} in beforeEach
 
       const result = remoteMedia.getEffectiveMaxFs();
-      
+
       // 'medium' resolution should map to 720p which is 3600
       assert.strictEqual(result, 3600);
     });
@@ -299,9 +300,9 @@ describe('RemoteMedia', () => {
 
       // Create a new RemoteMedia without resolution option
       const remoteMediaWithoutResolution = new RemoteMedia(fakeReceiveSlot, fakeMediaRequestManager);
-      
+
       const result = remoteMediaWithoutResolution.getEffectiveMaxFs();
-      
+
       assert.strictEqual(result, undefined);
     });
 
@@ -310,7 +311,7 @@ describe('RemoteMedia', () => {
       // remoteMedia was created with {resolution: 'medium'} in beforeEach
 
       const result = remoteMedia.getEffectiveMaxFs();
-      
+
       // Should return maxFrameSize (500) instead of resolution-based value (3600)
       assert.strictEqual(result, 920);
     });
@@ -330,7 +331,7 @@ describe('RemoteMedia', () => {
         testRemoteMedia.setSizeHint(0, 0); // Ensure maxFrameSize doesn't interfere
 
         const result = testRemoteMedia.getEffectiveMaxFs();
-        
+
         assert.strictEqual(result, expected, `Failed for resolution: ${resolution}`);
       });
     });

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/remoteMediaManager.ts
@@ -13,7 +13,7 @@ import {RemoteMediaGroup} from '@webex/plugin-meetings/src/multistream/remoteMed
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
 import {cloneDeep} from 'lodash';
-import {MediaRequest} from '@webex/plugin-meetings/src/multistream/mediaRequestManager';
+import {MediaRequest} from '@webex/plugin-meetings/src/multistream/types';
 import {CSI, ReceiveSlotId} from '@webex/plugin-meetings/src/multistream/receiveSlot';
 import testUtils from '../../../utils/testUtils';
 import LoggerProxy from '@webex/plugin-meetings/src/common/logs/logger-proxy';


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-784313](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-784313)

## This pull request addresses

Multistream media requests and H264 frame-size handling were spread across `mediaRequestManager.ts` and `remoteMedia.ts` (duplicated `maxFs` values, types colocated with implementation). That made it harder to keep codec parameters consistent with `@webex/internal-media-core` and to extend with additional codecs later.

## by making the following changes

- Add [`packages/@webex/plugin-meetings/src/multistream/types.ts`](packages/@webex/plugin-meetings/src/multistream/types.ts) for multistream request types: `MediaRequest`, `PolicyInfo`, `ActiveSpeakerPolicyInfo`, `ReceiverSelectedPolicyInfo`, `MediaRequestId`, `RemoteVideoResolution`, and related fields.
- Add [`packages/@webex/plugin-meetings/src/multistream/codec/types.ts`](packages/@webex/plugin-meetings/src/multistream/codec/types.ts) for `CodecInfo` / `H264CodecInfo` aligned with `H264EncodingParams` from `@webex/internal-media-core`.
- Add [`packages/@webex/plugin-meetings/src/multistream/codec/constants.ts`](packages/@webex/plugin-meetings/src/multistream/codec/constants.ts) for `H264_CODEC_PARAMETERS` (typed as `Record<SupportedResolution, H264EncodingParams>`) and `CODEC_DEFAULTS`.
- Refactor [`mediaRequestManager.ts`](packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts) to consume the new modules, simplify codec/degradation logic, and export **only** the class as **default** (types no longer re-exported from this file).
- Refactor [`remoteMedia.ts`](packages/@webex/plugin-meetings/src/multistream/remoteMedia.ts) to import types from `./types` and resolve `getMaxFs` via `H264_CODEC_PARAMETERS` (replaces local `MAX_FS_VALUES`).
- Update imports in [`remoteMediaGroup.ts`](packages/@webex/plugin-meetings/src/multistream/remoteMediaGroup.ts), [`remoteMediaManager.ts`](packages/@webex/plugin-meetings/src/multistream/remoteMediaManager.ts), [`meeting/index.ts`](packages/@webex/plugin-meetings/src/meeting/index.ts), [`members/index.ts`](packages/@webex/plugin-meetings/src/members/index.ts), and [`reconnection-manager/index.ts`](packages/@webex/plugin-meetings/src/reconnection-manager/index.ts) (including `MediaRequestManager` default import where applicable).
- Align unit tests under `packages/@webex/plugin-meetings/test/unit/spec/multistream/` and `test/unit/spec/meeting/index.js` with the new module layout.

**Note:** This is an internal module layout change. Any deep import of named exports from `mediaRequestManager.ts` or `MAX_FS_VALUES` from `remoteMedia.ts` would need to follow the new paths; the supported public SDK surface is unchanged unless your app relied on those internal paths.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

- Updated unit specs: `test/unit/spec/multistream/mediaRequestManager.ts`, `remoteMedia.ts`, `remoteMediaManager.ts`, and `test/unit/spec/meeting/index.js` to match new imports and types.
- **Please confirm:** run `yarn test:unit` in `packages/@webex/plugin-meetings` (or rely on CI) before merge.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->

- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

_(No standalone documentation change: internal refactor only; please run CI / `yarn test:unit` in `packages/@webex/plugin-meetings` and check the boxes above once verified.)_

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
