### PR TITLE
fix(datachannel): checkpoint lobby token refresh and llm resubscribe …

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3761,10 +3761,12 @@ export default class Meeting extends StatelessWebexPlugin {
       }
       this.rtcMetrics?.sendNextMetrics();
 
-      this.ensureDefaultDatachannelTokenAfterAdmit().then((isTokenFetched) => {
-        if (isTokenFetched) {
-          this.updateLLMConnection();
-        }
+      this.ensureDefaultDatachannelTokenAfterAdmit().catch((error) => {
+        LoggerProxy.logger.warn(
+          `Meeting:index#setUpLocusInfoSelfListener --> failed post-admit token prefetch flow: ${
+            error?.message || String(error)
+          }`
+        );
       });
 
       this.updateLLMConnection();

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3734,9 +3734,8 @@ export default class Meeting extends StatelessWebexPlugin {
       });
       this.updateLLMConnection();
     });
-    this.locusInfo.on(LOCUSINFO.EVENTS.SELF_ADMITTED_GUEST, async (payload) => {
+    this.locusInfo.on(LOCUSINFO.EVENTS.SELF_ADMITTED_GUEST, (payload) => {
       this.stopKeepAlive();
-      await this.ensureDefaultDatachannelTokenAfterAdmit();
 
       if (payload) {
         Trigger.trigger(
@@ -3761,6 +3760,11 @@ export default class Meeting extends StatelessWebexPlugin {
         });
       }
       this.rtcMetrics?.sendNextMetrics();
+
+      this.ensureDefaultDatachannelTokenAfterAdmit().then(() => {
+        this.updateLLMConnection();
+      });
+
       this.updateLLMConnection();
     });
 
@@ -6376,16 +6380,16 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {Promise<void>}
    */
   private async ensureDefaultDatachannelTokenAfterAdmit(): Promise<void> {
-    // @ts-ignore
-    const datachannelToken = this.webex.internal.llm.getDatachannelToken();
-    // @ts-ignore
-    const isDataChannelTokenEnabled = await this.webex.internal.llm.isDataChannelTokenEnabled();
-
-    if (!isDataChannelTokenEnabled || datachannelToken) {
-      return;
-    }
-
     try {
+      // @ts-ignore
+      const datachannelToken = this.webex.internal.llm.getDatachannelToken();
+      // @ts-ignore
+      const isDataChannelTokenEnabled = await this.webex.internal.llm.isDataChannelTokenEnabled();
+
+      if (!isDataChannelTokenEnabled || datachannelToken) {
+        return;
+      }
+
       const response = await this.meetingRequest.fetchDatachannelToken({
         locusUrl: this.locusUrl,
         requestingParticipantId: this.members.selfId,

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3761,8 +3761,10 @@ export default class Meeting extends StatelessWebexPlugin {
       }
       this.rtcMetrics?.sendNextMetrics();
 
-      this.ensureDefaultDatachannelTokenAfterAdmit().then(() => {
-        this.updateLLMConnection();
+      this.ensureDefaultDatachannelTokenAfterAdmit().then((isTokenFetched) => {
+        if (isTokenFetched) {
+          this.updateLLMConnection();
+        }
       });
 
       this.updateLLMConnection();
@@ -6377,9 +6379,9 @@ export default class Meeting extends StatelessWebexPlugin {
   /**
    * Ensures default-session data channel token exists after lobby admission.
    * Some lobby users do not receive a token until they are admitted.
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>} true when a new token is fetched and cached
    */
-  private async ensureDefaultDatachannelTokenAfterAdmit(): Promise<void> {
+  private async ensureDefaultDatachannelTokenAfterAdmit(): Promise<boolean> {
     try {
       // @ts-ignore
       const datachannelToken = this.webex.internal.llm.getDatachannelToken();
@@ -6387,7 +6389,7 @@ export default class Meeting extends StatelessWebexPlugin {
       const isDataChannelTokenEnabled = await this.webex.internal.llm.isDataChannelTokenEnabled();
 
       if (!isDataChannelTokenEnabled || datachannelToken) {
-        return;
+        return false;
       }
 
       const response = await this.meetingRequest.fetchDatachannelToken({
@@ -6398,7 +6400,7 @@ export default class Meeting extends StatelessWebexPlugin {
       const fetchedDatachannelToken = response?.body?.datachannelToken;
 
       if (!fetchedDatachannelToken) {
-        return;
+        return false;
       }
 
       // @ts-ignore
@@ -6406,6 +6408,8 @@ export default class Meeting extends StatelessWebexPlugin {
         fetchedDatachannelToken,
         DataChannelTokenType.Default
       );
+
+      return true;
     } catch (error) {
       const msg = error?.message || String(error);
 
@@ -6413,6 +6417,8 @@ export default class Meeting extends StatelessWebexPlugin {
         `Meeting:index#ensureDefaultDatachannelTokenAfterAdmit --> failed to proactively fetch default data channel token after admit: ${msg}`,
         {statusCode: error?.statusCode}
       );
+
+      return false;
     }
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3735,6 +3735,7 @@ export default class Meeting extends StatelessWebexPlugin {
     });
     this.locusInfo.on(LOCUSINFO.EVENTS.SELF_ADMITTED_GUEST, async (payload) => {
       this.stopKeepAlive();
+      await this.ensureDefaultDatachannelTokenAfterAdmit();
 
       if (payload) {
         Trigger.trigger(
@@ -5960,6 +5961,30 @@ export default class Meeting extends StatelessWebexPlugin {
   }
 
   /**
+   * Restores LLM subchannel subscriptions after reconnect when captions are active.
+   * @returns {void}
+   */
+  private restoreLLMSubscriptionsIfNeeded(): void {
+    try {
+      // @ts-ignore
+      const isCaptionBoxOn = this.webex.internal.voicea?.getIsCaptionBoxOn?.();
+
+      if (!isCaptionBoxOn) {
+        return;
+      }
+
+      // @ts-ignore
+      this.webex.internal.voicea.updateSubchannelSubscriptions({subscribe: ['transcription']});
+    } catch (error) {
+      const msg = error?.message || String(error);
+
+      LoggerProxy.logger.warn(
+        `Meeting:index#restoreLLMSubscriptionsIfNeeded --> failed to restore subscriptions after LLM online: ${msg}`
+      );
+    }
+  }
+
+  /**
    * This is a callback for the LLM event that is triggered when it comes online
    * This method in turn will trigger an event to the developers that the LLM is connected
    * @private
@@ -5967,8 +5992,8 @@ export default class Meeting extends StatelessWebexPlugin {
    * @returns {null}
    */
   private handleLLMOnline = (): void => {
-    // @ts-ignore
-    this.webex.internal.llm.off('online', this.handleLLMOnline);
+    this.restoreLLMSubscriptionsIfNeeded();
+
     Trigger.trigger(
       this,
       {
@@ -6200,6 +6225,8 @@ export default class Meeting extends StatelessWebexPlugin {
         // @ts-ignore - config coming from registerPlugin
         if (this.config.enableAutomaticLLM) {
           // @ts-ignore
+          this.webex.internal.llm.off('online', this.handleLLMOnline);
+          // @ts-ignore
           this.webex.internal.llm.on('online', this.handleLLMOnline);
           this.updateLLMConnection()
             .catch((error) => {
@@ -6338,6 +6365,48 @@ export default class Meeting extends StatelessWebexPlugin {
       this.webex.internal.llm.setDatachannelToken(
         practiceSessionDatachannelToken,
         DataChannelTokenType.PracticeSession
+      );
+    }
+  }
+
+  /**
+   * Ensures default-session data channel token exists after lobby admission.
+   * Some lobby users do not receive a token until they are admitted.
+   * @returns {Promise<void>}
+   */
+  private async ensureDefaultDatachannelTokenAfterAdmit(): Promise<void> {
+    // @ts-ignore
+    const datachannelToken = this.webex.internal.llm.getDatachannelToken();
+    // @ts-ignore
+    const isDataChannelTokenEnabled = await this.webex.internal.llm.isDataChannelTokenEnabled();
+
+    if (!isDataChannelTokenEnabled || datachannelToken) {
+      return;
+    }
+
+    try {
+      const response = await this.meetingRequest.fetchDatachannelToken({
+        locusUrl: this.locusUrl,
+        requestingParticipantId: this.members.selfId,
+        isPracticeSession: false,
+      });
+      const fetchedDatachannelToken = response?.body?.datachannelToken;
+
+      if (!fetchedDatachannelToken) {
+        return;
+      }
+
+      // @ts-ignore
+      this.webex.internal.llm.setDatachannelToken(
+        fetchedDatachannelToken,
+        DataChannelTokenType.Default
+      );
+    } catch (error) {
+      const msg = error?.message || String(error);
+
+      LoggerProxy.logger.warn(
+        `Meeting:index#ensureDefaultDatachannelTokenAfterAdmit --> failed to proactively fetch default data channel token after admit: ${msg}`,
+        {statusCode: error?.statusCode}
       );
     }
   }

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -208,6 +208,9 @@ const Webinar = WebexPlugin.extend({
    * @returns {Promise}
    */
   async updatePSDataChannel() {
+    this._updatePSDataChannelSequence = (this._updatePSDataChannelSequence || 0) + 1;
+    const invocationSequence = this._updatePSDataChannelSequence;
+
     const meeting = this.webex.meetings.getMeetingByType(_ID_, this.meetingId);
     const isPracticeSession = meeting?.isJoined() && this.isJoinPracticeSessionDataChannel();
 
@@ -278,6 +281,23 @@ const Webinar = WebexPlugin.extend({
     }
 
     const refreshedPracticeSessionToken = await this.ensurePracticeSessionDatachannelToken(meeting);
+
+    const latestPracticeSessionDatachannelUrl = get(
+      meeting,
+      'locusInfo.info.practiceSessionDatachannelUrl'
+    );
+    const isStillPracticeSession = meeting?.isJoined() && this.isJoinPracticeSessionDataChannel();
+
+    // Skip stale invocations after async refresh to avoid reconnecting a session
+    // that was already updated/cleaned by a newer state transition.
+    if (
+      invocationSequence !== this._updatePSDataChannelSequence ||
+      !isStillPracticeSession ||
+      !latestPracticeSessionDatachannelUrl ||
+      latestPracticeSessionDatachannelUrl !== practiceSessionDatachannelUrl
+    ) {
+      return undefined;
+    }
 
     if (refreshedPracticeSessionToken) {
       practiceSessionDatachannelToken = refreshedPracticeSessionToken;

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -155,6 +155,54 @@ const Webinar = WebexPlugin.extend({
   },
 
   /**
+   * Ensures practice-session token exists before registering the practice LLM channel.
+   * @param {object} meeting
+   * @returns {Promise<string|undefined>}
+   */
+  async ensurePracticeSessionDatachannelToken(meeting) {
+    // @ts-ignore
+    const isDataChannelTokenEnabled = await this.webex.internal.llm.isDataChannelTokenEnabled();
+
+    if (!isDataChannelTokenEnabled) {
+      return undefined;
+    }
+
+    // @ts-ignore
+    const cachedToken = this.webex.internal.llm.getDatachannelToken(
+      DataChannelTokenType.PracticeSession
+    );
+
+    if (cachedToken) {
+      return cachedToken;
+    }
+
+    try {
+      const refreshResponse = await meeting.refreshDataChannelToken();
+      const {datachannelToken, dataChannelTokenType} = refreshResponse?.body ?? {};
+
+      if (!datachannelToken) {
+        return undefined;
+      }
+
+      // @ts-ignore
+      this.webex.internal.llm.setDatachannelToken(
+        datachannelToken,
+        dataChannelTokenType || DataChannelTokenType.PracticeSession
+      );
+
+      return datachannelToken;
+    } catch (error) {
+      LoggerProxy.logger.warn(
+        `Webinar:index#ensurePracticeSessionDatachannelToken --> failed to proactively refresh practice-session token: ${
+          error?.message || String(error)
+        }`
+      );
+
+      return undefined;
+    }
+  },
+
+  /**
    * Connects to low latency mercury and reconnects if the address has changed
    * It will also disconnect if called when the meeting has ended
    * @returns {Promise}
@@ -174,7 +222,7 @@ const Webinar = WebexPlugin.extend({
       meeting?.locusInfo || {};
 
     // @ts-ignore
-    const practiceSessionDatachannelToken = this.webex.internal.llm.getDatachannelToken(
+    let practiceSessionDatachannelToken = this.webex.internal.llm.getDatachannelToken(
       DataChannelTokenType.PracticeSession
     );
 
@@ -227,6 +275,12 @@ const Webinar = WebexPlugin.extend({
       // @ts-ignore - Fix type
       this.webex.internal.llm.off('online', this._pendingOnlineListener);
       this._pendingOnlineListener = null;
+    }
+
+    const refreshedPracticeSessionToken = await this.ensurePracticeSessionDatachannelToken(meeting);
+
+    if (refreshedPracticeSessionToken) {
+      practiceSessionDatachannelToken = refreshedPracticeSessionToken;
     }
 
     // @ts-ignore - Fix type

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -10417,17 +10417,21 @@ describe('plugin-meetings', () => {
           );
           done();
         });
-        it('listens to the self admitted guest event', async () => {
+        it('listens to the self admitted guest event without blocking on token prefetch', async () => {
           meeting.stopKeepAlive = sinon.stub();
           meeting.updateLLMConnection = sinon.stub();
-          meeting.ensureDefaultDatachannelTokenAfterAdmit = sinon.stub().resolves();
+          let resolvePrefetch;
+
+          meeting.ensureDefaultDatachannelTokenAfterAdmit = sinon
+            .stub()
+            .returns(new Promise((resolve) => {
+              resolvePrefetch = resolve;
+            }));
           meeting.rtcMetrics = {
             sendNextMetrics: sinon.stub(),
           };
 
           meeting.locusInfo.emit({function: 'test', file: 'test'}, 'SELF_ADMITTED_GUEST', test1);
-
-          await Promise.resolve();
 
           assert.calledOnceWithExactly(meeting.stopKeepAlive);
           assert.calledOnceWithExactly(meeting.ensureDefaultDatachannelTokenAfterAdmit);
@@ -10449,6 +10453,11 @@ describe('plugin-meetings', () => {
               correlation_id: meeting.correlationId,
             }
           );
+
+          resolvePrefetch();
+          await Promise.resolve();
+
+          assert.calledTwice(meeting.updateLLMConnection);
         });
 
         it('listens to the breakouts changed event', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -10454,10 +10454,10 @@ describe('plugin-meetings', () => {
             }
           );
 
-          resolvePrefetch();
+          resolvePrefetch(false);
           await Promise.resolve();
 
-          assert.calledTwice(meeting.updateLLMConnection);
+          assert.calledOnce(meeting.updateLLMConnection);
         });
 
         it('listens to the breakouts changed event', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1981,11 +1981,12 @@ describe('plugin-meetings', () => {
       describe('#handleLLMOnline', () => {
         beforeEach(() => {
           webex.internal.llm.off = sinon.stub();
+          webex.internal.voicea.getIsCaptionBoxOn = sinon.stub().returns(false);
+          webex.internal.voicea.updateSubchannelSubscriptions = sinon.stub();
         });
 
-        it('turns off llm online, emits transcription connected events', () => {
+        it('emits transcription connected events', () => {
           meeting.handleLLMOnline();
-          assert.calledOnceWithExactly(webex.internal.llm.off, 'online', meeting.handleLLMOnline);
           assert.calledWith(
             TriggerProxy.trigger,
             sinon.match.instanceOf(Meeting),
@@ -1995,6 +1996,24 @@ describe('plugin-meetings', () => {
             },
             EVENT_TRIGGERS.MEETING_TRANSCRIPTION_CONNECTED
           );
+        });
+
+        it('restores transcription subscription when caption intent is enabled', () => {
+          webex.internal.voicea.getIsCaptionBoxOn.returns(true);
+
+          meeting.handleLLMOnline();
+
+          assert.calledOnceWithExactly(webex.internal.voicea.updateSubchannelSubscriptions, {
+            subscribe: ['transcription'],
+          });
+        });
+
+        it('does not restore transcription subscription when caption intent is disabled', () => {
+          webex.internal.voicea.getIsCaptionBoxOn.returns(false);
+
+          meeting.handleLLMOnline();
+
+          assert.notCalled(webex.internal.voicea.updateSubchannelSubscriptions);
         });
       });
 
@@ -2015,6 +2034,7 @@ describe('plugin-meetings', () => {
         it('should have #join', () => {
           assert.exists(meeting.join);
         });
+
         beforeEach(() => {
           setCorrelationIdSpy = sinon.spy(meeting, 'setCorrelationId');
           meeting.setLocus = sinon.stub().returns(true);
@@ -2168,7 +2188,6 @@ describe('plugin-meetings', () => {
             await meeting.join().catch(() => {
               assert.calledOnce(MeetingUtil.joinMeeting);
 
-              // Assert that client.locus.join.response error event is not sent from this function, it is now emitted from MeetingUtil.joinMeeting
               assert.calledOnce(webex.internal.newMetrics.submitClientEvent);
               assert.calledWithMatch(webex.internal.newMetrics.submitClientEvent, {
                 name: 'client.call.initiated',
@@ -2200,6 +2219,7 @@ describe('plugin-meetings', () => {
             });
           });
         });
+
         describe('lmm, transcription & permissionTokenRefresh decoupling', () => {
           beforeEach(() => {
             sandbox.stub(MeetingUtil, 'joinMeeting').returns(Promise.resolve(joinMeetingResult));
@@ -2270,7 +2290,6 @@ describe('plugin-meetings', () => {
               const locusInfoParseStub = sinon.stub(meeting.locusInfo, 'parse');
               sinon.stub(meeting, 'isJoined').returns(true);
 
-              // Set up llm.on stub to capture the registered listener when updateLLMConnection is called
               let locusLLMEventListener;
               meeting.webex.internal.llm.on = sinon.stub().callsFake((eventName, callback) => {
                 if (eventName === 'event:locus.state_message') {
@@ -2279,16 +2298,12 @@ describe('plugin-meetings', () => {
               });
               meeting.webex.internal.llm.off = sinon.stub();
 
-              // we need the real meeting.updateLLMConnection not the mock
               meeting.updateLLMConnection.restore();
 
-              // Call updateLLMConnection to register the listener
               await meeting.updateLLMConnection();
 
-              // Verify the listener was registered and we captured it
               assert.isDefined(locusLLMEventListener, 'LLM event listener should be registered');
 
-              // Now trigger the event
               const eventData = {
                 eventType: 'locus.state_message',
                 stateElementsMessage: {
@@ -2308,13 +2323,10 @@ describe('plugin-meetings', () => {
               sinon.stub(meeting.webex.internal.llm, 'hasEverConnected').value(true);
               sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').resolves({});
 
-              // Restore the real updateLLMConnection
               meeting.updateLLMConnection.restore();
 
-              // Call updateLLMConnection to start the timer
               await meeting.updateLLMConnection();
 
-              // Fast forward time by 3 minutes
               fakeClock.tick(3 * 60 * 1000);
 
               assert.calledWith(
@@ -2339,18 +2351,14 @@ describe('plugin-meetings', () => {
                 .stub(meeting.webex.internal.llm, 'getDatachannelUrl')
                 .returns('https://datachannel1.example.com');
 
-              // Restore the real updateLLMConnection
               meeting.updateLLMConnection.restore();
 
-              // First, connect LLM and start the timer
               isJoinedStub.returns(true);
               meeting.webex.internal.llm.isConnected.returns(false);
               await meeting.updateLLMConnection();
 
-              // Verify timer was started
               assert.exists(meeting.llmHealthCheckTimer);
 
-              // Now simulate that we're no longer joined
               isJoinedStub.returns(false);
               meeting.webex.internal.llm.isConnected.returns(true);
 
@@ -2358,10 +2366,8 @@ describe('plugin-meetings', () => {
 
               assert.calledOnce(meeting.webex.internal.llm.disconnectLLM);
 
-              // Verify the timer was cleared (should be undefined)
               assert.isUndefined(meeting.llmHealthCheckTimer);
 
-              // Fast forward time to ensure no metric is sent
               Metrics.sendBehavioralMetric.resetHistory();
               fakeClock.tick(3 * 60 * 1000);
 
@@ -2396,7 +2402,6 @@ describe('plugin-meetings', () => {
                 .stub()
                 .rejects(new CaptchaError('bad captcha'));
               const stateMachineFailSpy = sinon.spy(meeting.meetingFiniteStateMachine, 'fail');
-              const joinMeetingOptionsSpy = sinon.spy(MeetingUtil, 'joinMeetingOptions');
 
               try {
                 await meeting.join();
@@ -2410,8 +2415,7 @@ describe('plugin-meetings', () => {
                 );
                 assert.instanceOf(error, CaptchaError);
                 assert.equal(error.message, 'bad captcha');
-                // should not get to the end promise chain, which does do the join
-                assert.notCalled(joinMeetingOptionsSpy);
+                assert.notCalled(MeetingUtil.joinMeeting);
               }
             });
 
@@ -2420,7 +2424,6 @@ describe('plugin-meetings', () => {
                 .stub()
                 .rejects(new PasswordError('bad password'));
               const stateMachineFailSpy = sinon.spy(meeting.meetingFiniteStateMachine, 'fail');
-              const joinMeetingOptionsSpy = sinon.spy(MeetingUtil.joinMeetingOptions);
 
               try {
                 await meeting.join();
@@ -2434,8 +2437,7 @@ describe('plugin-meetings', () => {
                 );
                 assert.instanceOf(error, PasswordError);
                 assert.equal(error.message, 'bad password');
-                // should not get to the end promise chain, which does do the join
-                assert.notCalled(joinMeetingOptionsSpy);
+                assert.notCalled(MeetingUtil.joinMeeting);
               }
             });
 
@@ -2444,7 +2446,6 @@ describe('plugin-meetings', () => {
                 .stub()
                 .rejects(new PermissionError('bad permission'));
               const stateMachineFailSpy = sinon.spy(meeting.meetingFiniteStateMachine, 'fail');
-              const joinMeetingOptionsSpy = sinon.spy(MeetingUtil.joinMeetingOptions);
 
               try {
                 await meeting.join();
@@ -2458,13 +2459,13 @@ describe('plugin-meetings', () => {
                 );
                 assert.instanceOf(error, PermissionError);
                 assert.equal(error.message, 'bad permission');
-                // should not get to the end promise chain, which does do the join
-                assert.notCalled(joinMeetingOptionsSpy);
+                assert.notCalled(MeetingUtil.joinMeeting);
               }
             });
           });
         });
       });
+
 
       describe('#addMedia', () => {
         const muteStateStub = {
@@ -10413,14 +10414,20 @@ describe('plugin-meetings', () => {
           );
           done();
         });
-        it('listens to the self admitted guest event', (done) => {
+        it('listens to the self admitted guest event', async () => {
           meeting.stopKeepAlive = sinon.stub();
           meeting.updateLLMConnection = sinon.stub();
+          meeting.ensureDefaultDatachannelTokenAfterAdmit = sinon.stub().resolves();
           meeting.rtcMetrics = {
             sendNextMetrics: sinon.stub(),
           };
+
           meeting.locusInfo.emit({function: 'test', file: 'test'}, 'SELF_ADMITTED_GUEST', test1);
+
+          await Promise.resolve();
+
           assert.calledOnceWithExactly(meeting.stopKeepAlive);
+          assert.calledOnceWithExactly(meeting.ensureDefaultDatachannelTokenAfterAdmit);
           assert.calledThrice(TriggerProxy.trigger);
           assert.calledWith(
             TriggerProxy.trigger,
@@ -10439,7 +10446,6 @@ describe('plugin-meetings', () => {
               correlation_id: meeting.correlationId,
             }
           );
-          done();
         });
 
         it('listens to the breakouts changed event', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -33,6 +33,7 @@ describe('plugin-meetings', () => {
       webex.internal.llm = {
         getDatachannelToken: sinon.stub().returns(undefined),
         setDatachannelToken: sinon.stub(),
+        isDataChannelTokenEnabled: sinon.stub().resolves(false),
         isConnected: sinon.stub().returns(false),
         disconnectLLM: sinon.stub().resolves(),
         off: sinon.stub(),
@@ -265,6 +266,37 @@ describe('plugin-meetings', () => {
         webinar.practiceSessionEnabled = true;
         webex.internal.voicea.getIsCaptionBoxOn = sinon.stub().returns(false);
         webex.internal.voicea.updateSubchannelSubscriptions = sinon.stub();
+      });
+
+      it('refreshes practice-session token before register when cached token is missing', async () => {
+        webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+        webex.internal.llm.getDatachannelToken = sinon.stub().callsFake((tokenType) => {
+          if (tokenType === DataChannelTokenType.PracticeSession) return undefined;
+
+          return undefined;
+        });
+        meeting.refreshDataChannelToken = sinon.stub().resolves({
+          body: {
+            datachannelToken: 'ps-token-from-refresh',
+            dataChannelTokenType: DataChannelTokenType.PracticeSession,
+          },
+        });
+
+        await webinar.updatePSDataChannel();
+
+        assert.calledOnceWithExactly(meeting.refreshDataChannelToken);
+        assert.calledWithExactly(
+          webex.internal.llm.setDatachannelToken,
+          'ps-token-from-refresh',
+          DataChannelTokenType.PracticeSession
+        );
+        assert.calledWith(
+          webex.internal.llm.registerAndConnect,
+          'locus-url',
+          'dc-url',
+          'ps-token-from-refresh',
+          LLM_PRACTICE_SESSION
+        );
       });
 
       it('no-ops when practice session join eligibility is false', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -299,6 +299,34 @@ describe('plugin-meetings', () => {
         );
       });
 
+      it('does not reconnect if practice-session eligibility changes during async token refresh', async () => {
+        webex.internal.llm.isDataChannelTokenEnabled.resolves(true);
+        webex.internal.llm.getDatachannelToken = sinon.stub().returns(undefined);
+
+        let resolveRefresh;
+        meeting.refreshDataChannelToken = sinon.stub().returns(
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          })
+        );
+
+        const updatePromise = webinar.updatePSDataChannel();
+
+        webinar.practiceSessionEnabled = false;
+
+        resolveRefresh({
+          body: {
+            datachannelToken: 'stale-ps-token',
+            dataChannelTokenType: DataChannelTokenType.PracticeSession,
+          },
+        });
+
+        const result = await updatePromise;
+
+        assert.isUndefined(result);
+        assert.notCalled(webex.internal.llm.registerAndConnect);
+      });
+
       it('no-ops when practice session join eligibility is false', async () => {
         webinar.practiceSessionEnabled = false;
         const cleanupPSDataChannelStub = sinon.stub(webinar, 'cleanupPSDataChannel').resolves();


### PR DESCRIPTION

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-763776

## by making the following changes

- Lobby admission
After being admitted from the lobby, the user must actively request and obtain the session token to connect to backend services.

- Practice session promotion
Attendees in a practice session do not receive PS tokens initially; when promoted to panelist they must actively request the PS token to gain panel access.

- Reconnect and resubscribe
On reconnect the client reestablishes the LLM connection and may need to resubscribe to previous channel

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
