### PR TITLE
feat(calling): wire the sendWssRequest with makeRequest

### DIFF
--- a/packages/@webex/internal-plugin-mobius-socket/src/index.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/index.js
@@ -19,7 +19,19 @@ import config from './config';
  * @param {object} [mobiusSocketConfig={}]
  * @returns {MobiusSocket}
  */
-export function createMobiusSocket(webex, mobiusSocketConfig = {}) {
+let mobiusSocketInstance; // Keeping just one instance of MobiusSocket since there won't be multiple connections
+
+/**
+ * Creates or returns the singleton Mobius socket client for the provided Webex instance.
+ * @param {object} webex - The Webex SDK instance
+ * @param {object} [mobiusSocketConfig={}] - Optional configuration overrides
+ * @returns {MobiusSocket} The singleton MobiusSocket instance
+ */
+export function getMobiusSocketInstance(webex, mobiusSocketConfig = {}) {
+  if (mobiusSocketInstance) {
+    return mobiusSocketInstance;
+  }
+
   const webexConfig = webex.config || {};
   const mobiusConfig = {
     ...config.mobiusSocket,
@@ -32,7 +44,17 @@ export function createMobiusSocket(webex, mobiusSocketConfig = {}) {
     mobiussocket: mobiusConfig,
   };
 
-  return new MobiusSocket({}, {parent: webex});
+  mobiusSocketInstance = new MobiusSocket({}, {parent: webex});
+
+  return mobiusSocketInstance;
+}
+
+/**
+ * Resets the singleton MobiusSocket instance, allowing a new one to be created.
+ * @returns {void}
+ */
+export function resetMobiusSocketInstance() {
+  mobiusSocketInstance = undefined;
 }
 
 export default MobiusSocket;

--- a/packages/calling/src/CallingClient/CallingClient.test.ts
+++ b/packages/calling/src/CallingClient/CallingClient.test.ts
@@ -56,6 +56,13 @@ import {ServiceHost} from '../SDKConnector/types';
 import {METHOD_START_MESSAGE} from '../common/constants';
 import {METRIC_EVENT, CONNECTION_ACTION, METRIC_TYPE} from '../Metrics/types';
 import windowsChromiumIceWarmup from './windowsChromiumIceWarmupUtils';
+import {APIRequest} from './utils/request';
+
+jest.mock('@webex/internal-plugin-mobius-socket', () => ({
+  getMobiusSocketInstance: jest.fn().mockReturnValue({
+    sendWssRequest: jest.fn(),
+  }),
+}));
 
 global.crypto = {
   randomUUID: () => '12345678-1234-5678-1234-567812345678',
@@ -84,6 +91,11 @@ describe('CallingClient Tests', () => {
       originalProcessNextTick(resolve);
     });
   }
+
+  beforeEach(() => {
+    APIRequest.resetInstance();
+    APIRequest.getInstance({webex, isMobiusSocketEnabled: false});
+  });
 
   describe('CallingClient pick Mobius cluster using Service Host Tests', () => {
     afterAll(() => {

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import * as Media from '@webex/internal-media-core';
 // @ts-ignore - JS module without type declarations
-import {createMobiusSocket} from '@webex/internal-plugin-mobius-socket';
+import {getMobiusSocketInstance} from '@webex/internal-plugin-mobius-socket';
 import {Mutex} from 'async-mutex';
 import {METHOD_START_MESSAGE} from '../common/constants';
 import {
@@ -174,10 +174,11 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     this.mobiusHost = '';
 
     // MOBIUS SOCKET TODO: Fix this when feature flag is implemented
-    this.isMobiusSocketEnabled = config?.isMobiusSocketEnabled ?? false;
+    // this.isMobiusSocketEnabled = config?.isMobiusSocketEnabled ?? false;
+    this.isMobiusSocketEnabled = config?.isMobiusSocketEnabled ?? true;
 
     if (this.isMobiusSocketEnabled) {
-      this.mobiusSocket = createMobiusSocket(this.webex);
+      this.mobiusSocket = getMobiusSocketInstance(this.webex);
     }
 
     this.apiRequest = APIRequest.getInstance({webex: this.webex});

--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -31,6 +31,11 @@ import {CallError} from '../../Errors';
 import {METHOD_START_MESSAGE} from '../../common/constants';
 import {APIRequest} from '../utils/request';
 
+jest.mock('@webex/internal-plugin-mobius-socket', () => ({
+  getMobiusSocketInstance: jest.fn().mockReturnValue({
+    sendWssRequest: jest.fn(),
+  }),
+}));
 jest.mock('@webex/internal-media-core');
 
 const uploadLogsSpy = jest.spyOn(Utils, 'uploadLogs').mockResolvedValue(undefined);
@@ -134,6 +139,7 @@ describe('Call Tests', () => {
 
   beforeEach(() => {
     APIRequest.resetInstance();
+    APIRequest.getInstance({webex, isMobiusSocketEnabled: false});
     callManager = getCallManager(webex, defaultServiceIndicator);
   });
 
@@ -918,6 +924,7 @@ describe('State Machine handler tests', () => {
 
   beforeEach(() => {
     APIRequest.resetInstance();
+    APIRequest.getInstance({webex, isMobiusSocketEnabled: false});
     call = new Call(
       activeUrl,
       webex,
@@ -2601,6 +2608,7 @@ describe('Supplementary Services tests', () => {
 
   beforeEach(() => {
     APIRequest.resetInstance();
+    APIRequest.getInstance({webex, isMobiusSocketEnabled: false});
     /* Since we are not actually testing from the start of a call , so it's good to set the below
      * parameters manually
      */

--- a/packages/calling/src/CallingClient/line/line.test.ts
+++ b/packages/calling/src/CallingClient/line/line.test.ts
@@ -22,13 +22,24 @@ import SDKConnector from '../../SDKConnector';
 import {REGISTRATION_FILE} from '../constants';
 import {LOGGER} from '../../Logger/types';
 import * as regUtils from '../registration/register';
+import {APIRequest} from '../utils/request';
 
+jest.mock('@webex/internal-plugin-mobius-socket', () => ({
+  getMobiusSocketInstance: jest.fn().mockReturnValue({
+    sendWssRequest: jest.fn(),
+  }),
+}));
 jest.spyOn(utils, 'uploadLogs').mockResolvedValue(undefined);
 
 describe('Line Tests', () => {
   const mutex = new Mutex();
   const webex = getTestUtilsWebex();
   SDKConnector.setWebex(webex);
+
+  beforeEach(() => {
+    APIRequest.resetInstance();
+    APIRequest.getInstance({webex, isMobiusSocketEnabled: false});
+  });
 
   const defaultServiceData = {indicator: ServiceIndicator.CALLING, domain: ''};
   const createRegistrationSpy = jest.spyOn(regUtils, 'createRegistration');

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -41,6 +41,12 @@ import {IRegistration} from './types';
 import {METRIC_EVENT, REG_ACTION, METRIC_TYPE} from '../../Metrics/types';
 import {APIRequest} from '../utils/request';
 
+jest.mock('@webex/internal-plugin-mobius-socket', () => ({
+  getMobiusSocketInstance: jest.fn().mockReturnValue({
+    sendWssRequest: jest.fn(),
+  }),
+}));
+
 const webex = getTestUtilsWebex();
 const MockServiceData = {
   indicator: ServiceIndicator.CALLING,
@@ -160,6 +166,7 @@ describe('Registration Tests', () => {
 
   beforeEach(() => {
     APIRequest.resetInstance();
+    APIRequest.getInstance({webex, isMobiusSocketEnabled: false});
     setupRegistration(MockServiceData);
   });
 

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -1,12 +1,9 @@
 import {v4 as uuid} from 'uuid';
+// @ts-ignore - JS module without type declarations
+import {getMobiusSocketInstance} from '@webex/internal-plugin-mobius-socket';
 import {WebexRequestPayload} from '../../common/types';
 import {WebexSDK} from '../../SDKConnector/types';
-import {
-  APIRequestConfig,
-  APIRequestOptions,
-  MobiusSocketRequestOptions,
-  MobiusSocketResponse,
-} from './types';
+import {APIRequestConfig, APIRequestOptions, MobiusSocketResponse} from './types';
 import {deriveMobiusSocketMessageType} from './mobiusSocketMapper';
 import {MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
 
@@ -20,6 +17,8 @@ export class APIRequest {
   private static instance: APIRequest | undefined;
   private isMobiusSocketEnabled: boolean;
   private webex: WebexSDK;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private mobiusSocket: any;
 
   static getInstance(config: APIRequestConfig): APIRequest {
     if (!APIRequest.instance) {
@@ -43,7 +42,11 @@ export class APIRequest {
     }
 
     this.webex = config.webex;
-    this.isMobiusSocketEnabled = config.isMobiusSocketEnabled ?? false;
+    this.mobiusSocket = getMobiusSocketInstance(this.webex);
+
+    // TODO: Update this once feature flag is implemented
+    // this.isMobiusSocketEnabled = config.isMobiusSocketEnabled ?? false;
+    this.isMobiusSocketEnabled = config.isMobiusSocketEnabled ?? true;
   }
 
   /**
@@ -55,45 +58,25 @@ export class APIRequest {
     request: APIRequestOptions
   ): Promise<WebexRequestPayload | MobiusSocketResponse> {
     if (this.isMobiusSocketEnabled) {
-      const trackingId = `mobius-wss_${uuid()}`;
+      const trackingId = `webex-js-sdk_${uuid()}`;
       const socketType = deriveMobiusSocketMessageType(request.uri, request.method);
 
       if (socketType === MOBIUS_SOCKET_MESSAGE_TYPE.UNKNOWN) {
         throw new Error(`Unknown Mobius Socket message type: ${socketType}`);
       }
 
-      return this.mobiusSocketRequest({
+      return this.mobiusSocket.sendWssRequest({
         type: socketType,
         trackingId,
-        metadata: {}, // TODO: Add auth token to metadata
-        payload: request.body,
+        metadata: {
+          // userAgent: CALLING_USER_AGENT,
+          userAgent: 'mobius-ws-test-ui', // TODO: Confirm if this needs to be hardcoded
+        }, // TODO: Add auth token to metadata for call transfer etc
+        data: request.body,
       });
     }
 
     return this.webex.request(request);
-  }
-
-  /**
-   * Placeholder implementation for Mobius WebSocket request
-   * TODO: Implement WebSocket-based request handling
-   * This will use the Mobius WebSocket connection instead of HTTP
-   * @param options - Request options containing type, trackingId, metadata, and payload
-   * @returns Promise resolving to MobiusSocketResponse
-   */
-  private async mobiusSocketRequest(
-    options: MobiusSocketRequestOptions
-  ): Promise<MobiusSocketResponse> {
-    // Placeholder implementation - to be replaced with actual WebSocket logic
-    return Promise.resolve({
-      type: options.type,
-      trackingId: options.trackingId,
-      status: {
-        code: 501,
-        message: 'Not Implemented - Mobius Socket support coming soon',
-      },
-      metadata: options.metadata,
-      payload: options.payload,
-    });
   }
 }
 

--- a/packages/calling/src/CallingClient/utils/types.ts
+++ b/packages/calling/src/CallingClient/utils/types.ts
@@ -26,8 +26,8 @@ export interface MobiusSocketRequestOptions {
   trackingId: string;
   /** Optional metadata (uri, service, headers, etc.) */
   metadata?: Record<string, unknown>;
-  /** Optional request payload/body */
-  payload?: unknown;
+  /** Optional request data/body */
+  data?: unknown;
 }
 
 /**
@@ -36,10 +36,18 @@ export interface MobiusSocketRequestOptions {
 export type MobiusSocketResponse = {
   type: string;
   trackingId: string;
-  status: {
-    code: number;
-    message: string;
-  };
+  statusCode: number;
+  statusMessage: string;
   metadata?: Record<string, unknown>;
-  payload?: unknown;
+  data?: unknown;
 };
+
+/**
+ * Function signature for MobiusSocket.sendWssRequest.
+ * Sends a websocket request data and resolves when the matching response arrives.
+ */
+export type SendWssRequestFn = (
+  data: MobiusSocketRequestOptions,
+  sessionIdOrOptions?: string | Record<string, unknown>,
+  options?: Record<string, unknown>
+) => Promise<MobiusSocketResponse>;


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< PR-2: CAI-7823 >

## This pull request addresses

wire the sendWssRequest with makeRequest

## by making the following changes

**`@webex/internal-plugin-mobius-socket/src/index.js`**
- Renamed `createMobiusSocket` to `getMobiusSocketInstance` and made it a **singleton** — returns the cached instance on subsequent calls instead of creating a new `MobiusSocket` each time.
- Added `resetMobiusSocketInstance()` export for teardown/testing.

**`CallingClient/utils/request.ts`**
- Replaced the private `mobiusSocketRequest` placeholder (which returned a 501 stub) with a direct call to `this.mobiusSocket.sendWssRequest(...)` — the real MobiusSocket method.
- Added a `mobiusSocket` class variable, initialized via `getMobiusSocketInstance(this.webex)` in the constructor.
- Changed `isMobiusSocketEnabled` default from `false` to `true` (pending feature flag).
- Changed tracking ID prefix from `mobius-wss_` to `webex-js-sdk_`.
- Changed payload field from `payload` to `data` to match the MobiusSocket contract.

**`CallingClient/utils/types.ts`**
- Updated `MobiusSocketRequestOptions`: renamed `payload` → `data`.
- Updated `MobiusSocketResponse`: flattened `status.code`/`status.message` to `statusCode`/`statusMessage` to match the actual WSS response shape.
- Added `SendWssRequestFn` type matching the signature of `MobiusSocket.sendWssRequest`.

**`CallingClient/CallingClient.ts`**
- Updated import from `createMobiusSocket` → `getMobiusSocketInstance`.
- Changed `isMobiusSocketEnabled` default to `true`.

---

**4 test files changed**

Applied the same fix pattern across `call.test.ts`, `register.test.ts`, `CallingClient.test.ts`, and `line.test.ts`:
- Added `jest.mock('@webex/internal-plugin-mobius-socket')` returning a mock `getMobiusSocketInstance` with a stub `sendWssRequest`.
- Added `APIRequest.resetInstance()` + `APIRequest.getInstance({webex, isMobiusSocketEnabled: false})` in `beforeEach` blocks so existing tests continue using the HTTP path (`webex.request` mocks) rather than the WSS path.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Manually tested the auth and registration part. Auth is working successfully but registration failed due to to some backend issue (Payload being sent is correct)

**Note**: Tested the registration part by hardcoding the request in the code. Changes related to registration will follow this PR.

<img width="1378" height="663" alt="Screenshot 2026-04-17 at 3 11 40 PM" src="https://github.com/user-attachments/assets/5812adc1-6e9c-4845-ad4a-b38e066dcbdf" />


## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
