### PR TITLE
fix(calling): fix for ROAP ANSWER being sent before connect event 

### DIFF
--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -1170,6 +1170,10 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
     call['direction'] = CallDirection.INBOUND;
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
+    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+
+    // Progress is now deferred until ROAP offer is received
+    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     dummyEvent.type = 'E_SEND_CALL_CONNECT';
@@ -1235,6 +1239,10 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
 
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
+    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+
+    // Progress is now deferred until ROAP offer is received
+    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
     await call['handleOutgoingCallConnect']({type: 'E_SEND_CALL_CONNECT'} as CallEvent);
     /* state should not change since there is no offer received. */
@@ -1361,6 +1369,10 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
 
     call.sendCallStateMachineEvt({type: 'E_RECV_CALL_SETUP'} as CallEvent);
+    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+
+    // Progress is now deferred until ROAP offer is received
+    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     call.sendMediaStateMachineEvt({type: 'E_RECV_ROAP_OFFER', data: roapMessage} as RoapEvent);
@@ -1959,6 +1971,10 @@ describe('State Machine handler tests', () => {
     };
 
     call.sendCallStateMachineEvt(setupEvent as CallEvent);
+    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+
+    // Progress is now deferred until ROAP offer is received
+    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     const connectEvent = {type: 'E_SEND_CALL_CONNECT'};
@@ -2017,6 +2033,10 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
     call['direction'] = CallDirection.INBOUND;
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
+    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+
+    // Progress is now deferred until ROAP offer is received
+    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     dummyEvent.type = 'E_SEND_CALL_CONNECT';
@@ -2209,6 +2229,10 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
     call['direction'] = CallDirection.INBOUND;
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
+    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+
+    // Progress is now deferred until ROAP offer is received
+    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     dummyEvent.type = 'E_SEND_CALL_CONNECT';

--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -495,6 +495,7 @@ describe('Call Tests', () => {
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_CONNECT');
 
     // Connect is attempted by answer(), but is deferred because offer is not buffered yet.
+    const handleOutgoingCallConnectSpy = jest.spyOn(call as any, 'handleOutgoingCallConnect');
     expect(call['connectPending']).toBe(true);
     expect(call['mediaConnection'].roapMessageReceived).not.toHaveBeenCalled();
 
@@ -534,6 +535,7 @@ describe('Call Tests', () => {
       type: 'E_SEND_ROAP_ANSWER',
       data: expect.objectContaining({messageType: 'ANSWER'}),
     });
+    expect(handleOutgoingCallConnectSpy).toHaveBeenCalled();
     expect(call['mediaConnection'].roapMessageReceived).toHaveBeenLastCalledWith(delayedOffer);
     expect(call['connectPending']).toBe(false);
   });

--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -1170,7 +1170,7 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
     call['direction'] = CallDirection.INBOUND;
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     // Progress is now deferred until ROAP offer is received
     call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
@@ -1239,7 +1239,7 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
 
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     // Progress is now deferred until ROAP offer is received
     call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
@@ -1369,7 +1369,7 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
 
     call.sendCallStateMachineEvt({type: 'E_RECV_CALL_SETUP'} as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     // Progress is now deferred until ROAP offer is received
     call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
@@ -1380,7 +1380,7 @@ describe('State Machine handler tests', () => {
 
     await call['handleOutgoingCallConnect']({type: 'E_SEND_CALL_CONNECT'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_UNKNOWN');
-    expect(stateMachineSpy).toBeCalledTimes(3);
+    expect(stateMachineSpy).toBeCalledTimes(4);
     expect(warnSpy).toBeCalledTimes(3);
     expect(errorSpy).toBeCalledTimes(1);
   });
@@ -1971,7 +1971,7 @@ describe('State Machine handler tests', () => {
     };
 
     call.sendCallStateMachineEvt(setupEvent as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     // Progress is now deferred until ROAP offer is received
     call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
@@ -2033,7 +2033,7 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
     call['direction'] = CallDirection.INBOUND;
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     // Progress is now deferred until ROAP offer is received
     call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
@@ -2229,7 +2229,7 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
     call['direction'] = CallDirection.INBOUND;
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_RECV_CALL_SETUP');
+    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     // Progress is now deferred until ROAP offer is received
     call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);

--- a/packages/calling/src/CallingClient/calling/call.test.ts
+++ b/packages/calling/src/CallingClient/calling/call.test.ts
@@ -452,6 +452,92 @@ describe('Call Tests', () => {
     );
   });
 
+  it('sends connect before ROAP answer when inbound offer is delayed', async () => {
+    const mockStream = {
+      outputStream: {
+        getAudioTracks: jest.fn().mockReturnValue([mockTrack]),
+      },
+      on: jest.fn(),
+      getEffectByKind: jest.fn().mockImplementation(() => {
+        return mockEffect;
+      }),
+    };
+
+    const localAudioStream = mockStream as unknown as InternalMediaCoreModule.LocalMicrophoneStream;
+    const call = createCall(
+      activeUrl,
+      webex,
+      CallDirection.INBOUND,
+      deviceId,
+      mockLineId,
+      deleteCallFromCollection,
+      defaultServiceIndicator,
+      dest
+    ) as Call;
+
+    webex.request.mockReturnValue({
+      statusCode: 200,
+      body: {
+        callId: 'mock-call-id',
+      },
+    } as WebexRequestPayload);
+
+    call.sendCallStateMachineEvt({
+      type: 'E_RECV_CALL_SETUP',
+      data: {
+        seq: 1,
+        messageType: 'OFFER',
+      },
+    } as CallEvent);
+    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
+
+    await call.answer(localAudioStream);
+    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_CONNECT');
+
+    // Connect is attempted by answer(), but is deferred because offer is not buffered yet.
+    expect(call['connectPending']).toBe(true);
+    expect(call['mediaConnection'].roapMessageReceived).not.toHaveBeenCalled();
+
+    const delayedOffer = {
+      seq: 1,
+      messageType: 'OFFER',
+      sdp: 'v=0',
+      version: 1,
+    };
+
+    call.sendMediaStateMachineEvt({type: 'E_RECV_ROAP_OFFER', data: delayedOffer} as RoapEvent);
+    await flushPromises(2);
+    expect(call['mediaConnection'].roapMessageReceived).toHaveBeenCalledWith(delayedOffer);
+
+    const sendCallStateMachineEvtSpy = jest.spyOn(call, 'sendCallStateMachineEvt');
+    const sendMediaStateMachineEvtSpy = jest.spyOn(call, 'sendMediaStateMachineEvt');
+    const roapListener = (call['mediaConnection'].on as jest.Mock).mock.calls.find(
+      ([eventName]) =>
+        eventName === InternalMediaCoreModule.MediaConnectionEventNames.ROAP_MESSAGE_TO_SEND
+    )?.[1];
+
+    expect(roapListener).toBeDefined();
+
+    await roapListener({
+      roapMessage: {
+        messageType: 'ANSWER',
+        sdp: 'v=0',
+        seq: 1,
+        version: 2,
+      },
+    });
+    await flushPromises(2);
+
+    // On ANSWER from media layer, connect is retried first, then ROAP answer is posted.
+    expect(sendCallStateMachineEvtSpy).toHaveBeenNthCalledWith(1, {type: 'E_SEND_CALL_CONNECT'});
+    expect(sendMediaStateMachineEvtSpy).toHaveBeenNthCalledWith(1, {
+      type: 'E_SEND_ROAP_ANSWER',
+      data: expect.objectContaining({messageType: 'ANSWER'}),
+    });
+    expect(call['mediaConnection'].roapMessageReceived).toHaveBeenLastCalledWith(delayedOffer);
+    expect(call['connectPending']).toBe(false);
+  });
+
   it('testing enabling/disabling the BNR on an active call', async () => {
     const mockStream = {
       outputStream: {
@@ -1172,10 +1258,6 @@ describe('State Machine handler tests', () => {
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
-    // Progress is now deferred until ROAP offer is received
-    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
-
     dummyEvent.type = 'E_SEND_CALL_CONNECT';
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
 
@@ -1239,10 +1321,6 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
 
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
-
-    // Progress is now deferred until ROAP offer is received
-    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
     await call['handleOutgoingCallConnect']({type: 'E_SEND_CALL_CONNECT'} as CallEvent);
     /* state should not change since there is no offer received. */
@@ -1371,16 +1449,12 @@ describe('State Machine handler tests', () => {
     call.sendCallStateMachineEvt({type: 'E_RECV_CALL_SETUP'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
-    // Progress is now deferred until ROAP offer is received
-    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
-
     call.sendMediaStateMachineEvt({type: 'E_RECV_ROAP_OFFER', data: roapMessage} as RoapEvent);
     webex.request.mockRejectedValueOnce({statusCode: 403}).mockResolvedValue(statusPayload);
 
     await call['handleOutgoingCallConnect']({type: 'E_SEND_CALL_CONNECT'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_UNKNOWN');
-    expect(stateMachineSpy).toBeCalledTimes(4);
+    expect(stateMachineSpy).toBeCalledTimes(3);
     expect(warnSpy).toBeCalledTimes(3);
     expect(errorSpy).toBeCalledTimes(1);
   });
@@ -1973,10 +2047,6 @@ describe('State Machine handler tests', () => {
     call.sendCallStateMachineEvt(setupEvent as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
-    // Progress is now deferred until ROAP offer is received
-    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
-
     const connectEvent = {type: 'E_SEND_CALL_CONNECT'};
     call.sendCallStateMachineEvt(connectEvent as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_CONNECT');
@@ -2033,10 +2103,6 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
     call['direction'] = CallDirection.INBOUND;
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
-
-    // Progress is now deferred until ROAP offer is received
-    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     dummyEvent.type = 'E_SEND_CALL_CONNECT';
@@ -2229,10 +2295,6 @@ describe('State Machine handler tests', () => {
     webex.request.mockReturnValue(statusPayload);
     call['direction'] = CallDirection.INBOUND;
     call.sendCallStateMachineEvt(dummyEvent as CallEvent);
-    expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
-
-    // Progress is now deferred until ROAP offer is received
-    call.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'} as CallEvent);
     expect(call['callStateMachine'].state.value).toBe('S_SEND_CALL_PROGRESS');
 
     dummyEvent.type = 'E_SEND_CALL_CONNECT';

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -164,9 +164,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
 
   private mediaNegotiationCompleted: boolean;
 
-  private pendingProgressSend: boolean;
-
-  private answerPending: boolean;
+  private connectPending: boolean;
 
   private receivedRoapOKSeq: number;
 
@@ -243,8 +241,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     this.mobiusUrl = activeUrl;
     this.receivedRoapOKSeq = 0;
     this.mediaNegotiationCompleted = false;
-    this.pendingProgressSend = false;
-    this.answerPending = false;
+    this.connectPending = false;
 
     log.info(`Webex Calling Url:- ${this.mobiusUrl}`, {
       file: CALL_FILE,
@@ -959,13 +956,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       method: METHODS.HANDLE_INCOMING_CALL_SETUP,
     });
 
-    // Don't send progress immediately, wait for ROAP offer to avoid race condition
-    // where Connect gets skipped because the offer hasn't been buffered yet
-    this.pendingProgressSend = true;
-    log.info('Waiting for ROAP offer before sending progress', {
-      file: CALL_FILE,
-      method: METHODS.HANDLE_INCOMING_CALL_SETUP,
-    });
+    this.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'});
   }
 
   /**
@@ -1274,16 +1265,6 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_ALERTING,
       });
-
-      // If answer() was called before progress was sent, proceed to connect now
-      if (this.answerPending) {
-        log.info('Answer was pending, now sending connect', {
-          file: CALL_FILE,
-          method: METHODS.HANDLE_OUTGOING_CALL_ALERTING,
-        });
-        this.answerPending = false;
-        this.sendCallStateMachineEvt({type: 'E_SEND_CALL_CONNECT'});
-      }
     } catch (e) {
       log.error(`Failed to signal call progression: ${JSON.stringify(e)}`, {
         file: CALL_FILE,
@@ -1354,6 +1335,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_CONNECT,
       });
+      this.connectPending = true;
 
       return;
     }
@@ -2056,16 +2038,6 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         file: CALL_FILE,
         method: METHODS.HANDLE_INCOMING_ROAP_OFFER,
       });
-
-      // ROAP offer received, now safe to send progress (alerting) to Mobius
-      if (this.pendingProgressSend) {
-        this.pendingProgressSend = false;
-        log.info('ROAP offer received, now sending progress', {
-          file: CALL_FILE,
-          method: METHODS.HANDLE_INCOMING_ROAP_OFFER,
-        });
-        this.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'});
-      }
     } else if (this.receivedRoapOKSeq === message.seq - 2) {
       log.info('Waiting for Roap OK, buffer the remote offer for later handling', {
         file: CALL_FILE,
@@ -2288,13 +2260,6 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
 
     if (this.callStateMachine.state.value === 'S_SEND_CALL_PROGRESS') {
       this.sendCallStateMachineEvt({type: 'E_SEND_CALL_CONNECT'});
-    } else if (this.callStateMachine.state.value === 'S_RECV_CALL_SETUP') {
-      // Progress not yet sent (waiting for ROAP offer), mark answer as pending
-      log.info('Progress not yet sent, marking answer as pending', {
-        file: CALL_FILE,
-        method: METHODS.ANSWER,
-      });
-      this.answerPending = true;
     } else {
       log.warn(
         `Call cannot be answered because the state is : ${this.callStateMachine.state.value}`,
@@ -2744,6 +2709,10 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
           case RoapScenario.ANSWER:
             event.roapMessage.sdp = modifySdpForIPv4(event.roapMessage.sdp);
             this.localRoapMessage = event.roapMessage;
+            if (this.connectPending) {
+              this.connectPending = false;
+              this.sendCallStateMachineEvt({type: 'E_SEND_CALL_CONNECT'});
+            }
             this.sendMediaStateMachineEvt({type: 'E_SEND_ROAP_ANSWER', data: event.roapMessage});
             break;
 

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -1329,6 +1329,7 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private async handleOutgoingCallConnect(event: CallEvent) {
+    this.connectPending = false;
     log.info(`${METHOD_START_MESSAGE} with: ${this.getCorrelationId()}`, {
       file: CALL_FILE,
       method: METHODS.HANDLE_OUTGOING_CALL_CONNECT,
@@ -2715,7 +2716,6 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
             event.roapMessage.sdp = modifySdpForIPv4(event.roapMessage.sdp);
             this.localRoapMessage = event.roapMessage;
             if (this.connectPending) {
-              this.connectPending = false;
               this.sendCallStateMachineEvt({type: 'E_SEND_CALL_CONNECT'});
             }
             this.sendMediaStateMachineEvt({type: 'E_SEND_ROAP_ANSWER', data: event.roapMessage});
@@ -2729,7 +2729,6 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
             event.roapMessage.sdp = modifySdpForIPv4(event.roapMessage.sdp);
             this.localRoapMessage = event.roapMessage;
             if (this.connectPending) {
-              this.connectPending = false;
               this.sendCallStateMachineEvt({type: 'E_SEND_CALL_CONNECT'});
             }
             this.sendMediaStateMachineEvt({type: 'E_SEND_ROAP_OFFER', data: event.roapMessage});

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -451,6 +451,11 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
               },
             },
             on: {
+              E_SEND_CALL_CONNECT: {
+                cond: () => this.connectPending,
+                target: 'S_SEND_CALL_CONNECT',
+                actions: ['outgoingCallConnect'],
+              },
               E_CALL_ESTABLISHED: {
                 target: 'S_CALL_ESTABLISHED',
                 actions: ['callEstablished'],

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -2728,6 +2728,10 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
           case RoapScenario.OFFER_RESPONSE:
             event.roapMessage.sdp = modifySdpForIPv4(event.roapMessage.sdp);
             this.localRoapMessage = event.roapMessage;
+            if (this.connectPending) {
+              this.connectPending = false;
+              this.sendCallStateMachineEvt({type: 'E_SEND_CALL_CONNECT'});
+            }
             this.sendMediaStateMachineEvt({type: 'E_SEND_ROAP_OFFER', data: event.roapMessage});
             break;
 

--- a/packages/calling/src/CallingClient/calling/call.ts
+++ b/packages/calling/src/CallingClient/calling/call.ts
@@ -164,6 +164,10 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
 
   private mediaNegotiationCompleted: boolean;
 
+  private pendingProgressSend: boolean;
+
+  private answerPending: boolean;
+
   private receivedRoapOKSeq: number;
 
   private localAudioStream?: LocalMicrophoneStream;
@@ -239,6 +243,8 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
     this.mobiusUrl = activeUrl;
     this.receivedRoapOKSeq = 0;
     this.mediaNegotiationCompleted = false;
+    this.pendingProgressSend = false;
+    this.answerPending = false;
 
     log.info(`Webex Calling Url:- ${this.mobiusUrl}`, {
       file: CALL_FILE,
@@ -953,7 +959,13 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
       method: METHODS.HANDLE_INCOMING_CALL_SETUP,
     });
 
-    this.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'});
+    // Don't send progress immediately, wait for ROAP offer to avoid race condition
+    // where Connect gets skipped because the offer hasn't been buffered yet
+    this.pendingProgressSend = true;
+    log.info('Waiting for ROAP offer before sending progress', {
+      file: CALL_FILE,
+      method: METHODS.HANDLE_INCOMING_CALL_SETUP,
+    });
   }
 
   /**
@@ -1262,6 +1274,16 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         file: CALL_FILE,
         method: METHODS.HANDLE_OUTGOING_CALL_ALERTING,
       });
+
+      // If answer() was called before progress was sent, proceed to connect now
+      if (this.answerPending) {
+        log.info('Answer was pending, now sending connect', {
+          file: CALL_FILE,
+          method: METHODS.HANDLE_OUTGOING_CALL_ALERTING,
+        });
+        this.answerPending = false;
+        this.sendCallStateMachineEvt({type: 'E_SEND_CALL_CONNECT'});
+      }
     } catch (e) {
       log.error(`Failed to signal call progression: ${JSON.stringify(e)}`, {
         file: CALL_FILE,
@@ -2034,6 +2056,16 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
         file: CALL_FILE,
         method: METHODS.HANDLE_INCOMING_ROAP_OFFER,
       });
+
+      // ROAP offer received, now safe to send progress (alerting) to Mobius
+      if (this.pendingProgressSend) {
+        this.pendingProgressSend = false;
+        log.info('ROAP offer received, now sending progress', {
+          file: CALL_FILE,
+          method: METHODS.HANDLE_INCOMING_ROAP_OFFER,
+        });
+        this.sendCallStateMachineEvt({type: 'E_SEND_CALL_ALERTING'});
+      }
     } else if (this.receivedRoapOKSeq === message.seq - 2) {
       log.info('Waiting for Roap OK, buffer the remote offer for later handling', {
         file: CALL_FILE,
@@ -2256,6 +2288,13 @@ export class Call extends Eventing<CallEventTypes> implements ICall {
 
     if (this.callStateMachine.state.value === 'S_SEND_CALL_PROGRESS') {
       this.sendCallStateMachineEvt({type: 'E_SEND_CALL_CONNECT'});
+    } else if (this.callStateMachine.state.value === 'S_RECV_CALL_SETUP') {
+      // Progress not yet sent (waiting for ROAP offer), mark answer as pending
+      log.info('Progress not yet sent, marking answer as pending', {
+        file: CALL_FILE,
+        method: METHODS.ANSWER,
+      });
+      this.answerPending = true;
     } else {
       log.warn(
         `Call cannot be answered because the state is : ${this.callStateMachine.state.value}`,


### PR DESCRIPTION
# COMPLETES #https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-697740  

## This pull request addresses
Fixes race condition where Connect gets skipped because ROAP offer hasn't arrived yet due to network delay when answer() is called. 
We are attempting to send connect again before sending ROAP_ANSWER if call is already answered.

## by making the following changes
Updated state machine to be able to handle sending connect again before sending ROAP Answer
Based on connectPending flag, trigger E_SEND_CALL_CONNECT to attempt sending connect before ROAP_ANSWER.
Also added handling for OFFER_RESPONSE as well as requested by Krishna.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
Testing done using unit test, this is bit tricky to test as we will have to delay media websocket event from Mobius and receive it only after connect sending is already attempted.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
