### PR TITLE
fix(meetings): parsing Locus response in more calls to Locus APIs

### DIFF
--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -184,10 +184,7 @@ export default class ControlsOptionsManager {
         mainLocusUrl: this.mainLocusUrl,
       });
 
-      return previous.then(() =>
-        // @ts-ignore
-        this.request.request(requestParams)
-      );
+      return previous.then(() => this.sendControlsRequest(requestParams));
     }, Promise.resolve());
   }
 
@@ -274,8 +271,27 @@ export default class ControlsOptionsManager {
       mainLocusUrl: this.mainLocusUrl,
     });
 
-    // @ts-ignore
-    return this.request.request(requestParams);
+    return this.sendControlsRequest(requestParams);
+  }
+
+  /**
+   * Sends a controls request to Locus. When authorizingLocusUrl is present in the body,
+   * we use a plain request() because the response contains the main session Locus DTO
+   * instead of the breakout we're in, so we don't want to parse it as a delta.
+   * Otherwise we use locusDeltaRequest() for normal delta processing.
+   *
+   * @param {Object} requestParams - The request parameters from getControlsRequestParams.
+   * @returns {Promise<any>}
+   */
+  private sendControlsRequest(requestParams: {
+    uri: string;
+    body: Record<string, any>;
+    method: string;
+  }): Promise<any> {
+    return requestParams.body.authorizingLocusUrl
+      ? // @ts-ignore
+        this.request.request(requestParams)
+      : this.request.locusDeltaRequest(requestParams);
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/interpretation/index.ts
+++ b/packages/@webex/plugin-meetings/src/interpretation/index.ts
@@ -4,6 +4,7 @@
 import {WebexPlugin} from '@webex/webex-core';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {HTTP_VERBS, INTERPRETATION, LOCUSEVENT, MEETINGS} from '../constants';
+import MeetingUtil from '../meeting/util';
 
 import SILanguageCollection from './collection';
 
@@ -183,6 +184,8 @@ const SimultaneousInterpretation = WebexPlugin.extend({
    * @returns {Promise}
    */
   updateInterpreters(interpreters) {
+    const meeting = this.webex.meetings.meetingCollection.getByKey('locusUrl', this.locusUrl);
+
     return this.request({
       method: HTTP_VERBS.PATCH,
       uri: `${this.locusUrl}/controls`,
@@ -191,10 +194,16 @@ const SimultaneousInterpretation = WebexPlugin.extend({
           interpreters,
         },
       },
-    }).catch((error) => {
-      LoggerProxy.logger.error('Meeting:interpretation#updateInterpreters failed', error);
-      throw error;
-    });
+    })
+      .then((response) => {
+        MeetingUtil.updateLocusFromApiResponse(meeting, response);
+
+        return response;
+      })
+      .catch((error) => {
+        LoggerProxy.logger.error('Meeting:interpretation#updateInterpreters failed', error);
+        throw error;
+      });
   },
   /**
    * Change direction of interpretation for an interpreter participant
@@ -209,6 +218,8 @@ const SimultaneousInterpretation = WebexPlugin.extend({
       return Promise.reject(new Error('Missing self participant id'));
     }
 
+    const meeting = this.webex.meetings.meetingCollection.getByKey('locusUrl', this.locusUrl);
+
     return this.request({
       method: HTTP_VERBS.PATCH,
       uri: `${this.locusUrl}/participant/${this.selfParticipantId}/controls`,
@@ -220,10 +231,16 @@ const SimultaneousInterpretation = WebexPlugin.extend({
           order: this.order,
         },
       },
-    }).catch((error) => {
-      LoggerProxy.logger.error('Meeting:interpretation#changeDirection failed', error);
-      throw error;
-    });
+    })
+      .then((response) => {
+        MeetingUtil.updateLocusFromApiResponse(meeting, response);
+
+        return response;
+      })
+      .catch((error) => {
+        LoggerProxy.logger.error('Meeting:interpretation#changeDirection failed', error);
+        throw error;
+      });
   },
   /**
    * Sets up a listener for handoff requests from mercury

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -859,7 +859,11 @@ const MeetingUtil = {
       return response;
     }
 
-    if (response?.body?.locus) {
+    // locus API responses can come in different shapes:
+    if (
+      response?.body?.locus || // for APIs called on our participant - locus is one of props in the response body
+      response?.body?.url // for APIs that act on locus itself (like mute all), the body is the locus
+    ) {
       meeting.locusInfo.handleLocusAPIResponse(meeting, response.body);
     }
 

--- a/packages/@webex/plugin-meetings/src/meeting/util.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/util.ts
@@ -847,6 +847,19 @@ const MeetingUtil = {
   },
 
   /**
+   * Checks if Locus API response contains a Locus DTO
+   *
+   * @param {any} response http response from Locus API call
+   * @returns {boolean} true if response contains a Locus DTO
+   */
+  isLocusDtoInAPIResponse(response: any) {
+    return (
+      response?.body?.locus || // for APIs called on our participant - locus is one of props in the response body
+      response?.body?.url // for APIs that act on locus itself (like mute all), the body is the locus
+    );
+  },
+
+  /**
    * Updates the locus info for the meeting with the locus
    * information returned from API requests made to Locus
    * Returns the original response object
@@ -854,16 +867,13 @@ const MeetingUtil = {
    * @param {Object} response The response of the http request
    * @returns {Object}
    */
-  updateLocusFromApiResponse: (meeting, response) => {
+  updateLocusFromApiResponse: (meeting: any, response: any) => {
     if (!meeting) {
       return response;
     }
 
     // locus API responses can come in different shapes:
-    if (
-      response?.body?.locus || // for APIs called on our participant - locus is one of props in the response body
-      response?.body?.url // for APIs that act on locus itself (like mute all), the body is the locus
-    ) {
+    if (MeetingUtil.isLocusDtoInAPIResponse(response)) {
       meeting.locusInfo.handleLocusAPIResponse(meeting, response.body);
     }
 

--- a/packages/@webex/plugin-meetings/src/recording-controller/index.ts
+++ b/packages/@webex/plugin-meetings/src/recording-controller/index.ts
@@ -261,8 +261,7 @@ export default class RecordingController {
 
     LoggerProxy.logger.log(`RecordingController:index#recordingControls --> ${record}`);
 
-    // @ts-ignore
-    return this.request.request({
+    return this.request.locusDeltaRequest({
       uri: `${this.locusUrl}/${CONTROLS}`,
       body: {
         record,

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -391,7 +391,7 @@ const Webinar = WebexPlugin.extend({
    * @returns {Promise}
    */
   setPracticeSessionState(enabled) {
-    const meeting = this.webex.meetings.getMeetingByType(_ID_, this.meetingId);
+    const meeting = this.getValidatedWebinarMeeting();
 
     return this.request({
       method: HTTP_VERBS.PATCH,

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -18,6 +18,7 @@ import {
 
 import WebinarCollection from './collection';
 import LoggerProxy from '../common/logs/logger-proxy';
+import MeetingUtil from '../meeting/util';
 import {sanitizeParams} from './utils';
 
 /**
@@ -390,6 +391,8 @@ const Webinar = WebexPlugin.extend({
    * @returns {Promise}
    */
   setPracticeSessionState(enabled) {
+    const meeting = this.webex.meetings.getMeetingByType(_ID_, this.meetingId);
+
     return this.request({
       method: HTTP_VERBS.PATCH,
       uri: `${this.locusUrl}/controls`,
@@ -398,10 +401,16 @@ const Webinar = WebexPlugin.extend({
           enabled,
         },
       },
-    }).catch((error) => {
-      LoggerProxy.logger.error('Meeting:webinar#setPracticeSessionState failed', error);
-      throw error;
-    });
+    })
+      .then((response) => {
+        MeetingUtil.updateLocusFromApiResponse(meeting, response);
+
+        return response;
+      })
+      .catch((error) => {
+        LoggerProxy.logger.error('Meeting:webinar#setPracticeSessionState failed', error);
+        throw error;
+      });
   },
 
   /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
@@ -27,6 +27,7 @@ describe('plugin-meetings', () => {
                 beforeEach(() => {
                   request = {
                     request: sinon.stub().returns(Promise.resolve()),
+                    locusDeltaRequest: sinon.stub().returns(Promise.resolve()),
                   };
 
                   manager = new ControlsOptionsManager(request);
@@ -59,11 +60,11 @@ describe('plugin-meetings', () => {
 
                       const result = manager.setMuteOnEntry(true);
 
-                      assert.calledWith(request.request, {  uri: 'test/id/controls',
+                      assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                       body: { muteOnEntry: { enabled: true } },
                       method: HTTP_VERBS.PATCH});
 
-                      assert.deepEqual(result, request.request.firstCall.returnValue);
+                      assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
                     });
 
                     it('can set mute on entry when the display hint is available enabled=false', () => {
@@ -71,11 +72,11 @@ describe('plugin-meetings', () => {
 
                       const result = manager.setMuteOnEntry(false);
 
-                      assert.calledWith(request.request, {  uri: 'test/id/controls',
+                      assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                       body: { muteOnEntry: { enabled: false } },
                       method: HTTP_VERBS.PATCH});
 
-                      assert.deepEqual(result, request.request.firstCall.returnValue);
+                      assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
                     });
 
                     it('should send setMuteOnEntry to locusUrl without authorizingLocusUrl when in breakout', () => {
@@ -84,11 +85,11 @@ describe('plugin-meetings', () => {
 
                       const result = manager.setMuteOnEntry(true);
 
-                      assert.calledWith(request.request, {  uri: 'test/id/controls',
+                      assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                       body: { muteOnEntry: { enabled: true } },
                       method: HTTP_VERBS.PATCH});
 
-                      assert.deepEqual(result, request.request.firstCall.returnValue);
+                      assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
                     });
                   });
 
@@ -114,11 +115,11 @@ describe('plugin-meetings', () => {
 
                       const result = manager.setDisallowUnmute(true);
 
-                      assert.calledWith(request.request, {  uri: 'test/id/controls',
+                      assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                       body: { disallowUnmute: { enabled: true } },
                       method: HTTP_VERBS.PATCH});
 
-                      assert.deepEqual(result, request.request.firstCall.returnValue);
+                      assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
                     });
 
                     it('can set allow unmute when DISABLE_HARD_MUTE display hint is available', () => {
@@ -126,11 +127,11 @@ describe('plugin-meetings', () => {
 
                       const result = manager.setDisallowUnmute(false);
 
-                      assert.calledWith(request.request, {  uri: 'test/id/controls',
+                      assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                       body: { disallowUnmute: { enabled: false } },
                       method: HTTP_VERBS.PATCH});
 
-                      assert.deepEqual(result, request.request.firstCall.returnValue);
+                      assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
                     });
 
                     it('should send setDisallowUnmute to locusUrl without authorizingLocusUrl when in breakout', () => {
@@ -139,11 +140,11 @@ describe('plugin-meetings', () => {
 
                       const result = manager.setDisallowUnmute(true);
 
-                      assert.calledWith(request.request, {  uri: 'test/id/controls',
+                      assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                       body: { disallowUnmute: { enabled: true } },
                       method: HTTP_VERBS.PATCH});
 
-                      assert.deepEqual(result, request.request.firstCall.returnValue);
+                      assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
                     });
                   });
             });
@@ -154,6 +155,7 @@ describe('plugin-meetings', () => {
               beforeEach(() => {
                 request = {
                   request: sinon.stub().resolves(),
+                  locusDeltaRequest: sinon.stub().resolves(),
                 };
 
                 manager = new ControlsOptionsManager(request);
@@ -202,7 +204,7 @@ describe('plugin-meetings', () => {
 
                 return manager.update(audio, reactions)
                   .then(() => {
-                    assert.calledWith(request.request, {
+                    assert.calledWith(request.locusDeltaRequest, {
                       uri: 'test/id/controls',
                       body: {
                         audio: audio.properties,
@@ -210,7 +212,7 @@ describe('plugin-meetings', () => {
                       method: HTTP_VERBS.PATCH,
                     });
 
-                    assert.calledWith(request.request, {
+                    assert.calledWith(request.locusDeltaRequest, {
                       uri: 'test/id/controls',
                       body: {
                         reactions: reactions.properties,
@@ -253,7 +255,7 @@ describe('plugin-meetings', () => {
                 return manager.update(audio, reactions)
                   .then(() => {
                     // Audio controls go directly to current locusUrl (no cross-locus authorization)
-                    assert.calledWith(request.request, {
+                    assert.calledWith(request.locusDeltaRequest, {
                       uri: 'test/id/controls',
                       body: {
                         audio: audio.properties,
@@ -284,7 +286,7 @@ describe('plugin-meetings', () => {
 
                 return manager.update(audio)
                   .then(() => {
-                    assert.calledWith(request.request, {
+                    assert.calledWith(request.locusDeltaRequest, {
                       uri: 'test/id/controls',
                       body: {
                         audio: audio.properties,
@@ -324,6 +326,7 @@ describe('plugin-meetings', () => {
               beforeEach(() => {
                 request = {
                   request: sinon.stub().returns(Promise.resolve()),
+                  locusDeltaRequest: sinon.stub().returns(Promise.resolve()),
                 };
 
                 manager = new ControlsOptionsManager(request);
@@ -368,11 +371,11 @@ describe('plugin-meetings', () => {
 
                 const result = manager.setMuteAll(true, true, true);
 
-                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                 body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true } },
                 method: HTTP_VERBS.PATCH});
 
-                assert.deepEqual(result, request.request.firstCall.returnValue);
+                assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
               });
 
               it('can set mute all when the display hint is available mutedEnabled=true', () => {
@@ -380,11 +383,11 @@ describe('plugin-meetings', () => {
 
                 const result = manager.setMuteAll(true, true, true);
 
-                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                 body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true } },
                 method: HTTP_VERBS.PATCH});
 
-                assert.deepEqual(result, request.request.firstCall.returnValue);
+                assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
               });
 
               it('can set mute all when the display hint is available mutedEnabled=true', () => {
@@ -392,11 +395,11 @@ describe('plugin-meetings', () => {
 
                 const result = manager.setMuteAll(true, true, true);
 
-                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                 body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true } },
                 method: HTTP_VERBS.PATCH});
 
-                assert.deepEqual(result, request.request.firstCall.returnValue);
+                assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
               });
 
               it('can set mute all when the display hint is available mutedEnabled=false', () => {
@@ -404,11 +407,11 @@ describe('plugin-meetings', () => {
 
                 const result = manager.setMuteAll(false, false, false);
 
-                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                 body: { audio: { muted: false, disallowUnmute: false, muteOnEntry: false } },
                 method: HTTP_VERBS.PATCH});
 
-                assert.deepEqual(result, request.request.firstCall.returnValue);
+                assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
               });
 
               it('can set mute all panelists when the display hint is available mutedEnabled=true', () => {
@@ -416,11 +419,11 @@ describe('plugin-meetings', () => {
 
                 const result = manager.setMuteAll(true, true, true, ['panelist']);
 
-                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                   body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['panelist'] } },
                   method: HTTP_VERBS.PATCH});
 
-                assert.deepEqual(result, request.request.firstCall.returnValue);
+                assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
               });
 
               it('can set mute all attendees when the display hint is available mutedEnabled=true', () => {
@@ -428,11 +431,11 @@ describe('plugin-meetings', () => {
 
                 const result = manager.setMuteAll(true, true, true, ['attendee']);
 
-                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                   body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['attendee'] } },
                   method: HTTP_VERBS.PATCH});
 
-                assert.deepEqual(result, request.request.firstCall.returnValue);
+                assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
               });
 
               it('should send setMuteAll to locusUrl without authorizingLocusUrl when in breakout', () => {
@@ -441,11 +444,11 @@ describe('plugin-meetings', () => {
 
                 const result = manager.setMuteAll(true, true, true, ['attendee']);
 
-                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                   body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['attendee'] } },
                   method: HTTP_VERBS.PATCH});
 
-                assert.deepEqual(result, request.request.firstCall.returnValue);
+                assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
               });
 
               it('should send setMuteAll with PANELIST role to locusUrl without authorizingLocusUrl when in breakout', () => {
@@ -454,11 +457,11 @@ describe('plugin-meetings', () => {
 
                 const result = manager.setMuteAll(true, true, true, ['PANELIST']);
 
-                assert.calledWith(request.request, {  uri: 'test/id/controls',
+                assert.calledWith(request.locusDeltaRequest, {  uri: 'test/id/controls',
                   body: { audio: { muted: true, disallowUnmute: true, muteOnEntry: true, roles: ['PANELIST'] } },
                   method: HTTP_VERBS.PATCH});
 
-                assert.deepEqual(result, request.request.firstCall.returnValue);
+                assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
               });
             });
           });

--- a/packages/@webex/plugin-meetings/test/unit/spec/interpretation/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/interpretation/index.ts
@@ -9,6 +9,7 @@ describe('plugin-meetings', () => {
   describe('SimultaneousInterpretation', () => {
     let webex;
     let interpretation;
+    let mockMeeting;
 
     beforeEach(() => {
       // @ts-ignore
@@ -17,8 +18,17 @@ describe('plugin-meetings', () => {
       interpretation = new SimultaneousInterpretation({}, {parent: webex});
       interpretation.locusUrl = 'locusUrl';
       webex.request = sinon.stub().returns(Promise.resolve('REQUEST_RETURN_VALUE'));
-      webex.meetings = {};
-      webex.meetings.getMeetingByType = sinon.stub();
+      mockMeeting = {
+        locusInfo: {
+          handleLocusAPIResponse: sinon.stub(),
+        },
+      };
+      webex.meetings = {
+        getMeetingByType: sinon.stub(),
+        meetingCollection: {
+          getByKey: sinon.stub().returns(mockMeeting),
+        },
+      };
     });
 
     describe('#initialize', () => {
@@ -316,7 +326,8 @@ describe('plugin-meetings', () => {
             order : 0,
             isActive : true
           },];
-        webex.request.returns(Promise.resolve({}));
+        const mockResponse = {body: {locus: {url: 'locusUrl'}}};
+        webex.request.returns(Promise.resolve(mockResponse));
 
         await interpretation.updateInterpreters(sampleData);
         assert.calledOnceWithExactly(webex.request, {
@@ -328,6 +339,11 @@ describe('plugin-meetings', () => {
             },
           },
         });
+        assert.calledOnceWithExactly(
+          mockMeeting.locusInfo.handleLocusAPIResponse,
+          mockMeeting,
+          mockResponse.body
+        );
       });
 
       it('rejects with error', async () => {
@@ -354,7 +370,8 @@ describe('plugin-meetings', () => {
           order: 0,
           selfParticipantId: '123',
         });
-        webex.request.returns(Promise.resolve({}));
+        const mockResponse = {body: {locus: {url: 'locusUrl'}}};
+        webex.request.returns(Promise.resolve(mockResponse));
 
         await interpretation.changeDirection();
         assert.calledOnceWithExactly(webex.request, {
@@ -369,6 +386,11 @@ describe('plugin-meetings', () => {
             },
           },
         });
+        assert.calledOnceWithExactly(
+          mockMeeting.locusInfo.handleLocusAPIResponse,
+          mockMeeting,
+          mockResponse.body
+        );
       });
 
       it('request rejects with error', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/muteState.js
@@ -11,6 +11,7 @@ describe('plugin-meetings', () => {
   let audio;
   let video;
   let originalRemoteUpdateAudioVideo;
+  let originalUpdateLocusFromApiResponse;
 
   const fakeLocusResponse = {body: {locus: {info: 'this is a fake locus'}}};
 
@@ -45,6 +46,7 @@ describe('plugin-meetings', () => {
     };
 
     originalRemoteUpdateAudioVideo = MeetingUtil.remoteUpdateAudioVideo;
+    originalUpdateLocusFromApiResponse = MeetingUtil.updateLocusFromApiResponse;
 
     MeetingUtil.remoteUpdateAudioVideo = sinon.stub().resolves(fakeLocusResponse);
     MeetingUtil.updateLocusFromApiResponse = sinon.stub();
@@ -57,6 +59,7 @@ describe('plugin-meetings', () => {
 
   afterEach(() => {
     MeetingUtil.remoteUpdateAudioVideo = originalRemoteUpdateAudioVideo;
+    MeetingUtil.updateLocusFromApiResponse = originalUpdateLocusFromApiResponse;
   });
 
   describe('mute state library', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/utils.js
@@ -276,6 +276,31 @@ describe('plugin-meetings', () => {
         assert.notCalled(meeting.locusInfo.handleLocusAPIResponse);
       });
 
+      it('should call handleLocusAPIResponse when response body is an unwrapped LocusDTO', () => {
+        const meeting = {
+          locusInfo: {
+            handleLocusAPIResponse: sinon.stub(),
+          },
+        };
+
+        const originalResponse = {
+          body: {
+            url: 'https://locus-a.wbx2.com/locus/api/v1/loci/some-id',
+            participants: [],
+            self: {},
+          },
+        };
+
+        const response = MeetingUtil.updateLocusFromApiResponse(meeting, originalResponse);
+
+        assert.deepEqual(response, originalResponse);
+        assert.calledOnceWithExactly(
+          meeting.locusInfo.handleLocusAPIResponse,
+          meeting,
+          originalResponse.body
+        );
+      });
+
       it('should work with an undefined meeting', () => {
         const originalResponse = {
           body: {

--- a/packages/@webex/plugin-meetings/test/unit/spec/recording-controller/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/recording-controller/index.js
@@ -35,6 +35,7 @@ describe('plugin-meetings', () => {
         beforeEach(() => {
           request = {
             request: sinon.stub().returns(Promise.resolve()),
+            locusDeltaRequest: sinon.stub().returns(Promise.resolve()),
           };
 
           controller = new RecordingController(request);
@@ -69,13 +70,13 @@ describe('plugin-meetings', () => {
 
             const result = controller.startRecording();
 
-            assert.calledWith(request.request, {
+            assert.calledWith(request.locusDeltaRequest, {
               uri: `${locusUrl}/controls`,
               body: {record: {recording: true, paused: false}},
               method: HTTP_VERBS.PATCH,
             });
 
-            assert.deepEqual(result, request.request.firstCall.returnValue);
+            assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
           });
         });
 
@@ -103,13 +104,13 @@ describe('plugin-meetings', () => {
 
             const result = controller.stopRecording();
 
-            assert.calledWith(request.request, {
+            assert.calledWith(request.locusDeltaRequest, {
               uri: `${locusUrl}/controls`,
               body: {record: {recording: false, paused: false}},
               method: HTTP_VERBS.PATCH,
             });
 
-            assert.deepEqual(result, request.request.firstCall.returnValue);
+            assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
           });
         });
 
@@ -139,13 +140,13 @@ describe('plugin-meetings', () => {
 
             const result = controller.pauseRecording();
 
-            assert.calledWith(request.request, {
+            assert.calledWith(request.locusDeltaRequest, {
               uri: `${locusUrl}/controls`,
               body: {record: {recording: true, paused: true}},
               method: HTTP_VERBS.PATCH,
             });
 
-            assert.deepEqual(result, request.request.firstCall.returnValue);
+            assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
           });
         });
 
@@ -176,13 +177,13 @@ describe('plugin-meetings', () => {
 
             const result = controller.resumeRecording();
 
-            assert.calledWith(request.request, {
+            assert.calledWith(request.locusDeltaRequest, {
               uri: `${locusUrl}/controls`,
               body: {record: {recording: true, paused: false}},
               method: HTTP_VERBS.PATCH,
             });
 
-            assert.deepEqual(result, request.request.firstCall.returnValue);
+            assert.deepEqual(result, request.locusDeltaRequest.firstCall.returnValue);
           });
         });
       });


### PR DESCRIPTION
# COMPLETES #[SPARK-791327](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-791327)

## This pull request addresses
Sometimes Locus API responses contain body that has a property "locus" which contains the Locus DTO and sometimes the body itself is the Locus DTO. We have a util function updateLocusFromApiResponse() that's supposed to handle any Locus DTO in API responses but it was only handling the case if body has the "locus" prop, not when body is the Locus DTO.

## by making the following changes
Fixed updateLocusFromApiResponse() to handle both formats of Locus API responses. While testing I've realised that "mute all" response still doesn't get handled - it was because it's handled by ControlsOptionsManager and that class was not using the right method to invoke Locus APIs, so responses were not parsed. After that I asked AI to find other places that call Locus APIs and don't pass the responses to LocusInfo - it found a few more places.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
