### PR TITLE
fix(meetings): HashTreeParser has timers running after a meeting is destroyed

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -284,7 +284,8 @@ export const prepareDiagnosticMetricItem = (webex: any, item: any) => {
         devicePairingType: webex.devicemanager.getPairedMethod(),
         deviceURL: pairedDevice.url,
         isPersonalDevice: pairedDevice.mode === 'personal',
-        productName: pairedDevice.devices[0]?.productName,
+        productName:
+          pairedDevice.devices?.length > 0 ? pairedDevice.devices[0]?.productName : undefined,
       };
       item.eventPayload.event.pairingState = 'paired';
       item.eventPayload.event.pairedDevice = devicePayload;

--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -1461,6 +1461,16 @@ class HashTreeParser {
   }
 
   /**
+   * Cleans up the HashTreeParser, stopping all timers and clearing all internal state.
+   * After calling this, the parser should not be used anymore.
+   * @returns {void}
+   */
+  public cleanUp() {
+    this.stop();
+    this.dataSets = {};
+  }
+
+  /**
    * Resumes the HashTreeParser that was previously stopped.
    * @param {HashTreeMessage} message - The message to resume with, it must contain metadata with visible data sets info
    * @returns {void}

--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -269,7 +269,7 @@ class HashTreeParser {
   private sendInitializationSyncRequestToLocus(
     datasetName: string,
     debugText: string
-  ): Promise<{updateType: LocusInfoUpdateType; updatedObjects?: HashTreeObject[]}> {
+  ): Promise<LocusInfoUpdate> {
     const dataset = this.dataSets[datasetName];
 
     if (!dataset) {

--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -57,10 +57,15 @@ export const LocusInfoUpdateType = {
 } as const;
 
 export type LocusInfoUpdateType = Enum<typeof LocusInfoUpdateType>;
-export type LocusInfoUpdateCallback = (
-  updateType: LocusInfoUpdateType,
-  data?: {updatedObjects: HashTreeObject[]}
-) => void;
+export type LocusInfoUpdate =
+  | {
+      updateType: typeof LocusInfoUpdateType.OBJECTS_UPDATED;
+      updatedObjects: HashTreeObject[];
+    }
+  | {
+      updateType: typeof LocusInfoUpdateType.MEETING_ENDED;
+    };
+export type LocusInfoUpdateCallback = (update: LocusInfoUpdate) => void;
 
 interface LeafInfo {
   type: ObjectType;
@@ -227,7 +232,7 @@ class HashTreeParser {
   private initializeNewVisibleDataSet(
     visibleDataSetInfo: VisibleDataSetInfo,
     dataSetInfo: DataSet
-  ): Promise<{updateType: LocusInfoUpdateType; updatedObjects?: HashTreeObject[]}> {
+  ): Promise<LocusInfoUpdate> {
     if (this.isVisibleDataSet(dataSetInfo.name)) {
       LoggerProxy.logger.info(
         `HashTreeParser#initializeNewVisibleDataSet --> ${this.debugId} Data set "${dataSetInfo.name}" already exists, skipping init`
@@ -272,7 +277,7 @@ class HashTreeParser {
         `HashTreeParser#sendInitializationSyncRequestToLocus --> ${this.debugId} No data set found for ${datasetName}, cannot send the request for leaf data`
       );
 
-      return Promise.resolve(null);
+      return Promise.resolve({updateType: LocusInfoUpdateType.OBJECTS_UPDATED, updatedObjects: []});
     }
 
     const emptyLeavesData = new Array(dataset.leafCount).fill([]);
@@ -1015,7 +1020,7 @@ class HashTreeParser {
 
     // when we detect new visible datasets, it may be that the metadata about them is not
     // available in the message, they will require separate async initialization
-    let dataSetsRequiringInitialization = [];
+    let dataSetsRequiringInitialization: VisibleDataSetInfo[] = [];
 
     // first find out if there are any visible data set changes - they're signalled in Metadata object updates
     const metadataUpdates = (message.locusStateElements || []).filter((object) =>
@@ -1023,7 +1028,7 @@ class HashTreeParser {
     );
 
     if (metadataUpdates.length > 0) {
-      const updatedMetadataObjects = [];
+      const updatedMetadataObjects: HashTreeObject[] = [];
 
       metadataUpdates.forEach((object) => {
         // todo: once Locus supports it, we will use the "view" field here instead of dataSetNames
@@ -1052,7 +1057,7 @@ class HashTreeParser {
       }
     }
 
-    if (message.locusStateElements?.length > 0) {
+    if (message.locusStateElements && message.locusStateElements.length > 0) {
       // by this point we now have this.dataSets setup for data sets from this message
       // and hash trees created for the new visible data sets,
       // so we can now process all the updates from the message
@@ -1148,20 +1153,17 @@ class HashTreeParser {
    * @param {Object} updates parsed from a Locus message
    * @returns {void}
    */
-  private callLocusInfoUpdateCallback(updates: {
-    updateType: LocusInfoUpdateType;
-    updatedObjects?: HashTreeObject[];
-  }) {
+  private callLocusInfoUpdateCallback(updates: LocusInfoUpdate) {
     if (this.state === 'stopped') {
       return;
     }
 
-    const {updateType, updatedObjects} = updates;
+    const {updateType} = updates;
 
-    if (updateType === LocusInfoUpdateType.OBJECTS_UPDATED && updatedObjects?.length > 0) {
+    if (updateType === LocusInfoUpdateType.OBJECTS_UPDATED && updates.updatedObjects?.length > 0) {
       // Filter out updates for objects that already have a higher version in their datasets,
       // or removals for objects that still exist in any of their datasets
-      const filteredUpdates = updatedObjects.filter((object) => {
+      const filteredUpdates = updates.updatedObjects.filter((object) => {
         const {elementId} = object.htMeta;
         const {type, id, version} = elementId;
 
@@ -1198,10 +1200,10 @@ class HashTreeParser {
       });
 
       if (filteredUpdates.length > 0) {
-        this.locusInfoUpdateCallback(updateType, {updatedObjects: filteredUpdates});
+        this.locusInfoUpdateCallback({updateType, updatedObjects: filteredUpdates});
       }
     } else if (updateType !== LocusInfoUpdateType.OBJECTS_UPDATED) {
-      this.locusInfoUpdateCallback(updateType, {updatedObjects});
+      this.locusInfoUpdateCallback({updateType});
     }
   }
 
@@ -1592,15 +1594,20 @@ class HashTreeParser {
     );
 
     const url = `${dataSet.url}/sync`;
-    const body = {
+    const body: {
+      leafCount: number;
+      leafDataEntries: {leafIndex: number; elementIds: LeafDataItem[]}[];
+    } = {
       leafCount: dataSet.leafCount,
       leafDataEntries: [],
     };
 
     Object.keys(mismatchedLeavesData).forEach((index) => {
+      const leafIndex = parseInt(index, 10);
+
       body.leafDataEntries.push({
-        leafIndex: parseInt(index, 10),
-        elementIds: mismatchedLeavesData[index],
+        leafIndex,
+        elementIds: mismatchedLeavesData[leafIndex],
       });
     });
 

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -34,6 +34,7 @@ import BEHAVIORAL_METRICS from '../metrics/constants';
 import HashTreeParser, {
   DataSet,
   HashTreeMessage,
+  LocusInfoUpdate,
   LocusInfoUpdateType,
   Metadata,
 } from '../hashTree/hashTreeParser';
@@ -545,7 +546,7 @@ export default class LocusInfo extends EventsScope {
       dataSets: Array<DataSet>;
       locus: any;
     };
-    metadata: Metadata;
+    metadata: Metadata | null;
     replacedAt?: string;
   }): HashTreeParser {
     const parser = new HashTreeParser({
@@ -553,7 +554,7 @@ export default class LocusInfo extends EventsScope {
       metadata,
       webexRequest: this.webex.request.bind(this.webex),
       locusInfoUpdateCallback: this.updateFromHashTree.bind(this, locusUrl),
-      debugId: `HT-${locusUrl.split('/').pop().substring(0, 4)}`,
+      debugId: `HT-${locusUrl.split('/')?.pop()?.substring(0, 4)}`,
       excludedDataSets: this.webex.config.meetings.locus?.excludedDataSets,
     });
 
@@ -656,7 +657,7 @@ export default class LocusInfo extends EventsScope {
           );
           // first create the HashTreeParser, but don't initialize it with any data yet
           const hashTreeParser = this.createHashTreeParser({
-            locusUrl: data.locus.url,
+            locusUrl: data.locus.url as string,
             initialLocus: {
               locus: null,
               dataSets: [], // empty, because we don't have them yet
@@ -965,7 +966,7 @@ export default class LocusInfo extends EventsScope {
       // but it's buried inside the message, we need to find it and pass it to HashTreeParser constructor
       const metadata = message.locusStateElements?.find((el) => isMetadata(el));
 
-      if (metadata?.data?.visibleDataSets?.length > 0) {
+      if (metadata && metadata.data?.visibleDataSets?.length > 0) {
         LoggerProxy.logger.info(
           `Locus-info:index#handleHashTreeParserSwitch --> no hash tree parser found for locusUrl ${message.locusUrl}, creating a new one`
         );
@@ -1056,7 +1057,10 @@ export default class LocusInfo extends EventsScope {
 
     const entry = this.hashTreeParsers.get(message.locusUrl);
 
-    entry.parser.handleMessage(message);
+    // the check is just for typescript, the case of no entry in hashTreeParsers is handled in handleHashTreeParserSwitch() above
+    if (entry) {
+      entry.parser.handleMessage(message);
+    }
   }
 
   /**
@@ -1064,16 +1068,11 @@ export default class LocusInfo extends EventsScope {
    * Updates our locus info based on the data parsed by the hash tree parser.
    *
    * @param {string} locusUrl - the locus URL for which the update is received
-   * @param {LocusInfoUpdateType} updateType - The type of update received.
-   * @param {Object} [data] - Additional data for the update, if applicable.
+   * @param {LocusInfoUpdate} update - Details about the update.
    * @returns {void}
    */
-  private updateFromHashTree(
-    locusUrl: string,
-    updateType: LocusInfoUpdateType,
-    data?: {updatedObjects: HashTreeObject[]}
-  ) {
-    switch (updateType) {
+  private updateFromHashTree(locusUrl: string, update: LocusInfoUpdate) {
+    switch (update.updateType) {
       case LocusInfoUpdateType.OBJECTS_UPDATED: {
         // initialize our new locus
         let locus: LocusDTO = {
@@ -1087,7 +1086,7 @@ export default class LocusInfo extends EventsScope {
         // first go over all the updates and check what happens with the main locus object
         let locusObjectStateAfterUpdates: LocusObjectStateAfterUpdates =
           LocusObjectStateAfterUpdates.unchanged;
-        data.updatedObjects.forEach((object) => {
+        update.updatedObjects.forEach((object) => {
           if (object.htMeta.elementId.type.toLowerCase() === ObjectType.locus) {
             if (locusObjectStateAfterUpdates === LocusObjectStateAfterUpdates.updated) {
               // this code doesn't supported it right now,
@@ -1116,6 +1115,14 @@ export default class LocusInfo extends EventsScope {
 
         const hashTreeParserEntry = this.hashTreeParsers.get(locusUrl);
 
+        if (!hashTreeParserEntry) {
+          LoggerProxy.logger.warn(
+            `Locus-info:index#updateFromHashTree --> no HashTreeParser found for locusUrl ${locusUrl} when trying to apply updates from hash tree`
+          );
+
+          return;
+        }
+
         if (!hashTreeParserEntry.initializedFromHashTree) {
           // this is the first time we're getting an update for this locusUrl,
           // so it's probably a move to/from breakout. We need to start from a clean state,
@@ -1124,7 +1131,8 @@ export default class LocusInfo extends EventsScope {
             `Locus-info:index#updateFromHashTree --> first INITIAL update for locusUrl ${locusUrl}, starting from empty state`
           );
           hashTreeParserEntry.initializedFromHashTree = true;
-          locus.jsSdkMeta.forceReplaceMembers = true;
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          locus.jsSdkMeta!.forceReplaceMembers = true;
         } else if (
           // if Locus object is unchanged or removed, we need to keep using the existing locus
           // because the rest of the locusInfo code expects locus to always be present (with at least some of the fields)
@@ -1137,7 +1145,7 @@ export default class LocusInfo extends EventsScope {
           // copy over all of existing locus except participants
           LocusDtoTopLevelKeys.forEach((key) => {
             if (key !== 'participants') {
-              locus[key] = cloneDeep(this[key]);
+              (locus as Record<string, any>)[key] = cloneDeep((this as Record<string, any>)[key]);
             }
           });
         } else {
@@ -1145,14 +1153,16 @@ export default class LocusInfo extends EventsScope {
           // (except participants, which need to stay empty - that means "no participant changes")
           Object.values(ObjectTypeToLocusKeyMap).forEach((locusDtoKey) => {
             if (locusDtoKey !== 'participants') {
-              locus[locusDtoKey] = cloneDeep(this[locusDtoKey]);
+              (locus as Record<string, any>)[locusDtoKey] = cloneDeep(
+                (this as Record<string, any>)[locusDtoKey]
+              );
             }
           });
         }
 
         LoggerProxy.logger.info(
           `Locus-info:index#updateFromHashTree --> LOCUS object is ${locusObjectStateAfterUpdates}, all updates: ${JSON.stringify(
-            data.updatedObjects.map((o) => ({
+            update.updatedObjects.map((o) => ({
               type: o.htMeta.elementId.type,
               id: o.htMeta.elementId.id,
               hasData: !!o.data,
@@ -1160,7 +1170,7 @@ export default class LocusInfo extends EventsScope {
           )}`
         );
         // now apply all the updates from the hash tree onto the locus
-        data.updatedObjects.forEach((object) => {
+        update.updatedObjects.forEach((object) => {
           locus = this.updateLocusFromHashTreeObject(object, locus);
         });
 
@@ -1260,16 +1270,16 @@ export default class LocusInfo extends EventsScope {
    * @param {string} debugText string explaining the trigger for this call, added to logs for debugging purposes
    * @param {object} locus locus object
    * @param {object} metadata locus hash trees metadata
-   * @param {string} eventType locus event
    * @param {DataSet[]} dataSets
+   * @param {string} eventType locus event
    * @returns {void}
    */
   private onFullLocusWithHashTrees(
     debugText: string,
     locus: any,
     metadata: Metadata,
-    eventType?: string,
-    dataSets?: Array<DataSet>
+    dataSets: Array<DataSet>,
+    eventType?: string
   ) {
     if (!this.hashTreeParsers.has(locus.url)) {
       LoggerProxy.logger.info(
@@ -1289,7 +1299,8 @@ export default class LocusInfo extends EventsScope {
         metadata,
       });
       // we have a full locus to start with, so we consider Locus info to be "initialized"
-      this.hashTreeParsers.get(locus.url).initializedFromHashTree = true;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.hashTreeParsers.get(locus.url)!.initializedFromHashTree = true;
       this.onFullLocusCommon(locus, eventType);
     } else {
       // in this case the Locus we're getting is not necessarily the full one
@@ -1351,7 +1362,7 @@ export default class LocusInfo extends EventsScope {
         );
       }
       // this is the new hashmap Locus DTO format (only applicable to webinars for now)
-      this.onFullLocusWithHashTrees(debugText, locus, metadata, eventType, dataSets);
+      this.onFullLocusWithHashTrees(debugText, locus, metadata, dataSets, eventType);
     } else {
       this.onFullLocusClassic(debugText, locus, eventType);
     }

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -2870,4 +2870,17 @@ export default class LocusInfo extends EventsScope {
   clearMainSessionLocusCache() {
     this.mainSessionLocusCache = null;
   }
+
+  /**
+   * Cleans up all hash tree parsers and clears internal maps.
+   * @returns {void}
+   * @memberof LocusInfo
+   */
+  cleanUp() {
+    this.hashTreeParsers.forEach((entry) => {
+      entry.parser.cleanUp();
+    });
+    this.hashTreeParsers.clear();
+    this.hashTreeObjectId2ParticipantId.clear();
+  }
 }

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -371,6 +371,7 @@ const MeetingUtil = {
     meeting.breakouts.cleanUp();
     meeting.webinar.cleanUp();
     meeting.simultaneousInterpretation.cleanUp();
+    meeting.locusInfo.cleanUp();
     meeting.locusMediaRequest = undefined;
 
     meeting.webex?.internal?.newMetrics?.callDiagnosticMetrics?.clearEventLimitsForCorrelationId(

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -3655,4 +3655,44 @@ describe('HashTreeParser', () => {
       assert.notCalled(callback);
     });
   });
+
+  describe('#cleanUp', () => {
+    it('should stop the parser, clear all timers and clear all dataSets', () => {
+      const parser = createHashTreeParser();
+
+      // Send a message to set up sync timers via runSyncAlgorithm
+      const message = {
+        dataSets: [
+          {
+            ...createDataSet('main', 16, 1100),
+            root: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1',
+          },
+        ],
+        visibleDataSetsUrl,
+        locusUrl,
+        heartbeatIntervalMs: 5000,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'locus' as const, id: 0, version: 201},
+              dataSetNames: ['main'],
+            },
+            data: {someData: 'value'},
+          },
+        ],
+      };
+
+      parser.handleMessage(message, 'setup timers');
+
+      // Verify timers were set by handleMessage
+      expect(parser.dataSets.main.timer).to.not.be.undefined;
+      expect(parser.dataSets.main.heartbeatWatchdogTimer).to.not.be.undefined;
+
+      parser.cleanUp();
+
+      expect(parser.state).to.equal('stopped');
+      expect(parser.visibleDataSets).to.deep.equal([]);
+      expect(parser.dataSets).to.deep.equal({});
+    });
+  });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -553,7 +553,7 @@ describe('HashTreeParser', () => {
     );
 
     // Verify callback was called with OBJECTS_UPDATED and correct updatedObjects list
-    assert.calledWith(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+    assert.calledWith(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
       updatedObjects: [
         {
           htMeta: {
@@ -788,7 +788,7 @@ describe('HashTreeParser', () => {
       expect(parser.dataSets.self.version).to.equal(2100);
       expect(parser.dataSets['atd-unmuted'].version).to.equal(3100);
 
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+      assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
         updatedObjects: [
           {
             htMeta: {
@@ -919,7 +919,7 @@ describe('HashTreeParser', () => {
         {type: 'ControlEntry', id: 10101, version: 100}
       ]);
 
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+      assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
         updatedObjects: [
           {
             htMeta: {
@@ -1009,7 +1009,7 @@ describe('HashTreeParser', () => {
       assert.calledOnceWithExactly(mainPutItemsSpy, [{type: 'locus', id: 0, version: 201}]);
 
       // Verify callback was called only for known dataset
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+      assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
         updatedObjects: [
           {
             htMeta: {
@@ -1109,7 +1109,7 @@ describe('HashTreeParser', () => {
       assert.calledOnceWithExactly(selfPutItemSpy, {type: 'metadata', id: 5, version: 51});
 
       // Verify callback was called with metadata object and removed dataset objects
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+      assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
         updatedObjects: [
           // updated metadata object:
           {
@@ -1270,7 +1270,7 @@ describe('HashTreeParser', () => {
       assert.notCalled(atdUnmutedPutItemsSpy);
 
       // Verify callback was called with the updated object
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+      assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
         updatedObjects: [
           {
             htMeta: {
@@ -1498,7 +1498,7 @@ describe('HashTreeParser', () => {
       ]);
 
       // Verify callback was called with OBJECTS_UPDATED and all updated objects
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+      assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
         updatedObjects: [
           {
             htMeta: {
@@ -1563,9 +1563,7 @@ describe('HashTreeParser', () => {
           parser.handleMessage(sentinelMessage, 'sentinel message');
 
           // Verify callback was called with MEETING_ENDED
-          assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {
-            updatedObjects: undefined,
-          });
+          assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.MEETING_ENDED});
 
           // Verify that all timers were stopped
           Object.values(parser.dataSets).forEach((ds: any) => {
@@ -1587,9 +1585,7 @@ describe('HashTreeParser', () => {
         parser.handleMessage(sentinelMessage, 'sentinel message');
 
         // Verify callback was called with MEETING_ENDED
-        assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {
-          updatedObjects: undefined,
-        });
+        assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.MEETING_ENDED});
 
         // Verify that all timers were stopped
         Object.values(parser.dataSets).forEach((ds: any) => {
@@ -1685,7 +1681,7 @@ describe('HashTreeParser', () => {
         );
 
         // Verify that callback was called with synced objects
-        assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+        assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
           updatedObjects: [
             {
               htMeta: {
@@ -1747,9 +1743,7 @@ describe('HashTreeParser', () => {
             await clock.tickAsync(1000);
 
             // Verify callback was called with MEETING_ENDED
-            assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {
-              updatedObjects: undefined,
-            });
+            assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.MEETING_ENDED});
 
             // Verify all timers are stopped
             Object.values(parser.dataSets).forEach((ds: any) => {
@@ -1812,9 +1806,7 @@ describe('HashTreeParser', () => {
             await clock.tickAsync(1000);
 
             // Verify callback was called with MEETING_ENDED
-            assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {
-              updatedObjects: undefined,
-            });
+            assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.MEETING_ENDED});
 
             // Verify all timers are stopped
             Object.values(parser.dataSets).forEach((ds: any) => {
@@ -2052,7 +2044,7 @@ describe('HashTreeParser', () => {
         assert.equal(parser.dataSets.attendees.hashTree.numLeaves, 8);
 
         // Verify callback was called with the metadata update (appears twice - processed once for visible dataset changes, once in main loop)
-        assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+        assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
           updatedObjects: [
             {
               htMeta: {
@@ -2238,9 +2230,7 @@ describe('HashTreeParser', () => {
         await clock.tickAsync(0);
 
         // Verify callback was called with MEETING_ENDED
-        assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {
-          updatedObjects: undefined,
-        });
+        assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.MEETING_ENDED});
       });
 
       it('handles removal of visible data set', async () => {
@@ -2303,7 +2293,7 @@ describe('HashTreeParser', () => {
         assert.isUndefined(parser.dataSets['atd-unmuted'].timer);
 
         // Verify callback was called with the metadata update and the removed objects (metadata appears twice - processed once for dataset changes, once in main loop)
-        assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+        assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
           updatedObjects: [
             {
               htMeta: {
@@ -2922,7 +2912,7 @@ describe('HashTreeParser', () => {
       parser.handleMessage(updateMessage, 'update with newer version');
 
       // Callback should be called with the update
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+      assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
         updatedObjects: [
           {
             htMeta: {
@@ -2993,7 +2983,7 @@ describe('HashTreeParser', () => {
       parser.handleMessage(removalMessage, 'removal of non-existent object');
 
       // Callback should be called with the removal
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+      assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
         updatedObjects: [
           {
             htMeta: {
@@ -3128,7 +3118,7 @@ describe('HashTreeParser', () => {
       parser.handleMessage(mixedMessage, 'mixed updates');
 
       // Callback should be called with only the valid updates (participant 1 v110 and participant 3 v10)
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.OBJECTS_UPDATED, {
+      assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.OBJECTS_UPDATED,
         updatedObjects: [
           {
             htMeta: {
@@ -3306,9 +3296,7 @@ describe('HashTreeParser', () => {
       parser.handleMessage(sentinelMessage as any, 'sentinel message');
 
       // Callback should be called with MEETING_ENDED
-      assert.calledOnceWithExactly(callback, LocusInfoUpdateType.MEETING_ENDED, {
-        updatedObjects: undefined,
-      });
+      assert.calledOnceWithExactly(callback, {updateType: LocusInfoUpdateType.MEETING_ENDED});
     });
   });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -4413,6 +4413,31 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#cleanUp', () => {
+      it('calls cleanUp on all hash tree parsers and clears maps', () => {
+        const parser1 = {cleanUp: sinon.stub()};
+        const parser2 = {cleanUp: sinon.stub()};
+
+        locusInfo.hashTreeParsers.set('url1', {parser: parser1, initializedFromHashTree: true});
+        locusInfo.hashTreeParsers.set('url2', {parser: parser2, initializedFromHashTree: true});
+        locusInfo.hashTreeObjectId2ParticipantId.set(1, 'participant1');
+
+        locusInfo.cleanUp();
+
+        assert.calledOnce(parser1.cleanUp);
+        assert.calledOnce(parser2.cleanUp);
+        assert.equal(locusInfo.hashTreeParsers.size, 0);
+        assert.equal(locusInfo.hashTreeObjectId2ParticipantId.size, 0);
+      });
+
+      it('works when there are no hash tree parsers', () => {
+        locusInfo.cleanUp();
+
+        assert.equal(locusInfo.hashTreeParsers.size, 0);
+        assert.equal(locusInfo.hashTreeObjectId2ParticipantId.size, 0);
+      });
+    });
+
     describe('#handleOneonOneEvent', () => {
       beforeEach(() => {
         locusInfo.emitScoped = sinon.stub();

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -413,7 +413,7 @@ describe('plugin-meetings', () => {
           };
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [{htMeta: {elementId: {type: 'self'}}, data: newSelf}],
           });
 
@@ -440,7 +440,7 @@ describe('plugin-meetings', () => {
           locusInfo.info.isWebinar = true;
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [{htMeta: {elementId: {type: 'self'}}, data: newSelf}],
           });
 
@@ -473,7 +473,7 @@ describe('plugin-meetings', () => {
           locusInfo.info.isWebinar = true;
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [{htMeta: {elementId: {type: 'self'}}, data: newSelf}],
           });
 
@@ -501,7 +501,7 @@ describe('plugin-meetings', () => {
           };
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [{htMeta: {elementId: {type: 'fullState'}}, data: newFullState}],
           });
 
@@ -519,7 +519,7 @@ describe('plugin-meetings', () => {
           };
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [{htMeta: {elementId: {type: 'info'}}, data: newInfo}],
           });
 
@@ -537,7 +537,7 @@ describe('plugin-meetings', () => {
           };
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [{htMeta: {elementId: {type: 'links'}}, data: newLinks}],
           });
 
@@ -557,7 +557,7 @@ describe('plugin-meetings', () => {
           };
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [{htMeta: newLocusHtMeta, data: newLocus}],
           });
 
@@ -590,7 +590,7 @@ describe('plugin-meetings', () => {
           };
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               {
                 htMeta: newLocusHtMeta,
@@ -637,7 +637,7 @@ describe('plugin-meetings', () => {
           };
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               // first, a removal of LOCUS object
               {htMeta: {elementId: {type: 'locus'}}, data: null},
@@ -671,7 +671,7 @@ describe('plugin-meetings', () => {
           const newLocusHtMeta = {elementId: {type: 'locus', version: 99}};
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               // first, an update
               {htMeta: newLocusHtMeta, data: newLocus},
@@ -700,7 +700,7 @@ describe('plugin-meetings', () => {
           };
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               // first, an update
               {htMeta: {elementId: {type: 'locus'}}, data: newLocus1},
@@ -730,7 +730,7 @@ describe('plugin-meetings', () => {
           };
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
           // with 1 participant added, 1 updated, and 1 removed
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               {htMeta: {elementId: {type: 'participant', id: 'fake-ht-participant-1'}}, data: null},
               {
@@ -774,7 +774,7 @@ describe('plugin-meetings', () => {
           };
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
           // with 1 participant added, 1 updated, and 1 removed
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               {htMeta: {elementId: {type: 'mediashare', id: 'fake-ht-mediaShare-1'}}, data: null},
               {
@@ -807,7 +807,7 @@ describe('plugin-meetings', () => {
           };
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
           // with 1 embedded app added, 1 updated, and 1 removed
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               {htMeta: {elementId: {type: 'embeddedapp', id: 'fake-ht-embeddedApp-1'}}, data: null},
               {
@@ -844,7 +844,7 @@ describe('plugin-meetings', () => {
           };
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               {
                 htMeta: {elementId: {type: 'mediashare', id: 'fake-ht-mediaShare-2'}},
@@ -883,7 +883,7 @@ describe('plugin-meetings', () => {
           };
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               {
                 htMeta: {elementId: {type: 'controlentry', id: 'control-1'}},
@@ -911,7 +911,7 @@ describe('plugin-meetings', () => {
 
         it('should process locus update correctly when CONTROL object is received with no data', () => {
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               {
                 htMeta: {elementId: {type: 'controlentry', id: 'some-control-id'}},
@@ -935,7 +935,7 @@ describe('plugin-meetings', () => {
           const destroyStub = sinon.stub(locusInfo.webex.meetings, 'destroy');
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(MEETING_ENDED);
+          locusInfoUpdateCallback({updateType: MEETING_ENDED});
 
           assert.calledOnceWithExactly(collectionGetStub, locusInfo.meetingId);
           assert.calledOnceWithExactly(
@@ -953,7 +953,7 @@ describe('plugin-meetings', () => {
           const destroyStub = sinon.stub(locusInfo.webex.meetings, 'destroy');
 
           // simulate an update from the HashTreeParser (normally this would be triggered by incoming locus messages)
-          locusInfoUpdateCallback(MEETING_ENDED);
+          locusInfoUpdateCallback({updateType: MEETING_ENDED});
 
           assert.calledOnceWithExactly(collectionGetStub, locusInfo.meetingId);
           assert.notCalled(destroyStub);
@@ -963,7 +963,7 @@ describe('plugin-meetings', () => {
           const createdHashTreeParser = locusInfo.hashTreeParsers.get('fake-locus-url');
           createdHashTreeParser.initializedFromHashTree = false;
 
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               {
                 htMeta: {elementId: {type: 'self'}},
@@ -978,7 +978,7 @@ describe('plugin-meetings', () => {
         });
 
         it('should set forceReplaceMembers to false on subsequent updates (initializedFromHashTree is true)', () => {
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               {
                 htMeta: {elementId: {type: 'self'}},
@@ -994,7 +994,7 @@ describe('plugin-meetings', () => {
         it('should copy participant data to self when participant matches self identity and state is LEFT with reason MOVED', () => {
           locusInfo.self = {id: 'fake-self', identity: 'user-123'};
 
-          locusInfoUpdateCallback(OBJECTS_UPDATED, {
+          locusInfoUpdateCallback({updateType: OBJECTS_UPDATED,
             updatedObjects: [
               {
                 htMeta: {elementId: {type: 'participant', id: 99}},

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -60,6 +60,7 @@ describe('plugin-meetings', () => {
       meeting.annotaion = {cleanUp: sinon.stub()};
       meeting.getWebexObject = sinon.stub().returns(webex);
       meeting.simultaneousInterpretation = {cleanUp: sinon.stub()};
+      meeting.locusInfo = {cleanUp: sinon.stub()};
       meeting.trigger = sinon.stub();
       meeting.webex = webex;
       meeting.webex.internal.newMetrics.callDiagnosticMetrics =
@@ -89,6 +90,7 @@ describe('plugin-meetings', () => {
         assert.calledOnceWithExactly(meeting.cleanupLLMConneciton, {throwOnError: false});
         assert.calledOnce(meeting.breakouts.cleanUp);
         assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
+        assert.calledOnce(meeting.locusInfo.cleanUp);
         assert.calledOnce(webex.internal.device.meetingEnded);
         assert.calledOnceWithExactly(
           meeting.webex.internal.newMetrics.callDiagnosticMetrics.clearEventLimitsForCorrelationId,
@@ -110,6 +112,7 @@ describe('plugin-meetings', () => {
         assert.notCalled(meeting.cleanupLLMConneciton);
         assert.calledOnce(meeting.breakouts.cleanUp);
         assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
+        assert.calledOnce(meeting.locusInfo.cleanUp);
         assert.calledOnce(webex.internal.device.meetingEnded);
         assert.calledOnceWithExactly(
           meeting.webex.internal.newMetrics.callDiagnosticMetrics.clearEventLimitsForCorrelationId,
@@ -130,6 +133,7 @@ describe('plugin-meetings', () => {
         assert.notCalled(meeting.cleanupLLMConneciton);
         assert.calledOnce(meeting.breakouts.cleanUp);
         assert.calledOnce(meeting.simultaneousInterpretation.cleanUp);
+        assert.calledOnce(meeting.locusInfo.cleanUp);
         assert.calledOnce(webex.internal.device.meetingEnded);
         assert.calledOnceWithExactly(
           meeting.webex.internal.newMetrics.callDiagnosticMetrics.clearEventLimitsForCorrelationId,


### PR DESCRIPTION
# COMPLETES #[SPARK-797248](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-797248)

## This pull request addresses
When a SDK destroys a meeting, LocusInfo class doesn't know about this and so also HashTreeParser instances are not aware and they have some timers that might still be running and causing unnecessary syncs to Locus after the meeting is gone

## by making the following changes
Fixed it by adding a cleanUp() function in LocusInfo and HashTreeParser.
I've also fixed a bunch of eslint warnings/ts warning that I noticed.
And did a 1 line fix to avoid an exception being thrown when we send metrics while paired

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
