### PR TITLE
fix(meetings): added createLocusFromHashTreeMessage()

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -83,6 +83,89 @@ const LocusObjectStateAfterUpdates = {
 type LocusObjectStateAfterUpdates = Enum<typeof LocusObjectStateAfterUpdates>;
 
 /**
+ * Creates a locus object from the objects received in a hash tree message. It usually will be
+ * incomplete, because hash tree messages only contain the parts of locus that have changed,
+ * and some updates come separately over Mercury or LLM in separate messages.
+ *
+ * @param {HashTreeMessage} message hash tree message to created the locus from
+ * @returns {Object} the created locus object and metadata if present
+ */
+export function createLocusFromHashTreeMessage(message: HashTreeMessage): {
+  locus: LocusDTO;
+  metadata?: Metadata;
+} {
+  const locus: LocusDTO = {
+    participants: [],
+    url: message.locusUrl,
+  };
+  let metadata: Metadata | undefined;
+
+  if (!message.locusStateElements) {
+    return {locus, metadata};
+  }
+
+  for (const element of message.locusStateElements) {
+    if (!element.data) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    const type = element.htMeta.elementId.type.toLowerCase();
+
+    switch (type) {
+      case ObjectType.locus: {
+        // spread locus object data onto the top level, but remove keys managed by other ObjectTypes
+        const locusObjectData = {...element.data};
+
+        Object.values(ObjectTypeToLocusKeyMap).forEach((locusDtoKey) => {
+          delete locusObjectData[locusDtoKey];
+        });
+
+        Object.assign(locus, locusObjectData);
+        break;
+      }
+      case ObjectType.participant:
+        locus.participants.push(element.data);
+        break;
+      case ObjectType.mediaShare:
+        if (!locus.mediaShares) {
+          locus.mediaShares = [];
+        }
+        locus.mediaShares.push(element.data);
+        break;
+      case ObjectType.embeddedApp:
+        if (!locus.embeddedApps) {
+          locus.embeddedApps = [];
+        }
+        locus.embeddedApps.push(element.data);
+        break;
+      case ObjectType.control:
+        if (!locus.controls) {
+          locus.controls = {};
+        }
+        Object.assign(locus.controls, element.data);
+        break;
+      case ObjectType.links:
+      case ObjectType.info:
+      case ObjectType.fullState:
+      case ObjectType.self: {
+        const locusDtoKey = ObjectTypeToLocusKeyMap[type];
+        locus[locusDtoKey] = element.data;
+        break;
+      }
+      case ObjectType.metadata:
+        // metadata is not part of Locus DTO
+        metadata = {...element.data, htMeta: element.htMeta} as Metadata;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return {locus, metadata};
+}
+
+/**
  * @description LocusInfo extends ChildEmitter to convert locusInfo info a private emitter to parent object
  * @export
  * @private

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -69,6 +69,7 @@ import JoinForbiddenError from '../common/errors/join-forbidden-error';
 import {HashTreeMessage} from '../hashTree/hashTreeParser';
 import {HashTreeObject} from '../hashTree/types';
 import {isSelf} from '../hashTree/utils';
+import {createLocusFromHashTreeMessage} from '../locus-info';
 
 let mediaLogger;
 
@@ -522,41 +523,45 @@ export default class Meetings extends WebexPlugin {
       // };
       // rather then locus object change to locus url
 
-      if (data.eventType !== LOCUSEVENT.HASH_TREE_DATA_UPDATED) {
-        if (
-          data.locus &&
-          data.locus.fullState &&
-          data.locus.fullState.state === LOCUS.STATE.INACTIVE
-        ) {
-          // just ignore the event as its already ended and not active
-          LoggerProxy.logger.warn(
-            'Meetings:index#handleLocusEvent --> Locus event received for meeting, after it was ended.'
-          );
+      if (data.eventType === LOCUSEVENT.HASH_TREE_DATA_UPDATED) {
+        // We're about to create a new meeting object from this hash tree message.
+        // There is some existing (pre-hash trees) SDK logic here that requires a locus object
+        // (at the very minimum we need locus.url to be set)
+        // so we try to create locus from the received hash tree message
+        // it will not be complete, in most cases it will only have the self part, but that's still better than nothing
+        const {locus} = createLocusFromHashTreeMessage(data.stateElementsMessage);
 
-          return;
-        }
-
-        // When its wireless share or guest and user leaves the meeting we dont have to keep the meeting object
-        // Any future events will be neglected
-
-        if (
-          data.locus &&
-          data.locus.self &&
-          data.locus.self.state === _LEFT_ &&
-          data.locus.self.removed === true
-        ) {
-          // just ignore the event as its already ended and not active
-          LoggerProxy.logger.warn(
-            'Meetings:index#handleLocusEvent --> Locus event received for meeting, after it was ended.'
-          );
-
-          return;
-        }
+        data.locus = locus;
       }
 
-      if (data.eventType === LOCUSEVENT.HASH_TREE_DATA_UPDATED) {
-        // in hash tree messages we don't ge the locus object, but the meeting constructor needs at least locus.url
-        set(data, 'locus.url', data.stateElementsMessage.locusUrl);
+      if (
+        data.locus &&
+        data.locus.fullState &&
+        data.locus.fullState.state === LOCUS.STATE.INACTIVE
+      ) {
+        // just ignore the event as its already ended and not active
+        LoggerProxy.logger.warn(
+          'Meetings:index#handleLocusEvent --> Locus event received for meeting, after it was ended.'
+        );
+
+        return;
+      }
+
+      // When its wireless share or guest and user leaves the meeting we dont have to keep the meeting object
+      // Any future events will be neglected
+
+      if (
+        data.locus &&
+        data.locus.self &&
+        data.locus.self.state === _LEFT_ &&
+        data.locus.self.removed === true
+      ) {
+        // just ignore the event as its already ended and not active
+        LoggerProxy.logger.warn(
+          'Meetings:index#handleLocusEvent --> Locus event received for meeting, after it was ended.'
+        );
+
+        return;
       }
 
       this.create(data.locus, DESTINATION_TYPE.LOCUS_ID, useRandomDelayForInfo)

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -5,7 +5,7 @@ import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import testUtils from '../../../utils/testUtils';
 import Meetings from '@webex/plugin-meetings';
-import LocusInfo from '@webex/plugin-meetings/src/locus-info';
+import LocusInfo, {createLocusFromHashTreeMessage} from '@webex/plugin-meetings/src/locus-info';
 import SelfUtils from '@webex/plugin-meetings/src/locus-info/selfUtils';
 import InfoUtils from '@webex/plugin-meetings/src/locus-info/infoUtils';
 import EmbeddedAppsUtils from '@webex/plugin-meetings/src/locus-info/embeddedAppsUtils';
@@ -4369,6 +4369,173 @@ describe('plugin-meetings', () => {
         );
         assert.notCalled(getTheLocusToUpdateStub);
       });
+    });
+  });
+
+  describe('#createLocusFromHashTreeMessage', () => {
+    const LOCUS_URL = 'https://locus.example.com/loci/abc-123';
+
+    const createElement = (type, data) => ({
+      htMeta: {elementId: {type, id: 1, version: 1}},
+      data,
+    });
+
+    it('returns locus with url and empty participants when no locusStateElements', () => {
+      const result = createLocusFromHashTreeMessage({locusUrl: LOCUS_URL});
+
+      assert.deepEqual(result.locus, {participants: [], url: LOCUS_URL});
+      assert.isUndefined(result.metadata);
+    });
+
+    it('skips elements without data', () => {
+      const result = createLocusFromHashTreeMessage({
+        locusUrl: LOCUS_URL,
+        locusStateElements: [{htMeta: {elementId: {type: 'Self', id: 1, version: 1}}, data: null}],
+      });
+
+      assert.deepEqual(result.locus, {participants: [], url: LOCUS_URL});
+    });
+
+    [
+      {type: 'Self', locusKey: 'self', data: {id: 'self-1', state: 'JOINED'}},
+      {type: 'Info', locusKey: 'info', data: {webExMeetingId: '123'}},
+      {type: 'FullState', locusKey: 'fullState', data: {state: 'ACTIVE'}},
+      {type: 'Links', locusKey: 'links', data: {resources: {}}},
+    ].forEach(({type, locusKey, data}) => {
+      it(`maps ${type} element to locus.${locusKey}`, () => {
+        const result = createLocusFromHashTreeMessage({
+          locusUrl: LOCUS_URL,
+          locusStateElements: [createElement(type, data)],
+        });
+
+        assert.deepEqual(result.locus[locusKey], data);
+      });
+    });
+
+    it('pushes Participant elements to locus.participants', () => {
+      const p1 = {id: 'p1', state: 'JOINED'};
+      const p2 = {id: 'p2', state: 'LEFT'};
+
+      const result = createLocusFromHashTreeMessage({
+        locusUrl: LOCUS_URL,
+        locusStateElements: [createElement('Participant', p1), createElement('Participant', p2)],
+      });
+
+      assert.deepEqual(result.locus.participants, [p1, p2]);
+    });
+
+    it('pushes MediaShare elements to locus.mediaShares array', () => {
+      const share1 = {name: 'whiteboard'};
+      const share2 = {name: 'content'};
+
+      const result = createLocusFromHashTreeMessage({
+        locusUrl: LOCUS_URL,
+        locusStateElements: [
+          createElement('MediaShare', share1),
+          createElement('MediaShare', share2),
+        ],
+      });
+
+      assert.deepEqual(result.locus.mediaShares, [share1, share2]);
+    });
+
+    it('pushes EmbeddedApp elements to locus.embeddedApps array', () => {
+      const app = {appId: 'app-1', state: 'STARTED'};
+
+      const result = createLocusFromHashTreeMessage({
+        locusUrl: LOCUS_URL,
+        locusStateElements: [createElement('EmbeddedApp', app)],
+      });
+
+      assert.deepEqual(result.locus.embeddedApps, [app]);
+    });
+
+    it('merges ControlEntry elements into locus.controls', () => {
+      const control1 = {record: {recording: true}};
+      const control2 = {lock: {locked: false}};
+
+      const result = createLocusFromHashTreeMessage({
+        locusUrl: LOCUS_URL,
+        locusStateElements: [
+          createElement('ControlEntry', control1),
+          createElement('ControlEntry', control2),
+        ],
+      });
+
+      assert.deepEqual(result.locus.controls, {record: {recording: true}, lock: {locked: false}});
+    });
+
+    it('spreads Locus element data onto top level but removes managed keys', () => {
+      const locusData = {
+        url: 'should-be-overridden',
+        someTopLevelField: 'value',
+        // these are managed by other ObjectTypes and should be removed
+        links: {should: 'be removed'},
+        info: {should: 'be removed'},
+        fullState: {should: 'be removed'},
+        self: {should: 'be removed'},
+        participants: [{should: 'be removed'}],
+        mediaShares: [{should: 'be removed'}],
+        controls: {should: 'be removed'},
+        embeddedApps: [{should: 'be removed'}],
+      };
+
+      const result = createLocusFromHashTreeMessage({
+        locusUrl: LOCUS_URL,
+        locusStateElements: [createElement('Locus', locusData)],
+      });
+
+      assert.equal(result.locus.someTopLevelField, 'value');
+      assert.deepEqual(result.locus.participants, []);
+      assert.isUndefined(result.locus.links);
+      assert.isUndefined(result.locus.info);
+      assert.isUndefined(result.locus.fullState);
+      assert.isUndefined(result.locus.self);
+      assert.isUndefined(result.locus.mediaShares);
+      assert.isUndefined(result.locus.controls);
+      assert.isUndefined(result.locus.embeddedApps);
+    });
+
+    it('extracts Metadata element as metadata in the result', () => {
+      const metadataData = {visibleDataSets: [{name: 'ds1', url: 'http://ds1.url'}]};
+      const htMeta = {elementId: {type: 'Metadata', id: 99, version: 3}};
+
+      const result = createLocusFromHashTreeMessage({
+        locusUrl: LOCUS_URL,
+        locusStateElements: [{htMeta, data: metadataData}],
+      });
+
+      assert.deepEqual(result.metadata, {...metadataData, htMeta});
+      assert.isUndefined(result.locus.metadata);
+    });
+
+    it('handles a message with multiple element types', () => {
+      const selfData = {id: 'self-1'};
+      const participantData = {id: 'p1'};
+      const infoData = {webExMeetingId: '456'};
+
+      const result = createLocusFromHashTreeMessage({
+        locusUrl: LOCUS_URL,
+        locusStateElements: [
+          createElement('Self', selfData),
+          createElement('Participant', participantData),
+          createElement('Info', infoData),
+        ],
+      });
+
+      assert.deepEqual(result.locus.self, selfData);
+      assert.deepEqual(result.locus.participants, [participantData]);
+      assert.deepEqual(result.locus.info, infoData);
+      assert.equal(result.locus.url, LOCUS_URL);
+    });
+
+    it('ignores unknown element types', () => {
+      const result = createLocusFromHashTreeMessage({
+        locusUrl: LOCUS_URL,
+        locusStateElements: [createElement('UnknownType', {foo: 'bar'})],
+      });
+
+      assert.deepEqual(result.locus, {participants: [], url: LOCUS_URL});
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -2018,32 +2018,76 @@ describe('plugin-meetings', () => {
             });
           });
           it('should setup the meeting from a hash tree event', async () => {
-            const locus = {
-              id: uuid1,
-              self: {},
-              info: {
-                webExMeetingId,
-              },
+            const selfData = {};
+            const infoData = {webExMeetingId};
+            const hashTreeMessage = {
+              locusUrl: url1,
+              locusStateElements: [
+                {
+                  htMeta: {elementId: {type: 'Self', id: 1, version: 1}},
+                  data: selfData,
+                },
+                {
+                  htMeta: {elementId: {type: 'Info', id: 2, version: 1}},
+                  data: infoData,
+                },
+              ],
             };
-            const hashTreeMessage = {something: 'hashTreeData'};
             await webex.meetings.handleLocusEvent({
-              locus,
               eventType: 'locus.state_message',
               locusUrl: url1,
               stateElementsMessage: hashTreeMessage,
             });
             assert.calledWith(webex.meetings.meetingCollection.getByKey, 'locusUrl', url1);
-            assert.calledWith(
-              webex.meetings.meetingCollection.getByKey,
-              'meetingNumber',
-              webExMeetingId
-            );
             assert.calledOnce(initialSetup);
             assert.calledWith(initialSetup, {
               trigger: 'locus-message',
-              locus,
+              locus: {
+                participants: [],
+                url: url1,
+                self: selfData,
+                info: infoData,
+              },
               hashTreeMessage,
             });
+          });
+
+          it('should ignore hash tree event when created locus has INACTIVE fullState', async () => {
+            const hashTreeMessage = {
+              locusUrl: url1,
+              locusStateElements: [
+                {
+                  htMeta: {elementId: {type: 'FullState', id: 1, version: 1}},
+                  data: {state: 'INACTIVE'},
+                },
+              ],
+            };
+            await webex.meetings.handleLocusEvent({
+              eventType: 'locus.state_message',
+              locusUrl: url1,
+              stateElementsMessage: hashTreeMessage,
+            });
+            assert.notCalled(webex.meetings.create);
+            assert.notCalled(initialSetup);
+          });
+
+          it('should ignore hash tree event when created locus has self LEFT and removed', async () => {
+            const hashTreeMessage = {
+              locusUrl: url1,
+              locusStateElements: [
+                {
+                  htMeta: {elementId: {type: 'Self', id: 1, version: 1}},
+                  data: {state: 'LEFT', removed: true},
+                },
+              ],
+            };
+            await webex.meetings.handleLocusEvent({
+              eventType: 'locus.state_message',
+              locusUrl: url1,
+              stateElementsMessage: hashTreeMessage,
+            });
+            assert.notCalled(webex.meetings.create);
+            assert.notCalled(initialSetup);
           });
           it('should setup the meeting by difference event without replaces', async () => {
             await webex.meetings.handleLocusEvent({


### PR DESCRIPTION
# COMPLETES #[SPARK-781176](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-781176)

## This pull request addresses
Existing SDK code expects Locus objects in some places where messages are processed, but with hash trees, we receive messages in a different format and they contain only some parts of Locus

## by making the following changes
Added a function that creates a Locus DTO like object from a hash tree message. Using it only when we create a new meeting from a message, that means that it's safe to use it, because we don't need to check any version of the objects in the hash tree message, because it's a new meeting, so no local hash trees exist, yet.

I've done this, because it's needed for breakouts and is the 1st breakouts PR, there will be more, but it also fixes SPARK-781176 where SDK receives a hash tree message that contains self, metadata, info, locus and fullState and needs stuff from info to call AppAPI to get the meeting info.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
