### PR TITLE
feat(webinar 5k): delay to call voicea.announce() in PS

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -770,6 +770,11 @@ export default class Meeting extends StatelessWebexPlugin {
   private logUploadIntervalIndex: number;
   private mediaServerIp: string;
   private llmHealthCheckTimer?: ReturnType<typeof setTimeout>;
+  private defaultLLMConnectionInFlight?: {
+    promise: Promise<any>;
+    locusUrl?: string;
+    datachannelUrl?: string;
+  };
 
   /**
    * @param {Object} attrs
@@ -6303,44 +6308,76 @@ export default class Meeting extends StatelessWebexPlugin {
     // webinar panelist should use new data channel in practice session
     const dataChannelUrl = datachannelUrl;
 
-    // @ts-ignore - Fix type
-    if (this.webex.internal.llm.isConnected()) {
-      if (
-        // @ts-ignore - Fix type
-        url === this.webex.internal.llm.getLocusUrl() &&
-        // @ts-ignore - Fix type
-        dataChannelUrl === this.webex.internal.llm.getDatachannelUrl() &&
-        isJoined
-      ) {
+    if (this.defaultLLMConnectionInFlight) {
+      const {
+        promise,
+        locusUrl: pendingLocusUrl,
+        datachannelUrl: pendingDatachannelUrl,
+      } = this.defaultLLMConnectionInFlight;
+
+      if (url === pendingLocusUrl && dataChannelUrl === pendingDatachannelUrl) {
+        return promise;
+      }
+
+      await promise.catch(() => undefined);
+
+      return this.updateLLMConnection();
+    }
+
+    const connectPromise = (async () => {
+      // @ts-ignore - Fix type
+      if (this.webex.internal.llm.isConnected()) {
+        if (
+          // @ts-ignore - Fix type
+          url === this.webex.internal.llm.getLocusUrl() &&
+          // @ts-ignore - Fix type
+          dataChannelUrl === this.webex.internal.llm.getDatachannelUrl() &&
+          isJoined
+        ) {
+          return undefined;
+        }
+        await this.cleanupLLMConneciton({removeOnlineListener: false});
+      }
+
+      if (!isJoined) {
         return undefined;
       }
-      await this.cleanupLLMConneciton({removeOnlineListener: false});
-    }
 
-    if (!isJoined) {
-      return undefined;
-    }
+      // @ts-ignore - Fix type
+      return this.webex.internal.llm
+        .registerAndConnect(url, dataChannelUrl, finalToken)
+        .then((registerAndConnectResult) => {
+          // @ts-ignore - Fix type
+          this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);
+          // @ts-ignore - Fix type
+          this.webex.internal.llm.on('event:relay.event', this.processRelayEvent);
+          // @ts-ignore - Fix type
+          this.webex.internal.llm.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
+          // @ts-ignore - Fix type
+          this.webex.internal.llm.on(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
+          LoggerProxy.logger.info(
+            'Meeting:index#updateLLMConnection --> enabled to receive relay events!'
+          );
 
-    // @ts-ignore - Fix type
-    return this.webex.internal.llm
-      .registerAndConnect(url, dataChannelUrl, finalToken)
-      .then((registerAndConnectResult) => {
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.on('event:relay.event', this.processRelayEvent);
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.on(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
-        LoggerProxy.logger.info(
-          'Meeting:index#updateLLMConnection --> enabled to receive relay events!'
-        );
+          this.startLLMHealthCheckTimer();
 
-        this.startLLMHealthCheckTimer();
+          return Promise.resolve(registerAndConnectResult);
+        });
+    })();
 
-        return Promise.resolve(registerAndConnectResult);
-      });
+    const trackedConnectPromise = connectPromise.finally(() => {
+      if (this.defaultLLMConnectionInFlight?.promise === trackedConnectPromise) {
+        this.defaultLLMConnectionInFlight = undefined;
+      }
+    });
+
+    this.defaultLLMConnectionInFlight = {
+      promise: trackedConnectPromise,
+      locusUrl: url,
+      datachannelUrl: dataChannelUrl,
+    };
+
+    return trackedConnectPromise;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -9591,8 +9591,13 @@ export default class Meeting extends StatelessWebexPlugin {
     }
 
     this.annotation.deregisterEvents();
+    // @ts-ignore
+    this.webex.internal.voicea.deregisterEvents();
 
-    await this.cleanupLLMConneciton({throwOnError: false});
+    // @ts-ignore - config coming from registerPlugin
+    if (this.config?.enableAutomaticLLM) {
+      await this.cleanupLLMConneciton({throwOnError: false});
+    }
   };
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5874,37 +5874,35 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {void}
    */
   stopTranscription() {
-    if (this.transcription) {
-      // @ts-ignore
-      this.webex.internal.voicea.off(
-        VOICEAEVENTS.VOICEA_ANNOUNCEMENT,
-        this.voiceaListenerCallbacks[VOICEAEVENTS.VOICEA_ANNOUNCEMENT]
-      );
+    // @ts-ignore
+    this.webex.internal.voicea.off(
+      VOICEAEVENTS.VOICEA_ANNOUNCEMENT,
+      this.voiceaListenerCallbacks[VOICEAEVENTS.VOICEA_ANNOUNCEMENT]
+    );
 
-      // @ts-ignore
-      this.webex.internal.voicea.off(
-        VOICEAEVENTS.CAPTIONS_TURNED_ON,
-        this.voiceaListenerCallbacks[VOICEAEVENTS.CAPTIONS_TURNED_ON]
-      );
+    // @ts-ignore
+    this.webex.internal.voicea.off(
+      VOICEAEVENTS.CAPTIONS_TURNED_ON,
+      this.voiceaListenerCallbacks[VOICEAEVENTS.CAPTIONS_TURNED_ON]
+    );
 
-      // @ts-ignore
-      this.webex.internal.voicea.off(
-        VOICEAEVENTS.EVA_COMMAND,
-        this.voiceaListenerCallbacks[VOICEAEVENTS.EVA_COMMAND]
-      );
+    // @ts-ignore
+    this.webex.internal.voicea.off(
+      VOICEAEVENTS.EVA_COMMAND,
+      this.voiceaListenerCallbacks[VOICEAEVENTS.EVA_COMMAND]
+    );
 
-      // @ts-ignore
-      this.webex.internal.voicea.off(
-        VOICEAEVENTS.NEW_CAPTION,
-        this.voiceaListenerCallbacks[VOICEAEVENTS.NEW_CAPTION]
-      );
+    // @ts-ignore
+    this.webex.internal.voicea.off(
+      VOICEAEVENTS.NEW_CAPTION,
+      this.voiceaListenerCallbacks[VOICEAEVENTS.NEW_CAPTION]
+    );
 
-      // @ts-ignore
-      this.webex.internal.voicea.deregisterEvents();
+    // @ts-ignore
+    this.webex.internal.voicea.deregisterEvents();
 
-      this.areVoiceaEventsSetup = false;
-      this.triggerStopReceivingTranscriptionEvent();
-    }
+    this.areVoiceaEventsSetup = false;
+    this.triggerStopReceivingTranscriptionEvent();
   }
 
   /**
@@ -9585,14 +9583,10 @@ export default class Meeting extends StatelessWebexPlugin {
     }
     this.queuedMediaUpdates = [];
 
-    if (this.transcription) {
-      this.stopTranscription();
-      this.transcription = undefined;
-    }
+    this.stopTranscription();
+    this.transcription = undefined;
 
     this.annotation.deregisterEvents();
-    // @ts-ignore
-    this.webex.internal.voicea.deregisterEvents();
 
     // @ts-ignore - config coming from registerPlugin
     if (this.config?.enableAutomaticLLM) {

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -20,6 +20,9 @@ import WebinarCollection from './collection';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {sanitizeParams} from './utils';
 
+const PRACTICE_SESSION_ANNOUNCE_DELAY_MS = 3000;
+const practiceSessionAnnounceTimers = new WeakMap();
+
 /**
  * @class Webinar
  */
@@ -45,6 +48,19 @@ const Webinar = WebexPlugin.extend({
    */
   cleanUp() {
     this.cleanupPSDataChannel();
+  },
+
+  /**
+   * Clears any pending practice session announce timer.
+   * @returns {void}
+   */
+  clearPSDataChannelAnnounceTimer() {
+    const timer = practiceSessionAnnounceTimers.get(this);
+
+    if (practiceSessionAnnounceTimers.has(this)) {
+      clearTimeout(timer);
+      practiceSessionAnnounceTimers.delete(this);
+    }
   },
 
   /**
@@ -133,6 +149,8 @@ const Webinar = WebexPlugin.extend({
   async cleanupPSDataChannel() {
     const meeting = this.webex.meetings.getMeetingByType(_ID_, this.meetingId);
 
+    this.clearPSDataChannelAnnounceTimer();
+
     // @ts-ignore - Fix type
     await this.webex.internal.llm.disconnectLLM(
       {
@@ -217,8 +235,15 @@ const Webinar = WebexPlugin.extend({
           `event:relay.event:${LLM_PRACTICE_SESSION}`,
           meeting?.processRelayEvent
         );
-        // @ts-ignore - Fix type
-        this.webex.internal.voicea?.announce?.();
+        this.clearPSDataChannelAnnounceTimer();
+        practiceSessionAnnounceTimers.set(
+          this,
+          setTimeout(() => {
+            practiceSessionAnnounceTimers.delete(this);
+            // @ts-ignore - Fix type
+            this.webex.internal.voicea?.announce?.();
+          }, PRACTICE_SESSION_ANNOUNCE_DELAY_MS)
+        );
         LoggerProxy.logger.info(
           `Webinar:index#updatePSDataChannel --> enabled to receive relay events for default session for ${LLM_PRACTICE_SESSION}!`
         );

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -20,9 +20,6 @@ import WebinarCollection from './collection';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {sanitizeParams} from './utils';
 
-const PRACTICE_SESSION_ANNOUNCE_DELAY_MS = 3000;
-const practiceSessionAnnounceTimers = new WeakMap();
-
 /**
  * @class Webinar
  */
@@ -48,19 +45,6 @@ const Webinar = WebexPlugin.extend({
    */
   cleanUp() {
     this.cleanupPSDataChannel();
-  },
-
-  /**
-   * Clears any pending practice session announce timer.
-   * @returns {void}
-   */
-  clearPSDataChannelAnnounceTimer() {
-    const timer = practiceSessionAnnounceTimers.get(this);
-
-    if (practiceSessionAnnounceTimers.has(this)) {
-      clearTimeout(timer);
-      practiceSessionAnnounceTimers.delete(this);
-    }
   },
 
   /**
@@ -149,8 +133,6 @@ const Webinar = WebexPlugin.extend({
   async cleanupPSDataChannel() {
     const meeting = this.webex.meetings.getMeetingByType(_ID_, this.meetingId);
 
-    this.clearPSDataChannelAnnounceTimer();
-
     // @ts-ignore - Fix type
     await this.webex.internal.llm.disconnectLLM(
       {
@@ -206,6 +188,26 @@ const Webinar = WebexPlugin.extend({
     if (!practiceSessionDatachannelUrl) {
       return undefined;
     }
+
+    // The practice-session channel depends on the default session channel.
+    // @ts-ignore - Fix type
+    if (!this.webex.internal.llm.isConnected()) {
+      LoggerProxy.logger.info(
+        'Webinar:index#updatePSDataChannel --> waiting for default LLM session to connect'
+      );
+
+      await meeting?.updateLLMConnection?.();
+
+      // @ts-ignore - Fix type
+      if (!this.webex.internal.llm.isConnected()) {
+        LoggerProxy.logger.info(
+          'Webinar:index#updatePSDataChannel --> skipping practice session connect because default LLM session is not connected'
+        );
+
+        return undefined;
+      }
+    }
+
     // @ts-ignore - Fix type
     if (this.webex.internal.llm.isConnected(LLM_PRACTICE_SESSION)) {
       if (
@@ -235,15 +237,8 @@ const Webinar = WebexPlugin.extend({
           `event:relay.event:${LLM_PRACTICE_SESSION}`,
           meeting?.processRelayEvent
         );
-        this.clearPSDataChannelAnnounceTimer();
-        practiceSessionAnnounceTimers.set(
-          this,
-          setTimeout(() => {
-            practiceSessionAnnounceTimers.delete(this);
-            // @ts-ignore - Fix type
-            this.webex.internal.voicea?.announce?.();
-          }, PRACTICE_SESSION_ANNOUNCE_DELAY_MS)
-        );
+        // @ts-ignore - Fix type
+        this.webex.internal.voicea?.announce?.();
         LoggerProxy.logger.info(
           `Webinar:index#updatePSDataChannel --> enabled to receive relay events for default session for ${LLM_PRACTICE_SESSION}!`
         );

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -13106,7 +13106,6 @@ describe('plugin-meetings', () => {
             assert.calledOnce(meeting.clearLLMHealthCheckTimer);
             assert.calledOnce(meeting.stopTranscription);
             assert.calledOnce(meeting.annotation.deregisterEvents);
-            assert.calledOnce(webex.internal.voicea.deregisterEvents);
           });
           it('continues cleanup when disconnectLLM fails during meeting data cleanup', async () => {
             webex.internal.llm.disconnectLLM.rejects(new Error('disconnect failed'));
@@ -13127,7 +13126,6 @@ describe('plugin-meetings', () => {
             assert.calledOnce(meeting.clearLLMHealthCheckTimer);
             assert.calledOnce(meeting.stopTranscription);
             assert.calledOnce(meeting.annotation.deregisterEvents);
-            assert.calledOnce(webex.internal.voicea.deregisterEvents);
           });
         });
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -12684,12 +12684,8 @@ describe('plugin-meetings', () => {
           meeting.webinar.isJoinPracticeSessionDataChannel = sinon.stub().returns(false);
         });
 
-        const check = (
-          url,
-          practiceSessionDatachannelUrl,
-          {expectedMainCalled, expectedPracticeCalled}
-        ) => {
-          meeting.handleDataChannelUrlChange(url, practiceSessionDatachannelUrl);
+        const check = (url, {expectedMainCalled, expectedPracticeCalled}) => {
+          meeting.handleDataChannelUrlChange(url);
 
           if (expectedMainCalled) {
             assert.calledWith(updateLLMConnectionSpy);
@@ -12706,19 +12702,19 @@ describe('plugin-meetings', () => {
 
         it('calls deferred updateLLMConnection if datachannelURL is set and the enableAutomaticLLM is true', () => {
           meeting.config.enableAutomaticLLM = true;
-          check('some url', undefined, {expectedMainCalled: true, expectedPracticeCalled: false});
+          check('some url', {expectedMainCalled: true, expectedPracticeCalled: false});
         });
 
         it('does not call updateLLMConnection if datachannelURL is undefined', () => {
           meeting.config.enableAutomaticLLM = true;
-          check(undefined, undefined, {
+          check(undefined, {
             expectedMainCalled: false,
             expectedPracticeCalled: false,
           });
         });
 
         it('does not call updateLLMConnection if enableAutomaticLLM is false', () => {
-          check('some url', 'some practice url', {
+          check('some url', {
             expectedMainCalled: false,
             expectedPracticeCalled: false,
           });
@@ -12728,7 +12724,7 @@ describe('plugin-meetings', () => {
           meeting.config.enableAutomaticLLM = true;
           meeting.webinar.isJoinPracticeSessionDataChannel.returns(true);
 
-          check('some url', 'some practice url', {
+          check('some url', {
             expectedMainCalled: true,
             expectedPracticeCalled: true,
           });
@@ -12738,7 +12734,7 @@ describe('plugin-meetings', () => {
           meeting.config.enableAutomaticLLM = true;
           meeting.webinar.isJoinPracticeSessionDataChannel.returns(true);
 
-          check(undefined, 'some practice url', {
+          check(undefined, {
             expectedMainCalled: false,
             expectedPracticeCalled: false,
           });
@@ -13077,9 +13073,11 @@ describe('plugin-meetings', () => {
 
         describe('#clearMeetingData', () => {
           beforeEach(() => {
+            meeting.config.enableAutomaticLLM = true;
             webex.internal.llm.isConnected = sinon.stub().returns(true);
             webex.internal.llm.disconnectLLM = sinon.stub().resolves();
             webex.internal.llm.off = sinon.stub();
+            webex.internal.voicea.deregisterEvents = sinon.stub();
             meeting.annotation.deregisterEvents = sinon.stub();
             meeting.clearLLMHealthCheckTimer = sinon.stub();
             meeting.stopTranscription = sinon.stub();
@@ -13108,6 +13106,7 @@ describe('plugin-meetings', () => {
             assert.calledOnce(meeting.clearLLMHealthCheckTimer);
             assert.calledOnce(meeting.stopTranscription);
             assert.calledOnce(meeting.annotation.deregisterEvents);
+            assert.calledOnce(webex.internal.voicea.deregisterEvents);
           });
           it('continues cleanup when disconnectLLM fails during meeting data cleanup', async () => {
             webex.internal.llm.disconnectLLM.rejects(new Error('disconnect failed'));
@@ -13128,6 +13127,7 @@ describe('plugin-meetings', () => {
             assert.calledOnce(meeting.clearLLMHealthCheckTimer);
             assert.calledOnce(meeting.stopTranscription);
             assert.calledOnce(meeting.annotation.deregisterEvents);
+            assert.calledOnce(webex.internal.voicea.deregisterEvents);
           });
         });
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -215,11 +215,22 @@ describe('plugin-meetings', () => {
     describe('#updatePSDataChannel', () => {
       let meeting;
       let processRelayEvent;
+      let defaultSessionConnected;
+      let practiceSessionConnected;
 
       beforeEach(() => {
         processRelayEvent = sinon.stub();
+        defaultSessionConnected = false;
+        practiceSessionConnected = false;
+        webex.internal.llm.isConnected.callsFake(
+          (sessionId) =>
+            sessionId === LLM_PRACTICE_SESSION ? practiceSessionConnected : defaultSessionConnected
+        );
         meeting = {
           isJoined: sinon.stub().returns(true),
+          updateLLMConnection: sinon.stub().callsFake(async () => {
+            defaultSessionConnected = true;
+          }),
           processRelayEvent,
           locusInfo: {
             url: 'locus-url',
@@ -267,7 +278,8 @@ describe('plugin-meetings', () => {
       });
 
       it('no-ops when already connected to the same endpoints', async () => {
-        webex.internal.llm.isConnected.returns(true);
+        defaultSessionConnected = true;
+        practiceSessionConnected = true;
         webex.internal.llm.getLocusUrl.returns('locus-url');
         webex.internal.llm.getDatachannelUrl.returns('dc-url');
         const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
@@ -275,16 +287,15 @@ describe('plugin-meetings', () => {
         const result = await webinar.updatePSDataChannel();
 
         assert.isUndefined(result);
+        assert.notCalled(meeting.updateLLMConnection);
         assert.notCalled(cleanupPSDataChannelStub);
         assert.notCalled(webex.internal.llm.registerAndConnect);
       });
 
-      it('connects when eligible and delays announce by three seconds', async () => {
-        const clock = sinon.useFakeTimers();
-
-        try {
+      it('waits for the default session to connect before connecting practice session', async () => {
         const result = await webinar.updatePSDataChannel();
 
+        assert.calledOnceWithExactly(meeting.updateLLMConnection);
         assert.calledOnceWithExactly(
           webex.internal.llm.setDatachannelToken,
           'ps-token',
@@ -298,58 +309,40 @@ describe('plugin-meetings', () => {
           'ps-token',
           LLM_PRACTICE_SESSION
         );
-          assert.notCalled(webex.internal.voicea.announce);
-
-          await clock.tickAsync(2999);
-          assert.notCalled(webex.internal.voicea.announce);
-
-          await clock.tickAsync(1);
         assert.calledOnceWithExactly(webex.internal.voicea.announce);
         assert.equal(result, 'REGISTER_AND_CONNECT_RESULT');
-        } finally {
-          clock.restore();
-        }
       });
 
-      it('clears any pending delayed announce during cleanup', async () => {
-        const clock = sinon.useFakeTimers();
+      it('skips practice session connect when default session does not connect', async () => {
+        meeting.updateLLMConnection = sinon.stub().resolves();
 
-        try {
-          await webinar.updatePSDataChannel();
-          await webinar.cleanupPSDataChannel();
-          await clock.tickAsync(3000);
+        const result = await webinar.updatePSDataChannel();
 
-          assert.notCalled(webex.internal.voicea.announce);
-        } finally {
-          clock.restore();
-        }
+        assert.isUndefined(result);
+        assert.calledOnceWithExactly(meeting.updateLLMConnection);
+        assert.notCalled(webex.internal.llm.registerAndConnect);
+        assert.notCalled(webex.internal.voicea.announce);
       });
 
-      it('replaces the pending delayed announce when reconnecting', async () => {
-        const clock = sinon.useFakeTimers();
+      it('does not re-announce during cleanup after a successful connect', async () => {
+        await webinar.updatePSDataChannel();
+        await webinar.cleanupPSDataChannel();
 
-        try {
-          await webinar.updatePSDataChannel();
+        assert.calledOnceWithExactly(webex.internal.voicea.announce);
+      });
 
-          webex.internal.llm.isConnected.returns(true);
-          webex.internal.llm.getLocusUrl.returns('old-locus-url');
-          webex.internal.llm.getDatachannelUrl.returns('old-dc-url');
+      it('announces on each successful reconnect', async () => {
+        await webinar.updatePSDataChannel();
 
-          await clock.tickAsync(2999);
-          assert.notCalled(webex.internal.voicea.announce);
+        defaultSessionConnected = true;
+        practiceSessionConnected = true;
+        webex.internal.llm.getLocusUrl.returns('old-locus-url');
+        webex.internal.llm.getDatachannelUrl.returns('old-dc-url');
 
-          await webinar.updatePSDataChannel();
+        await webinar.updatePSDataChannel();
 
-          assert.calledTwice(webex.internal.llm.registerAndConnect);
-
-          await clock.tickAsync(1);
-          assert.notCalled(webex.internal.voicea.announce);
-
-          await clock.tickAsync(2999);
-          assert.calledOnceWithExactly(webex.internal.voicea.announce);
-        } finally {
-          clock.restore();
-        }
+        assert.calledTwice(webex.internal.llm.registerAndConnect);
+        assert.calledTwice(webex.internal.voicea.announce);
       });
 
       it('uses cached token when available', async () => {
@@ -372,7 +365,8 @@ describe('plugin-meetings', () => {
       });
 
       it('cleans up the existing practice session channel before reconnecting to new endpoints', async () => {
-        webex.internal.llm.isConnected.returns(true);
+        defaultSessionConnected = true;
+        practiceSessionConnected = true;
         const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();
 
         await webinar.updatePSDataChannel();

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -279,7 +279,10 @@ describe('plugin-meetings', () => {
         assert.notCalled(webex.internal.llm.registerAndConnect);
       });
 
-      it('connects when eligible', async () => {
+      it('connects when eligible and delays announce by three seconds', async () => {
+        const clock = sinon.useFakeTimers();
+
+        try {
         const result = await webinar.updatePSDataChannel();
 
         assert.calledOnceWithExactly(
@@ -295,8 +298,58 @@ describe('plugin-meetings', () => {
           'ps-token',
           LLM_PRACTICE_SESSION
         );
+          assert.notCalled(webex.internal.voicea.announce);
+
+          await clock.tickAsync(2999);
+          assert.notCalled(webex.internal.voicea.announce);
+
+          await clock.tickAsync(1);
         assert.calledOnceWithExactly(webex.internal.voicea.announce);
         assert.equal(result, 'REGISTER_AND_CONNECT_RESULT');
+        } finally {
+          clock.restore();
+        }
+      });
+
+      it('clears any pending delayed announce during cleanup', async () => {
+        const clock = sinon.useFakeTimers();
+
+        try {
+          await webinar.updatePSDataChannel();
+          await webinar.cleanupPSDataChannel();
+          await clock.tickAsync(3000);
+
+          assert.notCalled(webex.internal.voicea.announce);
+        } finally {
+          clock.restore();
+        }
+      });
+
+      it('replaces the pending delayed announce when reconnecting', async () => {
+        const clock = sinon.useFakeTimers();
+
+        try {
+          await webinar.updatePSDataChannel();
+
+          webex.internal.llm.isConnected.returns(true);
+          webex.internal.llm.getLocusUrl.returns('old-locus-url');
+          webex.internal.llm.getDatachannelUrl.returns('old-dc-url');
+
+          await clock.tickAsync(2999);
+          assert.notCalled(webex.internal.voicea.announce);
+
+          await webinar.updatePSDataChannel();
+
+          assert.calledTwice(webex.internal.llm.registerAndConnect);
+
+          await clock.tickAsync(1);
+          assert.notCalled(webex.internal.voicea.announce);
+
+          await clock.tickAsync(2999);
+          assert.calledOnceWithExactly(webex.internal.voicea.announce);
+        } finally {
+          clock.restore();
+        }
       });
 
       it('uses cached token when available', async () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

1. When panelist join a webinar in which practice session is running, panelist call voicea.announce() earlier than cantina set up voicea event listener, so cantina cannot get the announcement response.

2. Sometime when leave webinar, "this.transcription" in meeting/index will be undefined so skipps the cleanup work of voicea plugin and make the announce status is not "idle" which block the next announce() if join again.

## by making the following changes

1. Delay 3 seconds to call voicea.announce() after PS data channel connected.
2. Remove the condition "if(this.transcription)" to cleanup voicea anyway.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Web client panelist join 5k Webinar in  which PS already started, check whether it can get caption language list.
Web client leave webinar and join agian, check whether it can get caption language list.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
