### PR TITLE
fix(calling): clean up socket consumpation code

### DIFF
--- a/packages/calling/src/CallingClient/CallingClient.test.ts
+++ b/packages/calling/src/CallingClient/CallingClient.test.ts
@@ -97,7 +97,7 @@ describe('CallingClient Tests', () => {
 
   beforeEach(() => {
     APIRequest.resetInstance();
-    APIRequest.getInstance({webex, isMobiusSocketEnabled: false});
+    APIRequest.getInstance({webex});
   });
 
   describe('CallingClient pick Mobius cluster using Service Host Tests', () => {
@@ -845,6 +845,10 @@ describe('CallingClient Tests', () => {
     let mobiusSocketMock;
 
     beforeEach(async () => {
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue({value: true});
+      APIRequest.resetInstance();
+      APIRequest.getInstance({webex});
+
       mobiusSocketMock = (
         jest.requireMock('@webex/internal-plugin-mobius-socket') as {
           getMobiusSocketInstance: (w: unknown) => unknown;
@@ -858,7 +862,6 @@ describe('CallingClient Tests', () => {
 
       callingClient = await createClient(webex, {
         logger: {level: LOGGER.INFO},
-        isMobiusSocketEnabled: true,
       });
 
       const asyncEventOnCall = (mobiusSocketMock.on as jest.Mock).mock.calls.find(
@@ -870,6 +873,7 @@ describe('CallingClient Tests', () => {
     afterEach(() => {
       callingClient.removeAllListeners();
       callManager.removeAllListeners();
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue({value: false});
     });
 
     it('routes mobius.* async events to callManager', async () => {

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -2,8 +2,6 @@
 /* eslint-disable valid-jsdoc */
 /* eslint-disable @typescript-eslint/no-shadow */
 import * as Media from '@webex/internal-media-core';
-// @ts-ignore - JS module without type declarations
-import {getMobiusSocketInstance} from '@webex/internal-plugin-mobius-socket';
 import {Mutex} from 'async-mutex';
 import {METHOD_START_MESSAGE} from '../common/constants';
 import {
@@ -67,7 +65,6 @@ import {
 import {getMetricManager} from '../Metrics';
 import windowsChromiumIceWarmup from './windowsChromiumIceWarmupUtils';
 import {APIRequest} from './utils/request';
-import {isMobiusWssEnabled} from './utils';
 
 /**
  * The `CallingClient` module provides a set of APIs for line registration and calling functionalities within the SDK.
@@ -111,11 +108,6 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
   private apiRequest: APIRequest;
 
-  private isMobiusSocketEnabled: boolean;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private mobiusSocket: any;
-
   private isNetworkDown = false;
 
   private networkDownTimestamp = '';
@@ -152,14 +144,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     log.setLogger(logLevel, CALLING_CLIENT_FILE);
     validateServiceData(serviceData);
 
-    this.isMobiusSocketEnabled =
-      isMobiusWssEnabled(this.webex) || (config?.isMobiusSocketEnabled ?? false);
-
-    this.callManager = getCallManager(
-      this.webex,
-      serviceData.indicator,
-      this.isMobiusSocketEnabled
-    );
+    this.callManager = getCallManager(this.webex, serviceData.indicator);
     this.metricManager = getMetricManager(this.webex, serviceData.indicator);
 
     this.mediaEngine = Media;
@@ -182,14 +167,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     this.mobiusClusters = this.webex.internal.services.getMobiusClusters();
     this.mobiusHost = '';
 
-    if (this.isMobiusSocketEnabled) {
-      this.mobiusSocket = getMobiusSocketInstance(this.webex);
-    }
-
-    this.apiRequest = APIRequest.getInstance({
-      webex: this.webex,
-      isMobiusSocketEnabled: this.isMobiusSocketEnabled,
-    });
+    this.apiRequest = APIRequest.getInstance({webex: this.webex});
 
     this.registerSessionsListener();
 
@@ -237,7 +215,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
     await this.getMobiusServers();
 
-    if (this.isMobiusSocketEnabled) {
+    if (this.apiRequest.isSocketEnabled()) {
       await this.connectToMobiusSocket();
       this.registerMobiusSocketListener();
     }
@@ -683,7 +661,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
         try {
           log.log(`Trying primary WSS URI: ${wssUri}`, loggerContext);
           // eslint-disable-next-line no-await-in-loop
-          await this.mobiusSocket.connect(wssUri);
+          await this.apiRequest.connectToMobiusSocket(wssUri);
           log.log(
             `Successfully connected to Mobius socket on primary WSS URI: ${wssUri}`,
             loggerContext
@@ -710,7 +688,7 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
         try {
           log.log(`Trying backup WSS URI: ${wssUri}`, loggerContext);
           // eslint-disable-next-line no-await-in-loop
-          await this.mobiusSocket.connect(wssUri);
+          await this.apiRequest.connectToMobiusSocket(wssUri);
           log.log(
             `Successfully connected to Mobius socket on backup WSS URI: ${wssUri}`,
             loggerContext
@@ -734,10 +712,6 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       'All Mobius socket connection attempts exhausted for both primary and backup, continuing without socket',
       loggerContext
     );
-    log.warn(
-      'All Mobius socket connection attempts exhausted for both primary and backup, continuing without socket',
-      loggerContext
-    );
   }
 
   private registerMobiusSocketListener() {
@@ -745,12 +719,8 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       file: CALLING_CLIENT_FILE,
       method: METHODS.REGISTER_MOBIUS_SOCKET_LISTENER,
     });
-    this.sdkConnector.registerMobiusSocketListener<MobiusAsyncEvent>(
-      'event:async_event',
-      (event) => {
-        this.handleMobiusAsyncEvent(event);
-      }
-    );
+
+    this.apiRequest.registerMobiusSocketListener(this.handleMobiusAsyncEvent);
 
     log.info('Successfully registered listener for Mobius events', {
       file: CALLING_CLIENT_FILE,
@@ -758,12 +728,13 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     });
   }
 
+  // MOBIUS TODO: Check and remove this later. This might not be required.
   // private unregisterMobiusSocketListener() {
   //   log.info(METHOD_START_MESSAGE, {
   //     file: CALLING_CLIENT_FILE,
   //     method: METHODS.UNREGISTER_MOBIUS_SOCKET_LISTENER,
   //   });
-  //   this.sdkConnector.unregisterMobiusSocketListener('async_event');
+  //   this.apiRequest.unregisterMobiusSocketListener();
   // }
 
   private handleMobiusAsyncEvent = async (event?: MobiusAsyncEvent) => {
@@ -787,12 +758,12 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       // const line = Object.values(this.lineDict)[0];
       // line.registration.handleRegistrationDownEvent(event);
 
+      // TODO: check active calls and clean up the state and emit disconnect event
+
       return;
     }
 
-    if (eventType.startsWith('mobius.')) {
-      this.callManager.dequeueWsEvents(event);
-    }
+    this.callManager.dequeueWsEvents(event);
   };
 
   /**

--- a/packages/calling/src/CallingClient/calling/callManager.ts
+++ b/packages/calling/src/CallingClient/calling/callManager.ts
@@ -1,5 +1,6 @@
 /* eslint-disable dot-notation */
 /* eslint-disable valid-jsdoc */
+import {APIRequest} from '../utils/request';
 import {METHOD_START_MESSAGE} from '../../common/constants';
 import {CALL_MANAGER_FILE, METHODS} from '../constants';
 import {CALLING_CLIENT_EVENT_KEYS, CallEventTypes, LINE_EVENT_KEYS} from '../../Events/types';
@@ -30,8 +31,6 @@ export class CallManager extends Eventing<CallEventTypes> implements ICallManage
 
   private webex: WebexSDK;
 
-  private isMobiusSocketEnabled: boolean;
-
   private callCollection: Record<CorrelationId, ICall>;
 
   private activeMobiusUrl!: string;
@@ -40,20 +39,22 @@ export class CallManager extends Eventing<CallEventTypes> implements ICallManage
 
   private lineDict: Record<string, ILine>;
 
+  private apiRequest: APIRequest;
+
   /**
    * @param webex -.
    * @param indicator - Service Indicator.
    */
-  constructor(webex: WebexSDK, indicator: ServiceIndicator, isMobiusSocketEnabled: boolean) {
+  constructor(webex: WebexSDK, indicator: ServiceIndicator) {
     super();
     this.sdkConnector = SDKConnector;
     this.serviceIndicator = indicator;
-    this.isMobiusSocketEnabled = isMobiusSocketEnabled;
     if (!this.sdkConnector.getWebex()) {
       SDKConnector.setWebex(webex);
     }
     this.lineDict = {};
     this.webex = this.sdkConnector.getWebex();
+    this.apiRequest = APIRequest.getInstance({webex: this.webex});
     this.callCollection = {};
     this.activeMobiusUrl = '';
     this.listenForWsEvents();
@@ -131,7 +132,7 @@ export class CallManager extends Eventing<CallEventTypes> implements ICallManage
    * A listener for Mobius events.
    */
   private listenForWsEvents() {
-    if (!this.isMobiusSocketEnabled) {
+    if (!this.apiRequest.isSocketEnabled()) {
       this.sdkConnector.registerListener('event:mobius', async (event) => {
         this.dequeueWsEvents(event);
       });
@@ -494,13 +495,9 @@ export class CallManager extends Eventing<CallEventTypes> implements ICallManage
  * @param webex -.
  * @param indicator - Service Indicator.
  */
-export const getCallManager = (
-  webex: WebexSDK,
-  indicator: ServiceIndicator,
-  isMobiusSocketEnabled = false
-): ICallManager => {
+export const getCallManager = (webex: WebexSDK, indicator: ServiceIndicator): ICallManager => {
   if (!callManager) {
-    callManager = new CallManager(webex, indicator, isMobiusSocketEnabled);
+    callManager = new CallManager(webex, indicator);
   }
 
   return callManager;

--- a/packages/calling/src/CallingClient/types.ts
+++ b/packages/calling/src/CallingClient/types.ts
@@ -22,7 +22,6 @@ export interface CallingClientConfig {
   discovery?: DiscoveryConfig;
   serviceData?: ServiceData;
   jwe?: string;
-  isMobiusSocketEnabled?: boolean;
 }
 
 export type CallingClientErrorEmitterCallback = (

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -4,7 +4,7 @@ import {getMobiusSocketInstance} from '@webex/internal-plugin-mobius-socket';
 import {WebexRequestPayload} from '../../common/types';
 import {WebexSDK} from '../../SDKConnector/types';
 import log from '../../Logger';
-import {APIRequestConfig, APIRequestOptions, MobiusSocketResponse} from './types';
+import {APIRequestConfig, APIRequestOptions, MobiusAsyncEvent, MobiusSocketResponse} from './types';
 import {
   deriveMobiusSocketMessageType,
   isSupplementaryServiceMessageType,
@@ -84,8 +84,7 @@ export class APIRequest {
     }
 
     this.webex = config.webex;
-    this.isMobiusSocketEnabled =
-      isMobiusWssEnabled(config.webex) || (config.isMobiusSocketEnabled ?? false);
+    this.isMobiusSocketEnabled = isMobiusWssEnabled(config.webex) || false;
     this.mobiusSocket = getMobiusSocketInstance(this.webex);
   }
 
@@ -186,6 +185,16 @@ export class APIRequest {
     }
 
     return this.webex.request(request) as Promise<WebexRequestPayload>;
+  }
+
+  public registerMobiusSocketListener(cb: (data?: MobiusAsyncEvent) => void): void {
+    this.mobiusSocket.on('event:async_event', (data: MobiusAsyncEvent) => {
+      cb(data);
+    });
+  }
+
+  public unregisterMobiusSocketListener(): void {
+    this.mobiusSocket.off('event:async_event');
   }
 }
 

--- a/packages/calling/src/CallingClient/utils/types.ts
+++ b/packages/calling/src/CallingClient/utils/types.ts
@@ -1,3 +1,4 @@
+import {MobiusCallData, MobiusRegistrationDownData} from '../calling/types';
 import {WebexRequestPayload} from '../../common/types';
 import {WebexSDK} from '../../SDKConnector/types';
 
@@ -5,11 +6,6 @@ import {WebexSDK} from '../../SDKConnector/types';
  * Configuration for APIRequest class
  */
 export interface APIRequestConfig {
-  /**
-   * Interim SDK opt-in for Mobius WebSocket transport when WDM
-   * `webrtc-calling-over-ws` is not yet true (until prod rollout).
-   */
-  isMobiusSocketEnabled?: boolean;
   /** Webex SDK instance for making requests */
   webex: WebexSDK;
 }
@@ -54,3 +50,10 @@ export type SendWssRequestFn = (
   sessionIdOrOptions?: string | Record<string, unknown>,
   options?: Record<string, unknown>
 ) => Promise<MobiusSocketResponse>;
+
+export type MobiusAsyncEvent = {
+  type: string;
+  eventId: string;
+  trackingId: string;
+  data: MobiusCallData | MobiusRegistrationDownData;
+};

--- a/packages/calling/src/SDKConnector/index.ts
+++ b/packages/calling/src/SDKConnector/index.ts
@@ -1,6 +1,4 @@
 /* eslint-disable valid-jsdoc */
-// @ts-ignore - JS module without type declarations
-import {getMobiusSocketInstance} from '@webex/internal-plugin-mobius-socket';
 import {WebexRequestPayload} from '../common/types';
 import {ISDKConnector, WebexSDK} from './types';
 /* eslint-disable class-methods-use-this */
@@ -8,8 +6,6 @@ import {validateWebex} from './utils';
 
 let instance: ISDKConnector;
 let webex: WebexSDK;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let mobiusSocket: any;
 
 /**
  *
@@ -28,7 +24,6 @@ class SDKConnector implements ISDKConnector {
       throw error;
     } else if (success) {
       webex = webexInstance; // TODO: Object.freeze to prevent changes? That might break the reference chain though
-      mobiusSocket = getMobiusSocketInstance(webexInstance);
     } else {
       throw new Error('An unknown error occurred setting up the webex instance.');
     }
@@ -73,29 +68,6 @@ class SDKConnector implements ISDKConnector {
    */
   public unregisterListener(event: string): void {
     instance.getWebex().internal.mercury.off(event);
-  }
-
-  /**
-   * @param event - TODO.
-   * @param cb - TODO.
-   */
-  public registerMobiusSocketListener<T>(event: string, cb: (data?: T) => void): void {
-    if (!mobiusSocket) {
-      mobiusSocket = getMobiusSocketInstance(instance.getWebex());
-    }
-    mobiusSocket.on(event, (data: T) => {
-      cb(data);
-    });
-  }
-
-  /**
-   * @param event - TODO.
-   */
-  public unregisterMobiusSocketListener(event: string): void {
-    if (!mobiusSocket) {
-      mobiusSocket = getMobiusSocketInstance(instance.getWebex());
-    }
-    mobiusSocket.off(event);
   }
 }
 

--- a/packages/calling/src/SDKConnector/types.ts
+++ b/packages/calling/src/SDKConnector/types.ts
@@ -173,6 +173,4 @@ export interface ISDKConnector {
   get: () => ISDKConnector;
   registerListener: <T>(event: string, cb: (data?: T) => unknown) => void;
   unregisterListener: (event: string) => void;
-  registerMobiusSocketListener: <T>(event: string, cb: (data?: T) => unknown) => void;
-  unregisterMobiusSocketListener: (event: string) => void;
 }


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [CAI-7855](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7855) >

## This pull request addresses

Cleans up the socket listener registration and other related code.

## by making the following changes

**`CallingClient.ts`**
- Removed the private `isMobiusSocketEnabled` and `mobiusSocket` fields — `CallingClient` no longer holds its own socket reference.
- Removed the direct import of `getMobiusSocketInstance` and `isMobiusWssEnabled`; socket-enabled status is now read through `apiRequest.isSocketEnabled()`.
- Socket connection (`connectToMobiusSocket`) now delegates to `apiRequest.connectToMobiusSocket(wssUri)` instead of calling `this.mobiusSocket.connect(wssUri)` directly.
- Mobius socket listener registration now calls `apiRequest.registerMobiusSocketListener()` instead of routing through `SDKConnector.registerMobiusSocketListener()`.
- Removed duplicate "all attempts exhausted" warning log that was printed twice.
- Simplified the `handleMobiusAsyncEvent` handler — removed the `eventType.startsWith('mobius.')` guard, routing all non-registration-down events to `callManager.dequeueWsEvents`.

**`APIRequest` (`utils/request.ts` + `utils/types.ts`)**
- Removed the `isMobiusSocketEnabled` option from `APIRequestConfig` — the flag is now determined solely from the WDM feature flag via `isMobiusWssEnabled()`.
- Added two new public methods: `registerMobiusSocketListener(cb)` and `unregisterMobiusSocketListener()`, making `APIRequest` the single owner of the socket event subscription.
- Moved the `MobiusAsyncEvent` type definition from `calling/types` into `utils/types.ts` to co-locate it with `APIRequest`.

**`CallManager` (`calling/callManager.ts`)**
- Removed the `isMobiusSocketEnabled` constructor parameter and private field.
- `CallManager` now obtains socket-enabled status directly from `APIRequest.getInstance().isSocketEnabled()`.
- `getCallManager()` factory signature simplified — no longer accepts a third `isMobiusSocketEnabled` argument.

**`SDKConnector` (`SDKConnector/index.ts` + `types.ts`)**
- Removed `registerMobiusSocketListener` and `unregisterMobiusSocketListener` methods entirely from `SDKConnector` and its interface — socket listener management is now fully owned by `APIRequest`.
- Removed the module-level `mobiusSocket` variable and the `getMobiusSocketInstance` import.

**`CallingClientConfig` (`types.ts`)**
- Removed the `isMobiusSocketEnabled?: boolean` SDK config option, which was an interim opt-in before the WDM feature flag (`webrtc-calling-over-ws`) reached full production rollout.

**`CallingClient.test.ts`**
- Updated the "Mobius async_event routing" test to enable the WDM feature flag (`webex.internal.device.features.developer.get` returning `{value: true}`) so `APIRequest` correctly enables socket mode during the test, replacing the removed `isMobiusSocketEnabled: true` config option.
- Updated the global `beforeEach` to use the simplified `APIRequest.getInstance({webex})` call.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

Sanity test on happy path

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
