### PR TITLE
fix(meetings): route audio controls to current locus in breakout sessions

### DIFF
--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -258,15 +258,26 @@ export default class ControlsOptionsManager {
     if (error) {
       return Promise.reject(error);
     }
-    const extraBody =
-      this.mainLocusUrl && this.mainLocusUrl !== this.locusUrl
-        ? {authorizingLocusUrl: this.locusUrl}
-        : {};
+
+    // Audio controls (mute/unmute, muteOnEntry, disallowUnmute) are NOT in Locus's
+    // cross-locus GraphQL authorization allowlist (doesControlSupportRemoteLocusCall).
+    // Unlike update() which handles controls that DO support authorizingLocusUrl
+    // (video, reactions, share, etc.), audio MUST target the locus the caller is in.
+    // In breakout: locusUrl is the breakout URL — send directly there.
+    // Outside breakout: locusUrl === mainLocusUrl — same destination either way.
+    // See: https://sqbu-github.cisco.com/pages/WebExSquared/locus/api/controls/put-controls.html
+    const isInBreakout = this.mainLocusUrl && this.mainLocusUrl !== this.locusUrl;
+
+    if (isInBreakout) {
+      LoggerProxy.logger.log(
+        'ControlsOptionsManager:index#setControls --> in breakout session, sending audio controls directly to breakout locus (authorizingLocusUrl not supported for audio)'
+      );
+    }
 
     // @ts-ignore
     return this.request.request({
-      uri: `${this.mainLocusUrl || this.locusUrl}/${CONTROLS}`,
-      body: {...body, ...extraBody},
+      uri: `${this.locusUrl}/${CONTROLS}`,
+      body,
       method: HTTP_VERBS.PATCH,
     });
   }

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
@@ -340,14 +340,42 @@ describe('plugin-meetings', () => {
                 assert.deepEqual(result, request.request.firstCall.returnValue);
               });
 
-              it('request with mainLocusUrl and make locusUrl as authorizingLocusUrl if mainLocusUrl is exist and not same with locusUrl', () => {
+              it('sends audio controls directly to locusUrl even when mainLocusUrl differs (breakout session)', () => {
                 manager.setDisplayHints(['MUTE_ALL', 'DISABLE_HARD_MUTE', 'DISABLE_MUTE_ON_ENTRY']);
                 manager.mainLocusUrl = `test/main`;
 
                 const result = manager.setMuteAll(true, true, true, ['attendee']);
 
-                assert.calledWith(request.request, {  uri: 'test/main/controls',
-                  body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['attendee'] }, authorizingLocusUrl: 'test/id' },
+                // Audio controls must target the locus the caller is currently in (locusUrl),
+                // NOT mainLocusUrl, because Locus does not support authorizingLocusUrl for audio.
+                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                  body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['attendee'] } },
+                  method: HTTP_VERBS.PATCH});
+
+                assert.deepEqual(result, request.request.firstCall.returnValue);
+              });
+
+              it('sends setMuteOnEntry directly to locusUrl in breakout session', () => {
+                manager.setDisplayHints(['ENABLE_MUTE_ON_ENTRY']);
+                manager.mainLocusUrl = `test/main`;
+
+                const result = manager.setMuteOnEntry(true);
+
+                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                  body: { muteOnEntry: { enabled: true } },
+                  method: HTTP_VERBS.PATCH});
+
+                assert.deepEqual(result, request.request.firstCall.returnValue);
+              });
+
+              it('sends setDisallowUnmute directly to locusUrl in breakout session', () => {
+                manager.setDisplayHints(['ENABLE_HARD_MUTE']);
+                manager.mainLocusUrl = `test/main`;
+
+                const result = manager.setDisallowUnmute(true);
+
+                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                  body: { disallowUnmute: { enabled: true } },
                   method: HTTP_VERBS.PATCH});
 
                 assert.deepEqual(result, request.request.firstCall.returnValue);


### PR DESCRIPTION
## Summary

Fixes SPARK-785662: Mute All fails with HTTP 403 (error 2403031) when triggered by a host/cohost in a breakout session.

### Root Cause

PR #4540 (SPARK-478810) added breakout-aware routing to `ControlsOptionsManager`, directing control PATCH requests through `mainLocusUrl` with `authorizingLocusUrl` when in a breakout. This is correct for controls that support cross-locus GraphQL authorization (video, reactions, share, etc.), but **incorrect for audio controls** (mute/unmute, muteOnEntry, disallowUnmute).

Audio controls are not wired into Locus's cross-locus GraphQL authorization path. When audio controls are sent to `mainLocusUrl` with `authorizingLocusUrl`, Locus cannot verify moderator status via GraphQL and returns 403.

### Fix

`setControls()` now sends audio control PATCH requests directly to `this.locusUrl` (the locus the caller is currently in) without `authorizingLocusUrl`. The `update()` method retains its existing `mainLocusUrl` routing since it handles control types that DO support cross-locus authorization.

### Evidence

- **Locus engineer confirmation** (Scott Waldron): "Audio controls are not wired into the cross-locus GraphQL authorization path"
- **Locus API docs** ([put-controls](https://sqbu-github.cisco.com/pages/WebExSquared/locus/api/controls/put-controls.html)): `authorizingLocusUrl` documented for 9 control types; audio controls explicitly omit it
- **Locus backend source** (`UpdateControlStates.java`): `doesControlSupportRemoteLocusCall()` allowlist excludes audio
- **Native client** (`TelephonyAdapter.cpp`): Sends mute-all directly to breakout locus URL without `authorizingLocusUrl`
- **Confluence specs**: [WEBEX-182782 Breakout Hard Mute](https://confluence-eng-gpk2.cisco.com/conf/pages/viewpage.action?pageId=174022012) — "In BO, mute all/unmute all will not change MOE"
- **E2E validation**: Direct PATCH to breakout URL returns HTTP 200 ✅

### Testing

- All 25 `controls-options-manager` unit tests pass
- Added 3 new tests: `setMuteAll`, `setMuteOnEntry`, `setDisallowUnmute` in breakout context — verify audio controls target `locusUrl` not `mainLocusUrl`
- Pre-existing `util.js` test failures (49 failures on upstream/next) are unrelated

### Jira

[SPARK-785662](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-785662)
