### PR TITLE
fix(plugin-meetings): removed unnecessary metric call, added tests for other metric calls

### DIFF
--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -710,13 +710,6 @@ export default class LocusInfo extends EventsScope {
 
       // Active parser found - pass the API response to it
       if (isWrapped) {
-        if (!responseBody.dataSets) {
-          this.sendClassicVsHashTreeMismatchMetric(
-            meeting,
-            `expected hash tree dataSets in API response but they are missing`
-          );
-          // continuing as we can still manage without responseBody.dataSets, but this is very suspicious
-        }
         LoggerProxy.logger.info(
           'Locus-info:index#handleLocusAPIResponse --> passing Locus API response to HashTreeParser: ',
           responseBody

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -3385,6 +3385,51 @@ describe('plugin-meetings', () => {
 
         assert.calledOnceWithExactly(parserA.handleMessage, message);
       });
+
+      it('should send mismatch metric when eventType is not HASH_TREE_DATA_UPDATED', () => {
+        const locusUrlA = 'http://locus-url-A.com';
+        const parserA = {state: 'active', handleMessage: sinon.stub()};
+        locusInfo.hashTreeParsers.set(locusUrlA, {parser: parserA, initializedFromHashTree: true});
+
+        locusInfo.parse(mockMeeting, {
+          eventType: LOCUSEVENT.SELF_CHANGED,
+          stateElementsMessage: {locusUrl: locusUrlA, locusStateElements: [], dataSets: []},
+        });
+
+        assert.calledOnceWithExactly(
+          sendBehavioralMetricStub,
+          'js_sdk_locus_classic_vs_hash_tree_mismatch',
+          {
+            correlationId: mockMeeting.correlationId,
+            message: `got ${LOCUSEVENT.SELF_CHANGED}, expected ${LOCUSEVENT.HASH_TREE_DATA_UPDATED}`,
+          }
+        );
+        assert.notCalled(parserA.handleMessage);
+      });
+    });
+
+    describe('#sendClassicVsHashTreeMismatchMetric', () => {
+      it('should send the metric when called for the first time', () => {
+        locusInfo.sendClassicVsHashTreeMismatchMetric(mockMeeting, 'some mismatch');
+
+        assert.calledOnceWithExactly(
+          sendBehavioralMetricStub,
+          'js_sdk_locus_classic_vs_hash_tree_mismatch',
+          {
+            correlationId: mockMeeting.correlationId,
+            message: 'some mismatch',
+          }
+        );
+      });
+
+      it('should send the metric up to 5 times and stop after that', () => {
+        for (let i = 0; i < 7; i += 1) {
+          locusInfo.sendClassicVsHashTreeMismatchMetric(mockMeeting, `mismatch ${i}`);
+        }
+
+        assert.callCount(sendBehavioralMetricStub, 5);
+        assert.equal(locusInfo.classicVsHashTreeMismatchMetricCounter, 5);
+      });
     });
 
     describe('#handleLocusAPIResponse', () => {
@@ -3440,19 +3485,24 @@ describe('plugin-meetings', () => {
         assert.calledOnceWithExactly(locusInfo.handleLocusDelta, fakeLocus, mockMeeting);
       });
 
-      it('should send mismatch metric when hash tree parser exists but dataSets are missing in wrapped response', () => {
+      it('should send mismatch metric in classic mode when wrapped response has dataSets', () => {
         const fakeLocus = {url: 'http://locus-url.com'};
-        const mockHashTreeParser = {handleLocusUpdate: sinon.stub()};
-        locusInfo.hashTreeParsers.set(fakeLocus.url, {
-          parser: mockHashTreeParser,
-          initializedFromHashTree: true,
+        sinon.stub(locusInfo, 'handleLocusDelta');
+
+        locusInfo.handleLocusAPIResponse(mockMeeting, {
+          locus: fakeLocus,
+          dataSets: [{name: 'dataset1', url: 'test-url'}],
         });
-        sinon.stub(locusInfo, 'sendClassicVsHashTreeMismatchMetric');
 
-        locusInfo.handleLocusAPIResponse(mockMeeting, {locus: fakeLocus});
-
-        assert.calledOnce(locusInfo.sendClassicVsHashTreeMismatchMetric);
-        assert.calledOnce(mockHashTreeParser.handleLocusUpdate);
+        assert.calledOnceWithExactly(
+          sendBehavioralMetricStub,
+          'js_sdk_locus_classic_vs_hash_tree_mismatch',
+          {
+            correlationId: mockMeeting.correlationId,
+            message: 'unexpected hash tree dataSets in API response',
+          }
+        );
+        assert.calledOnce(locusInfo.handleLocusDelta);
       });
 
       describe('parser switch via API response', () => {


### PR DESCRIPTION
# COMPLETES #[SPARK-753139](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-753139)

## This pull request addresses
There are cases where in hash tree mode we may receive a Locus API response without any datasets - I've seen this with GET /loci responses and I think Locus team said it could also happen if there is no change in any datasets. We had a piece of code sending a metric in that case, so I've removed it. Also added unit tests for other cases when we send that metric.

## by making the following changes
removed unnecessary call to send metrics, added tests for other calls

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
