### PR TITLE
feat(plugin-meetings): enrich mute event payload with modifiedBy

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -2598,6 +2598,7 @@ export default class LocusInfo extends EventsScope {
           {
             muted: parsedSelves.current.remoteMuted,
             unmuteAllowed: parsedSelves.current.unmuteAllowed,
+            modifiedBy: parsedSelves.current.modifiedBy ?? null,
           }
         );
       }

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -2024,7 +2024,7 @@ describe('plugin-meetings', () => {
             function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
-          {muted: true, unmuteAllowed: true}
+          {muted: true, unmuteAllowed: true, modifiedBy: null}
         );
 
         // but sometimes "previous self" is defined, but without controls.audio.muted, so we test this here:
@@ -2039,7 +2039,7 @@ describe('plugin-meetings', () => {
             function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
-          {muted: true, unmuteAllowed: true}
+          {muted: true, unmuteAllowed: true, modifiedBy: null}
         );
       });
 
@@ -2098,7 +2098,7 @@ describe('plugin-meetings', () => {
             function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
-          {muted: true, unmuteAllowed: true}
+          {muted: true, unmuteAllowed: true, modifiedBy: null}
         );
       });
 
@@ -2237,7 +2237,7 @@ describe('plugin-meetings', () => {
             function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
-          {muted: true, unmuteAllowed: false}
+          {muted: true, unmuteAllowed: false, modifiedBy: null}
         );
 
         // now change only disallowUnmute
@@ -2255,7 +2255,28 @@ describe('plugin-meetings', () => {
             function: 'updateSelf',
           },
           LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
-          {muted: true, unmuteAllowed: true}
+          {muted: true, unmuteAllowed: true, modifiedBy: null}
+        );
+      });
+
+      it('should include modifiedBy in payload when muted by host', () => {
+        locusInfo.webex.internal.device.url = self.deviceUrl;
+        locusInfo.updateSelf(self);
+        const newSelf = cloneDeep(self);
+        newSelf.controls.audio.muted = true;
+        newSelf.controls.audio.meta = {modifiedBy: 'host-uuid-123'};
+
+        locusInfo.emitScoped = sinon.stub();
+        locusInfo.updateSelf(newSelf);
+
+        assert.calledWith(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'updateSelf',
+          },
+          LOCUSINFO.EVENTS.SELF_REMOTE_MUTE_STATUS_UPDATED,
+          {muted: true, unmuteAllowed: true, modifiedBy: 'host-uuid-123'}
         );
       });
 


### PR DESCRIPTION
# COMPLETES #SPARK-795472

## This pull request addresses

missing modifiedBy in the locusInfo update

## by making the following changes
adds modifiedBy to the SELF_REMOTE_MUTE_STATUS_UPDATED event payload so the web client can distinguish self-mute from remote-mute for notifications. The field is null when locus omits meta.modifiedBy (e.g., mute-on-entry or legacy DTO scenarios).

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Local web client manual testing via SDK linking, e2e, and unit. Code analysis re: safe to add modifiedBy. Also looked at the network traces provided by locus.

  ### N1 - Host self-mute (no alert)
  ![N1-host-self-mute-no-alert](https://github.com/user-attachments/assets/dc4fca98-62c2-46d3-be91-900bacf12eb2)

  ### N2 - Cohost self-mute (no alert)
  ![N2-cohost-self-mute-no-alert](https://github.com/user-attachments/assets/5fa6e5c9-8b38-48e6-932f-0a73a11b201e)

  ### N3 - Attendee self-mute (no alert)
  ![N3-attendee-self-mute-no-alert](https://github.com/user-attachments/assets/d680eb84-42cc-4fef-a6e4-20da90204e1c)

  ### N4 - Host mute-all (no self alert)
  ![N4-host-muteall-no-self-alert](https://github.com/user-attachments/assets/598a47fb-b6b2-4fe7-9048-b86258b9d606)

  ### N5 - Self unmute (no alert)
  ![N5-self-unmute-no-alert](https://github.com/user-attachments/assets/499e9086-e9ce-4bd7-a458-c743a393f286)

  ### N6 - Host self mute/unmute (no alert)
  ![N6-host-self-mute-unmute-no-alert](https://github.com/user-attachments/assets/b4cfacb6-a5f9-47a6-a8b0-ee3da74aa265)

  ### P1 - Host mutes cohost (alert)
  ![P1-host-mutes-cohost-alert](https://github.com/user-attachments/assets/3b5b87e9-96b7-42e4-bc98-2fde4e2cea6d)

  ### P1 - Host mutes cohost (host view)
  ![P1-host-mutes-cohost-hostview](https://github.com/user-attachments/assets/5bef3f36-5f07-4afa-8c9c-a0b72147d926)

  ### P2 - Host mutes attendee (alert)
  ![P2-host-mutes-attendee-alert](https://github.com/user-attachments/assets/435d7d0a-afbc-4590-bc30-72b6fd4f4824)

  ### P2 - Host mutes attendee (host view)
  ![P2-host-mutes-attendee-hostview](https://github.com/user-attachments/assets/b6c25290-9d7f-4896-a1d4-df97894238a4)

  ### P3 - Cohost mutes attendee (alert)
  ![P3-cohost-mutes-attendee-alert](https://github.com/user-attachments/assets/a1e6791d-0f67-4362-814c-8673bebd9213)

  ### P3 - Cohost mutes attendee (cohost view)
  ![P3-cohost-mutes-attendee-cohostview](https://github.com/user-attachments/assets/4d52460a-0115-492f-87f1-5ff7ac47350d)

  ### P4 - Mute-all hard: attendee hard alert
  ![P4-muteall-hard-attendee-hard-alert](https://github.com/user-attachments/assets/17eb0661-8005-4d8b-9a6c-b2839929bd68)

  ### P4 - Mute-all hard: cohost soft alert
  ![P4-muteall-hard-cohost-soft-alert](https://github.com/user-attachments/assets/25c00032-8fa2-4e10-8462-e716b157f329)

  ### P5 - Mute-all soft: attendee alert
  ![P5-muteall-soft-attendee-alert](https://github.com/user-attachments/assets/6fe2d9f3-1408-48e0-9e20-d465acd1c67d)

  ### P5 - Mute-all soft: cohost alert
  ![P5-muteall-soft-cohost-alert](https://github.com/user-attachments/assets/7a2ea66f-5e61-4735-8b51-25989b4d2eac)

  ### P6 - Unmute-all: attendee granted
  ![P6-unmuteall-attendee-granted](https://github.com/user-attachments/assets/9336d2be-d018-494d-a6a5-38e6007f2d67)

  ### P6 - Unmute-all: cohost state
  ![P6-unmuteall-cohost-state](https://github.com/user-attachments/assets/cf8e21e7-cfb4-4e78-9321-993b03c9ba19)

  ### P7 - Disallow unmute ON (attendee)
  ![P7-disallow-unmute-on-attendee](https://github.com/user-attachments/assets/5171d635-648a-45aa-b852-7bb695b89e8a)

  ### P8 - Disallow unmute OFF (attendee)
  ![P8-disallow-unmute-off-attendee](https://github.com/user-attachments/assets/1726b723-bb6e-4b84-be05-e0cacfdb9bdd)

  ### P9 - Disallow unmute then mute (attendee)
  ![P9-disallow-unmute-then-mute-attendee](https://github.com/user-attachments/assets/8ec75711-c18f-4cb1-8d2e-2b669986caae)

  ### P9 - Disallow unmute then allow, then unmute
  ![P9-idempotent-mute-no-alert](https://github.com/user-attachments/assets/4e6387f3-112a-4c53-b754-a59fb77f1e62)

  ### P10 - Self-muted + disallow unmute (attendee)
  ![P10-selfmuted-disallow-unmute-attendee](https://github.com/user-attachments/assets/5f5f8e2a-ea07-4318-ab5f-90c84f4db927)

  ### P11 - Mute on entry: attendee join alert
  ![P11-moe-join-attendee-alert](https://github.com/user-attachments/assets/8fbf0293-3974-46c0-bd3f-805c095aebc8)

  ### P12 - Mute on entry (hard): attendee join alert
  ![P12-moe-hard-join-attendee-alert](https://github.com/user-attachments/assets/88c3f993-40bb-4af3-8878-23e262fa9c9f)

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
