### PR TITLE
fix(mobius-socket): add async event dedup

### DIFF
--- a/packages/@webex/internal-plugin-mobius-socket/src/config.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/config.js
@@ -44,6 +44,12 @@ const mobiusSocketConfig = {
    * @type {String}
    */
   beforeLogoutOptionsCloseReason: process.env.MOBIUS_SOCKET_LOGOUT_REASON || 'done (forced)',
+  /**
+   * Maximum number of eventIds to retain in the dedup cache for suppressing
+   * duplicate async_event messages retransmitted by the server.
+   * @type {Number}
+   */
+  dedupCacheMaxSize: process.env.MOBIUS_SOCKET_DEDUP_CACHE_MAX_SIZE || 1000,
 };
 
 export default {

--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -157,7 +157,7 @@ const MobiusSocket = WebexPlugin.extend({
     this._seenAsyncEventIdsBySession.clear();
   },
 
-  _shouldSuppressDuplicateAsyncEvent(sessionId, envelope) {
+  _trackAsyncEventAndShouldSuppressDuplicate(sessionId, envelope) {
     if (envelope?.type !== 'async_event' || !envelope.eventId) {
       return false;
     }
@@ -177,12 +177,18 @@ const MobiusSocket = WebexPlugin.extend({
       return true;
     }
 
+    this.logger.info(
+      `${this.namespace}: tracking async_event for ${sessionId}, eventId=${envelope.eventId}`
+    );
     seenAsyncEventIds.set(envelope.eventId, true);
 
     if (seenAsyncEventIds.size > this.config.dedupCacheMaxSize) {
       const oldestEventId = seenAsyncEventIds.keys().next().value;
 
       seenAsyncEventIds.delete(oldestEventId);
+      this.logger.info(
+        `${this.namespace}: evicted oldest async_event from dedup cache for ${sessionId}, eventId=${oldestEventId}`
+      );
     }
 
     return false;
@@ -720,6 +726,8 @@ const MobiusSocket = WebexPlugin.extend({
         let options = {
           forceCloseDelay: this.config.forceCloseDelay,
           wssResponseTimeout: this.config.wssResponseTimeout,
+          skipAckEventId: this.config.skipAckEventId,
+          skipAckEventType: this.config.skipAckEventType,
           token: normalizeMobiusAuthToken(token.toString()),
           trackingId: `${this.webex.sessionId}_${Date.now()}`,
           logger: this.logger,
@@ -1065,7 +1073,7 @@ const MobiusSocket = WebexPlugin.extend({
       return Promise.resolve();
     }
 
-    if (this._shouldSuppressDuplicateAsyncEvent(sessionId, envelope)) {
+    if (this._trackAsyncEventAndShouldSuppressDuplicate(sessionId, envelope)) {
       return Promise.resolve();
     }
 

--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -60,6 +60,7 @@ const MobiusSocket = WebexPlugin.extend({
       type: 'object',
     },
     _seenAsyncEventIdsBySession: {
+      // Ampersand's property types are coarse-grained; Map is stored as an object value here.
       default: () => new Map(),
       type: 'object',
     },

--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -58,6 +58,10 @@ const MobiusSocket = WebexPlugin.extend({
       default: () => new Map(),
       type: 'object',
     },
+    _seenAsyncEventIdsBySession: {
+      default: () => new Map(),
+      type: 'object',
+    },
     localClusterServiceUrls: 'object',
     mercuryTimeOffset: {
       default: undefined,
@@ -130,6 +134,58 @@ const MobiusSocket = WebexPlugin.extend({
     socket.on('ping-pong-latency', (...args) =>
       this._emit(sessionId, 'ping-pong-latency', ...args)
     );
+  },
+
+  _getSeenAsyncEventIds(sessionId) {
+    let seenAsyncEventIds = this._seenAsyncEventIdsBySession.get(sessionId);
+
+    if (!seenAsyncEventIds) {
+      seenAsyncEventIds = new Map();
+      this._seenAsyncEventIdsBySession.set(sessionId, seenAsyncEventIds);
+    }
+
+    return seenAsyncEventIds;
+  },
+
+  _clearSeenAsyncEventIds(sessionId) {
+    if (sessionId) {
+      this._seenAsyncEventIdsBySession.delete(sessionId);
+
+      return;
+    }
+
+    this._seenAsyncEventIdsBySession.clear();
+  },
+
+  _shouldSuppressDuplicateAsyncEvent(sessionId, envelope) {
+    if (envelope?.type !== 'async_event' || !envelope.eventId) {
+      return false;
+    }
+
+    const seenAsyncEventIds = this._getSeenAsyncEventIds(sessionId);
+
+    if (seenAsyncEventIds.has(envelope.eventId)) {
+      const previousValue = seenAsyncEventIds.get(envelope.eventId);
+
+      // Refresh recency so frequently retransmitted eventIds stay protected longer.
+      seenAsyncEventIds.delete(envelope.eventId);
+      seenAsyncEventIds.set(envelope.eventId, previousValue);
+      this.logger.info(
+        `${this.namespace}: duplicate async_event suppressed for ${sessionId}, eventId=${envelope.eventId}`
+      );
+
+      return true;
+    }
+
+    seenAsyncEventIds.set(envelope.eventId, true);
+
+    if (seenAsyncEventIds.size > this.config.dedupCacheMaxSize) {
+      const oldestEventId = seenAsyncEventIds.keys().next().value;
+
+      seenAsyncEventIds.delete(oldestEventId);
+    }
+
+    return false;
   },
 
   /**
@@ -426,6 +482,8 @@ const MobiusSocket = WebexPlugin.extend({
       const sessionSocket = this.sockets.get(sessionId);
       const suffix = sessionId === this.defaultSessionId ? '' : `:${sessionId}`;
 
+      this._clearSeenAsyncEventIds(sessionId);
+
       if (sessionSocket) {
         sessionSocket.removeAllListeners('message');
         sessionSocket.connecting = false;
@@ -456,6 +514,7 @@ const MobiusSocket = WebexPlugin.extend({
       this.connected = false;
       this.sockets.clear();
       this.backoffCalls.clear();
+      this._clearSeenAsyncEventIds();
       // Clear connection promises to prevent stale promises
       if (this._connectPromises) {
         this._connectPromises.clear();
@@ -1003,6 +1062,10 @@ const MobiusSocket = WebexPlugin.extend({
 
       this._handleImminentShutdown(sessionId);
 
+      return Promise.resolve();
+    }
+
+    if (this._shouldSuppressDuplicateAsyncEvent(sessionId, envelope)) {
       return Promise.resolve();
     }
 

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
@@ -54,6 +54,26 @@ describe('plugin-mobius-socket', () => {
       });
     };
 
+    const createAsyncEvent = (eventId, eventType = 'custom.event') => ({
+      data: {
+        type: 'async_event',
+        eventId,
+        data: {
+          eventType,
+        },
+      },
+    });
+
+    const createSessionSocket = () => ({
+      close: sinon.stub().returns(Promise.resolve()),
+      removeAllListeners: sinon.stub(),
+    });
+
+    const countGenericEventEmits = (emitSpy, sessionId) =>
+      emitSpy
+        .getCalls()
+        .filter((call) => call.args[0] === sessionId && call.args[1] === 'event').length;
+
     beforeEach(() => {
       clock = FakeTimers.install({now: Date.now()});
     });
@@ -1326,6 +1346,72 @@ describe('plugin-mobius-socket', () => {
           // The early-return guard only emits 'event', so asserting these proves the normal path was taken.
           assert.calledWith(mobiusSocket._emit, mobiusSocket.defaultSessionId, 'event:conversation', event.data);
           assert.calledWith(mobiusSocket._emit, mobiusSocket.defaultSessionId, 'event:conversation.activity', event.data);
+        });
+      });
+
+      describe('#_onmessage() async_event deduplication', () => {
+        let originalDedupCacheMaxSize;
+
+        beforeEach(() => {
+          originalDedupCacheMaxSize = mobiusSocket.config.dedupCacheMaxSize;
+        });
+
+        afterEach(() => {
+          mobiusSocket.config.dedupCacheMaxSize = originalDedupCacheMaxSize;
+        });
+
+        it('suppresses duplicate async_event messages for the same session', async () => {
+          const emitSpy = sinon.spy(mobiusSocket, '_emit');
+
+          await mobiusSocket._onmessage('session-a', createAsyncEvent('evt-1'));
+          await mobiusSocket._onmessage('session-a', createAsyncEvent('evt-1'));
+
+          assert.equal(countGenericEventEmits(emitSpy, 'session-a'), 1);
+          emitSpy.restore();
+        });
+
+        it('suppresses duplicate async_event messages across socket replacement without disconnect', async () => {
+          const sessionId = 'session-a';
+          const emitSpy = sinon.spy(mobiusSocket, '_emit');
+          mobiusSocket.sockets.set(sessionId, createSessionSocket());
+
+          await mobiusSocket._onmessage(sessionId, createAsyncEvent('evt-2'));
+
+          mobiusSocket.sockets.set(sessionId, createSessionSocket());
+          await mobiusSocket._onmessage(sessionId, createAsyncEvent('evt-2'));
+
+          assert.equal(countGenericEventEmits(emitSpy, sessionId), 1);
+          emitSpy.restore();
+        });
+
+        it('evicts only the oldest eventId when the dedup cache exceeds max size', async () => {
+          const emitSpy = sinon.spy(mobiusSocket, '_emit');
+
+          mobiusSocket.config.dedupCacheMaxSize = 3;
+
+          await mobiusSocket._onmessage('session-a', createAsyncEvent('e1'));
+          await mobiusSocket._onmessage('session-a', createAsyncEvent('e2'));
+          await mobiusSocket._onmessage('session-a', createAsyncEvent('e3'));
+          await mobiusSocket._onmessage('session-a', createAsyncEvent('e4'));
+          await mobiusSocket._onmessage('session-a', createAsyncEvent('e2'));
+          await mobiusSocket._onmessage('session-a', createAsyncEvent('e1'));
+
+          assert.equal(countGenericEventEmits(emitSpy, 'session-a'), 5);
+          emitSpy.restore();
+        });
+
+        it('clears the session dedup cache on disconnect', async () => {
+          const sessionId = 'session-a';
+          const emitSpy = sinon.spy(mobiusSocket, '_emit');
+
+          await mobiusSocket._onmessage(sessionId, createAsyncEvent('evt-3'));
+
+          mobiusSocket.sockets.set(sessionId, createSessionSocket());
+          await mobiusSocket.disconnect(undefined, sessionId);
+          await mobiusSocket._onmessage(sessionId, createAsyncEvent('evt-3'));
+
+          assert.equal(countGenericEventEmits(emitSpy, sessionId), 2);
+          emitSpy.restore();
         });
       });
 

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/socket.js
@@ -762,6 +762,34 @@ describe('plugin-mobius-socket', () => {
         });
       });
 
+      it('preserves top-level type and eventId for async_event envelopes', () => {
+        mockWebSocket.emit('message', {
+          data: JSON.stringify({
+            type: 'async_event',
+            trackingId: 'SRV_bb000000-0000-0000-0000-000000000006',
+            eventId: 'f6a7b8c9-d0e1-2345-fabc-456789012345',
+            data: {
+              eventType: 'mobius.callinfo',
+              callId: 'fcf86aa5-5539-4c9f-8b72-667786ae9b6c',
+              deviceId: '334f3d50-1d26-4712-93f1-4972390cc565',
+            },
+          }),
+        });
+
+        assert.calledWith(spy, {
+          data: {
+            type: 'async_event',
+            trackingId: 'SRV_bb000000-0000-0000-0000-000000000006',
+            eventId: 'f6a7b8c9-d0e1-2345-fabc-456789012345',
+            data: {
+              eventType: 'mobius.callinfo',
+              callId: 'fcf86aa5-5539-4c9f-8b72-667786ae9b6c',
+              deviceId: '334f3d50-1d26-4712-93f1-4972390cc565',
+            },
+          },
+        });
+      });
+
       it('acknowledges async_event messages only', () => {
         sinon.spy(socket, '_acknowledge');
         mockWebSocket.emit('message', {


### PR DESCRIPTION
# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7843

## This pull request addresses

Duplicate `async_event` messages can be retransmitted by Mobius, which can cause the same event to be processed multiple times by consumers during an active session.

## by making the following changes

- Add session-scoped deduplication for `async_event` messages in `MobiusSocket`, keyed by `eventId`
- Keep dedup state at the `MobiusSocket` layer so duplicate suppression survives socket replacement for the same session
- Bound the dedup cache with oldest-entry eviction instead of clearing the entire cache at capacity
- Clear the session dedup cache on `disconnect()` and all caches on `disconnectAll()`
- Keep low-level socket behavior focused on parsing and ACKing `async_event` messages
- Add unit coverage for duplicate suppression, socket replacement without disconnect, bounded eviction, disconnect cache reset, and flat async envelope parsing

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
https://app.vidcast.io/share/c512f267-a387-4c3b-83ae-398b2e683383
- Targeted unit tests for Mobius socket async event deduplication
- Targeted unit tests for async event ACK behavior
- Targeted unit test verifying flat async event envelopes preserve top-level `type` and `eventId`
- Verified `git diff --check`
- Verified `eslint` on the updated source files

Note: the package test run completed successfully for the targeted Mocha tests, but the sandbox also prints unrelated `EPERM` noise from the helper server attempting to bind to `0.0.0.0:8000`.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
  - OpenAI Codex
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
