### PR TITLE
fix(meetings): fetching the correct locus url

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -810,8 +810,6 @@ export default class Meeting extends StatelessWebexPlugin {
   private logUploadIntervalIndex: number;
   private mediaServerIp: string;
   private llmHealthCheckTimer?: ReturnType<typeof setTimeout>;
-  private returnToMainRoapLocus?: LocusDTO;
-  private returnToMainSelfUrlPromise?: Promise<string>;
 
   /**
    * @param {Object} attrs
@@ -4068,108 +4066,6 @@ export default class Meeting extends StatelessWebexPlugin {
       Object.keys(object).forEach((key) => {
         this[key] = object[key];
       });
-    }
-  }
-
-  /**
-   * Marks that ROAP should resolve the main session selfUrl before sending because
-   * the current breakout locus has ended and may no longer accept /media requests.
-   * @param {LocusDTO} closedBreakoutLocus closed breakout locus
-   * @returns {void}
-   * @public
-   * @memberof Meeting
-   */
-  public updateClosedBreakoutLocus(closedBreakoutLocus: LocusDTO) {
-    this.returnToMainRoapLocus = closedBreakoutLocus;
-  }
-
-  /**
-   * Returns the selfUrl that ROAP /media should target.
-   * In the normal case this is just meeting.selfUrl. During a confirmed
-   * breakout-ended transition we first resolve the main session participant
-   * selfUrl so ROAP is not sent to the inactive breakout locus.
-   * @returns {Promise<string>}
-   * @public
-   * @memberof Meeting
-   */
-  public async resolveRoapMediaSelfUrl(): Promise<string> {
-    const closedBreakoutLocus = this.returnToMainRoapLocus;
-
-    if (!closedBreakoutLocus) {
-      if (!this.selfUrl) {
-        throw new Error('Cannot send ROAP: meeting selfUrl is not available');
-      }
-
-      return this.selfUrl;
-    }
-
-    if (!this.returnToMainSelfUrlPromise) {
-      this.returnToMainSelfUrlPromise = (async () => {
-        const cachedMainLocus = this.locusInfo?.mainSessionLocusCache;
-        let mainLocus =
-          cachedMainLocus?.self?.url &&
-          cachedMainLocus?.controls?.breakout?.sessionType !== BREAKOUTS.SESSION_TYPES.BREAKOUT &&
-          !cachedMainLocus?.self?.removed
-            ? cachedMainLocus
-            : undefined;
-
-        if (!mainLocus) {
-          const mainLocusUrl =
-            this.breakouts?.mainLocusUrl ||
-            cachedMainLocus?.url ||
-            MeetingsUtil.getThisDevice(closedBreakoutLocus, this.deviceUrl)?.replaces?.[0]
-              ?.locusUrl;
-
-          if (!mainLocusUrl) {
-            throw new Error('Cannot send ROAP: main locus URL is not available');
-          }
-
-          const response = await this.meetingRequest.getLocusDTO({url: mainLocusUrl});
-
-          mainLocus = response.body;
-        }
-
-        if (
-          !mainLocus?.self?.url ||
-          mainLocus?.controls?.breakout?.sessionType === BREAKOUTS.SESSION_TYPES.BREAKOUT ||
-          mainLocus?.self?.removed
-        ) {
-          throw new Error('Cannot send ROAP: main locus does not contain usable selfUrl');
-        }
-
-        const currentLocusUrl = this.locusUrl;
-
-        if (
-          currentLocusUrl &&
-          closedBreakoutLocus.url &&
-          mainLocus.url &&
-          currentLocusUrl !== closedBreakoutLocus.url &&
-          currentLocusUrl !== mainLocus.url
-        ) {
-          throw new Error(
-            'Cannot send ROAP: meeting moved to another locus during breakout return'
-          );
-        }
-
-        this.locusInfo.updateMainSessionLocusCache(mainLocus);
-        this.locusInfo.onFullLocus('return-to-main media selfUrl before ROAP', mainLocus);
-
-        if (this.selfUrl !== mainLocus.self.url) {
-          this.updateMeetingObject({selfUrl: mainLocus.self.url});
-        }
-
-        return mainLocus.self.url;
-      })();
-    }
-
-    try {
-      const selfUrl = await this.returnToMainSelfUrlPromise;
-
-      this.returnToMainRoapLocus = undefined;
-
-      return selfUrl;
-    } finally {
-      this.returnToMainSelfUrlPromise = undefined;
     }
   }
 
@@ -8663,7 +8559,7 @@ export default class Meeting extends StatelessWebexPlugin {
           regionCode: this.webex.meetings.geoHintInfo?.regionCode,
         },
         preferTranscoding: !this.isMultistream,
-        resolveMediaSelfUrl: () => this.resolveRoapMediaSelfUrl(),
+        getCurrentSelfUrl: () => this.selfUrl,
       },
       {
         // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -740,6 +740,7 @@ export default class Meeting extends StatelessWebexPlugin {
   isMoveToInProgress = false;
   registrationIdStatus: string;
   brbState: BrbState;
+  private promisesWaitingForPropUpdate: Record<string, Defer> = {};
 
   voiceaListenerCallbacks: object = {
     [VOICEAEVENTS.VOICEA_ANNOUNCEMENT]: (payload: Transcription['languageOptions']) => {
@@ -4065,6 +4066,11 @@ export default class Meeting extends StatelessWebexPlugin {
     if (object && Object.keys(object).length) {
       Object.keys(object).forEach((key) => {
         this[key] = object[key];
+
+        if (this.promisesWaitingForPropUpdate[key]) {
+          this.promisesWaitingForPropUpdate[key].resolve();
+          delete this.promisesWaitingForPropUpdate[key];
+        }
       });
     }
   }
@@ -8560,12 +8566,36 @@ export default class Meeting extends StatelessWebexPlugin {
         },
         preferTranscoding: !this.isMultistream,
         getCurrentSelfUrl: () => this.selfUrl,
+        waitForSelfUrlChange: () => this.waitForSelfUrlChange(),
       },
       {
         // @ts-ignore
         parent: this.webex,
       }
     );
+  }
+
+  /**
+   * Waits for LocusInfo to update meeting.selfUrl, with a timeout fallback.
+   * @returns {Promise<void>}
+   * @private
+   * @memberof Meeting
+   */
+  private waitForSelfUrlChange(): Promise<void> {
+    if (!this.promisesWaitingForPropUpdate.selfUrl) {
+      const pendingSelfUrlUpdate = new Defer();
+
+      this.promisesWaitingForPropUpdate.selfUrl = pendingSelfUrlUpdate;
+
+      setTimeout(() => {
+        if (this.promisesWaitingForPropUpdate.selfUrl === pendingSelfUrlUpdate) {
+          delete this.promisesWaitingForPropUpdate.selfUrl;
+          pendingSelfUrlUpdate.resolve();
+        }
+      }, 5000);
+    }
+
+    return this.promisesWaitingForPropUpdate.selfUrl.promise;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4065,9 +4065,15 @@ export default class Meeting extends StatelessWebexPlugin {
     // is not changed by any delta event
     if (object && Object.keys(object).length) {
       Object.keys(object).forEach((key) => {
+        const previousValue = this[key];
+
         this[key] = object[key];
 
-        if (this.promisesWaitingForPropUpdate[key]) {
+        const shouldResolveWaiter =
+          key !== 'selfUrl' ||
+          (this.promisesWaitingForPropUpdate[key] && previousValue !== object[key]);
+
+        if (this.promisesWaitingForPropUpdate[key] && shouldResolveWaiter) {
           this.promisesWaitingForPropUpdate[key].resolve();
           delete this.promisesWaitingForPropUpdate[key];
         }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -810,6 +810,8 @@ export default class Meeting extends StatelessWebexPlugin {
   private logUploadIntervalIndex: number;
   private mediaServerIp: string;
   private llmHealthCheckTimer?: ReturnType<typeof setTimeout>;
+  private returnToMainRoapLocus?: LocusDTO;
+  private returnToMainSelfUrlPromise?: Promise<string>;
 
   /**
    * @param {Object} attrs
@@ -4066,6 +4068,108 @@ export default class Meeting extends StatelessWebexPlugin {
       Object.keys(object).forEach((key) => {
         this[key] = object[key];
       });
+    }
+  }
+
+  /**
+   * Marks that ROAP should resolve the main session selfUrl before sending because
+   * the current breakout locus has ended and may no longer accept /media requests.
+   * @param {LocusDTO} closedBreakoutLocus closed breakout locus
+   * @returns {void}
+   * @public
+   * @memberof Meeting
+   */
+  public updateClosedBreakoutLocus(closedBreakoutLocus: LocusDTO) {
+    this.returnToMainRoapLocus = closedBreakoutLocus;
+  }
+
+  /**
+   * Returns the selfUrl that ROAP /media should target.
+   * In the normal case this is just meeting.selfUrl. During a confirmed
+   * breakout-ended transition we first resolve the main session participant
+   * selfUrl so ROAP is not sent to the inactive breakout locus.
+   * @returns {Promise<string>}
+   * @public
+   * @memberof Meeting
+   */
+  public async resolveRoapMediaSelfUrl(): Promise<string> {
+    const closedBreakoutLocus = this.returnToMainRoapLocus;
+
+    if (!closedBreakoutLocus) {
+      if (!this.selfUrl) {
+        throw new Error('Cannot send ROAP: meeting selfUrl is not available');
+      }
+
+      return this.selfUrl;
+    }
+
+    if (!this.returnToMainSelfUrlPromise) {
+      this.returnToMainSelfUrlPromise = (async () => {
+        const cachedMainLocus = this.locusInfo?.mainSessionLocusCache;
+        let mainLocus =
+          cachedMainLocus?.self?.url &&
+          cachedMainLocus?.controls?.breakout?.sessionType !== BREAKOUTS.SESSION_TYPES.BREAKOUT &&
+          !cachedMainLocus?.self?.removed
+            ? cachedMainLocus
+            : undefined;
+
+        if (!mainLocus) {
+          const mainLocusUrl =
+            this.breakouts?.mainLocusUrl ||
+            cachedMainLocus?.url ||
+            MeetingsUtil.getThisDevice(closedBreakoutLocus, this.deviceUrl)?.replaces?.[0]
+              ?.locusUrl;
+
+          if (!mainLocusUrl) {
+            throw new Error('Cannot send ROAP: main locus URL is not available');
+          }
+
+          const response = await this.meetingRequest.getLocusDTO({url: mainLocusUrl});
+
+          mainLocus = response.body;
+        }
+
+        if (
+          !mainLocus?.self?.url ||
+          mainLocus?.controls?.breakout?.sessionType === BREAKOUTS.SESSION_TYPES.BREAKOUT ||
+          mainLocus?.self?.removed
+        ) {
+          throw new Error('Cannot send ROAP: main locus does not contain usable selfUrl');
+        }
+
+        const currentLocusUrl = this.locusUrl;
+
+        if (
+          currentLocusUrl &&
+          closedBreakoutLocus.url &&
+          mainLocus.url &&
+          currentLocusUrl !== closedBreakoutLocus.url &&
+          currentLocusUrl !== mainLocus.url
+        ) {
+          throw new Error(
+            'Cannot send ROAP: meeting moved to another locus during breakout return'
+          );
+        }
+
+        this.locusInfo.updateMainSessionLocusCache(mainLocus);
+        this.locusInfo.onFullLocus('return-to-main media selfUrl before ROAP', mainLocus);
+
+        if (this.selfUrl !== mainLocus.self.url) {
+          this.updateMeetingObject({selfUrl: mainLocus.self.url});
+        }
+
+        return mainLocus.self.url;
+      })();
+    }
+
+    try {
+      const selfUrl = await this.returnToMainSelfUrlPromise;
+
+      this.returnToMainRoapLocus = undefined;
+
+      return selfUrl;
+    } finally {
+      this.returnToMainSelfUrlPromise = undefined;
     }
   }
 
@@ -8559,6 +8663,7 @@ export default class Meeting extends StatelessWebexPlugin {
           regionCode: this.webex.meetings.geoHintInfo?.regionCode,
         },
         preferTranscoding: !this.isMultistream,
+        resolveMediaSelfUrl: () => this.resolveRoapMediaSelfUrl(),
       },
       {
         // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -284,7 +284,7 @@ export class LocusMediaRequest extends WebexPlugin {
           // before Locus rejected the request. Re-send; getCurrentSelfUrl
           // will pick up the new URL. The returned promise replaces the
           // rejection, so the caller's pendingPromise resolves correctly.
-          return this.sendHttpRequest(request, selfUrlRetryCount + 1);
+          return this.sendHttpRequest(request, selfUrlRetryCount);
         }
 
         if (
@@ -355,17 +355,13 @@ export class LocusMediaRequest extends WebexPlugin {
     request: Request,
     selfUrlRetryCount: number
   ): Promise<boolean> {
-    const roapRequest = request.type === 'RoapMessage' ? request : undefined;
-
     if (selfUrlRetryCount >= MAX_SELF_URL_RETRY_COUNT) {
       return false;
     }
 
     const currentSelfUrl = this.getCurrentSelfUrl(request);
-    let waitedForSelfUrlChange = false;
 
     if (!currentSelfUrl || currentSelfUrl === request.selfUrl) {
-      waitedForSelfUrlChange = true;
       await this.config.waitForSelfUrlChange();
 
       const latestSelfUrl = this.getCurrentSelfUrl(request);
@@ -384,10 +380,11 @@ export class LocusMediaRequest extends WebexPlugin {
         return false;
       }
 
+      selfUrlRetryCount += 1;
       Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY, {
         correlation_id: this.config.correlationId,
         reason: 'selfUrlChangedAfterWait',
-        retryAttempt: selfUrlRetryCount + 1,
+        retryAttempt: selfUrlRetryCount,
         roapMessageType: roapRequest?.roapMessage?.messageType,
       });
     }

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -93,6 +93,7 @@ export type Config = {
   correlationId: string;
   meetingId: string;
   preferTranscoding: boolean;
+  resolveMediaSelfUrl?: () => string | undefined | Promise<string | undefined>;
 };
 
 /**
@@ -196,13 +197,13 @@ export class LocusMediaRequest extends WebexPlugin {
   /**
    * Prepares the uri and body for the media request to be sent to Locus
    */
-  private sendHttpRequest(request: Request) {
+  private async sendHttpRequest(request: Request) {
     // Resolve selfUrl lazily at send time — Locus rotates it on session
     // transitions (breakout end, move-to, lobby admit) and the value
     // captured upstream in roap/index.ts may be stale by the time we
     // leave the queue. Persist the resolved URL on the request so a
     // retry can detect a further rotation.
-    request.selfUrl = this.getCurrentSelfUrl(request.selfUrl);
+    request.selfUrl = await this.getCurrentSelfUrl(request);
     const uri = `${request.selfUrl}/${MEDIA}`;
 
     const {audioMuted, videoMuted} = this.getLatestMuteState();
@@ -271,10 +272,10 @@ export class LocusMediaRequest extends WebexPlugin {
 
         return result;
       })
-      .catch((e) => {
+      .catch(async (e) => {
         if (
           (e?.statusCode === 409 || e?.code === 409) &&
-          this.shouldRetryOnSelfUrlChange(request)
+          (await this.shouldRetryOnSelfUrlChange(request))
         ) {
           // In-flight race: selfUrl rotated after we left the queue but
           // before Locus rejected the request. Re-send — getCurrentSelfUrl
@@ -324,14 +325,26 @@ export class LocusMediaRequest extends WebexPlugin {
    * Returns the latest selfUrl for this meeting, falling back to the value
    * captured when the request was enqueued.
    */
-  private getCurrentSelfUrl(fallbackUrl: string): string {
+  private async getCurrentSelfUrl(request: Request): Promise<string> {
+    if (request.type === 'RoapMessage') {
+      const resolvedSelfUrl = await this.config.resolveMediaSelfUrl?.();
+
+      if (resolvedSelfUrl && resolvedSelfUrl !== request.selfUrl) {
+        LoggerProxy.logger.info(
+          `Meeting:LocusMediaRequest#getCurrentSelfUrl --> resolved updated selfUrl, using ${resolvedSelfUrl}`
+        );
+
+        return resolvedSelfUrl;
+      }
+    }
+
     // @ts-ignore
     const meeting = this.webex.meetings.meetingCollection.getByKey(
       'correlationId',
       this.config.correlationId
     );
 
-    if (meeting?.selfUrl && meeting.selfUrl !== fallbackUrl) {
+    if (meeting?.selfUrl && meeting.selfUrl !== request.selfUrl) {
       LoggerProxy.logger.info(
         `Meeting:LocusMediaRequest#getCurrentSelfUrl --> selfUrl updated since enqueue, using ${meeting.selfUrl}`
       );
@@ -339,7 +352,7 @@ export class LocusMediaRequest extends WebexPlugin {
       return meeting.selfUrl;
     }
 
-    return fallbackUrl;
+    return request.selfUrl;
   }
 
   /**
@@ -347,18 +360,18 @@ export class LocusMediaRequest extends WebexPlugin {
    * selfUrl. Mutates the retry counter when it returns true so the recursion
    * is bounded.
    */
-  private shouldRetryOnSelfUrlChange(request: Request): boolean {
+  private async shouldRetryOnSelfUrlChange(request: Request): Promise<boolean> {
+    if (request.type !== 'RoapMessage') {
+      return false;
+    }
+
     const retryCount = request.__selfUrlRetryCount ?? 0;
     if (retryCount >= 2) {
       return false;
     }
 
-    // @ts-ignore
-    const meeting = this.webex.meetings.meetingCollection.getByKey(
-      'correlationId',
-      this.config.correlationId
-    );
-    if (!meeting?.selfUrl || meeting.selfUrl === request.selfUrl) {
+    const latestSelfUrl = await this.getCurrentSelfUrl(request);
+    if (!latestSelfUrl || latestSelfUrl === request.selfUrl) {
       return false;
     }
 

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -6,6 +6,8 @@ import {WebexPlugin} from '@webex/webex-core';
 import {MEDIA, HTTP_VERBS, ROAP} from '../constants';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {ClientMediaPreferences} from '../reachability/reachability.types';
+import Metrics from '../metrics';
+import BEHAVIORAL_METRICS from '../metrics/constants';
 
 export type MediaRequestType = 'RoapMessage' | 'LocalMute';
 export type RequestResult = any;
@@ -91,9 +93,11 @@ export type Config = {
   correlationId: string;
   meetingId: string;
   preferTranscoding: boolean;
-  getCurrentSelfUrl?: () => string | undefined;
+  getCurrentSelfUrl: () => string | undefined;
   waitForSelfUrlChange?: () => Promise<void>;
 };
+
+const MAX_SELF_URL_RETRY_COUNT = 2;
 
 /**
  * Returns true if the request is triggering confluence creation in the server
@@ -278,18 +282,11 @@ export class LocusMediaRequest extends WebexPlugin {
         ) {
           const roapRequest = request.type === 'RoapMessage' ? request : undefined;
 
-          // @ts-ignore
-          this.webex.internal.newMetrics.submitClientEvent({
-            name: 'client.locus.media.retry',
-            options: {
-              meetingId: this.config.meetingId,
-              rawError: e,
-            },
-            payload: {
-              reason: 'selfUrlChangedAfter409',
-              retryAttempt: selfUrlRetryCount + 1,
-              roapMessageType: roapRequest?.roapMessage?.messageType,
-            },
+          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_MEDIA_RETRY, {
+            correlation_id: this.config.correlationId,
+            reason: 'selfUrlChangedAfter409',
+            retryAttempt: selfUrlRetryCount + 1,
+            roapMessageType: roapRequest?.roapMessage?.messageType,
           });
 
           // In-flight race: selfUrl rotated after we left the queue but
@@ -341,19 +338,16 @@ export class LocusMediaRequest extends WebexPlugin {
    * captured when the request was enqueued.
    */
   private getCurrentSelfUrl(request: Request): string {
-    const currentSelfUrl = this.config.getCurrentSelfUrl?.();
+    const currentSelfUrl = this.config.getCurrentSelfUrl();
 
-    if (request.type === 'RoapMessage' && currentSelfUrl && currentSelfUrl !== request.selfUrl) {
+    if (currentSelfUrl && currentSelfUrl !== request.selfUrl) {
       LoggerProxy.logger.info(
         `Meeting:LocusMediaRequest#getCurrentSelfUrl --> resolved updated selfUrl, using ${currentSelfUrl}`
       );
 
-      // @ts-ignore
-      this.webex.internal.newMetrics.submitClientEvent({
-        name: 'client.locus.selfUrlUpdated',
-        options: {
-          meetingId: this.config.meetingId,
-        },
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_MEDIA_RETRY, {
+        correlation_id: this.config.correlationId,
+        reason: 'selfUrlUpdatedBeforeMediaRequest',
       });
 
       return currentSelfUrl;
@@ -370,11 +364,7 @@ export class LocusMediaRequest extends WebexPlugin {
     request: Request,
     selfUrlRetryCount: number
   ): Promise<boolean> {
-    if (request.type !== 'RoapMessage') {
-      return false;
-    }
-
-    if (selfUrlRetryCount >= 2) {
+    if (selfUrlRetryCount >= MAX_SELF_URL_RETRY_COUNT) {
       return false;
     }
 

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -275,6 +275,22 @@ export class LocusMediaRequest extends WebexPlugin {
           e?.statusCode === 409 &&
           (await this.shouldRetryOnSelfUrlChange(request, selfUrlRetryCount))
         ) {
+          const roapRequest = request.type === 'RoapMessage' ? request : undefined;
+
+          // @ts-ignore
+          this.webex.internal.newMetrics.submitClientEvent({
+            name: 'client.locus.media.retry',
+            options: {
+              meetingId: this.config.meetingId,
+              rawError: e,
+            },
+            payload: {
+              reason: 'selfUrlChangedAfter409',
+              retryAttempt: selfUrlRetryCount + 1,
+              roapMessageType: roapRequest?.roapMessage?.messageType,
+            },
+          });
+
           // In-flight race: selfUrl rotated after we left the queue but
           // before Locus rejected the request. Re-send; getCurrentSelfUrl
           // will pick up the new URL. The returned promise replaces the
@@ -331,6 +347,14 @@ export class LocusMediaRequest extends WebexPlugin {
         `Meeting:LocusMediaRequest#getCurrentSelfUrl --> resolved updated selfUrl, using ${currentSelfUrl}`
       );
 
+      // @ts-ignore
+      this.webex.internal.newMetrics.submitClientEvent({
+        name: 'client.locus.selfUrlUpdated',
+        options: {
+          meetingId: this.config.meetingId,
+        },
+      });
+
       return currentSelfUrl;
     }
 
@@ -339,8 +363,7 @@ export class LocusMediaRequest extends WebexPlugin {
 
   /**
    * Decides whether a 409 warrants a retry against the meeting's latest
-   * selfUrl. Mutates the retry counter when it returns true so the recursion
-   * is bounded.
+   * selfUrl.
    */
   private async shouldRetryOnSelfUrlChange(
     request: Request,

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable valid-jsdoc */
 import {defer} from 'lodash';
-import {Defer, transferEvents} from '@webex/common';
+import {Defer} from '@webex/common';
 import {EventEmitter} from 'events';
 import {WebexPlugin} from '@webex/webex-core';
 import {MEDIA, HTTP_VERBS, ROAP} from '../constants';
@@ -18,7 +18,6 @@ export type RoapRequest = {
   reachability: any;
   clientMediaPreferences: ClientMediaPreferences;
   sequence?: any;
-  __selfUrlRetryCount?: number;
 };
 
 export type LocalMuteRequest = {
@@ -30,7 +29,6 @@ export type LocalMuteRequest = {
     audioMuted?: boolean;
     videoMuted?: boolean;
   };
-  __selfUrlRetryCount?: number;
 };
 
 export type Request = RoapRequest | LocalMuteRequest;
@@ -39,13 +37,13 @@ export type Request = RoapRequest | LocalMuteRequest;
 class InternalRequestInfo {
   public readonly request: Request;
   private pendingPromises: Defer[];
-  private sendRequestFn: (request: Request) => Promise<RequestResult>;
+  private sendRequestFn: (request: Request, selfUrlRetryCount: number) => Promise<RequestResult>;
 
   /** Constructor */
   constructor(
     request: Request,
     pendingPromise: Defer,
-    sendRequestFn: (request: Request) => Promise<RequestResult>
+    sendRequestFn: (request: Request, selfUrlRetryCount: number) => Promise<RequestResult>
   ) {
     this.request = request;
     this.pendingPromises = [pendingPromise];
@@ -71,7 +69,7 @@ class InternalRequestInfo {
    * is completed (no matter if it succeeded or failed).
    */
   public execute(): Promise<void> {
-    return this.sendRequestFn(this.request)
+    return this.sendRequestFn(this.request, 0)
       .then((result) => {
         // resolve all the pending promises associated with this request
         this.pendingPromises.forEach((d) => d.resolve(result));
@@ -93,7 +91,7 @@ export type Config = {
   correlationId: string;
   meetingId: string;
   preferTranscoding: boolean;
-  resolveMediaSelfUrl?: () => string | undefined | Promise<string | undefined>;
+  getCurrentSelfUrl?: () => string | undefined;
 };
 
 /**
@@ -197,13 +195,13 @@ export class LocusMediaRequest extends WebexPlugin {
   /**
    * Prepares the uri and body for the media request to be sent to Locus
    */
-  private async sendHttpRequest(request: Request) {
-    // Resolve selfUrl lazily at send time — Locus rotates it on session
+  private async sendHttpRequest(request: Request, selfUrlRetryCount: number) {
+    // Resolve selfUrl lazily at send time. Locus rotates it on session
     // transitions (breakout end, move-to, lobby admit) and the value
     // captured upstream in roap/index.ts may be stale by the time we
     // leave the queue. Persist the resolved URL on the request so a
     // retry can detect a further rotation.
-    request.selfUrl = await this.getCurrentSelfUrl(request);
+    request.selfUrl = this.getCurrentSelfUrl(request);
     const uri = `${request.selfUrl}/${MEDIA}`;
 
     const {audioMuted, videoMuted} = this.getLatestMuteState();
@@ -274,14 +272,14 @@ export class LocusMediaRequest extends WebexPlugin {
       })
       .catch(async (e) => {
         if (
-          (e?.statusCode === 409 || e?.code === 409) &&
-          (await this.shouldRetryOnSelfUrlChange(request))
+          e?.statusCode === 409 &&
+          (await this.shouldRetryOnSelfUrlChange(request, selfUrlRetryCount))
         ) {
           // In-flight race: selfUrl rotated after we left the queue but
-          // before Locus rejected the request. Re-send — getCurrentSelfUrl
+          // before Locus rejected the request. Re-send; getCurrentSelfUrl
           // will pick up the new URL. The returned promise replaces the
           // rejection, so the caller's pendingPromise resolves correctly.
-          return this.sendHttpRequest(request);
+          return this.sendHttpRequest(request, selfUrlRetryCount);
         }
 
         if (
@@ -325,31 +323,15 @@ export class LocusMediaRequest extends WebexPlugin {
    * Returns the latest selfUrl for this meeting, falling back to the value
    * captured when the request was enqueued.
    */
-  private async getCurrentSelfUrl(request: Request): Promise<string> {
-    if (request.type === 'RoapMessage') {
-      const resolvedSelfUrl = await this.config.resolveMediaSelfUrl?.();
+  private getCurrentSelfUrl(request: Request): string {
+    const currentSelfUrl = this.config.getCurrentSelfUrl?.();
 
-      if (resolvedSelfUrl && resolvedSelfUrl !== request.selfUrl) {
-        LoggerProxy.logger.info(
-          `Meeting:LocusMediaRequest#getCurrentSelfUrl --> resolved updated selfUrl, using ${resolvedSelfUrl}`
-        );
-
-        return resolvedSelfUrl;
-      }
-    }
-
-    // @ts-ignore
-    const meeting = this.webex.meetings.meetingCollection.getByKey(
-      'correlationId',
-      this.config.correlationId
-    );
-
-    if (meeting?.selfUrl && meeting.selfUrl !== request.selfUrl) {
+    if (request.type === 'RoapMessage' && currentSelfUrl && currentSelfUrl !== request.selfUrl) {
       LoggerProxy.logger.info(
-        `Meeting:LocusMediaRequest#getCurrentSelfUrl --> selfUrl updated since enqueue, using ${meeting.selfUrl}`
+        `Meeting:LocusMediaRequest#getCurrentSelfUrl --> resolved updated selfUrl, using ${currentSelfUrl}`
       );
 
-      return meeting.selfUrl;
+      return currentSelfUrl;
     }
 
     return request.selfUrl;
@@ -360,22 +342,25 @@ export class LocusMediaRequest extends WebexPlugin {
    * selfUrl. Mutates the retry counter when it returns true so the recursion
    * is bounded.
    */
-  private async shouldRetryOnSelfUrlChange(request: Request): Promise<boolean> {
+  private async shouldRetryOnSelfUrlChange(
+    request: Request,
+    selfUrlRetryCount: number
+  ): Promise<boolean> {
     if (request.type !== 'RoapMessage') {
       return false;
     }
 
-    const retryCount = request.__selfUrlRetryCount ?? 0;
-    if (retryCount >= 2) {
+    if (selfUrlRetryCount >= 2) {
       return false;
     }
 
-    const latestSelfUrl = await this.getCurrentSelfUrl(request);
-    if (!latestSelfUrl || latestSelfUrl === request.selfUrl) {
+    const currentSelfUrl = this.getCurrentSelfUrl(request);
+
+    if (!currentSelfUrl || currentSelfUrl === request.selfUrl) {
       return false;
     }
 
-    request.__selfUrlRetryCount = retryCount + 1;
+    selfUrlRetryCount += 1;
     LoggerProxy.logger.info(
       `Meeting:LocusMediaRequest#sendHttpRequest --> 409 conflict, retrying ${request.type} with updated selfUrl`
     );

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -92,6 +92,7 @@ export type Config = {
   meetingId: string;
   preferTranscoding: boolean;
   getCurrentSelfUrl?: () => string | undefined;
+  waitForSelfUrlChange?: () => Promise<void>;
 };
 
 /**
@@ -380,7 +381,17 @@ export class LocusMediaRequest extends WebexPlugin {
     const currentSelfUrl = this.getCurrentSelfUrl(request);
 
     if (!currentSelfUrl || currentSelfUrl === request.selfUrl) {
-      return false;
+      await this.config.waitForSelfUrlChange?.();
+
+      const latestSelfUrl = this.getCurrentSelfUrl(request);
+
+      if (!latestSelfUrl || latestSelfUrl === request.selfUrl) {
+        LoggerProxy.logger.info(
+          'Meeting:LocusMediaRequest#sendHttpRequest --> 409 conflict, no new selfUrl even after waiting'
+        );
+
+        return false;
+      }
     }
 
     selfUrlRetryCount += 1;

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -94,7 +94,7 @@ export type Config = {
   meetingId: string;
   preferTranscoding: boolean;
   getCurrentSelfUrl: () => string | undefined;
-  waitForSelfUrlChange?: () => Promise<void>;
+  waitForSelfUrlChange: () => Promise<void>;
 };
 
 const MAX_SELF_URL_RETRY_COUNT = 2;
@@ -280,20 +280,11 @@ export class LocusMediaRequest extends WebexPlugin {
           e?.statusCode === 409 &&
           (await this.shouldRetryOnSelfUrlChange(request, selfUrlRetryCount))
         ) {
-          const roapRequest = request.type === 'RoapMessage' ? request : undefined;
-
-          Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_MEDIA_RETRY, {
-            correlation_id: this.config.correlationId,
-            reason: 'selfUrlChangedAfter409',
-            retryAttempt: selfUrlRetryCount + 1,
-            roapMessageType: roapRequest?.roapMessage?.messageType,
-          });
-
           // In-flight race: selfUrl rotated after we left the queue but
           // before Locus rejected the request. Re-send; getCurrentSelfUrl
           // will pick up the new URL. The returned promise replaces the
           // rejection, so the caller's pendingPromise resolves correctly.
-          return this.sendHttpRequest(request, selfUrlRetryCount);
+          return this.sendHttpRequest(request, selfUrlRetryCount + 1);
         }
 
         if (
@@ -345,7 +336,7 @@ export class LocusMediaRequest extends WebexPlugin {
         `Meeting:LocusMediaRequest#getCurrentSelfUrl --> resolved updated selfUrl, using ${currentSelfUrl}`
       );
 
-      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.ADD_MEDIA_RETRY, {
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY, {
         correlation_id: this.config.correlationId,
         reason: 'selfUrlUpdatedBeforeMediaRequest',
       });
@@ -364,27 +355,42 @@ export class LocusMediaRequest extends WebexPlugin {
     request: Request,
     selfUrlRetryCount: number
   ): Promise<boolean> {
+    const roapRequest = request.type === 'RoapMessage' ? request : undefined;
+
     if (selfUrlRetryCount >= MAX_SELF_URL_RETRY_COUNT) {
       return false;
     }
 
     const currentSelfUrl = this.getCurrentSelfUrl(request);
+    let waitedForSelfUrlChange = false;
 
     if (!currentSelfUrl || currentSelfUrl === request.selfUrl) {
-      await this.config.waitForSelfUrlChange?.();
+      waitedForSelfUrlChange = true;
+      await this.config.waitForSelfUrlChange();
 
       const latestSelfUrl = this.getCurrentSelfUrl(request);
 
       if (!latestSelfUrl || latestSelfUrl === request.selfUrl) {
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY, {
+          correlation_id: this.config.correlationId,
+          reason: 'selfUrlNotChangedAfterWait',
+          retryAttempt: selfUrlRetryCount + 1,
+          roapMessageType: roapRequest?.roapMessage?.messageType,
+        });
         LoggerProxy.logger.info(
           'Meeting:LocusMediaRequest#sendHttpRequest --> 409 conflict, no new selfUrl even after waiting'
         );
 
         return false;
       }
-    }
 
-    selfUrlRetryCount += 1;
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY, {
+        correlation_id: this.config.correlationId,
+        reason: 'selfUrlChangedAfterWait',
+        retryAttempt: selfUrlRetryCount + 1,
+        roapMessageType: roapRequest?.roapMessage?.messageType,
+      });
+    }
     LoggerProxy.logger.info(
       `Meeting:LocusMediaRequest#sendHttpRequest --> 409 conflict, retrying ${request.type} with updated selfUrl`
     );

--- a/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/locusMediaRequest.ts
@@ -18,6 +18,7 @@ export type RoapRequest = {
   reachability: any;
   clientMediaPreferences: ClientMediaPreferences;
   sequence?: any;
+  __selfUrlRetryCount?: number;
 };
 
 export type LocalMuteRequest = {
@@ -29,6 +30,7 @@ export type LocalMuteRequest = {
     audioMuted?: boolean;
     videoMuted?: boolean;
   };
+  __selfUrlRetryCount?: number;
 };
 
 export type Request = RoapRequest | LocalMuteRequest;
@@ -195,6 +197,12 @@ export class LocusMediaRequest extends WebexPlugin {
    * Prepares the uri and body for the media request to be sent to Locus
    */
   private sendHttpRequest(request: Request) {
+    // Resolve selfUrl lazily at send time — Locus rotates it on session
+    // transitions (breakout end, move-to, lobby admit) and the value
+    // captured upstream in roap/index.ts may be stale by the time we
+    // leave the queue. Persist the resolved URL on the request so a
+    // retry can detect a further rotation.
+    request.selfUrl = this.getCurrentSelfUrl(request.selfUrl);
     const uri = `${request.selfUrl}/${MEDIA}`;
 
     const {audioMuted, videoMuted} = this.getLatestMuteState();
@@ -265,6 +273,17 @@ export class LocusMediaRequest extends WebexPlugin {
       })
       .catch((e) => {
         if (
+          (e?.statusCode === 409 || e?.code === 409) &&
+          this.shouldRetryOnSelfUrlChange(request)
+        ) {
+          // In-flight race: selfUrl rotated after we left the queue but
+          // before Locus rejected the request. Re-send — getCurrentSelfUrl
+          // will pick up the new URL. The returned promise replaces the
+          // rejection, so the caller's pendingPromise resolves correctly.
+          return this.sendHttpRequest(request);
+        }
+
+        if (
           isRequestAffectingConfluenceState(request) &&
           this.confluenceState === 'creation in progress'
         ) {
@@ -299,6 +318,56 @@ export class LocusMediaRequest extends WebexPlugin {
     }
 
     return promise;
+  }
+
+  /**
+   * Returns the latest selfUrl for this meeting, falling back to the value
+   * captured when the request was enqueued.
+   */
+  private getCurrentSelfUrl(fallbackUrl: string): string {
+    // @ts-ignore
+    const meeting = this.webex.meetings.meetingCollection.getByKey(
+      'correlationId',
+      this.config.correlationId
+    );
+
+    if (meeting?.selfUrl && meeting.selfUrl !== fallbackUrl) {
+      LoggerProxy.logger.info(
+        `Meeting:LocusMediaRequest#getCurrentSelfUrl --> selfUrl updated since enqueue, using ${meeting.selfUrl}`
+      );
+
+      return meeting.selfUrl;
+    }
+
+    return fallbackUrl;
+  }
+
+  /**
+   * Decides whether a 409 warrants a retry against the meeting's latest
+   * selfUrl. Mutates the retry counter when it returns true so the recursion
+   * is bounded.
+   */
+  private shouldRetryOnSelfUrlChange(request: Request): boolean {
+    const retryCount = request.__selfUrlRetryCount ?? 0;
+    if (retryCount >= 2) {
+      return false;
+    }
+
+    // @ts-ignore
+    const meeting = this.webex.meetings.meetingCollection.getByKey(
+      'correlationId',
+      this.config.correlationId
+    );
+    if (!meeting?.selfUrl || meeting.selfUrl === request.selfUrl) {
+      return false;
+    }
+
+    request.__selfUrlRetryCount = retryCount + 1;
+    LoggerProxy.logger.info(
+      `Meeting:LocusMediaRequest#sendHttpRequest --> 409 conflict, retrying ${request.type} with updated selfUrl`
+    );
+
+    return true;
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -515,19 +515,6 @@ export default class Meetings extends WebexPlugin {
         meeting.locusInfo.updateMainSessionLocusCache(data.locus); // here data.locus will never be a complete locus
       }
 
-      const isBreakoutEnded =
-        MeetingsUtil.isBreakoutLocusDTO(data.locus) &&
-        data.locus?.fullState?.state === LOCUS.STATE.INACTIVE &&
-        data.locus?.fullState?.endMeetingReason === EndMeetingReason.breakoutEnded;
-
-      if (
-        meeting &&
-        isBreakoutEnded &&
-        meeting.breakouts?.sessionType === BREAKOUTS.SESSION_TYPES.BREAKOUT
-      ) {
-        meeting.updateClosedBreakoutLocus(data.locus);
-      }
-
       if (!this.isNeedHandleLocusDTO(meeting, data.locus)) {
         LoggerProxy.logger.log(
           `Meetings:index#handleLocusEvent --> doesn't need to process locus event`

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -34,6 +34,7 @@ import {
   _JOIN_,
   _INCOMING_,
   LOCUS,
+  BREAKOUTS,
   _LEFT_,
   _ID_,
   MEETING_REMOVED_REASON,
@@ -73,7 +74,7 @@ import {HashTreeObject} from '../hashTree/types';
 import {isSelf} from '../hashTree/utils';
 
 import {createLocusFromHashTreeMessage, findMeetingForHashTreeMessage} from '../locus-info';
-import {LocusDTO} from '../locus-info/types';
+import {EndMeetingReason, LocusDTO} from '../locus-info/types';
 
 let mediaLogger;
 
@@ -513,6 +514,20 @@ export default class Meetings extends WebexPlugin {
       if (meeting && !MeetingsUtil.isBreakoutLocusDTO(data.locus)) {
         meeting.locusInfo.updateMainSessionLocusCache(data.locus); // here data.locus will never be a complete locus
       }
+
+      const isBreakoutEnded =
+        MeetingsUtil.isBreakoutLocusDTO(data.locus) &&
+        data.locus?.fullState?.state === LOCUS.STATE.INACTIVE &&
+        data.locus?.fullState?.endMeetingReason === EndMeetingReason.breakoutEnded;
+
+      if (
+        meeting &&
+        isBreakoutEnded &&
+        meeting.breakouts?.sessionType === BREAKOUTS.SESSION_TYPES.BREAKOUT
+      ) {
+        meeting.updateClosedBreakoutLocus(data.locus);
+      }
+
       if (!this.isNeedHandleLocusDTO(meeting, data.locus)) {
         LoggerProxy.logger.log(
           `Meetings:index#handleLocusEvent --> doesn't need to process locus event`

--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -34,7 +34,6 @@ import {
   _JOIN_,
   _INCOMING_,
   LOCUS,
-  BREAKOUTS,
   _LEFT_,
   _ID_,
   MEETING_REMOVED_REASON,
@@ -74,7 +73,7 @@ import {HashTreeObject} from '../hashTree/types';
 import {isSelf} from '../hashTree/utils';
 
 import {createLocusFromHashTreeMessage, findMeetingForHashTreeMessage} from '../locus-info';
-import {EndMeetingReason, LocusDTO} from '../locus-info/types';
+import {LocusDTO} from '../locus-info/types';
 
 let mediaLogger;
 

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -11,6 +11,7 @@ const BEHAVIORAL_METRICS = {
   ADD_MEDIA_SUCCESS: 'js_sdk_add_media_success',
   ADD_MEDIA_FAILURE: 'js_sdk_add_media_failures',
   ADD_MEDIA_RETRY: 'js_sdk_add_media_retry',
+  LOCUS_MEDIA_REQUEST_RETRY: 'js_sdk_locus_media_request_retry',
   ROAP_MERCURY_EVENT_RECEIVED: 'js_sdk_roap_mercury_received',
   CONNECTION_SUCCESS: 'js_sdk_connection_success',
   CONNECTION_FAILURE: 'js_sdk_connection_failures',

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
@@ -21,6 +21,7 @@ describe('LocusMediaRequest.send()', () => {
   let webexRequestStub;
   let mockWebex;
   let sendBehavioralMetricStub;
+  const waitForSelfUrlChange = () => Promise.resolve();
 
   const fakeLocusResponse = {
     locus: {something: 'whatever'},
@@ -156,6 +157,7 @@ describe('LocusMediaRequest.send()', () => {
         meetingId: 'meetingId',
         preferTranscoding: true,
         getCurrentSelfUrl: () => undefined,
+        waitForSelfUrlChange,
       },
       {
         parent: mockWebex,
@@ -214,6 +216,7 @@ describe('LocusMediaRequest.send()', () => {
         meetingId: 'meetingId',
         preferTranscoding: true,
         getCurrentSelfUrl: () => currentSelfUrl,
+        waitForSelfUrlChange,
       },
       {
         parent: mockWebex,
@@ -231,10 +234,14 @@ describe('LocusMediaRequest.send()', () => {
     assert.equal(result, fakeLocusResponse);
     assert.calledOnce(webexRequestStub);
     assert.equal(webexRequestStub.getCall(0).args[0].uri, 'newSelfUrl/media');
-    assert.calledOnceWithExactly(sendBehavioralMetricStub, BEHAVIORAL_METRICS.ADD_MEDIA_RETRY, {
-      correlation_id: 'correlationId',
-      reason: 'selfUrlUpdatedBeforeMediaRequest',
-    });
+    assert.calledOnceWithExactly(
+      sendBehavioralMetricStub,
+      BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY,
+      {
+        correlation_id: 'correlationId',
+        reason: 'selfUrlUpdatedBeforeMediaRequest',
+      }
+    );
   });
 
   it('retries a roap message with the latest resolved selfUrl after a conflict', async () => {
@@ -252,6 +259,7 @@ describe('LocusMediaRequest.send()', () => {
         meetingId: 'meetingId',
         preferTranscoding: true,
         getCurrentSelfUrl: () => currentSelfUrl,
+        waitForSelfUrlChange,
       },
       {
         parent: mockWebex,
@@ -276,16 +284,11 @@ describe('LocusMediaRequest.send()', () => {
     assert.calledTwice(webexRequestStub);
     assert.equal(webexRequestStub.getCall(0).args[0].uri, 'oldSelfUrl/media');
     assert.equal(webexRequestStub.getCall(1).args[0].uri, 'newSelfUrl/media');
-    assert.calledWith(sendBehavioralMetricStub, BEHAVIORAL_METRICS.ADD_MEDIA_RETRY, {
+    assert.calledWith(sendBehavioralMetricStub, BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY, {
       correlation_id: 'correlationId',
       reason: 'selfUrlUpdatedBeforeMediaRequest',
     });
-    assert.calledWith(sendBehavioralMetricStub, BEHAVIORAL_METRICS.ADD_MEDIA_RETRY, {
-      correlation_id: 'correlationId',
-      reason: 'selfUrlChangedAfter409',
-      retryAttempt: 1,
-      roapMessageType: 'ANSWER',
-    });
+    assert.calledOnce(sendBehavioralMetricStub);
   });
 
   it('does not retry a roap conflict when the resolved selfUrl has not changed', async () => {
@@ -300,6 +303,7 @@ describe('LocusMediaRequest.send()', () => {
         meetingId: 'meetingId',
         preferTranscoding: true,
         getCurrentSelfUrl: () => 'sameSelfUrl',
+        waitForSelfUrlChange,
       },
       {
         parent: mockWebex,
@@ -319,6 +323,57 @@ describe('LocusMediaRequest.send()', () => {
 
     assert.calledOnce(webexRequestStub);
     assert.equal(webexRequestStub.getCall(0).args[0].uri, 'sameSelfUrl/media');
+    assert.calledWith(sendBehavioralMetricStub, BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY, {
+      correlation_id: 'correlationId',
+      reason: 'selfUrlNotChangedAfterWait',
+      retryAttempt: 1,
+      roapMessageType: 'ANSWER',
+    });
+  });
+
+  it('retries a roap conflict when selfUrl changes after waiting', async () => {
+    let currentSelfUrl = 'sameSelfUrl';
+    const waitForSelfUrlChangeAndUpdate = async () => {
+      currentSelfUrl = 'newSelfUrlAfterWait';
+    };
+    locusMediaRequest = new LocusMediaRequest(
+      {
+        device: {
+          url: 'deviceUrl',
+          deviceType: 'deviceType',
+          regionCode: 'regionCode',
+        },
+        correlationId: 'correlationId',
+        meetingId: 'meetingId',
+        preferTranscoding: true,
+        getCurrentSelfUrl: () => currentSelfUrl,
+        waitForSelfUrlChange: waitForSelfUrlChangeAndUpdate,
+      },
+      {
+        parent: mockWebex,
+      }
+    );
+    webexRequestStub = sinon.stub(locusMediaRequest, 'request');
+    webexRequestStub.onFirstCall().rejects({statusCode: 409, message: 'conflict'});
+    webexRequestStub.onSecondCall().resolves(fakeLocusResponse);
+
+    const request = cloneDeep(exampleRoapRequestBody);
+
+    request.selfUrl = 'sameSelfUrl';
+    request.roapMessage.messageType = 'ANSWER';
+
+    const result = await locusMediaRequest.send(request);
+
+    assert.equal(result, fakeLocusResponse);
+    assert.calledTwice(webexRequestStub);
+    assert.equal(webexRequestStub.getCall(0).args[0].uri, 'sameSelfUrl/media');
+    assert.equal(webexRequestStub.getCall(1).args[0].uri, 'newSelfUrlAfterWait/media');
+    assert.calledWith(sendBehavioralMetricStub, BEHAVIORAL_METRICS.LOCUS_MEDIA_REQUEST_RETRY, {
+      correlation_id: 'correlationId',
+      reason: 'selfUrlChangedAfterWait',
+      retryAttempt: 1,
+      roapMessageType: 'ANSWER',
+    });
   });
 
   it('retries a local mute request with the latest resolved selfUrl after a conflict', async () => {
@@ -336,6 +391,7 @@ describe('LocusMediaRequest.send()', () => {
         meetingId: 'meetingId',
         preferTranscoding: true,
         getCurrentSelfUrl: () => currentSelfUrl,
+        waitForSelfUrlChange,
       },
       {
         parent: mockWebex,
@@ -374,6 +430,7 @@ describe('LocusMediaRequest.send()', () => {
         meetingId: 'meetingId',
         preferTranscoding: true,
         getCurrentSelfUrl: () => currentSelfUrl,
+        waitForSelfUrlChange,
       },
       {
         parent: mockWebex,

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/locusMediaRequest.ts
@@ -13,11 +13,14 @@ import {
 import testUtils from '../../../utils/testUtils';
 import {Defer} from '@webex/common';
 import {IP_VERSION} from '../../../../src/constants';
+import Metrics from '../../../../src/metrics';
+import BEHAVIORAL_METRICS from '../../../../src/metrics/constants';
 
 describe('LocusMediaRequest.send()', () => {
   let locusMediaRequest: LocusMediaRequest;
   let webexRequestStub;
   let mockWebex;
+  let sendBehavioralMetricStub;
 
   const fakeLocusResponse = {
     locus: {something: 'whatever'},
@@ -50,8 +53,16 @@ describe('LocusMediaRequest.send()', () => {
       },
       ipver: IP_VERSION.only_ipv4,
       reachability: {
-        version: '1',
-        result: 'some fake reachability result',
+        version: 1,
+        result: {
+          usedDiscoveryOptions: {
+            'early-call-min-clusters': 3,
+          },
+          metrics: {
+            'total-duration-ms': 10,
+          },
+          tests: {},
+        },
       },
     },
   };
@@ -132,6 +143,7 @@ describe('LocusMediaRequest.send()', () => {
         submitClientEvent: sinon.stub(),
       },
     };
+    sendBehavioralMetricStub = sinon.stub(Metrics, 'sendBehavioralMetric');
 
     locusMediaRequest = new LocusMediaRequest(
       {
@@ -143,12 +155,17 @@ describe('LocusMediaRequest.send()', () => {
         correlationId: 'correlationId',
         meetingId: 'meetingId',
         preferTranscoding: true,
+        getCurrentSelfUrl: () => undefined,
       },
       {
         parent: mockWebex,
       }
     );
     webexRequestStub = sinon.stub(locusMediaRequest, 'request').resolves(fakeLocusResponse);
+  });
+
+  afterEach(() => {
+    sendBehavioralMetricStub.restore();
   });
 
   const sendLocalMute = (muteOptions, overrides = {}) =>
@@ -167,6 +184,7 @@ describe('LocusMediaRequest.send()', () => {
 
     webexRequestStub.resetHistory();
     mockWebex.internal.newMetrics.submitClientEvent.resetHistory();
+    sendBehavioralMetricStub.resetHistory();
   };
 
   it('sends a roap message', async () => {
@@ -181,6 +199,214 @@ describe('LocusMediaRequest.send()', () => {
       upload: sinon.match.instanceOf(EventEmitter),
       download: sinon.match.instanceOf(EventEmitter),
     });
+  });
+
+  it('uses the latest resolved selfUrl when a queued roap message is sent', async () => {
+    let currentSelfUrl = 'oldSelfUrl';
+    locusMediaRequest = new LocusMediaRequest(
+      {
+        device: {
+          url: 'deviceUrl',
+          deviceType: 'deviceType',
+          regionCode: 'regionCode',
+        },
+        correlationId: 'correlationId',
+        meetingId: 'meetingId',
+        preferTranscoding: true,
+        getCurrentSelfUrl: () => currentSelfUrl,
+      },
+      {
+        parent: mockWebex,
+      }
+    );
+    webexRequestStub = sinon.stub(locusMediaRequest, 'request').resolves(fakeLocusResponse);
+
+    const request = cloneDeep(exampleRoapRequestBody);
+
+    request.selfUrl = 'oldSelfUrl';
+    currentSelfUrl = 'newSelfUrl';
+
+    const result = await locusMediaRequest.send(request);
+
+    assert.equal(result, fakeLocusResponse);
+    assert.calledOnce(webexRequestStub);
+    assert.equal(webexRequestStub.getCall(0).args[0].uri, 'newSelfUrl/media');
+    assert.calledOnceWithExactly(sendBehavioralMetricStub, BEHAVIORAL_METRICS.ADD_MEDIA_RETRY, {
+      correlation_id: 'correlationId',
+      reason: 'selfUrlUpdatedBeforeMediaRequest',
+    });
+  });
+
+  it('retries a roap message with the latest resolved selfUrl after a conflict', async () => {
+    let currentSelfUrl = 'oldSelfUrl';
+    const conflictError = {statusCode: 409, message: 'conflict'};
+
+    locusMediaRequest = new LocusMediaRequest(
+      {
+        device: {
+          url: 'deviceUrl',
+          deviceType: 'deviceType',
+          regionCode: 'regionCode',
+        },
+        correlationId: 'correlationId',
+        meetingId: 'meetingId',
+        preferTranscoding: true,
+        getCurrentSelfUrl: () => currentSelfUrl,
+      },
+      {
+        parent: mockWebex,
+      }
+    );
+    webexRequestStub = sinon.stub(locusMediaRequest, 'request');
+    webexRequestStub.onFirstCall().callsFake(() => {
+      currentSelfUrl = 'newSelfUrl';
+
+      return Promise.reject(conflictError);
+    });
+    webexRequestStub.onSecondCall().resolves(fakeLocusResponse);
+
+    const request = cloneDeep(exampleRoapRequestBody);
+
+    request.selfUrl = 'oldSelfUrl';
+    request.roapMessage.messageType = 'ANSWER';
+
+    const result = await locusMediaRequest.send(request);
+
+    assert.equal(result, fakeLocusResponse);
+    assert.calledTwice(webexRequestStub);
+    assert.equal(webexRequestStub.getCall(0).args[0].uri, 'oldSelfUrl/media');
+    assert.equal(webexRequestStub.getCall(1).args[0].uri, 'newSelfUrl/media');
+    assert.calledWith(sendBehavioralMetricStub, BEHAVIORAL_METRICS.ADD_MEDIA_RETRY, {
+      correlation_id: 'correlationId',
+      reason: 'selfUrlUpdatedBeforeMediaRequest',
+    });
+    assert.calledWith(sendBehavioralMetricStub, BEHAVIORAL_METRICS.ADD_MEDIA_RETRY, {
+      correlation_id: 'correlationId',
+      reason: 'selfUrlChangedAfter409',
+      retryAttempt: 1,
+      roapMessageType: 'ANSWER',
+    });
+  });
+
+  it('does not retry a roap conflict when the resolved selfUrl has not changed', async () => {
+    locusMediaRequest = new LocusMediaRequest(
+      {
+        device: {
+          url: 'deviceUrl',
+          deviceType: 'deviceType',
+          regionCode: 'regionCode',
+        },
+        correlationId: 'correlationId',
+        meetingId: 'meetingId',
+        preferTranscoding: true,
+        getCurrentSelfUrl: () => 'sameSelfUrl',
+      },
+      {
+        parent: mockWebex,
+      }
+    );
+    webexRequestStub = sinon.stub(locusMediaRequest, 'request').rejects({
+      statusCode: 409,
+      message: 'conflict',
+    });
+
+    const request = cloneDeep(exampleRoapRequestBody);
+
+    request.selfUrl = 'sameSelfUrl';
+    request.roapMessage.messageType = 'ANSWER';
+
+    await assert.isRejected(locusMediaRequest.send(request));
+
+    assert.calledOnce(webexRequestStub);
+    assert.equal(webexRequestStub.getCall(0).args[0].uri, 'sameSelfUrl/media');
+  });
+
+  it('retries a local mute request with the latest resolved selfUrl after a conflict', async () => {
+    let currentSelfUrl = 'oldSelfUrl';
+    await ensureConfluenceCreated();
+
+    locusMediaRequest = new LocusMediaRequest(
+      {
+        device: {
+          url: 'deviceUrl',
+          deviceType: 'deviceType',
+          regionCode: 'regionCode',
+        },
+        correlationId: 'correlationId',
+        meetingId: 'meetingId',
+        preferTranscoding: true,
+        getCurrentSelfUrl: () => currentSelfUrl,
+      },
+      {
+        parent: mockWebex,
+      }
+    );
+    webexRequestStub = sinon.stub(locusMediaRequest, 'request');
+    webexRequestStub.onFirstCall().callsFake(() => {
+      currentSelfUrl = 'newSelfUrl';
+
+      return Promise.reject({statusCode: 409, message: 'conflict'});
+    });
+    webexRequestStub.onSecondCall().resolves(fakeLocusResponse);
+
+    const result = await locusMediaRequest.send({
+      ...exampleLocalMuteRequestBody,
+      selfUrl: 'oldSelfUrl',
+      muteOptions: {audioMuted: false, videoMuted: true},
+    });
+
+    assert.equal(result, fakeLocusResponse);
+    assert.calledTwice(webexRequestStub);
+    assert.equal(webexRequestStub.getCall(0).args[0].uri, 'oldSelfUrl/media');
+    assert.equal(webexRequestStub.getCall(1).args[0].uri, 'newSelfUrl/media');
+  });
+
+  it('stops retrying roap conflicts after the selfUrl retry limit', async () => {
+    let currentSelfUrl = 'oldSelfUrl';
+    locusMediaRequest = new LocusMediaRequest(
+      {
+        device: {
+          url: 'deviceUrl',
+          deviceType: 'deviceType',
+          regionCode: 'regionCode',
+        },
+        correlationId: 'correlationId',
+        meetingId: 'meetingId',
+        preferTranscoding: true,
+        getCurrentSelfUrl: () => currentSelfUrl,
+      },
+      {
+        parent: mockWebex,
+      }
+    );
+    webexRequestStub = sinon.stub(locusMediaRequest, 'request');
+    webexRequestStub.onFirstCall().callsFake(() => {
+      currentSelfUrl = 'secondSelfUrl';
+
+      return Promise.reject({statusCode: 409, message: 'conflict'});
+    });
+    webexRequestStub.onSecondCall().callsFake(() => {
+      currentSelfUrl = 'thirdSelfUrl';
+
+      return Promise.reject({statusCode: 409, message: 'conflict'});
+    });
+    webexRequestStub.onThirdCall().callsFake(() => {
+      currentSelfUrl = 'fourthSelfUrl';
+
+      return Promise.reject({statusCode: 409, message: 'conflict'});
+    });
+
+    const request = cloneDeep(exampleRoapRequestBody);
+
+    request.selfUrl = 'oldSelfUrl';
+    request.roapMessage.messageType = 'ANSWER';
+
+    await assert.isRejected(locusMediaRequest.send(request));
+
+    assert.calledThrice(webexRequestStub);
+    assert.equal(webexRequestStub.getCall(0).args[0].uri, 'oldSelfUrl/media');
+    assert.equal(webexRequestStub.getCall(1).args[0].uri, 'secondSelfUrl/media');
+    assert.equal(webexRequestStub.getCall(2).args[0].uri, 'thirdSelfUrl/media');
   });
 
   it('sends correct metric event when roap message fails', async () => {


### PR DESCRIPTION
# COMPLETES #

## This pull request addresses
BEMS01973104 [New] EXTENDED CARE  ZD: #146772 - Breakout room issues with the JS SDK

## by making the following changes
Created new method to fetch the correct/accurate local url instead of using meeting.selfUrl which can be stale.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested


## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
