### PR TITLE
fix(task-refactor): add explicit on/off methods to ITask interface

### DIFF
--- a/packages/@webex/contact-center/src/services/task/Task.ts
+++ b/packages/@webex/contact-center/src/services/task/Task.ts
@@ -259,7 +259,7 @@ export default abstract class Task extends EventEmitter implements ITask {
   /**
    * Get the current state machine state
    */
-  protected getCurrentState(): TaskState | undefined {
+  public getCurrentState(): TaskState | undefined {
     return this.stateMachineService?.getSnapshot()?.value as TaskState;
   }
 
@@ -493,6 +493,9 @@ export default abstract class Task extends EventEmitter implements ITask {
       },
       cleanupResources: () => {
         this.emit(TASK_EVENTS.TASK_CLEANUP, this, {removeFromCollection: true});
+      },
+      requestEndConsultRetry: () => {
+        // Override in channel-specific implementations (Voice)
       },
     };
   }

--- a/packages/@webex/contact-center/src/services/task/TaskFactory.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskFactory.ts
@@ -22,11 +22,12 @@ export default class TaskFactory {
   ): Task {
     const mediaType = data.interaction.mediaType ?? MEDIA_CHANNEL.TELEPHONY;
     const {isEndTaskEnabled, isEndConsultEnabled} = configFlags;
-    const recordingEnabled = data?.interaction?.callProcessingDetails?.pauseResumeEnabled ?? true;
+    // Hardcode recording enabled for voice tasks - backend pauseResumeEnabled is unreliable
+    const isVoiceTask = mediaType === MEDIA_CHANNEL.TELEPHONY;
     const voiceControlOptions = {
       isEndTaskEnabled,
       isEndConsultEnabled,
-      isRecordingEnabled: recordingEnabled,
+      isRecordingEnabled: isVoiceTask ? true : (data?.interaction?.callProcessingDetails?.pauseResumeEnabled ?? true),
     };
     switch (mediaType) {
       case MEDIA_CHANNEL.TELEPHONY:

--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -22,7 +22,7 @@ import LoggerProxy from '../../logger-proxy';
 import {getIsConferenceInProgress, isSecondaryEpDnAgent, shouldAutoAnswerTask} from './TaskUtils';
 import TaskFactory from './TaskFactory';
 import WebRTC from './voice/WebRTC';
-import {TaskEvent, type TaskEventPayload} from './state-machine';
+import {TaskEvent, TaskState, type TaskEventPayload} from './state-machine';
 import {normalizeTaskData} from './taskDataNormalizer';
 import {ApiAIAssistant} from '../ApiAiAssistant';
 
@@ -347,6 +347,19 @@ export default class TaskManager extends EventEmitter {
       // including TASK_INCOMING which is now handled via the state machine callbacks
       if (stateMachineEvent) {
         task.sendStateMachineEvent(stateMachineEvent);
+
+        // After CONFERENCE_START in CONFERENCING state, also send CONSULT_END to clear consult state.
+        // Backend sends AgentConsultConferenced but does NOT send AgentConsultEnded after a merge,
+        // so agents in conference still see consultInProgress=true. We send CONSULT_END locally to fix this.
+        if (
+          stateMachineEvent.type === TaskEvent.CONFERENCE_START &&
+          task.getCurrentState() === TaskState.CONFERENCING
+        ) {
+          task.sendStateMachineEvent({
+            type: TaskEvent.CONSULT_END,
+            taskData: stateMachineEvent.taskData,
+          });
+        }
       }
 
       // Send transcript start/stop events for relevant CC events

--- a/packages/@webex/contact-center/src/services/task/TaskUtils.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskUtils.ts
@@ -82,7 +82,10 @@ export const getIsConsultInProgressForConferenceControls = (
     if (!m || m.mType !== 'consult') return false;
     if (!Array.isArray(m.participants) || m.participants.length === 0) return false;
 
-    return m.participants.some((participantId: string) => {
+    // After a conference merge, the consult leg may still exist but all participants
+    // from that consult are now in the main call. If ALL non-self participants in a
+    // consult leg are in the main call, the consult has been merged and is no longer "in progress".
+    const consultParticipantsOutsideMainCall = m.participants.filter((participantId: string) => {
       const p: any = interaction.participants?.[participantId];
       if (!p || p.hasLeft) return false;
       if (selfAgentId && participantId === selfAgentId) return false;
@@ -92,8 +95,12 @@ export const getIsConsultInProgressForConferenceControls = (
         p.isConsulted === true ||
         p.currentState === 'consulting';
 
+      // Include this participant if they're consulting AND not in main call yet
       return consultLegActive && !mainSet.has(participantId);
     });
+
+    // Consult is "in progress" only if there are participants actively consulting outside the main call
+    return consultParticipantsOutsideMainCall.length > 0;
   });
 };
 

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -12,7 +12,7 @@ import {setup} from 'xstate';
 import {TaskContext, TaskEventPayload, UIControlConfig, TaskActionsMap} from './types';
 import {TaskState, TaskEvent} from './constants';
 import {actions, createInitialContext} from './actions';
-import {guards} from './guards';
+import {guards, GuardParams} from './guards';
 import {getIsCustomerInCall} from '../TaskUtils';
 
 type TaskActionConfigMap = {[K in keyof typeof actions]: undefined};
@@ -105,7 +105,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             {
               guard: guards.isInteractionConnected,
               target: TaskState.CONNECTED,
-              actions: ['updateTaskData', 'emitTaskHydrate'],
+              actions: ['updateTaskData', 'enableRecordingControls', 'emitTaskHydrate'],
             },
             {
               guard: guards.isConferencingByParticipants,
@@ -130,7 +130,6 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             actions: [
               'updateTaskData',
               'setConsultInitiator',
-              'setConsultFromConference',
               'setConsultAgentJoined',
               'emitTaskConsultAccepted',
               'emitTaskConsulting',
@@ -154,13 +153,23 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             },
             {
               target: TaskState.CONNECTED,
-              actions: ['updateTaskData', 'emitTaskAssigned'],
+              actions: ['updateTaskData', 'enableRecordingControls', 'emitTaskAssigned'],
             },
           ],
           // AgentOfferContactRONA
           [TaskEvent.RONA]: {
             target: TaskState.TERMINATED,
             actions: ['updateTaskData', 'markEnded', 'emitTaskReject'],
+          },
+          // Agent declines incoming task
+          [TaskEvent.DECLINE]: {
+            target: TaskState.TERMINATED,
+            actions: ['updateTaskData', 'markEnded', 'emitTaskReject'],
+          },
+          // ContactEnded - backend event when customer/contact ends before agent connects
+          [TaskEvent.CONTACT_ENDED]: {
+            target: TaskState.TERMINATED,
+            actions: ['updateTaskData', 'markEnded', 'emitTaskEnd'],
           },
           // ContactEnded (customer can end call before connect or via agent softphone decline)
           [TaskEvent.TASK_WRAPUP]: {
@@ -225,31 +234,50 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // AgentContactAssigned can be resent after consult transfers; keep context in sync
           [TaskEvent.ASSIGN]: {
             target: TaskState.CONNECTED,
-            actions: ['updateTaskData', 'emitTaskAssigned'],
+            actions: ['updateTaskData', 'enableRecordingControls', 'emitTaskAssigned'],
           },
           // Click of hold button
           [TaskEvent.HOLD_INITIATED]: {
             target: TaskState.HOLD_INITIATING,
+          },
+          // Multi-login: another session held the call (AgentContactHeld without local HOLD_INITIATED)
+          [TaskEvent.HOLD_SUCCESS]: {
+            target: TaskState.HELD,
+            actions: ['updateTaskData', 'setHoldState', 'emitTaskHold'],
+          },
+          // Backend consult end event (after already transitioned to CONNECTED from CONSULTING)
+          // Clears consult state to hide consult UI controls
+          [TaskEvent.CONSULT_END]: {
+            actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+          },
+          // Backend consult failed event (after already transitioned to CONNECTED from CONSULTING)
+          // Clears consult state to hide consult UI controls
+          [TaskEvent.CONSULT_FAILED]: {
+            actions: ['updateTaskData', 'clearConsultState'],
           },
           // Click of the consult button
           [TaskEvent.CONSULT]: {
             target: TaskState.CONSULT_INITIATING,
             actions: ['setConsultInitiator', 'setConsultDestination'],
           },
+          // User initiates transfer (UI action)
+          [TaskEvent.TRANSFER]: {
+            actions: ['setTransferRequested'],
+          },
           // AgentConsultTransferred / AgentVTeamTransferred / AgentBlindTransferred
           [TaskEvent.TRANSFER_SUCCESS]: [
             {
               guard: guards.shouldWrapUpOrIsInitiator,
               target: TaskState.WRAPPING_UP,
-              actions: ['updateTaskData', 'markEnded', 'emitTaskWrapup'],
+              actions: ['updateTaskData', 'markEnded', 'emitTaskWrapup', 'clearTransferRequested'],
             },
             {
               // Receiver goes to connected as he receives transferSuccess event
-              actions: ['updateTaskData', 'clearConsultState'],
+              actions: ['updateTaskData', 'clearConsultState', 'clearTransferRequested'],
             },
           ],
           [TaskEvent.TRANSFER_FAILED]: {
-            actions: ['updateTaskData'],
+            actions: ['updateTaskData', 'clearTransferRequested'],
           },
           // AgentContactEnded Event
           [TaskEvent.CONTACT_ENDED]: [
@@ -294,8 +322,25 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // AgentContactHoldFailed Event
           [TaskEvent.HOLD_FAILED]: {
             target: TaskState.CONNECTED,
-            actions: ['updateTaskData'],
+            actions: ['updateTaskData', 'enableRecordingControls'],
           },
+          // Customer ends call while hold is in progress
+          [TaskEvent.CONTACT_ENDED]: [
+            {
+              guard: guards.conferenceInProgressFromEvent,
+              target: TaskState.CONFERENCING,
+              actions: ['updateTaskData', 'emitTaskConferenceStarted', 'requestCleanup'],
+            },
+            {
+              guard: guards.shouldWrapUp,
+              target: TaskState.WRAPPING_UP,
+              actions: ['updateTaskData', 'markEnded', 'emitTaskWrapup', 'requestCleanup'],
+            },
+            {
+              target: TaskState.TERMINATED,
+              actions: ['updateTaskData', 'markEnded', 'emitTaskEnd'],
+            },
+          ],
         },
       },
 
@@ -305,10 +350,29 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           [TaskEvent.UNHOLD_INITIATED]: {
             target: TaskState.RESUME_INITIATING,
           },
+          // Multi-login: another session resumed the call (AgentContactUnheld without local UNHOLD_INITIATED)
+          [TaskEvent.UNHOLD_SUCCESS]: {
+            target: TaskState.CONNECTED,
+            actions: ['updateTaskData', 'setHoldState', 'enableRecordingControls', 'emitTaskResume'],
+          },
+          // Backend consult end event (after already transitioned to HELD from CONSULTING)
+          // Clears consult state to hide consult UI controls
+          [TaskEvent.CONSULT_END]: {
+            actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+          },
+          // Backend consult failed event (after already transitioned to HELD from CONSULTING)
+          // Clears consult state to hide consult UI controls
+          [TaskEvent.CONSULT_FAILED]: {
+            actions: ['updateTaskData', 'clearConsultState'],
+          },
           // Click of the consult button
           [TaskEvent.CONSULT]: {
             target: TaskState.CONSULT_INITIATING,
             actions: ['setConsultInitiator', 'setConsultDestination'],
+          },
+          // User initiates transfer (UI action)
+          [TaskEvent.TRANSFER]: {
+            actions: ['setTransferRequested'],
           },
           // TODO: This may not be a valid transition, need to be removed
           // AgentConsultTransferred / AgentVTeamTransferred / AgentBlindTransferred
@@ -316,15 +380,15 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             {
               guard: guards.shouldWrapUpOrIsInitiator,
               target: TaskState.WRAPPING_UP,
-              actions: ['updateTaskData', 'markEnded', 'emitTaskWrapup'],
+              actions: ['updateTaskData', 'markEnded', 'emitTaskWrapup', 'clearTransferRequested'],
             },
             {
               target: TaskState.CONNECTED,
-              actions: ['updateTaskData', 'clearConsultState'],
+              actions: ['updateTaskData', 'clearConsultState', 'clearTransferRequested'],
             },
           ],
           [TaskEvent.TRANSFER_FAILED]: {
-            actions: ['updateTaskData'],
+            actions: ['updateTaskData', 'clearTransferRequested'],
           },
           [TaskEvent.CONTACT_ENDED]: [
             {
@@ -354,11 +418,28 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
         on: {
           [TaskEvent.UNHOLD_SUCCESS]: {
             target: TaskState.CONNECTED,
-            actions: ['updateTaskData', 'setHoldState', 'emitTaskResume'],
+            actions: ['updateTaskData', 'setHoldState', 'enableRecordingControls', 'emitTaskResume'],
           },
           [TaskEvent.UNHOLD_FAILED]: {
             target: TaskState.HELD,
           },
+          // Customer ends call while resume is in progress
+          [TaskEvent.CONTACT_ENDED]: [
+            {
+              guard: guards.conferenceInProgressFromEvent,
+              target: TaskState.CONFERENCING,
+              actions: ['updateTaskData', 'emitTaskConferenceStarted', 'requestCleanup'],
+            },
+            {
+              guard: guards.shouldWrapUp,
+              target: TaskState.WRAPPING_UP,
+              actions: ['updateTaskData', 'markEnded', 'emitTaskWrapup', 'requestCleanup'],
+            },
+            {
+              target: TaskState.TERMINATED,
+              actions: ['updateTaskData', 'markEnded', 'emitTaskEnd'],
+            },
+          ],
         },
       },
 
@@ -369,7 +450,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           },
           [TaskEvent.HOLD_FAILED]: {
             target: TaskState.CONNECTED,
-            actions: ['updateTaskData', 'handleConsultFailed'],
+            actions: ['updateTaskData', 'enableRecordingControls', 'handleConsultFailed'],
           },
           // AgentConsulting
           // NOTE: Don't set consultDestinationAgentJoined here - wait for CONSULTING_ACTIVE
@@ -377,6 +458,33 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             target: TaskState.CONSULTING,
             actions: ['updateTaskData', 'setConsultInitiator'],
           },
+          // AgentConsultEnded during CONSULT_INITIATING (cancel before consult establishes)
+          [TaskEvent.CONSULT_END]: [
+            {
+              // Cancel during initiation with main call on hold
+              guard: (args: GuardParams) => args.context.transferRequested !== true && guards.isPrimaryMediaOnHold(args),
+              target: TaskState.HELD,
+              actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+            },
+            {
+              // Transfer in progress with main call on hold
+              guard: (args: GuardParams) => args.context.transferRequested === true && guards.isPrimaryMediaOnHold(args),
+              target: TaskState.HELD,
+              actions: ['updateTaskData', 'clearConsultStatePreservingInitiator', 'emitTaskConsultEnd'],
+            },
+            {
+              // Cancel during initiation with main call connected
+              guard: ({context}) => context.transferRequested !== true,
+              target: TaskState.CONNECTED,
+              actions: ['updateTaskData', 'enableRecordingControls', 'clearConsultState', 'emitTaskConsultEnd'],
+            },
+            {
+              // Transfer in progress with main call connected
+              guard: ({context}) => context.transferRequested === true,
+              target: TaskState.CONNECTED,
+              actions: ['updateTaskData', 'enableRecordingControls', 'clearConsultStatePreservingInitiator', 'emitTaskConsultEnd'],
+            },
+          ],
           // AgentConsultFailed, API Failures, AgentCtqFailed
           [TaskEvent.CONSULT_FAILED]: [
             {
@@ -386,12 +494,9 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
               actions: ['updateTaskData', 'handleConsultFailed'],
             },
             {
-              guard: guards.isPrimaryMediaOnHold,
+              // Initiator: always return to HELD (main call was on hold during consult initiation)
+              // Remove isPrimaryMediaOnHold guard - it's unreliable, main call is always held during consult
               target: TaskState.HELD,
-              actions: ['updateTaskData', 'handleConsultFailed'],
-            },
-            {
-              target: TaskState.CONNECTED,
               actions: ['updateTaskData', 'handleConsultFailed'],
             },
           ],
@@ -404,9 +509,28 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             },
             {
               target: TaskState.CONNECTED,
-              actions: ['updateTaskData', 'clearConsultState'],
+              actions: ['updateTaskData', 'enableRecordingControls', 'clearConsultState'],
             },
           ],
+          // Customer ends call while consult is being initiated
+          [TaskEvent.CONTACT_ENDED]: [
+            {
+              // Conference still active → CONFERENCING
+              guard: guards.conferenceInProgressFromEvent,
+              target: TaskState.CONFERENCING,
+              actions: ['updateTaskData', 'emitTaskConferenceStarted', 'requestCleanup'],
+            },
+            {
+              // Default: go to WRAPPING_UP (matching CONSULTING state behavior)
+              target: TaskState.WRAPPING_UP,
+              actions: ['updateTaskData', 'markEnded', 'clearConsultState', 'emitTaskWrapup', 'requestCleanup'],
+            },
+          ],
+          // Backend explicitly requests wrapup during consult initiation
+          [TaskEvent.TASK_WRAPUP]: {
+            target: TaskState.WRAPPING_UP,
+            actions: ['updateTaskData', 'markEnded', 'emitTaskWrapup'],
+          },
         },
       },
 
@@ -414,7 +538,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
         on: {
           // AgentConsulting updates consulted agent arrival
           [TaskEvent.CONSULTING_ACTIVE]: {
-            actions: ['updateTaskData', 'setConsultAgentJoined', 'emitTaskConsulting'],
+            actions: ['updateTaskData', 'setConsultAgentJoined', 'requestEndConsultRetry', 'clearPendingEndConsult', 'emitTaskConsulting'],
           },
 
           // AgentConsultEnded
@@ -426,48 +550,95 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
                 (context.consultFromConference === true ||
                   guards.conferenceInProgressFromEvent({context, event})),
               target: TaskState.CONFERENCING,
-              actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+              actions: ['logStateTransition', 'updateTaskData', 'clearConsultStatePreservingInitiator', 'emitTaskConsultEnd'],
             },
             {
-              // Initiator (no conference) → HELD
-              guard: ({context}) => context.consultInitiator === true,
+              // Initiator canceling consult (no transfer) → HELD
+              // Fully clear all consult state since no transfer is expected
+              guard: ({context}) => context.consultInitiator === true && context.transferRequested !== true,
               target: TaskState.HELD,
-              actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+              actions: ['logStateTransition', 'updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+            },
+            {
+              // Initiator with transfer in progress → HELD
+              // Use clearConsultStatePreservingInitiator to keep consultInitiator for dial number transfers
+              // where backend sends AgentConsultEnded before AgentConsultTransferred
+              guard: ({context}) => context.consultInitiator === true && context.transferRequested === true,
+              target: TaskState.HELD,
+              actions: ['logStateTransition', 'updateTaskData', 'clearConsultStatePreservingInitiator', 'emitTaskConsultEnd'],
             },
             {
               // Consulted agent → TERMINATED
               target: TaskState.TERMINATED,
-              actions: ['updateTaskData'],
+              actions: ['logStateTransition', 'updateTaskData'],
             },
           ],
 
           // Switch between consult and main call (UI-driven toggle)
           [TaskEvent.SWITCH_TO_MAIN_CALL]: {
-            actions: ['handleSwitchToMainCall', 'emitTaskSwitchCall'],
+            actions: ['handleSwitchToMainCall', 'emitTaskSwitchCall', 'updateUIControlsAfterSwitch'],
           },
           [TaskEvent.SWITCH_TO_CONSULT]: {
-            actions: ['handleSwitchToConsult', 'emitTaskSwitchCall'],
+            actions: ['handleSwitchToConsult', 'emitTaskSwitchCall', 'updateUIControlsAfterSwitch'],
           },
           [TaskEvent.HOLD_SUCCESS]: {
-            actions: ['updateTaskData', 'setHoldState'],
+            actions: ['updateTaskData', 'setHoldState', 'updateUIControlsAfterSwitch'],
           },
           [TaskEvent.UNHOLD_SUCCESS]: {
-            actions: ['updateTaskData', 'setHoldState'],
+            actions: ['updateTaskData', 'setHoldState', 'updateUIControlsAfterSwitch'],
           },
 
+          // AgentConsultFailed - endConsult API failure during CONSULTING
+          // Mirror the CONSULT_END pattern for failure path
+          [TaskEvent.CONSULT_FAILED]: [
+            {
+              // Initiator returning to conference (flag set OR backend still shows conference)
+              guard: ({context, event}) =>
+                context.consultInitiator === true &&
+                (context.consultFromConference === true ||
+                  guards.conferenceInProgressFromEvent({context, event})),
+              target: TaskState.CONFERENCING,
+              actions: ['logStateTransition', 'updateTaskData', 'clearConsultStatePreservingInitiator', 'clearPendingEndConsult'],
+            },
+            {
+              // Initiator ending consult without transfer → HELD
+              // Always return to HELD (main call is on hold during active consult)
+              guard: ({context}) => context.consultInitiator === true && context.transferRequested !== true,
+              target: TaskState.HELD,
+              actions: ['logStateTransition', 'updateTaskData', 'clearConsultState', 'clearPendingEndConsult'],
+            },
+            {
+              // Initiator with transfer in progress → HELD
+              // Preserve consultInitiator for dial number transfers
+              guard: ({context}) => context.consultInitiator === true && context.transferRequested === true,
+              target: TaskState.HELD,
+              actions: ['logStateTransition', 'updateTaskData', 'clearConsultStatePreservingInitiator', 'clearPendingEndConsult'],
+            },
+            {
+              // Consulted agent or fallback - stay in CONSULTING for retry
+              // (Consulted agents shouldn't trigger failures, but handle defensively)
+              actions: ['updateTaskData', 'setPendingEndConsult'],
+            },
+          ],
+
+          // User initiates transfer (UI action)
+          [TaskEvent.TRANSFER]: {
+            actions: ['logStateTransition', 'setTransferRequested'],
+          },
           [TaskEvent.TRANSFER_SUCCESS]: [
             {
               guard: guards.shouldWrapUpOrIsInitiator,
               target: TaskState.WRAPPING_UP,
-              actions: ['updateTaskData', 'markEnded', 'emitTaskWrapup'],
+              actions: ['logStateTransition', 'updateTaskData', 'markEnded', 'emitTaskWrapup', 'clearTransferRequested'],
             },
             {
               target: TaskState.CONNECTED,
-              actions: ['updateTaskData', 'clearConsultState'],
+              // Use preserving variant to keep consultFromConference flag for conference-based transfers
+              actions: ['logStateTransition', 'updateTaskData', 'clearConsultStatePreservingConferenceFlag', 'clearTransferRequested'],
             },
           ],
           [TaskEvent.TRANSFER_FAILED]: {
-            actions: ['updateTaskData'],
+            actions: ['updateTaskData', 'clearTransferRequested'],
           },
           [TaskEvent.TRANSFER_CONFERENCE]: {
             // Track that this agent initiated the conference transfer so we can
@@ -525,7 +696,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // AgentContactAssigned - receiver side becomes connected to customer
           [TaskEvent.ASSIGN]: {
             target: TaskState.CONNECTED,
-            actions: ['updateTaskData', 'emitTaskAssigned'],
+            actions: ['updateTaskData', 'enableRecordingControls', 'emitTaskAssigned'],
           },
           // AgentContactEnded
           [TaskEvent.CONTACT_ENDED]: {
@@ -546,9 +717,11 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             target: TaskState.CONF_INITIATING,
           },
           // AgentConsultConferenced, ParticipantJoinedConference
+          // Use preserving variant to keep consultFromConference flag if this agent
+          // consulted from within a conference (needed for proper wrapup after transfer)
           [TaskEvent.CONFERENCE_START]: {
             target: TaskState.CONFERENCING,
-            actions: ['handleConferenceStarted', 'clearConsultState'],
+            actions: ['updateTaskData', 'clearConsultStatePreservingConferenceFlag', 'emitTaskConferenceStarted'],
           },
         },
       },
@@ -558,7 +731,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // AgentConsultConferenced, ParticipantJoinedConference
           [TaskEvent.CONFERENCE_START]: {
             target: TaskState.CONFERENCING,
-            actions: ['handleConferenceStarted'],
+            actions: ['updateTaskData', 'clearConsultStatePreservingConferenceFlag', 'emitTaskConferenceStarted'],
           },
           // AgentConsultConferenceFailed
           [TaskEvent.CONFERENCE_FAILED]: {
@@ -571,7 +744,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
       [TaskState.CONFERENCING]: {
         on: {
           [TaskEvent.CONFERENCE_START]: {
-            actions: ['updateTaskData', 'clearConsultState', 'emitTaskConferenceStarted'],
+            actions: ['updateTaskData', 'clearConsultStatePreservingConferenceFlag', 'emitTaskConferenceStarted'],
           },
           [TaskEvent.EXIT_CONFERENCE_SUCCESS]: [
             {
@@ -586,8 +759,10 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           ],
 
           // Needed as all agents in conference get this event, hence we need to clear the consult state
+          // Use preserving variant to avoid clearing consultFromConference if this agent initiated
+          // a consult-from-conference and is waiting for TRANSFER_SUCCESS
           [TaskEvent.CONSULT_END]: {
-            actions: ['updateTaskData', 'clearConsultState'],
+            actions: ['logStateTransition', 'updateTaskData', 'clearConsultStatePreservingConferenceFlag'],
           },
 
           [TaskEvent.HOLD_SUCCESS]: {
@@ -600,7 +775,27 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // Start a new consult from within an active conference
           [TaskEvent.CONSULT]: {
             target: TaskState.CONSULT_INITIATING,
-            actions: ['setConsultInitiator', 'setConsultDestination', 'setConsultFromConference'],
+            actions: ['logStateTransition', 'setConsultInitiator', 'setConsultDestination', 'setConsultFromConference'],
+          },
+
+          // Consult transfer from within conference
+          // This handles the case where agent transfers a consult while in a conference.
+          // The initiating agent should wrap up even though the conference continues.
+          [TaskEvent.TRANSFER_SUCCESS]: [
+            {
+              // If wrapUpRequired or agent was consult initiator → WRAPPING_UP
+              guard: guards.shouldWrapUpOrIsInitiator,
+              target: TaskState.WRAPPING_UP,
+              actions: ['logStateTransition', 'updateTaskData', 'markEnded', 'emitTaskWrapup', 'clearTransferRequested'],
+            },
+            {
+              // Otherwise stay in conference (for other agents who didn't initiate)
+              // Use preserving variant to avoid clearing flags for agents who may need them
+              actions: ['logStateTransition', 'updateTaskData', 'clearConsultStatePreservingConferenceFlag', 'clearTransferRequested'],
+            },
+          ],
+          [TaskEvent.TRANSFER_FAILED]: {
+            actions: ['updateTaskData', 'clearTransferRequested'],
           },
 
           // Participant leaves - handle conference downgrade scenarios
@@ -640,6 +835,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
               target: TaskState.CONNECTED,
               actions: [
                 'updateTaskData',
+                'enableRecordingControls',
                 'handleParticipantLeft',
                 'clearConsultState',
                 'emitTaskParticipantLeft',
@@ -687,7 +883,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
                 return getIsCustomerInCall(taskData.interaction, mainCallId);
               },
               target: TaskState.CONNECTED,
-              actions: ['updateTaskData', 'clearConsultState', 'emitTaskConferenceEnded'],
+              actions: ['updateTaskData', 'enableRecordingControls', 'clearConsultState', 'emitTaskConferenceEnded'],
             },
             {
               // Otherwise → TERMINATED

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -87,6 +87,13 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
           if (consultInitiator !== undefined) updates.consultInitiator = consultInitiator;
         }
 
+        // Force recording state for voice tasks to handle unreliable backend data
+        const isVoiceTask = taskData?.interaction?.mediaType === 'telephony';
+        if (isVoiceTask) {
+          updates.recordingControlsAvailable = true;
+          updates.recordingInProgress = true;
+        }
+
         return updates;
       })()
     : {};
@@ -104,9 +111,11 @@ export function createInitialContext(
     exitingConference: false,
     consultFromConference: false,
     transferConferenceRequested: false,
+    transferRequested: false,
     consultDestinationType: null,
     consultDestinationAgentJoined: false,
     consultCallHeld: false,
+    pendingEndConsult: false,
     recordingControlsAvailable: false,
     recordingInProgress: false,
     uiControlConfig,
@@ -192,22 +201,35 @@ export const actions: TaskActionsMap = {
 
   setConsultAgentJoined: assign(
     ({context, event}: {context: TaskContext; event: TaskEventPayload}) => {
-      if (context.consultDestinationAgentJoined) {
-        return {};
+      const updates: Partial<TaskContext> = {};
+
+      if (!context.consultDestinationAgentJoined) {
+        if (
+          event &&
+          event.type === TaskEvent.CONSULTING_ACTIVE &&
+          'consultDestinationAgentJoined' in event
+        ) {
+          const eventValue = (event as {consultDestinationAgentJoined: boolean})
+            .consultDestinationAgentJoined;
+          if (eventValue) {
+            updates.consultDestinationAgentJoined = true;
+          }
+        }
       }
 
-      if (
-        !event ||
-        event.type !== TaskEvent.CONSULTING_ACTIVE ||
-        !('consultDestinationAgentJoined' in event)
-      ) {
-        return {};
+      // Also initialize consultCallHeld from actual media state when consulting becomes active
+      // This ensures sync even if no HOLD/UNHOLD event was processed yet
+      const taskData = getTaskDataFromEvent(event);
+      const consultMediaResourceId = taskData?.consultMediaResourceId;
+      if (consultMediaResourceId && taskData?.interaction?.media) {
+        const consultMedia = taskData.interaction.media[consultMediaResourceId];
+        if (consultMedia) {
+          // Derive consultCallHeld from whether consult media is held
+          updates.consultCallHeld = consultMedia.isHold === true;
+        }
       }
 
-      const eventValue = (event as {consultDestinationAgentJoined: boolean})
-        .consultDestinationAgentJoined;
-
-      return eventValue ? {consultDestinationAgentJoined: true} : {};
+      return Object.keys(updates).length > 0 ? updates : {};
     }
   ),
 
@@ -232,23 +254,90 @@ export const actions: TaskActionsMap = {
     return {};
   }),
 
-  clearConsultState: assign({
-    consultDestinationType: null,
-    consultDestinationAgentJoined: false,
-    consultInitiator: false,
-    exitingConference: false,
-    consultCallHeld: false,
-    consultFromConference: false,
-    transferConferenceRequested: false,
+  enableRecordingControls: assign(() => ({
+    recordingControlsAvailable: true,
+  })),
+
+  clearConsultState: assign(() => {
+    return {
+      consultDestinationType: null as DestinationType | null,
+      consultDestinationAgentJoined: false,
+      consultInitiator: false,
+      exitingConference: false,
+      consultCallHeld: false,
+      consultFromConference: false,
+      transferConferenceRequested: false,
+      pendingEndConsult: false,
+    };
+  }),
+
+  /**
+   * Clear consult state but preserve consultFromConference flag.
+   * Used when CONFERENCE_START arrives while in CONFERENCING state with an active
+   * consult-from-conference. We need to preserve the flag so the agent can properly
+   * transition to wrapup after transferring that consult.
+   */
+  clearConsultStatePreservingConferenceFlag: assign(({context}: TaskActionArgs) => {
+    const preserveFlag = context.consultFromConference === true;
+    return {
+      consultDestinationType: context.consultFromConference ? context.consultDestinationType : null,
+      consultDestinationAgentJoined: false,
+      consultInitiator: preserveFlag ? context.consultInitiator : false,
+      exitingConference: false,
+      consultCallHeld: false,
+      consultFromConference: preserveFlag,
+      transferConferenceRequested: false,
+      pendingEndConsult: false,
+    };
+  }),
+
+  /**
+   * Clear consult state but conditionally preserve consultInitiator and consultFromConference.
+   * Used when CONSULT_END arrives but we expect TRANSFER_SUCCESS to follow.
+   * For dial numbers, backend sends AgentConsultEnded before AgentConsultTransferred,
+   * so we need to preserve consultInitiator for the wrapup transition.
+   * For conference consult transfers, we also preserve consultFromConference to ensure
+   * the agent transitions to wrapup even if the backend doesn't send wrapUpRequired=true.
+   * Only preserves if transferRequested is true (transfer in progress).
+   */
+  clearConsultStatePreservingInitiator: assign(({context}: TaskActionArgs) => {
+    const preserveInitiator = context.transferRequested === true;
+    const currentInitiator = context.consultInitiator;
+    const currentFromConference = context.consultFromConference;
+
+    const newInitiator = preserveInitiator ? currentInitiator : false;
+    const newFromConference = preserveInitiator ? currentFromConference : false;
+
+    // Always explicitly set consultInitiator and consultFromConference to avoid XState ambiguity
+    return {
+      consultDestinationType: null as DestinationType | null,
+      consultDestinationAgentJoined: false,
+      consultInitiator: newInitiator,
+      exitingConference: false,
+      consultCallHeld: false,
+      consultFromConference: newFromConference,
+      transferConferenceRequested: false,
+      pendingEndConsult: false,
+    };
+  }),
+
+  setTransferRequested: assign(() => {
+    return {transferRequested: true};
+  }),
+  clearTransferRequested: assign(() => {
+    return {transferRequested: false};
   }),
 
   setTransferConferenceRequested: assign({transferConferenceRequested: true}),
   clearTransferConferenceRequested: assign({transferConferenceRequested: false}),
 
+  setPendingEndConsult: assign({pendingEndConsult: true}),
+  clearPendingEndConsult: assign({pendingEndConsult: false}),
+
   setConsultCallHeld: assign({consultCallHeld: true}),
   clearConsultCallHeld: assign({consultCallHeld: false}),
-  handleSwitchToMainCall: assign({consultCallHeld: true}),
-  handleSwitchToConsult: assign({consultCallHeld: false}),
+  handleSwitchToMainCall: assign(() => ({consultCallHeld: true})),
+  handleSwitchToConsult: assign(() => ({consultCallHeld: false})),
   handleConferenceFailed: assign(({event}: TaskActionArgs) => {
     const taskData = getTaskDataFromEvent(event);
 
@@ -285,7 +374,10 @@ export const actions: TaskActionsMap = {
       return {};
     }
 
-    const interaction = context.taskData?.interaction;
+    // Get taskData from event - this is the UPDATED data from backend
+    // Don't use context.taskData because updateTaskData runs in parallel
+    const eventTaskData = getTaskDataFromEvent(event);
+    const interaction = eventTaskData?.interaction || context.taskData?.interaction;
     const mediaEntry = interaction?.media?.[mediaResourceId];
 
     if (!interaction || !mediaEntry) {
@@ -300,14 +392,32 @@ export const actions: TaskActionsMap = {
       },
     };
 
+    // During consulting: Derive consultCallHeld from actual media hold states
+    // This ensures sessions stay in sync regardless of which build initiated the switch
+    // Use consultMediaResourceId from EVENT taskData (the updated one)
+    const consultMediaResourceId = eventTaskData?.consultMediaResourceId || context.taskData?.consultMediaResourceId;
+    let updatedConsultCallHeld = context.consultCallHeld;
+
+    // If we have a consult media, derive the state from whether it's held
+    if (consultMediaResourceId) {
+      // After updating media, check if consult media is held
+      const consultMediaState = updatedMedia[consultMediaResourceId];
+      if (consultMediaState) {
+        // If consult media is held → we're on main call → consultCallHeld = true
+        // If consult media is not held → we're on consult call → consultCallHeld = false
+        updatedConsultCallHeld = consultMediaState.isHold === true;
+      }
+    }
+
     return {
       taskData: {
-        ...(context.taskData as TaskData),
+        ...(eventTaskData || context.taskData as TaskData),
         interaction: {
           ...interaction,
           media: updatedMedia,
         },
       },
+      consultCallHeld: updatedConsultCallHeld,
     };
   }),
 
@@ -316,9 +426,14 @@ export const actions: TaskActionsMap = {
     recordingInProgress: false,
   })),
 
+  logStateTransition: () => {
+    // State transition logging removed
+  },
+
   requestAutoAnswer: () => undefined,
   requestCleanup: () => undefined,
   cleanupResources: () => undefined,
+  requestEndConsultRetry: () => undefined,
 
   // Event emitters - placeholders overridden by consumers
   emitTaskIncoming: () => undefined,
@@ -348,4 +463,5 @@ export const actions: TaskActionsMap = {
   emitTaskConferenceFailed: () => undefined,
   emitTaskTransferConferenceFailed: () => undefined,
   emitTaskOutdialFailed: () => undefined,
+  updateUIControlsAfterSwitch: () => undefined,
 };

--- a/packages/@webex/contact-center/src/services/task/state-machine/constants.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/constants.ts
@@ -119,6 +119,7 @@ export enum TaskEvent {
   RESUME_RECORDING = 'RESUME_RECORDING',
 
   // Transfer events
+  TRANSFER = 'TRANSFER', // User-initiated transfer (UI action)
   TRANSFER_SUCCESS = 'TRANSFER_SUCCESS',
   TRANSFER_FAILED = 'TRANSFER_FAILED',
 

--- a/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
@@ -225,12 +225,27 @@ export const guards = {
   },
 
   /**
-   * Check if wrapUpRequired in payload OR is consult initiator
+   * Check if wrapUpRequired in payload OR is consult initiator OR consulting from conference OR initiated transfer.
+   *
+   * When an agent consults from within a conference and then transfers that consult,
+   * they're transferring ownership of the entire interaction (including the conference).
+   * The transferring agent should ALWAYS exit and wrapup, even if the backend doesn't
+   * explicitly set wrapUpRequired=true.
+   *
+   * For blind transfers, the agent who initiated the transfer should also wrapup,
+   * even if the backend doesn't set wrapUpRequired=true.
    */
   shouldWrapUpOrIsInitiator: ({context, event}: GuardParams): boolean => {
     const taskData = getTaskDataFromEvent(event);
+    const interactionId = context.taskData?.interactionId || taskData?.interactionId;
+    const wrapUpRequired = taskData?.wrapUpRequired;
+    const consultInitiator = context.consultInitiator;
+    const consultFromConference = context.consultFromConference;
+    const transferRequested = context.transferRequested;
 
-    return Boolean(taskData?.wrapUpRequired || context.consultInitiator);
+    const result = Boolean(wrapUpRequired || consultInitiator || consultFromConference || transferRequested);
+
+    return result;
   },
 
   /**

--- a/packages/@webex/contact-center/src/services/task/state-machine/types.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/types.ts
@@ -57,9 +57,11 @@ export interface TaskContext {
   exitingConference: boolean;
   consultFromConference: boolean;
   transferConferenceRequested: boolean;
+  transferRequested: boolean; // Tracks if transfer is in progress (for dial number consult transfer wrapup)
   consultDestinationType: DestinationType | null;
   consultDestinationAgentJoined: boolean;
   consultCallHeld: boolean;
+  pendingEndConsult: boolean; // Tracks if endConsult was attempted but failed, needs retry
 
   // Recording
   recordingControlsAvailable: boolean;
@@ -156,6 +158,7 @@ interface TaskEventPayloadMap {
   [TaskEvent.RECORDING_STARTED]: BaseEvent<TaskEvent.RECORDING_STARTED> & {taskData: TaskData};
   [TaskEvent.PAUSE_RECORDING]: BaseEvent<TaskEvent.PAUSE_RECORDING> & {taskData: TaskData};
   [TaskEvent.RESUME_RECORDING]: BaseEvent<TaskEvent.RESUME_RECORDING> & {taskData: TaskData};
+  [TaskEvent.TRANSFER]: BaseEvent<TaskEvent.TRANSFER>; // User-initiated transfer (no payload)
   [TaskEvent.TRANSFER_SUCCESS]: BaseEvent<TaskEvent.TRANSFER_SUCCESS> & {taskData?: TaskData};
   [TaskEvent.TRANSFER_FAILED]: BaseEvent<TaskEvent.TRANSFER_FAILED> & {
     reason?: string;
@@ -174,7 +177,7 @@ interface TaskEventPayloadMap {
   [TaskEvent.SWITCH_TO_MAIN_CALL]: BaseEvent<TaskEvent.SWITCH_TO_MAIN_CALL>;
   [TaskEvent.SWITCH_TO_CONSULT]: BaseEvent<TaskEvent.SWITCH_TO_CONSULT>;
   [TaskEvent.ACCEPT]: BaseEvent<TaskEvent.ACCEPT>;
-  [TaskEvent.DECLINE]: BaseEvent<TaskEvent.DECLINE>;
+  [TaskEvent.DECLINE]: BaseEvent<TaskEvent.DECLINE> & {taskData?: TaskData};
   [TaskEvent.END]: BaseEvent<TaskEvent.END> & {taskData?: TaskData};
   [TaskEvent.CTQ_CANCEL]: BaseEvent<TaskEvent.CTQ_CANCEL> & {taskData: TaskData};
   [TaskEvent.CTQ_CANCEL_FAILED]: BaseEvent<TaskEvent.CTQ_CANCEL_FAILED> & {taskData: TaskData};

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -76,7 +76,9 @@ function computeVoiceUIControls(
     interaction && mainCallId ? getConferenceParticipantsCount(interaction, mainCallId) : 0;
   const maxParticipants = participantCount >= MAX_PARTICIPANTS_IN_MULTIPARTY_CONFERENCE;
   const selfAgentId = config.agentId ?? taskData?.agentId;
-  const consultInProgress = getIsConsultInProgressForConferenceControls(
+
+  // Check backend for active consult legs
+  const consultInProgressFromBackend = getIsConsultInProgressForConferenceControls(
     interaction,
     mainCallId,
     selfAgentId
@@ -107,6 +109,10 @@ function computeVoiceUIControls(
   // Treat consult initiator as "in conference" even if mainCall participant list lags while consulting.
   const inConference = conferenceActive && (isConferencing || selfInMainCall || consultInitiator);
 
+  // Determine if a consult is actually in progress:
+  // Trust backend data - it correctly distinguishes between active and merged consult legs
+  const consultInProgress = consultInProgressFromBackend;
+
   // Check if this is a consulted agent (must be after isConsulting is computed).
   const isSoleAgentOnCall = participantCount <= 1 && !isConsulting && !inConference;
   const isConsulted =
@@ -128,11 +134,12 @@ function computeVoiceUIControls(
   const hasFullControls = !isConsulted || consultInitiator || inConference || isWrappingUp;
 
   return {
-    // Accept/Decline: WebRTC offered state only
+    // Accept/Decline: Voice tasks in offered state
     // For outdial, accept is disabled (auto-answer handles it), decline remains enabled
+    // For Extension mode (non-WebRTC), accept shows as disabled "Ringing" button
     accept:
-      isWebrtc && state === TaskState.OFFERED && !interaction?.isTerminated
-        ? {isVisible: true, isEnabled: !isOutdial}
+      state === TaskState.OFFERED && !interaction?.isTerminated
+        ? {isVisible: true, isEnabled: isWebrtc && !isOutdial}
         : DISABLED,
     decline:
       isWebrtc && state === TaskState.OFFERED && !interaction?.isTerminated
@@ -167,12 +174,15 @@ function computeVoiceUIControls(
       return DISABLED;
     })(),
 
-    // End: varies by state; during consulting only on main leg (consult held)
+    // End: varies by state; during consulting always disabled (must end consult or merge/transfer first)
     end: (() => {
       if (!config.isEndTaskEnabled) return DISABLED;
 
       if (isConsulting) {
-        return consultInitiator && consultCallHeld ? VISIBLE_ENABLED : DISABLED;
+        // Always show end button during consulting as disabled
+        // Can't end main call while consult is active - must end consult first or merge/transfer
+        if (!consultInitiator) return DISABLED;
+        return VISIBLE_DISABLED;
       }
 
       if (inConference) {
@@ -189,12 +199,12 @@ function computeVoiceUIControls(
     })(),
 
     // Transfer: connected/held, not in conference
+    // Hide completely during consulting (consultTransfer button used instead)
     transfer: (() => {
       if (!hasFullControls || inConference) return DISABLED;
       if (state === TaskState.CONNECTED || state === TaskState.HELD) return VISIBLE_ENABLED;
-      if (isConsulting && !conferenceFromBackend) {
-        return consultDestinationAgentJoined ? VISIBLE_ENABLED : VISIBLE_DISABLED;
-      }
+      // Hide blind transfer during consulting - consultTransfer button takes over
+      if (isConsulting) return DISABLED;
 
       return DISABLED;
     })(),
@@ -218,8 +228,16 @@ function computeVoiceUIControls(
       return {isVisible: true, isEnabled};
     })(),
 
-    // ConsultTransfer: always hidden (use transfer button)
-    consultTransfer: DISABLED,
+    // ConsultTransfer: visible during consulting for initiator
+    // Enabled only when on main call (consultCallHeld = true) and agent has joined
+    consultTransfer: (() => {
+      if (!hasFullControls || !isConsulting) return DISABLED;
+      // Only visible for consult initiator
+      if (!consultInitiator) return DISABLED;
+      // Can only transfer when on main call with customer (consult agent on hold)
+      const isEnabled = context.consultDestinationAgentJoined && consultCallHeld;
+      return {isVisible: true, isEnabled};
+    })(),
 
     // EndConsult: during consulting
     endConsult: (() => {
@@ -237,19 +255,22 @@ function computeVoiceUIControls(
       if (!recordingControlsAvailable || !config.isRecordingEnabled) return DISABLED;
       if (!hasFullControls || isConsulting || inConference) return DISABLED;
       if (state === TaskState.CONNECTED || state === TaskState.HELD) {
-        return recordingInProgress ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+        // Always enabled for voice calls to allow pause/resume from call start
+        return VISIBLE_ENABLED;
       }
 
       return DISABLED;
     })(),
 
-    // Conference: during consulting, enabled on both legs when agent joined
-    // Label changes based on leg: "Conference" on main leg, "Merge" on consult leg
+    // Conference: during consulting, enabled only when on main call
+    // Can only merge when on main call with customer (consult agent on hold)
     conference: (() => {
       if (!hasFullControls || !isConsulting) return DISABLED;
       if (!consultInitiator) return DISABLED;
 
-      return consultDestinationAgentJoined && !maxParticipants ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+      // Can only conference/merge when on main call with customer
+      const isEnabled = consultDestinationAgentJoined && consultCallHeld && !maxParticipants;
+      return isEnabled ? VISIBLE_ENABLED : VISIBLE_DISABLED;
     })(),
 
     // Wrapup: wrapping up state
@@ -272,11 +293,13 @@ function computeVoiceUIControls(
       return consultDestinationAgentJoined ? VISIBLE_ENABLED : VISIBLE_DISABLED;
     })(),
 
-    // MergeToConference: mirrors conference control, enabled on both legs
+    // MergeToConference: mirrors conference control, enabled only when on main call
     mergeToConference: (() => {
       if (!isConsulting || !consultInitiator) return DISABLED;
 
-      return consultDestinationAgentJoined && !maxParticipants ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+      // Can only merge when on main call with customer (consult agent on hold)
+      const isEnabled = consultDestinationAgentJoined && consultCallHeld && !maxParticipants;
+      return isEnabled ? VISIBLE_ENABLED : VISIBLE_DISABLED;
     })(),
 
     // SwitchToMainCall: consulting, on consult leg

--- a/packages/@webex/contact-center/src/services/task/types.ts
+++ b/packages/@webex/contact-center/src/services/task/types.ts
@@ -1521,6 +1521,22 @@ export type consultConferencePayloadData = {
  */
 export interface ITask extends EventEmitter {
   /**
+   * Registers a listener for the specified task event.
+   * @param event - A {@link TASK_EVENTS} value
+   * @param listener - Callback invoked when the event fires
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string, listener: (...args: any[]) => void): this;
+
+  /**
+   * Removes a previously registered listener for the specified task event.
+   * @param event - A {@link TASK_EVENTS} value
+   * @param listener - The same function reference passed to {@link on}
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  off(event: string, listener: (...args: any[]) => void): this;
+
+  /**
    * Event data received in the Contact Center events.
    * Contains detailed task information including interaction details, media resources,
    * and participant data as defined in {@link TaskData}

--- a/packages/@webex/contact-center/src/services/task/types.ts
+++ b/packages/@webex/contact-center/src/services/task/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-cycle */
 import EventEmitter from 'events';
 import type {AnyActorRef} from 'xstate';
-import {TaskEventPayload} from './state-machine';
+import {TaskEventPayload, TaskState} from './state-machine';
 import {Msg} from '../core/GlobalTypes';
 import AutoWrapup from './AutoWrapup';
 
@@ -1604,6 +1604,13 @@ export interface ITask extends EventEmitter {
    * @internal
    */
   sendStateMachineEvent: (event: TaskEventPayload) => void;
+
+  /**
+   * Returns the current state machine state.
+   * This is part of the migration to XState.
+   * @internal
+   */
+  getCurrentState(): TaskState | undefined;
 
   /**
    * Cancels the auto-wrapup timer for the task.

--- a/packages/@webex/contact-center/src/services/task/voice/Voice.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/Voice.ts
@@ -25,7 +25,7 @@ import Task from '../Task';
 import LoggerProxy from '../../../logger-proxy';
 import MetricsManager from '../../../metrics/MetricsManager';
 import {METRIC_EVENT_NAMES} from '../../../metrics/constants';
-import {TaskState, TaskEvent} from '../state-machine';
+import {TaskState, TaskEvent, TaskContext} from '../state-machine';
 import {WrapupData} from '../../config/types';
 import {getConsultMediaResourceId, getIsConferenceInProgress} from '../TaskUtils';
 
@@ -33,6 +33,7 @@ export default class Voice extends Task implements IVoice {
   // Cached consult destination — backend hold/unhold event payloads can clear
   private consultDestAgentId: string | null = null;
   private consultDestType: string | null = null;
+  private pendingEndConsultPayload: ConsultEndPayload | null = null;
 
   constructor(
     contact: ReturnType<typeof routingContact>,
@@ -574,8 +575,22 @@ export default class Voice extends Task implements IVoice {
         interactionId: this.data.interactionId,
       });
 
+      // Clear pending payload on success
+      this.pendingEndConsultPayload = null;
       return result;
     } catch (error) {
+      // Store payload for potential retry when CONSULTING_ACTIVE arrives
+      if (consultEndPayload) {
+        this.pendingEndConsultPayload = consultEndPayload;
+      }
+
+      // Send CONSULT_FAILED event to state machine before throwing
+      // This allows retry mechanism to trigger when CONSULTING_ACTIVE arrives
+      this.stateMachineService.send({
+        type: TaskEvent.CONSULT_FAILED,
+        reason: error.toString(),
+      });
+
       const {error: detailedError} = getErrorDetails(error, 'endConsult', CC_FILE);
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.TASK_CONSULT_END_FAILED,
@@ -617,8 +632,15 @@ export default class Voice extends Task implements IVoice {
         METRIC_EVENT_NAMES.TASK_TRANSFER_FAILED,
       ]);
 
-      // consult transfer path
-      if (this.data.interaction.state === 'consulting') {
+      // Dispatch TRANSFER event to state machine to set transferRequested flag
+      // This tracks that a transfer is in progress, used for dial number consult transfers
+      // where backend may send CONSULT_END before TRANSFER_SUCCESS
+      this.sendStateMachineEvent({type: TaskEvent.TRANSFER});
+
+      // consult transfer path - check state machine state, not backend interaction state
+      // State machine is the source of truth for whether we're in an active consult
+      const currentState = this.getCurrentState();
+      if (currentState === TaskState.CONSULTING) {
         let consultPayload: ConsultTransferPayLoad = {
           to: payload.to,
           destinationType: payload.destinationType,
@@ -1230,6 +1252,40 @@ export default class Voice extends Task implements IVoice {
       emitTaskOutdialFailed: this.createEmitSelfAction(TASK_EVENTS.TASK_OUTDIAL_FAILED, {
         updateTaskData: true,
       }),
+      // Override retry action to use stored payload with queueId
+      requestEndConsultRetry: ({context}: {context: TaskContext}) => {
+        if (context.pendingEndConsult && this.pendingEndConsultPayload) {
+          const payload = this.pendingEndConsultPayload;
+          LoggerProxy.info(`Retrying endConsult after CONSULTING_ACTIVE with stored payload`, {
+            module: CC_FILE,
+            method: 'requestEndConsultRetry',
+            interactionId: this.data?.interactionId,
+          });
+          setTimeout(() => {
+            this.endConsult(payload)
+              .then(() => {
+                LoggerProxy.info(`endConsult retry succeeded`, {
+                  module: CC_FILE,
+                  method: 'requestEndConsultRetry',
+                  interactionId: this.data?.interactionId,
+                });
+              })
+              .catch((error) => {
+                LoggerProxy.error(`endConsult retry failed: ${error.message}`, {
+                  module: CC_FILE,
+                  method: 'requestEndConsultRetry',
+                  interactionId: this.data?.interactionId,
+                });
+              });
+          }, 100);
+        }
+      },
+      // Force UI controls update after switch call events
+      // By the time this runs (after assign actions), snapshot should be updated
+      updateUIControlsAfterSwitch: () => {
+        // Force emit to ensure widget layer receives update
+        this.updateUiControls(true);
+      },
     };
   }
 }

--- a/packages/@webex/contact-center/src/services/task/voice/WebRTC.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/WebRTC.ts
@@ -10,6 +10,7 @@ import {
   VoiceUIControlOptions,
   VOICE_VARIANT,
 } from '../types';
+import {TaskEvent} from '../state-machine';
 import Voice from './Voice';
 import WebCallingService from '../../WebCallingService';
 import {WrapupData} from '../../config/types';
@@ -136,6 +137,9 @@ export default class WebRTC extends Voice implements IWebRTC {
 
       this.webCallingService.declineCall(this.data.interactionId);
       this.unregisterWebCallListeners();
+
+      // Send DECLINE event to state machine to transition to TERMINATED
+      this.sendStateMachineEvent({type: TaskEvent.DECLINE, taskData: this.data});
 
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.TASK_DECLINE_SUCCESS,

--- a/packages/@webex/contact-center/src/webex.js
+++ b/packages/@webex/contact-center/src/webex.js
@@ -10,6 +10,8 @@ import './index';
 
 import config from './webex-config';
 
+export * from './index';
+
 /**
  * Ensures global Buffer is defined, which is required for SDK functionality in some environments.
  * @ignore


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7779

## This pull request addresses

1. **Missing on()/off() type declarations on ITask interface**

As part of the task-refactor, the SDK's ITask interface extends Node's EventEmitter for on()/off() methods, but consumers like CC Widgets whose tsconfig.json restricts type resolution to "types": ["jest"] cannot resolve @types/node — resulting in TS2339: Property 'on'/'off' does not exist on type 'ITask' errors on every task.on() / task.off() call.

2. **Named exports unreachable from the SDK's main entry point**

The SDK's package.json maps "main" and "exports" to dist/webex.js, which only exported the Webex class as default. All named exports (TASK_EVENTS, getDefaultUIControls, AGENT_EVENTS, ContactCenter, etc.) were properly defined in dist/index.js but unreachable at runtime for consumers using import { TASK_EVENTS } from '@webex/contact-center'.

TypeScript compilation passed because types resolved from dist/types/index.d.ts, masking the fact that the runtime values were undefined. This caused the CC Widgets' addEventListeners() to crash silently on agent:dnRegistered, meaning no task event listeners (task:incoming, agent:stateChange, etc.) were ever registered — breaking incoming task rendering, modal popups, and RONA state updates.

## by making the following changes

**Fix 1: Self-contained ITask event methods**

- Added explicit on() and off() method declarations directly on the ITask interface, making it self-contained so consumers no longer depend on @types/node to resolve EventEmitter methods
- Used (...args: any[]) => void for the listener parameter to match Node's EventEmitter signature and avoid type narrowing issues with existing consumer callbacks

**Fix 2: Re-export named exports from webex.js**

- Added export * from './index' in src/webex.js so that all named exports from index.ts (enums, functions, classes, and constants) are forwarded through the main entry point (dist/webex.js)
- This ensures import { TASK_EVENTS, getDefaultUIControls, AGENT_EVENTS } from '@webex/contact-center' resolves correctly at runtime, not just at compile time

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
