### PR TITLE
feat(jmt): reduce missing rate of some metrics for no-interstitial joins

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -224,11 +224,17 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
    * @returns - latency
    */
   public getCallInitJoinReq() {
-    return this.getDiffBetweenTimestamps(
-      'internal.client.interstitial-window.click.joinbutton',
-      'client.locus.join.request',
-      {maximum: 1200000}
+    const interstitialShowedToJoinReq = this.getDiffBetweenTimestamps(
+      'internal.client.meeting.interstitial-window.showed',
+      'client.locus.join.request'
     );
+    const showInterstitialTime = this.getShowInterstitialTime() || 0;
+
+    if (typeof interstitialShowedToJoinReq !== 'number') {
+      return undefined;
+    }
+
+    return clamp(interstitialShowedToJoinReq - showInterstitialTime, 0, 1200000);
   }
 
   /**
@@ -411,10 +417,17 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
    * @returns - latency
    */
   public getInterstitialToJoinOK() {
-    return this.getDiffBetweenTimestamps(
-      'internal.client.interstitial-window.click.joinbutton',
+    const interstitialShowedToJoinResp = this.getDiffBetweenTimestamps(
+      'internal.client.meeting.interstitial-window.showed',
       'client.locus.join.response'
     );
+    const showInterstitialTime = this.getShowInterstitialTime() || 0;
+
+    if (typeof interstitialShowedToJoinResp !== 'number') {
+      return undefined;
+    }
+
+    return clamp(interstitialShowedToJoinResp - showInterstitialTime, 0, this.MAX_INTEGER);
   }
 
   /**
@@ -430,18 +443,19 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
    * @returns - latency
    */
   public getInterstitialToMediaOKJMT() {
-    const interstitialClickJoinToIceEnd = this.getDiffBetweenTimestamps(
-      'internal.client.interstitial-window.click.joinbutton',
+    const interstitialShowedToIceEnd = this.getDiffBetweenTimestamps(
+      'internal.client.meeting.interstitial-window.showed',
       'client.ice.end'
     );
+    const showInterstitialTime = this.getShowInterstitialTime() || 0;
     const stayLobbyTimeCappedByIceEnd = this.getStayLobbyTimeCappedBy('client.ice.end');
 
     if (
-      typeof interstitialClickJoinToIceEnd === 'number' &&
+      typeof interstitialShowedToIceEnd === 'number' &&
       typeof stayLobbyTimeCappedByIceEnd === 'number'
     ) {
       return clamp(
-        interstitialClickJoinToIceEnd - stayLobbyTimeCappedByIceEnd,
+        interstitialShowedToIceEnd - showInterstitialTime - stayLobbyTimeCappedByIceEnd,
         0,
         this.MAX_INTEGER
       );
@@ -456,17 +470,18 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
    */
   public getTotalJMT() {
     const clickToInterstitial = this.getClickToInterstitial();
-    const interstitialClickJoinToJoinLocusResponse = this.getDiffBetweenTimestamps(
-      'internal.client.interstitial-window.click.joinbutton',
+    const interstitialShowedToJoinLocusResponse = this.getDiffBetweenTimestamps(
+      'internal.client.meeting.interstitial-window.showed',
       'client.locus.join.response'
     );
+    const showInterstitialTime = this.getShowInterstitialTime() || 0;
 
     if (
       typeof clickToInterstitial === 'number' &&
-      typeof interstitialClickJoinToJoinLocusResponse === 'number'
+      typeof interstitialShowedToJoinLocusResponse === 'number'
     ) {
       return clamp(
-        clickToInterstitial + interstitialClickJoinToJoinLocusResponse,
+        clickToInterstitial + interstitialShowedToJoinLocusResponse - showInterstitialTime,
         0,
         this.MAX_INTEGER
       );
@@ -521,22 +536,24 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
    */
   public getTotalMediaJMT() {
     const clickToInterstitial = this.getClickToInterstitial();
-    const interstitialClickJoinToMediaEngineReady = this.getDiffBetweenTimestamps(
-      'internal.client.interstitial-window.click.joinbutton',
+    const interstitialShowedToMediaEngineReady = this.getDiffBetweenTimestamps(
+      'internal.client.meeting.interstitial-window.showed',
       'client.media-engine.ready'
     );
+    const showInterstitialTime = this.getShowInterstitialTime() || 0;
     const stayLobbyTimeCappedByMediaEngineReady = this.getStayLobbyTimeCappedBy(
       'client.media-engine.ready'
     );
 
     if (
       typeof clickToInterstitial === 'number' &&
-      typeof interstitialClickJoinToMediaEngineReady === 'number' &&
+      typeof interstitialShowedToMediaEngineReady === 'number' &&
       typeof stayLobbyTimeCappedByMediaEngineReady === 'number'
     ) {
       return clamp(
         clickToInterstitial +
-          interstitialClickJoinToMediaEngineReady -
+          interstitialShowedToMediaEngineReady -
+          showInterstitialTime -
           stayLobbyTimeCappedByMediaEngineReady,
         0,
         this.MAX_INTEGER
@@ -579,17 +596,20 @@ export default class CallDiagnosticLatencies extends WebexPlugin {
     const clickToInterstitialForClientJmt = this.precomputedLatencies.get(
       'internal.click.to.interstitial.for.client.jmt'
     );
-    const interstitialJoinToLocusJoinRequest = this.getDiffBetweenTimestamps(
-      'internal.client.interstitial-window.click.joinbutton',
+    const interstitialShowedToLocusJoinRequest = this.getDiffBetweenTimestamps(
+      'internal.client.meeting.interstitial-window.showed',
       'client.locus.join.request'
     );
+    const showInterstitialTime = this.getShowInterstitialTime() || 0;
 
     if (
       typeof clickToInterstitialForClientJmt === 'number' &&
-      typeof interstitialJoinToLocusJoinRequest === 'number'
+      typeof interstitialShowedToLocusJoinRequest === 'number'
     ) {
       return clamp(
-        clickToInterstitialForClientJmt + interstitialJoinToLocusJoinRequest,
+        clickToInterstitialForClientJmt +
+          interstitialShowedToLocusJoinRequest -
+          showInterstitialTime,
         0,
         this.MAX_INTEGER
       );

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-batcher.ts
@@ -192,6 +192,12 @@ describe('plugin-metrics', () => {
           webex.internal.newMetrics.callDiagnosticLatencies.getTotalJMTWithUserDelay = sinon
             .stub()
             .returns(64);
+          webex.internal.newMetrics.callDiagnosticLatencies.getInterstitialToJoinOK = sinon
+            .stub()
+            .returns(10);
+          webex.internal.newMetrics.callDiagnosticLatencies.getTotalJMT = sinon
+            .stub()
+            .returns(20);
           const promise = webex.internal.newMetrics.callDiagnosticMetrics.submitToCallDiagnostics(
             //@ts-ignore
             {event: {name: 'client.locus.join.response'}}
@@ -349,6 +355,9 @@ describe('plugin-metrics', () => {
           webex.internal.newMetrics.callDiagnosticLatencies.getStayLobbyTimeCappedBy = sinon
             .stub()
             .returns(1);
+          webex.internal.newMetrics.callDiagnosticLatencies.getTotalMediaJMT = sinon
+            .stub()
+            .returns(44);
           webex.internal.newMetrics.callDiagnosticLatencies.getTotalMediaJMTWithUserDelay = sinon
             .stub()
             .returns(43);

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics-latencies.ts
@@ -412,8 +412,10 @@ describe('internal-plugin-metrics', () => {
     });
 
     it('calculates getCallInitJoinReq correctly', () => {
+      cdl.saveTimestamp({key: 'internal.client.meeting.interstitial-window.showed', value: 5});
       cdl.saveTimestamp({key: 'internal.client.interstitial-window.click.joinbutton', value: 10});
       cdl.saveTimestamp({key: 'client.locus.join.request', value: 20});
+      // showedToJoinReq = 20-5 = 15, showInterstitialTime = 10-5 = 5, result = 15-5 = 10
       assert.deepEqual(cdl.getCallInitJoinReq(), 10);
     });
 
@@ -645,6 +647,10 @@ describe('internal-plugin-metrics', () => {
 
     it('calculates getInterstitialToJoinOK correctly', () => {
       cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 5,
+      });
+      cdl.saveTimestamp({
         key: 'internal.client.interstitial-window.click.joinbutton',
         value: 10,
       });
@@ -652,12 +658,13 @@ describe('internal-plugin-metrics', () => {
         key: 'client.locus.join.response',
         value: 20,
       });
+      // showedToJoinResp = 20-5 = 15, showInterstitialTime = 10-5 = 5, result = 15-5 = 10
       assert.deepEqual(cdl.getInterstitialToJoinOK(), 10);
     });
 
     it('calculates getInterstitialToJoinOK correctly when one value is not a number', () => {
       cdl.saveTimestamp({
-        key: 'internal.client.interstitial-window.click.joinbutton',
+        key: 'internal.client.meeting.interstitial-window.showed',
         value: 'ten' as unknown as number,
       });
       cdl.saveTimestamp({
@@ -674,10 +681,6 @@ describe('internal-plugin-metrics', () => {
 
     it('calculates getTotalJMT correctly', () => {
       cdl.saveTimestamp({
-        key: 'internal.client.interstitial-window.click.joinbutton',
-        value: 5,
-      });
-      cdl.saveTimestamp({
         key: 'internal.client.meeting.click.joinbutton',
         value: 10,
       });
@@ -686,28 +689,38 @@ describe('internal-plugin-metrics', () => {
         value: 20,
       });
       cdl.saveTimestamp({
+        key: 'internal.client.interstitial-window.click.joinbutton',
+        value: 25,
+      });
+      cdl.saveTimestamp({
         key: 'client.locus.join.response',
         value: 40,
       });
-      assert.deepEqual(cdl.getTotalJMT(), 45);
+      // clickToInterstitial = 20-10 = 10
+      // showedToJoinLocusResponse = 40-20 = 20
+      // showInterstitialTime = 25-20 = 5
+      // total = 10 + 20 - 5 = 25
+      assert.deepEqual(cdl.getTotalJMT(), 25);
     });
 
     it('calculates getTotalJMT correctly when clickToInterstitial is 0', () => {
       cdl.saveLatency('internal.click.to.interstitial', 0);
       cdl.saveTimestamp({
-        key: 'internal.client.interstitial-window.click.joinbutton',
+        key: 'internal.client.meeting.interstitial-window.showed',
         value: 20,
       });
       cdl.saveTimestamp({
         key: 'client.locus.join.response',
         value: 40,
       });
+      // showedToJoinLocusResponse = 40-20 = 20, showInterstitialTime = 0
+      // total = 0 + 20 - 0 = 20
       assert.deepEqual(cdl.getTotalJMT(), 20);
     });
 
     it('calculates getTotalJMT correctly when interstitialClickJoinToJoinLocusResponse is 0', () => {
       cdl.saveTimestamp({
-        key: 'internal.client.interstitial-window.click.joinbutton',
+        key: 'internal.client.meeting.interstitial-window.showed',
         value: 40,
       });
       cdl.saveLatency('internal.click.to.interstitial', 12);
@@ -715,12 +728,14 @@ describe('internal-plugin-metrics', () => {
         key: 'client.locus.join.response',
         value: 40,
       });
+      // showedToJoinLocusResponse = 0, showInterstitialTime = 0
+      // total = 12 + 0 - 0 = 12
       assert.deepEqual(cdl.getTotalJMT(), 12);
     });
 
     it('calculates getTotalJMT correctly when both clickToInterstitial and interstitialClickJoinToJoinLocusResponse are 0', () => {
       cdl.saveTimestamp({
-        key: 'internal.client.interstitial-window.click.joinbutton',
+        key: 'internal.client.meeting.interstitial-window.showed',
         value: 40,
       });
       cdl.saveLatency('internal.click.to.interstitial', 0);
@@ -733,7 +748,7 @@ describe('internal-plugin-metrics', () => {
 
     it('calculates getTotalJMT correctly when both clickToInterstitial is not a number', () => {
       cdl.saveTimestamp({
-        key: 'internal.client.interstitial-window.click.joinbutton',
+        key: 'internal.client.meeting.interstitial-window.showed',
         value: 40,
       });
       cdl.saveLatency('internal.click.to.interstitial', 'eleven' as unknown as number);
@@ -746,7 +761,7 @@ describe('internal-plugin-metrics', () => {
 
     it('calculates getTotalJMT correctly when it is greater than MAX_INTEGER', () => {
       cdl.saveTimestamp({
-        key: 'internal.client.interstitial-window.click.joinbutton',
+        key: 'internal.client.meeting.interstitial-window.showed',
         value: 5,
       });
       cdl.saveTimestamp({
@@ -887,7 +902,7 @@ describe('internal-plugin-metrics', () => {
 
     it('calculates getTotalMediaJMT correctly when it is greater than MAX_INTEGER', () => {
       cdl.saveTimestamp({key: 'internal.client.meeting.click.joinbutton', value: 5});
-      cdl.saveTimestamp({key: 'internal.client.meeting.interstitial-window.showed', value: 8});
+      cdl.saveTimestamp({key: 'internal.client.meeting.interstitial-window.showed', value: 10});
       cdl.saveTimestamp({key: 'internal.client.interstitial-window.click.joinbutton', value: 10});
       cdl.saveTimestamp({key: 'client.media-engine.ready', value: 4294967400});
       cdl.saveTimestamp({key: 'client.lobby.entered', value: 28});
@@ -993,6 +1008,10 @@ describe('internal-plugin-metrics', () => {
     it('calculates getClientJMT correctly', () => {
       cdl.saveLatency('internal.click.to.interstitial.for.client.jmt', 5);
       cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 1,
+      });
+      cdl.saveTimestamp({
         key: 'internal.client.interstitial-window.click.joinbutton',
         value: 2,
       });
@@ -1000,11 +1019,16 @@ describe('internal-plugin-metrics', () => {
         key: 'client.locus.join.request',
         value: 6,
       });
-      // clickToInterstitialForClientJmt (5) + interstitialJoinToLocusJoinRequest (6 - 2 = 4) = 9
+      // showedToLocusJoinRequest = 6-1 = 5, showInterstitialTime = 2-1 = 1
+      // clickToInterstitialForClientJmt (5) + 5 - 1 = 9
       assert.deepEqual(cdl.getClientJMT(), 9);
     });
 
     it('returns undefined for getClientJMT when clickToInterstitialForClientJmt is missing', () => {
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 1,
+      });
       cdl.saveTimestamp({
         key: 'internal.client.interstitial-window.click.joinbutton',
         value: 2,
@@ -1071,6 +1095,10 @@ describe('internal-plugin-metrics', () => {
 
     it('calculates getInterstitialToMediaOKJMT correctly', () => {
       cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 2,
+      });
+      cdl.saveTimestamp({
         key: 'internal.client.interstitial-window.click.joinbutton',
         value: 4,
       });
@@ -1086,10 +1114,17 @@ describe('internal-plugin-metrics', () => {
         key: 'client.ice.end',
         value: 14,
       });
+      // showedToIceEnd = 14-2 = 12, showInterstitialTime = 4-2 = 2
+      // stayLobbyTimeCappedByIceEnd = min(12,14)-10 = 2
+      // result = 12 - 2 - 2 = 8
       assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 8);
     });
 
     it('calculates getInterstitialToMediaOKJMT correctly when it is greater than MAX_INTEGER', () => {
+      cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 4,
+      });
       cdl.saveTimestamp({
         key: 'internal.client.interstitial-window.click.joinbutton',
         value: 4,
@@ -1111,6 +1146,10 @@ describe('internal-plugin-metrics', () => {
 
     it('calculates getInterstitialToMediaOKJMT correctly without lobby', () => {
       cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 2,
+      });
+      cdl.saveTimestamp({
         key: 'internal.client.interstitial-window.click.joinbutton',
         value: 4,
       });
@@ -1118,13 +1157,18 @@ describe('internal-plugin-metrics', () => {
         key: 'client.ice.end',
         value: 14,
       });
-      // no client.lobby.entered → stayLobbyTimeCappedByIceEnd = 0
-      // result = (14 - 4) - 0 = 10
+      // showedToIceEnd = 14-2 = 12, showInterstitialTime = 4-2 = 2
+      // stayLobbyTimeCappedByIceEnd = 0 (no lobby)
+      // result = 12 - 2 - 0 = 10
       assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 10);
     });
 
     it('calculates getInterstitialToMediaOKJMT correctly when there is no lobby and stayLobbyTime defaults to 0', () => {
       cdl.saveTimestamp({
+        key: 'internal.client.meeting.interstitial-window.showed',
+        value: 2,
+      });
+      cdl.saveTimestamp({
         key: 'internal.client.interstitial-window.click.joinbutton',
         value: 4,
       });
@@ -1132,8 +1176,9 @@ describe('internal-plugin-metrics', () => {
         key: 'client.ice.end',
         value: 14,
       });
-      // no client.lobby.entered → stayLobbyTimeCappedByIceEnd = 0
-      // result = (14 - 4) - 0 = 10
+      // showedToIceEnd = 14-2 = 12, showInterstitialTime = 4-2 = 2
+      // stayLobbyTimeCappedByIceEnd = 0 (no lobby)
+      // result = 12 - 2 - 0 = 10
       assert.deepEqual(cdl.getInterstitialToMediaOKJMT(), 10);
     });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-804212

## This pull request addresses
internal.client.interstitial-window.click.joinbutton is not guaranteed to exist (if no interstitial)
internal.client.meeting.interstitial-window.showed is (even when there's no interstitial)
the previous implementation would cause a bunch of metrics to be undefined cuz joinbutton even doesn't exist

## by making the following changes
for metrics where start point is click.joinbutton, switch to using showed as start point, then deduct showInterstitialTime (0 for no interstitial)

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
