### PR TITLE
fix(contact-center): consult flow state-machine fixes for task-refactor

### DIFF
--- a/packages/@webex/contact-center/src/services/task/Task.ts
+++ b/packages/@webex/contact-center/src/services/task/Task.ts
@@ -458,11 +458,9 @@ export default abstract class Task extends EventEmitter implements ITask {
         this.emit(TASK_EVENTS.TASK_REJECT, reason);
       },
       emitTaskWrapup: ({event}: {event?: TaskEventPayload}) => {
-        const wrapUpRequiredFromEvent =
-          event && typeof event === 'object' && 'taskData' in event
-            ? (event as {taskData?: TaskData}).taskData?.wrapUpRequired
-            : undefined;
-        const shouldEmitWrapup = Boolean(wrapUpRequiredFromEvent ?? this.data.wrapUpRequired);
+        this.updateTaskFromEvent(event);
+
+        const shouldEmitWrapup = Boolean(this.data.wrapUpRequired);
         if (!shouldEmitWrapup) {
           LoggerProxy.info(`Skipping task:wrapup event - wrapUpRequired is false`, {
             module: TASK_FILE,

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -95,7 +95,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             {
               guard: guards.isInteractionConsulting,
               target: TaskState.CONSULTING,
-              actions: ['updateTaskData', 'emitTaskHydrate'],
+              actions: ['updateTaskData', 'hydrateConsultState', 'emitTaskHydrate'],
             },
             {
               guard: guards.isInteractionHeld,
@@ -212,6 +212,12 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // AgentConsultFailed - when consulted agent (Agent 2) doesn't answer (RONA or decline)
           // Clears the incoming consult notification by transitioning to TERMINATED
           [TaskEvent.CONSULT_FAILED]: {
+            target: TaskState.TERMINATED,
+            actions: ['updateTaskData', 'clearConsultState', 'emitTaskReject'],
+          },
+          // AgentConsultEnded - when consult initiator (Agent 1) ends the consult before
+          // the consulted agent (Agent 2) accepts. Clears the incoming notification.
+          [TaskEvent.CONSULT_END]: {
             target: TaskState.TERMINATED,
             actions: ['updateTaskData', 'clearConsultState', 'emitTaskReject'],
           },
@@ -482,10 +488,10 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             actions: ['handleSwitchToConsult', 'emitTaskSwitchCall'],
           },
           [TaskEvent.HOLD_SUCCESS]: {
-            actions: ['updateTaskData', 'setHoldState'],
+            actions: ['updateTaskData', 'setHoldState', 'syncConsultCallHeld', 'emitTaskHold'],
           },
           [TaskEvent.UNHOLD_SUCCESS]: {
-            actions: ['updateTaskData', 'setHoldState'],
+            actions: ['updateTaskData', 'setHoldState', 'syncConsultCallHeld', 'emitTaskResume'],
           },
 
           [TaskEvent.TRANSFER_SUCCESS]: [

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -103,6 +103,11 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
               actions: ['updateTaskData', 'emitTaskHydrate'],
             },
             {
+              guard: guards.isAgentInWrapUp,
+              target: TaskState.WRAPPING_UP,
+              actions: ['updateTaskData', 'markEnded', 'emitTaskHydrate'],
+            },
+            {
               guard: guards.isInteractionConnected,
               target: TaskState.CONNECTED,
               actions: ['updateTaskData', 'emitTaskHydrate'],

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -95,17 +95,12 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             {
               guard: guards.isInteractionConsulting,
               target: TaskState.CONSULTING,
-              actions: ['updateTaskData', 'hydrateConsultState', 'emitTaskHydrate'],
+              actions: ['updateTaskData', 'emitTaskHydrate'],
             },
             {
               guard: guards.isInteractionHeld,
               target: TaskState.HELD,
               actions: ['updateTaskData', 'emitTaskHydrate'],
-            },
-            {
-              guard: guards.isAgentInWrapUp,
-              target: TaskState.WRAPPING_UP,
-              actions: ['updateTaskData', 'markEnded', 'emitTaskHydrate'],
             },
             {
               guard: guards.isInteractionConnected,
@@ -493,10 +488,10 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             actions: ['handleSwitchToConsult', 'emitTaskSwitchCall'],
           },
           [TaskEvent.HOLD_SUCCESS]: {
-            actions: ['updateTaskData', 'setHoldState', 'syncConsultCallHeld', 'emitTaskHold'],
+            actions: ['updateTaskData', 'setHoldState', 'emitTaskHold'],
           },
           [TaskEvent.UNHOLD_SUCCESS]: {
-            actions: ['updateTaskData', 'setHoldState', 'syncConsultCallHeld', 'emitTaskResume'],
+            actions: ['updateTaskData', 'setHoldState', 'emitTaskResume'],
           },
 
           [TaskEvent.TRANSFER_SUCCESS]: [

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -259,10 +259,82 @@ export const actions: TaskActionsMap = {
   setTransferConferenceRequested: assign({transferConferenceRequested: true}),
   clearTransferConferenceRequested: assign({transferConferenceRequested: false}),
 
+  /**
+   * Reconstruct consult context flags from hydrated task data on page refresh.
+   * During live flows these are set incrementally by setConsultInitiator,
+   * setConsultAgentJoined, and handleSwitchToMainCall/handleSwitchToConsult.
+   * After HYDRATE those actions never fire, so we derive the same flags from
+   * the backend snapshot.
+   */
+  hydrateConsultState: assign(({context, event}: TaskActionArgs) => {
+    const taskData = getTaskDataFromEvent(event);
+    if (!taskData?.interaction) return {};
+
+    const interaction = taskData.interaction;
+    const selfAgentId = context.uiControlConfig?.agentId ?? taskData?.agentId;
+
+    const derivedInitiator = determineConsultInitiator(taskData, selfAgentId);
+    const consultInitiator = derivedInitiator ?? taskData.isConsulted !== true;
+
+    const consultDestinationAgentJoined = Boolean(
+      interaction.participants &&
+        Object.values(interaction.participants).some(
+          (p: any) => p?.isConsulted === true && !p?.hasLeft
+        )
+    );
+
+    const consultMediaId = taskData.consultMediaResourceId;
+    const consultMedia: any = consultMediaId
+      ? interaction.media?.[consultMediaId]
+      : Object.values(interaction.media ?? {}).find((m: any) => m?.mType === 'consult');
+    const consultCallHeld = Boolean(consultMedia?.isHold);
+
+    return {
+      consultInitiator,
+      consultDestinationAgentJoined,
+      consultCallHeld,
+    };
+  }),
+
   setConsultCallHeld: assign({consultCallHeld: true}),
   clearConsultCallHeld: assign({consultCallHeld: false}),
   handleSwitchToMainCall: assign({consultCallHeld: true}),
   handleSwitchToConsult: assign({consultCallHeld: false}),
+
+  /**
+   * Derive consultCallHeld from remote hold/unhold events during consulting.
+   * Handles multi-login sync: when another session switches the call, the
+   * backend broadcasts AgentContactHeld/AgentContactUnheld to all sessions.
+   * Without this, consultCallHeld stays stale and activeLeg never changes.
+   */
+  syncConsultCallHeld: assign(({context, event}: TaskActionArgs) => {
+    if (
+      !event ||
+      (event.type !== TaskEvent.HOLD_SUCCESS && event.type !== TaskEvent.UNHOLD_SUCCESS)
+    ) {
+      return {};
+    }
+
+    const mediaResourceId =
+      'mediaResourceId' in event
+        ? (event as {mediaResourceId?: string}).mediaResourceId
+        : undefined;
+    if (!mediaResourceId) return {};
+
+    const taskData = context.taskData;
+    const consultMediaId = taskData?.consultMediaResourceId;
+
+    const isConsultMedia = consultMediaId
+      ? mediaResourceId === consultMediaId
+      : taskData?.interaction?.media?.[mediaResourceId]?.mType === 'consult';
+
+    if (!isConsultMedia) return {};
+
+    return {
+      consultCallHeld: event.type === TaskEvent.HOLD_SUCCESS,
+    };
+  }),
+
   handleConferenceFailed: assign(({event}: TaskActionArgs) => {
     const taskData = getTaskDataFromEvent(event);
 

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -91,7 +91,39 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
         if (!context.consultInitiator) {
           const selfAgentId = context.uiControlConfig.agentId ?? taskData?.agentId;
           const consultInitiator = determineConsultInitiator(taskData, selfAgentId);
-          if (consultInitiator !== undefined) updates.consultInitiator = consultInitiator;
+          if (consultInitiator !== undefined) {
+            updates.consultInitiator = consultInitiator;
+          } else if (
+            taskData.interaction?.state === 'consulting' &&
+            taskData.isConsulted === false
+          ) {
+            updates.consultInitiator = true;
+          }
+        }
+
+        if (taskData.interaction?.state === 'consulting') {
+          if (!context.consultDestinationAgentJoined) {
+            const hasJoinedConsultee = Boolean(
+              taskData.interaction.participants &&
+                Object.values(taskData.interaction.participants).some(
+                  (p: any) => p?.isConsulted === true && !p?.hasLeft
+                )
+            );
+            if (hasJoinedConsultee) updates.consultDestinationAgentJoined = true;
+          }
+
+          const effectiveConsultInitiator = updates.consultInitiator ?? context.consultInitiator;
+          if (effectiveConsultInitiator) {
+            const consultMediaId = taskData.consultMediaResourceId;
+            const consultMedia: any = consultMediaId
+              ? taskData.interaction.media?.[consultMediaId]
+              : Object.values(taskData.interaction.media ?? {}).find(
+                  (m: any) => m?.mType === 'consult'
+                );
+            if (consultMedia) {
+              updates.consultCallHeld = Boolean(consultMedia.isHold);
+            }
+          }
         }
 
         return updates;
@@ -259,81 +291,10 @@ export const actions: TaskActionsMap = {
   setTransferConferenceRequested: assign({transferConferenceRequested: true}),
   clearTransferConferenceRequested: assign({transferConferenceRequested: false}),
 
-  /**
-   * Reconstruct consult context flags from hydrated task data on page refresh.
-   * During live flows these are set incrementally by setConsultInitiator,
-   * setConsultAgentJoined, and handleSwitchToMainCall/handleSwitchToConsult.
-   * After HYDRATE those actions never fire, so we derive the same flags from
-   * the backend snapshot.
-   */
-  hydrateConsultState: assign(({context, event}: TaskActionArgs) => {
-    const taskData = getTaskDataFromEvent(event);
-    if (!taskData?.interaction) return {};
-
-    const interaction = taskData.interaction;
-    const selfAgentId = context.uiControlConfig?.agentId ?? taskData?.agentId;
-
-    const derivedInitiator = determineConsultInitiator(taskData, selfAgentId);
-    const consultInitiator = derivedInitiator ?? taskData.isConsulted !== true;
-
-    const consultDestinationAgentJoined = Boolean(
-      interaction.participants &&
-        Object.values(interaction.participants).some(
-          (p: any) => p?.isConsulted === true && !p?.hasLeft
-        )
-    );
-
-    const consultMediaId = taskData.consultMediaResourceId;
-    const consultMedia: any = consultMediaId
-      ? interaction.media?.[consultMediaId]
-      : Object.values(interaction.media ?? {}).find((m: any) => m?.mType === 'consult');
-    const consultCallHeld = Boolean(consultMedia?.isHold);
-
-    return {
-      consultInitiator,
-      consultDestinationAgentJoined,
-      consultCallHeld,
-    };
-  }),
-
   setConsultCallHeld: assign({consultCallHeld: true}),
   clearConsultCallHeld: assign({consultCallHeld: false}),
   handleSwitchToMainCall: assign({consultCallHeld: true}),
   handleSwitchToConsult: assign({consultCallHeld: false}),
-
-  /**
-   * Derive consultCallHeld from remote hold/unhold events during consulting.
-   * Handles multi-login sync: when another session switches the call, the
-   * backend broadcasts AgentContactHeld/AgentContactUnheld to all sessions.
-   * Without this, consultCallHeld stays stale and activeLeg never changes.
-   */
-  syncConsultCallHeld: assign(({context, event}: TaskActionArgs) => {
-    if (
-      !event ||
-      (event.type !== TaskEvent.HOLD_SUCCESS && event.type !== TaskEvent.UNHOLD_SUCCESS)
-    ) {
-      return {};
-    }
-
-    const mediaResourceId =
-      'mediaResourceId' in event
-        ? (event as {mediaResourceId?: string}).mediaResourceId
-        : undefined;
-    if (!mediaResourceId) return {};
-
-    const taskData = context.taskData;
-    const consultMediaId = taskData?.consultMediaResourceId;
-
-    const isConsultMedia = consultMediaId
-      ? mediaResourceId === consultMediaId
-      : taskData?.interaction?.media?.[mediaResourceId]?.mType === 'consult';
-
-    if (!isConsultMedia) return {};
-
-    return {
-      consultCallHeld: event.type === TaskEvent.HOLD_SUCCESS,
-    };
-  }),
 
   handleConferenceFailed: assign(({event}: TaskActionArgs) => {
     const taskData = getTaskDataFromEvent(event);
@@ -386,7 +347,7 @@ export const actions: TaskActionsMap = {
       },
     };
 
-    return {
+    const updates: Partial<TaskContext> = {
       taskData: {
         ...(context.taskData as TaskData),
         interaction: {
@@ -395,6 +356,17 @@ export const actions: TaskActionsMap = {
         },
       },
     };
+
+    const consultMediaId = context.taskData?.consultMediaResourceId;
+    const isConsultMedia = consultMediaId
+      ? mediaResourceId === consultMediaId
+      : mediaEntry?.mType === 'consult';
+
+    if (isConsultMedia && context.consultInitiator) {
+      updates.consultCallHeld = event.type === TaskEvent.HOLD_SUCCESS;
+    }
+
+    return updates;
   }),
 
   markEnded: assign(() => ({

--- a/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
@@ -102,6 +102,16 @@ export const guards = {
     return taskData?.interaction?.state === 'hold';
   },
 
+  isAgentInWrapUp: ({context, event}: GuardParams): boolean => {
+    const taskData = getTaskDataFromEvent(event);
+    if (!taskData) return false;
+
+    const selfAgentId = getSelfAgentId(context, taskData);
+    if (!selfAgentId) return false;
+
+    return taskData?.interaction?.participants?.[selfAgentId]?.isWrapUp === true;
+  },
+
   isInteractionConnected: ({event}: GuardParams): boolean => {
     const taskData = getTaskDataFromEvent(event);
 

--- a/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
@@ -84,10 +84,17 @@ export type GuardFunction = (params: GuardParams) => boolean;
 
 export const guards = {
   // Hydrate Guards
-  isInteractionTerminated: ({event}: GuardParams): boolean => {
+  isInteractionTerminated: ({context, event}: GuardParams): boolean => {
     const taskData = getTaskDataFromEvent(event);
 
-    return taskData?.interaction?.isTerminated === true;
+    if (taskData?.interaction?.isTerminated === true) return true;
+
+    const selfAgentId = getSelfAgentId(context, taskData);
+    if (selfAgentId && taskData?.interaction?.participants?.[selfAgentId]?.isWrapUp === true) {
+      return true;
+    }
+
+    return false;
   },
 
   isInteractionConsulting: ({event}: GuardParams): boolean => {
@@ -99,17 +106,14 @@ export const guards = {
   isInteractionHeld: ({event}: GuardParams): boolean => {
     const taskData = getTaskDataFromEvent(event);
 
-    return taskData?.interaction?.state === 'hold';
-  },
+    if (taskData?.interaction?.state === 'hold') return true;
 
-  isAgentInWrapUp: ({context, event}: GuardParams): boolean => {
-    const taskData = getTaskDataFromEvent(event);
-    if (!taskData) return false;
+    const mainMediaId = taskData?.interaction?.mainInteractionId || taskData?.interactionId;
+    if (mainMediaId && taskData?.interaction?.media?.[mainMediaId]?.isHold === true) {
+      return true;
+    }
 
-    const selfAgentId = getSelfAgentId(context, taskData);
-    if (!selfAgentId) return false;
-
-    return taskData?.interaction?.participants?.[selfAgentId]?.isWrapUp === true;
+    return false;
   },
 
   isInteractionConnected: ({event}: GuardParams): boolean => {

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -205,7 +205,7 @@ function computeVoiceInteractionUIControls(
       if (isWrappingUp) return DISABLED;
       if (isConsulting) return VISIBLE_ENABLED;
 
-      if (state === TaskState.CONNECTED || isConferencing) {
+      if (isConnected || isHeld || isConferencing) {
         if (inConference) return VISIBLE_ENABLED;
 
         return isHeld ? VISIBLE_DISABLED : VISIBLE_ENABLED;

--- a/packages/@webex/contact-center/test/unit/spec/services/task/voice/WebRTC.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/voice/WebRTC.ts
@@ -165,7 +165,7 @@ describe('WebRTC Task', () => {
       {type: TaskEvent.HOLD_INITIATED, mediaResourceId: taskData.mediaResourceId},
       {type: TaskEvent.HOLD_SUCCESS, mediaResourceId: taskData.mediaResourceId},
     ]);
-    expect(webRtc.uiControls.main.mute.isVisible).toBe(false);
+    expect(webRtc.uiControls.main.mute.isVisible).toBe(true);
     expect(webRtc.uiControls.main.mute.isEnabled).toBe(false);
   });
 


### PR DESCRIPTION
# COMPLETES #<https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7849>

## This pull request addresses

The CC Widgets task-refactor migration exposed eight issues in the SDK state machine. These affect page refresh during consult, consult hold state synchronization, early consult termination handling, hold/resume event emission during the CONSULTING state, missing auto-wrapup object creation after call end and consult transfer, incorrect state restoration on page refresh during wrapup, and incorrect HELD state restoration when the backend reports media-level hold without updating interaction state, and mute button disappearing during held state in desktop mode — all of which cause incorrect UI behavior in the widget layer.

## by making the following changes

**1. Hydrate consult context on page refresh (Issue 1)**

- Extended deriveTaskDataUpdates in actions.ts to reconstruct consultInitiator, consultDestinationAgentJoined, and consultCallHeld context flags from persisted taskData during rehydration — reusing the existing action instead of adding a new hydrateConsultState action
- Added taskData.isConsulted === false fallback (strict equality) for consultInitiator derivation to avoid misclassifying consulted agents when determineConsultInitiator returns undefined
- Gated consultCallHeld derivation behind consultInitiator check so only the initiating agent computes consult hold state 
- Without this, page refresh during an active consult left context flags empty, causing uiControls to compute no consult controls

**2. Sync consultCallHeld on hold/unhold events (Issue 2)**

- Enhanced existing setHoldState action in actions.ts to update context.consultCallHeld when HOLD_SUCCESS / UNHOLD_SUCCESS events target the consult media, gated behind context.consultInitiator — reusing the existing action instead of adding a new syncConsultCallHeld action
- Without this, hold/unhold events during consult did not update consultCallHeld, so consult-on-hold controls did not reflect the call switch

**3. Handle CONSULT_END in OFFERED state (Issue 3)**

- Added CONSULT_END handler to the OFFERED state in TaskStateMachine.ts, transitioning to TERMINATED
- Without this, when the initiator ended the consult before the consulted agent accepted, the consulted agent's task remained stuck in OFFERED state indefinitely

**4. Emit TASK_HOLD / TASK_RESUME during CONSULTING state (Issue 4)**

- Added emitTaskHold action to the HOLD_SUCCESS handler and emitTaskResume action to the UNHOLD_SUCCESS handler within the CONSULTING state in TaskStateMachine.ts
- Without this, hold/unhold during consulting did not emit TASK_HOLD / TASK_RESUME events, causing the widget to miss hold state changes and not display consult-on-hold timers

**5. Fix auto-wrapup object not created after call end and consult transfer (Issue 5)**

- Updated emitTaskWrapup in Task.ts to call updateTaskFromEvent(event) before evaluating wrapUpRequired, ensuring Task.data is populated with wrapUpRequired: true so setupAutoWrapupTimer creates the autoWrapup object correctly
- Without this, emitTaskWrapup checked a local variable extracted from the event but never persisted it to Task.data, so setupAutoWrapupTimer() saw wrapUpRequired as undefined and never created the autoWrapup object

**6. Restore WRAPPING_UP state on page refresh (Issue 6)**

- Enhanced isInteractionTerminated guard in guards.ts to also check participant[selfAgentId].isWrapUp === true for the current agent during the HYDRATE event — consolidated into the existing guard instead of adding a separate isAgentInWrapUp guard, per review feedback
- Without this, page refresh while an agent was in wrapup (e.g., after consult transfer) fell through to the isInteractionConnected guard and restored the task to CONNECTED state instead of WRAPPING_UP

**7. Restore HELD state on page refresh when media is on hold (Issue 7)**

- Enhanced isInteractionHeld guard in guards.ts to cross-check the primary media's isHold flag via mainInteractionId when interaction.state is not 'hold'
- The backend may report interaction.state: "connected" while media[mainInteractionId].isHold: true, causing the state machine to hydrate into CONNECTED instead of HELD
- Without this, page refresh during a held call required two clicks on Resume — the first incorrectly sending a hold request (AgentContactHeld) because the state machine was in CONNECTED

**8. Keep mute button visible (disabled) during held state in desktop mode (Issue 8)**

- In uiControlsComputer.ts, the mute visibility gate checked state === TaskState.CONNECTED || isConferencing, which excluded the HELD state entirely
- When the state machine transitioned to HELD, the mute logic fell through to return DISABLED (hidden), even though the existing isHeld ? VISIBLE_DISABLED : VISIBLE_ENABLED line was designed to handle this case — it was unreachable
- Changed the condition to isConnected || isHeld || isConferencing, keeping the mute button visible but disabled during hold

<img width="1480" height="816" alt="Incoming task not cleared at Agent 2 side when Agent 1 ends consult before acceptance" src="https://github.com/user-attachments/assets/408f7190-c7a9-4c87-a23c-c66a72c8b389" />

<img width="911" height="502" alt="image" src="https://github.com/user-attachments/assets/07d782a0-0ab8-41c0-a2ff-724d6a2bad8e" />


**Agent 2 consults → transfers to Agent 1 → Agent 2 sees wrapup → refresh page → should now show wrapup screen**

<img width="1486" height="798" alt="WrapUp Screen shouold be visible instead displaying call control on page refresh" src="https://github.com/user-attachments/assets/0dd8d482-7584-4bfd-8330-8a42eded51ab" />


### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Normal call: Agent ends call → auto-wrapup banner appears with countdown → task auto-wraps up
- Consult transfer: Agent 1 consults Agent 2 → Agent 2 accepts → Agent 1 switches consult to main → Agent 1 transfers → Agent 1 sees auto-wrapup banner and task auto-wraps up
- Page refresh during wrapup: Agent 2 consults Agent 1 → Agent 2 transfers → Agent 2 sees wrapup screen → page refresh → Agent 2 still sees wrapup screen (not call controls)
- Page refresh during consult: Agent in active consult → page refresh → consult controls restored correctly
- Multi-login hold/unhold sync: Hold/unhold from second browser session reflects correctly in first session
- Early consult end: Agent 1 ends consult before Agent 2 accepts → Agent 2's task transitions to TERMINATED

## The GAI Coding Policy And Copyright Annotation Best Practices

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor AI
- This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed contributing guidelines
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md) before submitting.