### PR TITLE
feat(calling): add mobius socket connection logic

### DIFF
--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -65,6 +65,9 @@ import {getMetricManager} from '../Metrics';
 import windowsChromiumIceWarmup from './windowsChromiumIceWarmupUtils';
 import {APIRequest} from './utils/request';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+const {createMobiusSocket} = require('@webex/internal-plugin-mobius-socket');
+
 /**
  * The `CallingClient` module provides a set of APIs for line registration and calling functionalities within the SDK.
  *
@@ -102,6 +105,15 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
   private lineDict: Record<string, ILine> = {};
 
   private apiRequest: APIRequest;
+
+  private primaryWssMobiusUris: string[];
+
+  private backupWssMobiusUris: string[];
+
+  private isMobiusSocketEnabled: boolean;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private mobiusSocket: any;
 
   private isNetworkDown = false;
 
@@ -157,8 +169,17 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
     this.primaryMobiusUris = [];
     this.backupMobiusUris = [];
+    this.primaryWssMobiusUris = [];
+    this.backupWssMobiusUris = [];
     this.mobiusClusters = this.webex.internal.services.getMobiusClusters();
     this.mobiusHost = '';
+
+    // MOBIUS SOCKET TODO: Fix this when feature flag is implemented
+    this.isMobiusSocketEnabled = config?.isMobiusSocketEnabled ?? false;
+
+    if (this.isMobiusSocketEnabled) {
+      this.mobiusSocket = createMobiusSocket(this.webex);
+    }
 
     this.apiRequest = APIRequest.getInstance({webex: this.webex});
 
@@ -207,6 +228,11 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     }
 
     await this.getMobiusServers();
+
+    if (this.isMobiusSocketEnabled) {
+      await this.connectToMobiusSocket();
+    }
+
     await this.createLine();
 
     this.setupNetworkEventListeners();
@@ -543,6 +569,8 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
           const mobiusUris = filterMobiusUris(mobiusServers, this.mobiusHost);
           this.primaryMobiusUris = mobiusUris.primary;
           this.backupMobiusUris = mobiusUris.backup;
+          this.primaryWssMobiusUris = mobiusUris.primaryWss;
+          this.backupWssMobiusUris = mobiusUris.backupWss;
 
           log.log(
             `Final list of Mobius Servers, primary: ${mobiusUris.primary} and backup: ${mobiusUris.backup}`,
@@ -606,6 +634,89 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       this.mobiusHost = `https://${this.mobiusClusters[0].host}${API_V1}`;
       this.primaryMobiusUris = [`${this.mobiusHost}${URL_ENDPOINT}`];
     }
+  }
+
+  /**
+   * Connects to the Mobius WebSocket using WSS URIs discovered during Mobius server discovery.
+   * Attempts primary WSS URIs first, then falls back to backup WSS URIs.
+   * If all attempts fail, logs a warning and continues without a socket connection.
+   */
+  private async connectToMobiusSocket(): Promise<void> {
+    const loggerContext = {
+      file: CALLING_CLIENT_FILE,
+      method: METHODS.CONNECT_TO_MOBIUS_SOCKET,
+    };
+
+    log.info(METHOD_START_MESSAGE, loggerContext);
+
+    if (!this.primaryWssMobiusUris.length && !this.backupWssMobiusUris.length) {
+      log.warn(
+        'No WSS URIs available from Mobius discovery, skipping socket connection',
+        loggerContext
+      );
+
+      return;
+    }
+
+    if (this.primaryWssMobiusUris.length) {
+      log.log(
+        `Attempting Mobius socket connection using primary WSS URIs (${this.primaryWssMobiusUris.length} available)`,
+        loggerContext
+      );
+
+      for (const wssUri of this.primaryWssMobiusUris) {
+        try {
+          log.log(`Trying primary WSS URI: ${wssUri}`, loggerContext);
+          // eslint-disable-next-line no-await-in-loop
+          await this.mobiusSocket.connect(wssUri);
+          log.log(
+            `Successfully connected to Mobius socket on primary WSS URI: ${wssUri}`,
+            loggerContext
+          );
+
+          return;
+        } catch (err: unknown) {
+          log.warn(`Primary WSS URI connection failed for ${wssUri}: ${err}`, loggerContext);
+        }
+      }
+
+      log.warn('All primary WSS URI connection attempts failed', loggerContext);
+    } else {
+      log.warn('No primary WSS URIs available, skipping to backup', loggerContext);
+    }
+
+    if (this.backupWssMobiusUris.length) {
+      log.log(
+        `Attempting Mobius socket connection using backup WSS URIs (${this.backupWssMobiusUris.length} available)`,
+        loggerContext
+      );
+
+      for (const wssUri of this.backupWssMobiusUris) {
+        try {
+          log.log(`Trying backup WSS URI: ${wssUri}`, loggerContext);
+          // eslint-disable-next-line no-await-in-loop
+          await this.mobiusSocket.connect(wssUri);
+          log.log(
+            `Successfully connected to Mobius socket on backup WSS URI: ${wssUri}`,
+            loggerContext
+          );
+
+          return;
+        } catch (err: unknown) {
+          log.warn(`Backup WSS URI connection failed for ${wssUri}: ${err}`, loggerContext);
+        }
+      }
+
+      log.warn('All backup WSS URI connection attempts failed', loggerContext);
+    } else {
+      log.warn('No backup WSS URIs available', loggerContext);
+    }
+
+    // MOBIUS WSS TODO: See if we need to throw an error here if all connection attempts fail
+    log.warn(
+      'All Mobius socket connection attempts exhausted for both primary and backup, continuing without socket',
+      loggerContext
+    );
   }
 
   /**

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -2,6 +2,8 @@
 /* eslint-disable valid-jsdoc */
 /* eslint-disable @typescript-eslint/no-shadow */
 import * as Media from '@webex/internal-media-core';
+// @ts-ignore - JS module without type declarations
+import {createMobiusSocket} from '@webex/internal-plugin-mobius-socket';
 import {Mutex} from 'async-mutex';
 import {METHOD_START_MESSAGE} from '../common/constants';
 import {
@@ -64,9 +66,6 @@ import {
 import {getMetricManager} from '../Metrics';
 import windowsChromiumIceWarmup from './windowsChromiumIceWarmupUtils';
 import {APIRequest} from './utils/request';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
-const {createMobiusSocket} = require('@webex/internal-plugin-mobius-socket');
 
 /**
  * The `CallingClient` module provides a set of APIs for line registration and calling functionalities within the SDK.

--- a/packages/calling/src/CallingClient/constants.ts
+++ b/packages/calling/src/CallingClient/constants.ts
@@ -232,4 +232,5 @@ export const METHODS = {
   UPLOAD_LOGS: 'uploadLogs',
   GET_SDK_CONNECTOR: 'getSDKConnector',
   GET_CONNECTED_CALL: 'getConnectedCall',
+  CONNECT_TO_MOBIUS_SOCKET: 'connectToMobiusSocket',
 };

--- a/packages/calling/src/CallingClient/types.ts
+++ b/packages/calling/src/CallingClient/types.ts
@@ -22,6 +22,7 @@ export interface CallingClientConfig {
   discovery?: DiscoveryConfig;
   serviceData?: ServiceData;
   jwe?: string;
+  isMobiusSocketEnabled?: boolean;
 }
 
 export type CallingClientErrorEmitterCallback = (

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -219,6 +219,9 @@ export function filterMobiusUris(mobiusServers: MobiusServers, defaultMobiusUrl:
     }
   }
 
+  // TODO (Remove this later): Hardcoding the wss urls for now with test server url
+  primaryWss.push('wss://mobius.aload-calling1.ciscospark.com/v1/calling/web');
+
   return {primary: primaryUris, backup: backupUris, primaryWss, backupWss};
 }
 

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -142,8 +142,10 @@ export function filterMobiusUris(mobiusServers: MobiusServers, defaultMobiusUrl:
     method: 'filterMobiusUris',
   };
 
-  const urisArrayPrimary = [];
-  const urisArrayBackup = [];
+  const urisArrayPrimary: string[] = [];
+  const urisArrayBackup: string[] = [];
+  const wssArrayPrimary: string[] = [];
+  const wssArrayBackup: string[] = [];
 
   if (mobiusServers?.primary?.uris) {
     log.info('Adding Primary uris', logContext);
@@ -152,10 +154,24 @@ export function filterMobiusUris(mobiusServers: MobiusServers, defaultMobiusUrl:
     }
   }
 
+  if (mobiusServers?.primary?.wss) {
+    log.info('Adding Primary wss uris', logContext);
+    for (const wssUri of mobiusServers.primary.wss) {
+      wssArrayPrimary.push(wssUri);
+    }
+  }
+
   if (mobiusServers?.backup?.uris) {
     log.info('Adding Backup uris', logContext);
     for (const uri of mobiusServers.backup.uris) {
       urisArrayBackup.push(`${uri}${URL_ENDPOINT}`);
+    }
+  }
+
+  if (mobiusServers?.backup?.wss) {
+    log.info('Adding Backup wss uris', logContext);
+    for (const wssUri of mobiusServers.backup.wss) {
+      wssArrayBackup.push(wssUri);
     }
   }
 
@@ -172,6 +188,8 @@ export function filterMobiusUris(mobiusServers: MobiusServers, defaultMobiusUrl:
 
   const primaryUris: string[] = [];
   const backupUris: string[] = [];
+  const primaryWss: string[] = [];
+  const backupWss: string[] = [];
 
   /* Remove duplicates from primary by keeping the order intact */
   for (let i = 0; i < urisArrayPrimary.length; i += 1) {
@@ -187,7 +205,21 @@ export function filterMobiusUris(mobiusServers: MobiusServers, defaultMobiusUrl:
     }
   }
 
-  return {primary: primaryUris, backup: backupUris};
+  /* Remove duplicates from primary wss by keeping the order intact */
+  for (let i = 0; i < wssArrayPrimary.length; i += 1) {
+    if (primaryWss.indexOf(wssArrayPrimary[i]) === -1) {
+      primaryWss.push(wssArrayPrimary[i]);
+    }
+  }
+
+  /* Remove duplicates from backup wss by keeping the order intact */
+  for (let i = 0; i < wssArrayBackup.length; i += 1) {
+    if (backupWss.indexOf(wssArrayBackup[i]) === -1) {
+      backupWss.push(wssArrayBackup[i]);
+    }
+  }
+
+  return {primary: primaryUris, backup: backupUris, primaryWss, backupWss};
 }
 
 /**

--- a/packages/calling/src/common/types.ts
+++ b/packages/calling/src/common/types.ts
@@ -75,6 +75,7 @@ export type Digit = string | number;
 export type ServerInfo = {
   region: string;
   uris: string[];
+  wss?: string[];
 };
 
 export type MobiusServers = {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #<Partially [CAI-7823](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7823)>

## This pull request addresses

This adds logic to connect to the mobius wss using the `internal-plugin-mobius-socket`

## by making the following changes

#### 1. `src/common/types.ts` (+1 line)
- Added optional `wss?: string[]` field to the `ServerInfo` type to model the new WSS endpoints returned by Mobius discovery.

#### 2. `src/CallingClient/types.ts` (+1 line)
- Added optional `isMobiusSocketEnabled?: boolean` to `CallingClientConfig`, providing a feature flag (default `false`) to gate the entire socket feature.

#### 3. `src/common/Utils.ts` (+35 lines, −3 lines)
- Extended `filterMobiusUris()` to also extract and deduplicate WSS URIs from the `primary.wss` and `backup.wss` arrays in the Mobius discovery response.
- Return type expanded from `{primary, backup}` to `{primary, backup, primaryWss, backupWss}` — fully backward-compatible.

#### 4. `src/CallingClient/constants.ts` (+1 line)
- Added `CONNECT_TO_MOBIUS_SOCKET: 'connectToMobiusSocket'` to the `METHODS` constant object for logger context.

#### 5. `src/CallingClient/CallingClient.ts` (+111 lines)
- **Import**: Added `require('@webex/internal-plugin-mobius-socket')` for `createMobiusSocket`.
- **New fields**: `primaryWssMobiusUris`, `backupWssMobiusUris`, `isMobiusSocketEnabled`, `mobiusSocket`.
- **Constructor**: Initializes WSS URI arrays, reads the feature flag from config, and conditionally creates a `MobiusSocket` instance via `createMobiusSocket(webex)`.
- **`getMobiusServers()`**: Now stores `primaryWss` and `backupWss` from the updated `filterMobiusUris` return.
- **`init()`**: Calls `connectToMobiusSocket()` after `getMobiusServers()` when `isMobiusSocketEnabled` is `true`.
- **`connectToMobiusSocket()` (new private method)**: Tries each primary WSS URI sequentially; if all fail, tries each backup WSS URI. Logs clearly distinguish primary vs backup attempts, successes, and failures. If all URIs are exhausted, logs a warning and continues without a socket connection.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
