### PR TITLE
fix: random code breaking changes done by eslint on file save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,11 +17,11 @@
     "**/dist": true
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit",
+    "source.fixAll.eslint": "explicit",
     "source.organizeImports": "never"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "eslint.format.enable": true,
+  "eslint.format.enable": false,
   "breadcrumbs.enabled": true,
   "prettier.bracketSameLine": true,
   "prettier.configPath": ".prettierrc"


### PR DESCRIPTION
## This pull request addresses
Some weeks ago I started getting random, code breaking changes in formatting when I saved a file in vscode. Disabling eslint fixed it, but having eslint disabled long term is not great.

## by making the following changes
AIs explanation of the fix:
two settings were causing conflicting edits on save:

"source.fixAll" → "source.fixAll.eslint": The unscoped source.fixAll triggered all fix-all providers (ESLint + Prettier + others) simultaneously, producing overlapping text edits. Scoping it to .eslint ensures only ESLint's fixer runs as a code action.
"eslint.format.enable" → false: This was registering ESLint as a document formatter in addition to its fix-all provider. Since Prettier is already the default formatter, having ESLint also format caused a second round of overlapping edits that corrupted the code.

It seems to have fixed it for me

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

just using SDK in vscode

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
