### PR TITLE
fix: stop destroying meeting on TERMINATING

### DIFF
--- a/packages/@webex/plugin-meetings/src/constants.ts
+++ b/packages/@webex/plugin-meetings/src/constants.ts
@@ -103,7 +103,6 @@ export const _JOINED_ = 'JOINED';
 export const _LOCUS_ID_ = 'LOCUS_ID';
 export const _LEFT_ = 'LEFT';
 export const _MOVED_ = 'MOVED';
-export const _BREAKOUT_ENDED_ = 'BREAKOUT_ENDED';
 export const _ON_HOLD_LOBBY_ = 'ON_HOLD_LOBBY';
 export const _MEETING_LINK_ = 'MEETING_LINK';
 export const _MEETING_UUID_ = 'MEETING_UUID';
@@ -418,7 +417,7 @@ export const HEADERS = {
 // Meeting actually ended
 export const MEETING_REMOVED_REASON = {
   SELF_REMOVED: 'SELF_REMOVED', // server or host removed you from the meeting
-  MEETING_INACTIVE_TERMINATING: 'MEETING_INACTIVE_TERMINATING', // Meeting got ended or everyone left the meeting
+  MEETING_INACTIVE_TERMINATING: 'MEETING_INACTIVE_TERMINATING', // Meeting got ended or everyone left the meeting (historically was sent on Locus TERMINATING or INACTIVE, but now only on INACTIVE as that's the final state)
   CLIENT_LEAVE_REQUEST: 'CLIENT_LEAVE_REQUEST', // You triggered leave meeting
   CLIENT_LEAVE_REQUEST_TAB_CLOSED: 'CLIENT_LEAVE_REQUEST_TAB_CLOSED', // You triggered leave meeting, such as closing the browser tab directly
   USER_ENDED_SHARE_STREAMS: 'USER_ENDED_SHARE_STREAMS', // user triggered stop share

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -19,7 +19,6 @@ import {
   RECORDING_STATE,
   Enum,
   SELF_ROLES,
-  _BREAKOUT_ENDED_,
 } from '../constants';
 
 import InfoUtils from './infoUtils';
@@ -1782,13 +1781,9 @@ export default class LocusInfo extends EventsScope {
         );
       }
     } else if (this.parsedLocus.fullState?.type === _MEETING_) {
-      if (
-        this.fullState &&
-        this.fullState.state === LOCUS.STATE.INACTIVE &&
-        this.fullState.endMeetingReason !== _BREAKOUT_ENDED_
-      ) {
+      if (this.fullState && MeetingsUtil.isWholeMeetingEnded(this.fullState)) {
         LoggerProxy.logger.warn(
-          'Locus-info:index#isMeetingActive --> Meeting is ending due to inactive or terminating'
+          'Locus-info:index#isMeetingActive --> Meeting is ending due to inactive'
         );
 
         // @ts-ignore

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -19,6 +19,7 @@ import {
   RECORDING_STATE,
   Enum,
   SELF_ROLES,
+  _BREAKOUT_ENDED_,
 } from '../constants';
 
 import InfoUtils from './infoUtils';
@@ -1783,9 +1784,8 @@ export default class LocusInfo extends EventsScope {
     } else if (this.parsedLocus.fullState?.type === _MEETING_) {
       if (
         this.fullState &&
-        (this.fullState.state === LOCUS.STATE.INACTIVE ||
-          // @ts-ignore
-          this.fullState.state === LOCUS.STATE.TERMINATING)
+        this.fullState.state === LOCUS.STATE.INACTIVE &&
+        this.fullState.endMeetingReason !== _BREAKOUT_ENDED_
       ) {
         LoggerProxy.logger.warn(
           'Locus-info:index#isMeetingActive --> Meeting is ending due to inactive or terminating'

--- a/packages/@webex/plugin-meetings/src/locus-info/types.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/types.ts
@@ -1,4 +1,21 @@
+import {Enum} from '../constants';
 import {HtMeta} from '../hashTree/types';
+
+export const EndMeetingReason = {
+  maxMeetingDuration: 'MAX_MEETING_DURATION',
+  allParticipantsLeft: 'ALL_PARTICIPANTS_LEFT',
+  sipHostLeft: 'SIP_HOST_LEFT',
+  noHost: 'NO_HOST',
+  waitingForMpsEndMeetingTimeout: 'WAITING_FOR_MPS_END_MEETING_TIMEOUT',
+  fraudDetection: 'FRAUD_DETECTION',
+  meetingEndedByHost: 'MEETING_ENDED_BY_HOST',
+  meetingUpdated: 'MEETING_UPDATED', // Locus code has comment about EndMeetingIfPossible reason for this one
+  meetingCancelled: 'MEETING_CANCELLED', // Locus code has comment about EndMeetingIfPossible reason for this one
+  autoEndWithSingleParticipant: 'AUTO_END_WITH_SINGLE_PARTICIPANT',
+  breakoutEnded: 'BREAKOUT_ENDED', // indicates that only a breakout session ended, not the whole meeting
+} as const;
+
+export type EndMeetingReason = Enum<typeof EndMeetingReason>;
 
 export type LocusFullState = {
   active: boolean;
@@ -6,10 +23,11 @@ export type LocusFullState = {
   lastActive: string;
   locked: boolean;
   sessionId: string;
-  seessionIds: string[];
+  sessionIds: string[];
   startTime: number;
   state: string;
   type: string;
+  endMeetingReason?: EndMeetingReason;
 };
 
 export type Links = {

--- a/packages/@webex/plugin-meetings/src/meetings/util.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/util.ts
@@ -7,7 +7,6 @@ import {
   _LEFT_,
   DESTINATION_TYPE,
   _MOVED_,
-  _BREAKOUT_ENDED_,
   BREAKOUTS,
   EVENT_TRIGGERS,
   LOCUS,
@@ -19,6 +18,7 @@ import Trigger from '../common/events/trigger-proxy';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import Metrics from '../metrics';
 import {MEETING_KEY} from './meetings.types';
+import {EndMeetingReason, LocusFullState} from '../locus-info/types';
 
 /**
  * Meetings Media Codec Missing Event
@@ -268,6 +268,18 @@ MeetingsUtil.getThisDevice = (newLocus: any, deviceUrl: string) => {
 };
 
 /**
+ * Checks if the fullState indicates the meeting has fully ended (not just a breakout move).
+ * @param {Object} fullState locus fullState data
+ * @returns {boolean}
+ */
+MeetingsUtil.isWholeMeetingEnded = (fullState: LocusFullState): boolean => {
+  return (
+    fullState.state === LOCUS.STATE.INACTIVE &&
+    fullState.endMeetingReason !== EndMeetingReason.breakoutEnded
+  );
+};
+
+/**
  * Checks if the self state in a locus indicates a breakout move or breakout end.
  * Returns true when:
  * - self state is LEFT with reason MOVED (regular breakout move), OR
@@ -279,7 +291,7 @@ MeetingsUtil.isSelfMovedOrBreakoutEnded = (locus: any): boolean => {
   const isSelfLeftMoved = locus?.self?.state === _LEFT_ && locus?.self?.reason === _MOVED_;
   const isBreakoutEnded =
     locus?.fullState?.state === LOCUS.STATE.INACTIVE &&
-    locus?.fullState?.endMeetingReason === _BREAKOUT_ENDED_;
+    locus?.fullState?.endMeetingReason === EndMeetingReason.breakoutEnded;
 
   return isSelfLeftMoved || isBreakoutEnded;
 };

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -27,6 +27,7 @@ import {
   _MEETING_,
   _SIP_BRIDGE_,
   _SPACE_SHARE_,
+  _BREAKOUT_ENDED_,
 } from '../../../../src/constants';
 
 import {self, selfWithInactivity} from './selfConstant';
@@ -4677,6 +4678,9 @@ describe('plugin-meetings', () => {
     });
 
     describe('#isMeetingActive', () => {
+      beforeEach(() => {
+        webex.internal.newMetrics.submitClientEvent.resetHistory();
+      });
       forEach([_CALL_, _SIP_BRIDGE_, _SPACE_SHARE_], (type) => {
         describe(`type = ${type}`, () => {
           it('sends client event correctly for state = inactive', () => {
@@ -4743,7 +4747,7 @@ describe('plugin-meetings', () => {
         });
       });
 
-      it('sends client event correctly for state = MEETING_INACTIVE_TERMINATING', () => {
+      it('sends client event correctly for state = MEETING_INACTIVE', () => {
         locusInfo.getLocusPartner = sinon.stub().returns({state: MEETING_STATE.STATES.LEFT});
         locusInfo.parsedLocus = {
           fullState: {
@@ -4765,7 +4769,7 @@ describe('plugin-meetings', () => {
         });
       });
 
-      it('sends client event correctly for state = FULLSTATE_REMOVED', () => {
+      it('does not send client event when state = INACTIVE and endMeetingReason = BREAKOUT_ENDED', () => {
         locusInfo.getLocusPartner = sinon.stub().returns({state: MEETING_STATE.STATES.LEFT});
         locusInfo.parsedLocus = {
           fullState: {
@@ -4774,17 +4778,41 @@ describe('plugin-meetings', () => {
         };
 
         locusInfo.fullState = {
-          removed: true,
+          state: LOCUS.STATE.INACTIVE,
+          endMeetingReason: _BREAKOUT_ENDED_,
         };
 
         locusInfo.isMeetingActive();
 
-        assert.calledWith(webex.internal.newMetrics.submitClientEvent, {
-          name: 'client.call.remote-ended',
-          options: {
-            meetingId: locusInfo.meetingId,
+        assert.notCalled(webex.internal.newMetrics.submitClientEvent);
+      });
+
+      it('sends client event correctly for state self removed', () => {
+        locusInfo.emitScoped = sinon.stub();
+        locusInfo.parsedLocus = {
+          fullState: {
+            type: _MEETING_,
           },
-        });
+          self: {
+            removed: true,
+          }
+        };
+
+        locusInfo.isMeetingActive();
+
+        assert.notCalled(webex.internal.newMetrics.submitClientEvent);
+        assert.calledOnceWithExactly(
+          locusInfo.emitScoped,
+          {
+            file: 'locus-info',
+            function: 'isMeetingActive',
+          },
+          EVENTS.DESTROY_MEETING,
+          {
+            reason: MEETING_REMOVED_REASON.SELF_REMOVED,
+            shouldLeave: false,
+          }
+        );
       });
     });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -27,7 +27,6 @@ import {
   _MEETING_,
   _SIP_BRIDGE_,
   _SPACE_SHARE_,
-  _BREAKOUT_ENDED_,
 } from '../../../../src/constants';
 
 import {self, selfWithInactivity} from './selfConstant';
@@ -4779,7 +4778,7 @@ describe('plugin-meetings', () => {
 
         locusInfo.fullState = {
           state: LOCUS.STATE.INACTIVE,
-          endMeetingReason: _BREAKOUT_ENDED_,
+          endMeetingReason: 'BREAKOUT_ENDED',
         };
 
         locusInfo.isMeetingActive();

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/utils.js
@@ -238,6 +238,19 @@ describe('plugin-meetings', () => {
       });
     });
 
+    describe('#isWholeMeetingEnded', () => {
+      [
+        {description: 'state is INACTIVE with no endMeetingReason', fullState: {state: 'INACTIVE'}, expected: true},
+        {description: 'state is INACTIVE with endMeetingReason OTHER', fullState: {state: 'INACTIVE', endMeetingReason: 'SOME_OTHER_REASON'}, expected: true},
+        {description: 'state is INACTIVE with endMeetingReason BREAKOUT_ENDED', fullState: {state: 'INACTIVE', endMeetingReason: 'BREAKOUT_ENDED'}, expected: false},
+        {description: 'state is not INACTIVE', fullState: {state: 'ACTIVE', endMeetingReason: 'SOME_OTHER_REASON'}, expected: false},
+      ].forEach(({description, fullState, expected}) => {
+        it(`returns ${expected} when ${description}`, () => {
+          assert.equal(MeetingsUtil.isWholeMeetingEnded(fullState), expected);
+        });
+      });
+    });
+
     describe('#isSelfMovedOrBreakoutEnded', () => {
       [
         {description: 'locus is undefined', locus: undefined, expected: false},


### PR DESCRIPTION
# COMPLETES #[SPARK-798051](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-798051)

## This pull request addresses
After this fix for SPARK-798051 was merged:
https://github.com/webex/webex-js-sdk/pull/4892

I've realised that there may still be edge cases where it won't work, because of the exising SDK code in LocusInfo.isMeetingActive() which destroys the meeting when it receives TERMINATING state.

So the flow is:
when we leave a breakout we should receive self=LEFT with reason=MOVED or fullState=INACTIVE with endMeetingReason=BREAKOUT_ENDED - this causes SDK to ignore those events (see LocusInfo.updateLocusInfo()) and not destroy the meeting, because we know there will be more events for a new breakout coming, so we don't want to destroy that meeting.
However, before fullState=INACTIVE we receive fullState=TERMINATING which causes meeting to be destroyed - this was reported as a problem by the devices team and when I looked at our code I could see it causing us the same problem.

When testing I found that TERMINATING is actually not causing the meeting to be destroyed for us, but only because we have another workaround in `LocusInfo.updateLocusFromHashTreeObject()` where if we receive a participant for self with state=LEFT, reason=MOVED, we copy it into self and Locus happens to send us the 2 changes (the self participant LEFT, MOVED and the fullState=TERMINATING) in the same LLM event, so then the check for self LEFT in updateLocusInfo() works, the event is ignored and the LocusInfo class is not updated, so fullState is not updated to TERMINATING and so the code in LocusInfo.isMeetingActive() doesn't destroy the meeting. However, I think it's still worth fixing this and removing the code that checks for fullState==TERMINATING, because there is no guarantee that Locus will always send these 2 changes together in a single event.

TLDR: this fixes a potential case where we would destroy a meeting when being moved from a breakout, but right now this edge case is not happening (but theoretically could happen)

Locus team said in the 5k webinar space that fullState TERMINATING is not something clients should really react to, it is always followed by INACTIVE and INACTIVE is the one we should listen for.

link to discussion in the space:
webexteams://im?space=ac0ff360-8226-11f0-84cb-4fc47ab024cc&message=caff6db0-3f35-11f1-8766-e34b93ef394e

## by making the following changes
removed the check for fullState TERMINATING when deciding to destroy the meeting, added also a check endMeetingReason !== _BREAKOUT_ENDED_

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
