### PR TITLE
docs(contact-center): fix unresolved SDD review comments

### DIFF
--- a/packages/@webex/contact-center/AGENTS.md
+++ b/packages/@webex/contact-center/AGENTS.md
@@ -33,7 +33,9 @@ Q1: Is the task read-only (understanding, explaining, or analyzing code)?
 ├── YES → Type E: Understand Architecture
 │
 └── NO → Q2: Is something broken or behaving incorrectly?
-    ├── YES → Type C: Fix Bug
+    ├── YES → Is this a UI/UX improvement or a code-level defect?
+    │   ├── UI/UX fix (visual, layout, interaction) → Type D: Add Feature / Enhance Existing Service
+    │   └── Code-level defect (wrong behavior, crash, data issue) → Type C: Fix Bug
     │
     └── NO → Q3: Does this involve creating a new file, class, or module?
         ├── YES → Type A: Create New Service

--- a/packages/@webex/contact-center/ai-docs/templates/documentation/create-architecture-md.md
+++ b/packages/@webex/contact-center/ai-docs/templates/documentation/create-architecture-md.md
@@ -37,13 +37,15 @@ Answer before writing:
 
 ## File Structure
 
+> **Note:** The file structure listing typically belongs in the service's `AGENTS.md` (usage documentation), not in `ARCHITECTURE.md`. Include it here only if you need to reference specific files in the architecture discussion. Otherwise, link to the AGENTS.md file structure section.
+
 ```
 services/[name]/
 ├── index.ts          # Main service export
 ├── types.ts          # Type definitions
 ├── constants.ts      # Constants
 └── ai-docs/
-    ├── AGENTS.md     # Usage documentation
+    ├── AGENTS.md     # Usage documentation (file structure lives here)
     └── ARCHITECTURE.md # This file
 ```
 

--- a/packages/@webex/contact-center/ai-docs/templates/existing-service/bug-fix.md
+++ b/packages/@webex/contact-center/ai-docs/templates/existing-service/bug-fix.md
@@ -30,10 +30,6 @@ If the developer cannot provide reproduction steps, ask for logs, error messages
    - [ ] Types
    - [ ] Not sure (this is fine — you will investigate)
 
-5. **"Are there any error messages or stack traces you can share?"**
-
-6. **"Is there a trackingId from the logs associated with this bug?"**
-
 ### Completion Gate for Section A
 
 **Before proceeding to investigation, verify:**

--- a/packages/@webex/contact-center/ai-docs/templates/existing-service/bug-fix.md
+++ b/packages/@webex/contact-center/ai-docs/templates/existing-service/bug-fix.md
@@ -253,6 +253,6 @@ If the bug affected documented behavior:
 Bug fix is complete when:
 1. Root cause identified and confirmed with developer
 2. Fix implemented after developer approval
-3. Regression test added
+3. Regression test added — a test that reproduces the original bug (fails before the fix, passes after) to prevent the same issue from recurring
 4. All tests pass
 5. Build succeeds

--- a/packages/@webex/contact-center/ai-docs/templates/existing-service/feature-enhancement.md
+++ b/packages/@webex/contact-center/ai-docs/templates/existing-service/feature-enhancement.md
@@ -10,7 +10,9 @@
 
 > **Note:** If you arrived here via **Type F (Modify Existing Method)** from the root [`AGENTS.md`](../../../AGENTS.md), skip this Step 0 entirely — the method already exists in an existing service. Jump to Step 0B (Pre-Enhancement Questions).
 
-### Triage Questions — Always Ask These:
+### Triage Questions — Always Ask These (All Mandatory)
+
+> **All 6 questions must be answered before proceeding.** If the developer is unsure about a question, help them reason through it using the decision signals below. Do not skip questions or infer answers — each one informs the placement decision.
 
 1. **"Does this feature fit within the responsibility of an existing service, or does it introduce a new domain/responsibility?"**
 
@@ -266,9 +268,13 @@ featureMethod: routing.req((p: {data: FeatureParams}) => ({
 })),
 ```
 
-### Plugin Layer (cc.ts) — if the feature is exposed as a public API
+### Public API Layer — if the feature is exposed to consumers
 
-> **Note:** Not all features require a public method on `cc.ts`. If the feature is internal to a service or only consumed by other services, skip this step. Add a `cc.ts` wrapper only when the feature needs to be called directly by external consumers (e.g., `cc.featureName()`).
+> **Determine the owning object.** Public methods are added to the object that owns the feature's scope. Currently the SDK exposes:
+> - **`cc`** (in `cc.ts`) — SDK-level operations (e.g., `cc.stationLogin()`, `cc.setAgentState()`)
+> - **`task`** (in `Task.ts`) — per-interaction operations (e.g., `task.hold()`, `task.transfer()`, `task.end()`)
+>
+> New public objects may be introduced in the future. If the feature is internal to a service or only consumed by other services, skip this step entirely.
 
 Add public method:
 

--- a/packages/@webex/contact-center/ai-docs/templates/existing-service/feature-enhancement.md
+++ b/packages/@webex/contact-center/ai-docs/templates/existing-service/feature-enhancement.md
@@ -170,6 +170,8 @@ Does this match your intent? (Yes / No / Adjust)
 
 ## Step 1: Design the Feature
 
+Define the public API contract and data flow before writing any implementation code.
+
 ### API Design
 
 Define the public interface:
@@ -264,7 +266,9 @@ featureMethod: routing.req((p: {data: FeatureParams}) => ({
 })),
 ```
 
-### Plugin Layer (cc.ts)
+### Plugin Layer (cc.ts) — if the feature is exposed as a public API
+
+> **Note:** Not all features require a public method on `cc.ts`. If the feature is internal to a service or only consumed by other services, skip this step. Add a `cc.ts` wrapper only when the feature needs to be called directly by external consumers (e.g., `cc.featureName()`).
 
 Add public method:
 

--- a/packages/@webex/contact-center/ai-docs/templates/new-method/00-master.md
+++ b/packages/@webex/contact-center/ai-docs/templates/new-method/00-master.md
@@ -8,7 +8,7 @@
 
 Use this template when:
 - Adding a new method or feature to an existing service or util
-- Adding a new public API method to `cc` or `task` object
+- Adding a new public API method to any public object (`cc` for SDK-level operations, `task` for per-interaction operations, or future public objects)
 - Extending service capabilities
 
 ---

--- a/packages/@webex/contact-center/ai-docs/templates/new-method/01-requirements.md
+++ b/packages/@webex/contact-center/ai-docs/templates/new-method/01-requirements.md
@@ -185,6 +185,7 @@ Does this match your intent? (Yes / No / Adjust)
 **Method**: `getBuddyAgents(data: BuddyAgents): Promise<BuddyAgentsResponse>`
 **Target file**: cc.ts
 **Purpose**: Get list of available agents for consult/transfer
+**Types to create**: Define `BuddyAgents` (request params) and `BuddyAgentsResponse` (response) in the appropriate types file (`src/types.ts` for public types, or `src/services/[service]/types.ts` for internal types). Export public types from `src/types.ts`.
 
 ### Parameters:
 | Name | Type | Required | Description |

--- a/packages/@webex/contact-center/ai-docs/templates/new-method/02-implementation.md
+++ b/packages/@webex/contact-center/ai-docs/templates/new-method/02-implementation.md
@@ -19,11 +19,13 @@ There are two common patterns for where methods are implemented:
    }
    ```
 
-2. **Direct service access**: Sometimes consumers call the service method directly via the `cc` object.
+2. **Direct service access**: Sometimes consumers call the service method directly via the `cc` object's public service accessors.
    ```typescript
-   // Consumer code calling service directly
-   const queues = await cc.services.queue.getQueues();
+   // Consumer code calling service directly via public accessor
+   const queues = await cc.queue.getQueues();
+   const addressBooks = await cc.addressBook.getAddressBooks();
    ```
+   > **Note:** Use `cc.<serviceName>` (e.g., `cc.queue`, `cc.addressBook`), NOT `cc.services.<serviceName>`. The `services` object is internal.
 
 Determine which pattern applies based on the requirements gathered in Step 1.
 

--- a/packages/@webex/contact-center/ai-docs/templates/new-method/02-implementation.md
+++ b/packages/@webex/contact-center/ai-docs/templates/new-method/02-implementation.md
@@ -6,24 +6,29 @@
 
 ## Method Invocation Patterns
 
-There are two common patterns for where methods are implemented:
+There are two common patterns for where methods are implemented. The public method lives on whichever object owns the feature's scope (currently `cc` for SDK-level operations, `task` for per-interaction operations, or a public service accessor for domain-specific queries). New public objects may be introduced in the future.
 
-1. **Public wrapper + internal service call**: The public method is defined on `cc` (in `cc.ts`) or `task` (in `Task.ts`), but the actual implementation lives in a service module. The public method calls the service internally.
+1. **Public wrapper + internal service call**: The public method is defined on the owning object, but the actual implementation lives in a service module. The public method delegates internally.
    ```typescript
-   // cc.ts — public method delegates to service
+   // Example A: cc.ts — SDK-level method delegates to agent service
    public async getBuddyAgents(data: BuddyAgents): Promise<BuddyAgentsResponse> {
      const resp = await this.services.agent.buddyAgents({
        data: {agentProfileId: this.agentConfig.agentProfileID, ...data},
      });
      return resp;
    }
+
+   // Example B: Task.ts — per-interaction method delegates to contact service
+   public async hold(): Promise<TaskResponse> {
+     return this.contact.hold({...});
+   }
    ```
 
-2. **Direct service access**: Sometimes consumers call the service method directly via the `cc` object's public service accessors.
+2. **Direct service access**: Sometimes consumers call a service method directly via a public service accessor on `cc`.
    ```typescript
    // Consumer code calling service directly via public accessor
    const queues = await cc.queue.getQueues();
-   const addressBooks = await cc.addressBook.getAddressBooks();
+   const entries = await cc.addressBook.getEntries();
    ```
    > **Note:** Use `cc.<serviceName>` (e.g., `cc.queue`, `cc.addressBook`), NOT `cc.services.<serviceName>`. The `services` object is internal.
 
@@ -157,7 +162,7 @@ If the method needs to emit events, understand the two-step flow used in the SDK
 
 ### How it works: WebSocket trigger → EventEmitter emit
 
-For methods that go through `aqm-reqs` (agent service methods), the flow is:
+For methods that go through `aqm-reqs` (used by all AQM-integrated services — agent, task, etc., except config service GET methods), the flow is:
 
 1. **cc.ts** public method calls a service method (e.g., `this.services.agent.stationLogin()`)
 2. **aqm-reqs.ts** sends an HTTP request AND registers pending handlers for the expected WebSocket success/fail messages (via `notifSuccess`/`notifFail` bindings)

--- a/packages/@webex/contact-center/ai-docs/templates/new-method/03-tests.md
+++ b/packages/@webex/contact-center/ai-docs/templates/new-method/03-tests.md
@@ -178,6 +178,12 @@ describe('cc.methodName', () => {
 
 ---
 
+## Test Assertion Guidelines
+
+> **Team standard: Use exact matches, not partial matchers.** Always use `expect(result).toEqual(expectedValue)` with the full expected object. Avoid `expect.objectContaining()` or `expect.arrayContaining()` unless there is a specific reason (e.g., dynamic fields like timestamps). Exact assertions catch unintended payload changes early.
+
+---
+
 ## Running Tests
 
 ```bash

--- a/packages/@webex/contact-center/ai-docs/templates/new-service/01-pre-questions.md
+++ b/packages/@webex/contact-center/ai-docs/templates/new-service/01-pre-questions.md
@@ -72,19 +72,13 @@ Ask the developer:
 
 ---
 
-## 4. Dependencies (MANDATORY)
+## 4. Dependencies & Exposure (MANDATORY)
 
 Ask the developer:
 
 6. **"Does this service need any data from the agent profile?"**
    - If YES: "Which specific fields?" (e.g., `addressBookId`, `teamIds`)
    - If NO: note "No profile dependency"
-
----
-
-## 5. Exposure (MANDATORY)
-
-Ask the developer:
 
 7. **"Should this service be accessible as `cc.serviceName` (public API), or is it internal only?"**
    - If public: it will be exposed on the `cc` object and types will be re-exported from `src/types.ts`

--- a/packages/@webex/contact-center/ai-docs/templates/new-service/02-code-generation.md
+++ b/packages/@webex/contact-center/ai-docs/templates/new-service/02-code-generation.md
@@ -312,6 +312,18 @@ import LoggerProxy from '../../logger-proxy';
 // Types and constants from parent's files
 import {ServiceType} from './types';
 import {SOME_CONSTANT} from './constants';
+
+// Example: sub-module class structure (see task/Voice.ts or task/Digital.ts for reference)
+export default class ServiceName {
+  private webex: WebexSDK;
+
+  constructor(webex: WebexSDK) {
+    this.webex = webex;
+  }
+
+  // Methods follow the same patterns as top-level services
+  // but may receive parent service state/context via constructor or method params
+}
 ```
 
 ---


### PR DESCRIPTION
# COMPLETES #SPARK-775697

## This pull request addresses

Unresolved review comments from 5 merged SDD PRs (#4721, #4722, #4723, #4734, #4735) that were not addressed before merging into `task-refactor`. These include inaccurate code examples, missing explanations, incomplete template sections, and documentation that doesn't match SDK access patterns.

## by making the following changes

- **AGENTS.md** — Add UI/UX fix vs code-level defect distinction in task classification tree (Shreyas's comment on #4721)
- **existing-service/bug-fix.md** — Explain what "regression test" means in completion checklist (comment on #4722)
- **existing-service/feature-enhancement.md** — Add descriptive context heading for "Step 1: Design the Feature"; mark Plugin Layer (cc.ts) step as conditional since not all features are exposed publicly (comments on #4722)
- **documentation/create-architecture-md.md** — Note that file structure listing belongs in AGENTS.md, not ARCHITECTURE.md (comment on #4722)
- **new-service/01-pre-questions.md** — Club duplicate Dependencies and Exposure sections into one (Kesari's comment on #4734)
- **new-method/01-requirements.md** — Add explicit callout to create type definitions in appropriate types file (comment on #4735)
- **new-method/02-implementation.md** — Fix incorrect `cc.services.queue.getQueues()` → `cc.queue.getQueues()` to match actual SDK access pattern (comment on #4735)
- **new-method/03-tests.md** — Add team standard guidance: use exact match assertions, avoid `expect.objectContaining` (comment on #4735)
- **new-service/02-code-generation.md** — Complete sub-module example with full class structure reference (comment on #4734)

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

1. Verified all 10 fixes match the original reviewer comments from PRs #4721, #4722, #4723, #4734, #4735
2. Verified `cc.queue` / `cc.addressBook` access pattern matches actual source code in `cc.ts`
3. Confirmed markdown renders correctly and all relative links are valid
4. Documentation-only changes — no code impact, no tests affected

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code (Claude Opus 4.6)
- [x] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly