### PR TITLE
feat(contact-center): add desktopProfileFilter to auxiliary-code endpoint

### DIFF
--- a/packages/@webex/contact-center/src/services/config/constants.ts
+++ b/packages/@webex/contact-center/src/services/config/constants.ts
@@ -166,7 +166,7 @@ export const endPointMap = {
   ) =>
     `organization/${orgId}/v2/auxiliary-code?page=${page}&pageSize=${pageSize}${
       filter && filter.length > 0 ? `&filter=id=in=(${filter})` : ''
-    }&attributes=${attributes}`,
+    }&attributes=${attributes}&desktopProfileFilter=true`,
 
   /**
    * Gets the endpoint for organization info.

--- a/packages/@webex/contact-center/test/unit/spec/services/config/index.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/config/index.ts
@@ -260,7 +260,7 @@ describe('AgentConfigService', () => {
 
       expect(mockWebexRequest.request).toHaveBeenCalledWith({
         service: mockWccAPIURL,
-        resource: `organization/${mockOrgId}/v2/auxiliary-code?page=${page}&pageSize=${pageSize}&filter=id=in=(${filter})&attributes=${attributes}`,
+        resource: `organization/${mockOrgId}/v2/auxiliary-code?page=${page}&pageSize=${pageSize}&filter=id=in=(${filter})&attributes=${attributes}&desktopProfileFilter=true`,
         method: 'GET',
       });
       expect(result).toEqual(mockResponse.body);


### PR DESCRIPTION
# COMPLETES # https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7807

## This pull request addresses

The need to filter auxiliary codes based on desktop profile settings when fetching auxiliary code data from the organization endpoint.

## by making the following changes

- Added `desktopProfileFilter=true` query parameter to the `listAuxCodes` endpoint in `packages/@webex/contact-center/src/services/config/constants.ts`
- Updated corresponding test expectations in `packages/@webex/contact-center/test/unit/spec/services/config/index.ts`

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

### Manual Testing
- Verified auxiliary code endpoint includes the new query parameter
- Confirmed desktop profile filtering works as expected
- Video demonstration: https://app.vidcast.io/share/408b91ee-790e-4162-b87a-2a9e15fe4523

### Automated Testing
- ✅ All existing unit tests pass
- ✅ Updated test expectations to match new endpoint format

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code
- [x] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)