### PR TITLE
feat(calling): add registration down event handling

### DIFF
--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -120,6 +120,14 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
   private mercuryUpTimestamp = '';
 
   /**
+   * Polling interval used to retry a deferred `REGISTRATION_DOWN` cleanup.
+   * Set when `Registration.handleRegistrationDownEvent` defers cleanup because
+   * active calls are present; cleared once the registration-down cleanup
+   * completes (`Registration.isRegistrationDownPending()` returns `false`).
+   */
+  private registrationDownInterval?: NodeJS.Timeout;
+
+  /**
    * @ignore
    */
   constructor(webex: WebexSDK, config?: CallingClientConfig) {
@@ -743,14 +751,23 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
     }
 
     if (eventType === MobiusEventType.REGISTRATION_DOWN) {
-      // const line = Object.values(this.lineDict)[0];
-      // line.registration.handleRegistrationDownEvent(event);
+      log.warn(`Received ${eventType} event from Mobius.`, loggerContext);
+      const line = Object.values(this.lineDict)[0];
 
-      // TODO: check active calls and clean up the state and emit disconnect event
-      log.warn(
-        'Received REGISTRATION_DOWN event from Mobius; teardown handling pending (TODO)',
-        loggerContext
-      );
+      await line.registration.handleRegistrationDownEvent(event);
+      clearInterval(this.registrationDownInterval);
+      this.registrationDownInterval = undefined;
+
+      if (line.registration.isRegistrationDownPending()) {
+        this.registrationDownInterval = setInterval(async () => {
+          await line.registration.handleRegistrationDownEvent(event);
+
+          if (!line.registration.isRegistrationDownPending()) {
+            clearInterval(this.registrationDownInterval);
+            this.registrationDownInterval = undefined;
+          }
+        }, 1000 * 30); // 30 seconds
+      }
 
       this.metricManager.submitMobiusSocketMetric(
         METRIC_EVENT.MOBIUS_SOCKET_ERROR,

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -754,6 +754,12 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       log.warn(`Received ${eventType} event from Mobius.`, loggerContext);
       const line = Object.values(this.lineDict)[0];
 
+      if (!line) {
+        log.warn('No line found, skipping registration down event', loggerContext);
+
+        return;
+      }
+
       await line.registration.handleRegistrationDownEvent(event);
       clearInterval(this.registrationDownInterval);
       this.registrationDownInterval = undefined;

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -120,14 +120,6 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
   private mercuryUpTimestamp = '';
 
   /**
-   * Polling interval used to retry a deferred `REGISTRATION_DOWN` cleanup.
-   * Set when `Registration.handleRegistrationDownEvent` defers cleanup because
-   * active calls are present; cleared once the registration-down cleanup
-   * completes (`Registration.isRegistrationDownPending()` returns `false`).
-   */
-  private registrationDownInterval?: NodeJS.Timeout;
-
-  /**
    * @ignore
    */
   constructor(webex: WebexSDK, config?: CallingClientConfig) {
@@ -761,19 +753,6 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
       }
 
       await line.registration.handleRegistrationDownEvent(event);
-      clearInterval(this.registrationDownInterval);
-      this.registrationDownInterval = undefined;
-
-      if (line.registration.isRegistrationDownPending()) {
-        this.registrationDownInterval = setInterval(async () => {
-          await line.registration.handleRegistrationDownEvent(event);
-
-          if (!line.registration.isRegistrationDownPending()) {
-            clearInterval(this.registrationDownInterval);
-            this.registrationDownInterval = undefined;
-          }
-        }, 1000 * 30); // 30 seconds
-      }
 
       this.metricManager.submitMobiusSocketMetric(
         METRIC_EVENT.MOBIUS_SOCKET_ERROR,

--- a/packages/calling/src/CallingClient/registration/ai-docs/AGENTS.md
+++ b/packages/calling/src/CallingClient/registration/ai-docs/AGENTS.md
@@ -57,6 +57,8 @@ The Registration module handles:
 | `isReconnectPending` | `(): boolean` | Returns `true` if reconnect is deferred |
 | `handleConnectionRestoration` | `(retry: boolean): Promise<boolean>` | Re-registers after network/Mercury recovery |
 | `setDeviceInfo` | `(body: Devices): void` | Hydrates device info from a Devices response |
+| `handleRegistrationDownEvent` | `(event?: MobiusAsyncEvent): Promise<void>` | Handles a Mobius `REGISTRATION_DOWN` async event; defers cleanup while calls are active, otherwise cleans up immediately. Safe to re-invoke |
+| `isRegistrationDownPending` | `(): boolean` | Returns `true` while a registration-down cleanup is deferred due to active calls |
 
 ---
 
@@ -101,7 +103,27 @@ Robust error handling is built in for registration and keepalive via `handleRegi
 
 ---
 
-### 4. Metrics and Observability
+### 4. Registration-Down Handling
+
+When Mobius emits a `REGISTRATION_DOWN` async event, `CallingClient` forwards it to `Registration.handleRegistrationDownEvent`:
+
+- **Active calls present:** `registrationDownPending` is set to `true` and the method returns early without running cleanup. `CallingClient` schedules a polling interval (every 30s) that re-invokes `handleRegistrationDownEvent` with the same event; once no active calls remain on a subsequent tick, the cleanup runs and the interval is cleared.
+- **No active calls:** cleanup runs immediately and `registrationDownPending` stays `false`.
+
+`handleRegistrationDownEvent` is safe to re-invoke: it is idempotent across repeated calls and only performs the teardown once the active-call precondition is met.
+
+Cleanup (under the shared mutex) performs:
+- `clearFailbackTimer()` and `clearKeepaliveTimer()`
+- Resets transient flags (`reconnectPending`, `scheduled429Retry`, `failoverImmediately`, `retryAfter`, `registerRetry`)
+- `clearFailoverState()` and `setStatus(RegistrationStatus.INACTIVE)`
+- Disconnects the Mobius WebSocket when `apiRequest.isSocketEnabled()` (code `3050`, reason `'done (permanent)'`)
+- Emits `LINE_EVENTS.UNREGISTERED` via `lineEmitter` so the SDK consumer is notified
+
+No `DELETE /devices/{id}` is sent because Mobius has already signaled that the registration is gone.
+
+---
+
+### 5. Metrics and Observability
 
 Registration events are instrumented with detailed metrics for observability and troubleshooting:
 

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -1882,48 +1882,38 @@ describe('Registration Tests', () => {
       expect(reg.registerRetry).toBe(false);
       expect(disconnectSocketSpy).not.toHaveBeenCalled();
       expect(lineEmitter).toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
-      expect(reg.isRegistrationDownPending()).toBe(false);
     });
 
-    it('defers cleanup when active calls are present', async () => {
+    it('ends the active call and still runs cleanup when an active call is present', async () => {
       const clearKeepaliveSpy = jest.spyOn(reg, 'clearKeepaliveTimer');
       const setStatusSpy = jest.spyOn(reg, 'setStatus');
 
-      reg.callManager.createCall();
+      const activeCall = reg.callManager.createCall() as ICall;
+      const endSpy = jest.spyOn(activeCall, 'end');
       expect(Object.keys(reg.callManager.getActiveCalls()).length).toBe(1);
 
       lineEmitter.mockClear();
 
       await reg.handleRegistrationDownEvent(registrationDownEvent as any);
 
-      expect(reg.isRegistrationDownPending()).toBe(true);
-      expect(infoSpy).toHaveBeenCalledWith(
-        'Active call(s) present, deferring registration-down cleanup till call cleanup.',
-        {file: REGISTRATION_FILE, method: METHODS.HANDLE_REGISTRATION_DOWN_EVENT}
-      );
-
-      expect(clearKeepaliveSpy).not.toHaveBeenCalled();
-      expect(setStatusSpy).not.toHaveBeenCalled();
-      expect(reg.getStatus()).toBe(RegistrationStatus.ACTIVE);
-      expect(lineEmitter).not.toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(clearKeepaliveSpy).toHaveBeenCalled();
+      expect(setStatusSpy).toHaveBeenCalledWith(RegistrationStatus.INACTIVE);
+      expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
+      expect(lineEmitter).toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
     });
 
-    it('runs deferred cleanup on re-invocation once active calls are cleared', async () => {
+    it('runs cleanup without calling end when no active call is present on re-invocation', async () => {
       const clearKeepaliveSpy = jest.spyOn(reg, 'clearKeepaliveTimer');
       const setStatusSpy = jest.spyOn(reg, 'setStatus');
 
-      reg.callManager.createCall();
-      expect(Object.keys(reg.callManager.getActiveCalls()).length).toBe(1);
-
       await reg.handleRegistrationDownEvent(registrationDownEvent as any);
-      expect(reg.isRegistrationDownPending()).toBe(true);
-      expect(clearKeepaliveSpy).not.toHaveBeenCalled();
-      expect(setStatusSpy).not.toHaveBeenCalled();
+      expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
+      clearKeepaliveSpy.mockClear();
+      setStatusSpy.mockClear();
+      lineEmitter.mockClear();
 
-      reg.callManager.callCollection = {};
       expect(Object.keys(reg.callManager.getActiveCalls()).length).toBe(0);
-
-      lineEmitter.mockClear();
 
       await reg.handleRegistrationDownEvent(registrationDownEvent as any);
 
@@ -1931,7 +1921,6 @@ describe('Registration Tests', () => {
       expect(setStatusSpy).toHaveBeenCalledWith(RegistrationStatus.INACTIVE);
       expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
       expect(lineEmitter).toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
-      expect(reg.isRegistrationDownPending()).toBe(false);
     });
 
     it('disconnects the Mobius WebSocket when socket is enabled', async () => {
@@ -1952,7 +1941,6 @@ describe('Registration Tests', () => {
       });
       expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
       expect(lineEmitter).toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
-      expect(reg.isRegistrationDownPending()).toBe(false);
     });
 
     it('still emits UNREGISTERED when socket disconnect fails', async () => {
@@ -1973,7 +1961,6 @@ describe('Registration Tests', () => {
       );
       expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
       expect(lineEmitter).toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
-      expect(reg.isRegistrationDownPending()).toBe(false);
     });
   });
 });

--- a/packages/calling/src/CallingClient/registration/register.test.ts
+++ b/packages/calling/src/CallingClient/registration/register.test.ts
@@ -1829,4 +1829,151 @@ describe('Registration Tests', () => {
       expect(status).toEqual(false);
     });
   });
+
+  describe('handleRegistrationDownEvent tests', () => {
+    const registrationDownEvent = {
+      type: 'async_event',
+      eventId: 'evt-1',
+      trackingId: 'tid-1',
+      data: {
+        eventType: 'registration.down',
+        deviceInfo: {
+          userId: 'u1',
+          device: {deviceId: 'd1', uri: 'https://mobius/device/d1', status: 'ACTIVE'},
+        },
+      },
+    };
+
+    beforeEach(async () => {
+      postRegistrationSpy.mockResolvedValueOnce(successPayload);
+      await reg.triggerRegistration();
+      expect(reg.getStatus()).toBe(RegistrationStatus.ACTIVE);
+    });
+
+    afterEach(() => {
+      const calls = Object.values(reg.callManager.getActiveCalls()) as ICall[];
+
+      calls.forEach((call) => {
+        call.end();
+      });
+      reg.callManager.callCollection = {};
+    });
+
+    it('runs cleanup immediately when no active calls are present (socket disabled)', async () => {
+      const clearKeepaliveSpy = jest.spyOn(reg, 'clearKeepaliveTimer');
+      const setStatusSpy = jest.spyOn(reg, 'setStatus');
+      const disconnectSocketSpy = jest.spyOn(
+        APIRequest.getInstance({webex}),
+        'disconnectFromMobiusSocket'
+      );
+
+      lineEmitter.mockClear();
+      expect(Object.keys(reg.callManager.getActiveCalls()).length).toBe(0);
+
+      await reg.handleRegistrationDownEvent(registrationDownEvent as any);
+
+      expect(clearKeepaliveSpy).toHaveBeenCalled();
+      expect(setStatusSpy).toHaveBeenCalledWith(RegistrationStatus.INACTIVE);
+      expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
+      expect(reg.reconnectPending).toBe(false);
+      expect(reg.scheduled429Retry).toBe(false);
+      expect(reg.failoverImmediately).toBe(false);
+      expect(reg.retryAfter).toBeUndefined();
+      expect(reg.registerRetry).toBe(false);
+      expect(disconnectSocketSpy).not.toHaveBeenCalled();
+      expect(lineEmitter).toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
+      expect(reg.isRegistrationDownPending()).toBe(false);
+    });
+
+    it('defers cleanup when active calls are present', async () => {
+      const clearKeepaliveSpy = jest.spyOn(reg, 'clearKeepaliveTimer');
+      const setStatusSpy = jest.spyOn(reg, 'setStatus');
+
+      reg.callManager.createCall();
+      expect(Object.keys(reg.callManager.getActiveCalls()).length).toBe(1);
+
+      lineEmitter.mockClear();
+
+      await reg.handleRegistrationDownEvent(registrationDownEvent as any);
+
+      expect(reg.isRegistrationDownPending()).toBe(true);
+      expect(infoSpy).toHaveBeenCalledWith(
+        'Active call(s) present, deferring registration-down cleanup till call cleanup.',
+        {file: REGISTRATION_FILE, method: METHODS.HANDLE_REGISTRATION_DOWN_EVENT}
+      );
+
+      expect(clearKeepaliveSpy).not.toHaveBeenCalled();
+      expect(setStatusSpy).not.toHaveBeenCalled();
+      expect(reg.getStatus()).toBe(RegistrationStatus.ACTIVE);
+      expect(lineEmitter).not.toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
+    });
+
+    it('runs deferred cleanup on re-invocation once active calls are cleared', async () => {
+      const clearKeepaliveSpy = jest.spyOn(reg, 'clearKeepaliveTimer');
+      const setStatusSpy = jest.spyOn(reg, 'setStatus');
+
+      reg.callManager.createCall();
+      expect(Object.keys(reg.callManager.getActiveCalls()).length).toBe(1);
+
+      await reg.handleRegistrationDownEvent(registrationDownEvent as any);
+      expect(reg.isRegistrationDownPending()).toBe(true);
+      expect(clearKeepaliveSpy).not.toHaveBeenCalled();
+      expect(setStatusSpy).not.toHaveBeenCalled();
+
+      reg.callManager.callCollection = {};
+      expect(Object.keys(reg.callManager.getActiveCalls()).length).toBe(0);
+
+      lineEmitter.mockClear();
+
+      await reg.handleRegistrationDownEvent(registrationDownEvent as any);
+
+      expect(clearKeepaliveSpy).toHaveBeenCalled();
+      expect(setStatusSpy).toHaveBeenCalledWith(RegistrationStatus.INACTIVE);
+      expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
+      expect(lineEmitter).toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
+      expect(reg.isRegistrationDownPending()).toBe(false);
+    });
+
+    it('disconnects the Mobius WebSocket when socket is enabled', async () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      jest.spyOn(apiRequest, 'isSocketEnabled').mockReturnValue(true);
+      const disconnectSocketSpy = jest
+        .spyOn(apiRequest, 'disconnectFromMobiusSocket')
+        .mockResolvedValue();
+
+      lineEmitter.mockClear();
+      expect(Object.keys(reg.callManager.getActiveCalls()).length).toBe(0);
+
+      await reg.handleRegistrationDownEvent(registrationDownEvent as any);
+
+      expect(disconnectSocketSpy).toHaveBeenCalledWith({
+        code: 3050,
+        reason: 'done (permanent)',
+      });
+      expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
+      expect(lineEmitter).toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
+      expect(reg.isRegistrationDownPending()).toBe(false);
+    });
+
+    it('still emits UNREGISTERED when socket disconnect fails', async () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      jest.spyOn(apiRequest, 'isSocketEnabled').mockReturnValue(true);
+      const disconnectSocketSpy = jest
+        .spyOn(apiRequest, 'disconnectFromMobiusSocket')
+        .mockRejectedValue(new Error('socket teardown failed'));
+
+      lineEmitter.mockClear();
+
+      await reg.handleRegistrationDownEvent(registrationDownEvent as any);
+
+      expect(disconnectSocketSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Mobius socket disconnect failed after registration-down'),
+        {file: REGISTRATION_FILE, method: METHODS.HANDLE_REGISTRATION_DOWN_EVENT}
+      );
+      expect(reg.getStatus()).toBe(RegistrationStatus.INACTIVE);
+      expect(lineEmitter).toHaveBeenCalledWith(LINE_EVENTS.UNREGISTERED);
+      expect(reg.isRegistrationDownPending()).toBe(false);
+    });
+  });
 });

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -11,7 +11,7 @@ import {
   SERVER_TYPE,
 } from '../../Metrics/types';
 import {getMetricManager} from '../../Metrics';
-import {ICallManager} from '../calling/types';
+import {ICallManager, MobiusAsyncEvent} from '../calling/types';
 import {getCallManager} from '../calling';
 import {LOGGER} from '../../Logger/types';
 import log from '../../Logger';
@@ -89,6 +89,7 @@ export class Registration implements IRegistration {
   private backupMobiusUris: string[];
   private registerRetry = false;
   private reconnectPending = false;
+  private registrationDownPending = false;
   private jwe?: string;
   private isCCFlow = false;
   private failoverImmediately = false;
@@ -1338,6 +1339,110 @@ export class Registration implements IRegistration {
         });
       }
     }
+  }
+
+  /**
+   * Handles an async REGISTRATION_DOWN event emitted by Mobius.
+   *
+   * If there are active calls, the cleanup is deferred by setting
+   * `registrationDownPending = true` and returning early; the caller
+   * ({@link CallingClient}) is expected to re-invoke this method
+   * periodically until {@link isRegistrationDownPending} returns `false`.
+   * Otherwise the cleanup runs immediately.
+   *
+   * The method is safe to re-invoke: once cleanup has completed,
+   * subsequent calls are no-ops at the cleanup stage (no active calls to
+   * tear down) and the pending flag stays `false`.
+   *
+   * @param event - The Mobius async event payload (trackingId/eventId used for logs).
+   */
+  public async handleRegistrationDownEvent(event?: MobiusAsyncEvent): Promise<void> {
+    const loggerContext = {
+      file: REGISTRATION_FILE,
+      method: METHODS.HANDLE_REGISTRATION_DOWN_EVENT,
+    };
+
+    log.info(
+      `Registration down received - trackingId: ${event?.trackingId ?? 'unknown'}, eventId: ${
+        event?.eventId ?? 'unknown'
+      }`,
+      loggerContext
+    );
+
+    if (Object.keys(this.callManager.getActiveCalls()).length > 0) {
+      this.registrationDownPending = true;
+      log.info(
+        'Active call(s) present, deferring registration-down cleanup till call cleanup.',
+        loggerContext
+      );
+
+      return;
+    }
+
+    await this.performRegistrationDownCleanup(METHODS.HANDLE_REGISTRATION_DOWN_EVENT);
+  }
+
+  /**
+   * Returns `true` while a registration-down cleanup is still deferred
+   * due to active calls. The `CallingClient` polls this flag (via repeated
+   * calls to {@link handleRegistrationDownEvent}) to decide when the
+   * deferred cleanup can proceed.
+   */
+  public isRegistrationDownPending(): boolean {
+    return this.registrationDownPending;
+  }
+
+  /**
+   * Cleans up registration-side state after a Mobius registration-down event.
+   *
+   * Stops timers, resets transient flags, clears failover cache, sets status to
+   * INACTIVE, tears down the Mobius WebSocket (when enabled), and finally emits
+   * `LINE_EVENTS.UNREGISTERED` so the SDK consumer is notified.
+   *
+   * Runs under the shared mutex to avoid racing with other registration flows.
+   * Idempotent: `registrationDownPending` is reset before emitting.
+   *
+   * @param caller - Identifier of the caller, used for logs.
+   */
+  private async performRegistrationDownCleanup(caller: string): Promise<void> {
+    const loggerContext = {
+      file: REGISTRATION_FILE,
+      method: METHODS.HANDLE_REGISTRATION_DOWN_EVENT,
+    };
+
+    log.info(`[${caller}] : Running registration-down cleanup`, loggerContext);
+
+    await this.mutex.runExclusive(async () => {
+      this.clearFailbackTimer();
+      this.clearKeepaliveTimer();
+
+      this.reconnectPending = false;
+      this.scheduled429Retry = false;
+      this.failoverImmediately = false;
+      this.retryAfter = undefined;
+      this.registerRetry = false;
+
+      this.clearFailoverState();
+      this.setStatus(RegistrationStatus.INACTIVE);
+
+      if (this.apiRequest.isSocketEnabled()) {
+        try {
+          await this.apiRequest.disconnectFromMobiusSocket({
+            code: 3050,
+            reason: 'done (permanent)',
+          });
+          log.log('Mobius socket disconnect complete after registration-down', loggerContext);
+        } catch (err) {
+          log.warn(
+            `Mobius socket disconnect failed after registration-down: ${String(err)}`,
+            loggerContext
+          );
+        }
+      }
+
+      this.registrationDownPending = false;
+      this.lineEmitter(LINE_EVENTS.UNREGISTERED);
+    });
   }
 }
 

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -89,7 +89,6 @@ export class Registration implements IRegistration {
   private backupMobiusUris: string[];
   private registerRetry = false;
   private reconnectPending = false;
-  private registrationDownPending = false;
   private jwe?: string;
   private isCCFlow = false;
   private failoverImmediately = false;
@@ -1342,17 +1341,8 @@ export class Registration implements IRegistration {
   }
 
   /**
-   * Handles an async REGISTRATION_DOWN event emitted by Mobius.
-   *
-   * If there are active calls, the cleanup is deferred by setting
-   * `registrationDownPending = true` and returning early; the caller
-   * ({@link CallingClient}) is expected to re-invoke this method
-   * periodically until {@link isRegistrationDownPending} returns `false`.
-   * Otherwise the cleanup runs immediately.
-   *
-   * The method is safe to re-invoke: once cleanup has completed,
-   * subsequent calls are no-ops at the cleanup stage (no active calls to
-   * tear down) and the pending flag stays `false`.
+   * Handles an async REGISTRATION_DOWN event emitted by Mobius. Ends the first
+   * active call (if any) and runs registration-side cleanup.
    *
    * @param event - The Mobius async event payload (trackingId/eventId used for logs).
    */
@@ -1369,27 +1359,10 @@ export class Registration implements IRegistration {
       loggerContext
     );
 
-    if (Object.keys(this.callManager.getActiveCalls()).length > 0) {
-      this.registrationDownPending = true;
-      log.info(
-        'Active call(s) present, deferring registration-down cleanup till call cleanup.',
-        loggerContext
-      );
-
-      return;
-    }
+    const [activeCall] = Object.values(this.callManager.getActiveCalls());
+    activeCall?.end();
 
     await this.performRegistrationDownCleanup(METHODS.HANDLE_REGISTRATION_DOWN_EVENT);
-  }
-
-  /**
-   * Returns `true` while a registration-down cleanup is still deferred
-   * due to active calls. The `CallingClient` polls this flag (via repeated
-   * calls to {@link handleRegistrationDownEvent}) to decide when the
-   * deferred cleanup can proceed.
-   */
-  public isRegistrationDownPending(): boolean {
-    return this.registrationDownPending;
   }
 
   /**
@@ -1400,7 +1373,6 @@ export class Registration implements IRegistration {
    * `LINE_EVENTS.UNREGISTERED` so the SDK consumer is notified.
    *
    * Runs under the shared mutex to avoid racing with other registration flows.
-   * Idempotent: `registrationDownPending` is reset before emitting.
    *
    * @param caller - Identifier of the caller, used for logs.
    */
@@ -1440,7 +1412,6 @@ export class Registration implements IRegistration {
         }
       }
 
-      this.registrationDownPending = false;
       this.lineEmitter(LINE_EVENTS.UNREGISTERED);
     });
   }

--- a/packages/calling/src/CallingClient/registration/types.ts
+++ b/packages/calling/src/CallingClient/registration/types.ts
@@ -112,22 +112,10 @@ export interface IRegistration {
   setDeviceInfo(body: Devices): void;
 
   /**
-   * Handles a Mobius REGISTRATION_DOWN async event.
-   *
-   * When active calls are present the cleanup is deferred and the method
-   * returns early with {@link isRegistrationDownPending} set to `true`;
-   * the caller is expected to re-invoke this method periodically until
-   * the pending flag clears. When no active calls are present the
-   * cleanup runs immediately.
+   * Handles a Mobius REGISTRATION_DOWN async event. Ends the first active
+   * call (if any) and runs registration-side cleanup.
    *
    * @param event - The Mobius async event payload (optional).
    */
   handleRegistrationDownEvent(event?: MobiusAsyncEvent): Promise<void>;
-
-  /**
-   * Returns `true` while a registration-down cleanup is still deferred
-   * because active calls were present. The `CallingClient` polls this
-   * flag to decide when the deferred cleanup can proceed.
-   */
-  isRegistrationDownPending(): boolean;
 }

--- a/packages/calling/src/CallingClient/registration/types.ts
+++ b/packages/calling/src/CallingClient/registration/types.ts
@@ -1,4 +1,5 @@
 import {Devices, IDeviceInfo, RegistrationStatus} from '../../common/types';
+import {MobiusAsyncEvent} from '../calling/types';
 
 export type Header = {
   [key: string]: string;
@@ -109,4 +110,24 @@ export interface IRegistration {
    * Populate deviceInfo from a devices response (e.g., getDevices API).
    */
   setDeviceInfo(body: Devices): void;
+
+  /**
+   * Handles a Mobius REGISTRATION_DOWN async event.
+   *
+   * When active calls are present the cleanup is deferred and the method
+   * returns early with {@link isRegistrationDownPending} set to `true`;
+   * the caller is expected to re-invoke this method periodically until
+   * the pending flag clears. When no active calls are present the
+   * cleanup runs immediately.
+   *
+   * @param event - The Mobius async event payload (optional).
+   */
+  handleRegistrationDownEvent(event?: MobiusAsyncEvent): Promise<void>;
+
+  /**
+   * Returns `true` while a registration-down cleanup is still deferred
+   * because active calls were present. The `CallingClient` polls this
+   * flag to decide when the deferred cleanup can proceed.
+   */
+  isRegistrationDownPending(): boolean;
 }


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [CAI-7866](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7866) >

## This pull request addresses

Handles `registration.down` event.

## by making the following changes

- **New `Registration.handleRegistrationDownEvent(event?)`** (`register.ts`, `types.ts`):
  - If any active calls exist, sets `registrationDownPending = true` and returns early (defers cleanup).
  - Otherwise, runs cleanup immediately.
  - Safe to re-invoke: idempotent across repeated calls.
- **New `Registration.isRegistrationDownPending()`**: exposes the pending flag so `CallingClient` can poll it.
- **New private `performRegistrationDownCleanup(caller)`** (runs under the shared mutex):
  - Stops `failbackTimer` and keepalive web worker.
  - Resets transient flags: `reconnectPending`, `scheduled429Retry`, `failoverImmediately`, `retryAfter`, `registerRetry`.
  - Clears the localStorage failover cache and sets status to `INACTIVE`.
  - If Mobius WebSocket is enabled, disconnects with code `3050` / reason `'done (permanent)'` (errors are logged but don’t block cleanup).
  - Emits `LINE_EVENTS.UNREGISTERED` to the SDK consumer.
  - Clears `registrationDownPending`.
  - No `DELETE /devices/{id}` — Mobius already signaled registration is gone.
- **`CallingClient.handleMobiusAsyncEvent`** (`CallingClient.ts`):
  - `MobiusEventType.REGISTRATION_DOWN` now invokes `line.registration.handleRegistrationDownEvent(event)` (replacing the prior TODO stub).
  - If the call leaves `isRegistrationDownPending() === true`, schedules a 30-second polling interval (`registrationDownInterval`) that re-invokes `handleRegistrationDownEvent` with the same event and self-clears once the pending flag goes `false`.
  - Prior interval (if any) is cleared on each new `REGISTRATION_DOWN` event to avoid stacking.
- **Events/metrics**: no new events or metrics; continues to emit existing `LINE_EVENTS.UNREGISTERED` and the pre-existing `MOBIUS_SOCKET_ERROR` / `REGISTRATION_DOWN` metric.
- **Docs + tests**: `registration/ai-docs/AGENTS.md` documents the polling protocol; 5 new unit tests in `register.test.ts` cover immediate cleanup, deferred cleanup, re-invocation after calls clear, socket-enabled teardown, and graceful handling of socket-disconnect failure.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Unit Tests. Further verification will be done when Mobius tests this by explicitly sending `registration.down` event.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
