### PR TITLE
feat(calling): handle failover and failback for device registration with mobius wss

### DIFF
--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -343,9 +343,11 @@ const MobiusSocket = WebexPlugin.extend({
    * Connect to Mobius for a specific session.
    * @param {string} [webSocketUrl] - Optional websocket URL override. Falls back to the device websocket URL.
    * @param {string} [sessionId=this.defaultSessionId] - The session identifier for this connection.
+   * @param {Object} [options={}] - Connection options.
+   * @param {boolean} [options.singleAttempt=false] - When true, bypass backoff retries and attempt a single connection. On failure the returned promise rejects immediately.
    * @returns {Promise<void>} Resolves when connection flow completes for the session.
    */
-  connect(webSocketUrl, sessionId = this.defaultSessionId) {
+  connect(webSocketUrl, sessionId = this.defaultSessionId, options = {}) {
     if (!this._connectPromises) this._connectPromises = new Map();
 
     // First check if there's already a connection promise for this session
@@ -374,13 +376,23 @@ const MobiusSocket = WebexPlugin.extend({
 
     this.connecting = true;
 
-    this.logger.info(`${this.namespace}: starting connection attempt for ${sessionId}`);
+    const {singleAttempt = false} = options;
+
+    this.logger.info(
+      `${this.namespace}: starting connection attempt for ${sessionId}${
+        singleAttempt ? ' (single attempt, no backoff)' : ''
+      }`
+    );
 
     const connectPromise = Promise.resolve(
       this.webex.internal.device.registered || this.webex.internal.device.register()
     )
       .then(() => {
         this.logger.info(`${this.namespace}: connecting ${sessionId}`);
+
+        if (singleAttempt) {
+          return this._connectSingleAttempt(resolvedUrl, sessionId);
+        }
 
         return this._connectWithBackoff(resolvedUrl, sessionId);
       })
@@ -820,6 +832,33 @@ const MobiusSocket = WebexPlugin.extend({
 
       call.start();
     });
+  },
+
+  _connectSingleAttempt(webSocketUrl, sessionId) {
+    const socket = new Socket();
+    socket.connecting = true;
+    this._attachSocketEventListeners(socket, sessionId);
+    this.sockets.set(sessionId, socket);
+
+    return this._prepareAndOpenSocket(socket, webSocketUrl, sessionId)
+      .then(() => {
+        socket.connecting = false;
+        socket.connected = true;
+        this.connecting = this.hasConnectingSockets();
+        this.connected = this.hasConnectedSockets();
+        this.hasEverConnected = true;
+        this._startTokenRefreshTimer();
+        this._emit(sessionId, 'online');
+      })
+      .catch((err) => {
+        this.lastError = err;
+        socket.connecting = false;
+        socket.connected = false;
+        this.sockets.delete(sessionId);
+        this.connecting = this.hasConnectingSockets();
+        this.connected = this.hasConnectedSockets();
+        throw err;
+      });
   },
 
   _emit(...args) {

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
@@ -568,6 +568,51 @@ describe('plugin-mobius-socket', () => {
           });
         });
       });
+
+      describe('when singleAttempt option is set', () => {
+        it('connects successfully without backoff', () => {
+          const promise = mobiusSocket.connect('ws://example.com', undefined, {singleAttempt: true});
+
+          assert.isTrue(mobiusSocket.connecting, 'MobiusSocket is connecting');
+          mockWebSocket.open();
+
+          return promise.then(() => {
+            assert.isTrue(mobiusSocket.connected, 'MobiusSocket is connected');
+            assert.isFalse(mobiusSocket.connecting, 'MobiusSocket is not connecting');
+            assert.isTrue(mobiusSocket.hasEverConnected, 'hasEverConnected is true');
+            assert.calledOnce(Socket.prototype.open);
+          });
+        });
+
+        it('rejects immediately on failure without retrying', () => {
+          clock.uninstall();
+          socketOpenStub.restore();
+          socketOpenStub = sinon
+            .stub(Socket.prototype, 'open')
+            .returns(Promise.reject(new ConnectionError({code: 4001})));
+
+          const promise = mobiusSocket.connect('ws://example.com', undefined, {singleAttempt: true});
+
+          return assert.isRejected(promise).then(() => {
+            assert.calledOnce(Socket.prototype.open);
+            assert.isFalse(mobiusSocket.connected, 'MobiusSocket is not connected');
+            assert.isFalse(mobiusSocket.connecting, 'MobiusSocket is not connecting');
+          });
+        });
+
+        it('does not use backoff strategy', () => {
+          const backoffSpy = sinon.spy(mobiusSocket, '_connectWithBackoff');
+
+          const promise = mobiusSocket.connect('ws://example.com', undefined, {singleAttempt: true});
+
+          mockWebSocket.open();
+
+          return promise.then(() => {
+            assert.notCalled(backoffSpy);
+            backoffSpy.restore();
+          });
+        });
+      });
     });
 
     describe('Websocket proxy agent', () => {

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -499,7 +499,7 @@ export class Registration implements IRegistration {
     let status;
     for (const mobiusUrl of this.primaryMobiusUris) {
       try {
-        const baseUri = mobiusUrl.replace(URL_ENDPOINT, '/');
+        const baseUri = mobiusUrl.replace(URL_ENDPOINT, '/').replace('wss://', 'https://');
         // eslint-disable-next-line no-await-in-loop
         const response = await this.webex.request({
           uri: `${baseUri}ping`,
@@ -882,6 +882,9 @@ export class Registration implements IRegistration {
         this.initiateFailback();
         break;
       } catch (err: unknown) {
+        // eslint-disable-next-line no-await-in-loop
+        await this.apiRequest.disconnectFromMobiusSocket();
+
         const body = err as WebexRequestPayload;
         // eslint-disable-next-line no-await-in-loop, @typescript-eslint/no-unused-vars
         abort = await handleRegistrationErrors(

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -1099,10 +1099,10 @@ export class Registration implements IRegistration {
 
       const stringToReplace = `${DEVICES_ENDPOINT_RESOURCE}/${restoreData.devices[0].deviceId}`;
 
-      const uri = restoreData.devices[0].uri.replace(stringToReplace, '');
+      let uri = restoreData.devices[0].uri.replace(stringToReplace, '');
 
       if (this.apiRequest.isSocketEnabled()) {
-        uri.replace('https://', 'wss://');
+        uri = uri.replace('https://', 'wss://');
       }
 
       this.setActiveMobiusUrl(uri);

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -479,9 +479,13 @@ export class Registration implements IRegistration {
       }
     } else {
       await uploadLogs();
-      emitFinalFailure((clientError: LineError) => {
-        this.lineEmitter(LINE_EVENTS.ERROR, undefined, clientError);
-      }, loggerContext);
+      emitFinalFailure(
+        (clientError: LineError) => {
+          this.lineEmitter(LINE_EVENTS.ERROR, undefined, clientError);
+        },
+        loggerContext,
+        interval < 0 ? 'Timer threshold exceeded during failover' : undefined
+      );
     }
   }
 
@@ -845,7 +849,7 @@ export class Registration implements IRegistration {
           const wssNormalizedUrl = url.endsWith('/') ? url.slice(0, -1) : url;
 
           // eslint-disable-next-line no-await-in-loop
-          await this.apiRequest.connectToMobiusSocket(wssNormalizedUrl);
+          await this.apiRequest.connectToMobiusSocket(wssNormalizedUrl, {singleAttempt: true});
         }
 
         // eslint-disable-next-line no-await-in-loop
@@ -883,7 +887,7 @@ export class Registration implements IRegistration {
         break;
       } catch (err: unknown) {
         // eslint-disable-next-line no-await-in-loop
-        await this.apiRequest.disconnectFromMobiusSocket();
+        await this.apiRequest.disconnectFromMobiusSocket({code: 3050, reason: 'done (permanent)'});
 
         const body = err as WebexRequestPayload;
         // eslint-disable-next-line no-await-in-loop, @typescript-eslint/no-unused-vars
@@ -1096,6 +1100,11 @@ export class Registration implements IRegistration {
       const stringToReplace = `${DEVICES_ENDPOINT_RESOURCE}/${restoreData.devices[0].deviceId}`;
 
       const uri = restoreData.devices[0].uri.replace(stringToReplace, '');
+
+      if (this.apiRequest.isSocketEnabled()) {
+        uri.replace('https://', 'wss://');
+      }
+
       this.setActiveMobiusUrl(uri);
       this.registrationStatus = RegistrationStatus.ACTIVE;
 

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -604,6 +604,14 @@ export class Registration implements IRegistration {
             method: this.executeFailback.name,
           });
           await this.deregister();
+
+          if (this.apiRequest.isSocketEnabled()) {
+            await this.apiRequest.disconnectFromMobiusSocket({
+              code: 3050,
+              reason: 'done (permanent)',
+            });
+          }
+
           const abort = await this.attemptRegistrationWithServers(FAILBACK_UTIL);
 
           if (this.scheduled429Retry || abort || this.isDeviceRegistered()) {

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -100,8 +100,10 @@ export class APIRequest {
    * On failure, throws a normalized WebexRequestPayload-shaped error.
    *
    * @param wssUrl - The Mobius WebSocket URL to connect to.
+   * @param options - Connection options.
+   * @param options.singleAttempt - When true, bypass backoff retries and attempt a single connection. On failure the returned promise rejects immediately.
    */
-  public async connectToMobiusSocket(wssUrl: string): Promise<void> {
+  public async connectToMobiusSocket(wssUrl: string, {singleAttempt = false} = {}): Promise<void> {
     const logContext = {
       file: REQUEST_FILE,
       method: METHODS.CONNECT_TO_MOBIUS_SOCKET,
@@ -116,7 +118,7 @@ export class APIRequest {
     log.info('Mobius WebSocket not connected, initiating connection', logContext);
 
     try {
-      await this.mobiusSocket.connect(wssUrl);
+      await this.mobiusSocket.connect(wssUrl, undefined, {singleAttempt});
       log.log('Mobius WebSocket connected successfully', logContext);
     } catch (err) {
       log.warn(`Mobius WebSocket connection failed: ${String(err)}`, logContext);
@@ -127,14 +129,14 @@ export class APIRequest {
   /**
    * Disconnects the default session from the Mobius WebSocket.
    */
-  public async disconnectFromMobiusSocket(): Promise<void> {
+  public async disconnectFromMobiusSocket(options?: {code: number; reason: string}): Promise<void> {
     const logContext = {
       file: REQUEST_FILE,
       method: 'disconnectFromMobiusSocket',
     };
 
     try {
-      await this.mobiusSocket.disconnect();
+      await this.mobiusSocket.disconnect(options);
       log.log('Mobius WebSocket disconnected successfully', logContext);
     } catch (err) {
       // silent error - no need to throw an error

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -125,6 +125,24 @@ export class APIRequest {
   }
 
   /**
+   * Disconnects the default session from the Mobius WebSocket.
+   */
+  public async disconnectFromMobiusSocket(): Promise<void> {
+    const logContext = {
+      file: REQUEST_FILE,
+      method: 'disconnectFromMobiusSocket',
+    };
+
+    try {
+      await this.mobiusSocket.disconnect();
+      log.log('Mobius WebSocket disconnected successfully', logContext);
+    } catch (err) {
+      // silent error - no need to throw an error
+      log.warn(`Mobius WebSocket disconnection failed: ${String(err)}`, logContext);
+    }
+  }
+
+  /**
    * Makes a request using HTTP or WebSocket transport per the flag set in the constructor.
    * When using WebSocket, the response is normalized to the WebexRequestPayload shape
    * so callers do not need to know which transport was used.

--- a/packages/calling/src/common/Utils.ts
+++ b/packages/calling/src/common/Utils.ts
@@ -305,13 +305,23 @@ function updateErrorContext(
  * @param caller - Method which called this handler.
  * @param file - File name from where error got reported.
  */
-export function emitFinalFailure(emitterCb: LineErrorEmitterCallback, loggerContext: LogContext) {
-  const clientError = createLineError('', {}, ERROR_TYPE.DEFAULT, RegistrationStatus.INACTIVE);
+export function emitFinalFailure(
+  emitterCb: LineErrorEmitterCallback,
+  loggerContext: LogContext,
+  message?: string
+) {
+  const clientError = createLineError(
+    message || '',
+    {},
+    ERROR_TYPE.DEFAULT,
+    RegistrationStatus.INACTIVE
+  );
 
   updateLineErrorContext(
     loggerContext,
     ERROR_TYPE.SERVICE_UNAVAILABLE,
-    'An unknown error occurred. Wait a moment and try again. Please contact the administrator if the problem persists.',
+    message ||
+      'An unknown error occurred. Wait a moment and try again. Please contact the administrator if the problem persists.',
     RegistrationStatus.INACTIVE,
     clientError
   );


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [CAI-7845](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7845) >

## This pull request addresses

Adds the logic to handle the device registration during normal flow along with failover and failback flows for mobius wss.

## by making the following changes

Connects to socket and attempt the registration and on failure, disconnects the current wss connection and connect to the next uri and attempt the registration. Rest of the flows are intact.

Making sure that the `/ping` requests are always made to the REST endpoint. This is required to check if the primary is up or not before attempting the failback logic.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested the failover logic by manually blocking the register request through wss

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Cursor 
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
