### PR TITLE
fix(calling): update flag and method name for mobius ws enablement

### DIFF
--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -67,7 +67,7 @@ import {
 import {getMetricManager} from '../Metrics';
 import windowsChromiumIceWarmup from './windowsChromiumIceWarmupUtils';
 import {APIRequest} from './utils/request';
-import {isWsFeatureEnabled} from './utils';
+import {isMobiusWssFlagEnabled} from './utils';
 
 /**
  * The `CallingClient` module provides a set of APIs for line registration and calling functionalities within the SDK.
@@ -153,7 +153,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     validateServiceData(serviceData);
 
     this.isMobiusSocketEnabled =
-      isWsFeatureEnabled(this.webex) || (config?.isMobiusSocketEnabled ?? false);
+      isMobiusWssFlagEnabled(this.webex) || (config?.isMobiusSocketEnabled ?? false);
 
     this.callManager = getCallManager(
       this.webex,

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -67,7 +67,7 @@ import {
 import {getMetricManager} from '../Metrics';
 import windowsChromiumIceWarmup from './windowsChromiumIceWarmupUtils';
 import {APIRequest} from './utils/request';
-import {isMobiusWssFlagEnabled} from './utils';
+import {isMobiusWssEnabled} from './utils';
 
 /**
  * The `CallingClient` module provides a set of APIs for line registration and calling functionalities within the SDK.
@@ -153,7 +153,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     validateServiceData(serviceData);
 
     this.isMobiusSocketEnabled =
-      isMobiusWssFlagEnabled(this.webex) || (config?.isMobiusSocketEnabled ?? false);
+      isMobiusWssEnabled(this.webex) || (config?.isMobiusSocketEnabled ?? false);
 
     this.callManager = getCallManager(
       this.webex,

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -7,7 +7,7 @@ import log from '../../Logger';
 import {APIRequestConfig, APIRequestOptions, MobiusSocketResponse} from './types';
 import {deriveMobiusSocketMessageType} from './mobiusSocketMapper';
 import {MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
-import {isMobiusWssFlagEnabled} from './wsFeatureFlag';
+import {isMobiusWssEnabled} from './wsFeatureFlag';
 import {METHODS, REQUEST_FILE} from '../constants';
 
 /**
@@ -82,7 +82,7 @@ export class APIRequest {
 
     this.webex = config.webex;
     this.isMobiusSocketEnabled =
-      isMobiusWssFlagEnabled(config.webex) || (config.isMobiusSocketEnabled ?? false);
+      isMobiusWssEnabled(config.webex) || (config.isMobiusSocketEnabled ?? false);
     this.mobiusSocket = getMobiusSocketInstance(this.webex);
   }
 

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -7,7 +7,7 @@ import log from '../../Logger';
 import {APIRequestConfig, APIRequestOptions, MobiusSocketResponse} from './types';
 import {deriveMobiusSocketMessageType} from './mobiusSocketMapper';
 import {MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
-import {isWsFeatureEnabled} from './wsFeatureFlag';
+import {isMobiusWssFlagEnabled} from './wsFeatureFlag';
 import {METHODS, REQUEST_FILE} from '../constants';
 
 /**
@@ -82,7 +82,7 @@ export class APIRequest {
 
     this.webex = config.webex;
     this.isMobiusSocketEnabled =
-      isWsFeatureEnabled(config.webex) || (config.isMobiusSocketEnabled ?? false);
+      isMobiusWssFlagEnabled(config.webex) || (config.isMobiusSocketEnabled ?? false);
     this.mobiusSocket = getMobiusSocketInstance(this.webex);
   }
 

--- a/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
+++ b/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
@@ -1,13 +1,13 @@
 import {WebexSDK} from '../../SDKConnector/types';
 
 /** WDM device-settings key for routing Mobius traffic over WebSocket. */
-export const WEBRTC_CALLING_OVER_WS_FEATURE_KEY = 'webrtc-calling-over-ws';
+export const WEBRTC_CALLING_OVER_WS_FEATURE_KEY = 'webrtc-calling-over-ws-CALL-219562';
 
 /**
  * Whether Webex Calling should use the Mobius WebSocket transport for API requests.
  * Reads WDM `webex.internal.device.settings['webrtc-calling-over-ws'].value`; must be
  * strictly `true` to enable WebSocket—otherwise use HTTP.
  */
-export function isWsFeatureEnabled(webex: WebexSDK): boolean {
+export function isMobiusWssFlagEnabled(webex: WebexSDK): boolean {
   return webex.internal?.device?.settings?.[WEBRTC_CALLING_OVER_WS_FEATURE_KEY]?.value === true;
 }

--- a/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
+++ b/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
@@ -7,8 +7,9 @@ export const WEBRTC_CALLING_OVER_WS_FEATURE_KEY = 'webrtc-calling-over-ws-CALL-2
  * Reads WDM `webex.internal.device.settings['webrtc-calling-over-ws'].value`; must be
  * strictly `true` to enable WebSocket—otherwise use HTTP.
  */
-export function isMobiusWssFlagEnabled(webex: WebexSDK): boolean {
+export function isMobiusWssEnabled(webex: WebexSDK): boolean {
   return (
-    webex.internal.device.features.developer.get(WEBRTC_CALLING_OVER_WS_FEATURE_KEY)?.value === true
+    webex.internal?.device?.features?.developer?.get(WEBRTC_CALLING_OVER_WS_FEATURE_KEY)?.value ===
+    true
   );
 }

--- a/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
+++ b/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
@@ -2,12 +2,13 @@ import {WebexSDK} from '../../SDKConnector/types';
 
 /** WDM device-settings key for routing Mobius traffic over WebSocket. */
 export const WEBRTC_CALLING_OVER_WS_FEATURE_KEY = 'webrtc-calling-over-ws-CALL-219562';
-
 /**
  * Whether Webex Calling should use the Mobius WebSocket transport for API requests.
  * Reads WDM `webex.internal.device.settings['webrtc-calling-over-ws'].value`; must be
  * strictly `true` to enable WebSocket—otherwise use HTTP.
  */
 export function isMobiusWssFlagEnabled(webex: WebexSDK): boolean {
-  return webex.internal?.device?.settings?.[WEBRTC_CALLING_OVER_WS_FEATURE_KEY]?.value === true;
+  return (
+    webex.internal.device.features.developer.get(WEBRTC_CALLING_OVER_WS_FEATURE_KEY)?.value === true
+  );
 }

--- a/packages/calling/src/SDKConnector/types.ts
+++ b/packages/calling/src/SDKConnector/types.ts
@@ -99,6 +99,10 @@ export interface WebexSDK {
       /** WDM / device-registration settings (e.g. `webrtc-calling-over-ws`). */
       settings?: Record<string, {value?: boolean} | undefined>;
       features: {
+        developer: {
+          models: Model[];
+          get: (key: string) => {value: boolean} | undefined;
+        };
         entitlement: {
           models: Model[];
         };

--- a/packages/calling/src/common/testUtil.ts
+++ b/packages/calling/src/common/testUtil.ts
@@ -52,6 +52,9 @@ export function getTestUtilsWebex() {
           entitlement: {
             models: [{_values: {key: 'bc-sp-standard'}}],
           },
+          developer: {
+            get: jest.fn().mockReturnValue({value: false}),
+          },
         },
       },
       encryption: {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [CAI-7723](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7723)

## This pull request addresses

Updates the name of the feature flag and method name (review comment from previous PR (#4871) on this)

## by making the following changes

* Changed the name of the feature flag in packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
* Updated the import and usage in packages/calling/src/CallingClient/utils/request.ts

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

Ran this in browser dev tools console: `calling.webex.internal.device.features.developer.get('webrtc-calling-over-ws-CALL-219562')?.value` to get this:

<img width="2552" height="1372" alt="Screenshot 2026-04-21 at 8 39 56 PM" src="https://github.com/user-attachments/assets/30574900-aeb2-44b6-81c6-250bf0b9b9c7" />


## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
