### PR TITLE
feat(plugin-meetings): add getIngressPayloadTypeCallback

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -19,9 +19,11 @@ import {
   ConnectionState,
   Errors,
   ErrorType,
+  MediaCodecMimeType,
   MediaConnectionEventNames,
   MediaContent,
   MediaType,
+  MultistreamRoapMediaConnection,
   RemoteTrackType,
   RoapMessage,
   StatsAnalyzer,
@@ -969,6 +971,20 @@ export default class Meeting extends StatelessWebexPlugin {
      * Object containing helper classes for managing media requests for audio/video/screenshare (for multistream media connections)
      * All multistream media requests sent out for this meeting have to go through them.
      */
+    const getIngressPayloadTypeCallback = (
+      mediaType: MediaType,
+      codecMimeType: MediaCodecMimeType
+    ) => {
+      if (this.mediaProperties?.webrtcMediaConnection instanceof MultistreamRoapMediaConnection) {
+        return this.mediaProperties.webrtcMediaConnection.getIngressPayloadType(
+          mediaType,
+          codecMimeType
+        );
+      }
+
+      return undefined;
+    };
+
     this.mediaRequestManagers = {
       audio: new MediaRequestManager(
         (mediaRequests) => {
@@ -984,6 +1000,7 @@ export default class Meeting extends StatelessWebexPlugin {
             mediaRequests
           );
         },
+        getIngressPayloadTypeCallback,
         {
           // @ts-ignore - config coming from registerPlugin
           degradationPreferences: this.config.degradationPreferences,
@@ -1005,6 +1022,7 @@ export default class Meeting extends StatelessWebexPlugin {
             mediaRequests
           );
         },
+        getIngressPayloadTypeCallback,
         {
           // @ts-ignore - config coming from registerPlugin
           degradationPreferences: this.config.degradationPreferences,
@@ -1026,6 +1044,7 @@ export default class Meeting extends StatelessWebexPlugin {
             mediaRequests
           );
         },
+        getIngressPayloadTypeCallback,
         {
           // @ts-ignore - config coming from registerPlugin
           degradationPreferences: this.config.degradationPreferences,
@@ -1047,6 +1066,7 @@ export default class Meeting extends StatelessWebexPlugin {
             mediaRequests
           );
         },
+        getIngressPayloadTypeCallback,
         {
           // @ts-ignore - config coming from registerPlugin
           degradationPreferences: this.config.degradationPreferences,

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -987,6 +987,10 @@ export default class Meeting extends StatelessWebexPlugin {
       return undefined;
     };
 
+    /**
+     * Object containing helper classes for managing media requests for audio/video/screenshare (for multistream media connections)
+     * All multistream media requests sent out for this meeting have to go through them.
+     */
     this.mediaRequestManagers = {
       audio: new MediaRequestManager(
         (mediaRequests) => {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -977,7 +977,11 @@ export default class Meeting extends StatelessWebexPlugin {
       mediaType: MediaType,
       codecMimeType: MediaCodecMimeType
     ): number | undefined => {
-      if (this.mediaProperties?.webrtcMediaConnection instanceof MultistreamRoapMediaConnection) {
+      if (
+        this.mediaProperties?.webrtcMediaConnection instanceof MultistreamRoapMediaConnection &&
+        this.mediaProperties.webrtcMediaConnection.getConnectionState() ===
+          ConnectionState.Connected
+      ) {
         return this.mediaProperties.webrtcMediaConnection.getIngressPayloadType(
           mediaType,
           codecMimeType

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -968,13 +968,15 @@ export default class Meeting extends StatelessWebexPlugin {
       (csi: CSI) => (this.members.findMemberByCsi(csi) as any)?.id
     );
     /**
-     * Object containing helper classes for managing media requests for audio/video/screenshare (for multistream media connections)
-     * All multistream media requests sent out for this meeting have to go through them.
+     * Retrieves the ingress RTP payload type for a given media type and codec from the active multistream connection.
+     * @param {MediaType} mediaType - The media type to look up.
+     * @param {MediaCodecMimeType} codecMimeType - The codec MIME type to look up.
+     * @returns {number|undefined} The ingress payload type, or undefined if the connection is not multistream.
      */
     const getIngressPayloadTypeCallback = (
       mediaType: MediaType,
       codecMimeType: MediaCodecMimeType
-    ) => {
+    ): number | undefined => {
       if (this.mediaProperties?.webrtcMediaConnection instanceof MultistreamRoapMediaConnection) {
         return this.mediaProperties.webrtcMediaConnection.getIngressPayloadType(
           mediaType,

--- a/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/mediaRequestManager.ts
@@ -9,6 +9,8 @@ import {
   getRecommendedMaxBitrateForFrameSize,
   RecommendedOpusBitrates,
   NamedMediaGroup,
+  MediaType,
+  MediaCodecMimeType,
 } from '@webex/internal-media-core';
 import {cloneDeepWith, debounce} from 'lodash';
 
@@ -69,6 +71,10 @@ type DegradationPreferences = {
 };
 
 type SendMediaRequestsCallback = (streamRequests: StreamRequest[]) => void;
+type GetIngressPayloadTypeCallback = (
+  mediaType: MediaType,
+  codecMimeType: MediaCodecMimeType
+) => number;
 type Kind = 'audio' | 'video';
 
 type Options = {
@@ -81,6 +87,8 @@ type ClientRequestsMap = {[key: MediaRequestId]: MediaRequest};
 
 export class MediaRequestManager {
   private sendMediaRequestsCallback: SendMediaRequestsCallback;
+
+  private getIngressPayloadTypeCallback: GetIngressPayloadTypeCallback;
 
   private kind: Kind;
 
@@ -98,8 +106,13 @@ export class MediaRequestManager {
   private numTotalSources: number;
   private numLiveSources: number;
 
-  constructor(sendMediaRequestsCallback: SendMediaRequestsCallback, options: Options) {
+  constructor(
+    sendMediaRequestsCallback: SendMediaRequestsCallback,
+    getIngressPayloadTypeCallback: GetIngressPayloadTypeCallback,
+    options: Options
+  ) {
     this.sendMediaRequestsCallback = sendMediaRequestsCallback;
+    this.getIngressPayloadTypeCallback = getIngressPayloadTypeCallback;
     this.counter = 0;
     this.numLiveSources = 0;
     this.numTotalSources = 0;
@@ -316,7 +329,10 @@ export class MediaRequestManager {
             this.getMaxPayloadBitsPerSecond(mr),
             mr.codecInfo && [
               WcmeCodecInfo.fromH264(
-                0x80,
+                this.getIngressPayloadTypeCallback(
+                  mr.receiveSlots[0].mediaType,
+                  MediaCodecMimeType.H264
+                ),
                 new H264Codec(
                   mr.codecInfo.maxFs,
                   mr.codecInfo.maxFps || CODEC_DEFAULTS.h264.maxFps,

--- a/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/multistream/mediaRequestManager.ts
@@ -6,6 +6,7 @@ import {assert} from '@webex/test-helper-chai';
 import {getMaxFs, MAX_FS_VALUES} from '@webex/plugin-meetings/src/multistream/remoteMedia';
 import FakeTimers from '@sinonjs/fake-timers';
 import * as InternalMediaCoreModule from '@webex/internal-media-core';
+import {MediaType} from '@webex/internal-media-core';
 import { expect } from 'chai';
 
 type ExpectedActiveSpeaker = {
@@ -49,15 +50,18 @@ describe('MediaRequestManager', () => {
   const MAX_PAYLOADBITSPS_1080p = 4000000;
 
   const NUM_SLOTS = 15;
+  const FAKE_H264_PAYLOAD_TYPE = 0x80;  
 
   let mediaRequestManager: MediaRequestManager;
   let sendMediaRequestsCallback;
+  let getIngressPayloadTypeCallback;
   let fakeWcmeSlots;
   let fakeReceiveSlots;
 
   beforeEach(() => {
     sendMediaRequestsCallback = sinon.stub();
-    mediaRequestManager = new MediaRequestManager(sendMediaRequestsCallback, {
+    getIngressPayloadTypeCallback = sinon.stub().returns(FAKE_H264_PAYLOAD_TYPE);
+    mediaRequestManager = new MediaRequestManager(sendMediaRequestsCallback, getIngressPayloadTypeCallback, {
       degradationPreferences,
       kind: 'video',
       trimRequestsToNumOfSources: false,
@@ -79,6 +83,7 @@ describe('MediaRequestManager', () => {
             on: sinon.stub(),
             off: sinon.stub(),
             sourceState: 'live',
+            mediaType: MediaType.VideoMain,
             wcmeReceiveSlot: fakeWcmeSlots[index],
           } as unknown as ReceiveSlot)
       );
@@ -158,7 +163,7 @@ describe('MediaRequestManager', () => {
             codecInfos: isCodecInfoDefined
               ? [
                   sinon.match({
-                    payloadType: 0x80,
+                    payloadType: FAKE_H264_PAYLOAD_TYPE,
                     h264: sinon.match({
                       maxMbps: expectedRequest.maxMbps,
                       maxFs: expectedRequest.maxFs,
@@ -179,7 +184,7 @@ describe('MediaRequestManager', () => {
             codecInfos: isCodecInfoDefined
               ? [
                   sinon.match({
-                    payloadType: 0x80,
+                    payloadType: FAKE_H264_PAYLOAD_TYPE,
                     h264: sinon.match({
                       maxMbps: expectedRequest.maxMbps,
                       maxFs: expectedRequest.maxFs,
@@ -279,7 +284,7 @@ describe('MediaRequestManager', () => {
         maxPayloadBitsPerSecond: MAX_PAYLOADBITSPS_360p,
         codecInfos: [
           sinon.match({
-            payloadType: 0x80,
+            payloadType: FAKE_H264_PAYLOAD_TYPE,
             h264: sinon.match({
               maxFs: MAX_FS_360p,
               maxFps: MAX_FPS,
@@ -297,7 +302,7 @@ describe('MediaRequestManager', () => {
         maxPayloadBitsPerSecond: MAX_PAYLOADBITSPS_720p,
         codecInfos: [
           sinon.match({
-            payloadType: 0x80,
+            payloadType: FAKE_H264_PAYLOAD_TYPE,
             h264: sinon.match({
               maxFs: MAX_FS_720p,
               maxFps: MAX_FPS,
@@ -315,7 +320,7 @@ describe('MediaRequestManager', () => {
         maxPayloadBitsPerSecond: MAX_PAYLOADBITSPS_1080p,
         codecInfos: [
           sinon.match({
-            payloadType: 0x80,
+            payloadType: FAKE_H264_PAYLOAD_TYPE,
             h264: sinon.match({
               maxFs: MAX_FS_1080p,
               maxFps: MAX_FPS,
@@ -919,7 +924,7 @@ describe('MediaRequestManager', () => {
     });
 
     it('returns the default maxPayloadBitsPerSecond if kind is "audio"', () => {
-      const mediaRequestManagerAudio = new MediaRequestManager(sendMediaRequestsCallback, {
+      const mediaRequestManagerAudio = new MediaRequestManager(sendMediaRequestsCallback, getIngressPayloadTypeCallback, {
         degradationPreferences,
         kind: 'audio',
         trimRequestsToNumOfSources: false,
@@ -1037,7 +1042,7 @@ describe('MediaRequestManager', () => {
 
   describe('trimming of requested receive slots', () => {
     beforeEach(() => {
-      mediaRequestManager = new MediaRequestManager(sendMediaRequestsCallback, {
+      mediaRequestManager = new MediaRequestManager(sendMediaRequestsCallback, getIngressPayloadTypeCallback, {
         degradationPreferences,
         kind: 'video',
         trimRequestsToNumOfSources: true,


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-784312](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-784312)

## This pull request addresses

The `MediaRequestManager` was using a hardcoded RTP payload type value (`0x80`) when constructing H.264 codec info for media stream requests. This meant the payload type did not reflect the actual negotiated ingress payload type from the underlying `MultistreamRoapMediaConnection`, which could lead to incorrect codec signaling.

## by making the following changes

- Added a `getIngressPayloadTypeCallback` in the `Meeting` constructor that queries the `MultistreamRoapMediaConnection` for the actual ingress RTP payload type given a `MediaType` and `MediaCodecMimeType`. Returns `undefined` if the connection is not a `MultistreamRoapMediaConnection`.
- Updated `MediaRequestManager` to accept `getIngressPayloadTypeCallback` as a constructor parameter (dependency injection), replacing the hardcoded `0x80` value in `sendRequests()` with a dynamic call to the callback.
- Passed the callback to all four `MediaRequestManager` instances (audio, video, screenShareVideo, screenShareAudio) created in the `Meeting` constructor.
- Added unit tests in `mediaRequestManager.ts` to verify the callback is invoked with the correct `mediaType` and `codecMimeType`, and that the returned payload type is used in the outgoing `StreamRequest` codec info.

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Verified all existing `MediaRequestManager` unit tests continue to pass (all checkmarks across active-speaker, receiver-selected, trimming, degradation, maxPayloadBitsPerSecond, and maxMbps test suites).
- Verified the `getIngressPayloadTypeCallback` is called with the correct `mediaType` (from the first receive slot) and `MediaCodecMimeType.H264` when `sendRequests()` is invoked.
- Verified the payload type returned by the callback is correctly used in the `codecInfos` of the outgoing `StreamRequest`.
- Verified the callback works with different `mediaType` values (e.g., `VideoMain`, `AudioMain`).
- Verified `createMediaConnection` tests in `media/index.ts` continue to pass without regressions.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [x] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.