### PR TITLE
fix(contact-center): read mediaResourceId from interaction.media in hold() to match resume()

### DIFF
--- a/packages/@webex/contact-center/src/services/task/index.ts
+++ b/packages/@webex/contact-center/src/services/task/index.ts
@@ -565,7 +565,10 @@ export default class Task extends EventEmitter implements ITask {
         METRIC_EVENT_NAMES.TASK_HOLD_FAILED,
       ]);
 
-      const effectiveMediaResourceId = mediaResourceId ?? this.data.mediaResourceId;
+      const {mainInteractionId} = this.data.interaction;
+      const defaultMediaResourceId =
+        this.data.interaction.media[mainInteractionId]?.mediaResourceId;
+      const effectiveMediaResourceId = mediaResourceId ?? defaultMediaResourceId;
 
       const response = await this.contact.hold({
         interactionId: this.data.interactionId,
@@ -599,7 +602,9 @@ export default class Task extends EventEmitter implements ITask {
         errorData: err.data?.errorData,
         reasonCode: err.data?.reasonCode,
       };
-      const effectiveMediaResourceId = mediaResourceId ?? this.data.mediaResourceId;
+      const defaultMediaResourceId =
+        this.data.interaction.media[this.data.interaction.mainInteractionId]?.mediaResourceId;
+      const effectiveMediaResourceId = mediaResourceId ?? defaultMediaResourceId;
 
       this.metricsManager.trackEvent(
         METRIC_EVENT_NAMES.TASK_HOLD_FAILED,

--- a/packages/@webex/contact-center/test/unit/spec/services/task/index.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/index.ts
@@ -691,6 +691,27 @@ describe('Task', () => {
     );
   });
 
+  it('should hold using mediaResourceId from interaction.media after recording event wipes top-level mediaResourceId', async () => {
+    // Set a DIFFERENT top-level mediaResourceId so we can distinguish the two sources
+    const staleTopLevelId = 'stale-top-level-media-resource-id';
+    const correctMediaId = task.data.interaction.media[task.data.interaction.mainInteractionId].mediaResourceId;
+    task.data.mediaResourceId = staleTopLevelId;
+
+    // Simulate recording event wiping top-level mediaResourceId (as reconcileData does)
+    delete task.data.mediaResourceId;
+
+    const expectedResponse: TaskResponse = {data: {interactionId: taskId}} as AgentContact;
+    contactMock.hold.mockResolvedValue(expectedResponse);
+
+    await task.hold();
+
+    // hold() should read from interaction.media, not the (now deleted) top-level field
+    expect(contactMock.hold).toHaveBeenCalledWith({
+      interactionId: taskId,
+      data: {mediaResourceId: correctMediaId},
+    });
+  });
+
   it('should handle errors in hold method', async () => {
     const error = {details: (global as any).makeFailure('Hold Failed')};
     contactMock.hold.mockImplementation(() => {


### PR DESCRIPTION
# COMPLETES # https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7507

## This pull request addresses

Hold/resume functionality breaking after any recording pause/resume cycle. The `hold()` method reads `mediaResourceId` from `this.data.mediaResourceId` (a top-level task data field), while `resume()` reads it from `this.data.interaction.media[mainInteractionId].mediaResourceId`. Recording events (`ContactRecordingPaused` / `ContactRecordingResumed`) don't include `mediaResourceId` at the top level, so `reconcileData()` deletes it. Subsequent `hold()` calls then send an empty `mediaResourceId` to the backend, which cannot identify the media resource to hold.

## by making the following changes

- Updated `hold()` in `packages/@webex/contact-center/src/services/task/index.ts` to read `mediaResourceId` from `this.data.interaction.media[mainInteractionId].mediaResourceId` — consistent with how `resume()` already reads it
- This applies to both the success path and the error handling path

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

### Manual Testing
- Linked patched SDK into widgets app via yarn link
- Confirmed hold/resume works correctly after recording pause/resume cycle (previously broken)
- Confirmed hold/resume still works correctly on a fresh call without recording events
- Video demonstration: https://app.vidcast.io/share/355ef012-b9ce-4b84-b35a-cc0f3cc5e303

### Automated Testing
- ✅ All 74 existing unit tests pass with no changes needed

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly