### PR TITLE
fix(internal-plugin-mobius-socket): use config-driven initial Mobius retries

### DIFF
--- a/packages/@webex/internal-plugin-mobius-socket/package.json
+++ b/packages/@webex/internal-plugin-mobius-socket/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "devMain": "src/index.js",
+  "files": ["package.json", "dist"],
   "repository": {
     "type": "git",
     "url": "https://github.com/webex/webex-js-sdk.git",

--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -315,6 +315,21 @@ const MobiusSocket = WebexPlugin.extend({
   },
 
   /**
+   * Get the websocket URL for a currently connected session.
+   * @param {string} [sessionId=this.defaultSessionId] - The session identifier.
+   * @returns {string|undefined} The connected websocket URL, or undefined when not connected.
+   */
+  getConnectedWebSocketUrl(sessionId = this.defaultSessionId) {
+    const socket = this.getSocket(sessionId);
+
+    if (!socket?.connected) {
+      return undefined;
+    }
+
+    return socket.url;
+  },
+
+  /**
    * Sends a payload on the active connected socket
    * @param {Object} payload - The data to send
    * @param {string} [sessionId=this.defaultSessionId] - The session identifier

--- a/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/src/mobius-socket.js
@@ -141,6 +141,11 @@ const MobiusSocket = WebexPlugin.extend({
     );
   },
 
+  /**
+   * Returns the per-session cache of seen async_event IDs, creating it on first access.
+   * @param {string} sessionId - The session identifier.
+   * @returns {Map<string, boolean>} Ordered cache of seen event IDs for the session.
+   */
   _getSeenAsyncEventIds(sessionId) {
     let seenAsyncEventIds = this._seenAsyncEventIdsBySession.get(sessionId);
 
@@ -152,6 +157,11 @@ const MobiusSocket = WebexPlugin.extend({
     return seenAsyncEventIds;
   },
 
+  /**
+   * Clears the dedup cache for one session or for all sessions when omitted.
+   * @param {string} [sessionId] - Optional session identifier.
+   * @returns {void}
+   */
   _clearSeenAsyncEventIds(sessionId) {
     if (sessionId) {
       this._seenAsyncEventIdsBySession.delete(sessionId);
@@ -162,6 +172,12 @@ const MobiusSocket = WebexPlugin.extend({
     this._seenAsyncEventIdsBySession.clear();
   },
 
+  /**
+   * Tracks a newly seen async_event ID and reports whether a duplicate should be suppressed.
+   * @param {string} sessionId - The session identifier.
+   * @param {object} envelope - Parsed websocket message envelope.
+   * @returns {boolean} True when the event has already been seen for this session.
+   */
   _trackAsyncEventAndShouldSuppressDuplicate(sessionId, envelope) {
     if (envelope?.type !== 'async_event' || !envelope.eventId) {
       return false;
@@ -406,11 +422,9 @@ const MobiusSocket = WebexPlugin.extend({
    * Connect to Mobius for a specific session.
    * @param {string} [webSocketUrl] - Optional websocket URL override. Falls back to the device websocket URL.
    * @param {string} [sessionId=this.defaultSessionId] - The session identifier for this connection.
-   * @param {Object} [options={}] - Connection options.
-   * @param {boolean} [options.singleAttempt=false] - When true, bypass backoff retries and attempt a single connection. On failure the returned promise rejects immediately.
    * @returns {Promise<void>} Resolves when connection flow completes for the session.
    */
-  connect(webSocketUrl, sessionId = this.defaultSessionId, options = {}) {
+  connect(webSocketUrl, sessionId = this.defaultSessionId) {
     if (!this._connectPromises) this._connectPromises = new Map();
 
     // First check if there's already a connection promise for this session
@@ -439,11 +453,11 @@ const MobiusSocket = WebexPlugin.extend({
 
     this.connecting = true;
 
-    const {singleAttempt = false} = options;
-
     this.logger.info(
       `${this.namespace}: starting connection attempt for ${sessionId}${
-        singleAttempt ? ' (single attempt, no backoff)' : ''
+        Number(this.config.initialConnectionMaxRetries) === 0 && !this.hasEverConnected
+          ? ' (initial retries disabled)'
+          : ''
       }`
     );
 
@@ -452,10 +466,6 @@ const MobiusSocket = WebexPlugin.extend({
     )
       .then(() => {
         this.logger.info(`${this.namespace}: connecting ${sessionId}`);
-
-        if (singleAttempt) {
-          return this._connectSingleAttempt(resolvedUrl, sessionId);
-        }
 
         return this._connectWithBackoff(resolvedUrl, sessionId);
       })
@@ -791,6 +801,13 @@ const MobiusSocket = WebexPlugin.extend({
       // eslint gets confused about whether call is actually used
       // eslint-disable-next-line prefer-const
       let call;
+      const isInitialConnect = !isShutdownSwitchover && !this.hasEverConnected;
+      const initialRetryLimit =
+        this.config.initialConnectionMaxRetries == null
+          ? null
+          : Number(this.config.initialConnectionMaxRetries);
+      const isInitialConnectWithoutRetries = isInitialConnect && initialRetryLimit === 0;
+
       const onComplete = (err, sid = sessionId) => {
         if (isShutdownSwitchover) {
           this._shutdownSwitchoverBackoffCalls.delete(sid);
@@ -851,12 +868,10 @@ const MobiusSocket = WebexPlugin.extend({
         })
       );
 
-      if (
-        this.config.initialConnectionMaxRetries &&
-        !this.hasEverConnected &&
-        !isShutdownSwitchover
-      ) {
-        call.failAfter(this.config.initialConnectionMaxRetries);
+      if (isInitialConnectWithoutRetries) {
+        call.retryIf(() => false);
+      } else if (isInitialConnect && initialRetryLimit > 0) {
+        call.failAfter(initialRetryLimit);
       } else if (this.config.maxRetries) {
         call.failAfter(this.config.maxRetries);
       }
@@ -878,6 +893,16 @@ const MobiusSocket = WebexPlugin.extend({
 
       call.on('callback', (err) => {
         if (err) {
+          if (isInitialConnectWithoutRetries) {
+            // retryIf(() => false) already disabled retries for this initial connect;
+            // this branch only avoids logging the generic "attempting retry" message.
+            this.logger.info(
+              `${this.namespace}: initial connect failed for ${sessionId}; retries already disabled`
+            );
+
+            return;
+          }
+
           const number = call.getNumRetries();
           const delay = Math.min(call.strategy_.nextBackoffDelay_, this.config.backoffTimeMax);
 
@@ -900,33 +925,6 @@ const MobiusSocket = WebexPlugin.extend({
 
       call.start();
     });
-  },
-
-  _connectSingleAttempt(webSocketUrl, sessionId) {
-    const socket = new Socket();
-    socket.connecting = true;
-    this._attachSocketEventListeners(socket, sessionId);
-    this.sockets.set(sessionId, socket);
-
-    return this._prepareAndOpenSocket(socket, webSocketUrl, sessionId)
-      .then(() => {
-        socket.connecting = false;
-        socket.connected = true;
-        this.connecting = this.hasConnectingSockets();
-        this.connected = this.hasConnectedSockets();
-        this.hasEverConnected = true;
-        this._startTokenRefreshTimer();
-        this._emit(sessionId, 'online');
-      })
-      .catch((err) => {
-        this.lastError = err;
-        socket.connecting = false;
-        socket.connected = false;
-        this.sockets.delete(sessionId);
-        this.connecting = this.hasConnectingSockets();
-        this.connected = this.hasConnectedSockets();
-        throw err;
-      });
   },
 
   _emit(...args) {

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
@@ -1068,6 +1068,29 @@ describe('plugin-mobius-socket', () => {
       });
     });
 
+    describe('#getConnectedWebSocketUrl()', () => {
+      it('returns the connected websocket url for the session', () => {
+        mobiusSocket.sockets.set(mobiusSocket.defaultSessionId, {
+          connected: true,
+          url: 'ws://connected-url.com',
+        });
+
+        assert.equal(
+          mobiusSocket.getConnectedWebSocketUrl(),
+          'ws://connected-url.com'
+        );
+      });
+
+      it('returns undefined when the session is not connected', () => {
+        mobiusSocket.sockets.set(mobiusSocket.defaultSessionId, {
+          connected: false,
+          url: 'ws://disconnected-url.com',
+        });
+
+        assert.isUndefined(mobiusSocket.getConnectedWebSocketUrl());
+      });
+    });
+
     describe('#_emit()', () => {
       it('emits Error-safe events and log the error with the call parameters', () => {
         const error = 'error';

--- a/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
+++ b/packages/@webex/internal-plugin-mobius-socket/test/unit/spec/mobius-socket.js
@@ -142,6 +142,8 @@ describe('plugin-mobius-socket', () => {
 
       mobiusSocket = webex.internal.mobiusSocket;
       mobiusSocket.defaultSessionId = 'mobius-websocket-session';
+      mobiusSocket.config.initialConnectionMaxRetries = mobiusConfig.mobiusSocket.initialConnectionMaxRetries;
+      mobiusSocket.config.maxRetries = mobiusConfig.mobiusSocket.maxRetries;
     });
 
     afterEach(async () => {
@@ -357,12 +359,27 @@ describe('plugin-mobius-socket', () => {
         });
 
         // skipping due to apparent bug with lolex in all browsers but Chrome.
-        // if initial retries is zero and mobiusSocket has never connected max retries is used
-        skipInBrowser(it)('fails after `maxRetries` attempts', () => {
+        // if initial retries is zero and mobiusSocket has never connected, do not retry
+        skipInBrowser(it)('fails immediately when `initialConnectionMaxRetries` is 0', () => {
           mobiusSocket.config.maxRetries = 2;
           mobiusSocket.config.initialConnectionMaxRetries = 0;
 
-          return check();
+          socketOpenStub.restore();
+          socketOpenStub = sinon.stub(Socket.prototype, 'open');
+          socketOpenStub.returns(Promise.reject(new ConnectionError()));
+          assert.notCalled(Socket.prototype.open);
+
+          const promise = mobiusSocket.connect();
+
+          return promiseTick(5)
+            .then(() => {
+              assert.calledOnce(Socket.prototype.open);
+
+              return assert.isRejected(promise);
+            })
+            .then(() => {
+              assert.calledOnce(Socket.prototype.open);
+            });
         });
 
         // initial retries is non-zero so takes precedence over maxRetries when mobiusSocket has never connected
@@ -589,9 +606,11 @@ describe('plugin-mobius-socket', () => {
         });
       });
 
-      describe('when singleAttempt option is set', () => {
-        it('connects successfully without backoff', () => {
-          const promise = mobiusSocket.connect('ws://example.com', undefined, {singleAttempt: true});
+      describe('when config.initialConnectionMaxRetries is set to 0', () => {
+        it('connects successfully through the shared backoff flow', () => {
+          const backoffSpy = sinon.spy(mobiusSocket, '_connectWithBackoff');
+          mobiusSocket.config.initialConnectionMaxRetries = 0;
+          const promise = mobiusSocket.connect('ws://example.com');
 
           assert.isTrue(mobiusSocket.connecting, 'MobiusSocket is connecting');
           mockWebSocket.open();
@@ -601,6 +620,9 @@ describe('plugin-mobius-socket', () => {
             assert.isFalse(mobiusSocket.connecting, 'MobiusSocket is not connecting');
             assert.isTrue(mobiusSocket.hasEverConnected, 'hasEverConnected is true');
             assert.calledOnce(Socket.prototype.open);
+            assert.calledOnce(backoffSpy);
+            assert.isUndefined(backoffSpy.firstCall.args[2]?.initialConnectionMaxRetries);
+            backoffSpy.restore();
           });
         });
 
@@ -610,25 +632,27 @@ describe('plugin-mobius-socket', () => {
           socketOpenStub = sinon
             .stub(Socket.prototype, 'open')
             .returns(Promise.reject(new ConnectionError({code: 4001})));
+          mobiusSocket.config.initialConnectionMaxRetries = 0;
 
-          const promise = mobiusSocket.connect('ws://example.com', undefined, {singleAttempt: true});
+          const promise = mobiusSocket.connect('ws://example.com');
 
           return assert.isRejected(promise).then(() => {
             assert.calledOnce(Socket.prototype.open);
             assert.isFalse(mobiusSocket.connected, 'MobiusSocket is not connected');
-            assert.isFalse(mobiusSocket.connecting, 'MobiusSocket is not connecting');
           });
         });
 
-        it('does not use backoff strategy', () => {
+        it('uses config-driven initial retry behavior in the shared backoff strategy', () => {
           const backoffSpy = sinon.spy(mobiusSocket, '_connectWithBackoff');
+          mobiusSocket.config.initialConnectionMaxRetries = 0;
 
-          const promise = mobiusSocket.connect('ws://example.com', undefined, {singleAttempt: true});
+          const promise = mobiusSocket.connect('ws://example.com');
 
           mockWebSocket.open();
 
           return promise.then(() => {
-            assert.notCalled(backoffSpy);
+            assert.calledOnce(backoffSpy);
+            assert.isUndefined(backoffSpy.firstCall.args[2]?.initialConnectionMaxRetries);
             backoffSpy.restore();
           });
         });
@@ -877,10 +901,7 @@ describe('plugin-mobius-socket', () => {
             const error = await assert.isRejected(promise);
             const lastError = mobiusSocket.getLastError();
 
-            assert.equal(
-              error.message,
-              `MobiusSocket Connection Aborted for ${mobiusSocket.defaultSessionId}`
-            );
+            assert.equal(error, realError);
             assert.isDefined(lastError);
             assert.equal(lastError, realError);
           });

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -857,7 +857,7 @@ export class Registration implements IRegistration {
           const wssNormalizedUrl = url.endsWith('/') ? url.slice(0, -1) : url;
 
           // eslint-disable-next-line no-await-in-loop
-          await this.apiRequest.connectToMobiusSocket(wssNormalizedUrl, {singleAttempt: true});
+          await this.apiRequest.connectToMobiusSocket(wssNormalizedUrl);
         }
 
         // eslint-disable-next-line no-await-in-loop

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -100,10 +100,8 @@ export class APIRequest {
    * On failure, throws a normalized WebexRequestPayload-shaped error.
    *
    * @param wssUrl - The Mobius WebSocket URL to connect to.
-   * @param options - Connection options.
-   * @param options.singleAttempt - When true, bypass backoff retries and attempt a single connection. On failure the returned promise rejects immediately.
    */
-  public async connectToMobiusSocket(wssUrl: string, {singleAttempt = false} = {}): Promise<void> {
+  public async connectToMobiusSocket(wssUrl: string): Promise<void> {
     const logContext = {
       file: REQUEST_FILE,
       method: METHODS.CONNECT_TO_MOBIUS_SOCKET,
@@ -118,7 +116,7 @@ export class APIRequest {
     log.info('Mobius WebSocket not connected, initiating connection', logContext);
 
     try {
-      await this.mobiusSocket.connect(wssUrl, undefined, {singleAttempt});
+      await this.mobiusSocket.connect(wssUrl);
       log.log('Mobius WebSocket connected successfully', logContext);
     } catch (err) {
       log.warn(`Mobius WebSocket connection failed: ${String(err)}`, logContext);


### PR DESCRIPTION
# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7852

## This pull request addresses

Mobius socket initial connection retry behavior was being controlled through ad hoc call-site logic instead of the existing config path. In practice, setting `initialConnectionMaxRetries` to `0` did not disable retries on the first connect because the old check treated `0` as falsy and fell through to the reconnect retry path.

## by making the following changes

- removes the special single-attempt connect path and keeps initial retry behavior config-driven
- updates the shared Mobius backoff flow so `config.initialConnectionMaxRetries === 0` means no retries for the initial connect
- preserves reconnect behavior through the existing `maxRetries` handling
- simplifies the retry-limit setup in `mobius-socket.js` and clarifies the callback logging around the no-retry case
- updates calling registration/request call sites and Mobius socket unit tests to match the config-driven behavior

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

- `yarn test:unit` in `packages/@webex/internal-plugin-mobius-socket`
- verified initial connect uses `initialConnectionMaxRetries` from config
- verified `initialConnectionMaxRetries = 0` disables retries for the first connect
- verified reconnect behavior still goes through `maxRetries`
- updated and ran unit tests covering inflight disconnect and config-driven no-retry behavior

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

Tool used: Codex

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly