### PR TITLE
fix(meetings): meeting.destroy() called for null meeting

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -730,11 +730,7 @@ export default class LocusInfo extends EventsScope {
    * @param {HashTreeMessage} message incoming hash tree message
    * @returns {void}
    */
-  private async handleHashTreeMessage(
-    meeting: any,
-    eventType: LOCUSEVENT,
-    message: HashTreeMessage
-  ) {
+  private handleHashTreeMessage(meeting: any, eventType: LOCUSEVENT, message: HashTreeMessage) {
     if (eventType !== LOCUSEVENT.HASH_TREE_DATA_UPDATED) {
       this.sendClassicVsHashTreeMismatchMetric(
         meeting,
@@ -843,11 +839,14 @@ export default class LocusInfo extends EventsScope {
       }
 
       case LocusInfoUpdateType.MEETING_ENDED: {
-        LoggerProxy.logger.info(
-          `Locus-info:index#updateFromHashTree --> received signal that meeting ended, destroying meeting ${this.meetingId}`
-        );
         const meeting = this.webex.meetings.meetingCollection.get(this.meetingId);
-        this.webex.meetings.destroy(meeting, MEETING_REMOVED_REASON.SELF_REMOVED);
+
+        if (meeting) {
+          LoggerProxy.logger.info(
+            `Locus-info:index#updateFromHashTree --> received signal that meeting ended, destroying meeting ${this.meetingId}`
+          );
+          this.webex.meetings.destroy(meeting, MEETING_REMOVED_REASON.SELF_REMOVED);
+        }
       }
     }
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -934,6 +934,20 @@ describe('plugin-meetings', () => {
             MEETING_REMOVED_REASON.SELF_REMOVED
           );
         });
+
+        // this could happen if meeting gets destroyed while we're doing some async hash tree operation like a sync
+        it('should handle MEETING_ENDED correctly when meeting is not found in the collection', () => {
+          const collectionGetStub = sinon
+            .stub(locusInfo.webex.meetings.meetingCollection, 'get')
+            .returns(null);
+          const destroyStub = sinon.stub(locusInfo.webex.meetings, 'destroy');
+
+          // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
+          locusInfoUpdateCallback(MEETING_ENDED);
+
+          assert.calledOnceWithExactly(collectionGetStub, locusInfo.meetingId);
+          assert.notCalled(destroyStub);
+        });
       });
     });
 


### PR DESCRIPTION
# COMPLETES #[SPARK-787833](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-787833)

## This pull request addresses
meetings.destroy() is called on a meeting object looked up from the collection. It may happen that the meeting has just been removed already and we call destroy() with null

## by making the following changes
Added a check for meeting being non-null.
Also removed a no lonver needed "async" for LocusInfo.handleHashTreeMessage() method - I think this was actually the thing causing the crash in the jira (see stack trace in the jira), because HashTreeParser was calling the callback with MEETING_ENDED synchronously, but because of the async keyword, this was done after all sync processing of the message was done and probably some other part of SDK already destroyed the meeting by then.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
