### PR TITLE
docs(calling): add SDD docs for SDKConnector

### DIFF
--- a/packages/calling/src/SDKConnector/ai-docs/AGENTS.md
+++ b/packages/calling/src/SDKConnector/ai-docs/AGENTS.md
@@ -1,0 +1,263 @@
+# SDKConnector Module
+
+## AI Agent Routing Instructions
+
+**If you are an AI assistant or automated tool:**
+
+- **First step:** Load the package-level patterns at `packages/calling/ai-docs/patterns/` — especially [architecture-patterns.md](../../../ai-docs/patterns/architecture-patterns.md) for the singleton pattern.
+- **Context:** SDKConnector is a foundational infrastructure module used by every other module in the package. Changes here have wide-reaching impact.
+- **For consumer context:** See [CallingClient/ai-docs/AGENTS.md](../../CallingClient/ai-docs/AGENTS.md) — CallingClient is the primary consumer that calls `setWebex()`.
+
+---
+
+## Overview
+
+`SDKConnector` is a **frozen singleton** that acts as the bridge between the calling SDK and the Webex SDK. It wraps the Webex SDK instance and provides a controlled interface for making HTTP requests and registering/unregistering Mercury WebSocket event listeners.
+
+Every module in the calling package — `CallingClient`, `CallManager`, `Call`, `Line`, `Registration`, `CallHistory`, `CallSettings`, `Contacts`, `Voicemail` — depends on `SDKConnector` to access the Webex SDK.
+
+**File:** `packages/calling/src/SDKConnector/index.ts`
+
+**Export:** `export default Object.freeze(new SDKConnector())`
+
+---
+
+## Purpose
+
+The SDKConnector module provides:
+
+- **Singleton Webex SDK access** — Ensures the entire calling package uses a single Webex SDK instance
+- **Set-once semantics** — `setWebex()` can only be called once; subsequent calls throw an error
+- **Validation** — Validates the Webex SDK instance before accepting it (authorization, readiness, Mercury availability)
+- **HTTP request proxy** — `request<T>()` delegates to `webex.request()`
+- **Mercury listener management** — `registerListener()` / `unregisterListener()` for WebSocket events
+
+---
+
+## Public API
+
+### ISDKConnector Interface
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `setWebex` | `(webexInstance: WebexSDK): void` | Sets the Webex SDK instance. Throws if called more than once or if validation fails. |
+| `getWebex` | `(): WebexSDK` | Returns the stored Webex SDK instance |
+| `get` | `(): ISDKConnector` | Returns the SDKConnector singleton instance |
+| `registerListener` | `<T>(event: string, cb: (data?: T) => unknown): void` | Registers a callback on Mercury WebSocket for the given event |
+| `unregisterListener` | `(event: string): void` | Removes the listener for the given Mercury event |
+
+### Additional Method (on class, not on interface)
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `request` | `<T>(request: WebexRequestPayload): Promise<T>` | Proxies an HTTP request through `webex.request()` |
+
+---
+
+## Singleton Pattern
+
+SDKConnector uses a module-level singleton with `Object.freeze()`:
+
+```typescript
+let instance: ISDKConnector;
+let webex: WebexSDK;
+
+class SDKConnector implements ISDKConnector {
+  public setWebex(webexInstance: WebexSDK): void {
+    if (instance) {
+      throw new Error('You cannot set the SDKConnector instance more than once');
+    }
+    const {error, success} = validateWebex(webexInstance);
+    if (error) throw error;
+    if (success) webex = webexInstance;
+    instance = this;
+  }
+
+  public get(): ISDKConnector { return instance; }
+  public getWebex(): WebexSDK { return webex; }
+
+  public request<T>(request: WebexRequestPayload): Promise<T> {
+    return instance.getWebex().request(request);
+  }
+
+  public registerListener<T>(event: string, cb: (data?: T) => void): void {
+    instance.getWebex().internal.mercury.on(event, (data: T) => cb(data));
+  }
+
+  public unregisterListener(event: string): void {
+    instance.getWebex().internal.mercury.off(event);
+  }
+}
+
+export default Object.freeze(new SDKConnector());
+```
+
+Key characteristics:
+- **Set once:** `setWebex()` stores the instance in a module-level `let` and rejects subsequent calls
+- **Frozen export:** `Object.freeze()` prevents property modification on the exported object
+- **Module-level closures:** `instance` and `webex` are private to the module, not on the class
+
+---
+
+## Validation
+
+Before accepting a Webex SDK instance, `validateWebex()` checks three prerequisites:
+
+```typescript
+export const validateWebex = (webexInstance: WebexSDK) => {
+  if (webexInstance.canAuthorize) {        // SDK can make authenticated requests
+    if (webexInstance.ready) {              // SDK is fully initialized
+      if (webexInstance.internal.mercury) { // Mercury WebSocket plugin is available
+        return {error: undefined, success: true};
+      }
+      return {error: new Error('webex.internal.mercury is not available'), success: false};
+    }
+    return {error: new Error('webex.ready is not true'), success: false};
+  }
+  return {error: new Error('webex.canAuthorize is not true'), success: false};
+};
+```
+
+| Check | Property | Failure Message |
+|-------|----------|-----------------|
+| Authorization | `webex.canAuthorize` | `'webex.canAuthorize is not true'` |
+| Readiness | `webex.ready` | `'webex.ready is not true'` |
+| Mercury | `webex.internal.mercury` | `'webex.internal.mercury is not available'` |
+
+---
+
+## Usage Patterns
+
+### Initialization (done by CallingClient)
+
+```typescript
+import SDKConnector from '../SDKConnector';
+
+// In constructor — set once
+if (!this.sdkConnector.getWebex()) {
+  SDKConnector.setWebex(webex);
+}
+this.webex = this.sdkConnector.getWebex();
+```
+
+### Making HTTP Requests
+
+```typescript
+const response = await this.webex.request({
+  method: HTTP_METHODS.POST,
+  uri: `${mobiusUrl}/${DEVICES_ENDPOINT_RESOURCE}`,
+  headers: {
+    'cisco-device-url': deviceUrl,
+    'spark-user-agent': CALLING_USER_AGENT,
+  },
+  body: requestBody,
+  service: ALLOWED_SERVICES.MOBIUS,
+});
+```
+
+### Registering Mercury WebSocket Listeners
+
+```typescript
+// Register for Mobius call events
+this.sdkConnector.registerListener<MobiusCallEvent>(
+  'event:mobius',
+  (event?: MobiusCallEvent) => {
+    if (event) this.dequeueWsEvents(event);
+  }
+);
+
+// Register for session events
+this.sdkConnector.registerListener<CallSessionEvent>(
+  'event:janus.user_recent_sessions',
+  (event?: CallSessionEvent) => {
+    if (event) this.emit(CALLING_CLIENT_EVENT_KEYS.USER_SESSION_INFO, event);
+  }
+);
+```
+
+### Unregistering Listeners
+
+```typescript
+this.sdkConnector.unregisterListener('event:ucm.voicemail_download_complete');
+```
+
+---
+
+## Consumers
+
+SDKConnector is imported and used by every module in the package:
+
+| Consumer | Usage |
+|----------|-------|
+| `CallingClient` | `setWebex()`, `registerListener()` for session events |
+| `CallManager` | `getWebex()`, `registerListener()` for Mobius WebSocket events |
+| `Call` | `getWebex()` for HTTP requests to Mobius call endpoints |
+| `Line` | `getWebex()` for line-level operations |
+| `Registration` | `setWebex()` fallback, `getWebex()` for device registration requests |
+| `CallHistory` | `getWebex()`, `registerListener()` for session/viewed/deleted events |
+| `CallSettings` | `getWebex()` for settings API calls |
+| `Voicemail` | `getWebex()`, `registerListener()`/`unregisterListener()` for voicemail events |
+| `Contacts` | `getWebex()` for contacts API calls |
+| `CallerId` | `getWebex()` for caller ID resolution |
+| `Utils` | `getWebex()` for log upload |
+
+---
+
+## WebexSDK Type
+
+The `WebexSDK` interface defines the expected shape of the Webex SDK instance. It serves as the contract between the calling package and the Webex SDK.
+
+### Top-Level Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `version` | `string` | SDK version |
+| `canAuthorize` | `boolean` | Whether the SDK can make authenticated requests |
+| `ready` | `boolean` | Whether the SDK is fully initialized |
+| `config.fedramp` | `boolean` | FedRAMP mode flag |
+| `request` | `<T>(payload) => Promise<T>` | HTTP request method |
+| `credentials.getUserToken` | `() => Promise<string>` | Access token retrieval |
+
+### Internal Plugins (`webex.internal`)
+
+| Plugin | Key Methods/Properties |
+|--------|----------------------|
+| `mercury` | `.on(event, cb)`, `.off(event)`, `.connected`, `.connecting` |
+| `device` | `.url`, `.userId`, `.orgId`, `.callingBehavior`, `.features` |
+| `services` | `._serviceUrls`, `.getMobiusClusters()`, `.fetchClientRegionInfo()`, `.get(service)` |
+| `metrics` | `.submitClientMetrics(name, data)` |
+| `encryption` | `.decryptText()`, `.encryptText()`, `.kms.*` |
+| `support` | `.submitLogs(metadata, logs, options)` |
+
+### Public Plugins
+
+| Plugin | Key Methods |
+|--------|------------|
+| `logger` | `.log()`, `.error()`, `.warn()`, `.info()`, `.trace()`, `.debug()` |
+| `people` | `.list(arg)` |
+| `boundedStorage` | `.get()`, `.put()`, `.del()` — used for failover cache |
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `index.ts` | `SDKConnector` class and frozen singleton export |
+| `types.ts` | `ISDKConnector`, `WebexSDK`, `ServiceHost`, `ClientRegionInfo`, `Logger` |
+| `utils.ts` | `validateWebex()` — validation logic |
+| `index.test.ts` | Unit tests (placeholder) |
+| `utils.test.ts` | Validation utility tests (placeholder) |
+
+---
+
+## Related Documentation
+
+- [Architecture](./ARCHITECTURE.md) — Internal design, data flow, security considerations
+- [Architecture Patterns](../../../ai-docs/patterns/architecture-patterns.md) — Singleton pattern
+- [CallingClient AGENTS.md](../../CallingClient/ai-docs/AGENTS.md) — Primary consumer
+- [Event Patterns](../../../ai-docs/patterns/event-patterns.md) — Mercury listener usage
+
+---
+
+_Last Updated: 2026-03-15_

--- a/packages/calling/src/SDKConnector/ai-docs/ARCHITECTURE.md
+++ b/packages/calling/src/SDKConnector/ai-docs/ARCHITECTURE.md
@@ -1,0 +1,265 @@
+# SDKConnector Module — Architecture
+
+## Component Overview
+
+SDKConnector is the lowest infrastructure layer in the calling package. It has no business logic — its sole purpose is to provide a validated, singleton gateway to the Webex SDK for all other modules.
+
+### Design Principles
+
+| Principle | Implementation |
+|-----------|---------------|
+| **Singleton** | Module-level `let instance`, frozen export, set-once guard |
+| **Validation** | Three-step check before accepting a Webex SDK instance |
+| **Encapsulation** | Modules access Webex SDK only through `SDKConnector`, never directly |
+| **Immutability** | `Object.freeze()` on the exported instance |
+| **Typed contract** | `WebexSDK` interface defines the expected SDK shape |
+
+---
+
+## Internal Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Module: SDKConnector/index.ts                              │
+│                                                             │
+│  ┌──────────────────────┐   ┌────────────────────────────┐  │
+│  │ let instance (module)│   │ let webex (module)          │  │
+│  │ ISDKConnector | null │   │ WebexSDK | undefined        │  │
+│  └──────────┬───────────┘   └────────────┬───────────────┘  │
+│             │                            │                  │
+│  ┌──────────▼────────────────────────────▼───────────────┐  │
+│  │              class SDKConnector                        │  │
+│  │                                                       │  │
+│  │  setWebex(webexInstance)                               │  │
+│  │    ├── Guard: instance already set? → throw            │  │
+│  │    ├── validateWebex(webexInstance) → {error, success}  │  │
+│  │    ├── Store: webex = webexInstance                     │  │
+│  │    └── Store: instance = this                          │  │
+│  │                                                       │  │
+│  │  get() → instance                                      │  │
+│  │  getWebex() → webex                                    │  │
+│  │  request(payload) → webex.request(payload)             │  │
+│  │  registerListener(event, cb) → mercury.on(event, cb)    │  │
+│  │  unregisterListener(event) → mercury.off(event)         │  │
+│  └───────────────────────────────────────────────────────┘  │
+│                                                             │
+│  export default Object.freeze(new SDKConnector())           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Data Flow
+
+### Initialization Sequence
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant CC as CallingClient
+    participant SDK as SDKConnector
+    participant Val as validateWebex()
+    participant Webex as Webex SDK
+
+    App->>CC: createClient(webex, config)
+    activate CC
+    CC->>SDK: SDKConnector.getWebex()
+    SDK-->>CC: undefined (not set yet)
+
+    CC->>SDK: SDKConnector.setWebex(webex)
+    activate SDK
+    SDK->>SDK: Guard: instance exists? → NO
+    SDK->>Val: validateWebex(webex)
+    activate Val
+    Val->>Webex: check canAuthorize
+    Val->>Webex: check ready
+    Val->>Webex: check internal.mercury
+    Val-->>SDK: {error: undefined, success: true}
+    deactivate Val
+
+    SDK->>SDK: webex = webexInstance
+    SDK->>SDK: instance = this
+    deactivate SDK
+
+    CC->>SDK: SDKConnector.getWebex()
+    SDK-->>CC: webex (WebexSDK)
+    deactivate CC
+```
+
+### Request Flow
+
+```mermaid
+sequenceDiagram
+    participant Consumer as Any Module
+    participant SDK as SDKConnector
+    participant Webex as Webex SDK
+    participant Mobius as Mobius API
+
+    Consumer->>SDK: this.webex = sdkConnector.getWebex()
+    Consumer->>Webex: webex.request({method, uri, headers, body, service})
+    Webex->>Mobius: HTTP request
+    Mobius-->>Webex: HTTP response
+    Webex-->>Consumer: response {statusCode, body}
+```
+
+### Mercury Listener Flow
+
+```mermaid
+sequenceDiagram
+    participant Consumer as CallManager / CallingClient / etc.
+    participant SDK as SDKConnector
+    participant Mercury as Mercury WebSocket
+    participant Mobius as Mobius Server
+
+    Consumer->>SDK: registerListener('event:mobius', callback)
+    SDK->>Mercury: mercury.on('event:mobius', wrappedCb)
+
+    Mobius->>Mercury: WebSocket message (event:mobius)
+    Mercury->>SDK: wrappedCb(data)
+    SDK->>Consumer: callback(data)
+
+    Note over Consumer: When done
+    Consumer->>SDK: unregisterListener('event:mobius')
+    SDK->>Mercury: mercury.off('event:mobius')
+```
+
+---
+
+## Lifecycle
+
+### State Machine
+
+```
+                    setWebex(webex)
+  UNINITIALIZED ─────────────────────► INITIALIZED
+  (instance = null)                    (instance = this, webex = webexInstance)
+       │                                      │
+       │ getWebex() → undefined               │ getWebex() → WebexSDK
+       │ setWebex() → validates & stores      │ setWebex() → throws Error
+       │                                      │ registerListener() → works
+                                              │ unregisterListener() → works
+                                              │ request() → works
+```
+
+The singleton has exactly two states:
+1. **Uninitialized** — before `setWebex()` is called. `getWebex()` returns `undefined`.
+2. **Initialized** — after `setWebex()` succeeds. All methods work. `setWebex()` cannot be called again.
+
+There is no `reset()` or `destroy()` — the singleton lives for the lifetime of the application.
+
+---
+
+## Validation Detail
+
+`validateWebex()` in `utils.ts` performs a sequential guard-clause check:
+
+```
+validateWebex(webexInstance)
+  │
+  ├── webexInstance.canAuthorize === true?
+  │   └── NO → {error: 'webex.canAuthorize is not true', success: false}
+  │
+  ├── webexInstance.ready === true?
+  │   └── NO → {error: 'webex.ready is not true', success: false}
+  │
+  ├── webexInstance.internal.mercury exists?
+  │   └── NO → {error: 'webex.internal.mercury is not available', success: false}
+  │
+  └── All passed → {error: undefined, success: true}
+```
+
+These checks ensure the Webex SDK is in a usable state before any calling module attempts to make requests or register listeners.
+
+---
+
+## WebexSDK Interface Map
+
+The `WebexSDK` interface in `types.ts` defines the full contract. Here's the dependency map showing which parts of the SDK are used by which calling modules:
+
+```
+WebexSDK
+├── .request()                    ← Call, Registration, CallingClient, CallHistory,
+│                                   CallSettings, Contacts, Voicemail
+├── .canAuthorize / .ready        ← validateWebex() (initialization only)
+├── .credentials.getUserToken()   ← Registration (keepalive web worker token refresh)
+├── .config.fedramp               ← CallingClient (Mobius URL selection)
+│
+├── .internal
+│   ├── .mercury
+│   │   ├── .on(event, cb)        ← registerListener() → CallManager, CallingClient,
+│   │   │                           CallHistory, Voicemail
+│   │   ├── .off(event)           ← unregisterListener() → Voicemail
+│   │   ├── .connected            ← CallingClient (network resilience checks)
+│   │   └── .connecting           ← CallingClient (network resilience checks)
+│   │
+│   ├── .device
+│   │   ├── .url                  ← CallingClient (cisco-device-url header)
+│   │   ├── .userId               ← CallingClient, Line (user identification)
+│   │   └── .orgId                ← Metrics
+│   │
+│   ├── .services
+│   │   ├── ._serviceUrls.mobius  ← CallingClient (Mobius URL)
+│   │   ├── .getMobiusClusters()  ← CallingClient (cluster discovery)
+│   │   └── .fetchClientRegionInfo() ← CallingClient (region discovery)
+│   │
+│   ├── .metrics
+│   │   └── .submitClientMetrics()← MetricManager (telemetry)
+│   │
+│   ├── .encryption               ← Voicemail (content encryption/decryption)
+│   │
+│   └── .support
+│       └── .submitLogs()         ← Utils.uploadLogs()
+│
+├── .logger                       ← CallingClient (logger adapter for media engine)
+├── .people.list()                ← CallerId (caller identity resolution)
+└── .boundedStorage               ← Registration (failover cache persistence)
+```
+
+---
+
+## Security Considerations
+
+- **Set-once guard:** Prevents any module from replacing the Webex SDK instance after initialization, which protects against accidental re-initialization or injection
+- **Frozen export:** `Object.freeze()` prevents property modification on the singleton
+- **Validation:** Ensures the SDK is authorized and ready before any network operations
+- **No credential storage:** SDKConnector does not store tokens — it delegates to `webex.credentials.getUserToken()` at the point of use
+
+---
+
+## Testing Notes
+
+The current test files (`index.test.ts`, `utils.test.ts`) are placeholders with `TODO` markers. When writing tests:
+
+- **Use `getTestUtilsWebex()`** from `common/testUtil.ts` for the mock Webex instance
+- **Reset module state** between tests — since SDKConnector is a singleton with set-once semantics, tests may need to use `jest.resetModules()` or test isolation
+- **Test validation:** Verify all three `validateWebex()` failure paths
+- **Test set-once guard:** Verify the second `setWebex()` call throws
+
+---
+
+## File Structure
+
+```
+SDKConnector/
+├── index.ts          # SDKConnector class, frozen singleton export
+├── types.ts          # ISDKConnector, WebexSDK, ServiceHost, ClientRegionInfo, Logger
+├── utils.ts          # validateWebex() validation logic
+├── index.test.ts     # Unit tests (placeholder)
+├── utils.test.ts     # Validation tests (placeholder)
+└── ai-docs/
+    ├── AGENTS.md     # Overview, API, usage patterns, consumers
+    └── ARCHITECTURE.md  # This file
+```
+
+---
+
+## Related Documentation
+
+- [SDKConnector AGENTS.md](./AGENTS.md) — Public API, usage patterns, consumer list
+- [Architecture Patterns](../../../ai-docs/patterns/architecture-patterns.md) — Singleton pattern reference
+- [Event Patterns](../../../ai-docs/patterns/event-patterns.md) — Mercury listener registration
+- [CallingClient ARCHITECTURE.md](../../CallingClient/ai-docs/ARCHITECTURE.md) — Primary consumer architecture
+
+---
+
+_Last Updated: 2026-03-15_


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Adds the SDD docs for the calling/src/SDKConnector

## by making the following changes

### Created: `packages/calling/src/SDKConnector/ai-docs/`

| File | Content |
|------|---------|
| **AGENTS.md** | Overview of the frozen singleton pattern, `ISDKConnector` API table, `validateWebex()` checks, usage patterns (initialization, HTTP requests, Mercury listeners), full consumer table showing all 18 files that import SDKConnector, `WebexSDK` type breakdown covering top-level properties and all internal plugins |
| **ARCHITECTURE.md** | Internal architecture diagram showing module-level closures, 3 Mermaid sequence diagrams (initialization, request flow, Mercury listener flow), lifecycle state machine (UNINITIALIZED → INITIALIZED), validation detail flowchart, `WebexSDK` interface dependency map showing which SDK properties are used by which calling modules, security considerations, and testing notes about the placeholder test files |

Key highlights specific to SDKConnector:
- Documented the **set-once semantics** and why `setWebex()` throws on re-invocation
- Mapped the full **`WebexSDK` interface** to actual consumers — showing exactly which SDK property is used by which calling module (e.g., `mercury.on` used by CallManager/CallingClient/CallHistory/Voicemail, `boundedStorage` used by Registration for failover cache)
- Noted that the test files are **placeholders** (`TODO`) and provided guidance on how to properly test a set-once singleton with `jest.resetModules()`

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor with calude-4.6-opus-high
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
