### PR TITLE
docs(contact-center): add SDK manifest generator for cross-repo sync

### DIFF
--- a/.claude/commands/generate-manifest.md
+++ b/.claude/commands/generate-manifest.md
@@ -1,0 +1,19 @@
+Generate the SDK manifest for @webex/contact-center.
+
+## What this does
+
+Runs `npx ts-node scripts/generate-manifest.ts` in the contact-center package to produce `sdk-manifest.yaml` — a machine-readable description of the public API surface.
+
+## Steps
+
+1. Navigate to `packages/@webex/contact-center/`
+2. Run: `npx ts-node scripts/generate-manifest.ts`
+3. Show a summary of what was generated (classes, methods, enums, types)
+4. If there are changes vs the previously committed manifest, show the diff with `git diff sdk-manifest.yaml`
+5. Remind the developer to commit `sdk-manifest.yaml` alongside their code changes
+
+## When to run
+
+- After changing any public method signature in cc.ts or Task.ts
+- After adding/removing/renaming exported types, enums, or constants
+- Before creating a PR that touches the public API surface

--- a/packages/@webex/contact-center/AGENTS.md
+++ b/packages/@webex/contact-center/AGENTS.md
@@ -429,6 +429,42 @@ Use this table to identify which service's ai-docs to load based on the develope
 
 ---
 
+## SDK Manifest (Cross-Repo Sync)
+
+This package generates a machine-readable `sdk-manifest.yaml` describing the public API surface.
+Consumers (e.g., ccWidgets) use this manifest to detect API changes and map impact.
+
+### When to regenerate
+- After changing any public method signature in `cc.ts` or `Task.ts`
+- After adding/removing/renaming exported types, enums, or constants
+- Before creating a PR that touches the public API surface
+
+### How to regenerate
+```bash
+npm run generate:manifest
+```
+
+### What it produces
+`sdk-manifest.yaml` — checked into git, ships with npm package. Contains:
+- Classes and public methods (params, return types, event emissions)
+- Exported enums with string values
+- Exported types/interfaces with field shapes
+- Exported constants
+
+### CI validation (future)
+```bash
+npm run generate:manifest && git diff --exit-code sdk-manifest.yaml
+```
+
+### SDK API Verification (MANDATORY for AI agents)
+Before generating code that changes a public API:
+1. Read `sdk-manifest.yaml` to understand the current contract
+2. After changes, run `npm run generate:manifest`
+3. Review the manifest diff — it shows the exact API surface impact
+4. Commit `sdk-manifest.yaml` alongside your code changes
+
+---
+
 ## Need More Context?
 
 - **TypeScript patterns**: [`ai-docs/patterns/typescript-patterns.md`](ai-docs/patterns/typescript-patterns.md)

--- a/packages/@webex/contact-center/package.json
+++ b/packages/@webex/contact-center/package.json
@@ -41,8 +41,13 @@
     "test": "yarn test:style && yarn test:unit",
     "test:style": "eslint 'src/**/*.ts'",
     "test:unit": "webex-legacy-tools test --unit --runner jest",
-    "deploy:npm": "yarn npm publish"
+    "deploy:npm": "yarn npm publish",
+    "generate:manifest": "ts-node scripts/generate-manifest.ts"
   },
+  "files": [
+    "dist/",
+    "sdk-manifest.yaml"
+  ],
   "dependencies": {
     "@types/platform": "1.3.4",
     "@webex/calling": "workspace:*",
@@ -61,6 +66,7 @@
     "@babel/core": "^7.22.11",
     "@babel/preset-typescript": "7.22.11",
     "@types/jest": "27.4.1",
+    "@types/js-yaml": "^4",
     "@typescript-eslint/eslint-plugin": "5.38.1",
     "@typescript-eslint/parser": "5.38.1",
     "@webex/babel-config-legacy": "workspace:*",
@@ -79,7 +85,9 @@
     "eslint-plugin-tsdoc": "0.2.14",
     "jest": "27.5.1",
     "jest-junit": "13.0.0",
+    "js-yaml": "^4.1.1",
     "prettier": "2.5.1",
+    "ts-morph": "^27.0.2",
     "typedoc": "^0.25.0",
     "typescript": "5.4.5"
   }

--- a/packages/@webex/contact-center/scripts/generate-manifest.ts
+++ b/packages/@webex/contact-center/scripts/generate-manifest.ts
@@ -1,0 +1,387 @@
+/**
+ * SDK Manifest Generator
+ *
+ * Uses ts-morph to statically analyze the @webex/contact-center package
+ * and produce a machine-readable sdk-manifest.yaml describing the public API surface.
+ *
+ * What it captures:
+ * - Exported classes and their public methods (params, return types)
+ * - Event emissions per method (trigger/emit calls resolved to string values)
+ * - Exported enums and their values
+ * - Exported types/interfaces and their fields
+ * - Exported constants
+ *
+ * Usage: npx ts-node scripts/generate-manifest.ts
+ */
+
+/* eslint-disable no-console, no-continue, import/no-extraneous-dependencies */
+import {
+  Project,
+  Node,
+  SyntaxKind,
+  ClassDeclaration,
+  TypeAliasDeclaration,
+  InterfaceDeclaration,
+  MethodDeclaration,
+} from 'ts-morph';
+import * as yaml from 'js-yaml';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PKG_ROOT = path.resolve(__dirname, '..');
+const ENTRY_FILE = path.join(PKG_ROOT, 'src/index.ts');
+const OUTPUT_FILE = path.join(PKG_ROOT, 'sdk-manifest.yaml');
+
+interface ParamInfo {
+  name: string;
+  type: string;
+  required: boolean;
+}
+
+interface MethodInfo {
+  params: ParamInfo[];
+  returns: string;
+  events_on_success: string[];
+  events_on_failure: string[];
+}
+
+interface ClassInfo {
+  source: string;
+  extends: string | null;
+  methods: Record<string, MethodInfo>;
+}
+
+interface FieldInfo {
+  name: string;
+  type: string;
+  required: boolean;
+}
+
+interface TypeInfo {
+  kind?: string;
+  fields?: FieldInfo[];
+  values?: string[];
+}
+
+interface Manifest {
+  name: string;
+  version: string;
+  generated_at: string;
+  generator: string;
+  classes: Record<string, ClassInfo>;
+  events: Record<string, Record<string, string>>;
+  types: Record<string, TypeInfo>;
+  constants: Record<string, string | number | boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitize type text by replacing absolute paths with relative ones.
+ */
+function sanitizeType(typeText: string): string {
+  // Replace absolute import paths with relative package paths
+  return typeText.replace(/import\("[^"]*\/packages\/@webex\/contact-center\/([^"]+)"\)\./g, '$1:');
+}
+
+/**
+ * Resolve an enum member access (e.g., AGENT_EVENTS.STATE_CHANGE) to its string value.
+ */
+function resolveEnumValue(project: Project, expression: string): string | null {
+  // expression might be like "TASK_EVENTS.TASK_INCOMING"
+  const parts = expression.split('.');
+  if (parts.length !== 2) return null;
+
+  const [enumName, memberName] = parts;
+
+  for (const sf of project.getSourceFiles()) {
+    const enumDec = sf.getEnum(enumName);
+    if (enumDec) {
+      const member = enumDec.getMember(memberName);
+      if (member) {
+        const val = member.getValue();
+
+        return typeof val === 'string' ? val : null;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract event emissions from a method body.
+ * Looks for patterns like:
+ *   this.trigger(SOME_ENUM.MEMBER, ...)
+ *   this.emit(SOME_ENUM.MEMBER, ...)
+ *
+ * Returns separate success/failure arrays based on try/catch context.
+ */
+function extractEvents(
+  project: Project,
+  method: MethodDeclaration
+): {success: string[]; failure: string[]} {
+  const success: string[] = [];
+  const failure: string[] = [];
+
+  const body = method.getBody();
+  if (!body) return {success, failure};
+
+  const callExpressions = body.getDescendantsOfKind(SyntaxKind.CallExpression);
+
+  for (const call of callExpressions) {
+    const expr = call.getExpression();
+
+    // Match this.trigger(...) or this.emit(...)
+    if (!Node.isPropertyAccessExpression(expr)) continue;
+    const methodName = expr.getName();
+    if (methodName !== 'trigger' && methodName !== 'emit') continue;
+
+    const objExpr = expr.getExpression();
+    if (!Node.isThisExpression(objExpr)) continue;
+
+    // Get the first argument (the event name)
+    const args = call.getArguments();
+    if (args.length === 0) continue;
+
+    const firstArg = args[0];
+    let eventValue: string | null = null;
+
+    if (Node.isStringLiteral(firstArg)) {
+      eventValue = firstArg.getLiteralValue();
+    } else if (Node.isPropertyAccessExpression(firstArg)) {
+      const enumExpr = firstArg.getText();
+      eventValue = resolveEnumValue(project, enumExpr);
+    }
+
+    if (!eventValue) continue;
+
+    // Determine if inside catch block
+    let parent = call.getParent();
+    let inCatch = false;
+    while (parent) {
+      if (Node.isCatchClause(parent)) {
+        inCatch = true;
+        break;
+      }
+      parent = parent.getParent();
+    }
+
+    if (inCatch) {
+      if (!failure.includes(eventValue)) failure.push(eventValue);
+    } else if (!success.includes(eventValue)) success.push(eventValue);
+  }
+
+  return {success, failure};
+}
+
+/**
+ * Extract public methods from a class declaration.
+ */
+function extractMethods(project: Project, cls: ClassDeclaration): Record<string, MethodInfo> {
+  const methods: Record<string, MethodInfo> = {};
+
+  for (const method of cls.getMethods()) {
+    // Skip private/protected
+    if (method.hasModifier(SyntaxKind.PrivateKeyword)) continue;
+    if (method.hasModifier(SyntaxKind.ProtectedKeyword)) continue;
+
+    // Skip methods starting with underscore (convention for internal)
+    const name = method.getName();
+    if (name.startsWith('_')) continue;
+
+    const params: ParamInfo[] = method.getParameters().map((p) => ({
+      name: p.getName(),
+      type: sanitizeType(p.getType().getText(p)),
+      required: !p.isOptional() && !p.hasInitializer(),
+    }));
+
+    const returnType = sanitizeType(method.getReturnType().getText(method));
+
+    const events = extractEvents(project, method);
+
+    methods[name] = {
+      params,
+      returns: returnType,
+      events_on_success: events.success,
+      events_on_failure: events.failure,
+    };
+  }
+
+  return methods;
+}
+
+/**
+ * Extract fields from an interface or type alias.
+ */
+function extractTypeFields(decl: InterfaceDeclaration | TypeAliasDeclaration): TypeInfo {
+  if (Node.isInterfaceDeclaration(decl)) {
+    const fields: FieldInfo[] = decl.getProperties().map((prop) => ({
+      name: prop.getName(),
+      type: sanitizeType(prop.getType().getText(prop)),
+      required: !prop.hasQuestionToken(),
+    }));
+
+    return {fields};
+  }
+
+  if (Node.isTypeAliasDeclaration(decl)) {
+    const typeNode = decl.getTypeNode();
+
+    // Union type like 'BROWSER' | 'EXTENSION' | 'AGENT_DN'
+    if (typeNode && Node.isUnionTypeNode(typeNode)) {
+      const values = typeNode.getTypeNodes().map((t) => t.getText());
+
+      return {kind: 'union', values};
+    }
+
+    // Object type literal
+    if (typeNode && Node.isTypeLiteral(typeNode)) {
+      const fields: FieldInfo[] = typeNode.getProperties().map((prop) => ({
+        name: prop.getName(),
+        type: sanitizeType(prop.getType().getText(prop)),
+        required: !prop.hasQuestionToken(),
+      }));
+
+      return {fields};
+    }
+
+    // Fallback: just record the type text
+    return {kind: 'alias', values: [sanitizeType(decl.getType().getText(decl))]};
+  }
+
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function generate(): void {
+  console.log('Loading TypeScript project...');
+  const project = new Project({
+    tsConfigFilePath: path.join(PKG_ROOT, 'tsconfig.json'),
+    skipAddingFilesFromTsConfig: false,
+  });
+
+  const entryFile = project.getSourceFileOrThrow(ENTRY_FILE);
+
+  console.log('Analyzing exports...');
+  const exportedDeclarations = entryFile.getExportedDeclarations();
+
+  const manifest: Manifest = {
+    name: '@webex/contact-center',
+    version: '',
+    generated_at: new Date().toISOString(),
+    generator: 'generate-manifest.ts v1.0',
+    classes: {},
+    events: {},
+    types: {},
+    constants: {},
+  };
+
+  // Read version from package.json
+  const pkgJson = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, 'package.json'), 'utf8'));
+  manifest.version = pkgJson.version || 'workspace';
+
+  // Track seen classes to skip 'default' re-export duplicates
+  const seenClassFiles = new Set<string>();
+  // Track seen enums to skip type re-exports (e.g., TaskEvents = TASK_EVENTS)
+  const seenEnumFiles = new Set<string>();
+
+  for (const [exportName, declarations] of exportedDeclarations) {
+    for (const decl of declarations) {
+      // --- Classes ---
+      if (Node.isClassDeclaration(decl)) {
+        const sourceFile = decl.getSourceFile();
+        const relativePath = path.relative(PKG_ROOT, sourceFile.getFilePath());
+
+        // Skip duplicate class exports (e.g., 'default' re-exporting ContactCenter)
+        if (seenClassFiles.has(relativePath)) continue;
+        seenClassFiles.add(relativePath);
+
+        console.log(`  Class: ${exportName}`);
+
+        const extendsClause = decl.getExtends();
+        const extendsText = extendsClause ? extendsClause.getText() : null;
+
+        manifest.classes[exportName] = {
+          source: relativePath,
+          extends: extendsText,
+          methods: extractMethods(project, decl),
+        };
+      }
+
+      // --- Enums ---
+      else if (Node.isEnumDeclaration(decl)) {
+        const sourceFile = decl.getSourceFile();
+        const enumKey = `${sourceFile.getFilePath()}:${decl.getName()}`;
+
+        // Skip duplicate enum exports (e.g., TaskEvents type re-export of TASK_EVENTS)
+        if (seenEnumFiles.has(enumKey)) continue;
+        seenEnumFiles.add(enumKey);
+
+        console.log(`  Enum: ${exportName}`);
+        const members: Record<string, string> = {};
+        for (const member of decl.getMembers()) {
+          const val = member.getValue();
+          if (typeof val === 'string') {
+            members[member.getName()] = val;
+          }
+        }
+        manifest.events[exportName] = members;
+      }
+
+      // --- Interfaces ---
+      else if (Node.isInterfaceDeclaration(decl)) {
+        manifest.types[exportName] = extractTypeFields(decl);
+      }
+
+      // --- Type Aliases ---
+      else if (Node.isTypeAliasDeclaration(decl)) {
+        manifest.types[exportName] = extractTypeFields(decl);
+      }
+
+      // --- Variable declarations (constants) ---
+      else if (Node.isVariableDeclaration(decl)) {
+        const init = decl.getInitializer();
+        if (init && Node.isStringLiteral(init)) {
+          manifest.constants[exportName] = init.getLiteralValue();
+        } else if (init && Node.isNumericLiteral(init)) {
+          manifest.constants[exportName] = init.getLiteralValue();
+        }
+      }
+    }
+  }
+
+  // Write YAML
+  const yamlContent = yaml.dump(manifest, {
+    lineWidth: 120,
+    noRefs: true,
+    sortKeys: false,
+    quotingType: '"',
+    forceQuotes: false,
+  });
+
+  fs.writeFileSync(OUTPUT_FILE, yamlContent, 'utf8');
+
+  // Summary
+  const classCount = Object.keys(manifest.classes).length;
+  const methodCount = Object.values(manifest.classes).reduce(
+    (sum, cls) => sum + Object.keys(cls.methods).length,
+    0
+  );
+  const enumCount = Object.keys(manifest.events).length;
+  const typeCount = Object.keys(manifest.types).length;
+  const constCount = Object.keys(manifest.constants).length;
+
+  console.log(`\nManifest generated: ${OUTPUT_FILE}`);
+  console.log(`  Classes: ${classCount} (${methodCount} methods)`);
+  console.log(`  Enums: ${enumCount}`);
+  console.log(`  Types: ${typeCount}`);
+  console.log(`  Constants: ${constCount}`);
+}
+
+generate();

--- a/packages/@webex/contact-center/sdk-manifest.yaml
+++ b/packages/@webex/contact-center/sdk-manifest.yaml
@@ -1,0 +1,1959 @@
+name: "@webex/contact-center"
+version: workspace
+generated_at: "2026-03-24T12:27:11.156Z"
+generator: generate-manifest.ts v1.0
+classes:
+  ContactCenter:
+    source: src/cc.ts
+    extends: WebexPlugin
+    methods:
+      register:
+        params: []
+        returns: Promise<Profile>
+        events_on_success: []
+        events_on_failure: []
+      deregister:
+        params: []
+        returns: Promise<void>
+        events_on_success: []
+        events_on_failure: []
+      getBuddyAgents:
+        params:
+          - name: data
+            type: BuddyAgents
+            required: true
+        returns: Promise<BuddyAgentsResponse>
+        events_on_success: []
+        events_on_failure: []
+      stationLogin:
+        params:
+          - name: data
+            type: AgentLogin
+            required: true
+        returns: Promise<StationLoginResponse>
+        events_on_success: []
+        events_on_failure: []
+      stationLogout:
+        params:
+          - name: data
+            type: Logout
+            required: true
+        returns: Promise<StationLogoutResponse>
+        events_on_success: []
+        events_on_failure: []
+      setAgentState:
+        params:
+          - name: data
+            type: StateChange
+            required: true
+        returns: Promise<SetStateResponse>
+        events_on_success: []
+        events_on_failure: []
+      startOutdial:
+        params:
+          - name: destination
+            type: string
+            required: true
+          - name: origin
+            type: string
+            required: true
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      getOutdialAniEntries:
+        params:
+          - name: params
+            type: OutdialAniParams
+            required: true
+        returns: Promise<OutdialAniEntriesResponse>
+        events_on_success: []
+        events_on_failure: []
+      uploadLogs:
+        params: []
+        returns: Promise<UploadLogsResponse>
+        events_on_success: []
+        events_on_failure: []
+      updateAgentProfile:
+        params:
+          - name: data
+            type: AgentProfileUpdate
+            required: true
+        returns: Promise<UpdateDeviceTypeResponse>
+        events_on_success: []
+        events_on_failure: []
+      getEntryPoints:
+        params:
+          - name: params
+            type: src/utils/PageCache:BaseSearchParams
+            required: false
+        returns: Promise<EntryPointListResponse>
+        events_on_success: []
+        events_on_failure: []
+      getQueues:
+        params:
+          - name: params
+            type: ContactServiceQueueSearchParams
+            required: false
+        returns: Promise<ContactServiceQueuesResponse>
+        events_on_success: []
+        events_on_failure: []
+  Task:
+    source: src/services/task/Task.ts
+    extends: EventEmitter
+    methods:
+      accept:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      decline:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      pauseRecording:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      resumeRecording:
+        params:
+          - name: resumeRecordingPayload
+            type: ResumeRecordingPayload
+            required: true
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      consult:
+        params:
+          - name: consultPayload
+            type: ConsultPayload
+            required: true
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      endConsult:
+        params:
+          - name: consultEndPayload
+            type: ConsultEndPayload
+            required: true
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      consultTransfer:
+        params:
+          - name: consultTransferPayload
+            type: ConsultTransferPayLoad
+            required: false
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      consultConference:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      exitConference:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      transferConference:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      switchCall:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      toggleMute:
+        params: []
+        returns: Promise<void>
+        events_on_success: []
+        events_on_failure: []
+      startTranscription:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success:
+          - task:transcriptionStarted
+        events_on_failure:
+          - task:transcriptionFailed
+      stopTranscription:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success:
+          - task:transcriptionStopped
+        events_on_failure: []
+      unregisterWebCallListeners:
+        params: []
+        returns: void
+        events_on_success: []
+        events_on_failure: []
+      cancelAutoWrapupTimer:
+        params: []
+        returns: void
+        events_on_success: []
+        events_on_failure: []
+      hold:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      resume:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      holdResume:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      sendStateMachineEvent:
+        params:
+          - name: event
+            type: TaskEventPayload
+            required: true
+        returns: void
+        events_on_success: []
+        events_on_failure: []
+      updateTaskData:
+        params:
+          - name: updatedData
+            type: TaskData
+            required: true
+          - name: shouldOverwrite
+            type: boolean
+            required: false
+        returns: ITask
+        events_on_success: []
+        events_on_failure: []
+      transfer:
+        params:
+          - name: transferPayload
+            type: TransferPayLoad
+            required: true
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      end:
+        params: []
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+      wrapup:
+        params:
+          - name: wrapupPayload
+            type: WrapupPayLoad
+            required: true
+        returns: Promise<TaskResponse>
+        events_on_success: []
+        events_on_failure: []
+  AddressBook:
+    source: src/services/AddressBook.ts
+    extends: null
+    methods:
+      getEntries:
+        params:
+          - name: params
+            type: AddressBookEntrySearchParams
+            required: false
+        returns: Promise<AddressBookEntriesResponse>
+        events_on_success: []
+        events_on_failure: []
+events:
+  TASK_EVENTS:
+    TASK_INCOMING: task:incoming
+    TASK_ASSIGNED: task:assigned
+    TASK_MEDIA: task:media
+    TASK_UNASSIGNED: task:unassigned
+    TASK_HOLD: task:hold
+    TASK_RESUME: task:resume
+    TASK_CONSULT_END: task:consultEnd
+    TASK_CONSULT_QUEUE_CANCELLED: task:consultQueueCancelled
+    TASK_CONSULT_QUEUE_FAILED: task:consultQueueFailed
+    TASK_UI_CONTROLS_UPDATED: task:ui-controls-updated
+    TASK_CONSULT_ACCEPTED: task:consultAccepted
+    TASK_CONSULTING: task:consulting
+    TASK_CONSULT_CREATED: task:consultCreated
+    TASK_OFFER_CONSULT: task:offerConsult
+    TASK_END: task:end
+    TASK_WRAPUP: task:wrapup
+    TASK_WRAPPEDUP: task:wrappedup
+    TASK_CLEANUP: task:cleanup
+    TASK_RECORDING_STARTED: task:recordingStarted
+    TASK_RECORDING_PAUSED: task:recordingPaused
+    TASK_RECORDING_PAUSE_FAILED: task:recordingPauseFailed
+    TASK_RECORDING_RESUMED: task:recordingResumed
+    TASK_RECORDING_RESUME_FAILED: task:recordingResumeFailed
+    TASK_REJECT: task:rejected
+    TASK_OUTDIAL_FAILED: task:outdialFailed
+    TASK_HYDRATE: task:hydrate
+    TASK_OFFER_CONTACT: task:offerContact
+    TASK_AUTO_ANSWERED: task:autoAnswered
+    TASK_CONFERENCE_ESTABLISHING: task:conferenceEstablishing
+    TASK_CONFERENCE_STARTED: task:conferenceStarted
+    TASK_CONFERENCE_FAILED: task:conferenceFailed
+    TASK_CONFERENCE_ENDED: task:conferenceEnded
+    TASK_PARTICIPANT_JOINED: task:participantJoined
+    TASK_PARTICIPANT_LEFT: task:participantLeft
+    TASK_CONFERENCE_TRANSFERRED: task:conferenceTransferred
+    TASK_CONFERENCE_TRANSFER_FAILED: task:conferenceTransferFailed
+    TASK_CONFERENCE_END_FAILED: task:conferenceEndFailed
+    TASK_PARTICIPANT_LEFT_FAILED: task:participantLeftFailed
+    TASK_EXIT_CONFERENCE: task:exitConference
+    TASK_TRANSFER_CONFERENCE: task:transferConference
+    TASK_SWITCH_CALL: task:switchCall
+    TASK_MERGED: task:merged
+    TASK_POST_CALL_ACTIVITY: task:postCallActivity
+    TASK_TRANSCRIPTION: task:transcription
+    TASK_TRANSCRIPTION_STARTED: task:transcriptionStarted
+    TASK_TRANSCRIPTION_STOPPED: task:transcriptionStopped
+    TASK_TRANSCRIPTION_FAILED: task:transcriptionFailed
+  AGENT_EVENTS:
+    AGENT_STATE_CHANGE: agent:stateChange
+    AGENT_MULTI_LOGIN: agent:multiLogin
+    AGENT_STATION_LOGIN_SUCCESS: agent:stationLoginSuccess
+    AGENT_STATION_LOGIN_FAILED: agent:stationLoginFailed
+    AGENT_LOGOUT_SUCCESS: agent:logoutSuccess
+    AGENT_LOGOUT_FAILED: agent:logoutFailed
+    AGENT_DN_REGISTERED: agent:dnRegistered
+    AGENT_RELOGIN_SUCCESS: agent:reloginSuccess
+    AGENT_STATE_CHANGE_SUCCESS: agent:stateChangeSuccess
+    AGENT_STATE_CHANGE_FAILED: agent:stateChangeFailed
+types:
+  EntryPointRecord:
+    fields:
+      - name: id
+        type: string
+        required: true
+      - name: name
+        type: string
+        required: true
+      - name: description
+        type: string
+        required: false
+      - name: type
+        type: string
+        required: true
+      - name: isActive
+        type: boolean
+        required: true
+      - name: orgId
+        type: string
+        required: true
+      - name: createdAt
+        type: string
+        required: false
+      - name: updatedAt
+        type: string
+        required: false
+      - name: settings
+        type: Record<string, any>
+        required: false
+  EntryPointListResponse:
+    kind: alias
+    values:
+      - PaginatedResponse<EntryPointRecord>
+  EntryPointSearchParams:
+    kind: alias
+    values:
+      - BaseSearchParams
+  AddressBookEntry:
+    fields:
+      - name: id
+        type: string
+        required: true
+      - name: organizationId
+        type: string
+        required: false
+      - name: version
+        type: number
+        required: false
+      - name: name
+        type: string
+        required: true
+      - name: number
+        type: string
+        required: true
+      - name: createdTime
+        type: number
+        required: false
+      - name: lastUpdatedTime
+        type: number
+        required: false
+  AddressBookEntriesResponse:
+    kind: alias
+    values:
+      - PaginatedResponse<AddressBookEntry>
+  AddressBookEntrySearchParams:
+    fields:
+      - name: addressBookId
+        type: string
+        required: false
+  ContactServiceQueuesResponse:
+    kind: alias
+    values:
+      - PaginatedResponse<ContactServiceQueue>
+  ContactServiceQueueSearchParams:
+    fields:
+      - name: desktopProfileFilter
+        type: boolean
+        required: false
+      - name: provisioningView
+        type: boolean
+        required: false
+      - name: singleObjectResponse
+        type: boolean
+        required: false
+  ContactServiceQueue:
+    fields:
+      - name: organizationId
+        type: string
+        required: false
+      - name: id
+        type: string
+        required: false
+      - name: version
+        type: number
+        required: false
+      - name: name
+        type: string
+        required: true
+      - name: description
+        type: string
+        required: false
+      - name: queueType
+        type: "\"INBOUND\" | \"OUTBOUND\""
+        required: true
+      - name: checkAgentAvailability
+        type: boolean
+        required: true
+      - name: channelType
+        type: "\"TELEPHONY\" | \"EMAIL\" | \"FAX\" | \"CHAT\" | \"VIDEO\" | \"OTHERS\" | \"SOCIAL_CHANNEL\""
+        required: true
+      - name: socialChannelType
+        type: "\"MESSAGEBIRD\" | \"MESSENGER\" | \"WHATSAPP\" | \"APPLE_BUSINESS_CHAT\" | \"GOOGLE_BUSINESS_MESSAGES\""
+        required: false
+      - name: serviceLevelThreshold
+        type: number
+        required: true
+      - name: maxActiveContacts
+        type: number
+        required: true
+      - name: maxTimeInQueue
+        type: number
+        required: true
+      - name: defaultMusicInQueueMediaFileId
+        type: string
+        required: true
+      - name: timezone
+        type: string
+        required: false
+      - name: active
+        type: boolean
+        required: true
+      - name: outdialCampaignEnabled
+        type: boolean
+        required: false
+      - name: monitoringPermitted
+        type: boolean
+        required: true
+      - name: parkingPermitted
+        type: boolean
+        required: true
+      - name: recordingPermitted
+        type: boolean
+        required: true
+      - name: recordingAllCallsPermitted
+        type: boolean
+        required: true
+      - name: pauseRecordingPermitted
+        type: boolean
+        required: true
+      - name: recordingPauseDuration
+        type: number
+        required: false
+      - name: controlFlowScriptUrl
+        type: string
+        required: true
+      - name: ivrRequeueUrl
+        type: string
+        required: true
+      - name: overflowNumber
+        type: string
+        required: false
+      - name: vendorId
+        type: string
+        required: false
+      - name: routingType
+        type: "\"LONGEST_AVAILABLE_AGENT\" | \"SKILLS_BASED\" | \"CIRCULAR\" | \"LINEAR\""
+        required: true
+      - name: skillBasedRoutingType
+        type: "\"LONGEST_AVAILABLE_AGENT\" | \"BEST_AVAILABLE_AGENT\""
+        required: false
+      - name: queueRoutingType
+        type: "\"TEAM_BASED\" | \"SKILL_BASED\" | \"AGENT_BASED\""
+        required: true
+      - name: queueSkillRequirements
+        type: QueueSkillRequirement[]
+        required: false
+      - name: agents
+        type: QueueAgent[]
+        required: false
+      - name: callDistributionGroups
+        type: CallDistributionGroup[]
+        required: true
+      - name: xspVersion
+        type: string
+        required: false
+      - name: subscriptionId
+        type: string
+        required: false
+      - name: assistantSkill
+        type: AssistantSkillMapping
+        required: false
+      - name: systemDefault
+        type: boolean
+        required: false
+      - name: agentsLastUpdatedByUserName
+        type: string
+        required: false
+      - name: agentsLastUpdatedByUserEmailPrefix
+        type: string
+        required: false
+      - name: agentsLastUpdatedTime
+        type: number
+        required: false
+      - name: createdTime
+        type: number
+        required: false
+      - name: lastUpdatedTime
+        type: number
+        required: false
+  CC_EVENTS:
+    kind: alias
+    values:
+      - >-
+        "Welcome" | "AgentReloginSuccess" | "AgentReloginFailed" | "AgentDNRegistered" | "Logout" | "AgentLogoutSuccess"
+        | "AgentLogoutFailed" | "StationLogin" | "AgentStationLoginSuccess" | "AgentStationLoginFailed" |
+        "AgentStateChange" | "AGENT_MULTI_LOGIN" | "AgentStateChangeSuccess" | "AgentStateChangeFailed" | "BuddyAgents"
+        | "BuddyAgentsRetrieveFailed" | "AgentContactReserved" | "AgentContactAssignFailed" | "AgentOfferContactRona" |
+        "AgentContactHeld" | "AgentContactHoldFailed" | "AgentContactUnheld" | "AgentContactUnHoldFailed" |
+        "AgentConsultCreated" | "AgentOfferConsult" | "AgentConsulting" | "AgentConsultFailed" | "AgentCtqFailed" |
+        "AgentCtqCancelled" | "AgentCtqCancelFailed" | "AgentConsultEnded" | "AgentConsultEndFailed" |
+        "AgentConsultConferenceEnded" | "AgentConsultConferencing" | "AgentConsultConferenced" |
+        "AgentConsultConferenceFailed" | "ParticipantJoinedConference" | "ParticipantLeftConference" |
+        "ParticipantLeftConferenceFailed" | "AgentConsultConferenceEndFailed" | "AgentConferenceTransferred" |
+        "AgentConferenceTransferFailed" | "ParticipantPostCallActivity" | "ConsultedParticipantMoving" |
+        "REAL_TIME_TRANSCRIPTION" | "TranscriptionFailed" | "AgentBlindTransferred" | "AgentBlindTransferFailed" |
+        "AgentVteamTransferred" | "AgentVteamTransferFailed" | "AgentConsultTransferring" | "AgentConsultTransferred" |
+        "AgentConsultTransferFailed" | "ContactRecordingPaused" | "ContactRecordingStarted" |
+        "ContactRecordingPauseFailed" | "ContactRecordingResumed" | "ContactRecordingResumeFailed" | "ContactEnded" |
+        "ContactMerged" | "ContactUpdated" | "ContactOwnerChanged" | "AgentContactEndFailed" | "AgentWrapup" |
+        "AgentWrappedUp" | "AgentWrapupFailed" | "AgentOutboundFailed" | "AgentContact" | "AgentOfferContact" |
+        "AgentContactAssigned" | "AgentContactUnassigned" | "AgentInviteFailed"
+  ContactCenterEvents:
+    kind: alias
+    values:
+      - >-
+        "Welcome" | "AgentReloginSuccess" | "AgentReloginFailed" | "AgentDNRegistered" | "Logout" | "AgentLogoutSuccess"
+        | "AgentLogoutFailed" | "StationLogin" | "AgentStationLoginSuccess" | "AgentStationLoginFailed" |
+        "AgentStateChange" | "AGENT_MULTI_LOGIN" | "AgentStateChangeSuccess" | "AgentStateChangeFailed" | "BuddyAgents"
+        | "BuddyAgentsRetrieveFailed" | "AgentContactReserved" | "AgentContactAssignFailed" | "AgentOfferContactRona" |
+        "AgentContactHeld" | "AgentContactHoldFailed" | "AgentContactUnheld" | "AgentContactUnHoldFailed" |
+        "AgentConsultCreated" | "AgentOfferConsult" | "AgentConsulting" | "AgentConsultFailed" | "AgentCtqFailed" |
+        "AgentCtqCancelled" | "AgentCtqCancelFailed" | "AgentConsultEnded" | "AgentConsultEndFailed" |
+        "AgentConsultConferenceEnded" | "AgentConsultConferencing" | "AgentConsultConferenced" |
+        "AgentConsultConferenceFailed" | "ParticipantJoinedConference" | "ParticipantLeftConference" |
+        "ParticipantLeftConferenceFailed" | "AgentConsultConferenceEndFailed" | "AgentConferenceTransferred" |
+        "AgentConferenceTransferFailed" | "ParticipantPostCallActivity" | "ConsultedParticipantMoving" |
+        "REAL_TIME_TRANSCRIPTION" | "TranscriptionFailed" | "AgentBlindTransferred" | "AgentBlindTransferFailed" |
+        "AgentVteamTransferred" | "AgentVteamTransferFailed" | "AgentConsultTransferring" | "AgentConsultTransferred" |
+        "AgentConsultTransferFailed" | "ContactRecordingPaused" | "ContactRecordingStarted" |
+        "ContactRecordingPauseFailed" | "ContactRecordingResumed" | "ContactRecordingResumeFailed" | "ContactEnded" |
+        "ContactMerged" | "ContactUpdated" | "ContactOwnerChanged" | "AgentContactEndFailed" | "AgentWrapup" |
+        "AgentWrappedUp" | "AgentWrapupFailed" | "AgentOutboundFailed" | "AgentContact" | "AgentOfferContact" |
+        "AgentContactAssigned" | "AgentContactUnassigned" | "AgentInviteFailed"
+  IContactCenter:
+    fields: []
+  CCPluginConfig:
+    fields:
+      - name: allowMultiLogin
+        type: boolean
+        required: true
+      - name: allowAutomatedRelogin
+        type: boolean
+        required: true
+      - name: clientType
+        type: string
+        required: true
+      - name: isKeepAliveEnabled
+        type: boolean
+        required: true
+      - name: force
+        type: boolean
+        required: true
+      - name: metrics
+        type: "{ clientName: string; clientType: string; }"
+        required: true
+      - name: logging
+        type: "{ enable: boolean; verboseEvents: boolean; }"
+        required: true
+      - name: callingClientConfig
+        type: CallingClientConfig
+        required: true
+  WebexSDK:
+    fields:
+      - name: version
+        type: string
+        required: true
+      - name: canAuthorize
+        type: boolean
+        required: true
+      - name: credentials
+        type: "{ getUserToken: () => Promise<string>; getOrgId: () => string; }"
+        required: true
+      - name: ready
+        type: boolean
+        required: true
+      - name: request
+        type: "<T>(payload: WebexRequestPayload) => Promise<T>"
+        required: true
+      - name: once
+        type: "(event: string, callBack: () => void) => void"
+        required: true
+      - name: internal
+        type: IWebexInternal
+        required: true
+      - name: logger
+        type: Logger
+        required: true
+  LoginOption:
+    kind: alias
+    values:
+      - "\"AGENT_DN\" | \"EXTENSION\" | \"BROWSER\""
+  AgentLogin:
+    fields:
+      - name: dialNumber
+        type: string
+        required: false
+      - name: teamId
+        type: string
+        required: true
+      - name: loginOption
+        type: LoginOption
+        required: true
+  AgentProfileUpdate:
+    kind: alias
+    values:
+      - "{ loginOption: LoginOption; dialNumber?: string; teamId: string; }"
+  StationLoginResponse:
+    kind: union
+    values:
+      - Agent.StationLoginSuccessResponse
+      - Error
+  StationLogoutResponse:
+    kind: union
+    values:
+      - Agent.LogoutSuccess
+      - Error
+  BuddyAgentsResponse:
+    kind: union
+    values:
+      - Agent.BuddyAgentsSuccess
+      - Error
+  BuddyAgents:
+    fields:
+      - name: mediaType
+        type: "\"telephony\" | \"chat\" | \"social\" | \"email\""
+        required: true
+      - name: state
+        type: "\"Available\" | \"Idle\""
+        required: false
+  SubscribeRequest:
+    fields:
+      - name: force
+        type: boolean
+        required: true
+      - name: isKeepAliveEnabled
+        type: boolean
+        required: true
+      - name: clientType
+        type: string
+        required: true
+      - name: allowMultiLogin
+        type: boolean
+        required: true
+  UploadLogsResponse:
+    fields:
+      - name: trackingid
+        type: string
+        required: false
+      - name: url
+        type: string
+        required: false
+      - name: userId
+        type: string
+        required: false
+      - name: feedbackId
+        type: string
+        required: false
+      - name: correlationId
+        type: string
+        required: false
+  UpdateDeviceTypeResponse:
+    kind: union
+    values:
+      - Agent.DeviceTypeUpdateSuccess
+      - Error
+  GenericError:
+    fields:
+      - name: details
+        type: "{ type: string; orgId: string; trackingId: string; data: Record<string, any>; }"
+        required: true
+  SetStateResponse:
+    kind: union
+    values:
+      - Agent.StateChangeSuccess
+      - Error
+  AgentContact:
+    kind: alias
+    values:
+      - >-
+        { type: string; orgId: string; trackingId: string; data: { mediaResourceId: string; eventType: string;
+        eventTime?: number; agentId: string; destAgentId: string; trackingId: string; consultMediaResourceId: string;
+        interaction: Interaction; participantId?: string; fromOwner?: boolean; toOwner?: boolean; childInteractionId?:
+        string; interactionId: string; orgId: string; owner: string; queueMgr: string; queueName?: string; type: string;
+        ronaTimeout?: number; isConsulted?: boolean; isConferencing: boolean; updatedBy?: string; destinationType?:
+        string; autoResumed?: boolean; reasonCode?: string | number; reason?: string; consultingAgentId?: string;
+        taskId?: string; task?: Interaction; supervisorId?: string; monitorType?: string; supervisorDN?: string; id?:
+        string; isWebCallMute?: boolean; reservationInteractionId?: string; reservedAgentChannelId?: string;
+        monitoringState?: { type: string; }; supervisorName?: string; }; }
+  ITask:
+    fields:
+      - name: data
+        type: TaskData
+        required: true
+      - name: webCallMap
+        type: Record<string, string>
+        required: true
+      - name: autoWrapup
+        type: AutoWrapup
+        required: false
+      - name: stateMachineService
+        type: AnyActorRef
+        required: false
+      - name: state
+        type: any
+        required: false
+      - name: sendStateMachineEvent
+        type: "(event: TaskEventPayload) => void"
+        required: true
+  Interaction:
+    fields:
+      - name: isFcManaged
+        type: boolean
+        required: true
+      - name: isTerminated
+        type: boolean
+        required: true
+      - name: mediaType
+        type: MEDIA_CHANNEL
+        required: true
+      - name: previousVTeams
+        type: string[]
+        required: true
+      - name: state
+        type: string
+        required: true
+      - name: currentVTeam
+        type: string
+        required: true
+      - name: participants
+        type: InteractionParticipants
+        required: true
+      - name: callAssociatedData
+        type: CallAssociatedData
+        required: false
+      - name: callAssociatedDetails
+        type: CallAssociatedDetails
+        required: false
+      - name: interactionId
+        type: string
+        required: true
+      - name: orgId
+        type: string
+        required: true
+      - name: createdTimestamp
+        type: number
+        required: false
+      - name: isWrapUpAssist
+        type: boolean
+        required: false
+      - name: parentInteractionId
+        type: string
+        required: false
+      - name: isMediaForked
+        type: boolean
+        required: false
+      - name: flowProperties
+        type: Record<string, unknown>
+        required: false
+      - name: mediaProperties
+        type: Record<string, unknown>
+        required: false
+      - name: callProcessingDetails
+        type: >-
+          { QMgrName: string; taskToBeSelfServiced: string; ani: string; displayAni: string; dnis: string; tenantId:
+          string; QueueId: string; vteamId: string; pauseResumeEnabled?: boolean; pauseDuration?: string; isPaused?:
+          boolean; recordInProgress?: boolean; recordingStarted?: boolean; customerRegion?: string; flowTagId?: string;
+          ctqInProgress?: boolean; outdialTransferToQueueEnabled?: boolean; convIvrTranscript?: string; customerName:
+          string; virtualTeamName: string; ronaTimeout: string; category: string; reason: string; sourceNumber: string;
+          sourcePage: string; appUser: string; customerNumber: string; reasonCode: string; IvrPath: string; pathId:
+          string; fromAddress: string; parentInteractionId?: string; childInteractionId?: string; relationshipType?:
+          string; parent_ANI?: string; parent_DNIS?: string; consultDestinationAgentJoined?: boolean | string;
+          consultDestinationAgentName?: string; parent_Agent_DN?: string; parent_Agent_Name?: string;
+          parent_Agent_TeamName?: string; isConferencing?: string; monitorType?: string; workflowName?: string;
+          workflowId?: string; monitoringInvisibleMode?: string; monitoringRequestId?: string;
+          participantInviteTimeout?: string; mohFileName?: string; CONTINUE_RECORDING_ON_TRANSFER?: string; EP_ID?:
+          string; ROUTING_TYPE?: string; fceRegisteredEvents?: string; isParked?: string; priority?: string;
+          routingStrategyId?: string; monitoringState?: string; BLIND_TRANSFER_IN_PROGRESS?: boolean; fcDesktopView?:
+          string; outdialAgentId?: string; }
+        required: true
+      - name: mainInteractionId
+        type: string
+        required: false
+      - name: queuedTimestamp
+        type: number
+        required: false
+      - name: media
+        type: Record<string, MediaEntry>
+        required: true
+      - name: owner
+        type: string
+        required: true
+      - name: mediaChannel
+        type: string
+        required: true
+      - name: contactDirection
+        type: "{ type: string; }"
+        required: true
+      - name: outboundType
+        type: string
+        required: false
+      - name: workflowManager
+        type: string
+        required: false
+      - name: callFlowParams
+        type: Record<string, FlowParameter>
+        required: false
+  TaskData:
+    fields:
+      - name: mediaResourceId
+        type: string
+        required: true
+      - name: eventType
+        type: string
+        required: true
+      - name: eventTime
+        type: number
+        required: false
+      - name: agentId
+        type: string
+        required: true
+      - name: destAgentId
+        type: string
+        required: true
+      - name: trackingId
+        type: string
+        required: true
+      - name: consultMediaResourceId
+        type: string
+        required: true
+      - name: interaction
+        type: Interaction
+        required: true
+      - name: participantId
+        type: string
+        required: false
+      - name: fromOwner
+        type: boolean
+        required: false
+      - name: toOwner
+        type: boolean
+        required: false
+      - name: childInteractionId
+        type: string
+        required: false
+      - name: interactionId
+        type: string
+        required: true
+      - name: orgId
+        type: string
+        required: true
+      - name: owner
+        type: string
+        required: true
+      - name: queueMgr
+        type: string
+        required: true
+      - name: queueName
+        type: string
+        required: false
+      - name: type
+        type: string
+        required: true
+      - name: ronaTimeout
+        type: number
+        required: false
+      - name: isConsulted
+        type: boolean
+        required: false
+      - name: isConferencing
+        type: boolean
+        required: true
+      - name: isConferenceInProgress
+        type: boolean
+        required: false
+      - name: updatedBy
+        type: string
+        required: false
+      - name: destinationType
+        type: string
+        required: false
+      - name: autoResumed
+        type: boolean
+        required: false
+      - name: reasonCode
+        type: string | number
+        required: false
+      - name: reason
+        type: string
+        required: false
+      - name: consultingAgentId
+        type: string
+        required: false
+      - name: taskId
+        type: string
+        required: false
+      - name: task
+        type: Interaction
+        required: false
+      - name: id
+        type: string
+        required: false
+      - name: isWebCallMute
+        type: boolean
+        required: false
+      - name: reservationInteractionId
+        type: string
+        required: false
+      - name: reservedAgentChannelId
+        type: string
+        required: false
+      - name: wrapUpRequired
+        type: boolean
+        required: false
+      - name: consultStatus
+        type: string
+        required: false
+      - name: isConsultInProgress
+        type: boolean
+        required: false
+      - name: isIncomingTask
+        type: boolean
+        required: false
+      - name: isOnHold
+        type: boolean
+        required: false
+      - name: isCustomerInCall
+        type: boolean
+        required: false
+      - name: conferenceParticipantsCount
+        type: number
+        required: false
+      - name: isSecondaryAgent
+        type: boolean
+        required: false
+      - name: isSecondaryEpDnAgent
+        type: boolean
+        required: false
+      - name: mpcState
+        type: string
+        required: false
+      - name: isAutoAnswering
+        type: boolean
+        required: false
+      - name: agentsPendingWrapUp
+        type: string[]
+        required: false
+  TaskResponse:
+    kind: union
+    values:
+      - AgentContact
+      - Error
+      - void
+  ConsultPayload:
+    fields:
+      - name: to
+        type: string
+        required: true
+      - name: destinationType
+        type: string
+        required: true
+      - name: holdParticipants
+        type: boolean
+        required: false
+  ConsultEndPayload:
+    fields:
+      - name: isConsult
+        type: boolean
+        required: true
+      - name: isSecondaryEpDnAgent
+        type: boolean
+        required: false
+      - name: queueId
+        type: string
+        required: false
+      - name: taskId
+        type: string
+        required: true
+  ConsultTransferPayLoad:
+    fields:
+      - name: to
+        type: string
+        required: true
+      - name: destinationType
+        type: string
+        required: true
+  DialerPayload:
+    fields:
+      - name: entryPointId
+        type: string
+        required: true
+      - name: destination
+        type: string
+        required: true
+      - name: direction
+        type: "\"OUTBOUND\""
+        required: true
+      - name: attributes
+        type: "{ [key: string]: string; }"
+        required: true
+      - name: mediaType
+        type: "\"telephony\" | \"chat\" | \"social\" | \"email\""
+        required: true
+      - name: outboundType
+        type: "\"OUTDIAL\" | \"CALLBACK\" | \"EXECUTE_FLOW\""
+        required: true
+      - name: origin
+        type: string
+        required: true
+  TransferPayLoad:
+    fields:
+      - name: to
+        type: string
+        required: true
+      - name: destinationType
+        type: string
+        required: true
+  ResumeRecordingPayload:
+    fields:
+      - name: autoResumed
+        type: boolean
+        required: true
+  WrapupPayLoad:
+    fields:
+      - name: wrapUpReason
+        type: string
+        required: true
+      - name: auxCodeId
+        type: string
+        required: true
+  StateChange:
+    fields:
+      - name: state
+        type: string
+        required: true
+      - name: auxCodeId
+        type: string
+        required: true
+      - name: lastStateChangeReason
+        type: string
+        required: false
+      - name: agentId
+        type: string
+        required: false
+  Logout:
+    fields:
+      - name: logoutReason
+        type: "\"User requested logout\" | \"Inactivity Logout\" | \"User requested agent profile update\""
+        required: false
+  StateChangeSuccess:
+    kind: alias
+    values:
+      - >-
+        { type: string; orgId: string; trackingId: string; data: { eventType: "AgentDesktopMessage"; agentId: string;
+        trackingId: string; auxCodeId: string; agentSessionId: string; orgId: string; status: string; subStatus:
+        "Available" | "Idle"; lastIdleCodeChangeTimestamp: number; lastStateChangeTimestamp: number; type:
+        "AgentStateChangeSuccess"; changedBy: string | null; changedById: string | null; changedByName: string | null;
+        lastStateChangeReason: string; }; }
+  StationLoginSuccess:
+    kind: alias
+    values:
+      - >-
+        { type: string; orgId: string; trackingId: string; data: { eventType: "AgentDesktopMessage"; agentId: string;
+        trackingId: string; auxCodeId: string; teamId: string; agentSessionId: string; orgId: string; interactionIds:
+        string[]; status: string; subStatus: "Available" | "Idle"; siteId: string; lastIdleCodeChangeTimestamp: number;
+        lastStateChangeTimestamp: number; profileType: string; channelsMap: Record<string, string[]>; dialNumber?:
+        string; roles?: string[]; supervisorSessionId?: string; type: "AgentStationLoginSuccess"; }; }
+  StationLoginSuccessResponse:
+    fields:
+      - name: eventType
+        type: "\"AgentDesktopMessage\""
+        required: true
+      - name: agentId
+        type: string
+        required: true
+      - name: trackingId
+        type: string
+        required: true
+      - name: auxCodeId
+        type: string
+        required: true
+      - name: teamId
+        type: string
+        required: true
+      - name: agentSessionId
+        type: string
+        required: true
+      - name: orgId
+        type: string
+        required: true
+      - name: interactionIds
+        type: string[]
+        required: true
+      - name: status
+        type: string
+        required: true
+      - name: subStatus
+        type: "\"Available\" | \"Idle\""
+        required: true
+      - name: siteId
+        type: string
+        required: true
+      - name: lastIdleCodeChangeTimestamp
+        type: number
+        required: true
+      - name: lastStateChangeTimestamp
+        type: number
+        required: true
+      - name: profileType
+        type: string
+        required: true
+      - name: mmProfile
+        type: "{ chat: number; email: number; social: number; telephony: number; }"
+        required: true
+      - name: dialNumber
+        type: string
+        required: false
+      - name: roles
+        type: string[]
+        required: false
+      - name: supervisorSessionId
+        type: string
+        required: false
+      - name: type
+        type: "\"AgentStationLoginSuccess\""
+        required: true
+      - name: notifsTrackingId
+        type: string
+        required: true
+  DeviceTypeUpdateSuccess:
+    kind: alias
+    values:
+      - "Omit<StationLoginSuccessResponse, \"type\"> & { type: \"AgentDeviceTypeUpdateSuccess\"; }"
+  LogoutSuccess:
+    kind: alias
+    values:
+      - >-
+        { type: string; orgId: string; trackingId: string; data: { eventType: "AgentDesktopMessage"; agentId: string;
+        trackingId: string; agentSessionId: string; orgId: string; status: string; subStatus: string; loggedOutBy?:
+        string; roles?: string[]; type: "AgentLogoutSuccess"; }; }
+  ReloginSuccess:
+    kind: alias
+    values:
+      - >-
+        { type: string; orgId: string; trackingId: string; data: { eventType: "AgentDesktopMessage"; agentId: string;
+        trackingId: string; auxCodeId: string; teamId: string; agentSessionId: string; dn: string; orgId: string;
+        interactionIds: string[]; isExtension: boolean; status: "LoggedIn"; subStatus: "Idle"; siteId: string;
+        lastIdleCodeChangeTimestamp: number; lastStateChangeTimestamp: number; lastStateChangeReason?: string;
+        profileType: string; channelsMap: Record<string, string[]>; dialNumber?: string; roles?: string[]; deviceType?:
+        DeviceType; deviceId?: string | null; isEmergencyModalAlreadyDisplayed?: boolean; type: "AgentReloginSuccess";
+        }; }
+  AgentState:
+    kind: union
+    values:
+      - "'Available'"
+      - "'Idle'"
+      - "'RONA'"
+      - string
+  UserStationLogin:
+    fields:
+      - name: dialNumber
+        type: string
+        required: false
+      - name: dn
+        type: string
+        required: false
+      - name: teamId
+        type: string
+        required: true
+      - name: teamName
+        type: string
+        required: true
+      - name: roles
+        type: string[]
+        required: false
+      - name: siteId
+        type: string
+        required: true
+      - name: usesOtherDN
+        type: boolean
+        required: true
+      - name: skillProfileId
+        type: string
+        required: false
+      - name: auxCodeId
+        type: string
+        required: true
+      - name: isExtension
+        type: boolean
+        required: false
+      - name: deviceType
+        type: string
+        required: false
+      - name: deviceId
+        type: string
+        required: false
+      - name: isEmergencyModalAlreadyDisplayed
+        type: boolean
+        required: false
+  DeviceType:
+    kind: union
+    values:
+      - LoginOption
+      - string
+  BuddyDetails:
+    fields:
+      - name: agentId
+        type: string
+        required: true
+      - name: state
+        type: string
+        required: true
+      - name: teamId
+        type: string
+        required: true
+      - name: dn
+        type: string
+        required: true
+      - name: agentName
+        type: string
+        required: true
+      - name: siteId
+        type: string
+        required: true
+  BuddyAgentsSuccess:
+    kind: alias
+    values:
+      - >-
+        { type: string; orgId: string; trackingId: string; data: { eventType: "AgentDesktopMessage"; agentId: string;
+        trackingId: string; agentSessionId: string; orgId: string; type: "BuddyAgents"; agentList: Array<BuddyDetails>;
+        }; }
+  Profile:
+    fields:
+      - name: microsoftConfig
+        type: "{ showUserDetailsMS?: boolean; stateSynchronizationMS?: boolean; }"
+        required: false
+      - name: webexConfig
+        type: "{ showUserDetailsWebex?: boolean; stateSynchronizationWebex?: boolean; }"
+        required: false
+      - name: teams
+        type: Team[]
+        required: true
+      - name: defaultDn
+        type: string
+        required: true
+      - name: dn
+        type: string
+        required: false
+      - name: forceDefaultDn
+        type: boolean
+        required: true
+      - name: forceDefaultDnForAgent
+        type: boolean
+        required: true
+      - name: regexUS
+        type: string | RegExp
+        required: true
+      - name: regexOther
+        type: string | RegExp
+        required: true
+      - name: agentId
+        type: string
+        required: true
+      - name: agentName
+        type: string
+        required: true
+      - name: agentMailId
+        type: string
+        required: true
+      - name: agentProfileID
+        type: string
+        required: true
+      - name: dialPlan
+        type: DialPlan
+        required: true
+      - name: multimediaProfileId
+        type: string
+        required: true
+      - name: skillProfileId
+        type: string
+        required: true
+      - name: siteId
+        type: string
+        required: true
+      - name: enterpriseId
+        type: string
+        required: true
+      - name: privacyShieldVisible
+        type: boolean
+        required: true
+      - name: idleCodes
+        type: Entity[]
+        required: true
+      - name: idleCodesList
+        type: string[]
+        required: false
+      - name: idleCodesAccess
+        type: "\"ALL\" | \"SPECIFIC\""
+        required: false
+      - name: wrapupCodes
+        type: Entity[]
+        required: true
+      - name: agentWrapUpCodes
+        type: agentWrapUpCodes
+        required: false
+      - name: agentDefaultWrapUpCode
+        type: agentDefaultWrapupCode
+        required: false
+      - name: defaultWrapupCode
+        type: string
+        required: true
+      - name: wrapUpData
+        type: WrapupData
+        required: true
+      - name: orgId
+        type: string
+        required: false
+      - name: isOutboundEnabledForTenant
+        type: boolean
+        required: true
+      - name: isOutboundEnabledForAgent
+        type: boolean
+        required: true
+      - name: isAdhocDialingEnabled
+        type: boolean
+        required: true
+      - name: isAgentAvailableAfterOutdial
+        type: boolean
+        required: true
+      - name: isCampaignManagementEnabled
+        type: boolean
+        required: true
+      - name: outDialEp
+        type: string
+        required: true
+      - name: isEndTaskEnabled
+        type: boolean
+        required: true
+      - name: isEndConsultEnabled
+        type: boolean
+        required: true
+      - name: lcmUrl
+        type: string
+        required: false
+      - name: agentDbId
+        type: string
+        required: true
+      - name: agentAnalyzerId
+        type: string
+        required: false
+      - name: allowConsultToQueue
+        type: boolean
+        required: true
+      - name: campaignManagerAdditionalInfo
+        type: string
+        required: false
+      - name: agentPersonalStatsEnabled
+        type: boolean
+        required: true
+      - name: addressBookId
+        type: string
+        required: false
+      - name: outdialANIId
+        type: string
+        required: false
+      - name: analyserUserId
+        type: string
+        required: false
+      - name: isCallMonitoringEnabled
+        type: boolean
+        required: false
+      - name: isMidCallMonitoringEnabled
+        type: boolean
+        required: false
+      - name: isBargeInEnabled
+        type: boolean
+        required: false
+      - name: isManagedTeamsEnabled
+        type: boolean
+        required: false
+      - name: isManagedQueuesEnabled
+        type: boolean
+        required: false
+      - name: isSendMessageEnabled
+        type: boolean
+        required: false
+      - name: isAgentStateChangeEnabled
+        type: boolean
+        required: false
+      - name: isSignOutAgentsEnabled
+        type: boolean
+        required: false
+      - name: urlMappings
+        type: URLMappings
+        required: false
+      - name: isTimeoutDesktopInactivityEnabled
+        type: boolean
+        required: true
+      - name: timeoutDesktopInactivityMins
+        type: number
+        required: false
+      - name: isAnalyzerEnabled
+        type: boolean
+        required: false
+      - name: tenantTimezone
+        type: string
+        required: false
+      - name: loginVoiceOptions
+        type: LoginOption[]
+        required: false
+      - name: deviceType
+        type: LoginOption
+        required: false
+      - name: currentTeamId
+        type: string
+        required: false
+      - name: webRtcEnabled
+        type: boolean
+        required: true
+      - name: organizationIdleCodes
+        type: Entity[]
+        required: false
+      - name: isRecordingManagementEnabled
+        type: boolean
+        required: false
+      - name: lostConnectionRecoveryTimeout
+        type: number
+        required: true
+      - name: maskSensitiveData
+        type: boolean
+        required: false
+      - name: isAgentLoggedIn
+        type: boolean
+        required: false
+      - name: lastStateAuxCodeId
+        type: string
+        required: false
+      - name: lastStateChangeTimestamp
+        type: number
+        required: false
+      - name: lastIdleCodeChangeTimestamp
+        type: number
+        required: false
+  AgentResponse:
+    fields:
+      - name: id
+        type: string
+        required: true
+      - name: ciUserId
+        type: string
+        required: true
+      - name: firstName
+        type: string
+        required: true
+      - name: lastName
+        type: string
+        required: true
+      - name: agentProfileId
+        type: string
+        required: true
+      - name: email
+        type: string
+        required: true
+      - name: teamIds
+        type: string[]
+        required: true
+      - name: multimediaProfileId
+        type: string
+        required: true
+      - name: skillProfileId
+        type: string
+        required: true
+      - name: siteId
+        type: string
+        required: true
+      - name: dbId
+        type: string
+        required: false
+      - name: defaultDialledNumber
+        type: string
+        required: false
+  DesktopProfileResponse:
+    fields:
+      - name: id
+        type: string
+        required: true
+      - name: name
+        type: string
+        required: true
+      - name: description
+        type: string
+        required: true
+      - name: parentType
+        type: string
+        required: true
+      - name: screenPopup
+        type: boolean
+        required: true
+      - name: loginVoiceOptions
+        type: LoginOption[]
+        required: true
+      - name: accessWrapUpCode
+        type: string
+        required: true
+      - name: accessIdleCode
+        type: string
+        required: true
+      - name: wrapUpCodes
+        type: string[]
+        required: true
+      - name: idleCodes
+        type: string[]
+        required: true
+      - name: dialPlanEnabled
+        type: boolean
+        required: true
+      - name: lastAgentRouting
+        type: boolean
+        required: true
+      - name: autoWrapUp
+        type: boolean
+        required: true
+      - name: agentPersonalGreeting
+        type: boolean
+        required: true
+      - name: autoAnswer
+        type: boolean
+        required: true
+      - name: autoWrapAfterSeconds
+        type: number
+        required: true
+      - name: agentAvailableAfterOutdial
+        type: boolean
+        required: true
+      - name: allowAutoWrapUpExtension
+        type: boolean
+        required: true
+      - name: accessQueue
+        type: string
+        required: true
+      - name: queues
+        type: string[]
+        required: true
+      - name: accessEntryPoint
+        type: string
+        required: true
+      - name: entryPoints
+        type: string[]
+        required: true
+      - name: accessBuddyTeam
+        type: string
+        required: true
+      - name: buddyTeams
+        type: string[]
+        required: true
+      - name: outdialEnabled
+        type: boolean
+        required: true
+      - name: outdialEntryPointId
+        type: string
+        required: true
+      - name: outdialANIId
+        type: string
+        required: true
+      - name: consultToQueue
+        type: boolean
+        required: true
+      - name: addressBookId
+        type: string
+        required: true
+      - name: viewableStatistics
+        type: >-
+          { id: string; agentStats: boolean; accessQueueStats: string; contactServiceQueues: string[];
+          loggedInTeamStats: boolean; accessTeamStats: string; teams: string[]; }
+        required: true
+      - name: agentDNValidation
+        type: string
+        required: true
+      - name: agentDNValidationCriterions
+        type: string[]
+        required: true
+      - name: dialPlans
+        type: string[]
+        required: true
+      - name: timeoutDesktopInactivityCustomEnabled
+        type: boolean
+        required: true
+      - name: timeoutDesktopInactivityMins
+        type: number
+        required: true
+      - name: showUserDetailsMS
+        type: boolean
+        required: true
+      - name: stateSynchronizationMS
+        type: boolean
+        required: true
+      - name: showUserDetailsWebex
+        type: boolean
+        required: true
+      - name: stateSynchronizationWebex
+        type: boolean
+        required: true
+      - name: thresholdRules
+        type: Record<string, string | number>[]
+        required: true
+      - name: active
+        type: boolean
+        required: true
+      - name: systemDefault
+        type: boolean
+        required: true
+      - name: createdTime
+        type: number
+        required: true
+      - name: lastUpdatedTime
+        type: number
+        required: true
+  MultimediaProfileResponse:
+    fields:
+      - name: organizationId
+        type: string
+        required: true
+      - name: id
+        type: string
+        required: true
+      - name: version
+        type: number
+        required: true
+      - name: name
+        type: string
+        required: true
+      - name: description
+        type: string
+        required: true
+      - name: chat
+        type: number
+        required: true
+      - name: email
+        type: number
+        required: true
+      - name: telephony
+        type: number
+        required: true
+      - name: social
+        type: number
+        required: true
+      - name: active
+        type: boolean
+        required: true
+      - name: blendingModeEnabled
+        type: boolean
+        required: true
+      - name: blendingMode
+        type: string
+        required: true
+      - name: systemDefault
+        type: boolean
+        required: true
+      - name: createdTime
+        type: number
+        required: true
+      - name: lastUpdatedTime
+        type: number
+        required: true
+  ListTeamsResponse:
+    fields:
+      - name: data
+        type: TeamList[]
+        required: true
+      - name: meta
+        type: "{ page: number; pageSize: number; totalPages: number; totalRecords: number; }"
+        required: true
+  ListAuxCodesResponse:
+    fields:
+      - name: data
+        type: AuxCode[]
+        required: true
+      - name: meta
+        type: "{ page: number; pageSize: number; totalPages: number; totalRecords: number; }"
+        required: true
+  SiteInfo:
+    fields:
+      - name: id
+        type: string
+        required: true
+      - name: name
+        type: string
+        required: true
+      - name: active
+        type: boolean
+        required: true
+      - name: multimediaProfileId
+        type: string
+        required: true
+      - name: systemDefault
+        type: boolean
+        required: true
+  OrgInfo:
+    fields:
+      - name: tenantId
+        type: string
+        required: true
+      - name: timezone
+        type: string
+        required: true
+  OrgSettings:
+    fields:
+      - name: webRtcEnabled
+        type: boolean
+        required: true
+      - name: maskSensitiveData
+        type: boolean
+        required: true
+      - name: campaignManagerEnabled
+        type: boolean
+        required: true
+  TenantData:
+    fields:
+      - name: timeoutDesktopInactivityMins
+        type: number
+        required: true
+      - name: forceDefaultDn
+        type: boolean
+        required: true
+      - name: dnDefaultRegex
+        type: string
+        required: true
+      - name: dnOtherRegex
+        type: string
+        required: true
+      - name: privacyShieldVisible
+        type: boolean
+        required: true
+      - name: outdialEnabled
+        type: boolean
+        required: true
+      - name: endCallEnabled
+        type: boolean
+        required: true
+      - name: endConsultEnabled
+        type: boolean
+        required: true
+      - name: callVariablesSuppressed
+        type: boolean
+        required: true
+      - name: timeoutDesktopInactivityEnabled
+        type: boolean
+        required: true
+      - name: lostConnectionRecoveryTimeout
+        type: number
+        required: true
+  URLMapping:
+    fields:
+      - name: id
+        type: string
+        required: true
+      - name: name
+        type: string
+        required: true
+      - name: url
+        type: string
+        required: true
+      - name: links
+        type: string[]
+        required: true
+      - name: createdTime
+        type: number
+        required: true
+      - name: lastUpdatedTime
+        type: number
+        required: true
+  DialPlanEntity:
+    fields:
+      - name: id
+        type: string
+        required: true
+      - name: regularExpression
+        type: string
+        required: true
+      - name: prefix
+        type: string
+        required: true
+      - name: strippedChars
+        type: string
+        required: true
+      - name: name
+        type: string
+        required: true
+  AuxCode:
+    fields:
+      - name: id
+        type: string
+        required: true
+      - name: active
+        type: boolean
+        required: true
+      - name: defaultCode
+        type: boolean
+        required: true
+      - name: isSystemCode
+        type: boolean
+        required: true
+      - name: description
+        type: string
+        required: true
+      - name: name
+        type: string
+        required: true
+      - name: workTypeCode
+        type: string
+        required: true
+  TeamList:
+    fields:
+      - name: id
+        type: string
+        required: true
+      - name: name
+        type: string
+        required: true
+      - name: teamType
+        type: string
+        required: true
+      - name: teamStatus
+        type: string
+        required: true
+      - name: active
+        type: boolean
+        required: true
+      - name: siteId
+        type: string
+        required: true
+      - name: siteName
+        type: string
+        required: true
+      - name: multiMediaProfileId
+        type: string
+        required: false
+      - name: userIds
+        type: string[]
+        required: true
+      - name: rankQueuesForTeam
+        type: boolean
+        required: true
+      - name: queueRankings
+        type: string[]
+        required: true
+      - name: dbId
+        type: string
+        required: false
+      - name: desktopLayoutId
+        type: string
+        required: false
+  WrapUpReason:
+    fields:
+      - name: isSystem
+        type: boolean
+        required: true
+      - name: name
+        type: string
+        required: true
+      - name: id
+        type: string
+        required: true
+      - name: isDefault
+        type: boolean
+        required: true
+  WebSocketEvent:
+    fields:
+      - name: type
+        type: CC_EVENTS
+        required: true
+      - name: data
+        type: >-
+          Agent.BuddyAgentsSuccess | Agent.LogoutSuccess | Agent.StateChangeSuccess | Agent.StationLoginSuccess |
+          Agent.ReloginSuccess | WelcomeEvent
+        required: true
+  WrapupData:
+    fields:
+      - name: wrapUpProps
+        type: >-
+          { autoWrapup?: boolean; autoWrapupInterval?: number; lastAgentRoute?: boolean; wrapUpReasonList:
+          Array<WrapUpReason>; wrapUpCodesList?: Array<string>; idleCodesAccess?: "ALL" | "SPECIFIC"; interactionId?:
+          string; allowCancelAutoWrapup?: boolean; }
+        required: true
+  Entity:
+    fields:
+      - name: isSystem
+        type: boolean
+        required: true
+      - name: name
+        type: string
+        required: true
+      - name: id
+        type: string
+        required: true
+      - name: isDefault
+        type: boolean
+        required: true
+  DialPlan:
+    fields:
+      - name: type
+        type: string
+        required: true
+      - name: dialPlanEntity
+        type: "{ regex: string; prefix: string; strippedChars: string; name: string; }[]"
+        required: true
+  AuxCodeType:
+    kind: union
+    values:
+      - typeof IDLE_CODE
+      - typeof WRAP_UP_CODE
+constants:
+  IDLE_CODE: IDLE_CODE
+  WRAP_UP_CODE: WRAP_UP_CODE

--- a/yarn.lock
+++ b/yarn.lock
@@ -4768,6 +4768,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ts-morph/common@npm:~0.28.1":
+  version: 0.28.1
+  resolution: "@ts-morph/common@npm:0.28.1"
+  dependencies:
+    minimatch: ^10.0.1
+    path-browserify: ^1.0.1
+    tinyglobby: ^0.2.14
+  checksum: bc3e879ff55fe8fe460d49124d10f74aba4ec92c261b7f65d48153a107e1b733676bb89e1c55fa4e5c045fe055c6c5247f7d340aaf1db1a44ffaf32ca2a00ec5
+  languageName: node
+  linkType: hard
+
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.11
   resolution: "@tsconfig/node10@npm:1.0.11"
@@ -5383,6 +5394,13 @@ __metadata:
     jest-matcher-utils: ^27.0.0
     pretty-format: ^27.0.0
   checksum: 5184f3eef4832d01ee8f59bed15eec45ccc8e29c724a5e6ce37bf74396b37bdf04f557000f45ba4fc38ae6075cf9cfcce3d7a75abc981023c61ceb27230a93e4
+  languageName: node
+  linkType: hard
+
+"@types/js-yaml@npm:^4":
+  version: 4.0.9
+  resolution: "@types/js-yaml@npm:4.0.9"
+  checksum: e5e5e49b5789a29fdb1f7d204f82de11cb9e8f6cb24ab064c616da5d6e1b3ccfbf95aa5d1498a9fbd3b9e745564e69b4a20b6c530b5a8bbb2d4eb830cda9bc69
   languageName: node
   linkType: hard
 
@@ -7545,6 +7563,7 @@ __metadata:
     "@babel/core": ^7.22.11
     "@babel/preset-typescript": 7.22.11
     "@types/jest": 27.4.1
+    "@types/js-yaml": ^4
     "@types/platform": 1.3.4
     "@typescript-eslint/eslint-plugin": 5.38.1
     "@typescript-eslint/parser": 5.38.1
@@ -7572,8 +7591,10 @@ __metadata:
     jest: 27.5.1
     jest-html-reporters: 3.0.11
     jest-junit: 13.0.0
+    js-yaml: ^4.1.1
     lodash: ^4.17.21
     prettier: 2.5.1
+    ts-morph: ^27.0.2
     typedoc: ^0.25.0
     typescript: 5.4.5
     uuid: ^3.3.2
@@ -11305,6 +11326,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: fb07bb66a0959c2843fc055838047e2a95ccebb837c519614afb067ebfdf2fa967ca8d712c35ced07f2cd26fc6f07964230b094891315ad74f11eba3d53178a0
+  languageName: node
+  linkType: hard
+
 "bare-events@npm:^2.0.0, bare-events@npm:^2.5.4, bare-events@npm:^2.7.0":
   version: 2.8.2
   resolution: "bare-events@npm:2.8.2"
@@ -11742,6 +11770,15 @@ __metadata:
   dependencies:
     balanced-match: ^1.0.0
   checksum: 01dff195e3646bc4b0d27b63d9bab84d2ebc06121ff5013ad6e5356daa5a9d6b60fa26cf73c74797f2dc3fbec112af13578d51f75228c1112b26c790a87b0488
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.2":
+  version: 5.0.4
+  resolution: "brace-expansion@npm:5.0.4"
+  dependencies:
+    balanced-match: ^4.0.2
+  checksum: ded86c0f0b138734110d67437fee52c1f97bc19175644788b1d71afec2d87d405cf05424ce428f88ae3abe8e09e13ee55f2675534b38076ef70e1e583ed75686
   languageName: node
   linkType: hard
 
@@ -13181,6 +13218,13 @@ __metadata:
   version: 4.6.0
   resolution: "co@npm:4.6.0"
   checksum: 5210d9223010eb95b29df06a91116f2cf7c8e0748a9013ed853b53f362ea0e822f1e5bb054fb3cefc645239a4cf966af1f6133a3b43f40d591f3b68ed6cf0510
+  languageName: node
+  linkType: hard
+
+"code-block-writer@npm:^13.0.3":
+  version: 13.0.3
+  resolution: "code-block-writer@npm:13.0.3"
+  checksum: 8e234f0ec2db9625d5efb9f05bdae79da6559bb4d9df94a6aa79a89a7b5ae25093b70d309fc5122840c9c07995cb14b4dd3f98a30f8878e3a3372e177df79454
   languageName: node
   linkType: hard
 
@@ -22516,6 +22560,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-yaml@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "js-yaml@npm:4.1.1"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:~3.13.1":
   version: 3.13.1
   resolution: "js-yaml@npm:3.13.1"
@@ -25318,6 +25373,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.0.1":
+  version: 10.2.4
+  resolution: "minimatch@npm:10.2.4"
+  dependencies:
+    brace-expansion: ^5.0.2
+  checksum: 56dce6b04c6b30b500d81d7a29822c108b7d58c46696ec7332d04a2bd104a5cb69e5c7ce93e1783dc66d61400d831e6e226ca101ac23665aff32ca303619dc3d
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^10.0.3":
   version: 10.1.1
   resolution: "minimatch@npm:10.1.1"
@@ -27134,7 +27198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-browserify@npm:^1.0.0":
+"path-browserify@npm:^1.0.0, path-browserify@npm:^1.0.1":
   version: 1.0.1
   resolution: "path-browserify@npm:1.0.1"
   checksum: c6d7fa376423fe35b95b2d67990060c3ee304fc815ff0a2dc1c6c3cfaff2bd0d572ee67e18f19d0ea3bbe32e8add2a05021132ac40509416459fffee35200699
@@ -31793,7 +31857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12":
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
   dependencies:
@@ -32126,6 +32190,16 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: b2ba677d32bd0024356ab8d43a1b88cb81ecad94be277b111975e626fd37a9ed17fd446a2e3a399a3c8534dcf89ea7c28a4bf4f094b153a4a9972c67b680ad0d
+  languageName: node
+  linkType: hard
+
+"ts-morph@npm:^27.0.2":
+  version: 27.0.2
+  resolution: "ts-morph@npm:27.0.2"
+  dependencies:
+    "@ts-morph/common": ~0.28.1
+    code-block-writer: ^13.0.3
+  checksum: 1ed2e89257d6f48fdce49bf51e1767787579220197efaa31ac25971c656c9a8a5a6bdd123042d16f83674eec119e4462a06f716187aec0b5e4740888ab5b73b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES #N/A (new tooling initiative)

## This pull request addresses

The need for automated cross-repo SDK synchronization. When SDK APIs change (methods, events, types), consumer repos (ccWidgets) currently discover breakage through manual changelog reading, compile-time errors, or runtime failures. There is no machine-readable contract that consumers can programmatically diff to detect what changed.

## by making the following changes

- **`scripts/generate-manifest.ts`**: ts-morph based AST analysis script that statically analyzes the `@webex/contact-center` package and extracts all exported classes (with public methods, params, return types, event emissions), enums, types/interfaces, and constants into a structured YAML file.
- **`sdk-manifest.yaml`**: Auto-generated machine-readable API surface contract. Added to `package.json` `files` array so it ships with the npm package. Consumers can diff this between versions to detect API changes.
- **`package.json`**: Added `generate:manifest` script and `files` array including `sdk-manifest.yaml`.
- **`.claude/commands/generate-manifest.md`**: `/generate-manifest` Claude Code skill for developers to regenerate the manifest locally.

**Key capabilities:**
- Extracts 3 classes, 37 public methods, 2 event enums, 71 types, 2 constants
- Resolves `this.trigger()`/`this.emit()` calls to actual event string values
- Deduplicates re-exported classes and type-only enum re-exports
- Sanitizes absolute paths to relative package paths

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [x] Ran `npx ts-node scripts/generate-manifest.ts` — generates sdk-manifest.yaml with 3 classes, 37 methods, 2 enums, 71 types, 2 constants
- [x] Verified event extraction: `startTranscription` correctly maps to `task:transcriptionStarted` (success) and `task:transcriptionFailed` (failure)
- [x] Verified deduplication: `default` class re-export and `TaskEvents`/`AgentEvents` type re-exports excluded
- [x] Verified no absolute paths in output YAML
- [x] End-to-end test: simulated API change (added param to `stationLogin`), regenerated manifest, diffed against previous version — change correctly detected

## The GAI Coding Policy And Copyright Annotation Best Practices

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code (Anthropic)
- [x] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [x] Automation

## I certified that

- [x] I have read and followed contributing guidelines
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly