### PR TITLE
fix(jmt): stayLobbyTimeCappedBy should return 0 if there's no lobby for the meeting

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -314,12 +314,16 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
    * @returns - latency
    */
   public getStayLobbyTimeCappedBy(endTimestampKey: MetricEventNames) {
-    const lobbyStartTimestamp = this.latencyTimestamps.get('client.locus.join.response'); // must exist
-    const lobbyEndTimestamp = this.latencyTimestamps.get('client.lobby.exited'); // might not exist
+    const lobbyStartTimestamp = this.latencyTimestamps.get('client.locus.join.response'); // might not exist (some meetings don't have lobby)
+    const lobbyEndTimestamp = this.latencyTimestamps.get('client.lobby.exited'); // might not exist (some meetings don't have lobby / user still in lobby at the time of measurement)
     const maximumEndTimestamp = this.latencyTimestamps.get(endTimestampKey); // must exist
 
-    if (typeof lobbyStartTimestamp !== 'number' || typeof maximumEndTimestamp !== 'number') {
+    if (typeof maximumEndTimestamp !== 'number') {
       return undefined;
+    }
+
+    if (typeof lobbyStartTimestamp !== 'number') {
+      return 0;
     }
 
     const endTimestamp =
@@ -426,7 +430,7 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
       'internal.client.interstitial-window.click.joinbutton',
       'client.ice.end'
     );
-    const stayLobbyTimeCappedByIceEnd = this.getStayLobbyTimeCappedBy('client.ice.end') ?? 0;
+    const stayLobbyTimeCappedByIceEnd = this.getStayLobbyTimeCappedBy('client.ice.end');
 
     if (
       typeof interstitialClickJoinToIceEnd === 'number' &&
@@ -517,8 +521,9 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
       'internal.client.interstitial-window.click.joinbutton',
       'client.media-engine.ready'
     );
-    const stayLobbyTimeCappedByMediaEngineReady =
-      this.getStayLobbyTimeCappedBy('client.media-engine.ready') ?? 0;
+    const stayLobbyTimeCappedByMediaEngineReady = this.getStayLobbyTimeCappedBy(
+      'client.media-engine.ready'
+    );
 
     if (
       typeof clickToInterstitial === 'number' &&

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -426,7 +426,7 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
       'internal.client.interstitial-window.click.joinbutton',
       'client.ice.end'
     );
-    const stayLobbyTimeCappedByIceEnd = this.getStayLobbyTimeCappedBy('client.ice.end');
+    const stayLobbyTimeCappedByIceEnd = this.getStayLobbyTimeCappedBy('client.ice.end') ?? 0;
 
     if (
       typeof interstitialClickJoinToIceEnd === 'number' &&
@@ -517,9 +517,8 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
       'internal.client.interstitial-window.click.joinbutton',
       'client.media-engine.ready'
     );
-    const stayLobbyTimeCappedByMediaEngineReady = this.getStayLobbyTimeCappedBy(
-      'client.media-engine.ready'
-    );
+    const stayLobbyTimeCappedByMediaEngineReady =
+      this.getStayLobbyTimeCappedBy('client.media-engine.ready') ?? 0;
 
     if (
       typeof clickToInterstitial === 'number' &&

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -303,27 +303,31 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
    * @returns - latency
    */
   public getStayLobbyTime() {
-    return this.getDiffBetweenTimestamps('client.locus.join.response', 'client.lobby.exited');
+    return this.getDiffBetweenTimestamps('client.lobby.entered', 'client.lobby.exited');
   }
 
   /**
    * Stay lobby time capped by a certain timestamp.
    * This is to handle the case where the target end timestamp could happen before the lobby is exited,
    * for example media-engine.ready or client.ice.end
+   * This is supposed to be called AFTER the end timestamp happens
    * @param endTimestampKey name of the target end event
    * @returns - latency
    */
   public getStayLobbyTimeCappedBy(endTimestampKey: MetricEventNames) {
-    const lobbyStartTimestamp = this.latencyTimestamps.get('client.locus.join.response'); // might not exist (some meetings don't have lobby)
-    const lobbyEndTimestamp = this.latencyTimestamps.get('client.lobby.exited'); // might not exist (some meetings don't have lobby / user still in lobby at the time of measurement)
+    const lobbyStartTimestamp = this.latencyTimestamps.get('client.lobby.entered'); // might not exist (some meetings don't have lobby)
+
+    if (typeof lobbyStartTimestamp !== 'number') {
+      // no lobby in the meeting, stayLobbyTime is 0
+      return 0;
+    }
+
+    const lobbyEndTimestamp = this.latencyTimestamps.get('client.lobby.exited'); // might not exist (if user still in lobby at the time of measurement)
     const maximumEndTimestamp = this.latencyTimestamps.get(endTimestampKey); // must exist
 
     if (typeof maximumEndTimestamp !== 'number') {
+      // the provided timestamp to be used as a cap should exist, return undefined if it doesn't
       return undefined;
-    }
-
-    if (typeof lobbyStartTimestamp !== 'number') {
-      return 0;
     }
 
     const endTimestamp =

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -509,7 +509,7 @@ describe('internal-plugin-metrics', () => {
 
     it('calculates getStayLobbyTime correctly', () => {
       cdl.saveTimestamp({
-        key: 'client.locus.join.response',
+        key: 'client.lobby.entered',
         value: 10,
       });
       cdl.saveTimestamp({
@@ -526,38 +526,38 @@ describe('internal-plugin-metrics', () => {
       });
 
       it('returns undefined when endTimestampKey is missing', () => {
-        cdl.saveTimestamp({key: 'client.locus.join.response', value: 10});
+        cdl.saveTimestamp({key: 'client.lobby.entered', value: 10});
         assert.deepEqual(cdl.getStayLobbyTimeCappedBy('client.media-engine.ready'), undefined);
       });
 
       it('uses maximumEndTimestamp when lobby end does not exist', () => {
-        cdl.saveTimestamp({key: 'client.locus.join.response', value: 10});
+        cdl.saveTimestamp({key: 'client.lobby.entered', value: 10});
         cdl.saveTimestamp({key: 'client.media-engine.ready', value: 50});
         assert.deepEqual(cdl.getStayLobbyTimeCappedBy('client.media-engine.ready'), 40);
       });
 
       it('uses lobby end when it is before maximumEndTimestamp', () => {
-        cdl.saveTimestamp({key: 'client.locus.join.response', value: 10});
+        cdl.saveTimestamp({key: 'client.lobby.entered', value: 10});
         cdl.saveTimestamp({key: 'client.lobby.exited', value: 30});
         cdl.saveTimestamp({key: 'client.media-engine.ready', value: 50});
         assert.deepEqual(cdl.getStayLobbyTimeCappedBy('client.media-engine.ready'), 20);
       });
 
       it('uses maximumEndTimestamp when lobby end is after it', () => {
-        cdl.saveTimestamp({key: 'client.locus.join.response', value: 10});
+        cdl.saveTimestamp({key: 'client.lobby.entered', value: 10});
         cdl.saveTimestamp({key: 'client.lobby.exited', value: 60});
         cdl.saveTimestamp({key: 'client.media-engine.ready', value: 50});
         assert.deepEqual(cdl.getStayLobbyTimeCappedBy('client.media-engine.ready'), 40);
       });
 
       it('clamps to 0 when result would be negative', () => {
-        cdl.saveTimestamp({key: 'client.locus.join.response', value: 100});
+        cdl.saveTimestamp({key: 'client.lobby.entered', value: 100});
         cdl.saveTimestamp({key: 'client.media-engine.ready', value: 50});
         assert.deepEqual(cdl.getStayLobbyTimeCappedBy('client.media-engine.ready'), 0);
       });
 
       it('clamps to MAX_INTEGER when result is very large', () => {
-        cdl.saveTimestamp({key: 'client.locus.join.response', value: 0});
+        cdl.saveTimestamp({key: 'client.lobby.entered', value: 0});
         cdl.saveTimestamp({key: 'client.media-engine.ready', value: 2147483648});
         assert.deepEqual(cdl.getStayLobbyTimeCappedBy('client.media-engine.ready'), 2147483647);
       });
@@ -852,7 +852,7 @@ describe('internal-plugin-metrics', () => {
       cdl.saveTimestamp({key: 'internal.client.interstitial-window.click.joinbutton', value: 10});
       cdl.saveTimestamp({key: 'client.media-engine.ready', value: 50});
       // interstitialClickJoinToMediaEngineReady = 50 - 10 = 40
-      cdl.saveTimestamp({key: 'client.locus.join.response', value: 20});
+      cdl.saveTimestamp({key: 'client.lobby.entered', value: 20});
       cdl.saveTimestamp({key: 'client.lobby.exited', value: 30});
       // stayLobbyTimeCappedByMediaEngineReady = min(30, 50) - 20 = 10
       // total = 3 + 40 - 10 = 33
@@ -866,11 +866,9 @@ describe('internal-plugin-metrics', () => {
       cdl.saveTimestamp({key: 'internal.client.interstitial-window.click.joinbutton', value: 10});
       cdl.saveTimestamp({key: 'client.media-engine.ready', value: 50});
       // interstitialClickJoinToMediaEngineReady = 40
-      cdl.saveTimestamp({key: 'client.locus.join.response', value: 20});
-      // no client.lobby.exited
-      // stayLobbyTimeCappedByMediaEngineReady = 50 - 20 = 30
-      // total = 3 + 40 - 30 = 13
-      assert.deepEqual(cdl.getTotalMediaJMT(), 13);
+      // no client.lobby.entered → stayLobbyTimeCappedByMediaEngineReady = 0
+      // total = 3 + 40 - 0 = 43
+      assert.deepEqual(cdl.getTotalMediaJMT(), 43);
     });
 
     it('calculates getTotalMediaJMT correctly with lobby exiting after media-engine.ready', () => {
@@ -880,7 +878,7 @@ describe('internal-plugin-metrics', () => {
       cdl.saveTimestamp({key: 'internal.client.interstitial-window.click.joinbutton', value: 10});
       cdl.saveTimestamp({key: 'client.media-engine.ready', value: 50});
       // interstitialClickJoinToMediaEngineReady = 40
-      cdl.saveTimestamp({key: 'client.locus.join.response', value: 20});
+      cdl.saveTimestamp({key: 'client.lobby.entered', value: 20});
       cdl.saveTimestamp({key: 'client.lobby.exited', value: 60});
       // stayLobbyTimeCappedByMediaEngineReady = min(60, 50) - 20 = 30
       // total = 3 + 40 - 30 = 13
@@ -892,7 +890,7 @@ describe('internal-plugin-metrics', () => {
       cdl.saveTimestamp({key: 'internal.client.meeting.interstitial-window.showed', value: 8});
       cdl.saveTimestamp({key: 'internal.client.interstitial-window.click.joinbutton', value: 10});
       cdl.saveTimestamp({key: 'client.media-engine.ready', value: 4294967400});
-      cdl.saveTimestamp({key: 'client.locus.join.response', value: 28});
+      cdl.saveTimestamp({key: 'client.lobby.entered', value: 28});
       cdl.saveTimestamp({key: 'client.lobby.exited', value: 30});
       assert.deepEqual(cdl.getTotalMediaJMT(), 2147483647);
     });
@@ -912,7 +910,7 @@ describe('internal-plugin-metrics', () => {
       cdl.saveTimestamp({key: 'internal.client.interstitial-window.click.joinbutton', value: 10});
       cdl.saveTimestamp({key: 'client.media-engine.ready', value: 50});
       // interstitialClickJoinToMediaEngineReady = 50 - 10 = 40
-      // no client.locus.join.response → stayLobbyTimeCappedByMediaEngineReady = undefined ?? 0 = 0
+      // no client.lobby.entered → stayLobbyTimeCappedByMediaEngineReady = 0
       // total = 3 + 40 - 0 = 43
       assert.deepEqual(cdl.getTotalMediaJMT(), 43);
     });
@@ -1070,7 +1068,7 @@ describe('internal-plugin-metrics', () => {
         value: 4,
       });
       cdl.saveTimestamp({
-        key: 'client.locus.join.response',
+        key: 'client.lobby.entered',
         value: 10,
       });
       cdl.saveTimestamp({
@@ -1090,7 +1088,7 @@ describe('internal-plugin-metrics', () => {
         value: 4,
       });
       cdl.saveTimestamp({
-        key: 'client.locus.join.response',
+        key: 'client.lobby.entered',
         value: 10,
       });
       cdl.saveTimestamp({
@@ -1110,14 +1108,12 @@ describe('internal-plugin-metrics', () => {
         value: 4,
       });
       cdl.saveTimestamp({
-        key: 'client.locus.join.response',
-        value: 8,
-      });
-      cdl.saveTimestamp({
         key: 'client.ice.end',
         value: 14,
       });
-      assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 4);
+      // no client.lobby.entered → stayLobbyTimeCappedByIceEnd = 0
+      // result = (14 - 4) - 0 = 10
+      assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 10);
     });
 
     it('calculates getInterstitialToMediaOKJMT correctly when there is no lobby and stayLobbyTime defaults to 0', () => {
@@ -1129,7 +1125,7 @@ describe('internal-plugin-metrics', () => {
         key: 'client.ice.end',
         value: 14,
       });
-      // stayLobbyTimeCappedByIceEnd = undefined ?? 0 = 0
+      // no client.lobby.entered → stayLobbyTimeCappedByIceEnd = 0
       // result = (14 - 4) - 0 = 10
       assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 10);
     });

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -905,6 +905,18 @@ describe('internal-plugin-metrics', () => {
       assert.deepEqual(cdl.getTotalMediaJMT(), undefined);
     });
 
+    it('calculates getTotalMediaJMT correctly when there is no lobby and stayLobbyTime defaults to 0', () => {
+      cdl.saveTimestamp({key: 'internal.client.meeting.click.joinbutton', value: 5});
+      cdl.saveTimestamp({key: 'internal.client.meeting.interstitial-window.showed', value: 8});
+      // clickToInterstitial = 8 - 5 = 3
+      cdl.saveTimestamp({key: 'internal.client.interstitial-window.click.joinbutton', value: 10});
+      cdl.saveTimestamp({key: 'client.media-engine.ready', value: 50});
+      // interstitialClickJoinToMediaEngineReady = 50 - 10 = 40
+      // no client.locus.join.response → stayLobbyTimeCappedByMediaEngineReady = undefined ?? 0 = 0
+      // total = 3 + 40 - 0 = 43
+      assert.deepEqual(cdl.getTotalMediaJMT(), 43);
+    });
+
     it('calculates getTotalMediaJMTWithUserDelay correctly', () => {
       cdl.saveLatency('internal.click.to.interstitial.with.user.delay', 7);
       // clickToInterstitialWithUserDelay = 7
@@ -1106,6 +1118,20 @@ describe('internal-plugin-metrics', () => {
         value: 14,
       });
       assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 4);
+    });
+
+    it('calculates getInterstitialToMediaOKJMT correctly when there is no lobby and stayLobbyTime defaults to 0', () => {
+      cdl.saveTimestamp({
+        key: 'internal.client.interstitial-window.click.joinbutton',
+        value: 4,
+      });
+      cdl.saveTimestamp({
+        key: 'client.ice.end',
+        value: 14,
+      });
+      // stayLobbyTimeCappedByIceEnd = undefined ?? 0 = 0
+      // result = (14 - 4) - 0 = 10
+      assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 10);
     });
 
     it('calculates getShareDuration correctly', () => {

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -520,9 +520,9 @@ describe('internal-plugin-metrics', () => {
     });
 
     describe('getStayLobbyTimeCappedBy', () => {
-      it('returns undefined when lobbyStartTimestamp is missing', () => {
+      it('returns 0 when lobbyStartTimestamp is missing', () => {
         cdl.saveTimestamp({key: 'client.media-engine.ready', value: 100});
-        assert.deepEqual(cdl.getStayLobbyTimeCappedBy('client.media-engine.ready'), undefined);
+        assert.deepEqual(cdl.getStayLobbyTimeCappedBy('client.media-engine.ready'), 0);
       });
 
       it('returns undefined when endTimestampKey is missing', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses
an earlier change changed how we use the stayLobbyTime in some JMT calculations (introducing the new stayLobbyTimeCappedBy function, but I forgot that some meetings don't have a lobby and therefore stayLobbyTime could be undefined

the previous implementation of those metrics that uses stayLobbyTime would treat lobbyTime as 0
the new implementation could potentially use an overly-long time period (up to the cap) as the "lobby time" for meetigns without lobby

## by making the following changes
treat lobbyTime as 0 in calculations if the start point (client.lobby.entered, we use this to determine if the meeting has a lobby or not) doesn't exist

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
