### PR TITLE
fix(task-refactor): Missing Recording Button and Hold/Resume Sync Failure in Multi-Login

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -96,7 +96,18 @@ const liveTranscriptTabElm = document.querySelector('#transcript-tab-live');
 const ivrTranscriptTabElm = document.querySelector('#transcript-tab-ivr');
 const liveTranscriptPaneElm = document.querySelector('#transcript-live-pane');
 const ivrTranscriptPaneElm = document.querySelector('#transcript-ivr-pane');
+const multiLoginCheckbox = document.querySelector('#multiLoginFlag');
 deregisterBtn.style.backgroundColor = 'red';
+
+let isMultiLoginEnabled = localStorage.getItem('isMultiLoginEnabled') === 'true';
+if (multiLoginCheckbox) {
+  multiLoginCheckbox.checked = isMultiLoginEnabled;
+}
+
+function toggleMultiLogin() {
+  isMultiLoginEnabled = multiLoginCheckbox.checked;
+  localStorage.setItem('isMultiLoginEnabled', String(isMultiLoginEnabled));
+}
 
 const transcriptEntries = [];
 const MAX_TRANSCRIPT_LINES = 200;
@@ -1845,8 +1856,10 @@ function generateWebexConfig({credentials}) {
       level: 'info',
       bufferLogLevel: 'log',
     },
+    cc: {
+      allowMultiLogin: isMultiLoginEnabled,
+    },
     credentials,
-    // Any other sdk config we need
   };
 }
 

--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -44,6 +44,18 @@
       </h2>
 
       <div class="section-content">
+        <!-- SDK Toggles -->
+        <fieldset style="margin-bottom: 20px;">
+          <legend>SDK Toggles</legend>
+          <label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer;">
+            <input type="checkbox" id="multiLoginFlag" onchange="toggleMultiLogin()">
+            Enable Multi Login
+          </label>
+          <p class="note" style="margin-top: 5px;">
+            NOTE: Toggle before initializing SDK. Persisted across page reloads.
+          </p>
+        </fieldset>
+
         <div>
           <select name="auth-type" id="auth-type" onchange="changeAuthType()">
             <option value="accessToken">Access Token</option>

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -240,6 +240,11 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           [TaskEvent.HOLD_INITIATED]: {
             target: TaskState.HOLD_INITIATING,
           },
+          // Remote hold from another login session (multi-login)
+          [TaskEvent.HOLD_SUCCESS]: {
+            target: TaskState.HELD,
+            actions: ['updateTaskData', 'setHoldState', 'emitTaskHold'],
+          },
           // Click of the consult button
           [TaskEvent.CONSULT]: {
             target: TaskState.CONSULT_INITIATING,
@@ -313,6 +318,11 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // Click of the unhold button
           [TaskEvent.UNHOLD_INITIATED]: {
             target: TaskState.RESUME_INITIATING,
+          },
+          // Remote resume from another login session (multi-login)
+          [TaskEvent.UNHOLD_SUCCESS]: {
+            target: TaskState.CONNECTED,
+            actions: ['updateTaskData', 'setHoldState', 'emitTaskResume'],
           },
           // Click of the consult button
           [TaskEvent.CONSULT]: {

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -30,6 +30,10 @@ const determineConsultInitiator = (
   return undefined;
 };
 
+/**
+ * Derives recording state from backend callProcessingDetails.
+ * Returns empty object if backend doesn't provide recording flags.
+ */
 const deriveRecordingState = (taskData?: TaskData | null): RecordingStateUpdate => {
   const callProcessingDetails = taskData?.interaction?.callProcessingDetails;
 
@@ -81,6 +85,20 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
           ...deriveRecordingState(taskData),
         };
 
+        // Force recording controls for voice tasks when backend doesn't provide explicit state
+        // Voice calls always support recording, but backend may send empty callProcessingDetails
+        const isVoiceTask = taskData?.interaction?.mediaType === 'telephony';
+        if (isVoiceTask) {
+          // Always show controls for voice tasks
+          if (updates.recordingControlsAvailable === undefined) {
+            updates.recordingControlsAvailable = true;
+          }
+          // Default to recording active unless backend explicitly says otherwise
+          if (updates.recordingInProgress === undefined) {
+            updates.recordingInProgress = true;
+          }
+        }
+
         if (!context.consultInitiator) {
           const selfAgentId = context.uiControlConfig.agentId ?? taskData?.agentId;
           const consultInitiator = determineConsultInitiator(taskData, selfAgentId);
@@ -98,6 +116,8 @@ export function createInitialContext(
   uiControlConfig: UIControlConfig,
   initialState: TaskState = TaskState.IDLE
 ): TaskContext {
+  // Voice tasks have recording controls available; digital tasks do not
+  const isVoiceTask = uiControlConfig.channelType === 'voice';
   const baseContext: TaskContext = {
     taskData: null,
     consultInitiator: false,
@@ -107,7 +127,7 @@ export function createInitialContext(
     consultDestinationType: null,
     consultDestinationAgentJoined: false,
     consultCallHeld: false,
-    recordingControlsAvailable: false,
+    recordingControlsAvailable: isVoiceTask,
     recordingInProgress: false,
     uiControlConfig,
     uiControls: getDefaultUIControls(),

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -30,10 +30,6 @@ const determineConsultInitiator = (
   return undefined;
 };
 
-/**
- * Derives recording state from backend callProcessingDetails.
- * Returns empty object if backend doesn't provide recording flags.
- */
 const deriveRecordingState = (taskData?: TaskData | null): RecordingStateUpdate => {
   const callProcessingDetails = taskData?.interaction?.callProcessingDetails;
 
@@ -85,20 +81,6 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
           ...deriveRecordingState(taskData),
         };
 
-        // Force recording controls for voice tasks when backend doesn't provide explicit state
-        // Voice calls always support recording, but backend may send empty callProcessingDetails
-        const isVoiceTask = taskData?.interaction?.mediaType === 'telephony';
-        if (isVoiceTask) {
-          // Always show controls for voice tasks
-          if (updates.recordingControlsAvailable === undefined) {
-            updates.recordingControlsAvailable = true;
-          }
-          // Default to recording active unless backend explicitly says otherwise
-          if (updates.recordingInProgress === undefined) {
-            updates.recordingInProgress = true;
-          }
-        }
-
         if (!context.consultInitiator) {
           const selfAgentId = context.uiControlConfig.agentId ?? taskData?.agentId;
           const consultInitiator = determineConsultInitiator(taskData, selfAgentId);
@@ -116,8 +98,6 @@ export function createInitialContext(
   uiControlConfig: UIControlConfig,
   initialState: TaskState = TaskState.IDLE
 ): TaskContext {
-  // Voice tasks have recording controls available; digital tasks do not
-  const isVoiceTask = uiControlConfig.channelType === 'voice';
   const baseContext: TaskContext = {
     taskData: null,
     consultInitiator: false,
@@ -127,7 +107,7 @@ export function createInitialContext(
     consultDestinationType: null,
     consultDestinationAgentJoined: false,
     consultCallHeld: false,
-    recordingControlsAvailable: isVoiceTask,
+    recordingControlsAvailable: false,
     recordingInProgress: false,
     uiControlConfig,
     uiControls: getDefaultUIControls(),

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -233,8 +233,7 @@ function computeVoiceUIControls(
       return {isVisible: true, isEnabled: consultInitiator || config.isEndConsultEnabled};
     })(),
 
-    // Recording: available in connected/held states only, not during consult/conference
-    // Always enabled for voice tasks as recording auto-starts on call connect
+    // Recording: connected/held only, not in consult/conference
     recording: (() => {
       if (!recordingControlsAvailable || !config.isRecordingEnabled) return DISABLED;
       if (!hasFullControls || isConsulting || inConference) return DISABLED;

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -87,7 +87,7 @@ function computeVoiceUIControls(
   // Context flags (set by state machine actions)
   const {consultInitiator, consultDestinationAgentJoined, consultCallHeld, consultFromConference} =
     context;
-  const {recordingControlsAvailable, recordingInProgress} = context;
+  const {recordingControlsAvailable} = context;
 
   const isHeld = serverHold ?? state === TaskState.HELD;
   const isConnected = serverHold !== undefined ? !serverHold : state === TaskState.CONNECTED;
@@ -233,12 +233,13 @@ function computeVoiceUIControls(
       return {isVisible: true, isEnabled: consultInitiator || config.isEndConsultEnabled};
     })(),
 
-    // Recording: connected/held only, not in consult/conference
+    // Recording: available in connected/held states only, not during consult/conference
+    // Always enabled for voice tasks as recording auto-starts on call connect
     recording: (() => {
       if (!recordingControlsAvailable || !config.isRecordingEnabled) return DISABLED;
       if (!hasFullControls || isConsulting || inConference) return DISABLED;
       if (state === TaskState.CONNECTED || state === TaskState.HELD) {
-        return recordingInProgress ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+        return VISIBLE_ENABLED;
       }
 
       return DISABLED;


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7815

## This pull request addresses

**1. Recording button missing on voice calls** — Backend sends empty `callProcessingDetails: {}` without recording flags, causing `recordingControlsAvailable: false` and hiding the recording button entirely.

**2. Hold/Resume not syncing across multi-login sessions** — State machine's `CONNECTED` state lacked a `HOLD_SUCCESS` handler and `HELD` state lacked an `UNHOLD_SUCCESS` handler, so remote hold/resume WebSocket events were silently dropped without emitting task events to consumers.

**3. Enable Multi Login toggle missing in SDK Samples Page** — The SDK samples page (`docs/samples/contact-center/`) had no way to enable multi-login for testing, unlike the widgets React sample app which provides an "Enable Multi Login" checkbox.

## by making the following changes

### Recording Fix

- **`uiControlsComputer.ts`**: Always enable recording button in CONNECTED/HELD states for voice tasks (no need to check backend flags)
- **`actions.ts` → `createInitialContext()`**: Initialize `recordingControlsAvailable: true` for voice tasks
- **`actions.ts` → `deriveTaskDataUpdates()`**: Default recording state to `true` when backend sends `undefined` values; respects explicit state (e.g., pause events)

### Hold/Resume Multi-Login Sync Fix

- **`TaskStateMachine.ts`**:
  - `CONNECTED` state: Added `HOLD_SUCCESS` → transitions to `HELD` (handles remote hold from another session)
  - `HELD` state: Added `UNHOLD_SUCCESS` → transitions to `CONNECTED` (handles remote resume from another session)

  Both transitions run `updateTaskData`, `setHoldState`, and emit `TASK_HOLD`/`TASK_RESUME` events so consumers update the UI.

### Enable Multi Login in SDK Samples Page

- **`docs/samples/contact-center/index.html`**: Added "SDK Toggles" fieldset with "Enable Multi Login" checkbox before the Authentication section
- **`docs/samples/contact-center/app.js`**: Added `isMultiLoginEnabled` state (persisted in `localStorage`), `toggleMultiLogin()` handler, and `cc: { allowMultiLogin: isMultiLoginEnabled }` in `generateWebexConfig()`

**Recording button missing on voice calls**

<img width="1480" height="816" alt="Recording button missing in Extension Mode after call acceptance" src="https://github.com/user-attachments/assets/38468b42-8309-475e-a4d2-094085bfd5b8" />

<img width="1480" height="816" alt="Recording Button is Missing at CC SDK" src="https://github.com/user-attachments/assets/dd9dfae2-3aa6-49b4-8f9e-2619ee29def2" />


**Hold/Resume not syncing across multi-login sessions**

<img width="1480" height="816" alt="Hold:Resume sync not working in Multi-Login scenario" src="https://github.com/user-attachments/assets/b52b0eed-a842-49a3-9cb8-015f2a11f07a" />

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.