### PR TITLE
feat(plugin-meetings): add support for BREAKOUT_ENDED

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -103,6 +103,7 @@ export const _JOINED_ = 'JOINED';
 export const _LOCUS_ID_ = 'LOCUS_ID';
 export const _LEFT_ = 'LEFT';
 export const _MOVED_ = 'MOVED';
+export const _BREAKOUT_ENDED_ = 'BREAKOUT_ENDED';
 export const _ON_HOLD_LOBBY_ = 'ON_HOLD_LOBBY';
 export const _MEETING_LINK_ = 'MEETING_LINK';
 export const _MEETING_UUID_ = 'MEETING_UUID';

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -1635,7 +1635,7 @@ export default class LocusInfo extends EventsScope {
    * @memberof LocusInfo
    */
   updateLocusInfo(locus) {
-    if (locus.self?.reason === 'MOVED' && locus.self?.state === 'LEFT') {
+    if (MeetingsUtil.isSelfMovedOrBreakoutEnded(locus)) {
       // When moved to a breakout session locus sends a message for the previous locus
       // indicating that we have been moved. It isn't helpful to continue parsing this
       // as it gets interpreted as if we have left the call

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -315,7 +315,7 @@ export default class Meetings extends WebexPlugin {
     const breakoutLocus = this.meetingCollection.getActiveBreakoutLocus(breakoutUrl);
 
     const isSelfJoined = newLocus?.self?.state === _JOINED_;
-    const isSelfMoved = newLocus?.self?.state === _LEFT_ && newLocus?.self?.reason === _MOVED_;
+    const isSelfMoved = MeetingsUtil.isSelfMovedOrBreakoutEnded(newLocus);
     // @ts-ignore
     const deviceFromNewLocus = MeetingsUtil.getThisDevice(newLocus, this.webex.internal.device.url);
     const isResourceMovedOnThisDevice =
@@ -392,7 +392,7 @@ export default class Meetings extends WebexPlugin {
   private isNeedHandleLocusDTO(meeting: any, newLocus: any) {
     if (newLocus) {
       const isNewLocusAsBreakout = MeetingsUtil.isBreakoutLocusDTO(newLocus);
-      const isSelfMoved = newLocus?.self?.state === _LEFT_ && newLocus?.self?.reason === _MOVED_;
+      const isSelfMoved = MeetingsUtil.isSelfMovedOrBreakoutEnded(newLocus);
       const isSelfMovedToLobby =
         newLocus?.self?.devices[0]?.intent?.reason === _ON_HOLD_LOBBY_ &&
         newLocus?.self?.devices[0]?.intent?.type === _WAIT_;

--- a/packages/@webex/plugin-meetings/src/meetings/util.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/util.ts
@@ -7,6 +7,7 @@ import {
   _LEFT_,
   DESTINATION_TYPE,
   _MOVED_,
+  _BREAKOUT_ENDED_,
   BREAKOUTS,
   EVENT_TRIGGERS,
   LOCUS,
@@ -264,6 +265,23 @@ MeetingsUtil.getThisDevice = (newLocus: any, deviceUrl: string) => {
   }
 
   return null;
+};
+
+/**
+ * Checks if the self state in a locus indicates a breakout move or breakout end.
+ * Returns true when:
+ * - self state is LEFT with reason MOVED (regular breakout move), OR
+ * - fullState is INACTIVE with endMeetingReason BREAKOUT_ENDED (breakout session ended)
+ * @param {Object} locus locus data
+ * @returns {boolean}
+ */
+MeetingsUtil.isSelfMovedOrBreakoutEnded = (locus: any): boolean => {
+  const isSelfLeftMoved = locus?.self?.state === _LEFT_ && locus?.self?.reason === _MOVED_;
+  const isBreakoutEnded =
+    locus?.fullState?.state === LOCUS.STATE.INACTIVE &&
+    locus?.fullState?.endMeetingReason === _BREAKOUT_ENDED_;
+
+  return isSelfLeftMoved || isBreakoutEnded;
 };
 
 /**

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -13,6 +13,7 @@ import MediaSharesUtils from '@webex/plugin-meetings/src/locus-info//mediaShares
 import LocusDeltaParser from '@webex/plugin-meetings/src/locus-info/parser';
 import Metrics from '@webex/plugin-meetings/src/metrics';
 import * as HashTreeParserModule from '@webex/plugin-meetings/src/hashTree/hashTreeParser';
+import MeetingsUtil from '@webex/plugin-meetings/src/meetings/util';
 
 import {
   LOCUSINFO,
@@ -3693,49 +3694,23 @@ describe('plugin-meetings', () => {
         assert.deepEqual(callOrder, ['updateLocusUrl', 'updateMeetingInfo']);
       });
 
-      it('#updateLocusInfo ignores breakout LEFT message', () => {
-        const newLocus = {
-          self: {
-            reason: 'MOVED',
-            state: 'LEFT',
-          },
-        };
+      it('#updateLocusInfo ignores locus when isSelfMovedOrBreakoutEnded returns true', () => {
+        const newLocus = {self: {state: 'JOINED'}};
+
+        sinon.stub(MeetingsUtil, 'isSelfMovedOrBreakoutEnded').returns(true);
 
         locusInfo.updateControls = sinon.stub();
-        locusInfo.updateConversationUrl = sinon.stub();
-        locusInfo.updateCreated = sinon.stub();
         locusInfo.updateFullState = sinon.stub();
-        locusInfo.updateHostInfo = sinon.stub();
-        locusInfo.updateMeetingInfo = sinon.stub();
-        locusInfo.updateMediaShares = sinon.stub();
-        locusInfo.updateReplaces = sinon.stub();
         locusInfo.updateSelf = sinon.stub();
-        locusInfo.updateLocusUrl = sinon.stub();
-        locusInfo.updateAclUrl = sinon.stub();
-        locusInfo.updateBasequence = sinon.stub();
-        locusInfo.updateSequence = sinon.stub();
-        locusInfo.updateEmbeddedApps = sinon.stub();
-        locusInfo.updateLinks = sinon.stub();
-        locusInfo.compareAndUpdate = sinon.stub();
 
         locusInfo.updateLocusInfo(newLocus);
 
+        assert.calledOnceWithExactly(MeetingsUtil.isSelfMovedOrBreakoutEnded, newLocus);
         assert.notCalled(locusInfo.updateControls);
-        assert.notCalled(locusInfo.updateConversationUrl);
-        assert.notCalled(locusInfo.updateCreated);
         assert.notCalled(locusInfo.updateFullState);
-        assert.notCalled(locusInfo.updateHostInfo);
-        assert.notCalled(locusInfo.updateMeetingInfo);
-        assert.notCalled(locusInfo.updateMediaShares);
-        assert.notCalled(locusInfo.updateReplaces);
         assert.notCalled(locusInfo.updateSelf);
-        assert.notCalled(locusInfo.updateLocusUrl);
-        assert.notCalled(locusInfo.updateAclUrl);
-        assert.notCalled(locusInfo.updateBasequence);
-        assert.notCalled(locusInfo.updateSequence);
-        assert.notCalled(locusInfo.updateEmbeddedApps);
-        assert.notCalled(locusInfo.updateLinks);
-        assert.notCalled(locusInfo.compareAndUpdate);
+
+        MeetingsUtil.isSelfMovedOrBreakoutEnded.restore();
       });
 
       it('#updateLocusInfo puts the Locus DTO top level properties at the right place in LocusInfo class', () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -3581,6 +3581,21 @@ describe('plugin-meetings', () => {
           'Meetings:index#isNeedHandleMainLocus --> self device left&moved in main locus with self joined status, not need to handle'
         );
       });
+
+      it('check breakout ended with self removed, return false', () => {
+        webex.meetings.meetingCollection.getActiveBreakoutLocus = sinon.stub().returns(null);
+        newLocus.self.state = 'LEFT';
+        newLocus.self.reason = 'OTHER';
+        newLocus.self.removed = true;
+        newLocus.fullState = {state: 'INACTIVE', endMeetingReason: 'BREAKOUT_ENDED'};
+        LoggerProxy.logger.log = sinon.stub();
+        const result = webex.meetings.isNeedHandleMainLocus(meeting, newLocus);
+        assert.equal(result, false);
+        assert.calledWith(
+          LoggerProxy.logger.log,
+          'Meetings:index#isNeedHandleMainLocus --> self moved main locus with self removed status or with device resource moved, not need to handle'
+        );
+      });
     });
 
     describe('#isNeedHandleLocusDTO', () => {
@@ -3637,6 +3652,18 @@ describe('plugin-meetings', () => {
         newLocus.self.state = 'LEFT';
         newLocus.self.reason = 'MOVED';
         newLocus.self.devices = [];
+        LoggerProxy.logger.log = sinon.stub();
+        const result = webex.meetings.isNeedHandleLocusDTO(meeting, newLocus);
+        assert.equal(result, false);
+      });
+      it('breakout session with breakout ended, return false', () => {
+        newLocus.controls.breakout = {
+          sessionType: 'BREAKOUT',
+        };
+        newLocus.self.state = 'LEFT';
+        newLocus.self.reason = 'OTHER';
+        newLocus.self.devices = [];
+        newLocus.fullState = {state: 'INACTIVE', endMeetingReason: 'BREAKOUT_ENDED'};
         LoggerProxy.logger.log = sinon.stub();
         const result = webex.meetings.isNeedHandleLocusDTO(meeting, newLocus);
         assert.equal(result, false);

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
@@ -238,6 +238,22 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#isSelfMovedOrBreakoutEnded', () => {
+      [
+        {description: 'locus is undefined', locus: undefined, expected: false},
+        {description: 'self state is JOINED', locus: {self: {state: 'JOINED', reason: 'OTHER'}}, expected: false},
+        {description: 'self state is LEFT with reason MOVED', locus: {self: {state: 'LEFT', reason: 'MOVED'}}, expected: true},
+        {description: 'fullState is INACTIVE with BREAKOUT_ENDED', locus: {self: {state: 'LEFT', reason: 'OTHER'}, fullState: {state: 'INACTIVE', endMeetingReason: 'BREAKOUT_ENDED'}}, expected: true},
+        {description: 'fullState is INACTIVE with different endMeetingReason', locus: {self: {state: 'LEFT', reason: 'OTHER'}, fullState: {state: 'INACTIVE', endMeetingReason: 'SOME_OTHER_REASON'}}, expected: false},
+        {description: 'fullState is missing', locus: {self: {state: 'LEFT', reason: 'OTHER'}}, expected: false},
+        {description: 'endMeetingReason is missing', locus: {self: {state: 'LEFT', reason: 'OTHER'}, fullState: {state: 'INACTIVE'}}, expected: false},
+      ].forEach(({description, locus, expected}) => {
+        it(`returns ${expected} when ${description}`, () => {
+          assert.equal(MeetingsUtil.isSelfMovedOrBreakoutEnded(locus), expected);
+        });
+      });
+    });
+
     describe('#joinedOnThisDevice', () => {
       it('return false if no devices in self', () => {
         const newLocus = {};


### PR DESCRIPTION
# COMPLETES #[SPARK-798051](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-798051)

## This pull request addresses
Locus added a new way to signal that breakout has ended, see the details here:
https://confluence-eng-gpk2.cisco.com/conf/x/79ORMQ
and here:
https://confluence-eng-gpk2.cisco.com/conf/spaces/LOCUS/pages/831641563/Locus+API+Release+Notes+10980-260418-f2cbf

## by making the following changes
added checks for BREAKOUT_ENDED in the same places that we do checks for state=LEFT, reason=MOVED

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
