### PR TITLE
fix(internal-plugin-mobius-socket): update websocket request flow

### DIFF
--- a/packages/@webex/internal-plugin-mobius-socket/README.md
+++ b/packages/@webex/internal-plugin-mobius-socket/README.md
@@ -112,7 +112,7 @@ Initial `connect()` attempts retry with exponential back-off and reject after a 
 | `backoffTimeMax` | `32000` | `MOBIUS_SOCKET_BACKOFF_TIME_MAX` | Maximum milliseconds between connection attempts. |
 | `backoffTimeReset` | `1000` | `MOBIUS_SOCKET_BACKOFF_TIME_RESET` | Initial milliseconds between connection attempts. |
 | `initialConnectionMaxRetries` | `2` | `MOBIUS_SOCKET_INITIAL_CONNECTION_MAX_RETRIES` | Maximum retries before the initial `connect()` promise rejects. |
-| `maxRetries` | `0` | `MOBIUS_SOCKET_MAX_RETRIES` | Maximum retries for reconnect attempts after the socket has connected once. |
+| `maxRetries` | `0` | `MOBIUS_SOCKET_MAX_RETRIES` | Maximum retries for reconnect attempts after the socket has connected once. `0` means unlimited retries. |
 | `forceCloseDelay` | `2000` | `MOBIUS_SOCKET_FORCE_CLOSE_DELAY` | Milliseconds to wait for a close frame before forcing socket closure. |
 | `wssResponseTimeout` | `10000` | `MOBIUS_SOCKET_RESPONSE_TIMEOUT` | Milliseconds to wait for websocket request/response messages, including auth, before timing out. |
 | `beforeLogoutOptionsCloseReason` | `done (forced)` | `MOBIUS_SOCKET_LOGOUT_REASON` | Close reason sent on logout. Set to a non-reconnectable reason to prevent reconnect on logout. |

--- a/packages/@webex/internal-plugin-mobius-socket/README.md
+++ b/packages/@webex/internal-plugin-mobius-socket/README.md
@@ -105,12 +105,14 @@ webex.init({
 
 ### Retries
 
-The default behaviour is to continue to try to connect with an exponential back-off. This behavior can be adjusted with the following config params:
+Initial `connect()` attempts retry with exponential back-off and reject after a limited number of retries by default. Reconnect behavior can still be configured separately. This behavior can be adjusted with the following config params:
 
 | Config Key | Default | Env Override | Description |
 |---|---|---|---|
 | `backoffTimeMax` | `32000` | `MOBIUS_SOCKET_BACKOFF_TIME_MAX` | Maximum milliseconds between connection attempts. |
 | `backoffTimeReset` | `1000` | `MOBIUS_SOCKET_BACKOFF_TIME_RESET` | Initial milliseconds between connection attempts. |
+| `initialConnectionMaxRetries` | `2` | `MOBIUS_SOCKET_INITIAL_CONNECTION_MAX_RETRIES` | Maximum retries before the initial `connect()` promise rejects. |
+| `maxRetries` | `0` | `MOBIUS_SOCKET_MAX_RETRIES` | Maximum retries for reconnect attempts after the socket has connected once. |
 | `forceCloseDelay` | `2000` | `MOBIUS_SOCKET_FORCE_CLOSE_DELAY` | Milliseconds to wait for a close frame before forcing socket closure. |
 | `wssResponseTimeout` | `10000` | `MOBIUS_SOCKET_RESPONSE_TIMEOUT` | Milliseconds to wait for websocket request/response messages, including auth, before timing out. |
 | `beforeLogoutOptionsCloseReason` | `done (forced)` | `MOBIUS_SOCKET_LOGOUT_REASON` | Close reason sent on logout. Set to a non-reconnectable reason to prevent reconnect on logout. |

--- a/packages/@webex/internal-plugin-mobius-socket/README.md
+++ b/packages/@webex/internal-plugin-mobius-socket/README.md
@@ -62,9 +62,9 @@ await mobiusSocket.disconnect();
 
 Mobius uses a token-based auth handshake:
 
-1. Client opens WebSocket and sends: `{type: 'auth', payload: {token: '<access_token>'}}`
-2. Server responds with: `{type: 'auth.response', status: {code: 200}}`
-3. Connection is established after a successful `auth.response`.
+1. Client opens WebSocket and sends: `{type: 'auth', data: {token: '<access_token>'}}`
+2. Server responds with: `{type: 'response_event', subtype: 'auth', statusCode: 200}`
+3. Connection is established after a successful auth `response_event`.
 
 Non-200 status codes are handled as auth failures with automatic retry via exponential backoff.
 
@@ -112,7 +112,7 @@ The default behaviour is to continue to try to connect with an exponential back-
 | `backoffTimeMax` | `32000` | `MOBIUS_SOCKET_BACKOFF_TIME_MAX` | Maximum milliseconds between connection attempts. |
 | `backoffTimeReset` | `1000` | `MOBIUS_SOCKET_BACKOFF_TIME_RESET` | Initial milliseconds between connection attempts. |
 | `forceCloseDelay` | `2000` | `MOBIUS_SOCKET_FORCE_CLOSE_DELAY` | Milliseconds to wait for a close frame before forcing socket closure. |
-| `authResponseTimeout` | `10000` | `MOBIUS_SOCKET_AUTH_RESPONSE_TIMEOUT` | Milliseconds to wait for `auth.response` before failing authorization. |
+| `wssResponseTimeout` | `10000` | `MOBIUS_SOCKET_RESPONSE_TIMEOUT` | Milliseconds to wait for websocket request/response messages, including auth, before timing out. |
 | `beforeLogoutOptionsCloseReason` | `done (forced)` | `MOBIUS_SOCKET_LOGOUT_REASON` | Close reason sent on logout. Set to a non-reconnectable reason to prevent reconnect on logout. |
 
 ## Contribute

--- a/packages/@webex/internal-plugin-mobius-socket/src/config.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/config.js
@@ -4,10 +4,15 @@
 
 const mobiusSocketConfig = {
   /**
-   * Milliseconds to wait for auth.response before declaring auth failed
+   * Milliseconds to wait for the auth websocket response before declaring auth failed
    * @type {number}
    */
   authResponseTimeout: process.env.MOBIUS_SOCKET_AUTH_RESPONSE_TIMEOUT || 10000,
+  /**
+   * Milliseconds to wait for a request/response style websocket message.
+   * @type {number}
+   */
+  wssResponseTimeout: process.env.MOBIUS_SOCKET_RESPONSE_TIMEOUT || 10000,
   /**
    * Maximum milliseconds between connection attempts
    * @type {Number}

--- a/packages/@webex/internal-plugin-mobius-socket/src/config.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/config.js
@@ -28,6 +28,7 @@ const mobiusSocketConfig = {
   initialConnectionMaxRetries: process.env.MOBIUS_SOCKET_INITIAL_CONNECTION_MAX_RETRIES || 2,
   /**
    * Maximum number of retries for reconnect attempts after the socket has connected once.
+   * A value of 0 means unlimited reconnect retries.
    * @type {Number}
    */
   maxRetries: process.env.MOBIUS_SOCKET_MAX_RETRIES || 0,

--- a/packages/@webex/internal-plugin-mobius-socket/src/config.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/config.js
@@ -22,6 +22,16 @@ const mobiusSocketConfig = {
    */
   backoffTimeReset: process.env.MOBIUS_SOCKET_BACKOFF_TIME_RESET || 1000,
   /**
+   * Maximum number of retries for the initial connect() flow before rejecting.
+   * @type {Number}
+   */
+  initialConnectionMaxRetries: process.env.MOBIUS_SOCKET_INITIAL_CONNECTION_MAX_RETRIES || 2,
+  /**
+   * Maximum number of retries for reconnect attempts after the socket has connected once.
+   * @type {Number}
+   */
+  maxRetries: process.env.MOBIUS_SOCKET_MAX_RETRIES || 0,
+  /**
    * Milliseconds to wait for a close frame before declaring the socket dead and
    * discarding it
    * @type {number}

--- a/packages/@webex/internal-plugin-mobius-socket/src/config.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/config.js
@@ -4,15 +4,13 @@
 
 const mobiusSocketConfig = {
   /**
-   * Milliseconds to wait for the auth websocket response before declaring auth failed
+   * Milliseconds to wait for websocket request/response messages, including auth.
    * @type {number}
    */
-  authResponseTimeout: process.env.MOBIUS_SOCKET_AUTH_RESPONSE_TIMEOUT || 10000,
-  /**
-   * Milliseconds to wait for a request/response style websocket message.
-   * @type {number}
-   */
-  wssResponseTimeout: process.env.MOBIUS_SOCKET_RESPONSE_TIMEOUT || 10000,
+  wssResponseTimeout:
+    process.env.MOBIUS_SOCKET_RESPONSE_TIMEOUT ||
+    process.env.MOBIUS_SOCKET_AUTH_RESPONSE_TIMEOUT ||
+    10000,
   /**
    * Maximum milliseconds between connection attempts
    * @type {Number}

--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -275,7 +275,7 @@ const MobiusSocket = WebexPlugin.extend({
     }
 
     return socket.sendRequest(payload, {
-      timeout: requestOptions.timeout || this.config.wssResponseTimeout || 10000,
+      timeout: requestOptions.timeout,
       matchesResponse: (response, request) =>
         response?.type === 'response_event' &&
         response?.subtype === request.type &&
@@ -660,7 +660,7 @@ const MobiusSocket = WebexPlugin.extend({
       ([webSocketUrl, token]) => {
         let options = {
           forceCloseDelay: this.config.forceCloseDelay,
-          wssResponseTimeout: this.config.wssResponseTimeout || 10000,
+          wssResponseTimeout: this.config.wssResponseTimeout,
           token: normalizeMobiusAuthToken(token.toString()),
           trackingId: `${this.webex.sessionId}_${Date.now()}`,
           logger: this.logger,

--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -20,6 +20,14 @@ import {
 const normalReconnectReasons = ['idle', 'done (forced)'];
 const DEFAULT_MOBIUS_WEBSOCKET_SESSION = 'mobius-websocket-session';
 
+function normalizeMobiusAuthToken(token) {
+  if (typeof token !== 'string') {
+    return token;
+  }
+
+  return token.replace(/^Bearer\s+/i, '');
+}
+
 const MobiusSocket = WebexPlugin.extend({
   namespace: 'MobiusSocket',
   lastError: undefined,
@@ -240,6 +248,73 @@ const MobiusSocket = WebexPlugin.extend({
   },
 
   /**
+   * Sends a websocket request and resolves when the matching response arrives.
+   * @param {Object} payload - The websocket request payload.
+   * @param {string|Object} [sessionIdOrOptions=this.defaultSessionId] - Session ID or request options.
+   * @param {Object} [options={}] - Additional request options.
+   * @returns {Promise<Object>}
+   */
+  sendWssRequest(payload, sessionIdOrOptions = this.defaultSessionId, options = {}) {
+    if (!payload || typeof payload !== 'object') {
+      return Promise.reject(new Error('`payload` is required'));
+    }
+
+    let sessionId = this.defaultSessionId;
+    let requestOptions = options;
+
+    if (typeof sessionIdOrOptions === 'string') {
+      sessionId = sessionIdOrOptions;
+    } else if (sessionIdOrOptions && typeof sessionIdOrOptions === 'object') {
+      requestOptions = sessionIdOrOptions;
+    }
+
+    const socket = this.getSocket(sessionId);
+
+    if (!socket || !socket.connected) {
+      return Promise.reject(new Error(`Mobius socket is not connected for session ${sessionId}`));
+    }
+
+    const normalizedPayload =
+      payload.type === 'auth' && typeof payload?.payload?.token === 'string'
+        ? {
+            ...payload,
+            payload: {
+              ...payload.payload,
+              token: normalizeMobiusAuthToken(payload.payload.token),
+            },
+          }
+        : payload;
+
+    return socket.sendRequest(normalizedPayload, {
+      timeout:
+        requestOptions.timeout ||
+        this.config.wssResponseTimeout ||
+        this.config.authResponseTimeout ||
+        10000,
+      matchesResponse: (response, request) =>
+        response?.type === 'response_event' &&
+        response?.subtype === request.type &&
+        response?.trackingId === request.trackingId,
+      getStatusCode: (response) =>
+        response?.statusCode || response?.status?.code || response?.data?.statusCode,
+      getStatusMessage: (response) =>
+        response?.statusMessage || response?.status?.message || response?.data?.statusMessage,
+      createError: (response, statusCode, statusMessage) =>
+        this._createWssResponseError(response, statusCode, statusMessage),
+      createTimeoutError: (request) =>
+        this._createWssResponseError(
+          {
+            type: 'response_event',
+            subtype: request.type,
+            trackingId: request.trackingId,
+          },
+          408,
+          'Mobius websocket response timed out'
+        ),
+    });
+  },
+
+  /**
    * Check if the plugin is connected
    * @returns {boolean} True if connected
    */
@@ -421,6 +496,20 @@ const MobiusSocket = WebexPlugin.extend({
     this.localClusterServiceUrls = message.localClusterServiceUrls;
   },
 
+  _createWssResponseError(response, statusCode, statusMessage) {
+    const error = new Error(
+      statusMessage || `Mobius websocket request failed with status ${statusCode || 'unknown'}`
+    );
+
+    error.name = 'MobiusSocketResponseError';
+    error.statusCode = statusCode;
+    error.statusMessage = statusMessage;
+    error.response = response;
+    error.trackingId = response?.trackingId;
+
+    return error;
+  },
+
   _applyOverrides(event) {
     if (!event || !event.headers) {
       return;
@@ -589,7 +678,7 @@ const MobiusSocket = WebexPlugin.extend({
         let options = {
           forceCloseDelay: this.config.forceCloseDelay,
           authResponseTimeout: this.config.authResponseTimeout,
-          token: token.toString(),
+          token: normalizeMobiusAuthToken(token.toString()),
           trackingId: `${this.webex.sessionId}_${Date.now()}`,
           logger: this.logger,
         };

--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -280,7 +280,7 @@ const MobiusSocket = WebexPlugin.extend({
    * @returns {Promise<Object>}
    */
   sendWssRequest(payload, sessionIdOrOptions = this.defaultSessionId, options = {}) {
-    if (!payload || typeof payload !== 'object') {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
       return Promise.reject(new Error('`payload` is required'));
     }
 
@@ -307,10 +307,8 @@ const MobiusSocket = WebexPlugin.extend({
         response?.type === 'response_event' &&
         response?.subtype === request.type &&
         response?.trackingId === request.trackingId,
-      getStatusCode: (response) =>
-        response?.statusCode || response?.status?.code || response?.data?.statusCode,
-      getStatusMessage: (response) =>
-        response?.statusMessage || response?.status?.message || response?.data?.statusMessage,
+      getStatusCode: (response) => response?.statusCode,
+      getStatusMessage: (response) => response?.statusMessage,
       createError: (response, statusCode, statusMessage) =>
         this._createWssResponseError(response, statusCode, statusMessage),
       createTimeoutError: (request) =>
@@ -689,8 +687,7 @@ const MobiusSocket = WebexPlugin.extend({
       ([webSocketUrl, token]) => {
         let options = {
           forceCloseDelay: this.config.forceCloseDelay,
-          wssResponseTimeout:
-            this.config.wssResponseTimeout || this.config.authResponseTimeout || 10000,
+          wssResponseTimeout: this.config.wssResponseTimeout || 10000,
           token: normalizeMobiusAuthToken(token.toString()),
           trackingId: `${this.webex.sessionId}_${Date.now()}`,
           logger: this.logger,

--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -28,31 +28,6 @@ function normalizeMobiusAuthToken(token) {
   return token.replace(/^Bearer\s+/i, '');
 }
 
-function normalizeAuthRequestPayload(payload) {
-  if (!payload || payload.type !== 'auth') {
-    return payload;
-  }
-
-  const token = payload?.data?.token || payload?.payload?.token;
-
-  if (typeof token !== 'string') {
-    return payload;
-  }
-
-  const normalizedToken = normalizeMobiusAuthToken(token);
-  const restPayload = {...payload};
-
-  delete restPayload.payload;
-
-  return {
-    ...restPayload,
-    data: {
-      ...(payload.data || {}),
-      token: normalizedToken,
-    },
-  };
-}
-
 const MobiusSocket = WebexPlugin.extend({
   namespace: 'MobiusSocket',
   lastError: undefined,
@@ -299,9 +274,7 @@ const MobiusSocket = WebexPlugin.extend({
       return Promise.reject(new Error(`Mobius socket is not connected for session ${sessionId}`));
     }
 
-    const normalizedPayload = normalizeAuthRequestPayload(payload);
-
-    return socket.sendRequest(normalizedPayload, {
+    return socket.sendRequest(payload, {
       timeout: requestOptions.timeout || this.config.wssResponseTimeout || 10000,
       matchesResponse: (response, request) =>
         response?.type === 'response_event' &&

--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -28,6 +28,31 @@ function normalizeMobiusAuthToken(token) {
   return token.replace(/^Bearer\s+/i, '');
 }
 
+function normalizeAuthRequestPayload(payload) {
+  if (!payload || payload.type !== 'auth') {
+    return payload;
+  }
+
+  const token = payload?.data?.token || payload?.payload?.token;
+
+  if (typeof token !== 'string') {
+    return payload;
+  }
+
+  const normalizedToken = normalizeMobiusAuthToken(token);
+  const restPayload = {...payload};
+
+  delete restPayload.payload;
+
+  return {
+    ...restPayload,
+    data: {
+      ...(payload.data || {}),
+      token: normalizedToken,
+    },
+  };
+}
+
 const MobiusSocket = WebexPlugin.extend({
   namespace: 'MobiusSocket',
   lastError: undefined,
@@ -274,23 +299,10 @@ const MobiusSocket = WebexPlugin.extend({
       return Promise.reject(new Error(`Mobius socket is not connected for session ${sessionId}`));
     }
 
-    const normalizedPayload =
-      payload.type === 'auth' && typeof payload?.payload?.token === 'string'
-        ? {
-            ...payload,
-            payload: {
-              ...payload.payload,
-              token: normalizeMobiusAuthToken(payload.payload.token),
-            },
-          }
-        : payload;
+    const normalizedPayload = normalizeAuthRequestPayload(payload);
 
     return socket.sendRequest(normalizedPayload, {
-      timeout:
-        requestOptions.timeout ||
-        this.config.wssResponseTimeout ||
-        this.config.authResponseTimeout ||
-        10000,
+      timeout: requestOptions.timeout || this.config.wssResponseTimeout || 10000,
       matchesResponse: (response, request) =>
         response?.type === 'response_event' &&
         response?.subtype === request.type &&
@@ -677,7 +689,8 @@ const MobiusSocket = WebexPlugin.extend({
       ([webSocketUrl, token]) => {
         let options = {
           forceCloseDelay: this.config.forceCloseDelay,
-          authResponseTimeout: this.config.authResponseTimeout,
+          wssResponseTimeout:
+            this.config.wssResponseTimeout || this.config.authResponseTimeout || 10000,
           token: normalizeMobiusAuthToken(token.toString()),
           trackingId: `${this.webex.sessionId}_${Date.now()}`,
           logger: this.logger,

--- a/packages/@webex/internal-plugin-mobius-socket/src/socket/constants.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/socket/constants.js
@@ -7,6 +7,5 @@ export const SOCKET_READY_STATE = Object.freeze({
 
 export const MESSAGE_TYPES = Object.freeze({
   AUTH: 'auth',
-  AUTH_RESPONSE: 'auth.response',
   EVENT_ACK: 'event_ack',
 });

--- a/packages/@webex/internal-plugin-mobius-socket/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/socket/socket-base.js
@@ -318,6 +318,8 @@ export default class Socket extends EventEmitter {
         });
       }
 
+      // Match pending request/response promises before emitting the public message event.
+      // The message is still emitted afterward for any external listeners that care about it.
       this._handlePendingResponse(data);
       this.emit('message', processedEvent);
     } catch (error) {
@@ -368,7 +370,7 @@ export default class Socket extends EventEmitter {
 
     const request = {...data};
     const trackingId = request.trackingId || this._createTrackingId();
-    const timeout = options.timeout || this.wssResponseTimeout || this.authResponseTimeout || 10000;
+    const timeout = options.timeout || this.wssResponseTimeout || 10000;
     const matchesResponse =
       options.matchesResponse ||
       ((response) => response?.trackingId === trackingId && response?.type === 'response_event');
@@ -473,7 +475,6 @@ export default class Socket extends EventEmitter {
         },
       },
       {
-        timeout: this.wssResponseTimeout || this.authResponseTimeout || 10000,
         matchesResponse: (response, request) =>
           response?.type === 'response_event' &&
           response?.subtype === MESSAGE_TYPES.AUTH &&

--- a/packages/@webex/internal-plugin-mobius-socket/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/socket/socket-base.js
@@ -372,13 +372,8 @@ export default class Socket extends EventEmitter {
     const matchesResponse =
       options.matchesResponse ||
       ((response) => response?.trackingId === trackingId && response?.type === 'response_event');
-    const getStatusCode =
-      options.getStatusCode ||
-      ((response) => response?.statusCode || response?.status?.code || response?.data?.statusCode);
-    const getStatusMessage =
-      options.getStatusMessage ||
-      ((response) =>
-        response?.statusMessage || response?.status?.message || response?.data?.statusMessage);
+    const getStatusCode = options.getStatusCode || ((response) => response?.statusCode);
+    const getStatusMessage = options.getStatusMessage || ((response) => response?.statusMessage);
     const createError =
       options.createError ||
       ((response, statusCode, statusMessage) =>
@@ -547,6 +542,7 @@ export default class Socket extends EventEmitter {
       return false;
     }
 
+    // Pending request correlation currently requires trackingId on the response.
     const pendingResponse = response.trackingId
       ? this._pendingResponses.get(response.trackingId)
       : undefined;
@@ -562,7 +558,15 @@ export default class Socket extends EventEmitter {
     const statusCode = pendingResponse.getStatusCode(response);
     const statusMessage = pendingResponse.getStatusMessage(response);
 
-    if (statusCode >= 200 && statusCode < 300) {
+    if (statusCode === undefined) {
+      pendingResponse.reject(
+        pendingResponse.createError(
+          response,
+          statusCode,
+          statusMessage || 'Socket response missing status code'
+        )
+      );
+    } else if (statusCode >= 200 && statusCode < 300) {
       pendingResponse.resolve(response);
     } else {
       pendingResponse.reject(pendingResponse.createError(response, statusCode, statusMessage));

--- a/packages/@webex/internal-plugin-mobius-socket/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/socket/socket-base.js
@@ -368,7 +368,7 @@ export default class Socket extends EventEmitter {
 
     const request = {...data};
     const trackingId = request.trackingId || this._createTrackingId();
-    const timeout = options.timeout || this.authResponseTimeout || 10000;
+    const timeout = options.timeout || this.wssResponseTimeout || this.authResponseTimeout || 10000;
     const matchesResponse =
       options.matchesResponse ||
       ((response) => response?.trackingId === trackingId && response?.type === 'response_event');
@@ -478,7 +478,7 @@ export default class Socket extends EventEmitter {
         },
       },
       {
-        timeout: this.authResponseTimeout || 10000,
+        timeout: this.wssResponseTimeout || this.authResponseTimeout || 10000,
         matchesResponse: (response, request) =>
           response?.type === 'response_event' &&
           response?.subtype === MESSAGE_TYPES.AUTH &&

--- a/packages/@webex/internal-plugin-mobius-socket/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/socket/socket-base.js
@@ -32,6 +32,7 @@ export default class Socket extends EventEmitter {
   constructor() {
     super();
     this._domain = 'unknown-domain';
+    this._pendingResponses = new Map();
     this.onmessage = this.onmessage.bind(this);
     this.onclose = this.onclose.bind(this);
     // Increase max listeners to avoid memory leak warning in tests
@@ -293,6 +294,7 @@ export default class Socket extends EventEmitter {
     this.logger.info(`socket,${this._domain}: closed`, event.code, event.reason);
 
     event = this._fixCloseCode(event);
+    this._rejectPendingResponses(new ConnectionError(event));
     this.emit('close', event);
 
     // Remove all listeners to (a) avoid reacting to late pongs and (b) ensure
@@ -316,6 +318,7 @@ export default class Socket extends EventEmitter {
         });
       }
 
+      this._handlePendingResponse(data);
       this.emit('message', processedEvent);
     } catch (error) {
       /* istanbul ignore next */
@@ -343,6 +346,88 @@ export default class Socket extends EventEmitter {
       socket.send(data);
 
       return resolve();
+    });
+  }
+
+  /**
+   * Sends a request and resolves when the matching response arrives.
+   * @param {Object} data
+   * @param {Object} [options={}]
+   * @param {Function} [options.matchesResponse]
+   * @param {Function} [options.createError]
+   * @param {Function} [options.createTimeoutError]
+   * @param {Function} [options.getStatusCode]
+   * @param {Function} [options.getStatusMessage]
+   * @param {number} [options.timeout]
+   * @returns {Promise<Object>}
+   */
+  sendRequest(data, options = {}) {
+    if (!isObject(data)) {
+      return Promise.reject(new Error('`data` is required'));
+    }
+
+    const request = {...data};
+    const trackingId = request.trackingId || this._createTrackingId();
+    const timeout = options.timeout || this.authResponseTimeout || 10000;
+    const matchesResponse =
+      options.matchesResponse ||
+      ((response) => response?.trackingId === trackingId && response?.type === 'response_event');
+    const getStatusCode =
+      options.getStatusCode ||
+      ((response) => response?.statusCode || response?.status?.code || response?.data?.statusCode);
+    const getStatusMessage =
+      options.getStatusMessage ||
+      ((response) =>
+        response?.statusMessage || response?.status?.message || response?.data?.statusMessage);
+    const createError =
+      options.createError ||
+      ((response, statusCode, statusMessage) =>
+        new ConnectionError({
+          code: statusCode,
+          reason: statusMessage || response?.reason || 'Socket request failed',
+        }));
+    const createTimeoutError =
+      options.createTimeoutError ||
+      (() =>
+        new ConnectionError({
+          reason: 'Socket response not received before timeout',
+        }));
+
+    if (this._pendingResponses.has(trackingId)) {
+      return Promise.reject(
+        new Error(`socket request already pending for trackingId ${trackingId}`)
+      );
+    }
+
+    request.trackingId = trackingId;
+
+    return new Promise((resolve, reject) => {
+      const timeoutId = safeSetTimeout(() => {
+        this._clearPendingResponse(trackingId);
+        reject(createTimeoutError(request));
+      }, timeout);
+
+      this._pendingResponses.set(trackingId, {
+        request,
+        matchesResponse,
+        getStatusCode,
+        getStatusMessage,
+        createError,
+        resolve: (response) => {
+          this._clearPendingResponse(trackingId);
+          resolve(response);
+        },
+        reject: (error) => {
+          this._clearPendingResponse(trackingId);
+          reject(error);
+        },
+        timeoutId,
+      });
+
+      this.send(request).catch((error) => {
+        this._clearPendingResponse(trackingId);
+        reject(error);
+      });
     });
   }
 
@@ -383,59 +468,34 @@ export default class Socket extends EventEmitter {
    * @returns {Promise}
    */
   _authorize() {
-    return new Promise((resolve, reject) => {
-      this.logger.info(`socket,${this._domain}: authorizing`);
-      let authResponseTimer;
+    this.logger.info(`socket,${this._domain}: authorizing`);
 
-      const cleanup = () => {
-        clearTimeout(authResponseTimer);
-        this.off('message', waitForAuthResponse);
-      };
-
-      const waitForAuthResponse = (event) => {
-        if (event.data?.type !== MESSAGE_TYPES.AUTH_RESPONSE) {
-          return;
-        }
-
-        cleanup();
-
-        const statusCode = event.data?.status?.code;
-
-        if (statusCode >= 200 && statusCode < 300) {
-          resolve();
-
-          return;
-        }
-
-        reject(
-          new NotAuthorized({
-            code: statusCode,
-            reason: event.data?.status?.message || 'Mobius auth failed',
-          })
-        );
-      };
-
-      this.on('message', waitForAuthResponse);
-      authResponseTimer = safeSetTimeout(() => {
-        cleanup();
-        reject(
-          new NotAuthorized({
-            reason: 'Mobius auth response not received before timeout',
-          })
-        );
-      }, this.authResponseTimeout || 10000);
-
-      this.send({
+    return this.sendRequest(
+      {
         type: MESSAGE_TYPES.AUTH,
-        trackingId: this._createTrackingId(),
-        payload: {
+        data: {
           token: this.token,
         },
-      }).catch((error) => {
-        cleanup();
-        reject(error);
-      });
-    });
+      },
+      {
+        timeout: this.authResponseTimeout || 10000,
+        matchesResponse: (response, request) =>
+          response?.type === 'response_event' &&
+          response?.subtype === MESSAGE_TYPES.AUTH &&
+          response?.trackingId === request.trackingId,
+        getStatusCode: (response) => response?.statusCode,
+        getStatusMessage: (response) => response?.statusMessage,
+        createError: (response, statusCode, statusMessage) =>
+          new NotAuthorized({
+            code: statusCode,
+            reason: statusMessage || 'Mobius auth failed',
+          }),
+        createTimeoutError: () =>
+          new NotAuthorized({
+            reason: 'Mobius auth response not received before timeout',
+          }),
+      }
+    );
   }
 
   /**
@@ -445,6 +505,70 @@ export default class Socket extends EventEmitter {
    */
   _createTrackingId() {
     return `${this.trackingId}_${uuid.v4()}`;
+  }
+
+  /**
+   * Clears a pending response entry.
+   * @param {string} trackingId
+   * @returns {void}
+   */
+  _clearPendingResponse(trackingId) {
+    const pendingResponse = this._pendingResponses.get(trackingId);
+
+    if (pendingResponse?.timeoutId) {
+      clearTimeout(pendingResponse.timeoutId);
+    }
+
+    this._pendingResponses.delete(trackingId);
+  }
+
+  /**
+   * Rejects all pending responses with the provided error.
+   * @param {Error} error
+   * @returns {void}
+   */
+  _rejectPendingResponses(error) {
+    if (!this._pendingResponses.size) {
+      return;
+    }
+
+    Array.from(this._pendingResponses.values()).forEach((pendingResponse) => {
+      pendingResponse.reject(error);
+    });
+  }
+
+  /**
+   * Handles incoming responses for pending requests.
+   * @param {Object} response
+   * @returns {boolean}
+   */
+  _handlePendingResponse(response) {
+    if (!response) {
+      return false;
+    }
+
+    const pendingResponse = response.trackingId
+      ? this._pendingResponses.get(response.trackingId)
+      : undefined;
+
+    if (!pendingResponse) {
+      return false;
+    }
+
+    if (!pendingResponse.matchesResponse(response, pendingResponse.request)) {
+      return false;
+    }
+
+    const statusCode = pendingResponse.getStatusCode(response);
+    const statusMessage = pendingResponse.getStatusMessage(response);
+
+    if (statusCode >= 200 && statusCode < 300) {
+      pendingResponse.resolve(response);
+    } else {
+      pendingResponse.reject(pendingResponse.createError(response, statusCode, statusMessage));
+    }
+
+    return true;
   }
 
   /**

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket-events.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket-events.js
@@ -42,6 +42,20 @@ describe('plugin-mobiusSocket', () => {
         sessionId: 'mobius-websocket-session',
       };
 
+      const emitAuthResponse = ({statusCode = 200, statusMessage = 'OK'} = {}) => {
+        const authRequest = JSON.parse(mockWebSocket.send.lastCall.args[0]);
+
+        mockWebSocket.emit('message', {
+          data: JSON.stringify({
+            type: 'response_event',
+            subtype: MESSAGE_TYPES.AUTH,
+            trackingId: authRequest.trackingId,
+            statusCode,
+            statusMessage,
+          }),
+        });
+      };
+
       beforeEach(() => {
         clock = FakeTimers.install({now: Date.now()});
       });
@@ -90,14 +104,9 @@ describe('plugin-mobiusSocket', () => {
 
           process.nextTick(() => {
             mockWebSocket.open();
-            // Simulate Mobius auth.response after socket open
+            // Simulate Mobius auth response after socket open
             process.nextTick(() => {
-              mockWebSocket.emit('message', {
-                data: JSON.stringify({
-                  type: MESSAGE_TYPES.AUTH_RESPONSE,
-                  status: {code: 200},
-                }),
-              });
+              emitAuthResponse();
             });
           });
 

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket-events.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket-events.js
@@ -17,7 +17,7 @@ import promiseTick from '../lib/promise-tick';
 describe('plugin-mobiusSocket', () => {
   describe('MobiusSocket', () => {
     describe('Events', () => {
-      let clock, mobiusSocket, mockWebSocket, socketOpenStub, webex;
+      let clock, mobiusSocket, mockWebSocket, originalSendSpy, socketOpenStub, webex;
 
       const fakeTestMessage = {
         id: uuid.v4(),
@@ -43,7 +43,8 @@ describe('plugin-mobiusSocket', () => {
       };
 
       const emitAuthResponse = ({statusCode = 200, statusMessage = 'OK'} = {}) => {
-        const authRequest = JSON.parse(mockWebSocket.send.lastCall.args[0]);
+        const sendSpy = mockWebSocket.send.lastCall ? mockWebSocket.send : originalSendSpy;
+        const authRequest = JSON.parse(sendSpy.lastCall.args[0]);
 
         mockWebSocket.emit('message', {
           data: JSON.stringify({
@@ -95,6 +96,7 @@ describe('plugin-mobiusSocket', () => {
         webex.logger = console;
 
         mockWebSocket = new MockWebSocket('ws://example.com');
+        originalSendSpy = mockWebSocket.send;
         sinon.stub(Socket, 'getWebSocketConstructor').returns(() => mockWebSocket);
 
         const origOpen = Socket.prototype.open;

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
@@ -915,6 +915,35 @@ describe('plugin-mobius-socket', () => {
         });
       });
 
+      it('rejects with a clear error when the matching response is missing status code', async () => {
+        await mobiusSocket.connect();
+
+        const requestPromise = mobiusSocket.sendWssRequest({
+          type: 'auth',
+          data: {
+            token: 'Bearer test',
+          },
+        });
+
+        await promiseTick();
+
+        const requestPayload = JSON.parse(mockWebSocket.send.lastCall.args[0]);
+
+        mockWebSocket.emit('message', {
+          data: JSON.stringify({
+            type: 'response_event',
+            subtype: 'auth',
+            trackingId: requestPayload.trackingId,
+          }),
+        });
+
+        await assert.isRejected(requestPromise).then((error) => {
+          assert.equal(error.name, 'MobiusSocketResponseError');
+          assert.isUndefined(error.statusCode);
+          assert.equal(error.statusMessage, 'Socket response missing status code');
+        });
+      });
+
       it('rejects pending requests when the active socket closes', async () => {
         await mobiusSocket.connect();
 
@@ -965,6 +994,14 @@ describe('plugin-mobius-socket', () => {
         });
 
         await requestPromise;
+      });
+
+      it('rejects array payloads', async () => {
+        await mobiusSocket.connect();
+
+        await assert.isRejected(mobiusSocket.sendWssRequest([])).then((error) => {
+          assert.equal(error.message, '`payload` is required');
+        });
       });
     });
 

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
@@ -833,14 +833,13 @@ describe('plugin-mobius-socket', () => {
         const requestPromise = mobiusSocket.sendWssRequest({
           type: 'auth',
           data: {
-            token: 'Bearer test',
+            token: 'test',
           },
         });
 
         await promiseTick();
 
         const requestPayload = JSON.parse(mockWebSocket.send.lastCall.args[0]);
-
         assert.equal(requestPayload.data.token, 'test');
 
         mockWebSocket.emit('message', {
@@ -876,7 +875,7 @@ describe('plugin-mobius-socket', () => {
         const requestPromise = mobiusSocket.sendWssRequest({
           type: 'auth',
           data: {
-            token: 'Bearer test',
+            token: 'test',
           },
         });
 
@@ -908,7 +907,7 @@ describe('plugin-mobius-socket', () => {
         const requestPromise = mobiusSocket.sendWssRequest({
           type: 'auth',
           data: {
-            token: 'Bearer test',
+            token: 'test',
           },
         });
 
@@ -928,7 +927,7 @@ describe('plugin-mobius-socket', () => {
         const requestPromise = mobiusSocket.sendWssRequest({
           type: 'auth',
           data: {
-            token: 'Bearer test',
+            token: 'test',
           },
         });
 
@@ -957,7 +956,7 @@ describe('plugin-mobius-socket', () => {
         const requestPromise = mobiusSocket.sendWssRequest({
           type: 'auth',
           data: {
-            token: 'Bearer test',
+            token: 'test',
           },
         });
 
@@ -971,36 +970,6 @@ describe('plugin-mobius-socket', () => {
           assert.equal(error.code, 1003);
           assert.equal(error.reason, 'service rejected request');
         });
-      });
-
-      it('converts legacy auth payload token requests to the data envelope', async () => {
-        await mobiusSocket.connect();
-
-        const requestPromise = mobiusSocket.sendWssRequest({
-          type: 'auth',
-          payload: {
-            token: 'Bearer test',
-          },
-        });
-
-        await promiseTick();
-
-        const requestPayload = JSON.parse(mockWebSocket.send.lastCall.args[0]);
-
-        assert.equal(requestPayload.data.token, 'test');
-        assert.isUndefined(requestPayload.payload);
-
-        mockWebSocket.emit('message', {
-          data: JSON.stringify({
-            type: 'response_event',
-            subtype: 'auth',
-            trackingId: requestPayload.trackingId,
-            statusCode: 200,
-            statusMessage: 'OK',
-          }),
-        });
-
-        await requestPromise;
       });
 
       it('rejects array payloads', async () => {

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
@@ -330,6 +330,13 @@ describe('plugin-mobius-socket', () => {
         };
 
         // skipping due to apparent bug with lolex in all browsers but Chrome.
+        skipInBrowser(it)('fails after default `initialConnectionMaxRetries` attempts', () => {
+          mobiusSocket.config.maxRetries = 0;
+
+          return check();
+        });
+
+        // skipping due to apparent bug with lolex in all browsers but Chrome.
         // if initial retries is zero and mobiusSocket has never connected max retries is used
         skipInBrowser(it)('fails after `maxRetries` attempts', () => {
           mobiusSocket.config.maxRetries = 2;

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
@@ -40,6 +40,20 @@ describe('plugin-mobius-socket', () => {
       trackingId: `suffix_${uuid.v4()}_${Date.now()}`,
     });
 
+    const emitAuthResponse = ({statusCode = 200, statusMessage = 'OK'} = {}) => {
+      const authRequest = JSON.parse(mockWebSocket.send.lastCall.args[0]);
+
+      mockWebSocket.emit('message', {
+        data: JSON.stringify({
+          type: 'response_event',
+          subtype: MESSAGE_TYPES.AUTH,
+          trackingId: authRequest.trackingId,
+          statusCode,
+          statusMessage,
+        }),
+      });
+    };
+
     beforeEach(() => {
       clock = FakeTimers.install({now: Date.now()});
     });
@@ -97,14 +111,9 @@ describe('plugin-mobius-socket', () => {
 
         process.nextTick(() => {
           mockWebSocket.open();
-          // Simulate Mobius auth.response after socket open
+          // Simulate Mobius auth response after socket open
           process.nextTick(() => {
-            mockWebSocket.emit('message', {
-              data: JSON.stringify({
-                type: MESSAGE_TYPES.AUTH_RESPONSE,
-                status: {code: 200},
-              }),
-            });
+            emitAuthResponse();
           });
         });
 
@@ -802,6 +811,129 @@ describe('plugin-mobius-socket', () => {
               assert.equal(lastError, realError);
             });
           });
+        });
+      });
+    });
+
+    describe('#sendWssRequest()', () => {
+      beforeEach(() => {
+        mobiusSocket.config.wssResponseTimeout = 100;
+      });
+
+      it('resolves when a matching response_event arrives', async () => {
+        await mobiusSocket.connect();
+
+        const requestPromise = mobiusSocket.sendWssRequest({
+          type: 'auth',
+          payload: {
+            token: 'Bearer test',
+          },
+        });
+
+        await promiseTick();
+
+        const requestPayload = JSON.parse(mockWebSocket.send.lastCall.args[0]);
+
+        assert.equal(requestPayload.payload.token, 'test');
+
+        mockWebSocket.emit('message', {
+          data: JSON.stringify({
+            type: 'response_event',
+            subtype: 'auth',
+            trackingId: requestPayload.trackingId,
+            statusCode: 200,
+            statusMessage: 'OK',
+          }),
+        });
+
+        const response = await requestPromise;
+
+        assert.equal(response.type, 'response_event');
+        assert.equal(response.subtype, 'auth');
+        assert.equal(response.trackingId, requestPayload.trackingId);
+        assert.equal(response.statusCode, 200);
+      });
+
+      it('strips the Bearer prefix from connect-time auth token', async () => {
+        await mobiusSocket.connect();
+
+        const authPayload = JSON.parse(mockWebSocket.send.firstCall.args[0]);
+
+        assert.equal(authPayload.type, MESSAGE_TYPES.AUTH);
+        assert.equal(authPayload.payload.token, 'FAKE');
+      });
+
+      it('rejects when a matching response_event is non-2xx', async () => {
+        await mobiusSocket.connect();
+
+        const requestPromise = mobiusSocket.sendWssRequest({
+          type: 'auth',
+          payload: {
+            token: 'Bearer test',
+          },
+        });
+
+        await promiseTick();
+
+        const requestPayload = JSON.parse(mockWebSocket.send.lastCall.args[0]);
+
+        mockWebSocket.emit('message', {
+          data: JSON.stringify({
+            type: 'response_event',
+            subtype: 'auth',
+            trackingId: requestPayload.trackingId,
+            statusCode: 403,
+            statusMessage: 'Forbidden',
+          }),
+        });
+
+        await assert.isRejected(requestPromise).then((error) => {
+          assert.equal(error.name, 'MobiusSocketResponseError');
+          assert.equal(error.statusCode, 403);
+          assert.equal(error.statusMessage, 'Forbidden');
+          assert.equal(error.trackingId, requestPayload.trackingId);
+        });
+      });
+
+      it('rejects when the matching response does not arrive before timeout', async () => {
+        await mobiusSocket.connect();
+
+        const requestPromise = mobiusSocket.sendWssRequest({
+          type: 'auth',
+          payload: {
+            token: 'Bearer test',
+          },
+        });
+
+        clock.tick(101);
+        await promiseTick();
+
+        await assert.isRejected(requestPromise).then((error) => {
+          assert.equal(error.name, 'MobiusSocketResponseError');
+          assert.equal(error.statusCode, 408);
+          assert.equal(error.statusMessage, 'Mobius websocket response timed out');
+        });
+      });
+
+      it('rejects pending requests when the active socket closes', async () => {
+        await mobiusSocket.connect();
+
+        const requestPromise = mobiusSocket.sendWssRequest({
+          type: 'auth',
+          payload: {
+            token: 'Bearer test',
+          },
+        });
+
+        mockWebSocket.emit('close', {
+          code: 1003,
+          reason: 'service rejected request',
+        });
+
+        await assert.isRejected(requestPromise).then((error) => {
+          assert.instanceOf(error, ConnectionError);
+          assert.equal(error.code, 1003);
+          assert.equal(error.reason, 'service rejected request');
         });
       });
     });

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
@@ -825,7 +825,7 @@ describe('plugin-mobius-socket', () => {
 
         const requestPromise = mobiusSocket.sendWssRequest({
           type: 'auth',
-          payload: {
+          data: {
             token: 'Bearer test',
           },
         });
@@ -834,7 +834,7 @@ describe('plugin-mobius-socket', () => {
 
         const requestPayload = JSON.parse(mockWebSocket.send.lastCall.args[0]);
 
-        assert.equal(requestPayload.payload.token, 'test');
+        assert.equal(requestPayload.data.token, 'test');
 
         mockWebSocket.emit('message', {
           data: JSON.stringify({
@@ -860,7 +860,7 @@ describe('plugin-mobius-socket', () => {
         const authPayload = JSON.parse(mockWebSocket.send.firstCall.args[0]);
 
         assert.equal(authPayload.type, MESSAGE_TYPES.AUTH);
-        assert.equal(authPayload.payload.token, 'FAKE');
+        assert.equal(authPayload.data.token, 'FAKE');
       });
 
       it('rejects when a matching response_event is non-2xx', async () => {
@@ -868,7 +868,7 @@ describe('plugin-mobius-socket', () => {
 
         const requestPromise = mobiusSocket.sendWssRequest({
           type: 'auth',
-          payload: {
+          data: {
             token: 'Bearer test',
           },
         });
@@ -900,7 +900,7 @@ describe('plugin-mobius-socket', () => {
 
         const requestPromise = mobiusSocket.sendWssRequest({
           type: 'auth',
-          payload: {
+          data: {
             token: 'Bearer test',
           },
         });
@@ -920,7 +920,7 @@ describe('plugin-mobius-socket', () => {
 
         const requestPromise = mobiusSocket.sendWssRequest({
           type: 'auth',
-          payload: {
+          data: {
             token: 'Bearer test',
           },
         });
@@ -935,6 +935,36 @@ describe('plugin-mobius-socket', () => {
           assert.equal(error.code, 1003);
           assert.equal(error.reason, 'service rejected request');
         });
+      });
+
+      it('converts legacy auth payload token requests to the data envelope', async () => {
+        await mobiusSocket.connect();
+
+        const requestPromise = mobiusSocket.sendWssRequest({
+          type: 'auth',
+          payload: {
+            token: 'Bearer test',
+          },
+        });
+
+        await promiseTick();
+
+        const requestPayload = JSON.parse(mockWebSocket.send.lastCall.args[0]);
+
+        assert.equal(requestPayload.data.token, 'test');
+        assert.isUndefined(requestPayload.payload);
+
+        mockWebSocket.emit('message', {
+          data: JSON.stringify({
+            type: 'response_event',
+            subtype: 'auth',
+            trackingId: requestPayload.trackingId,
+            statusCode: 200,
+            statusMessage: 'OK',
+          }),
+        });
+
+        await requestPromise;
       });
     });
 
@@ -1574,7 +1604,7 @@ describe('plugin-mobius-socket', () => {
           assert.isObject(callArgs[1]);
           assert.equal(callArgs[1].token, 'mock-token');
           assert.isDefined(callArgs[1].forceCloseDelay);
-          assert.isDefined(callArgs[1].authResponseTimeout);
+          assert.isDefined(callArgs[1].wssResponseTimeout);
         });
 
         it('should log with correct prefix for normal connection', async () => {
@@ -1595,7 +1625,7 @@ describe('plugin-mobius-socket', () => {
         it('should merge custom mobiusSocket options when provided', async () => {
           webex.config.defaultMobiusSocketOptions = {
             customOption: 'test-value',
-            authResponseTimeout: 99999,
+            wssResponseTimeout: 99999,
           };
 
           await mobiusSocket._prepareAndOpenSocket(mockSocket, undefined, false);
@@ -1603,7 +1633,7 @@ describe('plugin-mobius-socket', () => {
           const callArgs = mockSocket.open.firstCall.args;
 
           assert.equal(callArgs[1].customOption, 'test-value');
-          assert.equal(callArgs[1].authResponseTimeout, 99999); // Custom value overrides default
+          assert.equal(callArgs[1].wssResponseTimeout, 99999); // Custom value overrides default
         });
 
         it('should return the webSocketUrl after opening', async () => {

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
@@ -749,7 +749,7 @@ describe('plugin-mobius-socket', () => {
           const promise = mobiusSocket.connect();
 
           // Wait for the connect call to setup
-          return promiseTick(webex.internal.mobiusSocket.config.backoffTimeReset).then(() => {
+          return promiseTick(webex.internal.mobiusSocket.config.backoffTimeReset).then(async () => {
             // By this time backoffCall and mobiusSocket socket should be defined by the
             // 'connect' call
             assert.isDefined(mobiusSocket.backoffCalls.get('mobius-websocket-session'), 'MobiusSocket backoffCall is not defined');
@@ -761,10 +761,9 @@ describe('plugin-mobius-socket', () => {
             // The socket will never be unset (which seems bad)
             assert.isDefined(mobiusSocket.socket, 'MobiusSocket socket is not defined');
 
-            return assert.isRejected(promise).then((error) => {
-              // connection did not fail, so no last error
-              assert.isUndefined(mobiusSocket.getLastError());
-            });
+            await assert.isRejected(promise);
+            // connection did not fail, so no last error
+            assert.isUndefined(mobiusSocket.getLastError());
           });
         });
 
@@ -805,18 +804,20 @@ describe('plugin-mobius-socket', () => {
           const promise = mobiusSocket.connect();
 
           // Wait for the connect call to setup
-          return promiseTick(webex.internal.mobiusSocket.config.backoffTimeReset).then(() => {
+          return promiseTick(webex.internal.mobiusSocket.config.backoffTimeReset).then(async () => {
             // Calling disconnect will abort the backoffCall, close the socket, and
             // reject the connect
             mobiusSocket.disconnect();
 
-            return assert.isRejected(promise).then((error) => {
-              const lastError = mobiusSocket.getLastError();
+            const error = await assert.isRejected(promise);
+            const lastError = mobiusSocket.getLastError();
 
-              assert.equal(error.message, `MobiusSocket Connection Aborted for ${mobiusSocket.defaultSessionId}`);
-              assert.isDefined(lastError);
-              assert.equal(lastError, realError);
-            });
+            assert.equal(
+              error.message,
+              `MobiusSocket Connection Aborted for ${mobiusSocket.defaultSessionId}`
+            );
+            assert.isDefined(lastError);
+            assert.equal(lastError, realError);
           });
         });
       });
@@ -893,12 +894,12 @@ describe('plugin-mobius-socket', () => {
           }),
         });
 
-        await assert.isRejected(requestPromise).then((error) => {
-          assert.equal(error.name, 'MobiusSocketResponseError');
-          assert.equal(error.statusCode, 403);
-          assert.equal(error.statusMessage, 'Forbidden');
-          assert.equal(error.trackingId, requestPayload.trackingId);
-        });
+        const error = await assert.isRejected(requestPromise);
+
+        assert.equal(error.name, 'MobiusSocketResponseError');
+        assert.equal(error.statusCode, 403);
+        assert.equal(error.statusMessage, 'Forbidden');
+        assert.equal(error.trackingId, requestPayload.trackingId);
       });
 
       it('rejects when the matching response does not arrive before timeout', async () => {
@@ -914,11 +915,11 @@ describe('plugin-mobius-socket', () => {
         clock.tick(101);
         await promiseTick();
 
-        await assert.isRejected(requestPromise).then((error) => {
-          assert.equal(error.name, 'MobiusSocketResponseError');
-          assert.equal(error.statusCode, 408);
-          assert.equal(error.statusMessage, 'Mobius websocket response timed out');
-        });
+        const error = await assert.isRejected(requestPromise);
+
+        assert.equal(error.name, 'MobiusSocketResponseError');
+        assert.equal(error.statusCode, 408);
+        assert.equal(error.statusMessage, 'Mobius websocket response timed out');
       });
 
       it('rejects with a clear error when the matching response is missing status code', async () => {
@@ -943,11 +944,11 @@ describe('plugin-mobius-socket', () => {
           }),
         });
 
-        await assert.isRejected(requestPromise).then((error) => {
-          assert.equal(error.name, 'MobiusSocketResponseError');
-          assert.isUndefined(error.statusCode);
-          assert.equal(error.statusMessage, 'Socket response missing status code');
-        });
+        const error = await assert.isRejected(requestPromise);
+
+        assert.equal(error.name, 'MobiusSocketResponseError');
+        assert.isUndefined(error.statusCode);
+        assert.equal(error.statusMessage, 'Socket response missing status code');
       });
 
       it('rejects pending requests when the active socket closes', async () => {
@@ -965,19 +966,19 @@ describe('plugin-mobius-socket', () => {
           reason: 'service rejected request',
         });
 
-        await assert.isRejected(requestPromise).then((error) => {
-          assert.instanceOf(error, ConnectionError);
-          assert.equal(error.code, 1003);
-          assert.equal(error.reason, 'service rejected request');
-        });
+        const error = await assert.isRejected(requestPromise);
+
+        assert.instanceOf(error, ConnectionError);
+        assert.equal(error.code, 1003);
+        assert.equal(error.reason, 'service rejected request');
       });
 
       it('rejects array payloads', async () => {
         await mobiusSocket.connect();
 
-        await assert.isRejected(mobiusSocket.sendWssRequest([])).then((error) => {
-          assert.equal(error.message, '`payload` is required');
-        });
+        const error = await assert.isRejected(mobiusSocket.sendWssRequest([]));
+
+        assert.equal(error.message, '`payload` is required');
       });
     });
 

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/socket.js
@@ -134,7 +134,7 @@ describe('plugin-mobius-socket', () => {
       it('accepts a logLevelToken option', () => {
         const promise = socket.open('ws://example.com', {
           forceCloseDelay: mockoptions.forceCloseDelay,
-          wssResponseTimeout: mockoptions.authResponseTimeout,
+          wssResponseTimeout: mockoptions.wssResponseTimeout,
           logger: console,
           token: 'mocktoken',
           trackingId: 'mocktrackingid',
@@ -364,7 +364,7 @@ describe('plugin-mobius-socket', () => {
 
             s.open('ws://example.com', {
               forceCloseDelay: mockoptions.forceCloseDelay,
-              wssResponseTimeout: mockoptions.authResponseTimeout,
+              wssResponseTimeout: mockoptions.wssResponseTimeout,
               logger: console,
               token: 'mocktoken',
               trackingId: 'mocktrackingid',

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/socket.js
@@ -32,6 +32,20 @@ describe('plugin-mobius-socket', () => {
       config.mobiusSocket
     );
 
+    const emitAuthResponse = ({statusCode = 200, statusMessage = 'OK'} = {}) => {
+      const authRequest = JSON.parse(mockWebSocket.send.lastCall.args[0]);
+
+      mockWebSocket.emit('message', {
+        data: JSON.stringify({
+          type: 'response_event',
+          subtype: MESSAGE_TYPES.AUTH,
+          trackingId: authRequest.trackingId,
+          statusCode,
+          statusMessage,
+        }),
+      });
+    };
+
     beforeEach(() => {
       clock = FakeTimers.install({now: Date.now()});
     });
@@ -55,14 +69,9 @@ describe('plugin-mobius-socket', () => {
       const promise = socket.open('ws://example.com', mockoptions);
 
       mockWebSocket.open();
-      // Simulate Mobius auth.response (MockWebSocket.open auto-sends mercury.buffer_state which Mobius ignores)
+      // Simulate Mobius auth response (MockWebSocket.open auto-sends mercury.buffer_state which Mobius ignores)
       process.nextTick(() => {
-        mockWebSocket.emit('message', {
-          data: JSON.stringify({
-            type: MESSAGE_TYPES.AUTH_RESPONSE,
-            status: {code: 200},
-          }),
-        });
+        emitAuthResponse();
       });
 
       return promise;
@@ -135,12 +144,7 @@ describe('plugin-mobius-socket', () => {
         mockWebSocket.readyState = 1;
         mockWebSocket.emit('open');
 
-        mockWebSocket.emit('message', {
-          data: JSON.stringify({
-            type: MESSAGE_TYPES.AUTH_RESPONSE,
-            status: {code: 200},
-          }),
-        });
+        emitAuthResponse();
 
         return promise.then(() => {
           assert.equal(socket.logLevelToken, 'mocklogleveltoken');
@@ -379,20 +383,32 @@ describe('plugin-mobius-socket', () => {
           });
         });
 
-        it('resolves upon receiving auth.response', () => {
+        it('resolves upon receiving response_event auth response', () => {
           const s = new Socket();
           const promise = s.open('ws://example.com', mockoptions);
 
           mockWebSocket.readyState = 1;
           mockWebSocket.emit('open');
-          mockWebSocket.emit('message', {
-            data: JSON.stringify({
-              type: MESSAGE_TYPES.AUTH_RESPONSE,
-              status: {code: 200},
-            }),
-          });
+          emitAuthResponse();
 
           return promise.then(() => s.close());
+        });
+
+        it('rejects upon receiving a non-2xx auth response_event', () => {
+          const s = new Socket();
+          const promise = s.open('ws://example.com', mockoptions);
+
+          mockWebSocket.readyState = 1;
+          mockWebSocket.emit('open');
+          emitAuthResponse({statusCode: 401, statusMessage: 'Unauthorized'});
+
+          return assert.isRejected(promise).then((reason) => {
+            assert.instanceOf(reason, NotAuthorized);
+            assert.equal(reason.code, 401);
+            assert.match(reason.reason, /Unauthorized/);
+
+            return s.close();
+          });
         });
       });
     });
@@ -440,12 +456,7 @@ describe('plugin-mobius-socket', () => {
 
         mockWebSocket.readyState = 1;
         mockWebSocket.emit('open');
-        mockWebSocket.emit('message', {
-          data: JSON.stringify({
-            type: MESSAGE_TYPES.AUTH_RESPONSE,
-            status: {code: 200},
-          }),
-        });
+        emitAuthResponse();
 
         return promise.then(() => {
           const spy = sinon.spy();
@@ -477,12 +488,7 @@ describe('plugin-mobius-socket', () => {
 
         mockWebSocket.readyState = 1;
         mockWebSocket.emit('open');
-        mockWebSocket.emit('message', {
-          data: JSON.stringify({
-            type: MESSAGE_TYPES.AUTH_RESPONSE,
-            status: {code: 200},
-          }),
-        });
+        emitAuthResponse();
 
         return promise.then(() => {
           const spy = sinon.spy();
@@ -514,12 +520,7 @@ describe('plugin-mobius-socket', () => {
 
         mockWebSocket.readyState = 1;
         mockWebSocket.emit('open');
-        mockWebSocket.emit('message', {
-          data: JSON.stringify({
-            type: MESSAGE_TYPES.AUTH_RESPONSE,
-            status: {code: 200},
-          }),
-        });
+        emitAuthResponse();
 
         return promise.then(() => {
           const spy = sinon.spy();
@@ -551,12 +552,7 @@ describe('plugin-mobius-socket', () => {
 
         mockWebSocket.readyState = 1;
         mockWebSocket.emit('open');
-        mockWebSocket.emit('message', {
-          data: JSON.stringify({
-            type: MESSAGE_TYPES.AUTH_RESPONSE,
-            status: {code: 200},
-          }),
-        });
+        emitAuthResponse();
 
         return promise.then(() => {
           const spy = sinon.spy();

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/socket.js
@@ -134,7 +134,7 @@ describe('plugin-mobius-socket', () => {
       it('accepts a logLevelToken option', () => {
         const promise = socket.open('ws://example.com', {
           forceCloseDelay: mockoptions.forceCloseDelay,
-          authResponseTimeout: mockoptions.authResponseTimeout,
+          wssResponseTimeout: mockoptions.authResponseTimeout,
           logger: console,
           token: 'mocktoken',
           trackingId: 'mocktrackingid',
@@ -352,9 +352,9 @@ describe('plugin-mobius-socket', () => {
           const firstCallArgs = JSON.parse(mockWebSocket.send.firstCall.args[0]);
 
           assert.equal(firstCallArgs.type, MESSAGE_TYPES.AUTH);
-          assert.property(firstCallArgs, 'payload');
-          assert.property(firstCallArgs.payload, 'token');
-          assert.equal(firstCallArgs.payload.token, 'mocktoken');
+          assert.property(firstCallArgs, 'data');
+          assert.property(firstCallArgs.data, 'token');
+          assert.equal(firstCallArgs.data.token, 'mocktoken');
           assert.property(firstCallArgs, 'trackingId');
         });
 
@@ -364,7 +364,7 @@ describe('plugin-mobius-socket', () => {
 
             s.open('ws://example.com', {
               forceCloseDelay: mockoptions.forceCloseDelay,
-              authResponseTimeout: mockoptions.authResponseTimeout,
+              wssResponseTimeout: mockoptions.authResponseTimeout,
               logger: console,
               token: 'mocktoken',
               trackingId: 'mocktrackingid',
@@ -375,8 +375,8 @@ describe('plugin-mobius-socket', () => {
             const firstCallArgs = JSON.parse(mockWebSocket.send.firstCall.args[0]);
 
             assert.equal(firstCallArgs.type, MESSAGE_TYPES.AUTH);
-            assert.property(firstCallArgs, 'payload');
-            assert.equal(firstCallArgs.payload.token, 'mocktoken');
+            assert.property(firstCallArgs, 'data');
+            assert.equal(firstCallArgs.data.token, 'mocktoken');
             assert.property(firstCallArgs, 'trackingId');
 
             return s.close();


### PR DESCRIPTION
# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7824

## This pull request addresses

Aligning `@webex/internal-plugin-mobius-socket` with the current Mobius WebSocket request/response protocol.

The previous implementation still mixed older auth/response assumptions with the newer websocket flow. In particular, the package needed to:
- treat websocket messages as request/response operations correlated by `trackingId`
- handle auth responses as `response_event` messages with `subtype: 'auth'`
- use a consistent websocket response timeout for auth and non-auth requests
- send auth using the current `data.token` envelope

## by making the following changes

- moved the generic websocket request/response handling into `socket-base`
  - tracks pending requests by `trackingId`
  - resolves matching `response_event` responses
  - rejects non-2xx responses
  - times out pending requests
  - rejects pending requests when the socket closes
- updated socket auth to use the same request/response helper and current Mobius response format
  - waits for `type: 'response_event'`
  - matches `subtype: 'auth'`
  - sends auth as `{type: 'auth', data: {token}}`
- kept `MobiusSocket.sendWssRequest()` as the higher-level API on top of the socket helper
- normalized auth token handling so `Bearer ` prefixes are stripped before sending
- consolidated timeout behavior around `wssResponseTimeout`
  - config now uses `wssResponseTimeout` as the canonical websocket request/response timeout
  - retains fallback support for the older auth timeout env var
- updated unit tests and README examples to reflect the current websocket protocol

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

- Focused Mobius socket unit tests for auth and request/response handling:
  - `./node_modules/.bin/mocha --require @babel/register packages/@webex/internal-plugin-mobius-socket/test/unit/spec/socket.js packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js --grep "auth|sendWssRequest|authorize"`
- ESLint on touched Mobius socket source files:
  - `./node_modules/.bin/eslint packages/@webex/internal-plugin-mobius-socket/src/socket/socket-base.js packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js`
  
 tested connect and sending auth and receiving auth response in local samples
 https://app.vidcast.io/share/e4f383d1-9ccd-4b38-b3a6-029e877839c3

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
