### PR TITLE
fix(meetings): joinWithMedia retry logic

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5660,7 +5660,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
       const mediaResponse = await this.addMediaInternal(
         () => {
-          return this.joinWithMediaRetryInfo.retryCount === JOIN_WITH_MEDIA_RETRY_MAX_COUNT
+          return this.joinWithMediaRetryInfo.retryCount >= 1
             ? 'JOIN_MEETING_FINAL'
             : 'JOIN_MEETING_RETRY';
         },

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5712,8 +5712,8 @@ export default class Meeting extends StatelessWebexPlugin {
         });
       }
 
-      // we only want to call leave if join was successful and this was a retry or we won't be doing any more retries
-      if (joined && (retryCount > 0 || !shouldRetry)) {
+      // we only want to call leave if join was successful, and we won't be doing any more retries
+      if (joined && !shouldRetry) {
         try {
           await this.leave({resourceId: joinOptions?.resourceId, reason: 'joinWithMedia failure'});
         } catch (e) {

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -5576,7 +5576,7 @@ export default class Meeting extends StatelessWebexPlugin {
     } = {}
   ) {
     const {mediaOptions, joinOptions = {}} = options;
-    const {isRetry, prevJoinResponse, prevError} = this.joinWithMediaRetryInfo;
+    const {isRetry, prevJoinResponse} = this.joinWithMediaRetryInfo;
 
     if (!mediaOptions?.allowMediaInLobby) {
       return Promise.reject(
@@ -5602,7 +5602,7 @@ export default class Meeting extends StatelessWebexPlugin {
       );
     }
 
-    const shouldJoin = !joinResponse || (prevError && prevError instanceof UserNotJoinedError);
+    const shouldJoin = !joinResponse || joinResponse instanceof Error;
 
     try {
       let turnServerInfo;
@@ -5731,15 +5731,15 @@ export default class Meeting extends StatelessWebexPlugin {
         return this.joinWithMedia(options);
       }
 
-      const previousError = this.joinWithMediaRetryInfo?.prevError;
+      const {prevError} = this.joinWithMediaRetryInfo;
 
-      this.joinWithMediaRetryInfo = {isRetry: false, prevJoinResponse: undefined};
+      this.joinWithMediaRetryInfo = {
+        isRetry: false,
+        prevJoinResponse: undefined,
+        prevError: undefined,
+      };
 
-      if (isRetry && previousError) {
-        error.message = `First attempt error: ${previousError.message}\n\nSecond attempt error: ${error.message}`;
-      }
-
-      throw error;
+      throw prevError ?? error;
     }
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -795,7 +795,7 @@ export default class Meeting extends StatelessWebexPlugin {
   private deferSDPAnswer?: Defer; // used for waiting for a response
   private sdpResponseTimer?: ReturnType<typeof setTimeout>;
   private hasMediaConnectionConnectedAtLeastOnce: boolean;
-  private joinWithMediaRetryInfo?: {
+  private joinWithMediaRetryInfo: {
     retryCount: number;
     prevJoinResponse?: any;
     firstError?: Error;
@@ -5660,6 +5660,7 @@ export default class Meeting extends StatelessWebexPlugin {
 
       const mediaResponse = await this.addMediaInternal(
         () => {
+          // callback is not called when UserNotJoinedError is thrown
           return this.joinWithMediaRetryInfo.retryCount >= 1
             ? 'JOIN_MEETING_FINAL'
             : 'JOIN_MEETING_RETRY';

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -191,6 +191,7 @@ import AIEnableRequest from '../aiEnableRequest';
 const DEFAULT_ICE_PHASE_CALLBACK = () => 'JOIN_MEETING_FINAL';
 
 const LLM_HEALTHCHECK_TIMER_MS = 3 * 60 * 1000;
+const JOIN_WITH_MEDIA_RETRY_MAX_COUNT = 2;
 
 const logRequest = (request: any, {logText = ''}) => {
   LoggerProxy.logger.info(`${logText} - sending request`);
@@ -794,7 +795,7 @@ export default class Meeting extends StatelessWebexPlugin {
   private deferSDPAnswer?: Defer; // used for waiting for a response
   private sdpResponseTimer?: ReturnType<typeof setTimeout>;
   private hasMediaConnectionConnectedAtLeastOnce: boolean;
-  private joinWithMediaRetryInfo?: {isRetry: boolean; prevJoinResponse?: any; prevError?: Error};
+  private joinWithMediaRetryInfo?: {retryCount: number; prevJoinResponse?: any; prevError?: Error};
   private connectionStateHandler?: ConnectionStateHandler;
   private iceCandidateErrors: Map<string, number>;
   private iceCandidatesCount: number;
@@ -1668,11 +1669,11 @@ export default class Meeting extends StatelessWebexPlugin {
     /**
      * Information needed for a retry of a call to joinWithMedia
      * @instance
-     * @type {{isRetry: boolean; prevJoinResponse?: any}}
+     * @type {{retryCount: number; prevJoinResponse?: any}}
      * @private
      * @memberof Meeting
      */
-    this.joinWithMediaRetryInfo = {isRetry: false, prevJoinResponse: undefined};
+    this.joinWithMediaRetryInfo = {retryCount: 0, prevJoinResponse: undefined};
 
     /**
      * Connection state handler
@@ -5576,7 +5577,7 @@ export default class Meeting extends StatelessWebexPlugin {
     } = {}
   ) {
     const {mediaOptions, joinOptions = {}} = options;
-    const {isRetry, prevJoinResponse} = this.joinWithMediaRetryInfo;
+    const {retryCount, prevJoinResponse, prevError} = this.joinWithMediaRetryInfo;
 
     if (!mediaOptions?.allowMediaInLobby) {
       return Promise.reject(
@@ -5602,7 +5603,10 @@ export default class Meeting extends StatelessWebexPlugin {
       );
     }
 
-    const shouldJoin = !joinResponse || joinResponse instanceof Error;
+    const shouldJoin =
+      !joinResponse || // first try, when the join response is empty
+      (prevError && prevError instanceof UserNotJoinedError) || // last try failed with UserNotJoinedError
+      MeetingUtil.isUserInLeftState(this.locusInfo); // locus dropped the connection before we can re-try addMedia
 
     try {
       let turnServerInfo;
@@ -5650,14 +5654,16 @@ export default class Meeting extends StatelessWebexPlugin {
 
       const mediaResponse = await this.addMediaInternal(
         () => {
-          return this.joinWithMediaRetryInfo.isRetry ? 'JOIN_MEETING_FINAL' : 'JOIN_MEETING_RETRY';
+          return this.joinWithMediaRetryInfo.retryCount === JOIN_WITH_MEDIA_RETRY_MAX_COUNT
+            ? 'JOIN_MEETING_FINAL'
+            : 'JOIN_MEETING_RETRY';
         },
         turnServerInfo,
         forceTurnDiscovery,
         mediaOptions
       );
 
-      this.joinWithMediaRetryInfo = {isRetry: false, prevJoinResponse: undefined};
+      this.joinWithMediaRetryInfo = {retryCount: 0, prevJoinResponse: undefined};
 
       return {
         join: joinResponse,
@@ -5671,8 +5677,10 @@ export default class Meeting extends StatelessWebexPlugin {
 
       this.roap.abortTurnDiscovery();
 
-      // if this was the first attempt, let's do a retry
-      let shouldRetry = !isRetry;
+      // let's do a retry
+      let shouldRetry =
+        retryCount < 1 ||
+        (error instanceof UserNotJoinedError && retryCount < JOIN_WITH_MEDIA_RETRY_MAX_COUNT);
 
       if (
         CallDiagnosticUtils.isSdpOfferCreationError(error) ||
@@ -5698,7 +5706,7 @@ export default class Meeting extends StatelessWebexPlugin {
       }
 
       // we only want to call leave if join was successful and this was a retry or we won't be doing any more retries
-      if (joined && (isRetry || !shouldRetry)) {
+      if (joined && (retryCount > 0 || !shouldRetry)) {
         try {
           await this.leave({resourceId: joinOptions?.resourceId, reason: 'joinWithMedia failure'});
         } catch (e) {
@@ -5715,7 +5723,7 @@ export default class Meeting extends StatelessWebexPlugin {
           reason: error.message,
           stack: error.stack,
           leaveErrorReason: leaveError?.message,
-          isRetry,
+          isRetry: retryCount > 0,
         },
         {
           type: error.name,
@@ -5724,22 +5732,24 @@ export default class Meeting extends StatelessWebexPlugin {
 
       if (shouldRetry) {
         LoggerProxy.logger.warn('Meeting:index#joinWithMedia --> retrying call to joinWithMedia');
-        this.joinWithMediaRetryInfo.isRetry = true;
+        this.joinWithMediaRetryInfo.retryCount = retryCount + 1;
         this.joinWithMediaRetryInfo.prevJoinResponse = joinResponse;
-        this.joinWithMediaRetryInfo.prevError = error;
+        if (!this.joinWithMediaRetryInfo.prevError) {
+          this.joinWithMediaRetryInfo.prevError = error;
+        }
 
         return this.joinWithMedia(options);
       }
 
-      const {prevError} = this.joinWithMediaRetryInfo;
+      const previousError = this.joinWithMediaRetryInfo.prevError;
 
       this.joinWithMediaRetryInfo = {
-        isRetry: false,
+        retryCount: 0,
         prevJoinResponse: undefined,
         prevError: undefined,
       };
 
-      throw prevError ?? error;
+      throw previousError ?? error;
     }
   }
 
@@ -8740,7 +8750,7 @@ export default class Meeting extends StatelessWebexPlugin {
         numTransports,
         isMultistream: this.isMultistream,
         retriedWithTurnServer: this.addMediaData.retriedWithTurnServer,
-        isJoinWithMediaRetry: this.joinWithMediaRetryInfo.isRetry,
+        isJoinWithMediaRetry: this.joinWithMediaRetryInfo.retryCount > 0,
         ...reachabilityMetrics,
         ...iceCandidateErrors,
         iceCandidatesCount: this.iceCandidatesCount,
@@ -8785,7 +8795,7 @@ export default class Meeting extends StatelessWebexPlugin {
         turnServerUsed: this.turnServerUsed,
         retriedWithTurnServer: this.addMediaData.retriedWithTurnServer,
         isMultistream: this.isMultistream,
-        isJoinWithMediaRetry: this.joinWithMediaRetryInfo.isRetry,
+        isJoinWithMediaRetry: this.joinWithMediaRetryInfo.retryCount > 0,
         signalingState:
           this.mediaProperties.webrtcMediaConnection?.multistreamConnection?.pc?.pc
             ?.signalingState ||

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -794,7 +794,7 @@ export default class Meeting extends StatelessWebexPlugin {
   private deferSDPAnswer?: Defer; // used for waiting for a response
   private sdpResponseTimer?: ReturnType<typeof setTimeout>;
   private hasMediaConnectionConnectedAtLeastOnce: boolean;
-  private joinWithMediaRetryInfo?: {isRetry: boolean; prevJoinResponse?: any};
+  private joinWithMediaRetryInfo?: {isRetry: boolean; prevJoinResponse?: any; prevError?: Error};
   private connectionStateHandler?: ConnectionStateHandler;
   private iceCandidateErrors: Map<string, number>;
   private iceCandidatesCount: number;
@@ -5576,7 +5576,7 @@ export default class Meeting extends StatelessWebexPlugin {
     } = {}
   ) {
     const {mediaOptions, joinOptions = {}} = options;
-    const {isRetry, prevJoinResponse} = this.joinWithMediaRetryInfo;
+    const {isRetry, prevJoinResponse, prevError} = this.joinWithMediaRetryInfo;
 
     if (!mediaOptions?.allowMediaInLobby) {
       return Promise.reject(
@@ -5602,12 +5602,14 @@ export default class Meeting extends StatelessWebexPlugin {
       );
     }
 
+    const shouldJoin = !joinResponse || (prevError && prevError instanceof UserNotJoinedError);
+
     try {
       let turnServerInfo;
       let turnDiscoverySkippedReason;
       let forceTurnDiscovery = false;
 
-      if (!joinResponse) {
+      if (shouldJoin) {
         // This is the 1st attempt or a retry after join request failed -> we need to do a join with TURN discovery
 
         const turnDiscoveryRequest = await this.roap.generateTurnDiscoveryRequestMessage(
@@ -5724,11 +5726,18 @@ export default class Meeting extends StatelessWebexPlugin {
         LoggerProxy.logger.warn('Meeting:index#joinWithMedia --> retrying call to joinWithMedia');
         this.joinWithMediaRetryInfo.isRetry = true;
         this.joinWithMediaRetryInfo.prevJoinResponse = joinResponse;
+        this.joinWithMediaRetryInfo.prevError = error;
 
         return this.joinWithMedia(options);
       }
 
+      const previousError = this.joinWithMediaRetryInfo?.prevError;
+
       this.joinWithMediaRetryInfo = {isRetry: false, prevJoinResponse: undefined};
+
+      if (isRetry && previousError) {
+        error.message = `First attempt error: ${previousError.message}\n\nSecond attempt error: ${error.message}`;
+      }
 
       throw error;
     }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -795,7 +795,13 @@ export default class Meeting extends StatelessWebexPlugin {
   private deferSDPAnswer?: Defer; // used for waiting for a response
   private sdpResponseTimer?: ReturnType<typeof setTimeout>;
   private hasMediaConnectionConnectedAtLeastOnce: boolean;
-  private joinWithMediaRetryInfo?: {retryCount: number; prevJoinResponse?: any; prevError?: Error};
+  private joinWithMediaRetryInfo?: {
+    retryCount: number;
+    prevJoinResponse?: any;
+    firstError?: Error;
+    prevError?: Error;
+  };
+
   private connectionStateHandler?: ConnectionStateHandler;
   private iceCandidateErrors: Map<string, number>;
   private iceCandidatesCount: number;
@@ -5734,22 +5740,24 @@ export default class Meeting extends StatelessWebexPlugin {
         LoggerProxy.logger.warn('Meeting:index#joinWithMedia --> retrying call to joinWithMedia');
         this.joinWithMediaRetryInfo.retryCount = retryCount + 1;
         this.joinWithMediaRetryInfo.prevJoinResponse = joinResponse;
-        if (!this.joinWithMediaRetryInfo.prevError) {
-          this.joinWithMediaRetryInfo.prevError = error;
+        this.joinWithMediaRetryInfo.prevError = error;
+        if (!this.joinWithMediaRetryInfo.firstError) {
+          this.joinWithMediaRetryInfo.firstError = error;
         }
 
         return this.joinWithMedia(options);
       }
 
-      const previousError = this.joinWithMediaRetryInfo.prevError;
+      const {firstError} = this.joinWithMediaRetryInfo;
 
       this.joinWithMediaRetryInfo = {
         retryCount: 0,
         prevJoinResponse: undefined,
+        firstError: undefined,
         prevError: undefined,
       };
 
-      throw previousError ?? error;
+      throw firstError ?? error;
     }
   }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1587,9 +1587,10 @@ describe('plugin-meetings', () => {
 
           await testUtils.flushPromises();
 
-          // check the callback works correctly on the 2nd attempt
+          // check the callback works correctly on the 2nd attempt:
+          // retryCount=1 with a non-UserNotJoinedError is terminal, so icePhase must be JOIN_MEETING_FINAL
           assert.equal(icePhaseCallbacks.length, 2);
-          assert.equal(icePhaseCallbacks[1](), 'JOIN_MEETING_RETRY');
+          assert.equal(icePhaseCallbacks[1](), 'JOIN_MEETING_FINAL');
 
           // trigger 2nd failure
           addMediaInternalResults[1].reject(addMediaError);
@@ -1631,9 +1632,11 @@ describe('plugin-meetings', () => {
 
           await testUtils.flushPromises();
 
-          // 2nd attempt: retryCount=1 → JOIN_MEETING_RETRY
+          // 2nd attempt: retryCount=1 → JOIN_MEETING_FINAL
+          // (In real usage this callback is never invoked when UserNotJoinedError is thrown,
+          // because UserNotJoinedError is thrown before waitForMediaConnectionConnected() is reached.)
           assert.equal(icePhaseCallbacks.length, 2);
-          assert.equal(icePhaseCallbacks[1](), 'JOIN_MEETING_RETRY');
+          assert.equal(icePhaseCallbacks[1](), 'JOIN_MEETING_FINAL');
           addMediaInternalResults[1].reject(userNotJoinedError);
 
           await testUtils.flushPromises();

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1482,7 +1482,7 @@ describe('plugin-meetings', () => {
             name: 'client.ice.end',
             payload: {
               canProceed: false,
-              icePhase: 'JOIN_MEETING_RETRY',
+              icePhase: 'JOIN_MEETING_FINAL',
               errors: [fakeClientError],
             },
             options: {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1035,19 +1035,24 @@ describe('plugin-meetings', () => {
           meeting.join = sinon.stub().returns(Promise.reject(error));
           meeting.locusUrl = null; // when join fails, we end up with null locusUrl
 
-          const rejectedError = await assert.isRejected(meeting.joinWithMedia({mediaOptions: {allowMediaInLobby: true}}));
+          const thrownError = await assert.isRejected(
+            meeting.joinWithMedia({mediaOptions: {allowMediaInLobby: true}})
+          );
+
+          // should throw the first attempt's error
+          assert.equal(thrownError, error);
 
           assert.calledTwice(abortTurnDiscoveryStub);
 
           assert.calledTwice(Metrics.sendBehavioralMetric);
           assert.calledWith(
-            Metrics.sendBehavioralMetric.firstCall,
+            Metrics.sendBehavioralMetric,
             BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
             {
               correlation_id: meeting.correlationId,
               locus_id: undefined,
-              reason: 'fake',
-              stack: sinon.match.string,
+              reason: error.message,
+              stack: error.stack,
               leaveErrorReason: undefined,
               isRetry: false,
             },
@@ -1056,13 +1061,13 @@ describe('plugin-meetings', () => {
             }
           );
           assert.calledWith(
-            Metrics.sendBehavioralMetric.secondCall,
+            Metrics.sendBehavioralMetric,
             BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
             {
               correlation_id: meeting.correlationId,
               locus_id: undefined,
-              reason: 'fake',
-              stack: sinon.match.string,
+              reason: error.message,
+              stack: error.stack,
               leaveErrorReason: undefined,
               isRetry: true,
             },
@@ -1071,14 +1076,77 @@ describe('plugin-meetings', () => {
             }
           );
 
-          // error message should combine both attempt errors
-          assert.equal(rejectedError.message, 'First attempt error: fake\n\nSecond attempt error: fake');
-
           // resets joinWithMediaRetryInfo
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
             isRetry: false,
             prevJoinResponse: undefined,
+            prevError: undefined,
           });
+        });
+
+        it('should re-join on retry when join() fails on first attempt, and throw the first error if join fails again', async () => {
+          const firstJoinError = new Error('first join error');
+          const secondJoinError = new Error('second join error');
+
+          meeting.join = sinon
+            .stub()
+            .onFirstCall()
+            .rejects(firstJoinError)
+            .onSecondCall()
+            .rejects(secondJoinError);
+          meeting.locusUrl = null; // join never succeeds
+
+          const thrownError = await assert.isRejected(
+            meeting.joinWithMedia({joinOptions, mediaOptions})
+          );
+
+          // join() should be called twice — once for the first attempt, once for the re-join
+          assert.calledTwice(meeting.join);
+          // TURN discovery should be attempted twice (once per join)
+          assert.calledTwice(generateTurnDiscoveryRequestMessageStub);
+
+          // should throw the first attempt's error, not the second
+          assert.equal(thrownError, firstJoinError);
+
+          assert.calledTwice(Metrics.sendBehavioralMetric);
+          assert.calledWith(
+            Metrics.sendBehavioralMetric.firstCall,
+            BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
+            sinon.match({reason: firstJoinError.message, isRetry: false}),
+            sinon.match.any
+          );
+          assert.calledWith(
+            Metrics.sendBehavioralMetric.secondCall,
+            BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
+            sinon.match({reason: secondJoinError.message, isRetry: true}),
+            sinon.match.any
+          );
+
+          assert.deepEqual(meeting.joinWithMediaRetryInfo, {
+            isRetry: false,
+            prevJoinResponse: undefined,
+            prevError: undefined,
+          });
+        });
+
+        it('should NOT call join() again on retry when join() succeeded but addMediaInternal() failed', async () => {
+          const addMediaError = new Error('addMedia error');
+
+          meeting.addMediaInternal = sinon
+            .stub()
+            .onFirstCall()
+            .rejects(addMediaError)
+            .onSecondCall()
+            .resolves(test4);
+
+          const result = await meeting.joinWithMedia({joinOptions, mediaOptions});
+
+          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
+
+          // join() should only be called once — the successful join result is reused on retry
+          assert.calledOnce(meeting.join);
+          // TURN discovery request is only generated once (on the first attempt alongside join)
+          assert.calledOnce(generateTurnDiscoveryRequestMessageStub);
         });
 
         it('should resolve if join() fails the first time but succeeds the second time', async () => {
@@ -1143,11 +1211,12 @@ describe('plugin-meetings', () => {
           const leaveStub = sinon.stub(meeting, 'leave').rejects(leaveError);
           meeting.addMediaInternal = sinon.stub().rejects(addMediaError);
 
-          const rejectedError = await assert.isRejected(
+          await assert.isRejected(
             meeting.joinWithMedia({
               joinOptions: {resourceId: 'some resource'},
               mediaOptions: {allowMediaInLobby: true},
-            })
+            }),
+            addMediaError
           );
 
           assert.calledOnce(leaveStub);
@@ -1164,8 +1233,8 @@ describe('plugin-meetings', () => {
             {
               correlation_id: meeting.correlationId,
               locus_id: meeting.locusUrl.split('/').pop(),
-              reason: 'fake addMedia error',
-              stack: sinon.match.string,
+              reason: addMediaError.message,
+              stack: addMediaError.stack,
               leaveErrorReason: undefined,
               isRetry: false,
             },
@@ -1179,8 +1248,8 @@ describe('plugin-meetings', () => {
             {
               correlation_id: meeting.correlationId,
               locus_id: meeting.locusUrl.split('/').pop(),
-              reason: 'fake addMedia error',
-              stack: sinon.match.string,
+              reason: addMediaError.message,
+              stack: addMediaError.stack,
               leaveErrorReason: leaveError.message,
               isRetry: true,
             },
@@ -1188,9 +1257,32 @@ describe('plugin-meetings', () => {
               type: addMediaError.name,
             }
           );
+        });
 
-          // error message should combine both attempt errors
-          assert.equal(rejectedError.message, 'First attempt error: fake addMedia error\n\nSecond attempt error: fake addMedia error');
+        it('should throw the first attempt error when retry also fails with a different error', async () => {
+          const firstError = new Error('first attempt error');
+          const secondError = new Error('second attempt error');
+
+          meeting.addMediaInternal = sinon
+            .stub()
+            .onFirstCall()
+            .rejects(firstError)
+            .onSecondCall()
+            .rejects(secondError);
+
+          sinon.stub(meeting, 'leave').resolves();
+
+          const thrownError = await assert.isRejected(
+            meeting.joinWithMedia({
+              joinOptions,
+              mediaOptions,
+            })
+          );
+
+          // should throw the first error, not the second
+          assert.equal(thrownError, firstError);
+
+          assert.calledTwice(Metrics.sendBehavioralMetric);
         });
 
         it('should call leave() if addMediaInternal() fails with a browser media error (TypeError)', async () => {
@@ -1279,69 +1371,6 @@ describe('plugin-meetings', () => {
               type: addMediaError.name,
             }
           );
-        });
-
-        it('should re-join on retry if the first attempt failed with UserNotJoinedError', async () => {
-          const userNotJoinedError = new UserNotJoinedError();
-          const leaveStub = sinon.stub(meeting, 'leave');
-
-          meeting.addMediaInternal = sinon
-            .stub()
-            .onFirstCall()
-            .rejects(userNotJoinedError)
-            .onSecondCall()
-            .resolves(test4);
-
-          const result = await meeting.joinWithMedia({
-            joinOptions,
-            mediaOptions,
-          });
-
-          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
-
-          // join() should be called twice because UserNotJoinedError triggers a re-join
-          assert.calledTwice(meeting.join);
-          assert.notCalled(leaveStub);
-
-          assert.calledOnce(Metrics.sendBehavioralMetric);
-          assert.calledWith(
-            Metrics.sendBehavioralMetric.firstCall,
-            BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
-            {
-              correlation_id: meeting.correlationId,
-              locus_id: meeting.locusUrl.split('/').pop(),
-              reason: userNotJoinedError.message,
-              stack: userNotJoinedError.stack,
-              leaveErrorReason: undefined,
-              isRetry: false,
-            },
-            {
-              type: userNotJoinedError.name,
-            }
-          );
-        });
-
-        it('should not re-join on retry if the first attempt failed with a non-UserNotJoinedError and join had succeeded', async () => {
-          const addMediaError = new Error('fake addMedia error');
-          const leaveStub = sinon.stub(meeting, 'leave');
-
-          meeting.addMediaInternal = sinon
-            .stub()
-            .onFirstCall()
-            .rejects(addMediaError)
-            .onSecondCall()
-            .resolves(test4);
-
-          const result = await meeting.joinWithMedia({
-            joinOptions,
-            mediaOptions,
-          });
-
-          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
-
-          // join() should only be called once because a non-UserNotJoinedError doesn't trigger re-join
-          assert.calledOnce(meeting.join);
-          assert.notCalled(leaveStub);
         });
 
         it('should send the right CA events when media connection fails', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1265,24 +1265,35 @@ describe('plugin-meetings', () => {
           const firstError = new Error('first attempt error');
           const secondError = new Error('second attempt error');
 
-          meeting.addMediaInternal = sinon
-            .stub()
-            .onFirstCall()
-            .rejects(firstError)
-            .onSecondCall()
-            .rejects(secondError);
+          const addMediaInternalResults = [];
+          meeting.addMediaInternal = sinon.stub().callsFake(() => {
+            const defer = new Defer();
+            addMediaInternalResults.push(defer);
+            return defer.promise;
+          });
 
-          sinon.stub(meeting, 'leave').resolves();
+          const leaveStub = sinon.stub(meeting, 'leave').resolves();
 
-          const thrownError = await assert.isRejected(
-            meeting.joinWithMedia({
-              joinOptions,
-              mediaOptions,
-            })
-          );
+          const result = meeting.joinWithMedia({joinOptions, mediaOptions});
+
+          await testUtils.flushPromises();
+
+          // 1st attempt fails
+          addMediaInternalResults[0].reject(firstError);
+          await testUtils.flushPromises();
+
+          // leave() should NOT be called after the 1st attempt (intermediate retry)
+          assert.notCalled(leaveStub);
+
+          // 2nd (final) attempt fails
+          addMediaInternalResults[1].reject(secondError);
+          const thrownError = await assert.isRejected(result);
 
           // should throw the first error, not the second
           assert.equal(thrownError, firstError);
+
+          // leave() should only be called after the last (2nd) attempt
+          assert.calledOnce(leaveStub);
 
           assert.calledTwice(Metrics.sendBehavioralMetric);
         });
@@ -1291,24 +1302,37 @@ describe('plugin-meetings', () => {
           const userNotJoinedError = new UserNotJoinedError();
           const secondError = new Error('second attempt error');
 
-          meeting.addMediaInternal = sinon
-            .stub()
-            .onFirstCall()
-            .rejects(userNotJoinedError)
-            .onSecondCall()
-            .rejects(secondError);
+          const addMediaInternalResults = [];
+          meeting.addMediaInternal = sinon.stub().callsFake(() => {
+            const defer = new Defer();
+            addMediaInternalResults.push(defer);
+            return defer.promise;
+          });
 
-          sinon.stub(meeting, 'leave').resolves();
+          const leaveStub = sinon.stub(meeting, 'leave').resolves();
 
-          const thrownError = await assert.isRejected(
-            meeting.joinWithMedia({joinOptions, mediaOptions})
-          );
+          const result = meeting.joinWithMedia({joinOptions, mediaOptions});
+
+          await testUtils.flushPromises();
+
+          // 1st attempt fails with UserNotJoinedError — triggers a re-join
+          addMediaInternalResults[0].reject(userNotJoinedError);
+          await testUtils.flushPromises();
+
+          // leave() should NOT be called after the 1st attempt (intermediate retry)
+          assert.notCalled(leaveStub);
+
+          // 2nd (final) attempt fails
+          addMediaInternalResults[1].reject(secondError);
+          const thrownError = await assert.isRejected(result);
 
           // should throw the first (UserNotJoinedError), not the second
           assert.equal(thrownError, userNotJoinedError);
 
           // join() called twice: original + re-join triggered by UserNotJoinedError in prevError
           assert.calledTwice(meeting.join);
+          // leave() should only be called after the last (2nd) attempt
+          assert.calledOnce(leaveStub);
           assert.calledTwice(Metrics.sendBehavioralMetric);
         });
 
@@ -1317,26 +1341,44 @@ describe('plugin-meetings', () => {
           const secondUserNotJoinedError = new UserNotJoinedError('second');
           const thirdError = new Error('third attempt error');
 
-          meeting.addMediaInternal = sinon
-            .stub()
-            .onFirstCall()
-            .rejects(firstUserNotJoinedError)
-            .onSecondCall()
-            .rejects(secondUserNotJoinedError)
-            .onThirdCall()
-            .rejects(thirdError);
+          const addMediaInternalResults = [];
+          meeting.addMediaInternal = sinon.stub().callsFake(() => {
+            const defer = new Defer();
+            addMediaInternalResults.push(defer);
+            return defer.promise;
+          });
 
-          sinon.stub(meeting, 'leave').resolves();
+          const leaveStub = sinon.stub(meeting, 'leave').resolves();
 
-          const thrownError = await assert.isRejected(
-            meeting.joinWithMedia({joinOptions, mediaOptions})
-          );
+          const result = meeting.joinWithMedia({joinOptions, mediaOptions});
+
+          await testUtils.flushPromises();
+
+          // 1st attempt fails with UserNotJoinedError — triggers a re-join
+          addMediaInternalResults[0].reject(firstUserNotJoinedError);
+          await testUtils.flushPromises();
+
+          // leave() should NOT be called after the 1st attempt (intermediate retry)
+          assert.notCalled(leaveStub);
+
+          // 2nd attempt fails with UserNotJoinedError again — triggers another re-join
+          addMediaInternalResults[1].reject(secondUserNotJoinedError);
+          await testUtils.flushPromises();
+
+          // leave() should NOT be called after the 2nd attempt (intermediate retry)
+          assert.notCalled(leaveStub);
+
+          // 3rd (final) attempt fails
+          addMediaInternalResults[2].reject(thirdError);
+          const thrownError = await assert.isRejected(result);
 
           // should throw the very first error across all 3 attempts
           assert.equal(thrownError, firstUserNotJoinedError);
 
           // join() called 3 times: original + 2 re-joins triggered by prevError being UserNotJoinedError
           assert.calledThrice(meeting.join);
+          // leave() should only be called after the last (3rd) attempt
+          assert.calledOnce(leaveStub);
           assert.calledThrice(Metrics.sendBehavioralMetric);
         });
 
@@ -1616,7 +1658,7 @@ describe('plugin-meetings', () => {
               return defer.promise;
             });
 
-          sinon.stub(meeting, 'leave').resolves();
+          const leaveStub = sinon.stub(meeting, 'leave').resolves();
 
           const result = meeting.joinWithMedia({
             joinOptions,
@@ -1632,6 +1674,9 @@ describe('plugin-meetings', () => {
 
           await testUtils.flushPromises();
 
+          // leave() should NOT be called after the 1st attempt (intermediate retry)
+          assert.notCalled(leaveStub);
+
           // 2nd attempt: retryCount=1 → JOIN_MEETING_FINAL
           // (In real usage this callback is never invoked when UserNotJoinedError is thrown,
           // because UserNotJoinedError is thrown before waitForMediaConnectionConnected() is reached.)
@@ -1640,6 +1685,9 @@ describe('plugin-meetings', () => {
           addMediaInternalResults[1].reject(userNotJoinedError);
 
           await testUtils.flushPromises();
+
+          // leave() should NOT be called after the 2nd attempt (intermediate retry)
+          assert.notCalled(leaveStub);
 
           // 3rd attempt: retryCount=2 → JOIN_MEETING_FINAL
           assert.equal(icePhaseCallbacks.length, 3);
@@ -1650,6 +1698,9 @@ describe('plugin-meetings', () => {
 
           // should throw the first error
           assert.equal(thrownError, genericError);
+
+          // leave() should only be called once, after the last (3rd) attempt
+          assert.calledOnce(leaveStub);
         });
 
         it('should re-join when retrying after a UserNotJoinedError', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1655,6 +1655,8 @@ describe('plugin-meetings', () => {
         it('should re-join when retrying after a UserNotJoinedError', async () => {
           const userNotJoinedError = new UserNotJoinedError();
 
+          const leaveStub = sinon.stub(meeting, 'leave').resolves();
+
           meeting.addMediaInternal = sinon
             .stub()
             .onFirstCall()
@@ -1670,12 +1672,16 @@ describe('plugin-meetings', () => {
           assert.calledTwice(meeting.join);
           // TURN discovery should be attempted twice (once per join)
           assert.calledTwice(generateTurnDiscoveryRequestMessageStub);
+          // leave() should never be called when retrying after UserNotJoinedError
+          assert.notCalled(leaveStub);
         });
 
         it('should re-join when isUserInLeftState returns true on retry', async () => {
           const addMediaError = new Error('addMedia error');
 
           sinon.stub(MeetingUtil, 'isUserInLeftState').returns(true);
+
+          const leaveStub = sinon.stub(meeting, 'leave').resolves();
 
           meeting.addMediaInternal = sinon
             .stub()
@@ -1691,6 +1697,8 @@ describe('plugin-meetings', () => {
           // join() should be called twice — once for the first attempt, once because the user is in left state
           assert.calledTwice(meeting.join);
           assert.calledTwice(generateTurnDiscoveryRequestMessageStub);
+          // leave() should never be called when retrying after isUserInLeftState returns true
+          assert.notCalled(leaveStub);
         });
 
         [

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -963,7 +963,7 @@ describe('plugin-meetings', () => {
 
           // resets joinWithMediaRetryInfo
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
-            isRetry: false,
+            retryCount: 0,
             prevJoinResponse: undefined,
           });
         });
@@ -1078,7 +1078,7 @@ describe('plugin-meetings', () => {
 
           // resets joinWithMediaRetryInfo
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
-            isRetry: false,
+            retryCount: 0,
             prevJoinResponse: undefined,
             prevError: undefined,
           });
@@ -1123,7 +1123,7 @@ describe('plugin-meetings', () => {
           );
 
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
-            isRetry: false,
+            retryCount: 0,
             prevJoinResponse: undefined,
             prevError: undefined,
           });
@@ -1190,7 +1190,7 @@ describe('plugin-meetings', () => {
 
           // resets joinWithMediaRetryInfo
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
-            isRetry: false,
+            retryCount: 0,
             prevJoinResponse: undefined,
           });
         });
@@ -1427,7 +1427,7 @@ describe('plugin-meetings', () => {
             name: 'client.ice.end',
             payload: {
               canProceed: false,
-              icePhase: 'JOIN_MEETING_FINAL',
+              icePhase: 'JOIN_MEETING_RETRY',
               errors: [fakeClientError],
             },
             options: {
@@ -1534,12 +1534,105 @@ describe('plugin-meetings', () => {
 
           // check the callback works correctly on the 2nd attempt
           assert.equal(icePhaseCallbacks.length, 2);
-          assert.equal(icePhaseCallbacks[1](), 'JOIN_MEETING_FINAL');
+          assert.equal(icePhaseCallbacks[1](), 'JOIN_MEETING_RETRY');
 
           // trigger 2nd failure
           addMediaInternalResults[1].reject(addMediaError);
 
           await assert.isRejected(result);
+        });
+
+        it('should allow an additional retry when UserNotJoinedError occurs and return JOIN_MEETING_FINAL on the 3rd attempt', async () => {
+          const genericError = new Error('generic error');
+          const userNotJoinedError = new UserNotJoinedError();
+          const thirdError = new Error('third error');
+
+          const icePhaseCallbacks = [];
+          const addMediaInternalResults = [];
+
+          meeting.addMediaInternal = sinon
+            .stub()
+            .callsFake((icePhaseCallback) => {
+              const defer = new Defer();
+
+              icePhaseCallbacks.push(icePhaseCallback);
+              addMediaInternalResults.push(defer);
+              return defer.promise;
+            });
+
+          sinon.stub(meeting, 'leave').resolves();
+
+          const result = meeting.joinWithMedia({
+            joinOptions,
+            mediaOptions,
+          });
+
+          await testUtils.flushPromises();
+
+          // 1st attempt: retryCount=0 → JOIN_MEETING_RETRY
+          assert.equal(icePhaseCallbacks.length, 1);
+          assert.equal(icePhaseCallbacks[0](), 'JOIN_MEETING_RETRY');
+          addMediaInternalResults[0].reject(genericError);
+
+          await testUtils.flushPromises();
+
+          // 2nd attempt: retryCount=1 → JOIN_MEETING_RETRY
+          assert.equal(icePhaseCallbacks.length, 2);
+          assert.equal(icePhaseCallbacks[1](), 'JOIN_MEETING_RETRY');
+          addMediaInternalResults[1].reject(userNotJoinedError);
+
+          await testUtils.flushPromises();
+
+          // 3rd attempt: retryCount=2 → JOIN_MEETING_FINAL
+          assert.equal(icePhaseCallbacks.length, 3);
+          assert.equal(icePhaseCallbacks[2](), 'JOIN_MEETING_FINAL');
+          addMediaInternalResults[2].reject(thirdError);
+
+          const thrownError = await assert.isRejected(result);
+
+          // should throw the first error
+          assert.equal(thrownError, genericError);
+        });
+
+        it('should re-join when retrying after a UserNotJoinedError', async () => {
+          const userNotJoinedError = new UserNotJoinedError();
+
+          meeting.addMediaInternal = sinon
+            .stub()
+            .onFirstCall()
+            .rejects(userNotJoinedError)
+            .onSecondCall()
+            .resolves(test4);
+
+          const result = await meeting.joinWithMedia({joinOptions, mediaOptions});
+
+          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
+
+          // join() should be called twice — once for the first attempt, once for the re-join after UserNotJoinedError
+          assert.calledTwice(meeting.join);
+          // TURN discovery should be attempted twice (once per join)
+          assert.calledTwice(generateTurnDiscoveryRequestMessageStub);
+        });
+
+        it('should re-join when isUserInLeftState returns true on retry', async () => {
+          const addMediaError = new Error('addMedia error');
+
+          sinon.stub(MeetingUtil, 'isUserInLeftState').returns(true);
+
+          meeting.addMediaInternal = sinon
+            .stub()
+            .onFirstCall()
+            .rejects(addMediaError)
+            .onSecondCall()
+            .resolves(test4);
+
+          const result = await meeting.joinWithMedia({joinOptions, mediaOptions});
+
+          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
+
+          // join() should be called twice — once for the first attempt, once because the user is in left state
+          assert.calledTwice(meeting.join);
+          assert.calledTwice(generateTurnDiscoveryRequestMessageStub);
         });
 
         [

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1035,19 +1035,19 @@ describe('plugin-meetings', () => {
           meeting.join = sinon.stub().returns(Promise.reject(error));
           meeting.locusUrl = null; // when join fails, we end up with null locusUrl
 
-          await assert.isRejected(meeting.joinWithMedia({mediaOptions: {allowMediaInLobby: true}}));
+          const rejectedError = await assert.isRejected(meeting.joinWithMedia({mediaOptions: {allowMediaInLobby: true}}));
 
           assert.calledTwice(abortTurnDiscoveryStub);
 
           assert.calledTwice(Metrics.sendBehavioralMetric);
           assert.calledWith(
-            Metrics.sendBehavioralMetric,
+            Metrics.sendBehavioralMetric.firstCall,
             BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
             {
               correlation_id: meeting.correlationId,
               locus_id: undefined,
-              reason: error.message,
-              stack: error.stack,
+              reason: 'fake',
+              stack: sinon.match.string,
               leaveErrorReason: undefined,
               isRetry: false,
             },
@@ -1056,13 +1056,13 @@ describe('plugin-meetings', () => {
             }
           );
           assert.calledWith(
-            Metrics.sendBehavioralMetric,
+            Metrics.sendBehavioralMetric.secondCall,
             BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
             {
               correlation_id: meeting.correlationId,
               locus_id: undefined,
-              reason: error.message,
-              stack: error.stack,
+              reason: 'fake',
+              stack: sinon.match.string,
               leaveErrorReason: undefined,
               isRetry: true,
             },
@@ -1070,6 +1070,9 @@ describe('plugin-meetings', () => {
               type: error.name,
             }
           );
+
+          // error message should combine both attempt errors
+          assert.equal(rejectedError.message, 'First attempt error: fake\n\nSecond attempt error: fake');
 
           // resets joinWithMediaRetryInfo
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
@@ -1140,12 +1143,11 @@ describe('plugin-meetings', () => {
           const leaveStub = sinon.stub(meeting, 'leave').rejects(leaveError);
           meeting.addMediaInternal = sinon.stub().rejects(addMediaError);
 
-          await assert.isRejected(
+          const rejectedError = await assert.isRejected(
             meeting.joinWithMedia({
               joinOptions: {resourceId: 'some resource'},
               mediaOptions: {allowMediaInLobby: true},
-            }),
-            addMediaError
+            })
           );
 
           assert.calledOnce(leaveStub);
@@ -1162,8 +1164,8 @@ describe('plugin-meetings', () => {
             {
               correlation_id: meeting.correlationId,
               locus_id: meeting.locusUrl.split('/').pop(),
-              reason: addMediaError.message,
-              stack: addMediaError.stack,
+              reason: 'fake addMedia error',
+              stack: sinon.match.string,
               leaveErrorReason: undefined,
               isRetry: false,
             },
@@ -1177,8 +1179,8 @@ describe('plugin-meetings', () => {
             {
               correlation_id: meeting.correlationId,
               locus_id: meeting.locusUrl.split('/').pop(),
-              reason: addMediaError.message,
-              stack: addMediaError.stack,
+              reason: 'fake addMedia error',
+              stack: sinon.match.string,
               leaveErrorReason: leaveError.message,
               isRetry: true,
             },
@@ -1186,6 +1188,9 @@ describe('plugin-meetings', () => {
               type: addMediaError.name,
             }
           );
+
+          // error message should combine both attempt errors
+          assert.equal(rejectedError.message, 'First attempt error: fake addMedia error\n\nSecond attempt error: fake addMedia error');
         });
 
         it('should call leave() if addMediaInternal() fails with a browser media error (TypeError)', async () => {
@@ -1274,6 +1279,69 @@ describe('plugin-meetings', () => {
               type: addMediaError.name,
             }
           );
+        });
+
+        it('should re-join on retry if the first attempt failed with UserNotJoinedError', async () => {
+          const userNotJoinedError = new UserNotJoinedError();
+          const leaveStub = sinon.stub(meeting, 'leave');
+
+          meeting.addMediaInternal = sinon
+            .stub()
+            .onFirstCall()
+            .rejects(userNotJoinedError)
+            .onSecondCall()
+            .resolves(test4);
+
+          const result = await meeting.joinWithMedia({
+            joinOptions,
+            mediaOptions,
+          });
+
+          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
+
+          // join() should be called twice because UserNotJoinedError triggers a re-join
+          assert.calledTwice(meeting.join);
+          assert.notCalled(leaveStub);
+
+          assert.calledOnce(Metrics.sendBehavioralMetric);
+          assert.calledWith(
+            Metrics.sendBehavioralMetric.firstCall,
+            BEHAVIORAL_METRICS.JOIN_WITH_MEDIA_FAILURE,
+            {
+              correlation_id: meeting.correlationId,
+              locus_id: meeting.locusUrl.split('/').pop(),
+              reason: userNotJoinedError.message,
+              stack: userNotJoinedError.stack,
+              leaveErrorReason: undefined,
+              isRetry: false,
+            },
+            {
+              type: userNotJoinedError.name,
+            }
+          );
+        });
+
+        it('should not re-join on retry if the first attempt failed with a non-UserNotJoinedError and join had succeeded', async () => {
+          const addMediaError = new Error('fake addMedia error');
+          const leaveStub = sinon.stub(meeting, 'leave');
+
+          meeting.addMediaInternal = sinon
+            .stub()
+            .onFirstCall()
+            .rejects(addMediaError)
+            .onSecondCall()
+            .resolves(test4);
+
+          const result = await meeting.joinWithMedia({
+            joinOptions,
+            mediaOptions,
+          });
+
+          assert.deepEqual(result, {join: fakeJoinResult, media: test4, multistreamEnabled: true});
+
+          // join() should only be called once because a non-UserNotJoinedError doesn't trigger re-join
+          assert.calledOnce(meeting.join);
+          assert.notCalled(leaveStub);
         });
 
         it('should send the right CA events when media connection fails', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -1080,6 +1080,7 @@ describe('plugin-meetings', () => {
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
             retryCount: 0,
             prevJoinResponse: undefined,
+            firstError: undefined,
             prevError: undefined,
           });
         });
@@ -1125,6 +1126,7 @@ describe('plugin-meetings', () => {
           assert.deepEqual(meeting.joinWithMediaRetryInfo, {
             retryCount: 0,
             prevJoinResponse: undefined,
+            firstError: undefined,
             prevError: undefined,
           });
         });
@@ -1283,6 +1285,59 @@ describe('plugin-meetings', () => {
           assert.equal(thrownError, firstError);
 
           assert.calledTwice(Metrics.sendBehavioralMetric);
+        });
+
+        it('should throw the UserNotJoinedError as firstError when it occurs on the 1st attempt and 2nd attempt fails differently', async () => {
+          const userNotJoinedError = new UserNotJoinedError();
+          const secondError = new Error('second attempt error');
+
+          meeting.addMediaInternal = sinon
+            .stub()
+            .onFirstCall()
+            .rejects(userNotJoinedError)
+            .onSecondCall()
+            .rejects(secondError);
+
+          sinon.stub(meeting, 'leave').resolves();
+
+          const thrownError = await assert.isRejected(
+            meeting.joinWithMedia({joinOptions, mediaOptions})
+          );
+
+          // should throw the first (UserNotJoinedError), not the second
+          assert.equal(thrownError, userNotJoinedError);
+
+          // join() called twice: original + re-join triggered by UserNotJoinedError in prevError
+          assert.calledTwice(meeting.join);
+          assert.calledTwice(Metrics.sendBehavioralMetric);
+        });
+
+        it('should throw the first UserNotJoinedError when it occurs on both 1st and 2nd attempts and a 3rd attempt also fails', async () => {
+          const firstUserNotJoinedError = new UserNotJoinedError('first');
+          const secondUserNotJoinedError = new UserNotJoinedError('second');
+          const thirdError = new Error('third attempt error');
+
+          meeting.addMediaInternal = sinon
+            .stub()
+            .onFirstCall()
+            .rejects(firstUserNotJoinedError)
+            .onSecondCall()
+            .rejects(secondUserNotJoinedError)
+            .onThirdCall()
+            .rejects(thirdError);
+
+          sinon.stub(meeting, 'leave').resolves();
+
+          const thrownError = await assert.isRejected(
+            meeting.joinWithMedia({joinOptions, mediaOptions})
+          );
+
+          // should throw the very first error across all 3 attempts
+          assert.equal(thrownError, firstUserNotJoinedError);
+
+          // join() called 3 times: original + 2 re-joins triggered by prevError being UserNotJoinedError
+          assert.calledThrice(meeting.join);
+          assert.calledThrice(Metrics.sendBehavioralMetric);
         });
 
         it('should call leave() if addMediaInternal() fails with a browser media error (TypeError)', async () => {


### PR DESCRIPTION


# COMPLETES 
- SPARK-804808
- SPARK-804811

## This pull request addresses

- Meeting.joinWithMedia() returns the wrong error sometimes
- The retry in Meeting.joinWithMedia() sometimes doesn't work correctly

## by making the following changes

In joinWithMedia
- retry calls join when the last error was UserNotJoinedError
- retry preserve the previous error and report both when it fails

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
