### PR TITLE
feat(calling): handle device registration, normalize makeRequest response and error

### DIFF
--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -96,6 +96,10 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
   private backupMobiusUris: string[];
 
+  private primaryWssMobiusUris: string[];
+
+  private backupWssMobiusUris: string[];
+
   private mobiusClusters: ServiceHost[];
 
   private mobiusHost: string;
@@ -105,10 +109,6 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
   private lineDict: Record<string, ILine> = {};
 
   private apiRequest: APIRequest;
-
-  private primaryWssMobiusUris: string[];
-
-  private backupWssMobiusUris: string[];
 
   private isMobiusSocketEnabled: boolean;
 
@@ -819,8 +819,8 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       this.webex.internal.device.userId,
       this.webex.internal.device.url,
       this.mutex,
-      this.primaryMobiusUris,
-      this.backupMobiusUris,
+      this.apiRequest.isSocketEnabled() ? this.primaryWssMobiusUris : this.primaryMobiusUris,
+      this.apiRequest.isSocketEnabled() ? this.backupWssMobiusUris : this.backupMobiusUris,
       this.getLoggingLevel(),
       this.sdkConfig?.serviceData,
       this.sdkConfig?.jwe

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -9,6 +9,7 @@ import {METHOD_START_MESSAGE} from '../common/constants';
 import {
   filterMobiusUris,
   handleCallingClientErrors,
+  normalizeMobiusUris,
   uploadLogs,
   validateServiceData,
 } from '../common/Utils';
@@ -819,8 +820,12 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       this.webex.internal.device.userId,
       this.webex.internal.device.url,
       this.mutex,
-      this.apiRequest.isSocketEnabled() ? this.primaryWssMobiusUris : this.primaryMobiusUris,
-      this.apiRequest.isSocketEnabled() ? this.backupWssMobiusUris : this.backupMobiusUris,
+      this.apiRequest.isSocketEnabled()
+        ? normalizeMobiusUris(this.primaryWssMobiusUris)
+        : this.primaryMobiusUris,
+      this.apiRequest.isSocketEnabled()
+        ? normalizeMobiusUris(this.backupWssMobiusUris)
+        : this.backupMobiusUris,
       this.getLoggingLevel(),
       this.sdkConfig?.serviceData,
       this.sdkConfig?.jwe

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -222,10 +222,9 @@ export class Registration implements IRegistration {
    */
   private async deleteRegistration(url: string, deviceId: string, deviceUrl: string) {
     let response;
-    const devicesUrl = url.endsWith('/') ? url : `${url}/`;
 
     const requestObj = {
-      uri: `${devicesUrl}${DEVICES_ENDPOINT_RESOURCE}/${deviceId}`,
+      uri: `${url}${DEVICES_ENDPOINT_RESOURCE}/${deviceId}`,
       method: HTTP_METHODS.DELETE,
       headers: {
         [CISCO_DEVICE_URL]: deviceUrl,
@@ -269,10 +268,8 @@ export class Registration implements IRegistration {
       serviceData: this.jwe ? {...this.serviceData, jwe: this.jwe} : this.serviceData,
     };
 
-    const registrationUrl = url.endsWith('/') ? url : `${url}/`;
-
     return this.apiRequest.makeRequest({
-      uri: `${registrationUrl}device`,
+      uri: `${url}device`,
       method: HTTP_METHODS.POST,
       headers: {
         [CISCO_DEVICE_URL]: deviceInfo.clientDeviceUri,
@@ -845,8 +842,10 @@ export class Registration implements IRegistration {
         });
 
         if (this.apiRequest.isSocketEnabled()) {
+          const wssNormalizedUrl = url.endsWith('/') ? url.slice(0, -1) : url;
+
           // eslint-disable-next-line no-await-in-loop
-          await this.apiRequest.connectToMobiusSocket(url);
+          await this.apiRequest.connectToMobiusSocket(wssNormalizedUrl);
         }
 
         // eslint-disable-next-line no-await-in-loop

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -222,16 +222,27 @@ export class Registration implements IRegistration {
    */
   private async deleteRegistration(url: string, deviceId: string, deviceUrl: string) {
     let response;
+    const devicesUrl = url.endsWith('/') ? url : `${url}/`;
+
+    const requestObj = {
+      uri: `${devicesUrl}${DEVICES_ENDPOINT_RESOURCE}/${deviceId}`,
+      method: HTTP_METHODS.DELETE,
+      headers: {
+        [CISCO_DEVICE_URL]: deviceUrl,
+        [SPARK_USER_AGENT]: CALLING_USER_AGENT,
+      },
+      service: ALLOWED_SERVICES.MOBIUS,
+    };
+
+    if (this.apiRequest.isSocketEnabled()) {
+      // @ts-ignore - body is added for mobius wss support, it is not used for mobius http
+      requestObj.body = {
+        deviceId,
+      };
+    }
+
     try {
-      response = await this.apiRequest.makeRequest({
-        uri: `${url}${DEVICES_ENDPOINT_RESOURCE}/${deviceId}`,
-        method: HTTP_METHODS.DELETE,
-        headers: {
-          [CISCO_DEVICE_URL]: deviceUrl,
-          [SPARK_USER_AGENT]: CALLING_USER_AGENT,
-        },
-        service: ALLOWED_SERVICES.MOBIUS,
-      });
+      response = await this.apiRequest.makeRequest(requestObj);
     } catch (error) {
       log.warn(`Delete failed with Mobius: ${JSON.stringify(error)}`, {
         file: REGISTRATION_FILE,
@@ -258,8 +269,10 @@ export class Registration implements IRegistration {
       serviceData: this.jwe ? {...this.serviceData, jwe: this.jwe} : this.serviceData,
     };
 
+    const registrationUrl = url.endsWith('/') ? url : `${url}/`;
+
     return this.apiRequest.makeRequest({
-      uri: `${url}device`,
+      uri: `${registrationUrl}device`,
       method: HTTP_METHODS.POST,
       headers: {
         [CISCO_DEVICE_URL]: deviceInfo.clientDeviceUri,
@@ -830,6 +843,12 @@ export class Registration implements IRegistration {
           file: REGISTRATION_FILE,
           method: REGISTER_UTIL,
         });
+
+        if (this.apiRequest.isSocketEnabled()) {
+          // eslint-disable-next-line no-await-in-loop
+          await this.apiRequest.connectToMobiusSocket(url);
+        }
+
         // eslint-disable-next-line no-await-in-loop
         const resp = await this.postRegistration(url);
         this.clearFailoverState();

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -3,10 +3,49 @@ import {v4 as uuid} from 'uuid';
 import {getMobiusSocketInstance} from '@webex/internal-plugin-mobius-socket';
 import {WebexRequestPayload} from '../../common/types';
 import {WebexSDK} from '../../SDKConnector/types';
+import log from '../../Logger';
 import {APIRequestConfig, APIRequestOptions, MobiusSocketResponse} from './types';
 import {deriveMobiusSocketMessageType} from './mobiusSocketMapper';
 import {MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
 import {isWsFeatureEnabled} from './wsFeatureFlag';
+import {METHODS, REQUEST_FILE} from '../constants';
+
+/**
+ * Converts a MobiusSocketResponse into the WebexRequestPayload shape that
+ * all callers (registration, call, keepalive error-handlers) expect.
+ */
+function normalizeWsResponse(wsResponse: MobiusSocketResponse): WebexRequestPayload {
+  return {
+    statusCode: wsResponse.statusCode,
+    body: (wsResponse.data as object) ?? undefined,
+    headers: {
+      trackingid: wsResponse.trackingId,
+      ...((wsResponse.metadata as Record<string, string>) ?? {}),
+    },
+  };
+}
+
+/**
+ * Converts a MobiusSocketResponseError rejection into a WebexRequestPayload-shaped
+ * error so handleRegistrationErrors / handleCallErrors can process it identically.
+ */
+function normalizeWsError(err: unknown): WebexRequestPayload {
+  const wsErr = err as {
+    statusCode?: number;
+    statusMessage?: string;
+    response?: MobiusSocketResponse;
+    trackingId?: string;
+  };
+
+  return {
+    statusCode: wsErr.statusCode,
+    body: (wsErr.response?.data as object) ?? undefined,
+    headers: {
+      trackingid: wsErr.trackingId ?? wsErr.response?.trackingId ?? '',
+      ...((wsErr.response?.metadata as Record<string, string>) ?? {}),
+    },
+  };
+}
 
 /**
  * APIRequest routes Mobius traffic over HTTP (`webex.request`) or the Mobius WebSocket path
@@ -48,13 +87,51 @@ export class APIRequest {
   }
 
   /**
-   * Makes a request using HTTP or WebSocket transport per the flag set in the constructor.
-   * @param request - Request options (uri, method, body, headers, service)
-   * @returns Promise resolving to WebexRequestPayload or MobiusSocketResponse
+   * Whether the Mobius WebSocket transport is active for this instance.
    */
-  public async makeRequest(
-    request: APIRequestOptions
-  ): Promise<WebexRequestPayload | MobiusSocketResponse> {
+  public isSocketEnabled(): boolean {
+    return this.isMobiusSocketEnabled;
+  }
+
+  /**
+   * Ensures the Mobius WebSocket is connected before sending API requests.
+   * If the socket is already connected, resolves immediately. Otherwise,
+   * initiates a new connection to the provided WebSocket URL.
+   * On failure, throws a normalized WebexRequestPayload-shaped error.
+   *
+   * @param wssUrl - The Mobius WebSocket URL to connect to.
+   */
+  public async connectToMobiusSocket(wssUrl: string): Promise<void> {
+    const logContext = {
+      file: REQUEST_FILE,
+      method: METHODS.CONNECT_TO_MOBIUS_SOCKET,
+    };
+
+    if (this.mobiusSocket.isConnected()) {
+      log.info('Mobius WebSocket already connected', logContext);
+
+      return;
+    }
+
+    log.info('Mobius WebSocket not connected, initiating connection', logContext);
+
+    try {
+      await this.mobiusSocket.connect(wssUrl);
+      log.log('Mobius WebSocket connected successfully', logContext);
+    } catch (err) {
+      log.warn(`Mobius WebSocket connection failed: ${String(err)}`, logContext);
+      throw normalizeWsError(err);
+    }
+  }
+
+  /**
+   * Makes a request using HTTP or WebSocket transport per the flag set in the constructor.
+   * When using WebSocket, the response is normalized to the WebexRequestPayload shape
+   * so callers do not need to know which transport was used.
+   * @param request - Request options (uri, method, body, headers, service)
+   * @returns Promise resolving to WebexRequestPayload
+   */
+  public async makeRequest(request: APIRequestOptions): Promise<WebexRequestPayload> {
     if (this.isMobiusSocketEnabled) {
       const trackingId = `webex-js-sdk_${uuid()}`;
       const socketType = deriveMobiusSocketMessageType(request.uri, request.method);
@@ -63,18 +140,24 @@ export class APIRequest {
         throw new Error(`Unknown Mobius Socket message type: ${socketType}`);
       }
 
-      return this.mobiusSocket.sendWssRequest({
-        type: socketType,
-        trackingId,
-        metadata: {
-          // userAgent: CALLING_USER_AGENT,
-          userAgent: 'mobius-ws-test-ui', // TODO: Confirm if this needs to be hardcoded
-        }, // TODO: Add auth token to metadata for call transfer etc
-        data: request.body,
-      });
+      try {
+        const wsResponse: MobiusSocketResponse = await this.mobiusSocket.sendWssRequest({
+          type: socketType,
+          trackingId,
+          metadata: {
+            // userAgent: CALLING_USER_AGENT,
+            userAgent: 'mobius-ws-test-ui', // TODO: Confirm if this needs to be hardcoded
+          }, // TODO: Add auth token to metadata for call transfer etc
+          data: request.body,
+        });
+
+        return normalizeWsResponse(wsResponse);
+      } catch (err) {
+        throw normalizeWsError(err);
+      }
     }
 
-    return this.webex.request(request);
+    return this.webex.request(request) as Promise<WebexRequestPayload>;
   }
 }
 

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -1797,3 +1797,7 @@ export async function uploadLogs(
     return undefined;
   }
 }
+
+export function normalizeMobiusUris(urls: string[]): string[] {
+  return urls.map((url) => (!url.endsWith('/') ? `${url}/` : url));
+}


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< PR-3: [CAI-7823](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7823) >

## This pull request addresses

Handles the device registration for mobius wss flow.

## by making the following changes

### 1. `request.ts` — APIRequest class enhancements

- **Added `normalizeWsResponse` and `normalizeWsError` helper functions** that convert MobiusSocket responses/errors into the `WebexRequestPayload` shape, so all upstream callers (registration, call, keepalive error-handlers) can process them identically regardless of transport.
- **Added `isSocketEnabled()` method** — exposes whether the Mobius WebSocket transport is active.
- **Added `connectToMobiusSocket(wssUrl)` method** — checks if the socket is already connected via `isConnected()`; if not, connects to the provided URL. On failure, throws a normalized `WebexRequestPayload`-shaped error.
- **Updated `makeRequest()` return type** from `Promise<WebexRequestPayload | MobiusSocketResponse>` to `Promise<WebexRequestPayload>` — WebSocket responses are now normalized before returning, and errors are normalized before throwing.
- **Added imports** for `log` (Logger), `METHODS`, and `REQUEST_FILE` constants.

### 2. `register.ts` — Registration socket connection + URL fixes

- **Socket connection before registration** — In `attemptWssRegistrationWithServers`, added a check: if WebSocket transport is enabled, calls `this.apiRequest.connectToMobiusSocket(url)` before `postRegistration(url)` to ensure the socket is connected.
- **URL trailing-slash normalization** — Both `deleteRegistration` and `postRegistration` now ensure the base URL ends with `/` before appending path segments, preventing malformed URIs.
- **`deleteRegistration` body for WSS** — When socket transport is enabled, the delete request now includes a `body: { deviceId }` payload needed by the Mobius WebSocket protocol.

### 3. `CallingClient.ts` — WSS-aware server URI selection

- **Moved** `primaryWssMobiusUris` and `backupWssMobiusUris` field declarations higher in the class (cosmetic reorder).
- **Conditional URI selection** — When creating a Line, now passes WSS URIs (`primaryWssMobiusUris` / `backupWssMobiusUris`) if the socket transport is enabled, otherwise falls back to the standard HTTP URIs.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested the registration and de-registration flow through wss flow.

Vidcast - https://app.vidcast.io/share/e6b9da52-8ef7-4f95-9360-f6c9b64ad953

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
