### PR TITLE
fix(calling): read and use mobius-ws setting from wdm

### DIFF
--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -66,6 +66,7 @@ import {
 import {getMetricManager} from '../Metrics';
 import windowsChromiumIceWarmup from './windowsChromiumIceWarmupUtils';
 import {APIRequest} from './utils/request';
+import {isWsFeatureEnabled} from './utils';
 
 /**
  * The `CallingClient` module provides a set of APIs for line registration and calling functionalities within the SDK.
@@ -173,8 +174,8 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     this.mobiusClusters = this.webex.internal.services.getMobiusClusters();
     this.mobiusHost = '';
 
-    // MOBIUS SOCKET TODO: Fix this when feature flag is implemented
-    this.isMobiusSocketEnabled = config?.isMobiusSocketEnabled ?? false;
+    this.isMobiusSocketEnabled =
+      isWsFeatureEnabled(this.webex) || (config?.isMobiusSocketEnabled ?? false);
 
     if (this.isMobiusSocketEnabled) {
       this.mobiusSocket = createMobiusSocket(this.webex);

--- a/packages/calling/src/CallingClient/utils/index.ts
+++ b/packages/calling/src/CallingClient/utils/index.ts
@@ -2,3 +2,4 @@ export * from './request';
 export * from './types';
 export * from './mobiusSocketMapper';
 export * from './constants';
+export * from './wsFeatureFlag';

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -9,11 +9,12 @@ import {
 } from './types';
 import {deriveMobiusSocketMessageType} from './mobiusSocketMapper';
 import {MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
+import {isWsFeatureEnabled} from './wsFeatureFlag';
 
 /**
- * APIRequest class provides a unified interface for making requests
- * that can be routed through either HTTP (webex.request) or WebSocket
- * (mobiusSocketRequest) based on configuration.
+ * APIRequest routes Mobius traffic over HTTP (`webex.request`) or the Mobius WebSocket path
+ * (`mobiusSocketRequest`). `isMobiusSocketEnabled` is set in the constructor from WDM
+ * `webrtc-calling-over-ws` and/or SDK config (interim until WDM is fully in prod).
  */
 export class APIRequest {
   // eslint-disable-next-line no-use-before-define
@@ -34,8 +35,7 @@ export class APIRequest {
   }
 
   /**
-   * Creates an instance of APIRequest
-   * @param config - Configuration object containing webex instance and optional socket flag
+   * @param config - Webex instance plus optional SDK Mobius-socket override
    */
   constructor(config: APIRequestConfig) {
     if (!config.webex) {
@@ -43,11 +43,12 @@ export class APIRequest {
     }
 
     this.webex = config.webex;
-    this.isMobiusSocketEnabled = config.isMobiusSocketEnabled ?? false;
+    this.isMobiusSocketEnabled =
+      isWsFeatureEnabled(config.webex) || (config.isMobiusSocketEnabled ?? false);
   }
 
   /**
-   * Makes a request using either HTTP or WebSocket transport based on configuration
+   * Makes a request using HTTP or WebSocket transport per the flag set in the constructor.
    * @param request - Request options (uri, method, body, headers, service)
    * @returns Promise resolving to WebexRequestPayload or MobiusSocketResponse
    */

--- a/packages/calling/src/CallingClient/utils/types.ts
+++ b/packages/calling/src/CallingClient/utils/types.ts
@@ -5,7 +5,10 @@ import {WebexSDK} from '../../SDKConnector/types';
  * Configuration for APIRequest class
  */
 export interface APIRequestConfig {
-  /** Enable Mobius WebSocket transport (default: false) */
+  /**
+   * Interim SDK opt-in for Mobius WebSocket transport when WDM
+   * `webrtc-calling-over-ws` is not yet true (until prod rollout).
+   */
   isMobiusSocketEnabled?: boolean;
   /** Webex SDK instance for making requests */
   webex: WebexSDK;

--- a/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
+++ b/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
@@ -1,0 +1,13 @@
+import {WebexSDK} from '../../SDKConnector/types';
+
+/** WDM device-settings key for routing Mobius traffic over WebSocket. */
+export const WEBRTC_CALLING_OVER_WS_FEATURE_KEY = 'webrtc-calling-over-ws';
+
+/**
+ * Whether Webex Calling should use the Mobius WebSocket transport for API requests.
+ * Reads WDM `webex.internal.device.settings['webrtc-calling-over-ws'].value`; must be
+ * strictly `true` to enable WebSocket—otherwise use HTTP.
+ */
+export function isWsFeatureEnabled(webex: WebexSDK): boolean {
+  return webex.internal?.device?.settings?.[WEBRTC_CALLING_OVER_WS_FEATURE_KEY]?.value === true;
+}

--- a/packages/calling/src/SDKConnector/types.ts
+++ b/packages/calling/src/SDKConnector/types.ts
@@ -96,6 +96,8 @@ export interface WebexSDK {
       orgId: string;
       version: string;
       callingBehavior: string;
+      /** WDM / device-registration settings (e.g. `webrtc-calling-over-ws`). */
+      settings?: Record<string, {value?: boolean} | undefined>;
       features: {
         entitlement: {
           models: Model[];


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [CAI-7723](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7723)

## This pull request addresses

Reading and using the feature flag from Settings Service instead of SDK configuration to choose either HTTP requests or Mobius Requests

## by making the following changes

* Reading the setting from WDM plugin with a new Util `isWsFeatureEnabled`
* Using the value of setting to decide whether Mobius socket should be connected in `CallingClient.ts`
* Using the value of setting to decide whether requests should flow through HTTP or Mobius socket
* In addition, have retained the SDK config to test this feature until the Setting is rolled out to PROD. Right now the PR is against integration in the settings service repo: https://sqbu-github.cisco.com/WebExSquared/settings-service-definitions/pull/1157

## Pending Items

* Actual Testing with right config
* Removal of SDK config when the setting is PROD
* Unit Tests

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

* Tested some of the existing PROD config from the repo against `webex.internal.device.settings`
* An example:
    * File for the setting [enable-vidcast-transcripts-generation](https://sqbu-github.cisco.com/WebExSquared/settings-service-definitions/blob/main/definitions/production/settings/enable-vidcast-transcripts-generation.yaml)
    * Screenshot from SDK Sample app browser console for the same setting:
      <img width="1417" height="328" alt="Screenshot 2026-04-17 at 3 07 31 PM" src="https://github.com/user-attachments/assets/906631e7-a254-45a1-99b4-481e7b92af66" />


## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
