### PR TITLE
chore: deploy CD verification placeholder

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -380,6 +380,12 @@ jobs:
     needs: [publish-npm, publish-tag]
     runs-on: ubuntu-latest
 
+    outputs:
+      pr_number: ${{ steps.get-pr.outputs.pr_number }}
+      changelog_url: ${{ steps.post-comment.outputs.changelog_url }}
+      version: ${{ steps.post-comment.outputs.version }}
+      primary_version: ${{ steps.post-comment.outputs.primary_version }}
+
     steps:
       - name: Get PR Number
         id: get-pr
@@ -405,6 +411,7 @@ jobs:
             core.setOutput('pr_number', '');
 
       - name: Post Release Comment on PR
+        id: post-comment
         if: steps.get-pr.outputs.pr_number != ''
         uses: actions/github-script@v7
         with:
@@ -419,6 +426,7 @@ jobs:
             }
             const packageEntries = Object.entries(packageVersions);
             const version = packageVersions['webex'] ? `v${packageVersions['webex']}` : '';
+            core.setOutput('version', version);
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -431,6 +439,7 @@ jobs:
               const primaryPackage = packageVersions['webex']
                 ? 'webex' : packageEntries[0][0];
               const primaryVersion = packageVersions[primaryPackage];
+              core.setOutput('primary_version', `v${primaryVersion}`);
               const stableVersion = primaryVersion.replace(/-next\..*/, '').replace(/-[a-z]*\..*/, '');
 
               const cnameFile = await github.rest.repos.getContent({ owner, repo, path: 'docs/CNAME' });
@@ -441,6 +450,8 @@ jobs:
               }
               changelogUrl.searchParams.set('package', primaryPackage);
               changelogUrl.searchParams.set('version', primaryVersion);
+
+              core.setOutput('changelog_url', changelogUrl.toString());
 
               const releaseLine = version
                 ? `| **Released in:** [\`${version}\`](${repoUrl}/releases/tag/${version}) |`
@@ -523,3 +534,52 @@ jobs:
             } catch (error) {
               core.warning(`Failed to comment on PR #${prNumber}: ${error.message}`);
             }
+
+  notify-webex-space:
+    name: Send Webex Space Notification
+    needs: [publish-tag, publish-npm, comment-on-pr]
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Post Webex Space Message
+        env:
+          WEBEX_BOT_TOKEN: ${{ secrets.WEBEX_BOT_TOKEN }}
+          WEBEX_ROOM_ID: ${{ secrets.WEBEX_ROOM_ID }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          VERSION="${{ needs.comment-on-pr.outputs.primary_version }}"
+          PR_NUMBER="${{ needs.comment-on-pr.outputs.pr_number }}"
+          CHANGELOG_URL="${{ needs.comment-on-pr.outputs.changelog_url }}"
+
+          if [ -n "${PR_NUMBER}" ]; then
+            PR_LINK="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+          else
+            PR_LINK=""
+          fi
+
+          MESSAGE=""
+          if [ -n "${VERSION}" ]; then
+            MESSAGE="**Version:** ${VERSION}"
+          fi
+          if [ -n "${PR_LINK}" ]; then
+            MESSAGE="${MESSAGE}\n\n**PR:** [${COMMIT_MESSAGE}](${PR_LINK})"
+          fi
+          if [ -n "${CHANGELOG_URL}" ]; then
+            MESSAGE="${MESSAGE}\n\n**Changelog:** ${CHANGELOG_URL}"
+          fi
+
+          if [ -z "${MESSAGE}" ]; then
+            echo "No version or PR info available. Skipping notification."
+            exit 0
+          fi
+
+          echo "Sending message to Webex Space..."
+
+          curl -sSf \
+            -H "Authorization: Bearer ${WEBEX_BOT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"roomId\":\"${WEBEX_ROOM_ID}\",\"markdown\":\"${MESSAGE}\"}" \
+            https://webexapis.com/v1/messages > /dev/null
+
+          echo "Message sent successfully!"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -439,7 +439,7 @@ jobs:
               const primaryPackage = packageVersions['webex']
                 ? 'webex' : packageEntries[0][0];
               const primaryVersion = packageVersions[primaryPackage];
-              core.setOutput('primary_version', `v${primaryVersion}`);
+              core.setOutput('primary_version', `${primaryPackage}@${primaryVersion}`);
               const stableVersion = primaryVersion.replace(/-next\..*/, '').replace(/-[a-z]*\..*/, '');
 
               const cnameFile = await github.rest.repos.getContent({ owner, repo, path: 'docs/CNAME' });

--- a/docs/deploy-notify-test-placeholder.md
+++ b/docs/deploy-notify-test-placeholder.md
@@ -1,0 +1,4 @@
+# Deploy CD verification marker
+
+Short-lived file used to validate the release notification path after a merge to `next`.
+Remove this file once verification is complete.


### PR DESCRIPTION
Adds a short-lived doc marker to validate the deploy CD pipeline after merge to `next`.

Removes `docs/deploy-notify-test-placeholder.md` after verification.
