### PR TITLE
fix(plugin-meetings): send audio controls directly to current locus in breakouts

### DIFF
--- a/packages/@webex/plugin-meetings/src/controls-options-manager/constants.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/constants.ts
@@ -1,5 +1,18 @@
+import {camelCase} from 'lodash';
+import {Control, Setting} from './enums';
+
 const ENABLED = 'enabled';
 const CAN_SET = 'canSet';
 const CAN_UNSET = 'canUnset';
 
-export {ENABLED, CAN_SET, CAN_UNSET};
+/**
+ * Body keys that represent audio controls. These do not support cross-locus
+ * authorization and must be sent directly to the current locus URL.
+ */
+const AUDIO_CONTROL_BODY_KEYS: ReadonlySet<string> = new Set([
+  Control.audio,
+  camelCase(Setting.muteOnEntry),
+  camelCase(Setting.disallowUnmute),
+]);
+
+export {ENABLED, CAN_SET, CAN_UNSET, AUDIO_CONTROL_BODY_KEYS};

--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -172,15 +172,16 @@ export default class ControlsOptionsManager {
     });
 
     return payloads.reduce((previous, payload) => {
-      const extraBody =
-        this.mainLocusUrl && this.mainLocusUrl !== this.locusUrl
-          ? {authorizingLocusUrl: this.locusUrl}
-          : {};
+      const {targetUrl, extraBody} = Util.getControlsRequestParams({
+        body: payload,
+        locusUrl: this.locusUrl,
+        mainLocusUrl: this.mainLocusUrl,
+      });
 
       return previous.then(() =>
         // @ts-ignore
         this.request.request({
-          uri: `${this.mainLocusUrl || this.locusUrl}/${CONTROLS}`,
+          uri: `${targetUrl}/${CONTROLS}`,
           body: {...payload, ...extraBody},
           method: HTTP_VERBS.PATCH,
         })
@@ -258,14 +259,15 @@ export default class ControlsOptionsManager {
     if (error) {
       return Promise.reject(error);
     }
-    const extraBody =
-      this.mainLocusUrl && this.mainLocusUrl !== this.locusUrl
-        ? {authorizingLocusUrl: this.locusUrl}
-        : {};
+    const {targetUrl, extraBody} = Util.getControlsRequestParams({
+      body,
+      locusUrl: this.locusUrl,
+      mainLocusUrl: this.mainLocusUrl,
+    });
 
     // @ts-ignore
     return this.request.request({
-      uri: `${this.mainLocusUrl || this.locusUrl}/${CONTROLS}`,
+      uri: `${targetUrl}/${CONTROLS}`,
       body: {...body, ...extraBody},
       method: HTTP_VERBS.PATCH,
     });

--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -1,6 +1,6 @@
 import {camelCase} from 'lodash';
+import ParameterError from '../common/errors/parameter';
 import PermissionError from '../common/errors/permission';
-import {CONTROLS, HTTP_VERBS} from '../constants';
 import MeetingRequest from '../meeting/request';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {Control, Setting} from './enums';
@@ -153,6 +153,12 @@ export default class ControlsOptionsManager {
    * @returns {Promise<Array<any>>}- Promise resolving if the request was successful.
    */
   public update(...controls: Array<ControlConfig>) {
+    if (!this.locusUrl) {
+      return Promise.reject(
+        new ParameterError('The locusUrl for this controls request must be defined.')
+      );
+    }
+
     const payloads = controls.map((control) => {
       if (!Object.keys(Control).includes(control.scope)) {
         throw new Error(
@@ -172,7 +178,7 @@ export default class ControlsOptionsManager {
     });
 
     return payloads.reduce((previous, payload) => {
-      const {targetUrl, extraBody} = Util.getControlsRequestParams({
+      const requestParams = Util.getControlsRequestParams({
         body: payload,
         locusUrl: this.locusUrl,
         mainLocusUrl: this.mainLocusUrl,
@@ -180,11 +186,7 @@ export default class ControlsOptionsManager {
 
       return previous.then(() =>
         // @ts-ignore
-        this.request.request({
-          uri: `${targetUrl}/${CONTROLS}`,
-          body: {...payload, ...extraBody},
-          method: HTTP_VERBS.PATCH,
-        })
+        this.request.request(requestParams)
       );
     }, Promise.resolve());
   }
@@ -201,6 +203,12 @@ export default class ControlsOptionsManager {
     [Setting.muteOnEntry]?: boolean;
     [Setting.roles]?: Array<string>;
   }): Promise<any> {
+    if (!this.locusUrl) {
+      return Promise.reject(
+        new ParameterError('The associated locusUrl for this controls request must be defined.')
+      );
+    }
+
     LoggerProxy.logger.log(
       `ControlsOptionsManager:index#setControls --> ${JSON.stringify(setting)}`
     );
@@ -259,18 +267,15 @@ export default class ControlsOptionsManager {
     if (error) {
       return Promise.reject(error);
     }
-    const {targetUrl, extraBody} = Util.getControlsRequestParams({
+
+    const requestParams = Util.getControlsRequestParams({
       body,
       locusUrl: this.locusUrl,
       mainLocusUrl: this.mainLocusUrl,
     });
 
     // @ts-ignore
-    return this.request.request({
-      uri: `${targetUrl}/${CONTROLS}`,
-      body: {...body, ...extraBody},
-      method: HTTP_VERBS.PATCH,
-    });
+    return this.request.request(requestParams);
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -155,7 +155,7 @@ export default class ControlsOptionsManager {
   public update(...controls: Array<ControlConfig>) {
     if (!this.locusUrl) {
       return Promise.reject(
-        new ParameterError('The locusUrl for this controls request must be defined.')
+        new ParameterError('The associated locusUrl for update() controls must be defined.')
       );
     }
 
@@ -205,7 +205,7 @@ export default class ControlsOptionsManager {
   }): Promise<any> {
     if (!this.locusUrl) {
       return Promise.reject(
-        new ParameterError('The associated locusUrl for this controls request must be defined.')
+        new ParameterError('The associated locusUrl for setControls() must be defined.')
       );
     }
 

--- a/packages/@webex/plugin-meetings/src/controls-options-manager/util.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/util.ts
@@ -448,9 +448,20 @@ class Utils {
    * Meeting-wide audio control actions (e.g., muting panelists across all breakouts
    * from a single request) are not currently supported through this mechanism.
    *
+   * Note: This is a pure computation function — it does not validate that locusUrl is
+   * defined. Callers (update, setControls) must guard against falsy locusUrl before
+   * invoking this function.
+   *
+   * Note: Mixed audio and non-audio keys in a single body (e.g., {audio: {...},
+   * raiseHand: {...}}) are treated as non-audio and routed to mainLocusUrl with
+   * authorizingLocusUrl. This means the audio portion would go through unsupported
+   * cross-locus authorization. Callers must not produce mixed payloads — update()
+   * sends each control scope as a separate request, and setControls() only handles
+   * audio-related settings.
+   *
    * @param {object} options
    * @param {Record<string, any>} options.body - The request body.
-   * @param {string} options.locusUrl - The current locus URL.
+   * @param {string} options.locusUrl - The current locus URL. Must be defined (callers must validate).
    * @param {string} [options.mainLocusUrl] - The main locus URL.
    * @returns {{ uri: string, body: Record<string, any>, method: string }}
    */

--- a/packages/@webex/plugin-meetings/src/controls-options-manager/util.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/util.ts
@@ -1,4 +1,4 @@
-import {DISPLAY_HINTS} from '../constants';
+import {CONTROLS, DISPLAY_HINTS, HTTP_VERBS} from '../constants';
 import {Control} from './enums';
 import {AUDIO_CONTROL_BODY_KEYS} from './constants';
 import {
@@ -452,28 +452,27 @@ class Utils {
    * @param {Record<string, any>} options.body - The request body.
    * @param {string} options.locusUrl - The current locus URL.
    * @param {string} [options.mainLocusUrl] - The main locus URL.
-   * @returns {{ targetUrl: string, extraBody: Record<string, any> }}
+   * @returns {{ uri: string, body: Record<string, any>, method: string }}
    */
   public static getControlsRequestParams(options: {
     body: Record<string, any>;
     locusUrl: string;
     mainLocusUrl?: string;
   }): {
-    targetUrl: string;
-    extraBody: Record<string, any>;
+    uri: string;
+    body: Record<string, any>;
+    method: string;
   } {
     const {body, locusUrl, mainLocusUrl} = options;
 
-    if (!locusUrl) {
-      return {targetUrl: locusUrl, extraBody: {}};
-    }
-
     const isAudio = Utils.isAudioControl(body);
     const inBreakout = Utils.isBreakoutLocusUrl(locusUrl, mainLocusUrl);
+    const targetUrl = inBreakout && !isAudio ? mainLocusUrl : locusUrl;
 
     return {
-      extraBody: inBreakout && !isAudio ? {authorizingLocusUrl: locusUrl} : {},
-      targetUrl: inBreakout && !isAudio ? mainLocusUrl : locusUrl,
+      uri: `${targetUrl}/${CONTROLS}`,
+      body: inBreakout && !isAudio ? {...body, authorizingLocusUrl: locusUrl} : body,
+      method: HTTP_VERBS.PATCH,
     };
   }
 }

--- a/packages/@webex/plugin-meetings/src/controls-options-manager/util.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/util.ts
@@ -1,5 +1,6 @@
 import {DISPLAY_HINTS} from '../constants';
 import {Control} from './enums';
+import {AUDIO_CONTROL_BODY_KEYS} from './constants';
 import {
   ControlConfig,
   AudioProperties,
@@ -399,6 +400,81 @@ class Utils {
     }
 
     return determinant;
+  }
+
+  /**
+   * Check if all body keys represent audio controls.
+   *
+   * @param {Record<string, any>} body - The request body to inspect.
+   * @returns {boolean} - True if every key in the body is an audio control key.
+   */
+  public static isAudioControl(body: Record<string, any>): boolean {
+    return Object.keys(body).every((key) => AUDIO_CONTROL_BODY_KEYS.has(key));
+  }
+
+  /**
+   * Check if the current locus URL differs from the main locus URL,
+   * indicating a breakout session.
+   *
+   * @param {string} locusUrl - The current locus URL.
+   * @param {string} [mainLocusUrl] - The main locus URL.
+   * @returns {boolean} - True if in a breakout session.
+   */
+  public static isBreakoutLocusUrl(locusUrl: string, mainLocusUrl?: string): boolean {
+    return Boolean(mainLocusUrl) && mainLocusUrl !== locusUrl;
+  }
+
+  /**
+   * Resolve the target URL and extra body fields for a controls request,
+   * handling breakout session routing
+   *
+   * The authorizingLocusUrl mechanism on PATCH /loci/{lid}/controls is not supported
+   * for audio control updates (mute/unmute, muteOnEntry, disallowUnmute).
+   *
+   * Audio controls are not wired into the cross-locus GraphQL authorization path that
+   * other control types (raiseHand, viewParticipantList, admit, reactions, etc.) use.
+   * Specifically, the GraphQL authorization layer does not recognize audio as a control
+   * type eligible for remote locus authorization.
+   *
+   * This means authorizingLocusUrl is effectively ignored for audio controls and the
+   * server evaluates the request against the target locus only, where the host may not
+   * be currently joined.
+   *
+   * Audio control updates must be sent directly to the locus the user is currently in.
+   * If the host is in a breakout and wants to mute participants in that breakout, the
+   * request should target the breakout locus URL directly, not the main session locus
+   * with authorizingLocusUrl.
+   *
+   * Meeting-wide audio control actions (e.g., muting panelists across all breakouts
+   * from a single request) are not currently supported through this mechanism.
+   *
+   * @param {object} options
+   * @param {Record<string, any>} options.body - The request body.
+   * @param {string} options.locusUrl - The current locus URL.
+   * @param {string} [options.mainLocusUrl] - The main locus URL.
+   * @returns {{ targetUrl: string, extraBody: Record<string, any> }}
+   */
+  public static getControlsRequestParams(options: {
+    body: Record<string, any>;
+    locusUrl: string;
+    mainLocusUrl?: string;
+  }): {
+    targetUrl: string;
+    extraBody: Record<string, any>;
+  } {
+    const {body, locusUrl, mainLocusUrl} = options;
+
+    if (!locusUrl) {
+      return {targetUrl: locusUrl, extraBody: {}};
+    }
+
+    const isAudio = Utils.isAudioControl(body);
+    const inBreakout = Utils.isBreakoutLocusUrl(locusUrl, mainLocusUrl);
+
+    return {
+      extraBody: inBreakout && !isAudio ? {authorizingLocusUrl: locusUrl} : {},
+      targetUrl: inBreakout && !isAudio ? mainLocusUrl : locusUrl,
+    };
   }
 }
 

--- a/packages/@webex/plugin-meetings/src/controls-options-manager/util.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/util.ts
@@ -426,38 +426,32 @@ class Utils {
 
   /**
    * Resolve the target URL and extra body fields for a controls request,
-   * handling breakout session routing
-   *
-   * The authorizingLocusUrl mechanism on PATCH /loci/{lid}/controls is not supported
-   * for audio control updates (mute/unmute, muteOnEntry, disallowUnmute).
-   *
-   * Audio controls are not wired into the cross-locus GraphQL authorization path that
-   * other control types (raiseHand, viewParticipantList, admit, reactions, etc.) use.
-   * Specifically, the GraphQL authorization layer does not recognize audio as a control
-   * type eligible for remote locus authorization.
-   *
-   * This means authorizingLocusUrl is effectively ignored for audio controls and the
-   * server evaluates the request against the target locus only, where the host may not
-   * be currently joined.
-   *
-   * Audio control updates must be sent directly to the locus the user is currently in.
-   * If the host is in a breakout and wants to mute participants in that breakout, the
-   * request should target the breakout locus URL directly, not the main session locus
-   * with authorizingLocusUrl.
-   *
-   * Meeting-wide audio control actions (e.g., muting panelists across all breakouts
-   * from a single request) are not currently supported through this mechanism.
-   *
-   * Note: This is a pure computation function — it does not validate that locusUrl is
-   * defined. Callers (update, setControls) must guard against falsy locusUrl before
+   * handling breakout session routing. Note: This is a pure computation function.
+   * It does not validate that locusUrl is
+   * defined. Callers must guard against falsy locusUrl before
    * invoking this function.
-   *
-   * Note: Mixed audio and non-audio keys in a single body (e.g., {audio: {...},
+   * Mixed audio and non-audio keys in a single body (e.g., {audio: {...},
    * raiseHand: {...}}) are treated as non-audio and routed to mainLocusUrl with
    * authorizingLocusUrl. This means the audio portion would go through unsupported
    * cross-locus authorization. Callers must not produce mixed payloads — update()
    * sends each control scope as a separate request, and setControls() only handles
    * audio-related settings.
+   *
+   * The authorizingLocusUrl mechanism on PATCH /loci/{lid}/controls is not supported
+   * for audio control updates (mute/unmute, muteOnEntry, disallowUnmute).
+   * Audio controls are not wired into the cross-locus GraphQL authorization path that
+   * other control types (raiseHand, viewParticipantList, admit, reactions, etc.) use.
+   * Specifically, the GraphQL authorization layer does not recognize audio as a control
+   * type eligible for remote locus authorization.
+   * This means authorizingLocusUrl is effectively ignored for audio controls and the
+   * server evaluates the request against the target locus only, where the host may not
+   * be currently joined.
+   * Audio control updates must be sent directly to the locus the user is currently in.
+   * If the host is in a breakout and wants to mute participants in that breakout, the
+   * request should target the breakout locus URL directly, not the main session locus
+   * with authorizingLocusUrl.
+   * Meeting-wide audio control actions (e.g., muting panelists across all breakouts
+   * from a single request) are not currently supported through this mechanism.
    *
    * @param {object} options
    * @param {Record<string, any>} options.body - The request body.

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
@@ -76,6 +76,19 @@ describe('plugin-meetings', () => {
 
                       assert.deepEqual(result, request.request.firstCall.returnValue);
                     });
+
+                    it('should send setMuteOnEntry to locusUrl without authorizingLocusUrl when in breakout', () => {
+                      manager.setDisplayHints(['ENABLE_MUTE_ON_ENTRY']);
+                      manager.mainLocusUrl = 'test/main';
+
+                      const result = manager.setMuteOnEntry(true);
+
+                      assert.calledWith(request.request, {  uri: 'test/id/controls',
+                      body: { muteOnEntry: { enabled: true } },
+                      method: HTTP_VERBS.PATCH});
+
+                      assert.deepEqual(result, request.request.firstCall.returnValue);
+                    });
                   });
 
                   describe('setDisallowUnmute', () => {
@@ -114,6 +127,19 @@ describe('plugin-meetings', () => {
 
                       assert.calledWith(request.request, {  uri: 'test/id/controls',
                       body: { disallowUnmute: { enabled: false } },
+                      method: HTTP_VERBS.PATCH});
+
+                      assert.deepEqual(result, request.request.firstCall.returnValue);
+                    });
+
+                    it('should send setDisallowUnmute to locusUrl without authorizingLocusUrl when in breakout', () => {
+                      manager.setDisplayHints(['ENABLE_HARD_MUTE']);
+                      manager.mainLocusUrl = 'test/main';
+
+                      const result = manager.setDisallowUnmute(true);
+
+                      assert.calledWith(request.request, {  uri: 'test/id/controls',
+                      body: { disallowUnmute: { enabled: true } },
                       method: HTTP_VERBS.PATCH});
 
                       assert.deepEqual(result, request.request.firstCall.returnValue);
@@ -203,7 +229,7 @@ describe('plugin-meetings', () => {
                   });
               });
 
-              it('should call request with mainLocusUrl and locusUrl as authorizingLocusUrl if mainLocusUrl is exist and not same with locusUrl', () => {
+              it('should send audio controls to locusUrl without authorizingLocusUrl and non-audio to mainLocusUrl with authorizingLocusUrl when in breakout', () => {
                 const restorable = Util.canUpdate;
                 Util.canUpdate = sinon.stub().returns(true);
                 manager.mainLocusUrl = 'test/main';
@@ -213,20 +239,64 @@ describe('plugin-meetings', () => {
 
                 return manager.update(audio, reactions)
                   .then(() => {
+                    // Audio controls go directly to current locusUrl (no cross-locus authorization)
                     assert.calledWith(request.request, {
-                      uri: 'test/main/controls',
+                      uri: 'test/id/controls',
                       body: {
                         audio: audio.properties,
-                        authorizingLocusUrl: 'test/id'
                       },
                       method: HTTP_VERBS.PATCH,
                     });
 
+                    // Non-audio controls go to mainLocusUrl with authorizingLocusUrl
                     assert.calledWith(request.request, {
                       uri: 'test/main/controls',
                       body: {
                         reactions: reactions.properties,
                         authorizingLocusUrl: 'test/id'
+                      },
+                      method: HTTP_VERBS.PATCH,
+                    });
+
+                    Util.canUpdate = restorable;
+                  });
+              });
+
+              it('should send audio controls to locusUrl without authorizingLocusUrl when in breakout', () => {
+                const restorable = Util.canUpdate;
+                Util.canUpdate = sinon.stub().returns(true);
+                manager.mainLocusUrl = 'test/main';
+
+                const audio = {scope: 'audio', properties: {muted: true, disallowUnmute: false}};
+
+                return manager.update(audio)
+                  .then(() => {
+                    assert.calledWith(request.request, {
+                      uri: 'test/id/controls',
+                      body: {
+                        audio: audio.properties,
+                      },
+                      method: HTTP_VERBS.PATCH,
+                    });
+
+                    Util.canUpdate = restorable;
+                  });
+              });
+
+              it('should send non-audio controls to mainLocusUrl with authorizingLocusUrl when in breakout', () => {
+                const restorable = Util.canUpdate;
+                Util.canUpdate = sinon.stub().returns(true);
+                manager.mainLocusUrl = 'test/main';
+
+                const reactions = {scope: 'reactions', properties: {enabled: true}};
+
+                return manager.update(reactions)
+                  .then(() => {
+                    assert.calledWith(request.request, {
+                      uri: 'test/main/controls',
+                      body: {
+                        reactions: reactions.properties,
+                        authorizingLocusUrl: 'test/id',
                       },
                       method: HTTP_VERBS.PATCH,
                     });
@@ -340,14 +410,27 @@ describe('plugin-meetings', () => {
                 assert.deepEqual(result, request.request.firstCall.returnValue);
               });
 
-              it('request with mainLocusUrl and make locusUrl as authorizingLocusUrl if mainLocusUrl is exist and not same with locusUrl', () => {
+              it('should send setMuteAll to locusUrl without authorizingLocusUrl when in breakout', () => {
                 manager.setDisplayHints(['MUTE_ALL', 'DISABLE_HARD_MUTE', 'DISABLE_MUTE_ON_ENTRY']);
                 manager.mainLocusUrl = `test/main`;
 
                 const result = manager.setMuteAll(true, true, true, ['attendee']);
 
-                assert.calledWith(request.request, {  uri: 'test/main/controls',
-                  body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['attendee'] }, authorizingLocusUrl: 'test/id' },
+                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                  body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['attendee'] } },
+                  method: HTTP_VERBS.PATCH});
+
+                assert.deepEqual(result, request.request.firstCall.returnValue);
+              });
+
+              it('should send setMuteAll with PANELIST role to locusUrl without authorizingLocusUrl when in breakout', () => {
+                manager.setDisplayHints(['MUTE_ALL', 'ENABLE_HARD_MUTE', 'ENABLE_MUTE_ON_ENTRY']);
+                manager.mainLocusUrl = `test/main`;
+
+                const result = manager.setMuteAll(true, true, true, ['PANELIST']);
+
+                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                  body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['PANELIST'] } },
                   method: HTTP_VERBS.PATCH});
 
                 assert.deepEqual(result, request.request.firstCall.returnValue);

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
@@ -1,5 +1,6 @@
 import ControlsOptionsManager from '@webex/plugin-meetings/src/controls-options-manager';
 import Util from '@webex/plugin-meetings/src/controls-options-manager/util';
+import ParameterError from '@webex/plugin-meetings/src/common/errors/parameter';
 import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
 import { HTTP_VERBS } from '@webex/plugin-meetings/src/constants';
@@ -164,6 +165,18 @@ describe('plugin-meetings', () => {
                 });
               });
 
+              it('should reject with ParameterError when locusUrl is not set', () => {
+                const noLocusManager = new ControlsOptionsManager(request);
+
+                const result = noLocusManager.update({scope: 'audio', properties: {muted: true}});
+
+                assert.notCalled(request.request);
+                return assert.isRejected(result).then((err) => {
+                  assert.instanceOf(err, ParameterError);
+                  assert.match(err.message, /locusUrl.*must be defined/);
+                });
+              });
+
               it('should throw an error if the scope is not supported', () => {
                 const scope = 'invalid';
 
@@ -320,6 +333,18 @@ describe('plugin-meetings', () => {
                   mainLocusUrl: '',
                   displayHints: [],
                 })
+              });
+
+              it('should reject with ParameterError when locusUrl is not set', () => {
+                const noLocusManager = new ControlsOptionsManager(request);
+
+                const result = noLocusManager.setMuteAll(true, true, true);
+
+                assert.notCalled(request.request);
+                return assert.isRejected(result).then((err) => {
+                  assert.instanceOf(err, ParameterError);
+                  assert.match(err.message, /locusUrl.*must be defined/);
+                });
               });
 
               it('rejects when correct display hint is not present mutedEnabled=false', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/util.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/util.js
@@ -951,6 +951,42 @@ describe('plugin-meetings', () => {
           assert.deepEqual(result.body, {raiseHand: {enabled: true}});
           assert.equal(result.method, 'PATCH');
         });
+
+        it('should return locusUrl when mainLocusUrl is null', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {raiseHand: {enabled: true}},
+            locusUrl,
+            mainLocusUrl: null,
+          });
+
+          assert.equal(result.uri, 'locus/breakout/controls');
+          assert.deepEqual(result.body, {raiseHand: {enabled: true}});
+          assert.equal(result.method, 'PATCH');
+        });
+
+        it('should return locusUrl when mainLocusUrl is empty string', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {raiseHand: {enabled: true}},
+            locusUrl,
+            mainLocusUrl: '',
+          });
+
+          assert.equal(result.uri, 'locus/breakout/controls');
+          assert.deepEqual(result.body, {raiseHand: {enabled: true}});
+          assert.equal(result.method, 'PATCH');
+        });
+
+        it('should return locusUrl for audio controls when not in a breakout', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {audio: {muted: true}},
+            locusUrl: 'locus/main',
+            mainLocusUrl: 'locus/main',
+          });
+
+          assert.equal(result.uri, 'locus/main/controls');
+          assert.deepEqual(result.body, {audio: {muted: true}});
+          assert.equal(result.method, 'PATCH');
+        });
       });
     });
   });

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/util.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/util.js
@@ -799,6 +799,151 @@ describe('plugin-meetings', () => {
           );
         });
       });
+
+      describe('isAudioControl()', () => {
+        it('should return true when all body keys are audio control keys', () => {
+          assert.isTrue(ControlsOptionsUtil.isAudioControl({audio: {muted: true}}));
+        });
+
+        it('should return true when body has muteOnEntry key', () => {
+          assert.isTrue(ControlsOptionsUtil.isAudioControl({muteOnEntry: {enabled: true}}));
+        });
+
+        it('should return true when body has disallowUnmute key', () => {
+          assert.isTrue(ControlsOptionsUtil.isAudioControl({disallowUnmute: {enabled: true}}));
+        });
+
+        it('should return true when body has multiple audio control keys', () => {
+          assert.isTrue(ControlsOptionsUtil.isAudioControl({audio: {muted: true}, muteOnEntry: {enabled: true}, disallowUnmute: {enabled: true}}));
+        });
+
+        it('should return false when body has a non-audio control key', () => {
+          assert.isFalse(ControlsOptionsUtil.isAudioControl({raiseHand: {enabled: true}}));
+        });
+
+        it('should return false when body has a mix of audio and non-audio keys', () => {
+          assert.isFalse(ControlsOptionsUtil.isAudioControl({audio: {muted: true}, raiseHand: {enabled: true}}));
+        });
+
+        it('should return true for an empty body', () => {
+          assert.isTrue(ControlsOptionsUtil.isAudioControl({}));
+        });
+      });
+
+      describe('isBreakoutLocusUrl()', () => {
+        it('should return true when mainLocusUrl differs from locusUrl', () => {
+          assert.isTrue(ControlsOptionsUtil.isBreakoutLocusUrl('locus/breakout', 'locus/main'));
+        });
+
+        it('should return false when mainLocusUrl equals locusUrl', () => {
+          assert.isFalse(ControlsOptionsUtil.isBreakoutLocusUrl('locus/main', 'locus/main'));
+        });
+
+        it('should return false when mainLocusUrl is undefined', () => {
+          assert.isFalse(ControlsOptionsUtil.isBreakoutLocusUrl('locus/breakout', undefined));
+        });
+
+        it('should return false when mainLocusUrl is null', () => {
+          assert.isFalse(ControlsOptionsUtil.isBreakoutLocusUrl('locus/breakout', null));
+        });
+
+        it('should return false when mainLocusUrl is empty string', () => {
+          assert.isFalse(ControlsOptionsUtil.isBreakoutLocusUrl('locus/breakout', ''));
+        });
+      });
+
+      describe('getControlsRequestParams()', () => {
+        const locusUrl = 'locus/breakout';
+        const mainLocusUrl = 'locus/main';
+
+        it('should return locusUrl and no extraBody when not in a breakout', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {raiseHand: {enabled: true}},
+            locusUrl: 'locus/main',
+            mainLocusUrl: 'locus/main',
+          });
+
+          assert.equal(result.targetUrl, 'locus/main');
+          assert.deepEqual(result.extraBody, {});
+        });
+
+        it('should return mainLocusUrl with authorizingLocusUrl for non-audio controls in a breakout', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {raiseHand: {enabled: true}},
+            locusUrl,
+            mainLocusUrl,
+          });
+
+          assert.equal(result.targetUrl, mainLocusUrl);
+          assert.deepEqual(result.extraBody, {authorizingLocusUrl: locusUrl});
+        });
+
+        it('should return locusUrl without authorizingLocusUrl for audio controls in a breakout', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {audio: {muted: true}},
+            locusUrl,
+            mainLocusUrl,
+          });
+
+          assert.equal(result.targetUrl, locusUrl);
+          assert.deepEqual(result.extraBody, {});
+        });
+
+        it('should return locusUrl without authorizingLocusUrl for muteOnEntry in a breakout', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {muteOnEntry: {enabled: true}},
+            locusUrl,
+            mainLocusUrl,
+          });
+
+          assert.equal(result.targetUrl, locusUrl);
+          assert.deepEqual(result.extraBody, {});
+        });
+
+        it('should return locusUrl without authorizingLocusUrl for disallowUnmute in a breakout', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {disallowUnmute: {enabled: true}},
+            locusUrl,
+            mainLocusUrl,
+          });
+
+          assert.equal(result.targetUrl, locusUrl);
+          assert.deepEqual(result.extraBody, {});
+        });
+
+        it('should return mainLocusUrl with authorizingLocusUrl for mixed audio and non-audio in a breakout', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {audio: {muted: true}, raiseHand: {enabled: true}},
+            locusUrl,
+            mainLocusUrl,
+          });
+
+          assert.equal(result.targetUrl, mainLocusUrl);
+          assert.deepEqual(result.extraBody, {authorizingLocusUrl: locusUrl});
+        });
+
+        it('should return locusUrl and no extraBody when mainLocusUrl is undefined', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {raiseHand: {enabled: true}},
+            locusUrl,
+            mainLocusUrl: undefined,
+          });
+
+          assert.equal(result.targetUrl, locusUrl);
+          assert.deepEqual(result.extraBody, {});
+        });
+
+        it('should return undefined targetUrl and no extraBody when locusUrl is undefined', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {audio: {muted: true}},
+            locusUrl: undefined,
+            mainLocusUrl: 'locus/main',
+          });
+
+          assert.equal(result.targetUrl, undefined);
+          assert.deepEqual(result.extraBody, {});
+        });
+      });
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/util.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/util.js
@@ -856,18 +856,6 @@ describe('plugin-meetings', () => {
         const locusUrl = 'locus/breakout';
         const mainLocusUrl = 'locus/main';
 
-        it('should return request params with undefined-based uri when locusUrl is falsy', () => {
-          const result = ControlsOptionsUtil.getControlsRequestParams({
-            body: {audio: {muted: true}},
-            locusUrl: undefined,
-            mainLocusUrl: 'locus/main',
-          });
-
-          assert.equal(result.uri, 'undefined/controls');
-          assert.deepEqual(result.body, {audio: {muted: true}});
-          assert.equal(result.method, 'PATCH');
-        });
-
         it('should return full request params targeting locusUrl when not in a breakout', () => {
           const result = ControlsOptionsUtil.getControlsRequestParams({
             body: {raiseHand: {enabled: true}},
@@ -925,18 +913,6 @@ describe('plugin-meetings', () => {
 
           assert.equal(result.uri, 'locus/breakout/controls');
           assert.deepEqual(result.body, {disallowUnmute: {enabled: true}});
-          assert.equal(result.method, 'PATCH');
-        });
-
-        it('should return mainLocusUrl with authorizingLocusUrl for mixed audio and non-audio in a breakout', () => {
-          const result = ControlsOptionsUtil.getControlsRequestParams({
-            body: {audio: {muted: true}, raiseHand: {enabled: true}},
-            locusUrl,
-            mainLocusUrl,
-          });
-
-          assert.equal(result.uri, 'locus/main/controls');
-          assert.deepEqual(result.body, {audio: {muted: true}, raiseHand: {enabled: true}, authorizingLocusUrl: locusUrl});
           assert.equal(result.method, 'PATCH');
         });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/util.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/util.js
@@ -856,26 +856,40 @@ describe('plugin-meetings', () => {
         const locusUrl = 'locus/breakout';
         const mainLocusUrl = 'locus/main';
 
-        it('should return locusUrl and no extraBody when not in a breakout', () => {
+        it('should return request params with undefined-based uri when locusUrl is falsy', () => {
+          const result = ControlsOptionsUtil.getControlsRequestParams({
+            body: {audio: {muted: true}},
+            locusUrl: undefined,
+            mainLocusUrl: 'locus/main',
+          });
+
+          assert.equal(result.uri, 'undefined/controls');
+          assert.deepEqual(result.body, {audio: {muted: true}});
+          assert.equal(result.method, 'PATCH');
+        });
+
+        it('should return full request params targeting locusUrl when not in a breakout', () => {
           const result = ControlsOptionsUtil.getControlsRequestParams({
             body: {raiseHand: {enabled: true}},
             locusUrl: 'locus/main',
             mainLocusUrl: 'locus/main',
           });
 
-          assert.equal(result.targetUrl, 'locus/main');
-          assert.deepEqual(result.extraBody, {});
+          assert.equal(result.uri, 'locus/main/controls');
+          assert.deepEqual(result.body, {raiseHand: {enabled: true}});
+          assert.equal(result.method, 'PATCH');
         });
 
-        it('should return mainLocusUrl with authorizingLocusUrl for non-audio controls in a breakout', () => {
+        it('should return mainLocusUrl with authorizingLocusUrl in body for non-audio controls in a breakout', () => {
           const result = ControlsOptionsUtil.getControlsRequestParams({
             body: {raiseHand: {enabled: true}},
             locusUrl,
             mainLocusUrl,
           });
 
-          assert.equal(result.targetUrl, mainLocusUrl);
-          assert.deepEqual(result.extraBody, {authorizingLocusUrl: locusUrl});
+          assert.equal(result.uri, 'locus/main/controls');
+          assert.deepEqual(result.body, {raiseHand: {enabled: true}, authorizingLocusUrl: locusUrl});
+          assert.equal(result.method, 'PATCH');
         });
 
         it('should return locusUrl without authorizingLocusUrl for audio controls in a breakout', () => {
@@ -885,8 +899,9 @@ describe('plugin-meetings', () => {
             mainLocusUrl,
           });
 
-          assert.equal(result.targetUrl, locusUrl);
-          assert.deepEqual(result.extraBody, {});
+          assert.equal(result.uri, 'locus/breakout/controls');
+          assert.deepEqual(result.body, {audio: {muted: true}});
+          assert.equal(result.method, 'PATCH');
         });
 
         it('should return locusUrl without authorizingLocusUrl for muteOnEntry in a breakout', () => {
@@ -896,8 +911,9 @@ describe('plugin-meetings', () => {
             mainLocusUrl,
           });
 
-          assert.equal(result.targetUrl, locusUrl);
-          assert.deepEqual(result.extraBody, {});
+          assert.equal(result.uri, 'locus/breakout/controls');
+          assert.deepEqual(result.body, {muteOnEntry: {enabled: true}});
+          assert.equal(result.method, 'PATCH');
         });
 
         it('should return locusUrl without authorizingLocusUrl for disallowUnmute in a breakout', () => {
@@ -907,8 +923,9 @@ describe('plugin-meetings', () => {
             mainLocusUrl,
           });
 
-          assert.equal(result.targetUrl, locusUrl);
-          assert.deepEqual(result.extraBody, {});
+          assert.equal(result.uri, 'locus/breakout/controls');
+          assert.deepEqual(result.body, {disallowUnmute: {enabled: true}});
+          assert.equal(result.method, 'PATCH');
         });
 
         it('should return mainLocusUrl with authorizingLocusUrl for mixed audio and non-audio in a breakout', () => {
@@ -918,30 +935,21 @@ describe('plugin-meetings', () => {
             mainLocusUrl,
           });
 
-          assert.equal(result.targetUrl, mainLocusUrl);
-          assert.deepEqual(result.extraBody, {authorizingLocusUrl: locusUrl});
+          assert.equal(result.uri, 'locus/main/controls');
+          assert.deepEqual(result.body, {audio: {muted: true}, raiseHand: {enabled: true}, authorizingLocusUrl: locusUrl});
+          assert.equal(result.method, 'PATCH');
         });
 
-        it('should return locusUrl and no extraBody when mainLocusUrl is undefined', () => {
+        it('should return locusUrl when mainLocusUrl is undefined', () => {
           const result = ControlsOptionsUtil.getControlsRequestParams({
             body: {raiseHand: {enabled: true}},
             locusUrl,
             mainLocusUrl: undefined,
           });
 
-          assert.equal(result.targetUrl, locusUrl);
-          assert.deepEqual(result.extraBody, {});
-        });
-
-        it('should return undefined targetUrl and no extraBody when locusUrl is undefined', () => {
-          const result = ControlsOptionsUtil.getControlsRequestParams({
-            body: {audio: {muted: true}},
-            locusUrl: undefined,
-            mainLocusUrl: 'locus/main',
-          });
-
-          assert.equal(result.targetUrl, undefined);
-          assert.deepEqual(result.extraBody, {});
+          assert.equal(result.uri, 'locus/breakout/controls');
+          assert.deepEqual(result.body, {raiseHand: {enabled: true}});
+          assert.equal(result.method, 'PATCH');
         });
       });
     });


### PR DESCRIPTION
# COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-393351

## This pull request addresses

When a host is in a breakout session and attempts to mute participants using audio controls (`mute`/`unmute`, `muteOnEntry`, `disallowUnmute`), the SDK was sending the PATCH request to the **main session locus URL** with `authorizingLocusUrl` pointing to the breakout. However, the Locus controls API does not support `authorizingLocusUrl` for audio controls — they are not wired into the cross-locus GraphQL authorization path. The server ignores the field and evaluates the request against the target locus only, resulting in **403 Forbidden** (errorCode `2403031`) because the host is not joined to the main locus directly.

## by making the following changes

- **`constants.ts`**: Added `AUDIO_CONTROL_BODY_KEYS` as a `ReadonlySet<string>` containing `audio`, `muteOnEntry`, and `disallowUnmute` — the body keys that do not support cross-locus authorization.
- **`util.ts`**: Added three static helper methods:
  - `isAudioControl(body)` — checks if all body keys are audio control keys
  - `isBreakoutLocusUrl(locusUrl, mainLocusUrl)` — detects breakout session by URL comparison
  - `getControlsRequestParams({body, locusUrl, mainLocusUrl})` — resolves `targetUrl` and `extraBody` for the controls request, routing audio controls directly to `locusUrl` and non-audio controls to `mainLocusUrl` with `authorizingLocusUrl`
- **`index.ts`**: Both `update()` and `setControls()` now delegate routing to `Util.getControlsRequestParams()` instead of inline logic.
- **`test/.../util.js`**: Added unit tests for `isAudioControl()`, `isBreakoutLocusUrl()`, and `getControlsRequestParams()`.
- **`test/.../index.js`**: Added integration tests for all breakout audio routing scenarios.

Non-breakout behavior is completely unchanged.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- See comments below for additional tests completed
- `setMuteAll` in breakout → sends to `locusUrl` without `authorizingLocusUrl` (attendee and PANELIST roles)
- `setMuteOnEntry` in breakout → sends to `locusUrl` without `authorizingLocusUrl`
- `setDisallowUnmute` in breakout → sends to `locusUrl` without `authorizingLocusUrl`
- `update()` with audio scope in breakout → sends to `locusUrl` without `authorizingLocusUrl`
- `update()` with non-audio scope in breakout → sends to `mainLocusUrl` with `authorizingLocusUrl`
- Mixed `update(audio, reactions)` in breakout → audio routed to `locusUrl`, reactions to `mainLocusUrl`
- All existing non-breakout tests continue to pass (28 index tests + 21 new util tests = 49 total)
- `isAudioControl()` edge cases: empty body, single audio key, mixed keys, non-audio keys
- `isBreakoutLocusUrl()` edge cases: undefined/null/empty mainLocusUrl, matching URLs
- `getControlsRequestParams()` scenarios: non-breakout, breakout audio, breakout non-audio, mixed body keys

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.