### PR TITLE
fix(meetings): incorrect handling of control update in API responses

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -450,7 +450,7 @@ class HashTreeParser {
     // object mapping dataset names to arrays of leaf data
     const leafInfo: Record<string, Array<LeafInfo>> = {};
 
-    const findAndStoreMetaData = (currentLocusPart: any) => {
+    const findAndStoreMetaData = (currentLocusPart: any, currentLocusPartName: string) => {
       if (typeof currentLocusPart !== 'object' || currentLocusPart === null) {
         return;
       }
@@ -465,10 +465,18 @@ class HashTreeParser {
         };
 
         if (copyData) {
-          newLeafInfo.data = cloneDeep(currentLocusPart);
+          if ((type as string).toLowerCase() === ObjectType.control) {
+            // control entries require special handling, because they are signalled by Locus
+            // differently when coming in messages vs API responses
+            newLeafInfo.data = {
+              [currentLocusPartName]: cloneDeep(currentLocusPart),
+            };
+          } else {
+            newLeafInfo.data = cloneDeep(currentLocusPart);
 
-          // remove any nested other objects that have their own htMeta
-          deleteNestedObjectsWithHtMeta(newLeafInfo.data);
+            // remove any nested other objects that have their own htMeta
+            deleteNestedObjectsWithHtMeta(newLeafInfo.data);
+          }
         }
 
         for (const dataSetName of dataSetNames) {
@@ -480,19 +488,19 @@ class HashTreeParser {
       }
 
       if (Array.isArray(currentLocusPart)) {
-        for (const item of currentLocusPart) {
-          findAndStoreMetaData(item);
+        for (const [index, item] of currentLocusPart.entries()) {
+          findAndStoreMetaData(item, index.toString());
         }
       } else {
         for (const key of Object.keys(currentLocusPart)) {
           if (Object.prototype.hasOwnProperty.call(currentLocusPart, key)) {
-            findAndStoreMetaData(currentLocusPart[key]);
+            findAndStoreMetaData(currentLocusPart[key], key);
           }
         }
       }
     };
 
-    findAndStoreMetaData(locus);
+    findAndStoreMetaData(locus, 'locus');
 
     return leafInfo;
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -861,6 +861,116 @@ describe('HashTreeParser', () => {
       });
     });
 
+    it('handles updates to control entries correctly', () => {
+      const parser = createHashTreeParser();
+
+      const mainPutItemsSpy = sinon.spy(parser.dataSets.main.hashTree, 'putItems');
+
+      // Create a locus update with new htMeta information for some things
+      const locusUpdate = {
+        dataSets: [
+          createDataSet('main', 16, 1100),
+        ],
+        locus: {
+          url: 'https://locus-a.wbx2.com/locus/api/v1/loci/97d64a5f',
+          htMeta: {
+            elementId: {
+              type: 'locus',
+              id: 0,
+              version: 200, // same version
+            },
+            dataSetNames: ['main'],
+          },
+          participants: [],
+          controls: {
+            lock: {
+              locked: true,
+              htMeta: {
+                elementId: {
+                  type: 'ControlEntry',
+                  id: 10100,
+                  version: 100,
+                },
+                dataSetNames: ['main'],
+              },
+            },
+            stream: {
+              streaming: true,
+              htMeta: {
+                elementId: {
+                  type: 'ControlEntry',
+                  id: 10101,
+                  version: 100,
+                },
+                dataSetNames: ['main'],
+              },
+            } 
+          }
+        },
+      };
+
+      // Call handleLocusUpdate
+      parser.handleLocusUpdate(locusUpdate);
+
+      // Verify putItems was called on main hash tree with correct data
+      assert.calledOnceWithExactly(mainPutItemsSpy, [
+        {type: 'locus', id: 0, version: 200},
+        {type: 'ControlEntry', id: 10100, version: 100},
+        {type: 'ControlEntry', id: 10101, version: 100}
+      ]);
+
+      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+        updatedObjects: [
+          {
+            htMeta: {
+              elementId: {
+                type: 'ControlEntry',
+                id: 10100,
+                version: 100,
+              },
+              dataSetNames: ['main'],
+            },
+            data: {
+              lock: {
+                locked: true,
+                htMeta: {
+                  elementId: {
+                    type: 'ControlEntry',
+                    id: 10100,
+                    version: 100,
+                  },
+                  dataSetNames: ['main'],
+                },
+              },
+            },
+          },
+          {
+            htMeta: {
+              elementId: {
+                type: 'ControlEntry',
+                id: 10101,
+                version: 100,
+              },
+              dataSetNames: ['main'],
+            },
+            data: {
+              stream: {
+                streaming: true,
+                htMeta: {
+                  elementId: {
+                    type: 'ControlEntry',
+                    id: 10101,
+                    version: 100,
+                  },
+                  dataSetNames: ['main'],
+                },
+              },
+            },
+          }
+        ],
+      });
+    });
+
     it('handles unknown datasets gracefully', () => {
       const parser = createHashTreeParser();
 


### PR DESCRIPTION
# COMPLETES #[SPARK-794239](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-794239)

## This pull request addresses
Locus sends updates for control entries in an inconsistent way. When they come in messages, the htMeta field is at the same level as the control entry key, while in API responses it is 1 level below.
For example:
locked status update in a message contains an entry like this in locusStateElements array:
```
{
    "htMeta": {
        "elementId": {
            "type": "ControlEntry",
            "id": 5085,
            "version": 139944494926500
        },
        "dataSetNames": [
            "main"
        ]
    },
    "data": {
        "lock": {    <------------ lock is here, so htMeta is not inside it, but outside
            "locked": true,
            "lockReason": "hostInitiate",
            "meta": {
                ...
            },                            
        }
    }
},
```
while in the API responses, the entry for lock status inside locus.controls looks like this:
```
lock: {
    "locked": false,
    "meta": {
        "lastModified": "2026-04-02T18:18:14.035Z"
    },
    "htMeta": {   <------------- htMeta is inside "lock"
        "elementId": {
            "type": "ControlEntry",
            "id": 5085,
            "version": 139944466940350
        },
        "dataSetNames": [
            "main"
        ]
    }
}
```
so when parsing API response, we need to keep track of the name of the parent prop and create the data object so that it contains that parent prop as the top level key.


## by making the following changes
updated the code for parsing hash tree api responses.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests, manual e2e test with web app on convergedats

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
