### PR TITLE
test(calling): add and update the unit tests for files related to mobius socket under calling client

### DIFF
--- a/packages/calling/src/CallingClient/utils/mobiusSocketMapper.test.ts
+++ b/packages/calling/src/CallingClient/utils/mobiusSocketMapper.test.ts
@@ -1,0 +1,296 @@
+import {HTTP_METHODS} from '../../common/types';
+import log from '../../Logger';
+import {
+  deriveMobiusSocketMessageType,
+  isSupplementaryServiceMessageType,
+} from './mobiusSocketMapper';
+import {MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
+
+describe('mobiusSocketMapper', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    warnSpy = jest.spyOn(log, 'warn');
+  });
+
+  describe('deriveMobiusSocketMessageType', () => {
+    describe('Supplementary services', () => {
+      it('should return CALL_HOLD for hold service URI', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/services/callhold/hold';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.POST);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_HOLD);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return CALL_RESUME for resume service URI', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/services/callhold/resume';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.POST);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_RESUME);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return CALL_TRANSFER for transfer commit service URI', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/services/calltransfer/commit';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.POST);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_TRANSFER);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return UNKNOWN and log warning for unrecognized supplementary service', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/services/unknown/action';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.POST);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.UNKNOWN);
+        expect(warnSpy).toHaveBeenCalledWith(
+          `Unrecognized supplementary service uri - uri: ${uri}, httpMethod: ${HTTP_METHODS.POST}`,
+          {
+            file: 'mobiusSocketMapper',
+            method: 'deriveMobiusSocketMessageType',
+          }
+        );
+      });
+    });
+
+    describe('Call operations', () => {
+      it('should return CALL_SETUP for call setup URI', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/call';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.POST);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_SETUP);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return CALL_MEDIA for call media URI', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/calls/call-456/media';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.PATCH);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_MEDIA);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return CALL_STATUS for call status URI', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/calls/call-456/status';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.PATCH);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_STATUS);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return CALL_STATE for calls/{callId} with PATCH method', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/calls/call-456';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.PATCH);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_STATE);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return CALL_DELETE for calls/{callId} with DELETE method', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/calls/call-456';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.DELETE);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_DELETE);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return UNKNOWN and log warning for calls/{callId} with unrecognized HTTP method', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/calls/call-456';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.GET);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.UNKNOWN);
+        expect(warnSpy).toHaveBeenCalledWith(
+          `Unrecognized httpMethod for calls/{callId} - uri: ${uri}, httpMethod: ${HTTP_METHODS.GET}`,
+          {
+            file: 'mobiusSocketMapper',
+            method: 'deriveMobiusSocketMessageType',
+          }
+        );
+      });
+    });
+
+    describe('Device operations', () => {
+      it('should return REGISTER for device registration URI', () => {
+        const uri = '/api/v1/calling/web/device';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.POST);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.REGISTER);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return UNREGISTER for devices/{deviceId} with DELETE method', () => {
+        const uri = '/api/v1/calling/web/devices/device-123';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.DELETE);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.UNREGISTER);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return DEVICE_GET for devices/{deviceId} with GET method', () => {
+        const uri = '/api/v1/calling/web/devices/device-123';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.GET);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.DEVICE_GET);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return UNKNOWN and log warning for devices/{deviceId} with unrecognized HTTP method', () => {
+        const uri = '/api/v1/calling/web/devices/device-123';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.PATCH);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.UNKNOWN);
+        expect(warnSpy).toHaveBeenCalledWith(
+          `Unrecognized httpMethod for devices/{deviceId} - uri: ${uri}, httpMethod: ${HTTP_METHODS.PATCH}`,
+          {
+            file: 'mobiusSocketMapper',
+            method: 'deriveMobiusSocketMessageType',
+          }
+        );
+      });
+
+      it('should return DEVICE_STATUS for devices/{deviceId}/status URI', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/status';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.PATCH);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.DEVICE_STATUS);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return DEVICE_LIST for devices list URI without trailing ID', () => {
+        const uri = '/api/v1/calling/web/devices';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.GET);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.DEVICE_LIST);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should return DEVICE_LIST for devices list URI with query parameters', () => {
+        const uri = '/api/v1/calling/web/devices?userid=user-789';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.GET);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.DEVICE_LIST);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('should return UNKNOWN and log warning when uri is undefined', () => {
+        const result = deriveMobiusSocketMessageType(undefined, HTTP_METHODS.GET);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.UNKNOWN);
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Cannot derive Mobius socket message type: uri is empty',
+          {
+            file: 'mobiusSocketMapper',
+            method: 'deriveMobiusSocketMessageType',
+          }
+        );
+      });
+
+      it('should return UNKNOWN and log warning when uri is empty string', () => {
+        const result = deriveMobiusSocketMessageType('', HTTP_METHODS.GET);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.UNKNOWN);
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Cannot derive Mobius socket message type: uri is empty',
+          {
+            file: 'mobiusSocketMapper',
+            method: 'deriveMobiusSocketMessageType',
+          }
+        );
+      });
+
+      it('should return UNKNOWN and log warning for completely unrecognized URI pattern', () => {
+        const uri = '/api/v1/completely/unrecognized/path';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.POST);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.UNKNOWN);
+        expect(warnSpy).toHaveBeenCalledWith(
+          `Unrecognized uri pattern for Mobius socket - uri: ${uri}, httpMethod: ${HTTP_METHODS.POST}`,
+          {
+            file: 'mobiusSocketMapper',
+            method: 'deriveMobiusSocketMessageType',
+          }
+        );
+      });
+
+      it('should handle URI with /calls/ in path correctly for DEVICE_STATUS (not call-related)', () => {
+        const uri = '/api/v1/calling/web/devices/device-123/status';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.PATCH);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.DEVICE_STATUS);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should prioritize call sub-resources over bare call patterns', () => {
+        const mediaUri = '/api/v1/calling/web/devices/device-123/calls/call-456/media';
+        const statusUri = '/api/v1/calling/web/devices/device-123/calls/call-456/status';
+
+        expect(deriveMobiusSocketMessageType(mediaUri, HTTP_METHODS.PATCH)).toBe(
+          MOBIUS_SOCKET_MESSAGE_TYPE.CALL_MEDIA
+        );
+        expect(deriveMobiusSocketMessageType(statusUri, HTTP_METHODS.PATCH)).toBe(
+          MOBIUS_SOCKET_MESSAGE_TYPE.CALL_STATUS
+        );
+      });
+    });
+  });
+
+  describe('isSupplementaryServiceMessageType', () => {
+    it('should return true for CALL_HOLD message type', () => {
+      const result = isSupplementaryServiceMessageType(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_HOLD);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for CALL_RESUME message type', () => {
+      const result = isSupplementaryServiceMessageType(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_RESUME);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for CALL_TRANSFER message type', () => {
+      const result = isSupplementaryServiceMessageType(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_TRANSFER);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for REGISTER message type', () => {
+      const result = isSupplementaryServiceMessageType(MOBIUS_SOCKET_MESSAGE_TYPE.REGISTER);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for CALL_SETUP message type', () => {
+      const result = isSupplementaryServiceMessageType(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_SETUP);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for CALL_STATE message type', () => {
+      const result = isSupplementaryServiceMessageType(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_STATE);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for CALL_DELETE message type', () => {
+      const result = isSupplementaryServiceMessageType(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_DELETE);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for DEVICE_STATUS message type', () => {
+      const result = isSupplementaryServiceMessageType(MOBIUS_SOCKET_MESSAGE_TYPE.DEVICE_STATUS);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for UNKNOWN message type', () => {
+      const result = isSupplementaryServiceMessageType(MOBIUS_SOCKET_MESSAGE_TYPE.UNKNOWN);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/calling/src/CallingClient/utils/request.test.ts
+++ b/packages/calling/src/CallingClient/utils/request.test.ts
@@ -1,0 +1,680 @@
+import {v4 as uuid} from 'uuid';
+import {getTestUtilsWebex} from '../../common/testUtil';
+import {HTTP_METHODS, WebexRequestPayload} from '../../common/types';
+import log from '../../Logger';
+import {APIRequest, createAPIRequest} from './request';
+import {getMobiusSocketInstance} from '../../mobius-socket';
+import {getMetricManager} from '../../Metrics';
+import {METRIC_EVENT, METRIC_TYPE, MOBIUS_SOCKET_ACTION} from '../../Metrics/types';
+import {isMobiusWssEnabled} from './wsFeatureFlag';
+import {MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
+import {MobiusSocketResponse, MobiusAsyncEvent} from './types';
+
+// Mock dependencies
+jest.mock('../../mobius-socket', () => ({
+  getMobiusSocketInstance: jest.fn(),
+}));
+jest.mock('../../Metrics', () => ({
+  getMetricManager: jest.fn(),
+}));
+jest.mock('./wsFeatureFlag', () => ({
+  isMobiusWssEnabled: jest.fn(),
+}));
+jest.mock('uuid', () => ({
+  v4: jest.fn(),
+}));
+
+describe('APIRequest', () => {
+  let webex: ReturnType<typeof getTestUtilsWebex>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockMobiusSocket: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockMetricManager: any;
+  let infoSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    APIRequest.resetInstance();
+    webex = getTestUtilsWebex();
+    jest.clearAllMocks();
+
+    mockMobiusSocket = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      sendWssRequest: jest.fn().mockResolvedValue({
+        statusCode: 200,
+        trackingId: 'test-tracking-id',
+        data: {deviceId: 'test-device-id'},
+      }),
+      isConnected: jest.fn().mockReturnValue(false),
+      getConnectedWebSocketUrl: jest.fn().mockReturnValue('wss://test.webex.com'),
+      on: jest.fn(),
+      off: jest.fn(),
+    };
+
+    mockMetricManager = {
+      submitMobiusSocketMetric: jest.fn(),
+    };
+
+    (getMobiusSocketInstance as jest.Mock).mockReturnValue(mockMobiusSocket);
+    (getMetricManager as jest.Mock).mockReturnValue(mockMetricManager);
+    (isMobiusWssEnabled as jest.Mock).mockReturnValue(false);
+    (uuid as jest.Mock).mockReturnValue('mock-uuid-12345');
+
+    infoSpy = jest.spyOn(log, 'info');
+    logSpy = jest.spyOn(log, 'log');
+    warnSpy = jest.spyOn(log, 'warn');
+    errorSpy = jest.spyOn(log, 'error');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Constructor and singleton pattern', () => {
+    it('should create instance with webex config and HTTP transport', () => {
+      const apiRequest = APIRequest.getInstance({webex});
+
+      expect(apiRequest).toBeDefined();
+      expect(getMobiusSocketInstance).toHaveBeenCalledWith(webex);
+      expect(getMetricManager).toHaveBeenCalledWith(webex);
+      expect(isMobiusWssEnabled).toHaveBeenCalledWith(webex);
+      expect(infoSpy).toHaveBeenCalledWith('APIRequest initialized with transport: HTTP', {
+        file: 'REQUEST',
+        method: 'constructor',
+      });
+    });
+
+    it('should create instance with webex config and WSS transport when feature flag enabled', () => {
+      (isMobiusWssEnabled as jest.Mock).mockReturnValue(true);
+
+      const apiRequest = APIRequest.getInstance({webex});
+
+      expect(apiRequest).toBeDefined();
+      expect(infoSpy).toHaveBeenCalledWith('APIRequest initialized with transport: WSS', {
+        file: 'REQUEST',
+        method: 'constructor',
+      });
+    });
+
+    it('should throw error if webex is missing from config', () => {
+      expect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        APIRequest.getInstance({webex: undefined as any});
+      }).toThrow('WebexSDK instance is required');
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'APIRequest instantiation failed: WebexSDK instance is required',
+        {
+          file: 'REQUEST',
+          method: 'constructor',
+        }
+      );
+    });
+
+    it('should return same instance on subsequent getInstance() calls', () => {
+      const instance1 = APIRequest.getInstance({webex});
+      const instance2 = APIRequest.getInstance({webex});
+
+      expect(instance1).toBe(instance2);
+    });
+
+    it('should clear singleton when resetInstance() is called', () => {
+      const instance1 = APIRequest.getInstance({webex});
+
+      APIRequest.resetInstance();
+
+      const instance2 = APIRequest.getInstance({webex});
+
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  describe('createAPIRequest factory', () => {
+    it('should create APIRequest instance using factory function', () => {
+      const apiRequest = createAPIRequest({webex});
+
+      expect(apiRequest).toBeDefined();
+      expect(apiRequest).toBeInstanceOf(APIRequest);
+    });
+  });
+
+  describe('isSocketEnabled', () => {
+    it('should return false when WSS is disabled', () => {
+      (isMobiusWssEnabled as jest.Mock).mockReturnValue(false);
+      const apiRequest = APIRequest.getInstance({webex});
+
+      const result = apiRequest.isSocketEnabled();
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true when WSS is enabled', () => {
+      (isMobiusWssEnabled as jest.Mock).mockReturnValue(true);
+      const apiRequest = APIRequest.getInstance({webex});
+
+      const result = apiRequest.isSocketEnabled();
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('connectToMobiusSocket', () => {
+    it('should return immediately if socket is already connected', async () => {
+      mockMobiusSocket.isConnected.mockReturnValue(true);
+      mockMobiusSocket.getConnectedWebSocketUrl.mockReturnValue('wss://existing.webex.com');
+      const apiRequest = APIRequest.getInstance({webex});
+
+      const result = await apiRequest.connectToMobiusSocket('wss://test.webex.com');
+
+      expect(result).toBe('wss://existing.webex.com');
+      expect(mockMobiusSocket.connect).not.toHaveBeenCalled();
+      expect(infoSpy).toHaveBeenCalledWith('Mobius WebSocket already connected', {
+        file: 'REQUEST',
+        method: 'connectToMobiusSocket',
+      });
+      expect(mockMetricManager.submitMobiusSocketMetric).not.toHaveBeenCalled();
+    });
+
+    it('should initiate new connection if not connected', async () => {
+      mockMobiusSocket.isConnected.mockReturnValue(false);
+      const apiRequest = APIRequest.getInstance({webex});
+      const wssUrl = 'wss://test.webex.com/api/v1';
+
+      const result = await apiRequest.connectToMobiusSocket(wssUrl);
+
+      expect(mockMobiusSocket.connect).toHaveBeenCalledWith(wssUrl);
+      expect(result).toBe(wssUrl);
+      expect(infoSpy).toHaveBeenCalledWith(
+        'Mobius WebSocket not connected, initiating connection',
+        {
+          file: 'REQUEST',
+          method: 'connectToMobiusSocket',
+        }
+      );
+    });
+
+    it('should submit success metric on successful connection', async () => {
+      mockMobiusSocket.isConnected.mockReturnValue(false);
+      const apiRequest = APIRequest.getInstance({webex});
+      const wssUrl = 'wss://mobius.webex.com/api/v1';
+
+      await apiRequest.connectToMobiusSocket(wssUrl);
+
+      expect(logSpy).toHaveBeenCalledWith('Mobius WebSocket connected successfully', {
+        file: 'REQUEST',
+        method: 'connectToMobiusSocket',
+      });
+      expect(mockMetricManager.submitMobiusSocketMetric).toHaveBeenCalledWith(
+        METRIC_EVENT.MOBIUS_SOCKET,
+        MOBIUS_SOCKET_ACTION.CONNECT,
+        METRIC_TYPE.BEHAVIORAL,
+        wssUrl
+      );
+    });
+
+    it('should throw normalized error on connection failure', async () => {
+      const connectionError = {
+        statusCode: 503,
+        statusMessage: 'Service Unavailable',
+        trackingId: 'error-tracking-id',
+        response: {
+          statusCode: 503,
+          trackingId: 'error-tracking-id',
+          data: {error: 'Connection failed'},
+          metadata: {'x-error': 'true'},
+        },
+      };
+      mockMobiusSocket.isConnected.mockReturnValue(false);
+      mockMobiusSocket.connect.mockRejectedValue(connectionError);
+      const apiRequest = APIRequest.getInstance({webex});
+      const wssUrl = 'wss://mobius.webex.com/api/v1';
+
+      await expect(apiRequest.connectToMobiusSocket(wssUrl)).rejects.toEqual({
+        statusCode: 503,
+        body: {error: 'Connection failed'},
+        headers: {
+          trackingid: 'error-tracking-id',
+          'x-error': 'true',
+        },
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Mobius WebSocket connection failed'),
+        {
+          file: 'REQUEST',
+          method: 'connectToMobiusSocket',
+        }
+      );
+      expect(mockMetricManager.submitMobiusSocketMetric).toHaveBeenCalledWith(
+        METRIC_EVENT.MOBIUS_SOCKET_ERROR,
+        MOBIUS_SOCKET_ACTION.CONNECT,
+        METRIC_TYPE.BEHAVIORAL,
+        wssUrl,
+        undefined,
+        expect.any(String)
+      );
+    });
+
+    it('should handle connection error with minimal error object', async () => {
+      const minimalError = {statusCode: 500};
+      mockMobiusSocket.isConnected.mockReturnValue(false);
+      mockMobiusSocket.connect.mockRejectedValue(minimalError);
+      const apiRequest = APIRequest.getInstance({webex});
+
+      await expect(apiRequest.connectToMobiusSocket('wss://test.webex.com')).rejects.toEqual({
+        statusCode: 500,
+        body: undefined,
+        headers: {
+          trackingid: '',
+        },
+      });
+    });
+  });
+
+  describe('disconnectFromMobiusSocket', () => {
+    it('should disconnect successfully', async () => {
+      const apiRequest = APIRequest.getInstance({webex});
+
+      await apiRequest.disconnectFromMobiusSocket();
+
+      expect(mockMobiusSocket.disconnect).toHaveBeenCalledWith(undefined);
+      expect(infoSpy).toHaveBeenCalledWith('Disconnecting from Mobius WebSocket', {
+        file: 'REQUEST',
+        method: 'disconnectFromMobiusSocket',
+      });
+      expect(logSpy).toHaveBeenCalledWith('Mobius WebSocket disconnected successfully', {
+        file: 'REQUEST',
+        method: 'disconnectFromMobiusSocket',
+      });
+    });
+
+    it('should submit success metric after disconnect', async () => {
+      const apiRequest = APIRequest.getInstance({webex});
+
+      await apiRequest.disconnectFromMobiusSocket();
+
+      expect(mockMetricManager.submitMobiusSocketMetric).toHaveBeenCalledWith(
+        METRIC_EVENT.MOBIUS_SOCKET,
+        MOBIUS_SOCKET_ACTION.DISCONNECT,
+        METRIC_TYPE.BEHAVIORAL
+      );
+    });
+
+    it('should disconnect with custom options', async () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const options = {code: 1000, reason: 'Normal closure'};
+
+      await apiRequest.disconnectFromMobiusSocket(options);
+
+      expect(mockMobiusSocket.disconnect).toHaveBeenCalledWith(options);
+    });
+
+    it('should handle disconnect error silently and log warning', async () => {
+      mockMobiusSocket.disconnect.mockRejectedValue(new Error('Disconnect failed'));
+      const apiRequest = APIRequest.getInstance({webex});
+
+      await expect(apiRequest.disconnectFromMobiusSocket()).resolves.not.toThrow();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Mobius WebSocket disconnection failed: Error: Disconnect failed',
+        {
+          file: 'REQUEST',
+          method: 'disconnectFromMobiusSocket',
+        }
+      );
+    });
+
+    it('should submit error metric on disconnect failure', async () => {
+      mockMobiusSocket.disconnect.mockRejectedValue(new Error('Disconnect failed'));
+      const apiRequest = APIRequest.getInstance({webex});
+
+      await apiRequest.disconnectFromMobiusSocket();
+
+      expect(mockMetricManager.submitMobiusSocketMetric).toHaveBeenCalledWith(
+        METRIC_EVENT.MOBIUS_SOCKET_ERROR,
+        MOBIUS_SOCKET_ACTION.DISCONNECT,
+        METRIC_TYPE.BEHAVIORAL,
+        undefined,
+        undefined,
+        'Error: Disconnect failed'
+      );
+    });
+  });
+
+  describe('makeRequest - HTTP transport', () => {
+    it('should route through webex.request when WSS is disabled', async () => {
+      (isMobiusWssEnabled as jest.Mock).mockReturnValue(false);
+      const apiRequest = APIRequest.getInstance({webex});
+      const requestOptions = {
+        uri: '/api/v1/calling/web/device',
+        method: HTTP_METHODS.POST,
+        body: {userId: 'user-123'},
+      };
+      const expectedResponse: WebexRequestPayload = {
+        statusCode: 200,
+        body: {deviceId: 'device-456'},
+      };
+      webex.request.mockResolvedValue(expectedResponse);
+
+      const result = await apiRequest.makeRequest(requestOptions);
+
+      expect(webex.request).toHaveBeenCalledWith(requestOptions);
+      expect(result).toEqual(expectedResponse);
+      expect(infoSpy).toHaveBeenCalledWith('Dispatching request via HTTP ', {
+        file: 'REQUEST',
+        method: 'makeRequest',
+      });
+    });
+
+    it('should pass request options unchanged to webex.request', async () => {
+      (isMobiusWssEnabled as jest.Mock).mockReturnValue(false);
+      const apiRequest = APIRequest.getInstance({webex});
+      const requestOptions = {
+        uri: '/api/v1/calling/web/devices/device-123',
+        method: HTTP_METHODS.GET,
+        headers: {'x-custom-header': 'value'},
+      };
+      webex.request.mockResolvedValue({statusCode: 200});
+
+      await apiRequest.makeRequest(requestOptions);
+
+      expect(webex.request).toHaveBeenCalledWith(requestOptions);
+    });
+
+    it('should return webex.request result directly', async () => {
+      (isMobiusWssEnabled as jest.Mock).mockReturnValue(false);
+      const apiRequest = APIRequest.getInstance({webex});
+      const expectedResponse = {
+        statusCode: 404,
+        body: {error: 'Not found'},
+        headers: {'x-tracking-id': 'track-123'},
+      };
+      webex.request.mockResolvedValue(expectedResponse);
+
+      const result = await apiRequest.makeRequest({
+        uri: '/api/v1/test',
+        method: HTTP_METHODS.GET,
+      });
+
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe('makeRequest - WebSocket transport', () => {
+    beforeEach(() => {
+      (isMobiusWssEnabled as jest.Mock).mockReturnValue(true);
+    });
+
+    it('should derive socket message type from URI and method', async () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const requestOptions = {
+        uri: '/api/v1/calling/web/device',
+        method: HTTP_METHODS.POST,
+        body: {userId: 'user-123'},
+      };
+
+      await apiRequest.makeRequest(requestOptions);
+
+      expect(mockMobiusSocket.sendWssRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MOBIUS_SOCKET_MESSAGE_TYPE.REGISTER,
+        })
+      );
+      expect(infoSpy).toHaveBeenCalledWith('Dispatching request via WSS ', {
+        file: 'REQUEST',
+        method: 'makeRequest',
+      });
+    });
+
+    it('should throw error if message type is UNKNOWN', async () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const requestOptions = {
+        uri: '/api/v1/unrecognized/path',
+        method: HTTP_METHODS.POST,
+      };
+
+      await expect(apiRequest.makeRequest(requestOptions)).rejects.toThrow(
+        'Unknown Mobius Socket message type: UNKNOWN'
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown Mobius Socket message type'),
+        {
+          file: 'REQUEST',
+          method: 'makeRequest',
+        }
+      );
+    });
+
+    it('should generate tracking ID with webex-js-sdk prefix', async () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const requestOptions = {
+        uri: '/api/v1/calling/web/device',
+        method: HTTP_METHODS.POST,
+      };
+
+      await apiRequest.makeRequest(requestOptions);
+
+      expect(uuid).toHaveBeenCalled();
+      expect(mockMobiusSocket.sendWssRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trackingId: 'webex-js-sdk_mock-uuid-12345',
+        })
+      );
+    });
+
+    it('should send WSS request with correct payload structure', async () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const requestOptions = {
+        uri: '/api/v1/calling/web/device',
+        method: HTTP_METHODS.POST,
+        body: {userId: 'user-123'},
+        headers: {'x-custom': 'header-value'},
+      };
+
+      await apiRequest.makeRequest(requestOptions);
+
+      expect(mockMobiusSocket.sendWssRequest).toHaveBeenCalledWith({
+        type: MOBIUS_SOCKET_MESSAGE_TYPE.REGISTER,
+        trackingId: 'webex-js-sdk_mock-uuid-12345',
+        metadata: {
+          'x-custom': 'header-value',
+          userAgent: 'webex-calling/beta',
+          authorization: '',
+        },
+        data: {userId: 'user-123'},
+      });
+    });
+
+    it('should get user token for supplementary services (CALL_HOLD)', async () => {
+      webex.credentials.getUserToken.mockResolvedValue('Bearer token-abc-123');
+      const apiRequest = APIRequest.getInstance({webex});
+      const requestOptions = {
+        uri: '/api/v1/calling/web/devices/device-123/services/callhold/hold',
+        method: HTTP_METHODS.POST,
+      };
+
+      await apiRequest.makeRequest(requestOptions);
+
+      expect(webex.credentials.getUserToken).toHaveBeenCalled();
+      expect(mockMobiusSocket.sendWssRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MOBIUS_SOCKET_MESSAGE_TYPE.CALL_HOLD,
+          metadata: expect.objectContaining({
+            authorization: 'Bearer token-abc-123',
+          }),
+        })
+      );
+    });
+
+    it('should not get user token for non-supplementary services', async () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const requestOptions = {
+        uri: '/api/v1/calling/web/device',
+        method: HTTP_METHODS.POST,
+      };
+
+      await apiRequest.makeRequest(requestOptions);
+
+      expect(webex.credentials.getUserToken).not.toHaveBeenCalled();
+      expect(mockMobiusSocket.sendWssRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            authorization: '',
+          }),
+        })
+      );
+    });
+
+    it('should normalize success response to WebexRequestPayload shape', async () => {
+      const wsResponse: MobiusSocketResponse = {
+        type: 'register.response',
+        statusCode: 201,
+        statusMessage: 'Created',
+        trackingId: 'track-123',
+        data: {deviceId: 'device-456', correlationId: 'corr-789'},
+        metadata: {'x-response-header': 'value'},
+      };
+      mockMobiusSocket.sendWssRequest.mockResolvedValue(wsResponse);
+      const apiRequest = APIRequest.getInstance({webex});
+
+      const result = await apiRequest.makeRequest({
+        uri: '/api/v1/calling/web/device',
+        method: HTTP_METHODS.POST,
+      });
+
+      expect(result).toEqual({
+        statusCode: 201,
+        body: {deviceId: 'device-456', correlationId: 'corr-789'},
+        headers: {
+          trackingid: 'track-123',
+          'x-response-header': 'value',
+        },
+      });
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('WSS request succeeded'), {
+        file: 'REQUEST',
+        method: 'makeRequest',
+      });
+    });
+
+    it('should normalize error to WebexRequestPayload shape', async () => {
+      const wsError = {
+        statusCode: 400,
+        statusMessage: 'Bad Request',
+        trackingId: 'error-track-456',
+        response: {
+          statusCode: 400,
+          trackingId: 'error-track-456',
+          data: {error: 'Invalid request'},
+          metadata: {'x-error-code': 'ERR001'},
+        },
+      };
+      mockMobiusSocket.sendWssRequest.mockRejectedValue(wsError);
+      const apiRequest = APIRequest.getInstance({webex});
+
+      await expect(
+        apiRequest.makeRequest({
+          uri: '/api/v1/calling/web/device',
+          method: HTTP_METHODS.POST,
+        })
+      ).rejects.toEqual({
+        statusCode: 400,
+        body: {error: 'Invalid request'},
+        headers: {
+          trackingid: 'error-track-456',
+          'x-error-code': 'ERR001',
+        },
+      });
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('WSS request failed'), {
+        file: 'REQUEST',
+        method: 'makeRequest',
+      });
+    });
+  });
+
+  describe('registerMobiusSocketListener', () => {
+    it('should attach listener to event:async_event', () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const callback = jest.fn();
+
+      apiRequest.registerMobiusSocketListener(callback);
+
+      expect(mockMobiusSocket.on).toHaveBeenCalledWith('event:async_event', expect.any(Function));
+      expect(infoSpy).toHaveBeenCalledWith('Attaching Mobius async event listener', {
+        file: 'REQUEST',
+        method: 'registerMobiusSocketListener',
+      });
+      expect(logSpy).toHaveBeenCalledWith('Mobius async event listener attached', {
+        file: 'REQUEST',
+        method: 'registerMobiusSocketListener',
+      });
+    });
+
+    it('should invoke callback with event data when async event received', () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const callback = jest.fn();
+      const mockEvent: MobiusAsyncEvent = {
+        type: 'event:async_event',
+        eventId: 'evt-123',
+        trackingId: 'track-456',
+        data: {
+          eventType: 'registration.down',
+        } as any,
+      };
+
+      apiRequest.registerMobiusSocketListener(callback);
+
+      const attachedCallback = mockMobiusSocket.on.mock.calls[0][1];
+      attachedCallback(mockEvent);
+
+      expect(callback).toHaveBeenCalledWith(mockEvent);
+    });
+
+    it('should submit LISTENER_REGISTERED metric', () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const callback = jest.fn();
+
+      apiRequest.registerMobiusSocketListener(callback);
+
+      expect(mockMetricManager.submitMobiusSocketMetric).toHaveBeenCalledWith(
+        METRIC_EVENT.MOBIUS_SOCKET,
+        MOBIUS_SOCKET_ACTION.LISTENER_REGISTERED,
+        METRIC_TYPE.BEHAVIORAL
+      );
+    });
+  });
+
+  describe('unregisterMobiusSocketListener', () => {
+    it('should detach listener from event:async_event', () => {
+      const apiRequest = APIRequest.getInstance({webex});
+
+      apiRequest.unregisterMobiusSocketListener();
+
+      expect(mockMobiusSocket.off).toHaveBeenCalledWith('event:async_event');
+      expect(infoSpy).toHaveBeenCalledWith('Detaching Mobius async event listener', {
+        file: 'REQUEST',
+        method: 'unregisterMobiusSocketListener',
+      });
+      expect(logSpy).toHaveBeenCalledWith('Mobius async event listener detached', {
+        file: 'REQUEST',
+        method: 'unregisterMobiusSocketListener',
+      });
+    });
+
+    it('should submit LISTENER_UNREGISTERED metric', () => {
+      const apiRequest = APIRequest.getInstance({webex});
+
+      apiRequest.unregisterMobiusSocketListener();
+
+      expect(mockMetricManager.submitMobiusSocketMetric).toHaveBeenCalledWith(
+        METRIC_EVENT.MOBIUS_SOCKET,
+        MOBIUS_SOCKET_ACTION.LISTENER_UNREGISTERED,
+        METRIC_TYPE.BEHAVIORAL
+      );
+    });
+  });
+});

--- a/packages/calling/src/CallingClient/utils/wsFeatureFlag.test.ts
+++ b/packages/calling/src/CallingClient/utils/wsFeatureFlag.test.ts
@@ -1,0 +1,175 @@
+import {getTestUtilsWebex} from '../../common/testUtil';
+import log from '../../Logger';
+import {isMobiusWssEnabled, WEBRTC_CALLING_OVER_WS_FEATURE_KEY} from './wsFeatureFlag';
+
+describe('wsFeatureFlag', () => {
+  let webex: ReturnType<typeof getTestUtilsWebex>;
+
+  beforeEach(() => {
+    webex = getTestUtilsWebex();
+    jest.clearAllMocks();
+  });
+
+  describe('WEBRTC_CALLING_OVER_WS_FEATURE_KEY', () => {
+    it('should export the correct feature key constant', () => {
+      expect(WEBRTC_CALLING_OVER_WS_FEATURE_KEY).toBe('webrtc-calling-over-ws-CALL-219562');
+    });
+  });
+
+  describe('isMobiusWssEnabled', () => {
+    let traceSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      traceSpy = jest.spyOn(log, 'trace');
+    });
+
+    it('should return true when feature flag is enabled with boolean true', () => {
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue({value: true});
+
+      const result = isMobiusWssEnabled(webex);
+
+      expect(result).toBe(true);
+      expect(webex.internal.device.features.developer.get).toHaveBeenCalledWith(
+        WEBRTC_CALLING_OVER_WS_FEATURE_KEY
+      );
+      expect(traceSpy).toHaveBeenCalledWith(
+        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: true`,
+        {
+          file: 'wsFeatureFlag',
+          method: 'isMobiusWssEnabled',
+        }
+      );
+    });
+
+    it('should return false when feature flag is disabled with boolean false', () => {
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue({value: false});
+
+      const result = isMobiusWssEnabled(webex);
+
+      expect(result).toBe(false);
+      expect(traceSpy).toHaveBeenCalledWith(
+        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: false`,
+        {
+          file: 'wsFeatureFlag',
+          method: 'isMobiusWssEnabled',
+        }
+      );
+    });
+
+    it('should return false when feature flag value is undefined', () => {
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue({value: undefined});
+
+      const result = isMobiusWssEnabled(webex);
+
+      expect(result).toBe(false);
+      expect(traceSpy).toHaveBeenCalledWith(
+        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: false`,
+        {
+          file: 'wsFeatureFlag',
+          method: 'isMobiusWssEnabled',
+        }
+      );
+    });
+
+    it('should return false when feature flag returns null', () => {
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue(null);
+
+      const result = isMobiusWssEnabled(webex);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when feature flag value is truthy but not boolean true (number)', () => {
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue({value: 1});
+
+      const result = isMobiusWssEnabled(webex);
+
+      expect(result).toBe(false);
+      expect(traceSpy).toHaveBeenCalledWith(
+        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: false`,
+        {
+          file: 'wsFeatureFlag',
+          method: 'isMobiusWssEnabled',
+        }
+      );
+    });
+
+    it('should return false when feature flag value is truthy but not boolean true (string)', () => {
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue({value: 'true'});
+
+      const result = isMobiusWssEnabled(webex);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when feature flag value is truthy but not boolean true (object)', () => {
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue({value: {}});
+
+      const result = isMobiusWssEnabled(webex);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when webex.internal.device.features is missing', () => {
+      const webexWithoutFeatures = {
+        ...webex,
+        internal: {
+          ...webex.internal,
+          device: {
+            ...webex.internal.device,
+            features: undefined,
+          },
+        },
+      };
+
+      const result = isMobiusWssEnabled(webexWithoutFeatures as any);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when webex.internal.device.features.developer is missing', () => {
+      const webexWithoutDeveloper = {
+        ...webex,
+        internal: {
+          ...webex.internal,
+          device: {
+            ...webex.internal.device,
+            features: {
+              entitlement: webex.internal.device.features.entitlement,
+              developer: undefined,
+            },
+          },
+        },
+      };
+
+      const result = isMobiusWssEnabled(webexWithoutDeveloper as any);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when webex.internal.device is missing', () => {
+      const webexWithoutDevice = {
+        ...webex,
+        internal: {
+          ...webex.internal,
+          device: undefined,
+        },
+      };
+
+      const result = isMobiusWssEnabled(webexWithoutDevice as any);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when webex.internal is missing', () => {
+      const webexWithoutInternal = {
+        ...webex,
+        internal: undefined,
+      };
+
+      const result = isMobiusWssEnabled(webexWithoutInternal as any);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/calling/src/Metrics/index.test.ts
+++ b/packages/calling/src/Metrics/index.test.ts
@@ -1,7 +1,15 @@
 /* eslint-disable dot-notation */
 import {getMockDeviceInfo, getTestUtilsWebex} from '../common/testUtil';
 import {getMetricManager} from './index';
-import {METRIC_TYPE, METRIC_EVENT, REG_ACTION, VOICEMAIL_ACTION, UPLOAD_LOGS_ACTION} from './types';
+import {
+  METRIC_TYPE,
+  METRIC_EVENT,
+  REG_ACTION,
+  VOICEMAIL_ACTION,
+  UPLOAD_LOGS_ACTION,
+  CONNECTION_ACTION,
+  MOBIUS_SOCKET_ACTION,
+} from './types';
 import {REGISTRATION_UTIL, VERSION} from '../CallingClient/constants';
 import {createClientError} from '../Errors/catalog/CallingDeviceError';
 import {CallErrorObject, ErrorObject, ERROR_LAYER, ERROR_TYPE} from '../Errors/types';
@@ -722,7 +730,7 @@ describe('CALLING: Metric tests', () => {
 
       metricManager.submitConnectionMetrics(
         METRIC_EVENT.CONNECTION_ERROR,
-        'network_flap' as any,
+        CONNECTION_ACTION.NETWORK_FLAP,
         METRIC_TYPE.BEHAVIORAL,
         downTimestamp,
         upTimestamp
@@ -753,7 +761,7 @@ describe('CALLING: Metric tests', () => {
 
       metricManager.submitConnectionMetrics(
         METRIC_EVENT.CONNECTION_ERROR,
-        'mercury_down' as any,
+        CONNECTION_ACTION.MERCURY_DOWN,
         METRIC_TYPE.OPERATIONAL,
         downTimestamp,
         upTimestamp
@@ -963,7 +971,7 @@ describe('CALLING: Metric tests', () => {
 
       metricManager.submitMobiusSocketMetric(
         METRIC_EVENT.MOBIUS_SOCKET,
-        'connect' as any,
+        MOBIUS_SOCKET_ACTION.CONNECT,
         METRIC_TYPE.BEHAVIORAL,
         wssUrl,
         trackingId
@@ -992,7 +1000,7 @@ describe('CALLING: Metric tests', () => {
 
       metricManager.submitMobiusSocketMetric(
         METRIC_EVENT.MOBIUS_SOCKET,
-        'disconnect' as any,
+        MOBIUS_SOCKET_ACTION.DISCONNECT,
         METRIC_TYPE.BEHAVIORAL
       );
 
@@ -1019,7 +1027,7 @@ describe('CALLING: Metric tests', () => {
 
       metricManager.submitMobiusSocketMetric(
         METRIC_EVENT.MOBIUS_SOCKET,
-        'listener_registered' as any,
+        MOBIUS_SOCKET_ACTION.LISTENER_REGISTERED,
         METRIC_TYPE.BEHAVIORAL
       );
 
@@ -1046,7 +1054,7 @@ describe('CALLING: Metric tests', () => {
 
       metricManager.submitMobiusSocketMetric(
         METRIC_EVENT.MOBIUS_SOCKET,
-        'listener_unregistered' as any,
+        MOBIUS_SOCKET_ACTION.LISTENER_UNREGISTERED,
         METRIC_TYPE.BEHAVIORAL
       );
 
@@ -1078,7 +1086,7 @@ describe('CALLING: Metric tests', () => {
 
       metricManager.submitMobiusSocketMetric(
         METRIC_EVENT.MOBIUS_SOCKET_ERROR,
-        'connect' as any,
+        MOBIUS_SOCKET_ACTION.CONNECT,
         METRIC_TYPE.BEHAVIORAL,
         wssUrl,
         trackingId,
@@ -1115,7 +1123,7 @@ describe('CALLING: Metric tests', () => {
 
       metricManager.submitMobiusSocketMetric(
         METRIC_EVENT.MOBIUS_SOCKET_ERROR,
-        'registration_down' as any,
+        MOBIUS_SOCKET_ACTION.REGISTRATION_DOWN,
         METRIC_TYPE.BEHAVIORAL,
         undefined,
         trackingId,
@@ -1134,7 +1142,7 @@ describe('CALLING: Metric tests', () => {
 
       metricManager.submitMobiusSocketMetric(
         'invalidMetricName' as unknown as METRIC_EVENT,
-        'connect' as any,
+        MOBIUS_SOCKET_ACTION.CONNECT,
         METRIC_TYPE.BEHAVIORAL
       );
 

--- a/packages/calling/src/Metrics/index.test.ts
+++ b/packages/calling/src/Metrics/index.test.ts
@@ -584,6 +584,75 @@ describe('CALLING: Metric tests', () => {
       expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.VOICEMAIL_ERROR, expectedData2);
     });
 
+    it('submit voicemail metric with undefined process object', () => {
+      // Save original process
+      const originalProcess = global.process;
+
+      // Mock process as undefined (browser environment)
+      (global as any).process = undefined;
+
+      const expectedData = {
+        tags: {
+          action: VOICEMAIL_ACTION.GET_VOICEMAILS,
+          device_id: mockDeviceInfo.device.deviceId,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          calling_sdk_version: VERSION,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitVoicemailMetric(
+        METRIC_EVENT.VOICEMAIL,
+        VOICEMAIL_ACTION.GET_VOICEMAILS,
+        METRIC_TYPE.BEHAVIORAL
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.VOICEMAIL, expectedData);
+
+      // Restore process
+      global.process = originalProcess;
+    });
+
+    it('submit voicemail error metric with undefined process object', () => {
+      // Save original process
+      const originalProcess = global.process;
+
+      // Mock process as undefined (browser environment)
+      (global as any).process = undefined;
+
+      const errorMessage = 'Network error';
+      const expectedData = {
+        tags: {
+          action: VOICEMAIL_ACTION.MARK_READ,
+          device_id: mockDeviceInfo.device.deviceId,
+          message_id: 'msg-123',
+          error: errorMessage,
+          status_code: 500,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          calling_sdk_version: VERSION,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitVoicemailMetric(
+        METRIC_EVENT.VOICEMAIL_ERROR,
+        VOICEMAIL_ACTION.MARK_READ,
+        METRIC_TYPE.BEHAVIORAL,
+        'msg-123',
+        errorMessage,
+        500
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.VOICEMAIL_ERROR, expectedData);
+
+      // Restore process
+      global.process = originalProcess;
+    });
+
     it('submit unknown voicemail metric', () => {
       const logSpy = jest.spyOn(log, 'warn');
 
@@ -631,6 +700,458 @@ describe('CALLING: Metric tests', () => {
       );
 
       expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.BNR_ENABLED, expectedData);
+    });
+  });
+
+  describe('Connection metric tests', () => {
+    beforeAll(() => metricManager.setDeviceInfo(mockDeviceInfo));
+
+    it('submit connection metric for network flap', () => {
+      const downTimestamp = '2026-05-04T10:00:00.000Z';
+      const upTimestamp = '2026-05-04T10:05:00.000Z';
+
+      const expectedData = {
+        tags: {
+          metricAction: 'network_flap',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          downTimestamp,
+          upTimestamp,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitConnectionMetrics(
+        METRIC_EVENT.CONNECTION_ERROR,
+        'network_flap' as any,
+        METRIC_TYPE.BEHAVIORAL,
+        downTimestamp,
+        upTimestamp
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.CONNECTION_ERROR, expectedData);
+    });
+
+    it('submit connection metric for mercury down', () => {
+      const downTimestamp = '2026-05-04T10:10:00.000Z';
+      const upTimestamp = '2026-05-04T10:15:00.000Z';
+
+      const expectedData = {
+        tags: {
+          metricAction: 'mercury_down',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          downTimestamp,
+          upTimestamp,
+        },
+        type: METRIC_TYPE.OPERATIONAL,
+      };
+
+      metricManager.submitConnectionMetrics(
+        METRIC_EVENT.CONNECTION_ERROR,
+        'mercury_down' as any,
+        METRIC_TYPE.OPERATIONAL,
+        downTimestamp,
+        upTimestamp
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.CONNECTION_ERROR, expectedData);
+    });
+  });
+
+  describe('Region Info metric tests', () => {
+    beforeAll(() => metricManager.setDeviceInfo(mockDeviceInfo));
+
+    it('submit region info metric with all parameters', () => {
+      const trackingId = 'track-region-123';
+      const mobiusHost = 'mobius-us-east.webex.com';
+      const clientRegion = 'US-EAST';
+      const countryCode = 'US';
+
+      const expectedData = {
+        tags: {
+          action: 'region-info',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          mobius_host: mobiusHost,
+          client_region: clientRegion,
+          country_code: countryCode,
+          tracking_id: trackingId,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitRegionInfoMetric(
+        METRIC_EVENT.MOBIUS_DISCOVERY,
+        'region-info',
+        METRIC_TYPE.BEHAVIORAL,
+        mobiusHost,
+        clientRegion,
+        countryCode,
+        trackingId
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.MOBIUS_DISCOVERY, expectedData);
+    });
+
+    it('submit region info metric without tracking ID', () => {
+      const mobiusHost = 'mobius-eu-west.webex.com';
+      const clientRegion = 'EU-WEST';
+      const countryCode = 'GB';
+
+      const expectedData = {
+        tags: {
+          action: 'region-info',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          mobius_host: mobiusHost,
+          client_region: clientRegion,
+          country_code: countryCode,
+          tracking_id: undefined,
+        },
+        type: METRIC_TYPE.OPERATIONAL,
+      };
+
+      metricManager.submitRegionInfoMetric(
+        METRIC_EVENT.MOBIUS_DISCOVERY,
+        'region-info',
+        METRIC_TYPE.OPERATIONAL,
+        mobiusHost,
+        clientRegion,
+        countryCode,
+        undefined
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.MOBIUS_DISCOVERY, expectedData);
+    });
+  });
+
+  describe('Mobius Servers metric tests', () => {
+    beforeAll(() => metricManager.setDeviceInfo(mockDeviceInfo));
+
+    it('submit mobius servers metric with primary and backup servers', () => {
+      const trackingId = 'track-servers-456';
+      const mobiusServers = {
+        primary: {
+          region: 'US-EAST',
+          uris: [
+            'wss://mobius-us-east-1.webex.com/api/v1',
+            'wss://mobius-us-east-2.webex.com/api/v1',
+          ],
+        },
+        backup: {
+          region: 'US-WEST',
+          uris: ['wss://mobius-us-west-1.webex.com/api/v1'],
+        },
+      };
+
+      const expectedData = {
+        tags: {
+          action: 'mobius-servers',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          primary_mobius_servers_region: 'US-EAST',
+          primary_mobius_servers_uris:
+            'wss://mobius-us-east-1.webex.com/api/v1,wss://mobius-us-east-2.webex.com/api/v1',
+          backup_mobius_servers_region: 'US-WEST',
+          backup_mobius_servers_uris: 'wss://mobius-us-west-1.webex.com/api/v1',
+          tracking_id: trackingId,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitMobiusServersMetric(
+        METRIC_EVENT.MOBIUS_DISCOVERY,
+        'mobius-servers',
+        METRIC_TYPE.BEHAVIORAL,
+        mobiusServers,
+        trackingId
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.MOBIUS_DISCOVERY, expectedData);
+    });
+
+    it('submit mobius servers metric without tracking ID', () => {
+      const mobiusServers = {
+        primary: {
+          region: 'EU-CENTRAL',
+          uris: ['wss://mobius-eu-central.webex.com/api/v1'],
+        },
+        backup: {
+          region: 'EU-WEST',
+          uris: [
+            'wss://mobius-eu-west.webex.com/api/v1',
+            'wss://mobius-eu-west-2.webex.com/api/v1',
+          ],
+        },
+      };
+
+      const expectedData = {
+        tags: {
+          action: 'mobius-servers',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          primary_mobius_servers_region: 'EU-CENTRAL',
+          primary_mobius_servers_uris: 'wss://mobius-eu-central.webex.com/api/v1',
+          backup_mobius_servers_region: 'EU-WEST',
+          backup_mobius_servers_uris:
+            'wss://mobius-eu-west.webex.com/api/v1,wss://mobius-eu-west-2.webex.com/api/v1',
+          tracking_id: undefined,
+        },
+        type: METRIC_TYPE.OPERATIONAL,
+      };
+
+      metricManager.submitMobiusServersMetric(
+        METRIC_EVENT.MOBIUS_DISCOVERY,
+        'mobius-servers',
+        METRIC_TYPE.OPERATIONAL,
+        mobiusServers,
+        undefined
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.MOBIUS_DISCOVERY, expectedData);
+    });
+  });
+
+  describe('Mobius Socket metric tests', () => {
+    beforeAll(() => metricManager.setDeviceInfo(mockDeviceInfo));
+
+    it('submit mobius socket connect success metric', () => {
+      const wssUrl = 'wss://mobius.webex.com/api/v1';
+      const trackingId = 'track-socket-123';
+
+      const expectedData = {
+        tags: {
+          action: 'connect',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          wss_url: wssUrl,
+          tracking_id: trackingId,
+          event_type: undefined,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitMobiusSocketMetric(
+        METRIC_EVENT.MOBIUS_SOCKET,
+        'connect' as any,
+        METRIC_TYPE.BEHAVIORAL,
+        wssUrl,
+        trackingId
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.MOBIUS_SOCKET, expectedData);
+    });
+
+    it('submit mobius socket disconnect success metric', () => {
+      const expectedData = {
+        tags: {
+          action: 'disconnect',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          wss_url: undefined,
+          tracking_id: undefined,
+          event_type: undefined,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitMobiusSocketMetric(
+        METRIC_EVENT.MOBIUS_SOCKET,
+        'disconnect' as any,
+        METRIC_TYPE.BEHAVIORAL
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.MOBIUS_SOCKET, expectedData);
+    });
+
+    it('submit mobius socket listener registered metric', () => {
+      const expectedData = {
+        tags: {
+          action: 'listener_registered',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          wss_url: undefined,
+          tracking_id: undefined,
+          event_type: undefined,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitMobiusSocketMetric(
+        METRIC_EVENT.MOBIUS_SOCKET,
+        'listener_registered' as any,
+        METRIC_TYPE.BEHAVIORAL
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.MOBIUS_SOCKET, expectedData);
+    });
+
+    it('submit mobius socket listener unregistered metric', () => {
+      const expectedData = {
+        tags: {
+          action: 'listener_unregistered',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          wss_url: undefined,
+          tracking_id: undefined,
+          event_type: undefined,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitMobiusSocketMetric(
+        METRIC_EVENT.MOBIUS_SOCKET,
+        'listener_unregistered' as any,
+        METRIC_TYPE.BEHAVIORAL
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.MOBIUS_SOCKET, expectedData);
+    });
+
+    it('submit mobius socket error metric with connection failure', () => {
+      const wssUrl = 'wss://mobius.webex.com/api/v1';
+      const trackingId = 'track-error-456';
+      const error = 'WebSocket connection failed: timeout';
+
+      const expectedData = {
+        tags: {
+          action: 'connect',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          wss_url: wssUrl,
+          tracking_id: trackingId,
+          event_type: undefined,
+          error,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitMobiusSocketMetric(
+        METRIC_EVENT.MOBIUS_SOCKET_ERROR,
+        'connect' as any,
+        METRIC_TYPE.BEHAVIORAL,
+        wssUrl,
+        trackingId,
+        error
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(
+        METRIC_EVENT.MOBIUS_SOCKET_ERROR,
+        expectedData
+      );
+    });
+
+    it('submit mobius socket error metric with registration down event', () => {
+      const trackingId = 'track-regdown-789';
+      const eventType = 'registration.down';
+
+      const expectedData = {
+        tags: {
+          action: 'registration_down',
+          device_id: mockDeviceInfo.device.deviceId,
+          service_indicator: ServiceIndicator.CALLING,
+        },
+        fields: {
+          device_url: mockDeviceInfo.device.clientDeviceUri,
+          mobius_url: mockDeviceInfo.device.uri,
+          calling_sdk_version: MOCK_VERSION_NUMBER,
+          wss_url: undefined,
+          tracking_id: trackingId,
+          event_type: eventType,
+          error: undefined,
+        },
+        type: METRIC_TYPE.BEHAVIORAL,
+      };
+
+      metricManager.submitMobiusSocketMetric(
+        METRIC_EVENT.MOBIUS_SOCKET_ERROR,
+        'registration_down' as any,
+        METRIC_TYPE.BEHAVIORAL,
+        undefined,
+        trackingId,
+        undefined,
+        eventType
+      );
+
+      expect(submitClientMetricSpy).toBeCalledOnceWith(
+        METRIC_EVENT.MOBIUS_SOCKET_ERROR,
+        expectedData
+      );
+    });
+
+    it('submit unknown mobius socket metric', () => {
+      const logSpy = jest.spyOn(log, 'warn');
+
+      metricManager.submitMobiusSocketMetric(
+        'invalidMetricName' as unknown as METRIC_EVENT,
+        'connect' as any,
+        METRIC_TYPE.BEHAVIORAL
+      );
+
+      expect(submitClientMetricSpy).not.toBeCalled();
+      expect(logSpy).toBeCalledOnceWith(
+        'Invalid metric name received. Rejecting request to submit metric.',
+        {
+          file: 'metric',
+          method: 'submitMobiusSocketMetric',
+        }
+      );
     });
   });
 

--- a/packages/calling/src/Metrics/index.test.ts
+++ b/packages/calling/src/Metrics/index.test.ts
@@ -499,7 +499,13 @@ describe('CALLING: Metric tests', () => {
   });
 
   describe('Voicemail metric tests', () => {
+    const originalProcess: NodeJS.Process = global.process;
+
     beforeAll(() => metricManager.setDeviceInfo(mockDeviceInfo));
+
+    afterEach(() => {
+      global.process = originalProcess;
+    });
 
     it('submit voicemail success metric', () => {
       const expectedData1 = {
@@ -585,9 +591,6 @@ describe('CALLING: Metric tests', () => {
     });
 
     it('submit voicemail metric with undefined process object', () => {
-      // Save original process
-      const originalProcess = global.process;
-
       // Mock process as undefined (browser environment)
       (global as any).process = undefined;
 
@@ -610,15 +613,9 @@ describe('CALLING: Metric tests', () => {
       );
 
       expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.VOICEMAIL, expectedData);
-
-      // Restore process
-      global.process = originalProcess;
     });
 
     it('submit voicemail error metric with undefined process object', () => {
-      // Save original process
-      const originalProcess = global.process;
-
       // Mock process as undefined (browser environment)
       (global as any).process = undefined;
 
@@ -648,9 +645,6 @@ describe('CALLING: Metric tests', () => {
       );
 
       expect(submitClientMetricSpy).toBeCalledOnceWith(METRIC_EVENT.VOICEMAIL_ERROR, expectedData);
-
-      // Restore process
-      global.process = originalProcess;
     });
 
     it('submit unknown voicemail metric', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [CAI-7871](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7871) >

## This pull request addresses

Add/Update the unit tests related to mobius socket under `CallingClient` and `Metrics`.

## by making the following changes

### New test files for utils

  1. wsFeatureFlag.test.ts - 12 tests
    - Feature flag resolution with strict boolean checking
    - Edge cases for missing properties and truthy values
    - 100% coverage (all statements, branches, functions, lines)
  2. mobiusSocketMapper.test.ts - 31 tests
    - URI pattern matching for all Mobius socket message types
    - Supplementary services, call operations, device operations
    - Edge cases and unknown patterns with logging verification
    - 100% coverage (all statements, branches, functions, lines)
  3. request.test.ts - 34 tests
    - Singleton pattern and instance management
    - Socket connection/disconnection with metrics
    - HTTP vs WebSocket transport routing
    - Request normalization and error handling
    - Listener registration/unregistration
    - 100% lines, 100% functions, 93.33% branches

 ### Metrics Module: New test suites added:

  4. Connection metric tests (2 tests)
    - Network flap and mercury down/up events
    - Tests submitConnectionMetrics method
  5. Region Info metric tests (2 tests)
    - Region discovery metrics with/without tracking ID
    - Tests submitRegionInfoMetric method
  6. Mobius Servers metric tests (2 tests)
    - Primary and backup server discovery
    - Tests submitMobiusServersMetric method
  7. Mobius Socket metric tests (7 tests)
    - Connect, disconnect, listener registration/unregistration
    - Error metrics with connection failures and registration down events
    - Invalid metric name handling
    - Tests submitMobiusSocketMetric method (NEW for WebSocket functionality)
  8. Enhanced Voicemail tests (2 additional tests)
    - Browser environment (undefined process object)
    - Coverage for environment fallback logic


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
