### PR TITLE
feat(task-refactor): export TaskUIControls, getDefaultUIControls; add…

### DIFF
--- a/packages/@webex/contact-center/src/index.ts
+++ b/packages/@webex/contact-center/src/index.ts
@@ -137,7 +137,13 @@ export type {
   TransferPayLoad,
   ResumeRecordingPayload,
   WrapupPayLoad,
+  /** UI control types for task buttons */
+  TaskUIControls,
+  TaskUIControlState,
 } from './services/task/types';
+
+/** UI controls utilities */
+export {getDefaultUIControls} from './services/task/state-machine/uiControlsComputer';
 
 /** Agent related types */
 export type {

--- a/packages/@webex/contact-center/src/services/task/types.ts
+++ b/packages/@webex/contact-center/src/services/task/types.ts
@@ -1090,7 +1090,7 @@ export type TaskData = {
   agentsPendingWrapUp?: string[];
 };
 
-type TaskUIControlState = {
+export type TaskUIControlState = {
   isVisible: boolean;
   isEnabled: boolean;
 };
@@ -1540,6 +1540,13 @@ export interface ITask extends EventEmitter {
   autoWrapup?: AutoWrapup;
 
   /**
+   * Latest UI controls derived from the state machine.
+   * Each control has `isVisible` and `isEnabled` flags computed from current task state.
+   * Subscribe to {@link TASK_EVENTS.TASK_UI_CONTROLS_UPDATED} for change notifications.
+   */
+  uiControls: TaskUIControls;
+
+  /**
    * State machine instance for managing task state transitions and derived properties.
    * The state machine handles:
    * - State transitions (IDLE → OFFERED → CONNECTED → HELD, etc.)
@@ -1778,11 +1785,6 @@ export interface ITask extends EventEmitter {
  * @public
  */
 export interface IDigital extends Omit<ITask, 'updateTaskData'> {
-  /**
-   * UI controls configuration
-   */
-  uiControls: TaskUIControls;
-
   /**
    * Updates the task data
    * @param newData - Updated task data

--- a/packages/@webex/contact-center/src/services/task/types.ts
+++ b/packages/@webex/contact-center/src/services/task/types.ts
@@ -1544,7 +1544,7 @@ export interface ITask extends EventEmitter {
    * Each control has `isVisible` and `isEnabled` flags computed from current task state.
    * Subscribe to {@link TASK_EVENTS.TASK_UI_CONTROLS_UPDATED} for change notifications.
    */
-  uiControls: TaskUIControls;
+  readonly uiControls: TaskUIControls;
 
   /**
    * State machine instance for managing task state transitions and derived properties.


### PR DESCRIPTION

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7779

## This pull request addresses

The CC Widgets task refactor migration requires TaskUIControls, TaskUIControlState, and getDefaultUIControls to be importable from @webex/contact-center. Currently, TaskUIControlState is a local (non-exported) type, getDefaultUIControls is not re-exported from the package entry point, and the uiControls property is missing from the base ITask interface — forcing widgets to rely on concrete class types instead of the public interface.

## by making the following changes

- Export TaskUIControlState from services/task/types.ts (was a local type)
- Add uiControls: TaskUIControls to the ITask interface so all task types expose it through the base contract
- Remove the now-redundant uiControls declaration from IDigital (inherited from ITask)
- Re-export TaskUIControls, TaskUIControlState (types) and getDefaultUIControls (function) from the package entry point (index.ts)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- yarn build:local — build passes with no errors
- yarn workspace @webex/contact-center test:unit — all unit tests passing
- Locally linked SDK to CC Widgets via yarn link — confirmed TaskUIControls, TaskUIControlState, and getDefaultUIControls are importable from @webex/contact-center

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
