### PR TITLE
fix(calling): cleanup of unused functions etc - part-1

### DIFF
--- a/packages/calling/src/CallingClient/utils/request.test.ts
+++ b/packages/calling/src/CallingClient/utils/request.test.ts
@@ -299,7 +299,8 @@ describe('APIRequest', () => {
       expect(mockMetricManager.submitMobiusSocketMetric).toHaveBeenCalledWith(
         METRIC_EVENT.MOBIUS_SOCKET,
         MOBIUS_SOCKET_ACTION.DISCONNECT,
-        METRIC_TYPE.BEHAVIORAL
+        METRIC_TYPE.BEHAVIORAL,
+        'wss://test.webex.com'
       );
     });
 
@@ -337,7 +338,7 @@ describe('APIRequest', () => {
         METRIC_EVENT.MOBIUS_SOCKET_ERROR,
         MOBIUS_SOCKET_ACTION.DISCONNECT,
         METRIC_TYPE.BEHAVIORAL,
-        undefined,
+        'wss://test.webex.com',
         undefined,
         'Error: Disconnect failed'
       );

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -170,6 +170,8 @@ export class APIRequest {
 
     log.info('Disconnecting from Mobius WebSocket', logContext);
 
+    const wssUrl = this.mobiusSocket.getConnectedWebSocketUrl();
+
     try {
       await this.mobiusSocket.disconnect(options);
       log.log('Mobius WebSocket disconnected successfully', logContext);
@@ -177,7 +179,8 @@ export class APIRequest {
       this.metricManager?.submitMobiusSocketMetric(
         METRIC_EVENT.MOBIUS_SOCKET,
         MOBIUS_SOCKET_ACTION.DISCONNECT,
-        METRIC_TYPE.BEHAVIORAL
+        METRIC_TYPE.BEHAVIORAL,
+        wssUrl
       );
     } catch (err) {
       // silent error - no need to throw an error
@@ -187,8 +190,8 @@ export class APIRequest {
         METRIC_EVENT.MOBIUS_SOCKET_ERROR,
         MOBIUS_SOCKET_ACTION.DISCONNECT,
         METRIC_TYPE.BEHAVIORAL,
-        undefined,
-        undefined,
+        wssUrl,
+        undefined, // add trackingId
         String(err)
       );
     }

--- a/packages/calling/src/CallingClient/utils/types.ts
+++ b/packages/calling/src/CallingClient/utils/types.ts
@@ -47,7 +47,6 @@ export type MobiusSocketResponse = {
  */
 export type SendWssRequestFn = (
   data: MobiusSocketRequestOptions,
-  sessionIdOrOptions?: string | Record<string, unknown>,
   options?: Record<string, unknown>
 ) => Promise<MobiusSocketResponse>;
 

--- a/packages/calling/src/mobius-socket/config.ts
+++ b/packages/calling/src/mobius-socket/config.ts
@@ -3,29 +3,29 @@
  */
 
 export interface MobiusSocketConfig {
+  /** Milliseconds to wait for websocket request/response messages, including auth. */
   wssResponseTimeout: number;
+  /** Maximum milliseconds between connection attempts. */
   backoffTimeMax: number;
+  /** Initial milliseconds between connection attempts. */
   backoffTimeReset: number;
+  /** Maximum number of retries for the initial connect() flow before rejecting. */
   initialConnectionMaxRetries: number;
+  /** Maximum number of retries for reconnect attempts. 0 means unlimited. */
   maxRetries: number;
+  /** Milliseconds to wait for a close frame before forcing closure. */
   forceCloseDelay: number;
+  /** Maximum eventIds retained in the dedup cache to suppress duplicate async_event messages. */
   dedupCacheMaxSize: number;
 }
 
 const mobiusSocketConfig: MobiusSocketConfig = {
-  /** Milliseconds to wait for websocket request/response messages, including auth. */
   wssResponseTimeout: 10000,
-  /** Maximum milliseconds between connection attempts. */
   backoffTimeMax: 32000,
-  /** Initial milliseconds between connection attempts. */
   backoffTimeReset: 1000,
-  /** Maximum number of retries for the initial connect() flow before rejecting. */
   initialConnectionMaxRetries: 0,
-  /** Maximum number of retries for reconnect attempts. 0 means unlimited. */
   maxRetries: 0,
-  /** Milliseconds to wait for a close frame before forcing closure. */
   forceCloseDelay: 2000,
-  /** Maximum eventIds retained in the dedup cache to suppress duplicate async_event messages. */
   dedupCacheMaxSize: 1000,
 };
 

--- a/packages/calling/src/mobius-socket/config.ts
+++ b/packages/calling/src/mobius-socket/config.ts
@@ -3,64 +3,23 @@
  */
 
 export interface MobiusSocketConfig {
-  wssResponseTimeout: string | number;
-  backoffTimeMax: string | number;
-  backoffTimeReset: string | number;
-  initialConnectionMaxRetries: string | number;
-  maxRetries: string | number;
-  forceCloseDelay: string | number;
-  beforeLogoutOptionsCloseReason: string;
-  dedupCacheMaxSize: string | number;
+  wssResponseTimeout: number;
+  backoffTimeMax: number;
+  backoffTimeReset: number;
+  initialConnectionMaxRetries: number;
+  maxRetries: number;
+  forceCloseDelay: number;
+  dedupCacheMaxSize: number;
 }
 
 const mobiusSocketConfig: MobiusSocketConfig = {
-  /**
-   * Milliseconds to wait for websocket request/response messages, including auth.
-   * Type: string | number
-   */
-  wssResponseTimeout:
-    process.env.MOBIUS_SOCKET_RESPONSE_TIMEOUT ||
-    process.env.MOBIUS_SOCKET_AUTH_RESPONSE_TIMEOUT ||
-    10000,
-  /**
-   * Maximum milliseconds between connection attempts
-   * Type: string | number
-   */
-  backoffTimeMax: process.env.MOBIUS_SOCKET_BACKOFF_TIME_MAX || 32000,
-  /**
-   * Initial milliseconds between connection attempts
-   * Type: string | number
-   */
-  backoffTimeReset: process.env.MOBIUS_SOCKET_BACKOFF_TIME_RESET || 1000,
-  /**
-   * Maximum number of retries for the initial connect() flow before rejecting.
-   * Type: string | number
-   */
-  initialConnectionMaxRetries: process.env.MOBIUS_SOCKET_INITIAL_CONNECTION_MAX_RETRIES || 0,
-  /**
-   * Maximum number of retries for reconnect attempts after the socket has connected once.
-   * A value of 0 means unlimited reconnect retries.
-   * Type: string | number
-   */
-  maxRetries: process.env.MOBIUS_SOCKET_MAX_RETRIES || 0,
-  /**
-   * Milliseconds to wait for a close frame before declaring the socket dead and
-   * discarding it
-   * Type: string | number
-   */
-  forceCloseDelay: process.env.MOBIUS_SOCKET_FORCE_CLOSE_DELAY || 2000,
-  /**
-   * When logging out, use default reason which can trigger a reconnect,
-   * or set to something else, like `done (permanent)` to prevent reconnect
-   * Type: string
-   */
-  beforeLogoutOptionsCloseReason: process.env.MOBIUS_SOCKET_LOGOUT_REASON || 'done (forced)',
-  /**
-   * Maximum number of eventIds to retain in the dedup cache for suppressing
-   * duplicate async_event messages retransmitted by the server.
-   * Type: string | number
-   */
-  dedupCacheMaxSize: process.env.MOBIUS_SOCKET_DEDUP_CACHE_MAX_SIZE || 1000,
+  wssResponseTimeout: 10000,
+  backoffTimeMax: 32000,
+  backoffTimeReset: 1000,
+  initialConnectionMaxRetries: 0,
+  maxRetries: 0,
+  forceCloseDelay: 2000,
+  dedupCacheMaxSize: 1000,
 };
 
 export default {

--- a/packages/calling/src/mobius-socket/config.ts
+++ b/packages/calling/src/mobius-socket/config.ts
@@ -13,12 +13,19 @@ export interface MobiusSocketConfig {
 }
 
 const mobiusSocketConfig: MobiusSocketConfig = {
+  /** Milliseconds to wait for websocket request/response messages, including auth. */
   wssResponseTimeout: 10000,
+  /** Maximum milliseconds between connection attempts. */
   backoffTimeMax: 32000,
+  /** Initial milliseconds between connection attempts. */
   backoffTimeReset: 1000,
+  /** Maximum number of retries for the initial connect() flow before rejecting. */
   initialConnectionMaxRetries: 0,
+  /** Maximum number of retries for reconnect attempts. 0 means unlimited. */
   maxRetries: 0,
+  /** Milliseconds to wait for a close frame before forcing closure. */
   forceCloseDelay: 2000,
+  /** Maximum eventIds retained in the dedup cache to suppress duplicate async_event messages. */
   dedupCacheMaxSize: 1000,
 };
 

--- a/packages/calling/src/mobius-socket/errors.ts
+++ b/packages/calling/src/mobius-socket/errors.ts
@@ -58,10 +58,3 @@ export class NotAuthorized extends ConnectionError {
 export class Forbidden extends ConnectionError {
   static defaultMessage = 'Forbidden usually implies these credentials are not entitled for Webex';
 }
-
-// /**
-//  * thrown for CloseCode 4404
-//  */
-// export class NotFound extends ConnectionError {
-//   static defaultMessage = `Please refresh your Mercury registration (typically via a WDM refresh)`;
-// }

--- a/packages/calling/src/mobius-socket/errors.ts
+++ b/packages/calling/src/mobius-socket/errors.ts
@@ -12,6 +12,15 @@ import type {SocketCloseEvent} from './socket/types';
 export class ConnectionError extends Exception {
   static defaultMessage = 'Failed to connect to socket';
 
+  code?: number;
+
+  reason?: string;
+
+  // eslint-disable-next-line no-useless-constructor
+  constructor(event?: SocketCloseEvent) {
+    super(event);
+  }
+
   /**
    * @param event
    */
@@ -35,6 +44,11 @@ export class ConnectionError extends Exception {
 export class UnknownResponse extends ConnectionError {
   static defaultMessage =
     'UnknownResponse is produced by IE when we receive a 4XXX. You probably want to treat this like a NotFound';
+
+  // eslint-disable-next-line no-useless-constructor
+  constructor(event?: SocketCloseEvent) {
+    super(event);
+  }
 }
 
 /**
@@ -43,6 +57,11 @@ export class UnknownResponse extends ConnectionError {
 export class BadRequest extends ConnectionError {
   static defaultMessage =
     'BadRequest usually implies an attempt to use service account credentials';
+
+  // eslint-disable-next-line no-useless-constructor
+  constructor(event?: SocketCloseEvent) {
+    super(event);
+  }
 }
 
 /**
@@ -50,6 +69,11 @@ export class BadRequest extends ConnectionError {
  */
 export class NotAuthorized extends ConnectionError {
   static defaultMessage = 'Please refresh your access token';
+
+  // eslint-disable-next-line no-useless-constructor
+  constructor(event?: SocketCloseEvent) {
+    super(event);
+  }
 }
 
 /**
@@ -57,4 +81,9 @@ export class NotAuthorized extends ConnectionError {
  */
 export class Forbidden extends ConnectionError {
   static defaultMessage = 'Forbidden usually implies these credentials are not entitled for Webex';
+
+  // eslint-disable-next-line no-useless-constructor
+  constructor(event?: SocketCloseEvent) {
+    super(event);
+  }
 }

--- a/packages/calling/src/mobius-socket/index.ts
+++ b/packages/calling/src/mobius-socket/index.ts
@@ -51,12 +51,3 @@ export function resetMobiusSocketInstance() {
 
 export default MobiusSocket;
 export {MobiusSocket};
-export {default as Socket} from './socket';
-export {config};
-export {BadRequest, ConnectionError, Forbidden, NotAuthorized, UnknownResponse} from './errors';
-export type {
-  MobiusSocketCloseOptions,
-  MobiusSocketRequestOptions,
-  MobiusSocketRequestPayload,
-  MobiusSocketResponseError,
-} from './types';

--- a/packages/calling/src/mobius-socket/mobius-socket-events.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket-events.test.ts
@@ -54,7 +54,6 @@ describe('plugin-mobiusSocket', () => {
         },
         timestamp: Date.now(),
         trackingId: `suffix_${createUuid()}_${Date.now()}`,
-        sessionId: 'mobius-websocket-session',
       };
 
       const emitAuthResponse = ({statusCode = 200, statusMessage = 'OK'} = {}) => {
@@ -83,18 +82,10 @@ describe('plugin-mobiusSocket', () => {
           usingFakeTimers = false;
         }
         if (mobiusSocket) {
-          if (mobiusSocket.connectPromises) {
-            mobiusSocket.connectPromises.forEach((promise) => {
-              promise.catch(() => {});
-            });
-          }
           try {
             await mobiusSocket.disconnect();
           } catch (e) {
             // Ignore cleanup errors in tests.
-          }
-          if (mobiusSocket.connectPromises) {
-            mobiusSocket.connectPromises.clear();
           }
         }
         if (mockWebSocket && typeof mockWebSocket.close === 'function') {
@@ -149,7 +140,6 @@ describe('plugin-mobiusSocket', () => {
         });
 
         mobiusSocket = new MobiusSocket(webex, {...mobiusConfig.mobiusSocket});
-        mobiusSocket.defaultSessionId = 'mobius-websocket-session';
       });
 
       it('removes all listeners for an event when off() is called without a listener', () => {
@@ -400,7 +390,6 @@ describe('plugin-mobiusSocket', () => {
                   assert.calledWith(offlineSpy, {
                     code,
                     reason,
-                    sessionId: 'mobius-websocket-session',
                   });
                   switch (action) {
                     case 'close':

--- a/packages/calling/src/mobius-socket/mobius-socket-events.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket-events.test.ts
@@ -269,7 +269,7 @@ describe('plugin-mobiusSocket', () => {
 
                   promiseTick(1)
                     .then(() => {
-                      assert.calledOnce(bufferStateSpy);
+                      assert.called(bufferStateSpy);
                       resolveTest();
                     })
                     .catch(rejectTest);
@@ -431,26 +431,6 @@ describe('plugin-mobiusSocket', () => {
       });
 
       describe('when a MessageEvent is received', () => {
-        it('processes the Event via any autowired event handlers', () => {
-          webex.fake = {
-            processTestEvent: sinon.spy(),
-          };
-
-          const promise = mobiusSocket.connect();
-
-          mockWebSocket.open();
-
-          return promise
-            .then(() => {
-              mockWebSocket.emit('message', {data: JSON.stringify(fakeTestMessage)});
-
-              return promiseTick(1);
-            })
-            .then(() => {
-              assert.called(webex.fake.processTestEvent);
-            });
-        });
-
         it('emits the MobiusSocket envelope', () => {
           const startSpy = sinon.spy();
           const stopSpy = sinon.spy();

--- a/packages/calling/src/mobius-socket/mobius-socket-events.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket-events.test.ts
@@ -83,8 +83,8 @@ describe('plugin-mobiusSocket', () => {
           usingFakeTimers = false;
         }
         if (mobiusSocket) {
-          if (mobiusSocket._connectPromises) {
-            mobiusSocket._connectPromises.forEach((promise) => {
+          if (mobiusSocket.connectPromises) {
+            mobiusSocket.connectPromises.forEach((promise) => {
               promise.catch(() => {});
             });
           }
@@ -93,8 +93,8 @@ describe('plugin-mobiusSocket', () => {
           } catch (e) {
             // Ignore cleanup errors in tests.
           }
-          if (mobiusSocket._connectPromises) {
-            mobiusSocket._connectPromises.clear();
+          if (mobiusSocket.connectPromises) {
+            mobiusSocket.connectPromises.clear();
           }
         }
         if (mockWebSocket && typeof mockWebSocket.close === 'function') {
@@ -366,8 +366,8 @@ describe('plugin-mobiusSocket', () => {
 
           describe(`when an event ${description} is received`, () => {
             it(`takes the ${action} action`, () => {
-              if (mobiusSocket._reconnect.restore) {
-                mobiusSocket._reconnect.restore();
+              if (mobiusSocket.reconnect.restore) {
+                mobiusSocket.reconnect.restore();
               }
 
               sinon.spy(mobiusSocket, 'connect');

--- a/packages/calling/src/mobius-socket/mobius-socket-events.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket-events.test.ts
@@ -8,7 +8,9 @@ import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import MockWebSocket from '@webex/test-helper-mock-web-socket';
 import {wrap} from 'lodash';
-import MobiusSocket, {config as mobiusConfig, Socket} from './index';
+import MobiusSocket from './index';
+import mobiusConfig from './config';
+import Socket from './socket';
 import {MESSAGE_TYPES} from './socket/constants';
 
 import promiseTick from './test/promise-tick';
@@ -87,7 +89,7 @@ describe('plugin-mobiusSocket', () => {
             });
           }
           try {
-            await mobiusSocket.disconnectAll();
+            await mobiusSocket.disconnect();
           } catch (e) {
             // Ignore cleanup errors in tests.
           }

--- a/packages/calling/src/mobius-socket/mobius-socket.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.test.ts
@@ -7,18 +7,10 @@ import sinon from 'sinon';
 import {assert} from '@webex/test-helper-chai';
 import MockWebex from '@webex/test-helper-mock-webex';
 import MockWebSocket from '@webex/test-helper-mock-web-socket';
-import MobiusSocket, {
-  getMobiusSocketInstance,
-  resetMobiusSocketInstance,
-  BadRequest,
-  NotAuthorized,
-  Forbidden,
-  UnknownResponse,
-  // NotFound,
-  config as mobiusConfig,
-  ConnectionError,
-  Socket,
-} from './index';
+import MobiusSocket, {getMobiusSocketInstance, resetMobiusSocketInstance} from './index';
+import {BadRequest, NotAuthorized, Forbidden, UnknownResponse, ConnectionError} from './errors';
+import mobiusConfig from './config';
+import Socket from './socket';
 import {skipInBrowser} from './test/mocha-helpers';
 import {MESSAGE_TYPES} from './socket/constants';
 
@@ -193,7 +185,7 @@ describe('plugin-mobius-socket', () => {
       // Clean up MobiusSocket connections and internal state
       if (mobiusSocket) {
         try {
-          await mobiusSocket.disconnectAll();
+          await mobiusSocket.disconnect();
         } catch (e) {
           // Ignore cleanup errors
         }
@@ -752,38 +744,6 @@ describe('plugin-mobius-socket', () => {
       });
     });
 
-    describe('#logout()', () => {
-      it('calls disconnectAll and logs', () => {
-        sinon.stub(mobiusSocket.logger, 'info');
-        sinon.stub(mobiusSocket, 'disconnectAll');
-        mobiusSocket.logout();
-        assert.called(mobiusSocket.disconnectAll);
-        assert.calledOnce(mobiusSocket.logger.info);
-        assert.calledWith(mobiusSocket.logger.info.getCall(0), 'MobiusSocket: logout() called');
-      });
-
-      it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send code 3050 for logout', () => {
-        sinon.stub(mobiusSocket, 'disconnectAll');
-        mobiusSocket.config.beforeLogoutOptionsCloseReason = 'done (permanent)';
-        mobiusSocket.logout();
-        assert.calledWith(mobiusSocket.disconnectAll, {code: 3050, reason: 'done (permanent)'});
-      });
-
-      it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send code 3050 for logout if the reason is different than standard', () => {
-        sinon.stub(mobiusSocket, 'disconnectAll');
-        mobiusSocket.config.beforeLogoutOptionsCloseReason = 'test';
-        mobiusSocket.logout();
-        assert.calledWith(mobiusSocket.disconnectAll, {code: 3050, reason: 'test'});
-      });
-
-      it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send undefined for logout if the reason is same as standard', () => {
-        sinon.stub(mobiusSocket, 'disconnectAll');
-        mobiusSocket.config.beforeLogoutOptionsCloseReason = 'done (forced)';
-        mobiusSocket.logout();
-        assert.calledWith(mobiusSocket.disconnectAll, undefined);
-      });
-    });
-
     describe('#disconnect()', () => {
       it('disconnects the WebSocket', () =>
         mobiusSocket
@@ -908,8 +868,6 @@ describe('plugin-mobius-socket', () => {
             assert.isDefined(mobiusSocket.socket, 'MobiusSocket socket is not defined');
 
             await assert.isRejected(promise);
-            // connection did not fail, so no last error
-            assert.isUndefined(mobiusSocket.getLastError());
           });
         });
 
@@ -938,30 +896,6 @@ describe('plugin-mobius-socket', () => {
 
             // Ensure the promise was actually rejected (short-circuited)
             return assert.isRejected(promise);
-          });
-        });
-
-        it('sets lastError when retrying', () => {
-          const realError = new Error('FORCED');
-          mobiusSocket.config.initialConnectionMaxRetries = 1;
-
-          socketOpenStub.restore();
-          socketOpenStub = sinon.stub(Socket.prototype, 'open');
-          socketOpenStub.onCall(0).returns(Promise.reject(realError));
-          const promise = mobiusSocket.connect();
-
-          // Wait for the connect call to setup
-          return promiseTick(mobiusSocket.config.backoffTimeReset).then(async () => {
-            // Calling disconnect will abort the backoffCall, close the socket, and
-            // reject the connect
-            mobiusSocket.disconnect();
-
-            const error = await assert.isRejected(promise);
-            const lastError = mobiusSocket.getLastError();
-
-            assert.match(error.message, /MobiusSocket Connection Aborted/);
-            assert.isDefined(lastError);
-            assert.equal(lastError, realError);
           });
         });
       });

--- a/packages/calling/src/mobius-socket/mobius-socket.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.test.ts
@@ -224,15 +224,8 @@ describe('plugin-mobius-socket', () => {
       });
 
       it('connects to MobiusSocket using default url', () => {
-        webex.internal.feature.updateFeature = sinon.stub();
         const promise = mobiusSocket.connect();
-        const envelope = {
-          data: {
-            featureToggle: {
-              'feature-name': true,
-            },
-          },
-        };
+
         assert.isFalse(mobiusSocket.connected, 'MobiusSocket is not connected');
         assert.isTrue(mobiusSocket.connecting, 'MobiusSocket is connecting');
         mockWebSocket.open();
@@ -241,85 +234,6 @@ describe('plugin-mobius-socket', () => {
           assert.isTrue(mobiusSocket.connected, 'MobiusSocket is connected');
           assert.isFalse(mobiusSocket.connecting, 'MobiusSocket is not connecting');
           assert.calledWith(socketOpenStub, 'ws://example.com', sinon.match.any);
-          mobiusSocket.emit('event:featureToggle_update', envelope);
-          assert.calledOnceWithExactly(
-            webex.internal.feature.updateFeature,
-            envelope.data.featureToggle
-          );
-          sinon.restore();
-        });
-      });
-
-      it('connects to MobiusSocket but does not call updateFeature', () => {
-        webex.internal.feature.updateFeature = sinon.stub();
-        const promise = mobiusSocket.connect();
-        const envelope = {};
-
-        return promise.then(() => {
-          mobiusSocket.emit('event:featureToggle_update', envelope);
-          assert.notCalled(webex.internal.feature.updateFeature);
-          sinon.restore();
-        });
-      });
-      it('MobiusSocket emit event:ActiveClusterStatusEvent, call services switchActiveClusterIds', () => {
-        const promise = mobiusSocket.connect();
-        const activeClusterEventEnvelope = {
-          data: {
-            activeClusters: {
-              wdm: 'wdm-cluster-id.com',
-            },
-          },
-        };
-        mockWebSocket.open();
-
-        return promise.then(() => {
-          mobiusSocket.emit('event:ActiveClusterStatusEvent', activeClusterEventEnvelope);
-          assert.calledOnceWithExactly(
-            webex.internal.services.switchActiveClusterIds,
-            activeClusterEventEnvelope.data.activeClusters
-          );
-          sinon.restore();
-        });
-      });
-      it('MobiusSocket emit event:ActiveClusterStatusEvent with no data, not call services switchActiveClusterIds', () => {
-        webex.internal.feature.updateFeature = sinon.stub();
-        const promise = mobiusSocket.connect();
-        const envelope = {};
-
-        return promise.then(() => {
-          mobiusSocket.emit('event:ActiveClusterStatusEvent', envelope);
-          assert.notCalled(webex.internal.services.switchActiveClusterIds);
-          sinon.restore();
-        });
-      });
-      it('MobiusSocket emit event:u2c.cache-invalidation, call services invalidateCache', () => {
-        const promise = mobiusSocket.connect();
-        const u2cInvalidateEventEnvelope = {
-          data: {
-            timestamp: '1759289614',
-          },
-        };
-
-        mockWebSocket.open();
-
-        return promise.then(() => {
-          mobiusSocket.emit('event:u2c.cache-invalidation', u2cInvalidateEventEnvelope);
-          assert.calledOnceWithExactly(
-            webex.internal.services.invalidateCache,
-            u2cInvalidateEventEnvelope.data.timestamp
-          );
-          sinon.restore();
-        });
-      });
-      it('MobiusSocket emit event:u2c.cache-invalidation with no data, not call services switchActiveClusterIds', () => {
-        webex.internal.feature.updateFeature = sinon.stub();
-        const promise = mobiusSocket.connect();
-        const envelope = {};
-
-        return promise.then(() => {
-          mobiusSocket.emit('event:u2c.cache-invalidation', envelope);
-          assert.notCalled(webex.internal.services.invalidateCache);
-          sinon.restore();
         });
       });
 
@@ -1087,96 +1001,6 @@ describe('plugin-mobius-socket', () => {
       });
     });
 
-    describe('#_applyOverrides()', () => {
-      const lastSeenActivityDate = 'Some date';
-      const lastReadableActivityDate = 'Some other date';
-
-      it('merges a single header field with data', () => {
-        const envelope = {
-          headers: {
-            'data.activity.target.lastSeenActivityDate': lastSeenActivityDate,
-          },
-          data: {
-            activity: {},
-          },
-        };
-
-        mobiusSocket.applyOverrides(envelope);
-
-        assert.equal(envelope.data.activity.target.lastSeenActivityDate, lastSeenActivityDate);
-      });
-
-      it('merges a multiple header fields with data', () => {
-        const envelope = {
-          headers: {
-            'data.activity.target.lastSeenActivityDate': lastSeenActivityDate,
-            'data.activity.target.lastReadableActivityDate': lastReadableActivityDate,
-          },
-          data: {
-            activity: {},
-          },
-        };
-
-        mobiusSocket.applyOverrides(envelope);
-
-        assert.equal(envelope.data.activity.target.lastSeenActivityDate, lastSeenActivityDate);
-        assert.equal(
-          envelope.data.activity.target.lastReadableActivityDate,
-          lastReadableActivityDate
-        );
-      });
-
-      it('merges headers when MobiusSocket messages arrive', () => {
-        const envelope = {
-          headers: {
-            'data.activity.target.lastSeenActivityDate': lastSeenActivityDate,
-          },
-          data: {
-            activity: {},
-          },
-        };
-
-        mobiusSocket.applyOverrides(envelope);
-
-        assert.equal(envelope.data.activity.target.lastSeenActivityDate, lastSeenActivityDate);
-      });
-    });
-
-    describe('#_setTimeOffset', () => {
-      it('sets mercuryTimeOffset based on the difference between wsWriteTimestamp and now', () => {
-        const event = {
-          data: {
-            wsWriteTimestamp: Date.now() - 60000,
-          },
-        };
-        assert.isUndefined(mobiusSocket.mercuryTimeOffset);
-        mobiusSocket.setTimeOffset(event);
-        assert.isDefined(mobiusSocket.mercuryTimeOffset);
-        assert.isTrue(mobiusSocket.mercuryTimeOffset > 0);
-      });
-      it('handles negative offsets', () => {
-        const event = {
-          data: {
-            wsWriteTimestamp: Date.now() + 60000,
-          },
-        };
-        mobiusSocket.setTimeOffset(event);
-        assert.isTrue(mobiusSocket.mercuryTimeOffset < 0);
-      });
-      it('handles invalid wsWriteTimestamp', () => {
-        const invalidTimestamps = [null, -1, 'invalid', undefined];
-        invalidTimestamps.forEach((invalidTimestamp) => {
-          const event = {
-            data: {
-              wsWriteTimestamp: invalidTimestamp,
-            },
-          };
-          mobiusSocket.setTimeOffset(event);
-          assert.isUndefined(mobiusSocket.mercuryTimeOffset);
-        });
-      });
-    });
-
     describe('#_prepareUrl()', () => {
       it('returns the provided URL as-is (no Mercury URL transforms)', () =>
         mobiusSocket.prepareUrl('ws://provided.com').then((wsUrl) => {
@@ -1259,13 +1083,11 @@ describe('plugin-mobius-socket', () => {
         beforeEach(() => {
           sinon.stub(mobiusSocket, 'handleImminentShutdown');
           sinon.stub(mobiusSocket, 'emitEvent');
-          sinon.stub(mobiusSocket, 'setTimeOffset');
         });
 
         afterEach(() => {
           mobiusSocket.handleImminentShutdown.restore();
           mobiusSocket.emitEvent.restore();
-          mobiusSocket.setTimeOffset.restore();
         });
 
         it('should trigger _handleImminentShutdown on shutdown message', () => {
@@ -1280,7 +1102,7 @@ describe('plugin-mobius-socket', () => {
           assert.calledOnce(mobiusSocket.handleImminentShutdown);
           assert.calledWith(
             mobiusSocket.emitEvent,
-            'event:mercury_shutdown_imminent',
+            'event:mobius_shutdown_imminent',
             shutdownEvent.data
           );
           assert.instanceOf(result, Promise);
@@ -1317,14 +1139,10 @@ describe('plugin-mobius-socket', () => {
       describe('#_onmessage() with missing data or eventType', () => {
         beforeEach(() => {
           sinon.stub(mobiusSocket, 'emitEvent');
-          sinon.stub(mobiusSocket, 'setTimeOffset');
-          sinon.stub(mobiusSocket, 'applyOverrides');
         });
 
         afterEach(() => {
           mobiusSocket.emitEvent.restore();
-          mobiusSocket.setTimeOffset.restore();
-          mobiusSocket.applyOverrides.restore();
         });
 
         it('should not throw when envelope.data is undefined', () => {
@@ -1453,32 +1271,6 @@ describe('plugin-mobius-socket', () => {
 
           assert.equal(countGenericEventEmits(emitSpy), 2);
           emitSpy.restore();
-        });
-      });
-
-      describe('#_getEventHandlers()', () => {
-        it('should return an empty array when eventType is undefined', () => {
-          const result = mobiusSocket.getEventHandlers(undefined);
-
-          assert.deepEqual(result, []);
-        });
-
-        it('should return an empty array when eventType is null', () => {
-          const result = mobiusSocket.getEventHandlers(null);
-
-          assert.deepEqual(result, []);
-        });
-
-        it('should return an empty array when eventType is an empty string', () => {
-          const result = mobiusSocket.getEventHandlers('');
-
-          assert.deepEqual(result, []);
-        });
-
-        it('should return an empty array when namespace is not registered', () => {
-          const result = mobiusSocket.getEventHandlers('unknownNamespace.someEvent');
-
-          assert.deepEqual(result, []);
         });
       });
 
@@ -1650,7 +1442,7 @@ describe('plugin-mobius-socket', () => {
 
           const emitCalls = mobiusSocket.emitEvent.getCalls();
           const hasCompleteEvent = emitCalls.some(
-            (call) => call.args[0] === 'event:mercury_shutdown_switchover_complete'
+            (call) => call.args[0] === 'event:mobius_shutdown_switchover_complete'
           );
 
           assert.isTrue(hasCompleteEvent, 'Should emit switchover complete event');
@@ -1667,7 +1459,7 @@ describe('plugin-mobius-socket', () => {
           const emitCalls = mobiusSocket.emitEvent.getCalls();
           const hasFailureEvent = emitCalls.some(
             (call) =>
-              call.args[0] === 'event:mercury_shutdown_switchover_failed' &&
+              call.args[0] === 'event:mobius_shutdown_switchover_failed' &&
               call.args[1] &&
               call.args[1].reason === testError
           );
@@ -1833,7 +1625,7 @@ describe('plugin-mobius-socket', () => {
             onSuccess: (newSocket, url) => {
               mobiusSocket.socket = newSocket;
               mobiusSocket.connected = true;
-              mobiusSocket.emitEvent('event:mercury_shutdown_switchover_complete', {
+              mobiusSocket.emitEvent('event:mobius_shutdown_switchover_complete', {
                 url,
               });
             },
@@ -1841,7 +1633,7 @@ describe('plugin-mobius-socket', () => {
 
           assert.calledWith(
             mobiusSocket.emitEvent,
-            'event:mercury_shutdown_switchover_complete',
+            'event:mobius_shutdown_switchover_complete',
             sinon.match.has('url', 'ws://new-socket.com')
           );
         });

--- a/packages/calling/src/mobius-socket/mobius-socket.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.test.ts
@@ -105,9 +105,8 @@ describe('plugin-mobius-socket', () => {
       removeAllListeners: sinon.stub(),
     });
 
-    const countGenericEventEmits = (emitSpy, sessionId) =>
-      emitSpy.getCalls().filter((call) => call.args[0] === sessionId && call.args[1] === 'event')
-        .length;
+    const countGenericEventEmits = (emitSpy) =>
+      emitSpy.getCalls().filter((call) => call.args[0] === 'event').length;
 
     beforeEach(() => {
       jest.useFakeTimers({doNotFake: ['nextTick']});
@@ -173,7 +172,6 @@ describe('plugin-mobius-socket', () => {
       });
 
       mobiusSocket = new MobiusSocket(webex, {...mobiusConfig.mobiusSocket});
-      mobiusSocket.defaultSessionId = 'mobius-websocket-session';
     });
 
     afterEach(async () => {
@@ -188,10 +186,6 @@ describe('plugin-mobius-socket', () => {
           await mobiusSocket.disconnect();
         } catch (e) {
           // Ignore cleanup errors
-        }
-        // Clear any remaining connection promises
-        if (mobiusSocket.connectPromises) {
-          mobiusSocket.connectPromises.clear();
         }
       }
 
@@ -852,16 +846,13 @@ describe('plugin-mobius-socket', () => {
           return promiseTick(mobiusSocket.config.backoffTimeReset).then(async () => {
             // By this time backoffCall and mobiusSocket socket should be defined by the
             // 'connect' call
-            assert.isDefined(
-              mobiusSocket.backoffCalls.get('mobius-websocket-session'),
-              'MobiusSocket backoffCall is not defined'
-            );
+            assert.isDefined(mobiusSocket.backoffCall, 'MobiusSocket backoffCall is not defined');
             assert.isDefined(mobiusSocket.socket, 'MobiusSocket socket is not defined');
             // Calling disconnect will abort the backoffCall, close the socket, and
             // reject the connect
             mobiusSocket.disconnect();
             assert.isUndefined(
-              mobiusSocket.backoffCalls.get('mobius-websocket-session'),
+              mobiusSocket.backoffCall,
               'MobiusSocket backoffCall is still defined'
             );
             // The socket will never be unset (which seems bad)
@@ -878,21 +869,14 @@ describe('plugin-mobius-socket', () => {
 
           let reason;
 
-          mobiusSocket.backoffCalls.clear();
+          mobiusSocket.backoffCall = undefined;
 
-          const promise = mobiusSocket.attemptConnection(
-            'ws://example.com',
-            'mobius-websocket-session',
-            (_reason) => {
-              reason = _reason;
-            }
-          );
+          const promise = mobiusSocket.attemptConnection('ws://example.com', (_reason) => {
+            reason = _reason;
+          });
 
           return promiseTick(mobiusSocket.config.backoffTimeReset).then(() => {
-            assert.equal(
-              reason.message,
-              `MobiusSocket: prevent socket open when backoffCall no longer defined for ${mobiusSocket.defaultSessionId}`
-            );
+            assert.match(reason.message, /prevent socket open when backoffCall no longer defined/);
 
             // Ensure the promise was actually rejected (short-circuited)
             return assert.isRejected(promise);
@@ -1061,20 +1045,20 @@ describe('plugin-mobius-socket', () => {
     });
 
     describe('#getConnectedWebSocketUrl()', () => {
-      it('returns the connected websocket url for the session', () => {
-        mobiusSocket.sockets.set(mobiusSocket.defaultSessionId, {
+      it('returns the connected websocket url', () => {
+        mobiusSocket.socket = {
           connected: true,
           url: 'ws://connected-url.com',
-        });
+        };
 
         assert.equal(mobiusSocket.getConnectedWebSocketUrl(), 'ws://connected-url.com');
       });
 
-      it('returns undefined when the session is not connected', () => {
-        mobiusSocket.sockets.set(mobiusSocket.defaultSessionId, {
+      it('returns undefined when not connected', () => {
+        mobiusSocket.socket = {
           connected: false,
           url: 'ws://disconnected-url.com',
-        });
+        };
 
         assert.isUndefined(mobiusSocket.getConnectedWebSocketUrl());
       });
@@ -1089,15 +1073,13 @@ describe('plugin-mobius-socket', () => {
         });
         sinon.stub(mobiusSocket.logger, 'error');
 
-        return Promise.resolve(
-          mobiusSocket.emitEvent(mobiusSocket.defaultSessionId, 'break', event)
-        ).then((res) => {
+        return Promise.resolve(mobiusSocket.emitEvent('break', event)).then((res) => {
           assert.calledWith(
             mobiusSocket.logger.error,
             'MobiusSocket: error occurred in event handler:',
             error,
             ' with args: ',
-            [mobiusSocket.defaultSessionId, 'break', event]
+            ['break', event]
           );
 
           return res;
@@ -1168,7 +1150,7 @@ describe('plugin-mobius-socket', () => {
           },
         };
         assert.isUndefined(mobiusSocket.mercuryTimeOffset);
-        mobiusSocket.setTimeOffset('mobius-websocket-session', event);
+        mobiusSocket.setTimeOffset(event);
         assert.isDefined(mobiusSocket.mercuryTimeOffset);
         assert.isTrue(mobiusSocket.mercuryTimeOffset > 0);
       });
@@ -1178,7 +1160,7 @@ describe('plugin-mobius-socket', () => {
             wsWriteTimestamp: Date.now() + 60000,
           },
         };
-        mobiusSocket.setTimeOffset('mobius-websocket-session', event);
+        mobiusSocket.setTimeOffset(event);
         assert.isTrue(mobiusSocket.mercuryTimeOffset < 0);
       });
       it('handles invalid wsWriteTimestamp', () => {
@@ -1189,7 +1171,7 @@ describe('plugin-mobius-socket', () => {
               wsWriteTimestamp: invalidTimestamp,
             },
           };
-          mobiusSocket.setTimeOffset('mobius-websocket-session', event);
+          mobiusSocket.setTimeOffset(event);
           assert.isUndefined(mobiusSocket.mercuryTimeOffset);
         });
       });
@@ -1210,15 +1192,13 @@ describe('plugin-mobius-socket', () => {
     describe('shutdown protocol', () => {
       describe('#_handleImminentShutdown()', () => {
         let connectWithBackoffStub;
-        const sessionId = 'mobius-websocket-session';
 
         beforeEach(() => {
           mobiusSocket.connected = true;
-          mobiusSocket.sockets.set(sessionId, {
+          mobiusSocket.socket = {
             url: 'ws://old-socket.com',
             removeAllListeners: sinon.stub(),
-          });
-          mobiusSocket.socket = mobiusSocket.sockets.get(sessionId);
+          };
           connectWithBackoffStub = sinon.stub(mobiusSocket, 'connectWithBackoff');
           connectWithBackoffStub.returns(Promise.resolve());
           sinon.stub(mobiusSocket, 'emitEvent');
@@ -1227,43 +1207,39 @@ describe('plugin-mobius-socket', () => {
         afterEach(() => {
           connectWithBackoffStub.restore();
           mobiusSocket.emitEvent.restore();
-          mobiusSocket.sockets.clear();
         });
 
         it('should be idempotent - no-op if already in progress', () => {
-          // Simulate an existing switchover in progress by seeding the backoff map
-          mobiusSocket.shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
+          mobiusSocket.shutdownSwitchoverBackoffCall = {placeholder: true};
 
-          mobiusSocket.handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown();
 
           assert.notCalled(connectWithBackoffStub);
         });
 
         it('should set switchover flags when called', () => {
-          mobiusSocket.handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown();
 
           assert.calledOnce(connectWithBackoffStub);
           const callArgs = connectWithBackoffStub.firstCall.args;
           assert.isUndefined(callArgs[0]); // webSocketUrl
-          assert.equal(callArgs[1], sessionId); // sessionId
-          assert.isObject(callArgs[2]); // context
-          assert.isTrue(callArgs[2].isShutdownSwitchover);
-          assert.isObject(callArgs[2].attemptOptions);
-          assert.isTrue(callArgs[2].attemptOptions.isShutdownSwitchover);
+          assert.isObject(callArgs[1]); // context
+          assert.isTrue(callArgs[1].isShutdownSwitchover);
+          assert.isObject(callArgs[1].attemptOptions);
+          assert.isTrue(callArgs[1].attemptOptions.isShutdownSwitchover);
         });
 
         it('should call _connectWithBackoff with correct parameters', (done) => {
-          mobiusSocket.handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown();
 
           process.nextTick(() => {
             assert.calledOnce(connectWithBackoffStub);
             const callArgs = connectWithBackoffStub.firstCall.args;
             assert.isUndefined(callArgs[0]); // webSocketUrl
-            assert.equal(callArgs[1], sessionId); // sessionId
-            assert.isObject(callArgs[2]); // context
-            assert.isTrue(callArgs[2].isShutdownSwitchover);
-            assert.isObject(callArgs[2].attemptOptions);
-            assert.isTrue(callArgs[2].attemptOptions.isShutdownSwitchover);
+            assert.isObject(callArgs[1]); // context
+            assert.isTrue(callArgs[1].isShutdownSwitchover);
+            assert.isObject(callArgs[1].attemptOptions);
+            assert.isTrue(callArgs[1].attemptOptions.isShutdownSwitchover);
             done();
           });
         });
@@ -1272,12 +1248,9 @@ describe('plugin-mobius-socket', () => {
           connectWithBackoffStub.restore();
           sinon.stub(mobiusSocket, 'connectWithBackoff').throws(new Error('Connection failed'));
 
-          mobiusSocket.handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown();
 
-          // When an exception happens synchronously, the placeholder entry
-          // should be removed from the map.
-          const switchoverCall = mobiusSocket.shutdownSwitchoverBackoffCalls.get(sessionId);
-          assert.isUndefined(switchoverCall);
+          assert.isUndefined(mobiusSocket.shutdownSwitchoverBackoffCall);
           mobiusSocket.connectWithBackoff.restore();
         });
       });
@@ -1302,12 +1275,11 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          const result = mobiusSocket.onmessage(mobiusSocket.defaultSessionId, shutdownEvent);
+          const result = mobiusSocket.onmessage(shutdownEvent);
 
           assert.calledOnce(mobiusSocket.handleImminentShutdown);
           assert.calledWith(
             mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
             'event:mercury_shutdown_imminent',
             shutdownEvent.data
           );
@@ -1321,7 +1293,7 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          mobiusSocket.onmessage(mobiusSocket.defaultSessionId, shutdownEvent);
+          mobiusSocket.onmessage(shutdownEvent);
 
           assert.calledOnce(mobiusSocket.handleImminentShutdown);
         });
@@ -1336,7 +1308,7 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          mobiusSocket.onmessage(mobiusSocket.defaultSessionId, regularEvent);
+          mobiusSocket.onmessage(regularEvent);
 
           assert.notCalled(mobiusSocket.handleImminentShutdown);
         });
@@ -1363,15 +1335,10 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          const result = mobiusSocket.onmessage(mobiusSocket.defaultSessionId, event);
+          const result = mobiusSocket.onmessage(event);
 
           assert.instanceOf(result, Promise);
-          assert.calledWith(
-            mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
-            'event',
-            event.data
-          );
+          assert.calledWith(mobiusSocket.emitEvent, 'event', event.data);
         });
 
         it('should not throw when data.eventType is undefined', () => {
@@ -1385,15 +1352,10 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          const result = mobiusSocket.onmessage(mobiusSocket.defaultSessionId, event);
+          const result = mobiusSocket.onmessage(event);
 
           assert.instanceOf(result, Promise);
-          assert.calledWith(
-            mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
-            'event',
-            event.data
-          );
+          assert.calledWith(mobiusSocket.emitEvent, 'event', event.data);
         });
 
         it('should emit generic event for messages without eventType (e.g. subscription responses)', () => {
@@ -1407,16 +1369,11 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          const result = mobiusSocket.onmessage(mobiusSocket.defaultSessionId, event);
+          const result = mobiusSocket.onmessage(event);
 
           assert.instanceOf(result, Promise);
           assert.calledOnce(mobiusSocket.emitEvent);
-          assert.calledWith(
-            mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
-            'event',
-            event.data
-          );
+          assert.calledWith(mobiusSocket.emitEvent, 'event', event.data);
         });
 
         it('should still process messages with a valid eventType', async () => {
@@ -1428,22 +1385,10 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          await mobiusSocket.onmessage(mobiusSocket.defaultSessionId, event);
+          await mobiusSocket.onmessage(event);
 
-          // Normal flow emits namespace-specific events after processing handlers.
-          // The early-return guard only emits 'event', so asserting these proves the normal path was taken.
-          assert.calledWith(
-            mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
-            'event:conversation',
-            event.data
-          );
-          assert.calledWith(
-            mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
-            'event:conversation.activity',
-            event.data
-          );
+          assert.calledWith(mobiusSocket.emitEvent, 'event:conversation', event.data);
+          assert.calledWith(mobiusSocket.emitEvent, 'event:conversation.activity', event.data);
         });
       });
 
@@ -1458,27 +1403,26 @@ describe('plugin-mobius-socket', () => {
           mobiusSocket.config.dedupCacheMaxSize = originalDedupCacheMaxSize;
         });
 
-        it('suppresses duplicate async_event messages for the same session', async () => {
+        it('suppresses duplicate async_event messages', async () => {
           const emitSpy = sinon.spy(mobiusSocket, 'emitEvent');
 
-          await mobiusSocket.onmessage('session-a', createAsyncEvent('evt-1'));
-          await mobiusSocket.onmessage('session-a', createAsyncEvent('evt-1'));
+          await mobiusSocket.onmessage(createAsyncEvent('evt-1'));
+          await mobiusSocket.onmessage(createAsyncEvent('evt-1'));
 
-          assert.equal(countGenericEventEmits(emitSpy, 'session-a'), 1);
+          assert.equal(countGenericEventEmits(emitSpy), 1);
           emitSpy.restore();
         });
 
         it('suppresses duplicate async_event messages across socket replacement without disconnect', async () => {
-          const sessionId = 'session-a';
           const emitSpy = sinon.spy(mobiusSocket, 'emitEvent');
-          mobiusSocket.sockets.set(sessionId, createSessionSocket());
+          mobiusSocket.socket = createSessionSocket();
 
-          await mobiusSocket.onmessage(sessionId, createAsyncEvent('evt-2'));
+          await mobiusSocket.onmessage(createAsyncEvent('evt-2'));
 
-          mobiusSocket.sockets.set(sessionId, createSessionSocket());
-          await mobiusSocket.onmessage(sessionId, createAsyncEvent('evt-2'));
+          mobiusSocket.socket = createSessionSocket();
+          await mobiusSocket.onmessage(createAsyncEvent('evt-2'));
 
-          assert.equal(countGenericEventEmits(emitSpy, sessionId), 1);
+          assert.equal(countGenericEventEmits(emitSpy), 1);
           emitSpy.restore();
         });
 
@@ -1487,28 +1431,27 @@ describe('plugin-mobius-socket', () => {
 
           mobiusSocket.config.dedupCacheMaxSize = 3;
 
-          await mobiusSocket.onmessage('session-a', createAsyncEvent('e1'));
-          await mobiusSocket.onmessage('session-a', createAsyncEvent('e2'));
-          await mobiusSocket.onmessage('session-a', createAsyncEvent('e3'));
-          await mobiusSocket.onmessage('session-a', createAsyncEvent('e4'));
-          await mobiusSocket.onmessage('session-a', createAsyncEvent('e2'));
-          await mobiusSocket.onmessage('session-a', createAsyncEvent('e1'));
+          await mobiusSocket.onmessage(createAsyncEvent('e1'));
+          await mobiusSocket.onmessage(createAsyncEvent('e2'));
+          await mobiusSocket.onmessage(createAsyncEvent('e3'));
+          await mobiusSocket.onmessage(createAsyncEvent('e4'));
+          await mobiusSocket.onmessage(createAsyncEvent('e2'));
+          await mobiusSocket.onmessage(createAsyncEvent('e1'));
 
-          assert.equal(countGenericEventEmits(emitSpy, 'session-a'), 5);
+          assert.equal(countGenericEventEmits(emitSpy), 5);
           emitSpy.restore();
         });
 
-        it('clears the session dedup cache on disconnect', async () => {
-          const sessionId = 'session-a';
+        it('clears the dedup cache on disconnect', async () => {
           const emitSpy = sinon.spy(mobiusSocket, 'emitEvent');
 
-          await mobiusSocket.onmessage(sessionId, createAsyncEvent('evt-3'));
+          await mobiusSocket.onmessage(createAsyncEvent('evt-3'));
 
-          mobiusSocket.sockets.set(sessionId, createSessionSocket());
-          await mobiusSocket.disconnect(undefined, sessionId);
-          await mobiusSocket.onmessage(sessionId, createAsyncEvent('evt-3'));
+          mobiusSocket.socket = createSessionSocket();
+          await mobiusSocket.disconnect();
+          await mobiusSocket.onmessage(createAsyncEvent('evt-3'));
 
-          assert.equal(countGenericEventEmits(emitSpy, sessionId), 2);
+          assert.equal(countGenericEventEmits(emitSpy), 2);
           emitSpy.restore();
         });
       });
@@ -1553,7 +1496,6 @@ describe('plugin-mobius-socket', () => {
             removeAllListeners: sinon.stub(),
           };
           mobiusSocket.socket = mockSocket;
-          mobiusSocket.sockets.set(mobiusSocket.defaultSessionId, mockSocket);
           mobiusSocket.connected = true;
           sinon.stub(mobiusSocket, 'emitEvent');
           sinon.stub(mobiusSocket, 'reconnect');
@@ -1570,15 +1512,10 @@ describe('plugin-mobius-socket', () => {
             reason: 'replaced during shutdown',
           };
 
-          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, mockSocket);
+          mobiusSocket.onclose(closeEvent, mockSocket);
 
-          assert.calledWith(
-            mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
-            'offline.permanent',
-            closeEvent
-          );
-          assert.notCalled(mobiusSocket.reconnect); // No reconnect for 4001 on active socket
+          assert.calledWith(mobiusSocket.emitEvent, 'offline.permanent', closeEvent);
+          assert.notCalled(mobiusSocket.reconnect);
           assert.isFalse(mobiusSocket.connected);
         });
 
@@ -1588,16 +1525,11 @@ describe('plugin-mobius-socket', () => {
             reason: 'replaced during shutdown',
           };
 
-          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, anotherSocket);
+          mobiusSocket.onclose(closeEvent, anotherSocket);
 
-          assert.calledWith(
-            mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
-            'offline.replaced',
-            closeEvent
-          );
+          assert.calledWith(mobiusSocket.emitEvent, 'offline.replaced', closeEvent);
           assert.notCalled(mobiusSocket.reconnect);
-          assert.isTrue(mobiusSocket.connected); // Should remain connected
+          assert.isTrue(mobiusSocket.connected);
           assert.strictEqual(mobiusSocket.socket, mockSocket);
         });
 
@@ -1608,26 +1540,15 @@ describe('plugin-mobius-socket', () => {
           };
 
           // Test non-active socket
-          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, anotherSocket);
-          assert.calledWith(
-            mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
-            'offline.replaced',
-            closeEvent
-          );
+          mobiusSocket.onclose(closeEvent, anotherSocket);
+          assert.calledWith(mobiusSocket.emitEvent, 'offline.replaced', closeEvent);
 
           // Reset the spy call history
           mobiusSocket.emitEvent.resetHistory();
 
           // Test active socket
-          mobiusSocket.sockets.set(mobiusSocket.defaultSessionId, mockSocket);
-          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, mockSocket);
-          assert.calledWith(
-            mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
-            'offline.permanent',
-            closeEvent
-          );
+          mobiusSocket.onclose(closeEvent, mockSocket);
+          assert.calledWith(mobiusSocket.emitEvent, 'offline.permanent', closeEvent);
         });
 
         it('should handle missing sourceSocket parameter (treats as non-active)', () => {
@@ -1636,15 +1557,9 @@ describe('plugin-mobius-socket', () => {
             reason: 'replaced during shutdown',
           };
 
-          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent); // No sourceSocket parameter
+          mobiusSocket.onclose(closeEvent, undefined);
 
-          // With simplified logic, undefined !== this.socket, so isActiveSocket = false
-          assert.calledWith(
-            mobiusSocket.emitEvent,
-            mobiusSocket.defaultSessionId,
-            'offline.replaced',
-            closeEvent
-          );
+          assert.calledWith(mobiusSocket.emitEvent, 'offline.replaced', closeEvent);
           assert.notCalled(mobiusSocket.reconnect);
         });
 
@@ -1654,12 +1569,8 @@ describe('plugin-mobius-socket', () => {
             reason: 'replaced during shutdown',
           };
 
-          // Close non-active socket (not the active one)
-          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, anotherSocket);
+          mobiusSocket.onclose(closeEvent, anotherSocket);
 
-          // Verify listeners were removed from the old socket
-          // The _onclose method checks if sourceSocket !== this.socket (non-active)
-          // and then calls removeAllListeners in the else branch
           assert.calledOnce(anotherSocket.removeAllListeners);
         });
 
@@ -1669,25 +1580,21 @@ describe('plugin-mobius-socket', () => {
             reason: 'replaced during shutdown',
           };
 
-          // Close active socket
-          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, mockSocket);
+          mobiusSocket.onclose(closeEvent, mockSocket);
 
-          // Verify listeners were removed from active socket
           assert.calledOnce(mockSocket.removeAllListeners);
         });
       });
 
       describe('shutdown switchover with retry logic', () => {
         let connectWithBackoffStub;
-        const sessionId = 'mobius-websocket-session';
 
         beforeEach(() => {
           mobiusSocket.connected = true;
-          mobiusSocket.sockets.set(sessionId, {
+          mobiusSocket.socket = {
             url: 'ws://old-socket.com',
             removeAllListeners: sinon.stub(),
-          });
-          mobiusSocket.socket = mobiusSocket.sockets.get(sessionId);
+          };
           connectWithBackoffStub = sinon.stub(mobiusSocket, 'connectWithBackoff');
           sinon.stub(mobiusSocket, 'emitEvent');
         });
@@ -1695,64 +1602,55 @@ describe('plugin-mobius-socket', () => {
         afterEach(() => {
           connectWithBackoffStub.restore();
           mobiusSocket.emitEvent.restore();
-          mobiusSocket.sockets.clear();
         });
 
         it('should call _connectWithBackoff with shutdown switchover context', (done) => {
           connectWithBackoffStub.returns(Promise.resolve());
 
-          mobiusSocket.handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown();
 
           process.nextTick(() => {
             assert.calledOnce(connectWithBackoffStub);
             const callArgs = connectWithBackoffStub.firstCall.args;
 
             assert.isUndefined(callArgs[0]); // webSocketUrl
-            assert.equal(callArgs[1], sessionId);
-            assert.isObject(callArgs[2]);
-            assert.isTrue(callArgs[2].isShutdownSwitchover);
-            assert.isObject(callArgs[2].attemptOptions);
-            assert.isTrue(callArgs[2].attemptOptions.isShutdownSwitchover);
+            assert.isObject(callArgs[1]);
+            assert.isTrue(callArgs[1].isShutdownSwitchover);
+            assert.isObject(callArgs[1].attemptOptions);
+            assert.isTrue(callArgs[1].attemptOptions.isShutdownSwitchover);
             done();
           });
         });
 
-        it('should set _shutdownSwitchoverInProgress flag during switchover', () => {
-          // With the new behavior, "in progress" is represented by the presence
-          // of an entry in _shutdownSwitchoverBackoffCalls.
-          // Since _connectWithBackoff is stubbed in this suite, simulate its side-effect
-          // of seeding the backoff-call map entry.
+        it('should set shutdownSwitchoverBackoffCall during switchover', () => {
           connectWithBackoffStub.callsFake(() => {
-            mobiusSocket.shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
+            mobiusSocket.shutdownSwitchoverBackoffCall = {placeholder: true};
 
             return new Promise(() => {}); // Never resolves
           });
 
-          mobiusSocket.handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown();
 
-          const switchoverBackoffCall = mobiusSocket.shutdownSwitchoverBackoffCalls.get(sessionId);
-          assert.isOk(switchoverBackoffCall);
+          assert.isOk(mobiusSocket.shutdownSwitchoverBackoffCall);
         });
 
         it('should emit success event when switchover completes', async () => {
-          connectWithBackoffStub.callsFake((url, sid, context) => {
+          connectWithBackoffStub.callsFake((url, context) => {
             if (context && context.attemptOptions && context.attemptOptions.onSuccess) {
-              const mockSocket = {url: 'ws://new-socket.com'};
-              context.attemptOptions.onSuccess(mockSocket, 'ws://new-socket.com');
+              const newSocket = {url: 'ws://new-socket.com'};
+              context.attemptOptions.onSuccess(newSocket, 'ws://new-socket.com');
             }
 
             return Promise.resolve();
           });
 
-          mobiusSocket.handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown();
 
           await promiseTick(50);
 
           const emitCalls = mobiusSocket.emitEvent.getCalls();
           const hasCompleteEvent = emitCalls.some(
-            (call) =>
-              call.args[0] === sessionId &&
-              call.args[1] === 'event:mercury_shutdown_switchover_complete'
+            (call) => call.args[0] === 'event:mercury_shutdown_switchover_complete'
           );
 
           assert.isTrue(hasCompleteEvent, 'Should emit switchover complete event');
@@ -1763,16 +1661,15 @@ describe('plugin-mobius-socket', () => {
 
           connectWithBackoffStub.returns(Promise.reject(testError));
 
-          mobiusSocket.handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown();
           await promiseTick(50);
 
           const emitCalls = mobiusSocket.emitEvent.getCalls();
           const hasFailureEvent = emitCalls.some(
             (call) =>
-              call.args[0] === sessionId &&
-              call.args[1] === 'event:mercury_shutdown_switchover_failed' &&
-              call.args[2] &&
-              call.args[2].reason === testError
+              call.args[0] === 'event:mercury_shutdown_switchover_failed' &&
+              call.args[1] &&
+              call.args[1].reason === testError
           );
 
           assert.isTrue(hasFailureEvent, 'Should emit switchover failed event');
@@ -1781,7 +1678,7 @@ describe('plugin-mobius-socket', () => {
         it('should allow old socket to be closed by server after switchover failure', async () => {
           connectWithBackoffStub.returns(Promise.reject(new Error('Failed')));
 
-          mobiusSocket.handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown();
           await promiseTick(50);
 
           assert.equal(mobiusSocket.socket.removeAllListeners.callCount, 0);
@@ -1883,14 +1780,13 @@ describe('plugin-mobius-socket', () => {
       describe('#_attemptConnection() with shutdown switchover', () => {
         let prepareAndOpenSocketStub;
         let callback;
-        const sessionId = 'mobius-websocket-session';
 
         beforeEach(() => {
           prepareAndOpenSocketStub = sinon
             .stub(mobiusSocket, 'prepareAndOpenSocket')
             .returns(Promise.resolve('ws://new-socket.com'));
           callback = sinon.stub();
-          mobiusSocket.shutdownSwitchoverBackoffCalls.set(sessionId, {abort: sinon.stub()});
+          mobiusSocket.shutdownSwitchoverBackoffCall = {abort: sinon.stub()};
           mobiusSocket.socket = {url: 'ws://test.com'};
           mobiusSocket.connected = true;
           sinon.stub(mobiusSocket, 'emitEvent');
@@ -1901,28 +1797,28 @@ describe('plugin-mobius-socket', () => {
           prepareAndOpenSocketStub.restore();
           mobiusSocket.emitEvent.restore();
           mobiusSocket.attachSocketEventListeners.restore();
-          mobiusSocket.shutdownSwitchoverBackoffCalls.clear();
+          mobiusSocket.shutdownSwitchoverBackoffCall = undefined;
         });
 
         it('should not set socket reference before opening for shutdown switchover', async () => {
           const originalSocket = mobiusSocket.socket;
 
-          await mobiusSocket.attemptConnection('ws://test.com', sessionId, callback, {
+          await mobiusSocket.attemptConnection('ws://test.com', callback, {
             isShutdownSwitchover: true,
             onSuccess: (newSocket, url) => {
               assert.exists(newSocket);
               assert.equal(url, 'ws://test.com');
-              assert.equal(mobiusSocket.socket, originalSocket);
             },
           });
 
+          // During shutdown switchover, this.socket should remain the old socket
           assert.equal(mobiusSocket.socket, originalSocket);
         });
 
         it('should call onSuccess callback with new socket and URL for shutdown', async () => {
           const onSuccessStub = sinon.stub();
 
-          await mobiusSocket.attemptConnection('ws://test.com', sessionId, callback, {
+          await mobiusSocket.attemptConnection('ws://test.com', callback, {
             isShutdownSwitchover: true,
             onSuccess: onSuccessStub,
           });
@@ -1932,12 +1828,12 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should emit shutdown switchover complete event', async () => {
-          await mobiusSocket.attemptConnection('ws://test.com', sessionId, callback, {
+          await mobiusSocket.attemptConnection('ws://test.com', callback, {
             isShutdownSwitchover: true,
             onSuccess: (newSocket, url) => {
               mobiusSocket.socket = newSocket;
               mobiusSocket.connected = true;
-              mobiusSocket.emitEvent(sessionId, 'event:mercury_shutdown_switchover_complete', {
+              mobiusSocket.emitEvent('event:mercury_shutdown_switchover_complete', {
                 url,
               });
             },
@@ -1945,7 +1841,6 @@ describe('plugin-mobius-socket', () => {
 
           assert.calledWith(
             mobiusSocket.emitEvent,
-            sessionId,
             'event:mercury_shutdown_switchover_complete',
             sinon.match.has('url', 'ws://new-socket.com')
           );
@@ -1955,7 +1850,7 @@ describe('plugin-mobius-socket', () => {
           prepareAndOpenSocketStub.returns(Promise.reject(new Error('Connection failed')));
 
           await mobiusSocket
-            .attemptConnection('ws://test.com', sessionId, callback, {
+            .attemptConnection('ws://test.com', callback, {
               isShutdownSwitchover: true,
             })
             .catch(() => {});
@@ -1964,10 +1859,10 @@ describe('plugin-mobius-socket', () => {
           assert.instanceOf(callback.firstCall.args[0], Error);
         });
 
-        it('should check _shutdownSwitchoverBackoffCall for shutdown connections', () => {
-          mobiusSocket.shutdownSwitchoverBackoffCalls.clear();
+        it('should check shutdownSwitchoverBackoffCall for shutdown connections', () => {
+          mobiusSocket.shutdownSwitchoverBackoffCall = undefined;
 
-          const result = mobiusSocket.attemptConnection('ws://test.com', sessionId, callback, {
+          const result = mobiusSocket.attemptConnection('ws://test.com', callback, {
             isShutdownSwitchover: true,
           });
 
@@ -1979,27 +1874,25 @@ describe('plugin-mobius-socket', () => {
       });
 
       describe('#_connectWithBackoff() with shutdown switchover', () => {
-        const sessionId = 'mobius-websocket-session';
-
         it('should use shutdown-specific parameters when called', () => {
           const connectWithBackoffStub = sinon
             .stub(mobiusSocket, 'connectWithBackoff')
             .returns(Promise.resolve());
 
-          mobiusSocket.handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown();
 
           assert.calledOnce(connectWithBackoffStub);
           const callArgs = connectWithBackoffStub.firstCall.args;
-          assert.equal(callArgs[1], sessionId);
-          assert.isObject(callArgs[2]);
-          assert.isTrue(callArgs[2].isShutdownSwitchover);
+          assert.isUndefined(callArgs[0]); // webSocketUrl
+          assert.isObject(callArgs[1]);
+          assert.isTrue(callArgs[1].isShutdownSwitchover);
 
           connectWithBackoffStub.restore();
         });
 
         it('should pass shutdown switchover options to _attemptConnection', () => {
           const attemptStub = sinon.stub(mobiusSocket, 'attemptConnection');
-          attemptStub.callsFake((url, sid, cb) => cb());
+          attemptStub.callsFake((url, cb) => cb());
 
           const context = {
             isShutdownSwitchover: true,
@@ -2009,30 +1902,29 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          const promise = mobiusSocket.connectWithBackoff(undefined, sessionId, context);
+          const promise = mobiusSocket.connectWithBackoff(undefined, context);
 
           return promise.then(() => {
             assert.calledOnce(attemptStub);
             const callArgs = attemptStub.firstCall.args;
-            assert.equal(callArgs[1], sessionId);
-            assert.isObject(callArgs[3]);
-            assert.isTrue(callArgs[3].isShutdownSwitchover);
+            assert.isObject(callArgs[2]);
+            assert.isTrue(callArgs[2].isShutdownSwitchover);
             attemptStub.restore();
           });
         });
 
         it('should set and clear state flags appropriately', () => {
-          sinon.stub(mobiusSocket, 'attemptConnection').callsFake((url, sid, cb) => cb());
+          sinon.stub(mobiusSocket, 'attemptConnection').callsFake((url, cb) => cb());
 
-          mobiusSocket.shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
+          mobiusSocket.shutdownSwitchoverBackoffCall = {placeholder: true};
 
-          const promise = mobiusSocket.connectWithBackoff(undefined, sessionId, {
+          const promise = mobiusSocket.connectWithBackoff(undefined, {
             isShutdownSwitchover: true,
             attemptOptions: {isShutdownSwitchover: true, onSuccess: () => {}},
           });
 
           return promise.then(() => {
-            assert.isUndefined(mobiusSocket.shutdownSwitchoverBackoffCalls.get(sessionId));
+            assert.isUndefined(mobiusSocket.shutdownSwitchoverBackoffCall);
             mobiusSocket.attemptConnection.restore();
           });
         });
@@ -2040,30 +1932,30 @@ describe('plugin-mobius-socket', () => {
 
       describe('#disconnect() with shutdown switchover in progress', () => {
         let abortStub;
-        const sessionId = 'mobius-websocket-session';
 
         beforeEach(() => {
-          mobiusSocket.sockets.clear();
-          mobiusSocket.sockets.set(sessionId, {
+          mobiusSocket.socket = {
             close: sinon.stub().returns(Promise.resolve()),
             removeAllListeners: sinon.stub(),
-          });
+            connecting: false,
+            connected: true,
+          };
           abortStub = sinon.stub();
-          mobiusSocket.shutdownSwitchoverBackoffCalls.set(sessionId, {abort: abortStub});
+          mobiusSocket.shutdownSwitchoverBackoffCall = {abort: abortStub};
         });
 
         it('should abort shutdown switchover backoff call on disconnect', async () => {
-          await mobiusSocket.disconnect(undefined, sessionId);
+          await mobiusSocket.disconnect();
 
           assert.calledOnce(abortStub);
         });
 
         it('should handle disconnect when no switchover is in progress', async () => {
-          mobiusSocket.shutdownSwitchoverBackoffCalls.clear();
+          mobiusSocket.shutdownSwitchoverBackoffCall = undefined;
 
-          await mobiusSocket.disconnect(undefined, sessionId);
+          await mobiusSocket.disconnect();
 
-          assert.calledOnce(mobiusSocket.sockets.get(sessionId).close);
+          assert.calledOnce(mobiusSocket.socket.close);
         });
       });
     });

--- a/packages/calling/src/mobius-socket/mobius-socket.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.test.ts
@@ -190,8 +190,8 @@ describe('plugin-mobius-socket', () => {
           // Ignore cleanup errors
         }
         // Clear any remaining connection promises
-        if (mobiusSocket._connectPromises) {
-          mobiusSocket._connectPromises.clear();
+        if (mobiusSocket.connectPromises) {
+          mobiusSocket.connectPromises.clear();
         }
       }
 
@@ -626,7 +626,7 @@ describe('plugin-mobius-socket', () => {
 
       describe('when config.initialConnectionMaxRetries is set to 0', () => {
         it('connects successfully through the shared backoff flow', () => {
-          const backoffSpy = sinon.spy(mobiusSocket, '_connectWithBackoff');
+          const backoffSpy = sinon.spy(mobiusSocket, 'connectWithBackoff');
           mobiusSocket.config.initialConnectionMaxRetries = 0;
           const promise = mobiusSocket.connect('ws://example.com');
 
@@ -662,7 +662,7 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('uses config-driven initial retry behavior in the shared backoff strategy', () => {
-          const backoffSpy = sinon.spy(mobiusSocket, '_connectWithBackoff');
+          const backoffSpy = sinon.spy(mobiusSocket, 'connectWithBackoff');
           mobiusSocket.config.initialConnectionMaxRetries = 0;
 
           const promise = mobiusSocket.connect('ws://example.com');
@@ -880,7 +880,7 @@ describe('plugin-mobius-socket', () => {
 
           mobiusSocket.backoffCalls.clear();
 
-          const promise = mobiusSocket._attemptConnection(
+          const promise = mobiusSocket.attemptConnection(
             'ws://example.com',
             'mobius-websocket-session',
             (_reason) => {
@@ -1090,7 +1090,7 @@ describe('plugin-mobius-socket', () => {
         sinon.stub(mobiusSocket.logger, 'error');
 
         return Promise.resolve(
-          mobiusSocket._emit(mobiusSocket.defaultSessionId, 'break', event)
+          mobiusSocket.emitEvent(mobiusSocket.defaultSessionId, 'break', event)
         ).then((res) => {
           assert.calledWith(
             mobiusSocket.logger.error,
@@ -1119,7 +1119,7 @@ describe('plugin-mobius-socket', () => {
           },
         };
 
-        mobiusSocket._applyOverrides(envelope);
+        mobiusSocket.applyOverrides(envelope);
 
         assert.equal(envelope.data.activity.target.lastSeenActivityDate, lastSeenActivityDate);
       });
@@ -1135,7 +1135,7 @@ describe('plugin-mobius-socket', () => {
           },
         };
 
-        mobiusSocket._applyOverrides(envelope);
+        mobiusSocket.applyOverrides(envelope);
 
         assert.equal(envelope.data.activity.target.lastSeenActivityDate, lastSeenActivityDate);
         assert.equal(
@@ -1154,7 +1154,7 @@ describe('plugin-mobius-socket', () => {
           },
         };
 
-        mobiusSocket._applyOverrides(envelope);
+        mobiusSocket.applyOverrides(envelope);
 
         assert.equal(envelope.data.activity.target.lastSeenActivityDate, lastSeenActivityDate);
       });
@@ -1168,7 +1168,7 @@ describe('plugin-mobius-socket', () => {
           },
         };
         assert.isUndefined(mobiusSocket.mercuryTimeOffset);
-        mobiusSocket._setTimeOffset('mobius-websocket-session', event);
+        mobiusSocket.setTimeOffset('mobius-websocket-session', event);
         assert.isDefined(mobiusSocket.mercuryTimeOffset);
         assert.isTrue(mobiusSocket.mercuryTimeOffset > 0);
       });
@@ -1178,7 +1178,7 @@ describe('plugin-mobius-socket', () => {
             wsWriteTimestamp: Date.now() + 60000,
           },
         };
-        mobiusSocket._setTimeOffset('mobius-websocket-session', event);
+        mobiusSocket.setTimeOffset('mobius-websocket-session', event);
         assert.isTrue(mobiusSocket.mercuryTimeOffset < 0);
       });
       it('handles invalid wsWriteTimestamp', () => {
@@ -1189,7 +1189,7 @@ describe('plugin-mobius-socket', () => {
               wsWriteTimestamp: invalidTimestamp,
             },
           };
-          mobiusSocket._setTimeOffset('mobius-websocket-session', event);
+          mobiusSocket.setTimeOffset('mobius-websocket-session', event);
           assert.isUndefined(mobiusSocket.mercuryTimeOffset);
         });
       });
@@ -1197,12 +1197,12 @@ describe('plugin-mobius-socket', () => {
 
     describe('#_prepareUrl()', () => {
       it('returns the provided URL as-is (no Mercury URL transforms)', () =>
-        mobiusSocket._prepareUrl('ws://provided.com').then((wsUrl) => {
+        mobiusSocket.prepareUrl('ws://provided.com').then((wsUrl) => {
           assert.equal(wsUrl, 'ws://provided.com');
         }));
 
       it('falls back to device webSocketUrl when no URL is provided', () =>
-        mobiusSocket._prepareUrl().then((wsUrl) => {
+        mobiusSocket.prepareUrl().then((wsUrl) => {
           assert.equal(wsUrl, 'ws://example.com');
         }));
     });
@@ -1219,28 +1219,28 @@ describe('plugin-mobius-socket', () => {
             removeAllListeners: sinon.stub(),
           });
           mobiusSocket.socket = mobiusSocket.sockets.get(sessionId);
-          connectWithBackoffStub = sinon.stub(mobiusSocket, '_connectWithBackoff');
+          connectWithBackoffStub = sinon.stub(mobiusSocket, 'connectWithBackoff');
           connectWithBackoffStub.returns(Promise.resolve());
-          sinon.stub(mobiusSocket, '_emit');
+          sinon.stub(mobiusSocket, 'emitEvent');
         });
 
         afterEach(() => {
           connectWithBackoffStub.restore();
-          mobiusSocket._emit.restore();
+          mobiusSocket.emitEvent.restore();
           mobiusSocket.sockets.clear();
         });
 
         it('should be idempotent - no-op if already in progress', () => {
           // Simulate an existing switchover in progress by seeding the backoff map
-          mobiusSocket._shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
+          mobiusSocket.shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
 
-          mobiusSocket._handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown(sessionId);
 
           assert.notCalled(connectWithBackoffStub);
         });
 
         it('should set switchover flags when called', () => {
-          mobiusSocket._handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown(sessionId);
 
           assert.calledOnce(connectWithBackoffStub);
           const callArgs = connectWithBackoffStub.firstCall.args;
@@ -1253,7 +1253,7 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should call _connectWithBackoff with correct parameters', (done) => {
-          mobiusSocket._handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown(sessionId);
 
           process.nextTick(() => {
             assert.calledOnce(connectWithBackoffStub);
@@ -1270,29 +1270,29 @@ describe('plugin-mobius-socket', () => {
 
         it('should handle exceptions during switchover', () => {
           connectWithBackoffStub.restore();
-          sinon.stub(mobiusSocket, '_connectWithBackoff').throws(new Error('Connection failed'));
+          sinon.stub(mobiusSocket, 'connectWithBackoff').throws(new Error('Connection failed'));
 
-          mobiusSocket._handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown(sessionId);
 
           // When an exception happens synchronously, the placeholder entry
           // should be removed from the map.
-          const switchoverCall = mobiusSocket._shutdownSwitchoverBackoffCalls.get(sessionId);
+          const switchoverCall = mobiusSocket.shutdownSwitchoverBackoffCalls.get(sessionId);
           assert.isUndefined(switchoverCall);
-          mobiusSocket._connectWithBackoff.restore();
+          mobiusSocket.connectWithBackoff.restore();
         });
       });
 
       describe('#_onmessage() with shutdown message', () => {
         beforeEach(() => {
-          sinon.stub(mobiusSocket, '_handleImminentShutdown');
-          sinon.stub(mobiusSocket, '_emit');
-          sinon.stub(mobiusSocket, '_setTimeOffset');
+          sinon.stub(mobiusSocket, 'handleImminentShutdown');
+          sinon.stub(mobiusSocket, 'emitEvent');
+          sinon.stub(mobiusSocket, 'setTimeOffset');
         });
 
         afterEach(() => {
-          mobiusSocket._handleImminentShutdown.restore();
-          mobiusSocket._emit.restore();
-          mobiusSocket._setTimeOffset.restore();
+          mobiusSocket.handleImminentShutdown.restore();
+          mobiusSocket.emitEvent.restore();
+          mobiusSocket.setTimeOffset.restore();
         });
 
         it('should trigger _handleImminentShutdown on shutdown message', () => {
@@ -1302,11 +1302,11 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          const result = mobiusSocket._onmessage(mobiusSocket.defaultSessionId, shutdownEvent);
+          const result = mobiusSocket.onmessage(mobiusSocket.defaultSessionId, shutdownEvent);
 
-          assert.calledOnce(mobiusSocket._handleImminentShutdown);
+          assert.calledOnce(mobiusSocket.handleImminentShutdown);
           assert.calledWith(
-            mobiusSocket._emit,
+            mobiusSocket.emitEvent,
             mobiusSocket.defaultSessionId,
             'event:mercury_shutdown_imminent',
             shutdownEvent.data
@@ -1321,9 +1321,9 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          mobiusSocket._onmessage(mobiusSocket.defaultSessionId, shutdownEvent);
+          mobiusSocket.onmessage(mobiusSocket.defaultSessionId, shutdownEvent);
 
-          assert.calledOnce(mobiusSocket._handleImminentShutdown);
+          assert.calledOnce(mobiusSocket.handleImminentShutdown);
         });
 
         it('should not trigger shutdown handling for non-shutdown messages', () => {
@@ -1336,23 +1336,23 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          mobiusSocket._onmessage(mobiusSocket.defaultSessionId, regularEvent);
+          mobiusSocket.onmessage(mobiusSocket.defaultSessionId, regularEvent);
 
-          assert.notCalled(mobiusSocket._handleImminentShutdown);
+          assert.notCalled(mobiusSocket.handleImminentShutdown);
         });
       });
 
       describe('#_onmessage() with missing data or eventType', () => {
         beforeEach(() => {
-          sinon.stub(mobiusSocket, '_emit');
-          sinon.stub(mobiusSocket, '_setTimeOffset');
-          sinon.stub(mobiusSocket, '_applyOverrides');
+          sinon.stub(mobiusSocket, 'emitEvent');
+          sinon.stub(mobiusSocket, 'setTimeOffset');
+          sinon.stub(mobiusSocket, 'applyOverrides');
         });
 
         afterEach(() => {
-          mobiusSocket._emit.restore();
-          mobiusSocket._setTimeOffset.restore();
-          mobiusSocket._applyOverrides.restore();
+          mobiusSocket.emitEvent.restore();
+          mobiusSocket.setTimeOffset.restore();
+          mobiusSocket.applyOverrides.restore();
         });
 
         it('should not throw when envelope.data is undefined', () => {
@@ -1363,10 +1363,15 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          const result = mobiusSocket._onmessage(mobiusSocket.defaultSessionId, event);
+          const result = mobiusSocket.onmessage(mobiusSocket.defaultSessionId, event);
 
           assert.instanceOf(result, Promise);
-          assert.calledWith(mobiusSocket._emit, mobiusSocket.defaultSessionId, 'event', event.data);
+          assert.calledWith(
+            mobiusSocket.emitEvent,
+            mobiusSocket.defaultSessionId,
+            'event',
+            event.data
+          );
         });
 
         it('should not throw when data.eventType is undefined', () => {
@@ -1380,10 +1385,15 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          const result = mobiusSocket._onmessage(mobiusSocket.defaultSessionId, event);
+          const result = mobiusSocket.onmessage(mobiusSocket.defaultSessionId, event);
 
           assert.instanceOf(result, Promise);
-          assert.calledWith(mobiusSocket._emit, mobiusSocket.defaultSessionId, 'event', event.data);
+          assert.calledWith(
+            mobiusSocket.emitEvent,
+            mobiusSocket.defaultSessionId,
+            'event',
+            event.data
+          );
         });
 
         it('should emit generic event for messages without eventType (e.g. subscription responses)', () => {
@@ -1397,11 +1407,16 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          const result = mobiusSocket._onmessage(mobiusSocket.defaultSessionId, event);
+          const result = mobiusSocket.onmessage(mobiusSocket.defaultSessionId, event);
 
           assert.instanceOf(result, Promise);
-          assert.calledOnce(mobiusSocket._emit);
-          assert.calledWith(mobiusSocket._emit, mobiusSocket.defaultSessionId, 'event', event.data);
+          assert.calledOnce(mobiusSocket.emitEvent);
+          assert.calledWith(
+            mobiusSocket.emitEvent,
+            mobiusSocket.defaultSessionId,
+            'event',
+            event.data
+          );
         });
 
         it('should still process messages with a valid eventType', async () => {
@@ -1413,18 +1428,18 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          await mobiusSocket._onmessage(mobiusSocket.defaultSessionId, event);
+          await mobiusSocket.onmessage(mobiusSocket.defaultSessionId, event);
 
           // Normal flow emits namespace-specific events after processing handlers.
           // The early-return guard only emits 'event', so asserting these proves the normal path was taken.
           assert.calledWith(
-            mobiusSocket._emit,
+            mobiusSocket.emitEvent,
             mobiusSocket.defaultSessionId,
             'event:conversation',
             event.data
           );
           assert.calledWith(
-            mobiusSocket._emit,
+            mobiusSocket.emitEvent,
             mobiusSocket.defaultSessionId,
             'event:conversation.activity',
             event.data
@@ -1444,10 +1459,10 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('suppresses duplicate async_event messages for the same session', async () => {
-          const emitSpy = sinon.spy(mobiusSocket, '_emit');
+          const emitSpy = sinon.spy(mobiusSocket, 'emitEvent');
 
-          await mobiusSocket._onmessage('session-a', createAsyncEvent('evt-1'));
-          await mobiusSocket._onmessage('session-a', createAsyncEvent('evt-1'));
+          await mobiusSocket.onmessage('session-a', createAsyncEvent('evt-1'));
+          await mobiusSocket.onmessage('session-a', createAsyncEvent('evt-1'));
 
           assert.equal(countGenericEventEmits(emitSpy, 'session-a'), 1);
           emitSpy.restore();
@@ -1455,29 +1470,29 @@ describe('plugin-mobius-socket', () => {
 
         it('suppresses duplicate async_event messages across socket replacement without disconnect', async () => {
           const sessionId = 'session-a';
-          const emitSpy = sinon.spy(mobiusSocket, '_emit');
+          const emitSpy = sinon.spy(mobiusSocket, 'emitEvent');
           mobiusSocket.sockets.set(sessionId, createSessionSocket());
 
-          await mobiusSocket._onmessage(sessionId, createAsyncEvent('evt-2'));
+          await mobiusSocket.onmessage(sessionId, createAsyncEvent('evt-2'));
 
           mobiusSocket.sockets.set(sessionId, createSessionSocket());
-          await mobiusSocket._onmessage(sessionId, createAsyncEvent('evt-2'));
+          await mobiusSocket.onmessage(sessionId, createAsyncEvent('evt-2'));
 
           assert.equal(countGenericEventEmits(emitSpy, sessionId), 1);
           emitSpy.restore();
         });
 
         it('evicts only the oldest eventId when the dedup cache exceeds max size', async () => {
-          const emitSpy = sinon.spy(mobiusSocket, '_emit');
+          const emitSpy = sinon.spy(mobiusSocket, 'emitEvent');
 
           mobiusSocket.config.dedupCacheMaxSize = 3;
 
-          await mobiusSocket._onmessage('session-a', createAsyncEvent('e1'));
-          await mobiusSocket._onmessage('session-a', createAsyncEvent('e2'));
-          await mobiusSocket._onmessage('session-a', createAsyncEvent('e3'));
-          await mobiusSocket._onmessage('session-a', createAsyncEvent('e4'));
-          await mobiusSocket._onmessage('session-a', createAsyncEvent('e2'));
-          await mobiusSocket._onmessage('session-a', createAsyncEvent('e1'));
+          await mobiusSocket.onmessage('session-a', createAsyncEvent('e1'));
+          await mobiusSocket.onmessage('session-a', createAsyncEvent('e2'));
+          await mobiusSocket.onmessage('session-a', createAsyncEvent('e3'));
+          await mobiusSocket.onmessage('session-a', createAsyncEvent('e4'));
+          await mobiusSocket.onmessage('session-a', createAsyncEvent('e2'));
+          await mobiusSocket.onmessage('session-a', createAsyncEvent('e1'));
 
           assert.equal(countGenericEventEmits(emitSpy, 'session-a'), 5);
           emitSpy.restore();
@@ -1485,13 +1500,13 @@ describe('plugin-mobius-socket', () => {
 
         it('clears the session dedup cache on disconnect', async () => {
           const sessionId = 'session-a';
-          const emitSpy = sinon.spy(mobiusSocket, '_emit');
+          const emitSpy = sinon.spy(mobiusSocket, 'emitEvent');
 
-          await mobiusSocket._onmessage(sessionId, createAsyncEvent('evt-3'));
+          await mobiusSocket.onmessage(sessionId, createAsyncEvent('evt-3'));
 
           mobiusSocket.sockets.set(sessionId, createSessionSocket());
           await mobiusSocket.disconnect(undefined, sessionId);
-          await mobiusSocket._onmessage(sessionId, createAsyncEvent('evt-3'));
+          await mobiusSocket.onmessage(sessionId, createAsyncEvent('evt-3'));
 
           assert.equal(countGenericEventEmits(emitSpy, sessionId), 2);
           emitSpy.restore();
@@ -1500,25 +1515,25 @@ describe('plugin-mobius-socket', () => {
 
       describe('#_getEventHandlers()', () => {
         it('should return an empty array when eventType is undefined', () => {
-          const result = mobiusSocket._getEventHandlers(undefined);
+          const result = mobiusSocket.getEventHandlers(undefined);
 
           assert.deepEqual(result, []);
         });
 
         it('should return an empty array when eventType is null', () => {
-          const result = mobiusSocket._getEventHandlers(null);
+          const result = mobiusSocket.getEventHandlers(null);
 
           assert.deepEqual(result, []);
         });
 
         it('should return an empty array when eventType is an empty string', () => {
-          const result = mobiusSocket._getEventHandlers('');
+          const result = mobiusSocket.getEventHandlers('');
 
           assert.deepEqual(result, []);
         });
 
         it('should return an empty array when namespace is not registered', () => {
-          const result = mobiusSocket._getEventHandlers('unknownNamespace.someEvent');
+          const result = mobiusSocket.getEventHandlers('unknownNamespace.someEvent');
 
           assert.deepEqual(result, []);
         });
@@ -1540,13 +1555,13 @@ describe('plugin-mobius-socket', () => {
           mobiusSocket.socket = mockSocket;
           mobiusSocket.sockets.set(mobiusSocket.defaultSessionId, mockSocket);
           mobiusSocket.connected = true;
-          sinon.stub(mobiusSocket, '_emit');
-          sinon.stub(mobiusSocket, '_reconnect');
+          sinon.stub(mobiusSocket, 'emitEvent');
+          sinon.stub(mobiusSocket, 'reconnect');
         });
 
         afterEach(() => {
-          mobiusSocket._emit.restore();
-          mobiusSocket._reconnect.restore();
+          mobiusSocket.emitEvent.restore();
+          mobiusSocket.reconnect.restore();
         });
 
         it('should handle active socket close with 4001 - permanent failure', () => {
@@ -1555,15 +1570,15 @@ describe('plugin-mobius-socket', () => {
             reason: 'replaced during shutdown',
           };
 
-          mobiusSocket._onclose(mobiusSocket.defaultSessionId, closeEvent, mockSocket);
+          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, mockSocket);
 
           assert.calledWith(
-            mobiusSocket._emit,
+            mobiusSocket.emitEvent,
             mobiusSocket.defaultSessionId,
             'offline.permanent',
             closeEvent
           );
-          assert.notCalled(mobiusSocket._reconnect); // No reconnect for 4001 on active socket
+          assert.notCalled(mobiusSocket.reconnect); // No reconnect for 4001 on active socket
           assert.isFalse(mobiusSocket.connected);
         });
 
@@ -1573,15 +1588,15 @@ describe('plugin-mobius-socket', () => {
             reason: 'replaced during shutdown',
           };
 
-          mobiusSocket._onclose(mobiusSocket.defaultSessionId, closeEvent, anotherSocket);
+          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, anotherSocket);
 
           assert.calledWith(
-            mobiusSocket._emit,
+            mobiusSocket.emitEvent,
             mobiusSocket.defaultSessionId,
             'offline.replaced',
             closeEvent
           );
-          assert.notCalled(mobiusSocket._reconnect);
+          assert.notCalled(mobiusSocket.reconnect);
           assert.isTrue(mobiusSocket.connected); // Should remain connected
           assert.strictEqual(mobiusSocket.socket, mockSocket);
         });
@@ -1593,22 +1608,22 @@ describe('plugin-mobius-socket', () => {
           };
 
           // Test non-active socket
-          mobiusSocket._onclose(mobiusSocket.defaultSessionId, closeEvent, anotherSocket);
+          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, anotherSocket);
           assert.calledWith(
-            mobiusSocket._emit,
+            mobiusSocket.emitEvent,
             mobiusSocket.defaultSessionId,
             'offline.replaced',
             closeEvent
           );
 
           // Reset the spy call history
-          mobiusSocket._emit.resetHistory();
+          mobiusSocket.emitEvent.resetHistory();
 
           // Test active socket
           mobiusSocket.sockets.set(mobiusSocket.defaultSessionId, mockSocket);
-          mobiusSocket._onclose(mobiusSocket.defaultSessionId, closeEvent, mockSocket);
+          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, mockSocket);
           assert.calledWith(
-            mobiusSocket._emit,
+            mobiusSocket.emitEvent,
             mobiusSocket.defaultSessionId,
             'offline.permanent',
             closeEvent
@@ -1621,16 +1636,16 @@ describe('plugin-mobius-socket', () => {
             reason: 'replaced during shutdown',
           };
 
-          mobiusSocket._onclose(mobiusSocket.defaultSessionId, closeEvent); // No sourceSocket parameter
+          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent); // No sourceSocket parameter
 
           // With simplified logic, undefined !== this.socket, so isActiveSocket = false
           assert.calledWith(
-            mobiusSocket._emit,
+            mobiusSocket.emitEvent,
             mobiusSocket.defaultSessionId,
             'offline.replaced',
             closeEvent
           );
-          assert.notCalled(mobiusSocket._reconnect);
+          assert.notCalled(mobiusSocket.reconnect);
         });
 
         it('should clean up event listeners from non-active socket when it closes', () => {
@@ -1640,7 +1655,7 @@ describe('plugin-mobius-socket', () => {
           };
 
           // Close non-active socket (not the active one)
-          mobiusSocket._onclose(mobiusSocket.defaultSessionId, closeEvent, anotherSocket);
+          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, anotherSocket);
 
           // Verify listeners were removed from the old socket
           // The _onclose method checks if sourceSocket !== this.socket (non-active)
@@ -1655,7 +1670,7 @@ describe('plugin-mobius-socket', () => {
           };
 
           // Close active socket
-          mobiusSocket._onclose(mobiusSocket.defaultSessionId, closeEvent, mockSocket);
+          mobiusSocket.onclose(mobiusSocket.defaultSessionId, closeEvent, mockSocket);
 
           // Verify listeners were removed from active socket
           assert.calledOnce(mockSocket.removeAllListeners);
@@ -1673,20 +1688,20 @@ describe('plugin-mobius-socket', () => {
             removeAllListeners: sinon.stub(),
           });
           mobiusSocket.socket = mobiusSocket.sockets.get(sessionId);
-          connectWithBackoffStub = sinon.stub(mobiusSocket, '_connectWithBackoff');
-          sinon.stub(mobiusSocket, '_emit');
+          connectWithBackoffStub = sinon.stub(mobiusSocket, 'connectWithBackoff');
+          sinon.stub(mobiusSocket, 'emitEvent');
         });
 
         afterEach(() => {
           connectWithBackoffStub.restore();
-          mobiusSocket._emit.restore();
+          mobiusSocket.emitEvent.restore();
           mobiusSocket.sockets.clear();
         });
 
         it('should call _connectWithBackoff with shutdown switchover context', (done) => {
           connectWithBackoffStub.returns(Promise.resolve());
 
-          mobiusSocket._handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown(sessionId);
 
           process.nextTick(() => {
             assert.calledOnce(connectWithBackoffStub);
@@ -1708,14 +1723,14 @@ describe('plugin-mobius-socket', () => {
           // Since _connectWithBackoff is stubbed in this suite, simulate its side-effect
           // of seeding the backoff-call map entry.
           connectWithBackoffStub.callsFake(() => {
-            mobiusSocket._shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
+            mobiusSocket.shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
 
             return new Promise(() => {}); // Never resolves
           });
 
-          mobiusSocket._handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown(sessionId);
 
-          const switchoverBackoffCall = mobiusSocket._shutdownSwitchoverBackoffCalls.get(sessionId);
+          const switchoverBackoffCall = mobiusSocket.shutdownSwitchoverBackoffCalls.get(sessionId);
           assert.isOk(switchoverBackoffCall);
         });
 
@@ -1729,11 +1744,11 @@ describe('plugin-mobius-socket', () => {
             return Promise.resolve();
           });
 
-          mobiusSocket._handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown(sessionId);
 
           await promiseTick(50);
 
-          const emitCalls = mobiusSocket._emit.getCalls();
+          const emitCalls = mobiusSocket.emitEvent.getCalls();
           const hasCompleteEvent = emitCalls.some(
             (call) =>
               call.args[0] === sessionId &&
@@ -1748,10 +1763,10 @@ describe('plugin-mobius-socket', () => {
 
           connectWithBackoffStub.returns(Promise.reject(testError));
 
-          mobiusSocket._handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown(sessionId);
           await promiseTick(50);
 
-          const emitCalls = mobiusSocket._emit.getCalls();
+          const emitCalls = mobiusSocket.emitEvent.getCalls();
           const hasFailureEvent = emitCalls.some(
             (call) =>
               call.args[0] === sessionId &&
@@ -1766,7 +1781,7 @@ describe('plugin-mobius-socket', () => {
         it('should allow old socket to be closed by server after switchover failure', async () => {
           connectWithBackoffStub.returns(Promise.reject(new Error('Failed')));
 
-          mobiusSocket._handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown(sessionId);
           await promiseTick(50);
 
           assert.equal(mobiusSocket.socket.removeAllListeners.callCount, 0);
@@ -1783,7 +1798,7 @@ describe('plugin-mobius-socket', () => {
             open: sinon.stub().returns(Promise.resolve()),
           };
           prepareUrlStub = sinon
-            .stub(mobiusSocket, '_prepareUrl')
+            .stub(mobiusSocket, 'prepareUrl')
             .returns(Promise.resolve('ws://example.com'));
           getUserTokenStub = webex.credentials.getUserToken;
           getUserTokenStub.returns(
@@ -1798,7 +1813,7 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should prepare URL and get user token', async () => {
-          await mobiusSocket._prepareAndOpenSocket(mockSocket, 'ws://test.com', false);
+          await mobiusSocket.prepareAndOpenSocket(mockSocket, 'ws://test.com', false);
 
           assert.calledOnce(prepareUrlStub);
           assert.calledWith(prepareUrlStub, 'ws://test.com');
@@ -1806,7 +1821,7 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should open socket with correct options for normal connection', async () => {
-          await mobiusSocket._prepareAndOpenSocket(mockSocket, undefined, false);
+          await mobiusSocket.prepareAndOpenSocket(mockSocket, undefined, false);
 
           assert.calledOnce(mockSocket.open);
           const callArgs = mockSocket.open.firstCall.args;
@@ -1819,7 +1834,7 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should log with correct prefix for normal connection', async () => {
-          await mobiusSocket._prepareAndOpenSocket(mockSocket, undefined, false);
+          await mobiusSocket.prepareAndOpenSocket(mockSocket, undefined, false);
 
           // The method should complete successfully - we're testing it runs without error
           // Actual log message verification is complex due to existing stubs in parent scope
@@ -1827,7 +1842,7 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should log with shutdown prefix for shutdown connection', async () => {
-          await mobiusSocket._prepareAndOpenSocket(mockSocket, undefined, true);
+          await mobiusSocket.prepareAndOpenSocket(mockSocket, undefined, true);
 
           // The method should complete successfully with shutdown flag
           assert.calledOnce(mockSocket.open);
@@ -1839,7 +1854,7 @@ describe('plugin-mobius-socket', () => {
             wssResponseTimeout: 99999,
           };
 
-          await mobiusSocket._prepareAndOpenSocket(mockSocket, undefined, false);
+          await mobiusSocket.prepareAndOpenSocket(mockSocket, undefined, false);
 
           const callArgs = mockSocket.open.firstCall.args;
 
@@ -1848,7 +1863,7 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should return the webSocketUrl after opening', async () => {
-          const result = await mobiusSocket._prepareAndOpenSocket(mockSocket, undefined, false);
+          const result = await mobiusSocket.prepareAndOpenSocket(mockSocket, undefined, false);
 
           assert.equal(result, 'ws://example.com');
         });
@@ -1857,7 +1872,7 @@ describe('plugin-mobius-socket', () => {
           mockSocket.open.returns(Promise.reject(new Error('Open failed')));
 
           try {
-            await mobiusSocket._prepareAndOpenSocket(mockSocket, undefined, false);
+            await mobiusSocket.prepareAndOpenSocket(mockSocket, undefined, false);
             assert.fail('Should have thrown an error');
           } catch (err) {
             assert.equal(err.message, 'Open failed');
@@ -1872,27 +1887,27 @@ describe('plugin-mobius-socket', () => {
 
         beforeEach(() => {
           prepareAndOpenSocketStub = sinon
-            .stub(mobiusSocket, '_prepareAndOpenSocket')
+            .stub(mobiusSocket, 'prepareAndOpenSocket')
             .returns(Promise.resolve('ws://new-socket.com'));
           callback = sinon.stub();
-          mobiusSocket._shutdownSwitchoverBackoffCalls.set(sessionId, {abort: sinon.stub()});
+          mobiusSocket.shutdownSwitchoverBackoffCalls.set(sessionId, {abort: sinon.stub()});
           mobiusSocket.socket = {url: 'ws://test.com'};
           mobiusSocket.connected = true;
-          sinon.stub(mobiusSocket, '_emit');
-          sinon.stub(mobiusSocket, '_attachSocketEventListeners');
+          sinon.stub(mobiusSocket, 'emitEvent');
+          sinon.stub(mobiusSocket, 'attachSocketEventListeners');
         });
 
         afterEach(() => {
           prepareAndOpenSocketStub.restore();
-          mobiusSocket._emit.restore();
-          mobiusSocket._attachSocketEventListeners.restore();
-          mobiusSocket._shutdownSwitchoverBackoffCalls.clear();
+          mobiusSocket.emitEvent.restore();
+          mobiusSocket.attachSocketEventListeners.restore();
+          mobiusSocket.shutdownSwitchoverBackoffCalls.clear();
         });
 
         it('should not set socket reference before opening for shutdown switchover', async () => {
           const originalSocket = mobiusSocket.socket;
 
-          await mobiusSocket._attemptConnection('ws://test.com', sessionId, callback, {
+          await mobiusSocket.attemptConnection('ws://test.com', sessionId, callback, {
             isShutdownSwitchover: true,
             onSuccess: (newSocket, url) => {
               assert.exists(newSocket);
@@ -1907,7 +1922,7 @@ describe('plugin-mobius-socket', () => {
         it('should call onSuccess callback with new socket and URL for shutdown', async () => {
           const onSuccessStub = sinon.stub();
 
-          await mobiusSocket._attemptConnection('ws://test.com', sessionId, callback, {
+          await mobiusSocket.attemptConnection('ws://test.com', sessionId, callback, {
             isShutdownSwitchover: true,
             onSuccess: onSuccessStub,
           });
@@ -1917,17 +1932,19 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should emit shutdown switchover complete event', async () => {
-          await mobiusSocket._attemptConnection('ws://test.com', sessionId, callback, {
+          await mobiusSocket.attemptConnection('ws://test.com', sessionId, callback, {
             isShutdownSwitchover: true,
             onSuccess: (newSocket, url) => {
               mobiusSocket.socket = newSocket;
               mobiusSocket.connected = true;
-              mobiusSocket._emit(sessionId, 'event:mercury_shutdown_switchover_complete', {url});
+              mobiusSocket.emitEvent(sessionId, 'event:mercury_shutdown_switchover_complete', {
+                url,
+              });
             },
           });
 
           assert.calledWith(
-            mobiusSocket._emit,
+            mobiusSocket.emitEvent,
             sessionId,
             'event:mercury_shutdown_switchover_complete',
             sinon.match.has('url', 'ws://new-socket.com')
@@ -1938,7 +1955,7 @@ describe('plugin-mobius-socket', () => {
           prepareAndOpenSocketStub.returns(Promise.reject(new Error('Connection failed')));
 
           await mobiusSocket
-            ._attemptConnection('ws://test.com', sessionId, callback, {
+            .attemptConnection('ws://test.com', sessionId, callback, {
               isShutdownSwitchover: true,
             })
             .catch(() => {});
@@ -1948,9 +1965,9 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should check _shutdownSwitchoverBackoffCall for shutdown connections', () => {
-          mobiusSocket._shutdownSwitchoverBackoffCalls.clear();
+          mobiusSocket.shutdownSwitchoverBackoffCalls.clear();
 
-          const result = mobiusSocket._attemptConnection('ws://test.com', sessionId, callback, {
+          const result = mobiusSocket.attemptConnection('ws://test.com', sessionId, callback, {
             isShutdownSwitchover: true,
           });
 
@@ -1966,10 +1983,10 @@ describe('plugin-mobius-socket', () => {
 
         it('should use shutdown-specific parameters when called', () => {
           const connectWithBackoffStub = sinon
-            .stub(mobiusSocket, '_connectWithBackoff')
+            .stub(mobiusSocket, 'connectWithBackoff')
             .returns(Promise.resolve());
 
-          mobiusSocket._handleImminentShutdown(sessionId);
+          mobiusSocket.handleImminentShutdown(sessionId);
 
           assert.calledOnce(connectWithBackoffStub);
           const callArgs = connectWithBackoffStub.firstCall.args;
@@ -1981,7 +1998,7 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should pass shutdown switchover options to _attemptConnection', () => {
-          const attemptStub = sinon.stub(mobiusSocket, '_attemptConnection');
+          const attemptStub = sinon.stub(mobiusSocket, 'attemptConnection');
           attemptStub.callsFake((url, sid, cb) => cb());
 
           const context = {
@@ -1992,7 +2009,7 @@ describe('plugin-mobius-socket', () => {
             },
           };
 
-          const promise = mobiusSocket._connectWithBackoff(undefined, sessionId, context);
+          const promise = mobiusSocket.connectWithBackoff(undefined, sessionId, context);
 
           return promise.then(() => {
             assert.calledOnce(attemptStub);
@@ -2005,18 +2022,18 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should set and clear state flags appropriately', () => {
-          sinon.stub(mobiusSocket, '_attemptConnection').callsFake((url, sid, cb) => cb());
+          sinon.stub(mobiusSocket, 'attemptConnection').callsFake((url, sid, cb) => cb());
 
-          mobiusSocket._shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
+          mobiusSocket.shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
 
-          const promise = mobiusSocket._connectWithBackoff(undefined, sessionId, {
+          const promise = mobiusSocket.connectWithBackoff(undefined, sessionId, {
             isShutdownSwitchover: true,
             attemptOptions: {isShutdownSwitchover: true, onSuccess: () => {}},
           });
 
           return promise.then(() => {
-            assert.isUndefined(mobiusSocket._shutdownSwitchoverBackoffCalls.get(sessionId));
-            mobiusSocket._attemptConnection.restore();
+            assert.isUndefined(mobiusSocket.shutdownSwitchoverBackoffCalls.get(sessionId));
+            mobiusSocket.attemptConnection.restore();
           });
         });
       });
@@ -2032,7 +2049,7 @@ describe('plugin-mobius-socket', () => {
             removeAllListeners: sinon.stub(),
           });
           abortStub = sinon.stub();
-          mobiusSocket._shutdownSwitchoverBackoffCalls.set(sessionId, {abort: abortStub});
+          mobiusSocket.shutdownSwitchoverBackoffCalls.set(sessionId, {abort: abortStub});
         });
 
         it('should abort shutdown switchover backoff call on disconnect', async () => {
@@ -2042,7 +2059,7 @@ describe('plugin-mobius-socket', () => {
         });
 
         it('should handle disconnect when no switchover is in progress', async () => {
-          mobiusSocket._shutdownSwitchoverBackoffCalls.clear();
+          mobiusSocket.shutdownSwitchoverBackoffCalls.clear();
 
           await mobiusSocket.disconnect(undefined, sessionId);
 

--- a/packages/calling/src/mobius-socket/mobius-socket.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.ts
@@ -10,13 +10,7 @@ import backoff from 'backoff';
 
 import type {WebexSDK} from '../SDKConnector/types';
 import Socket from './socket';
-import {
-  BadRequest,
-  Forbidden,
-  NotAuthorized,
-  UnknownResponse,
-  // NotFound
-} from './errors';
+import {BadRequest, Forbidden, NotAuthorized, UnknownResponse} from './errors';
 import type {MobiusSocketConfig} from './config';
 import type {SocketResponse} from './socket/types';
 import type {
@@ -283,22 +277,6 @@ class MobiusSocket extends EventEmitter {
   }
 
   /**
-   * Get the last error.
-   * @returns {unknown} The last error.
-   */
-  getLastError(): unknown {
-    return this.lastError;
-  }
-
-  /**
-   * Get all active socket connections
-   * @returns {Map} Map of sessionId to socket instances
-   */
-  getSockets() {
-    return this.sockets;
-  }
-
-  /**
    * Get a specific socket by connection ID
    * @param {string} sessionId - The connection identifier
    * @returns {Socket|undefined} The socket instance or undefined if not found
@@ -320,22 +298,6 @@ class MobiusSocket extends EventEmitter {
     }
 
     return socket.url;
-  }
-
-  /**
-   * Sends a payload on the active connected socket
-   * @param {Object} payload - The data to send
-   * @param {string} [sessionId=this.defaultSessionId] - The session identifier
-   * @returns {Promise}
-   */
-  send(payload: Record<string, unknown>, sessionId = this.defaultSessionId): Promise<void> {
-    const socket = this.getSocket(sessionId);
-
-    if (!socket || !socket.connected) {
-      return Promise.reject(new Error(`Mobius socket is not connected for session ${sessionId}`));
-    }
-
-    return socket.send(payload);
   }
 
   /**
@@ -494,17 +456,6 @@ class MobiusSocket extends EventEmitter {
     return connectPromise;
   }
 
-  logout(): Promise<void> {
-    this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: logout() called`);
-
-    return this.disconnectAll(
-      this.config.beforeLogoutOptionsCloseReason &&
-        !normalReconnectReasons.includes(this.config.beforeLogoutOptionsCloseReason)
-        ? {code: 3050, reason: this.config.beforeLogoutOptionsCloseReason}
-        : undefined
-    );
-  }
-
   /**
    * Disconnect a Mobius socket for a specific session.
    * @param {object} [options] - Optional websocket close options (for example: `{code, reason}`).
@@ -564,34 +515,6 @@ class MobiusSocket extends EventEmitter {
     });
   }
 
-  /**
-   * Disconnect all socket connections
-   * @param {object} options - Close options
-   * @returns {Promise} Promise that resolves when all connections are closed
-   */
-  disconnectAll(options?: MobiusSocketCloseOptions): Promise<void> {
-    const disconnectPromises = [];
-
-    for (const sessionId of this.sockets.keys()) {
-      disconnectPromises.push(this.disconnect(options, sessionId));
-    }
-
-    return Promise.all(disconnectPromises).then(() => {
-      this.connected = false;
-      this.socket = undefined;
-      this.sockets.clear();
-      this.backoffCalls.clear();
-      this._shutdownSwitchoverBackoffCalls.clear();
-      this._clearSeenAsyncEventIds();
-      this._stopTokenRefreshTimer();
-      this._connectPromises.clear();
-    });
-  }
-
-  processRegistrationStatusEvent(message) {
-    this.localClusterServiceUrls = message.localClusterServiceUrls;
-  }
-
   // eslint-disable-next-line class-methods-use-this
   _createWssResponseError(
     response: SocketResponse,
@@ -627,16 +550,6 @@ class MobiusSocket extends EventEmitter {
     if (!webSocketUrl) {
       webSocketUrl = this.webex.internal.device.webSocketUrl;
     }
-
-    // TODO: Validate the host against the service catalog
-    // const hostFromUrl = url.parse(webSocketUrl, true)?.host;
-    // const isValidHost = this.webex.internal.services.isValidHost(hostFromUrl);
-    // if (!isValidHost) {
-    //   this.logger.error(
-    //     `${MOBIUS_SOCKET_NAMESPACE}: host ${hostFromUrl} is not a valid host from host catalog`
-    //   );
-    //   return Promise.resolve('');
-    // }
 
     return Promise.resolve(webSocketUrl);
   }
@@ -709,8 +622,6 @@ class MobiusSocket extends EventEmitter {
         }
 
         // Normal connection error handling (existing complex logic)
-        this.lastError = reason; // remember the last error
-
         const backoffCallNormal = this.backoffCalls.get(sessionId);
         // Suppress connection errors that appear to be network related. This
         // may end up suppressing metrics during outages, but we might not care
@@ -744,12 +655,6 @@ class MobiusSocket extends EventEmitter {
 
           return this.webex.credentials.refresh({force: true}).then(() => callback(reason));
         }
-        // // NotFound implies expired web socket url
-        // else if (reason instanceof NotFound) {
-        //   this.logger.info(`mercury: received not found error, refreshing device registration`);
-        //   return this.webex.internal.device.refresh()
-        //     .then(() => callback(reason));
-        // }
         // BadRequest implies current credentials are for a Service Account
         // Forbidden implies current user is not entitled for Webex
         if (reason instanceof BadRequest || reason instanceof Forbidden) {

--- a/packages/calling/src/mobius-socket/mobius-socket.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.ts
@@ -5,7 +5,6 @@
  */
 
 import {EventEmitter} from 'events';
-import {camelCase, set} from 'lodash';
 import backoff from 'backoff';
 
 import type {WebexSDK} from '../SDKConnector/types';
@@ -50,11 +49,8 @@ class MobiusSocket extends EventEmitter {
     this.shutdownSwitchoverBackoffCall = undefined;
     this.seenAsyncEventIds = new Map();
     this.connectPromise = undefined;
-    this.mercuryTimeOffset = undefined;
     this.tokenRefreshTimer = undefined;
     this.tokenRefreshInFlight = undefined;
-
-    this.bindInternalEvents();
   }
 
   public off(eventName: string, listener?: (...args: unknown[]) => void) {
@@ -67,46 +63,6 @@ class MobiusSocket extends EventEmitter {
     return this;
   }
 
-  private bindInternalEvents() {
-    /*
-      When one of these legacy feature gets updated, this event would be triggered
-        * group-message-notifications
-        * mention-notifications
-        * thread-notifications
-    */
-    this.on('event:featureToggle_update', (envelope) => {
-      if (envelope && envelope.data) {
-        this.webex.internal.feature.updateFeature(envelope.data.featureToggle);
-      }
-    });
-    /*
-     * When Cluster Migrations, notify clients using ActiveClusterStatusEvent via mercury
-     * https://wwwin-github.cisco.com/pages/Webex/crr-docs/techdocs/rr-002.html#wip-notifying-clients-of-cluster-migrations
-     * */
-    this.on('event:ActiveClusterStatusEvent', (envelope) => {
-      if (
-        typeof this.webex.internal.services?.switchActiveClusterIds === 'function' &&
-        envelope &&
-        envelope.data
-      ) {
-        this.webex.internal.services.switchActiveClusterIds(envelope.data?.activeClusters);
-      }
-    });
-    /*
-     * Using cache-invalidation via mercury to instead the method of polling via the new /timestamp endpoint from u2c
-     * https://wwwin-github.cisco.com/pages/Webex/crr-docs/techdocs/rr-005.html#websocket-notifications
-     * */
-    this.on('event:u2c.cache-invalidation', (envelope) => {
-      if (
-        typeof this.webex.internal.services?.invalidateCache === 'function' &&
-        envelope &&
-        envelope.data
-      ) {
-        this.webex.internal.services.invalidateCache(envelope.data?.timestamp);
-      }
-    });
-  }
-
   /**
    * Attach event listeners to a socket.
    * @param {Socket} socket - The socket to attach listeners to
@@ -115,9 +71,6 @@ class MobiusSocket extends EventEmitter {
   private attachSocketEventListeners(socket) {
     socket.on('close', (event) => this.onclose(event, socket));
     socket.on('message', (...args) => this.onmessage(...args));
-    socket.on('pong', (...args) => this.setTimeOffset(...args));
-    socket.on('sequence-mismatch', (...args) => this.emitEvent('sequence-mismatch', ...args));
-    socket.on('ping-pong-latency', (...args) => this.emitEvent('ping-pong-latency', ...args));
   }
 
   /**
@@ -132,8 +85,8 @@ class MobiusSocket extends EventEmitter {
 
     if (this.seenAsyncEventIds.has(envelope.eventId)) {
       // Refresh recency so frequently retransmitted eventIds stay protected longer.
+      // This deletion and setting again makes the data recent since javascript map maintains order as well
       const previousValue = this.seenAsyncEventIds.get(envelope.eventId);
-
       this.seenAsyncEventIds.delete(envelope.eventId);
       this.seenAsyncEventIds.set(envelope.eventId, previousValue);
       this.logger.info(
@@ -143,7 +96,7 @@ class MobiusSocket extends EventEmitter {
       return true;
     }
 
-    this.logger.info(
+    this.logger.log(
       `${MOBIUS_SOCKET_NAMESPACE}: tracking async_event, eventId=${envelope.eventId}`
     );
     this.seenAsyncEventIds.set(envelope.eventId, true);
@@ -152,7 +105,7 @@ class MobiusSocket extends EventEmitter {
       const oldestEventId = this.seenAsyncEventIds.keys().next().value;
 
       this.seenAsyncEventIds.delete(oldestEventId);
-      this.logger.info(
+      this.logger.log(
         `${MOBIUS_SOCKET_NAMESPACE}: evicted oldest async_event from dedup cache, eventId=${oldestEventId}`
       );
     }
@@ -192,7 +145,7 @@ class MobiusSocket extends EventEmitter {
             this.socket = newSocket;
             this.connected = true;
 
-            this.emitEvent('event:mercury_shutdown_switchover_complete', {
+            this.emitEvent('event:mobius_shutdown_switchover_complete', {
               url: webSocketUrl,
             });
 
@@ -214,12 +167,12 @@ class MobiusSocket extends EventEmitter {
             `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover exhausted retries; will fall back to normal reconnection: `,
             err
           );
-          this.emitEvent('event:mercury_shutdown_switchover_failed', {reason: err});
+          this.emitEvent('event:mobius_shutdown_switchover_failed', {reason: err});
         });
     } catch (e) {
       this.logger.error(`${MOBIUS_SOCKET_NAMESPACE}: [shutdown] error during switchover`, e);
       this.shutdownSwitchoverBackoffCall = undefined;
-      this.emitEvent('event:mercury_shutdown_switchover_failed', {reason: e});
+      this.emitEvent('event:mobius_shutdown_switchover_failed', {reason: e});
     }
   }
 
@@ -253,7 +206,7 @@ class MobiusSocket extends EventEmitter {
       return Promise.reject(new Error('Mobius socket is not connected'));
     }
 
-    return this.socket.sendRequest(payload, {
+    const requestConfigOptions = {
       timeout: options.timeout,
       matchesResponse: (response, request) =>
         response?.type === 'response_event' &&
@@ -273,7 +226,9 @@ class MobiusSocket extends EventEmitter {
           408,
           'Mobius websocket response timed out'
         ),
-    });
+    };
+
+    return this.socket.sendRequest(payload, requestConfigOptions);
   }
 
   /**
@@ -311,7 +266,6 @@ class MobiusSocket extends EventEmitter {
     }
 
     // Cache the caller-provided URL for reconnect
-    const resolvedUrl = webSocketUrl || this.socketUrl;
     if (webSocketUrl) {
       this.socketUrl = webSocketUrl;
     }
@@ -332,7 +286,7 @@ class MobiusSocket extends EventEmitter {
       .then(() => {
         this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: connecting`);
 
-        return this.connectWithBackoff(resolvedUrl);
+        return this.connectWithBackoff(this.socketUrl);
       })
       .finally(() => {
         this.connectPromise = undefined;
@@ -350,10 +304,9 @@ class MobiusSocket extends EventEmitter {
    */
   public disconnect(options?: MobiusSocketCloseOptions): MobiusSocketDisconnectResult {
     this.logger.info(
-      `${MOBIUS_SOCKET_NAMESPACE}#disconnect: connecting state: ${
-        this.connecting
-      }, connected state: ${this.connected}, socket exists: ${!!this
-        .socket}, options: ${JSON.stringify(options)}`
+      `${MOBIUS_SOCKET_NAMESPACE}#disconnect: connecting state: ${this.connecting},
+       connected state: ${this.connected}, socket exists: ${!!this.socket},
+       options: ${JSON.stringify(options)}`
     );
 
     if (this.backoffCall) {
@@ -361,13 +314,14 @@ class MobiusSocket extends EventEmitter {
       this.backoffCall.abort();
       this.backoffCall = undefined;
     }
+
     if (this.shutdownSwitchoverBackoffCall) {
       this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: aborting shutdown switchover connection`);
       this.shutdownSwitchoverBackoffCall.abort();
       this.shutdownSwitchoverBackoffCall = undefined;
     }
-    this.connectPromise = undefined;
 
+    this.connectPromise = undefined;
     this.seenAsyncEventIds.clear();
 
     if (!this.socket) {
@@ -377,12 +331,11 @@ class MobiusSocket extends EventEmitter {
       return Promise.resolve();
     }
 
-    const currentSocket = this.socket;
-    currentSocket.removeAllListeners('message');
-    currentSocket.connecting = false;
-    currentSocket.connected = false;
+    this.socket.removeAllListeners('message');
+    this.socket.connecting = false;
+    this.socket.connected = false;
 
-    return Promise.resolve(currentSocket.close(options || undefined)).finally(() => {
+    return Promise.resolve(this.socket.close(options || undefined)).finally(() => {
       this.connected = false;
       this.stopTokenRefreshTimer();
     });
@@ -407,20 +360,9 @@ class MobiusSocket extends EventEmitter {
     return error;
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  private applyOverrides(event) {
-    if (!event || !event.headers) {
-      return;
-    }
-    const headerKeys = Object.keys(event.headers);
-
-    headerKeys.forEach((keyPath) => {
-      set(event, keyPath, event.headers[keyPath]);
-    });
-  }
-
   private prepareUrl(webSocketUrl) {
     if (!webSocketUrl) {
+      // TODO: Circle back to this logic when mobius implements the shutdown switchover
       webSocketUrl = this.webex.internal.device.webSocketUrl;
     }
 
@@ -719,42 +661,13 @@ class MobiusSocket extends EventEmitter {
       this.emit(eventName, ...args);
     } catch (error) {
       // Safely handle errors without causing additional issues during cleanup
-      try {
-        this.logger.error(
-          `${MOBIUS_SOCKET_NAMESPACE}: error occurred in event handler:`,
-          error,
-          ' with args: ',
-          [eventName, ...args]
-        );
-      } catch (logError) {
-        // If even logging fails, just ignore to prevent cascading errors during cleanup
-        // eslint-disable-next-line no-console
-        console.error('MobiusSocket emitEvent error handling failed:', logError);
-      }
+      this.logger.error(
+        `${MOBIUS_SOCKET_NAMESPACE}: error occurred in event handler:`,
+        error,
+        ' with args: ',
+        [eventName, ...args]
+      );
     }
-  }
-
-  private getEventHandlers(eventType) {
-    if (!eventType) {
-      return [];
-    }
-    const [namespace, name] = eventType.split('.');
-    const handlers = [];
-
-    if (!this.webex[namespace] && !this.webex.internal[namespace]) {
-      return handlers;
-    }
-
-    const handlerName = camelCase(`process_${name}_event`);
-
-    if ((this.webex[namespace] || this.webex.internal[namespace])[handlerName]) {
-      handlers.push({
-        name: handlerName,
-        namespace,
-      });
-    }
-
-    return handlers;
   }
 
   private startTokenRefreshTimer() {
@@ -921,17 +834,16 @@ class MobiusSocket extends EventEmitter {
   }
 
   private onmessage(event) {
-    this.setTimeOffset(event);
     const envelope = event.data;
 
-    if (process.env.ENABLE_MERCURY_LOGGING) {
+    if (process.env.ENABLE_MOBIUS_LOGGING) {
       this.logger.debug(`${MOBIUS_SOCKET_NAMESPACE}: message envelope: `, envelope);
     }
 
     // Handle shutdown message shape: { type: 'shutdown' }
     if (envelope && envelope.type === 'shutdown') {
       this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: [shutdown] imminent shutdown message received`);
-      this.emitEvent('event:mercury_shutdown_imminent', envelope);
+      this.emitEvent('event:mobius_shutdown_imminent', envelope); // This is not yet not implemented, keeping for future support
 
       this.handleImminentShutdown();
 
@@ -950,9 +862,7 @@ class MobiusSocket extends EventEmitter {
     // Use data/payload if present, otherwise treat the envelope itself as the data (flat format)
     const data = envelope.data || envelope;
 
-    this.applyOverrides(data);
-
-    // Support both Mercury-enveloped (data.eventType) and flat (eventType) formats
+    // Support both Mobius-enveloped (data.eventType) and flat (eventType) formats
     const eventType = data?.eventType || envelope.eventType;
 
     if (!eventType) {
@@ -961,47 +871,23 @@ class MobiusSocket extends EventEmitter {
       return Promise.resolve();
     }
 
-    return this.getEventHandlers(eventType)
-      .reduce(
-        (promise, handler) =>
-          promise.then(() => {
-            const {namespace, name} = handler;
+    try {
+      // TODO: Remove if event:namespace is not required
+      this.emitEvent('event', envelope);
+      const [namespace] = eventType.split('.');
+      this.emitEvent(`event:${namespace}`, envelope);
 
-            return new Promise((resolve) => {
-              resolve((this.webex[namespace] || this.webex.internal[namespace])[name](data));
-            }).catch((reason) =>
-              this.logger.error(
-                `${MOBIUS_SOCKET_NAMESPACE}: error occurred in autowired event handler for ${eventType}`,
-                reason
-              )
-            );
-          }),
-        Promise.resolve()
-      )
-      .then(() => {
-        this.emitEvent('event', envelope);
-        const [namespace] = eventType.split('.');
-
-        if (namespace === eventType) {
-          this.emitEvent(`event:${namespace}`, envelope);
-        } else {
-          this.emitEvent(`event:${namespace}`, envelope);
-          this.emitEvent(`event:${eventType}`, envelope);
-        }
-      })
-      .catch((reason) => {
-        this.logger.error(
-          `${MOBIUS_SOCKET_NAMESPACE}: error occurred processing socket message`,
-          reason
-        );
-      });
-  }
-
-  private setTimeOffset(event) {
-    const {wsWriteTimestamp} = event.data;
-    if (typeof wsWriteTimestamp === 'number' && wsWriteTimestamp > 0) {
-      this.mercuryTimeOffset = Date.now() - wsWriteTimestamp;
+      if (namespace !== eventType) {
+        this.emitEvent(`event:${eventType}`, envelope);
+      }
+    } catch (reason) {
+      this.logger.error(
+        `${MOBIUS_SOCKET_NAMESPACE}: error occurred processing socket message`,
+        reason
+      );
     }
+
+    return Promise.resolve();
   }
 
   private reconnect(webSocketUrl) {

--- a/packages/calling/src/mobius-socket/mobius-socket.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.ts
@@ -50,17 +50,17 @@ class MobiusSocket extends EventEmitter {
     this.socket = undefined;
     this.sockets = new Map();
     this.backoffCalls = new Map();
-    this._shutdownSwitchoverBackoffCalls = new Map();
-    this._seenAsyncEventIdsBySession = new Map();
-    this._connectPromises = new Map();
+    this.shutdownSwitchoverBackoffCalls = new Map();
+    this.seenAsyncEventIdsBySession = new Map();
+    this.connectPromises = new Map();
     this.mercuryTimeOffset = undefined;
-    this._tokenRefreshTimer = undefined;
-    this._tokenRefreshInFlight = undefined;
+    this.tokenRefreshTimer = undefined;
+    this.tokenRefreshInFlight = undefined;
 
-    this._bindInternalEvents();
+    this.bindInternalEvents();
   }
 
-  off(eventName: string, listener?: (...args: unknown[]) => void) {
+  public off(eventName: string, listener?: (...args: unknown[]) => void) {
     if (listener) {
       return super.off(eventName, listener);
     }
@@ -70,7 +70,7 @@ class MobiusSocket extends EventEmitter {
     return this;
   }
 
-  _bindInternalEvents() {
+  private bindInternalEvents() {
     /*
       When one of these legacy feature gets updated, this event would be triggered
         * group-message-notifications
@@ -116,15 +116,15 @@ class MobiusSocket extends EventEmitter {
    * @param {sessionId} sessionId - The socket related session ID
    * @returns {void}
    */
-  _attachSocketEventListeners(socket, sessionId) {
-    socket.on('close', (event) => this._onclose(sessionId, event, socket));
-    socket.on('message', (...args) => this._onmessage(sessionId, ...args));
-    socket.on('pong', (...args) => this._setTimeOffset(sessionId, ...args));
+  private attachSocketEventListeners(socket, sessionId) {
+    socket.on('close', (event) => this.onclose(sessionId, event, socket));
+    socket.on('message', (...args) => this.onmessage(sessionId, ...args));
+    socket.on('pong', (...args) => this.setTimeOffset(sessionId, ...args));
     socket.on('sequence-mismatch', (...args) =>
-      this._emit(sessionId, 'sequence-mismatch', ...args)
+      this.emitEvent(sessionId, 'sequence-mismatch', ...args)
     );
     socket.on('ping-pong-latency', (...args) =>
-      this._emit(sessionId, 'ping-pong-latency', ...args)
+      this.emitEvent(sessionId, 'ping-pong-latency', ...args)
     );
   }
 
@@ -133,12 +133,12 @@ class MobiusSocket extends EventEmitter {
    * @param {string} sessionId - The session identifier.
    * @returns {Map<string, boolean>} Ordered cache of seen event IDs for the session.
    */
-  _getSeenAsyncEventIds(sessionId) {
-    let seenAsyncEventIds = this._seenAsyncEventIdsBySession.get(sessionId);
+  private getSeenAsyncEventIds(sessionId) {
+    let seenAsyncEventIds = this.seenAsyncEventIdsBySession.get(sessionId);
 
     if (!seenAsyncEventIds) {
       seenAsyncEventIds = new Map();
-      this._seenAsyncEventIdsBySession.set(sessionId, seenAsyncEventIds);
+      this.seenAsyncEventIdsBySession.set(sessionId, seenAsyncEventIds);
     }
 
     return seenAsyncEventIds;
@@ -149,14 +149,14 @@ class MobiusSocket extends EventEmitter {
    * @param {string} [sessionId] - Optional session identifier.
    * @returns {void}
    */
-  _clearSeenAsyncEventIds(sessionId) {
+  private clearSeenAsyncEventIds(sessionId) {
     if (sessionId) {
-      this._seenAsyncEventIdsBySession.delete(sessionId);
+      this.seenAsyncEventIdsBySession.delete(sessionId);
 
       return;
     }
 
-    this._seenAsyncEventIdsBySession.clear();
+    this.seenAsyncEventIdsBySession.clear();
   }
 
   /**
@@ -165,12 +165,12 @@ class MobiusSocket extends EventEmitter {
    * @param {object} envelope - Parsed websocket message envelope.
    * @returns {boolean} True when the event has already been seen for this session.
    */
-  _trackAsyncEventAndShouldSuppressDuplicate(sessionId, envelope) {
+  private trackAsyncEventAndShouldSuppressDuplicate(sessionId, envelope) {
     if (envelope?.type !== 'async_event' || !envelope.eventId) {
       return false;
     }
 
-    const seenAsyncEventIds = this._getSeenAsyncEventIds(sessionId);
+    const seenAsyncEventIds = this.getSeenAsyncEventIds(sessionId);
 
     if (seenAsyncEventIds.has(envelope.eventId)) {
       const previousValue = seenAsyncEventIds.get(envelope.eventId);
@@ -209,13 +209,13 @@ class MobiusSocket extends EventEmitter {
    * @param {string} sessionId - The session ID for which the shutdown is imminent
    * @returns {void}
    */
-  _handleImminentShutdown(sessionId) {
+  private handleImminentShutdown(sessionId) {
     const oldSocket = this.sockets.get(sessionId);
 
     try {
       // Idempotent: if we already have a switchover backoff call for this session,
       // a switchover is in progress – do nothing.
-      if (this._shutdownSwitchoverBackoffCalls.get(sessionId)) {
+      if (this.shutdownSwitchoverBackoffCalls.get(sessionId)) {
         this.logger.info(
           `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover already in progress for ${sessionId}`
         );
@@ -228,7 +228,7 @@ class MobiusSocket extends EventEmitter {
         `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover start, id=${switchoverId} for ${sessionId}`
       );
 
-      this._connectWithBackoff(undefined, sessionId, {
+      this.connectWithBackoff(undefined, sessionId, {
         isShutdownSwitchover: true,
         attemptOptions: {
           isShutdownSwitchover: true,
@@ -241,7 +241,7 @@ class MobiusSocket extends EventEmitter {
             this.socket = this.sockets.get(this.defaultSessionId);
             this.connected = this.hasConnectedSockets(); // remain connected throughout
 
-            this._emit(sessionId, 'event:mercury_shutdown_switchover_complete', {
+            this.emitEvent(sessionId, 'event:mercury_shutdown_switchover_complete', {
               url: webSocketUrl,
             });
 
@@ -263,7 +263,7 @@ class MobiusSocket extends EventEmitter {
             `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover exhausted retries; will fall back to normal reconnection for ${sessionId}: `,
             err
           );
-          this._emit(sessionId, 'event:mercury_shutdown_switchover_failed', {reason: err});
+          this.emitEvent(sessionId, 'event:mercury_shutdown_switchover_failed', {reason: err});
           // Old socket will eventually close with 4001, triggering normal reconnection
         });
     } catch (e) {
@@ -271,8 +271,8 @@ class MobiusSocket extends EventEmitter {
         `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] error during switchover for ${sessionId}`,
         e
       );
-      this._shutdownSwitchoverBackoffCalls.delete(sessionId);
-      this._emit(sessionId, 'event:mercury_shutdown_switchover_failed', {reason: e});
+      this.shutdownSwitchoverBackoffCalls.delete(sessionId);
+      this.emitEvent(sessionId, 'event:mercury_shutdown_switchover_failed', {reason: e});
     }
   }
 
@@ -281,7 +281,7 @@ class MobiusSocket extends EventEmitter {
    * @param {string} sessionId - The connection identifier
    * @returns {Socket|undefined} The socket instance or undefined if not found
    */
-  getSocket(sessionId = this.defaultSessionId) {
+  public getSocket(sessionId = this.defaultSessionId) {
     return this.sockets.get(sessionId);
   }
 
@@ -290,7 +290,7 @@ class MobiusSocket extends EventEmitter {
    * @param {string} [sessionId=this.defaultSessionId] - The session identifier.
    * @returns {string|undefined} The connected websocket URL, or undefined when not connected.
    */
-  getConnectedWebSocketUrl(sessionId = this.defaultSessionId): string | undefined {
+  public getConnectedWebSocketUrl(sessionId = this.defaultSessionId): string | undefined {
     const socket = this.getSocket(sessionId);
 
     if (!socket?.connected) {
@@ -307,7 +307,7 @@ class MobiusSocket extends EventEmitter {
    * @param {Object} [options={}] - Additional request options.
    * @returns {Promise<Object>}
    */
-  sendWssRequest(
+  public sendWssRequest(
     payload: MobiusSocketRequestPayload,
     sessionIdOrRequestOptions: string | MobiusSocketRequestOptions = this.defaultSessionId,
     options: MobiusSocketRequestOptions = {}
@@ -340,9 +340,9 @@ class MobiusSocket extends EventEmitter {
       getStatusCode: (response) => response?.statusCode,
       getStatusMessage: (response) => response?.statusMessage,
       createError: (response, statusCode, statusMessage) =>
-        this._createWssResponseError(response, statusCode, statusMessage),
+        this.createWssResponseError(response, statusCode, statusMessage),
       createTimeoutError: (request) =>
-        this._createWssResponseError(
+        this.createWssResponseError(
           {
             type: 'response_event',
             subtype: request.type,
@@ -358,7 +358,7 @@ class MobiusSocket extends EventEmitter {
    * Check if the plugin is connected
    * @returns {boolean} True if connected
    */
-  isConnected(): boolean {
+  public isConnected(): boolean {
     return this.connected;
   }
 
@@ -367,7 +367,7 @@ class MobiusSocket extends EventEmitter {
    * @param {string} [sessionId] - Optional session identifier
    * @returns {boolean|undefined} True if the socket is connected
    */
-  hasConnectedSockets(sessionId): boolean {
+  public hasConnectedSockets(sessionId): boolean {
     if (sessionId) {
       return Boolean(this.sockets.get(sessionId)?.connected);
     }
@@ -386,7 +386,7 @@ class MobiusSocket extends EventEmitter {
    * @param {string} [sessionId=this.defaultSessionId] - The session identifier
    * @returns {boolean|undefined} True if the socket is connecting
    */
-  hasConnectingSockets(sessionId = this.defaultSessionId): boolean {
+  public hasConnectingSockets(sessionId = this.defaultSessionId): boolean {
     const socket = this.sockets.get(sessionId || this.defaultSessionId);
 
     return Boolean(socket?.connecting);
@@ -398,14 +398,14 @@ class MobiusSocket extends EventEmitter {
    * @param {string} [sessionId=this.defaultSessionId] - The session identifier for this connection.
    * @returns {Promise<void>} Resolves when connection flow completes for the session.
    */
-  connect(webSocketUrl?: string, sessionId = this.defaultSessionId): Promise<void> {
+  public connect(webSocketUrl?: string, sessionId = this.defaultSessionId): Promise<void> {
     // First check if there's already a connection promise for this session
-    if (this._connectPromises.has(sessionId)) {
+    if (this.connectPromises.has(sessionId)) {
       this.logger.info(
         `${MOBIUS_SOCKET_NAMESPACE}: connection ${sessionId} already in progress, returning existing promise`
       );
 
-      return this._connectPromises.get(sessionId);
+      return this.connectPromises.get(sessionId);
     }
 
     const sessionSocket = this.sockets.get(sessionId);
@@ -445,13 +445,13 @@ class MobiusSocket extends EventEmitter {
       .then(() => {
         this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: connecting ${sessionId}`);
 
-        return this._connectWithBackoff(resolvedUrl, sessionId);
+        return this.connectWithBackoff(resolvedUrl, sessionId);
       })
       .finally(() => {
-        this._connectPromises.delete(sessionId);
+        this.connectPromises.delete(sessionId);
       });
 
-    this._connectPromises.set(sessionId, connectPromise);
+    this.connectPromises.set(sessionId, connectPromise);
 
     return connectPromise;
   }
@@ -462,7 +462,7 @@ class MobiusSocket extends EventEmitter {
    * @param {string} [sessionId=this.defaultSessionId] - The session identifier to disconnect.
    * @returns {Promise<void>} Resolves after disconnect cleanup and close handling are initiated/completed.
    */
-  disconnect(
+  public disconnect(
     options?: MobiusSocketCloseOptions,
     sessionId = this.defaultSessionId
   ): MobiusSocketDisconnectResult {
@@ -479,25 +479,25 @@ class MobiusSocket extends EventEmitter {
       backoffCall.abort();
       this.backoffCalls.delete(sessionId);
     }
-    const shutdownSwitchoverBackoffCall = this._shutdownSwitchoverBackoffCalls.get(sessionId);
+    const shutdownSwitchoverBackoffCall = this.shutdownSwitchoverBackoffCalls.get(sessionId);
     if (shutdownSwitchoverBackoffCall) {
       this.logger.info(
         `${MOBIUS_SOCKET_NAMESPACE}: aborting shutdown switchover connection ${sessionId}`
       );
       shutdownSwitchoverBackoffCall.abort();
-      this._shutdownSwitchoverBackoffCalls.delete(sessionId);
+      this.shutdownSwitchoverBackoffCalls.delete(sessionId);
     }
     // Clean up any pending connection promises
-    this._connectPromises.delete(sessionId);
+    this.connectPromises.delete(sessionId);
 
     const sessionSocket = this.sockets.get(sessionId);
 
-    this._clearSeenAsyncEventIds(sessionId);
+    this.clearSeenAsyncEventIds(sessionId);
 
     if (!sessionSocket) {
       this.connected = this.hasConnectedSockets();
       if (!this.hasConnectedSockets()) {
-        this._stopTokenRefreshTimer();
+        this.stopTokenRefreshTimer();
       }
 
       return Promise.resolve();
@@ -510,13 +510,13 @@ class MobiusSocket extends EventEmitter {
     return Promise.resolve(sessionSocket.close(options || undefined)).finally(() => {
       this.connected = this.hasConnectedSockets();
       if (!this.hasConnectedSockets()) {
-        this._stopTokenRefreshTimer();
+        this.stopTokenRefreshTimer();
       }
     });
   }
 
   // eslint-disable-next-line class-methods-use-this
-  _createWssResponseError(
+  private createWssResponseError(
     response: SocketResponse,
     statusCode?: number,
     statusMessage?: string
@@ -535,7 +535,7 @@ class MobiusSocket extends EventEmitter {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  _applyOverrides(event) {
+  private applyOverrides(event) {
     if (!event || !event.headers) {
       return;
     }
@@ -546,7 +546,7 @@ class MobiusSocket extends EventEmitter {
     });
   }
 
-  _prepareUrl(webSocketUrl) {
+  private prepareUrl(webSocketUrl) {
     if (!webSocketUrl) {
       webSocketUrl = this.webex.internal.device.webSocketUrl;
     }
@@ -554,17 +554,17 @@ class MobiusSocket extends EventEmitter {
     return Promise.resolve(webSocketUrl);
   }
 
-  _attemptConnection(socketUrl, sessionId, callback, options = {}) {
+  private attemptConnection(socketUrl, sessionId, callback, options = {}) {
     const {isShutdownSwitchover = false, onSuccess = null} = options;
 
     const socket = new Socket();
     socket.connecting = true;
     let newWSUrl;
 
-    this._attachSocketEventListeners(socket, sessionId);
+    this.attachSocketEventListeners(socket, sessionId);
 
     const backoffCall = isShutdownSwitchover
-      ? this._shutdownSwitchoverBackoffCalls.get(sessionId)
+      ? this.shutdownSwitchoverBackoffCalls.get(sessionId)
       : this.backoffCalls.get(sessionId);
 
     // Check appropriate backoff call based on connection type
@@ -587,7 +587,7 @@ class MobiusSocket extends EventEmitter {
       this.sockets.set(sessionId, socket);
     }
 
-    return this._prepareAndOpenSocket(socket, socketUrl, sessionId, isShutdownSwitchover)
+    return this.prepareAndOpenSocket(socket, socketUrl, sessionId, isShutdownSwitchover)
       .then((webSocketUrl) => {
         newWSUrl = webSocketUrl;
 
@@ -628,7 +628,7 @@ class MobiusSocket extends EventEmitter {
         // (especially since many of our outages happen in a way that client
         // metrics can't be trusted).
         if (reason.code !== 1006 && backoffCallNormal && backoffCallNormal?.getNumRetries() > 0) {
-          this._emit(sessionId, 'connection_failed', reason, {
+          this.emitEvent(sessionId, 'connection_failed', reason, {
             sessionId,
             retries: backoffCallNormal?.getNumRetries(),
           });
@@ -677,10 +677,10 @@ class MobiusSocket extends EventEmitter {
       });
   }
 
-  _prepareAndOpenSocket(socket, socketUrl, sessionId, isShutdownSwitchover = false) {
+  private prepareAndOpenSocket(socket, socketUrl, sessionId, isShutdownSwitchover = false) {
     const logPrefix = isShutdownSwitchover ? '[shutdown] switchover' : 'connection';
 
-    return Promise.all([this._prepareUrl(socketUrl), this.webex.credentials.getUserToken()]).then(
+    return Promise.all([this.prepareUrl(socketUrl), this.webex.credentials.getUserToken()]).then(
       ([webSocketUrl, token]) => {
         let options = {
           forceCloseDelay: this.config.forceCloseDelay,
@@ -688,7 +688,7 @@ class MobiusSocket extends EventEmitter {
           skipAckEventId: this.config.skipAckEventId,
           skipAckEventType: this.config.skipAckEventType,
           token: normalizeMobiusAuthToken(token.toString()),
-          refreshToken: () => this._refreshToken(),
+          refreshToken: () => this.refreshToken(),
           trackingId: `${this.webex.sessionId}_${Date.now()}`,
           logger: this.logger,
         };
@@ -716,7 +716,7 @@ class MobiusSocket extends EventEmitter {
     );
   }
 
-  _connectWithBackoff(webSocketUrl, sessionId, context = {}): Promise<void> {
+  private connectWithBackoff(webSocketUrl, sessionId, context = {}): Promise<void> {
     const {isShutdownSwitchover = false, attemptOptions = {}} = context;
 
     return new Promise((resolve, reject) => {
@@ -732,7 +732,7 @@ class MobiusSocket extends EventEmitter {
 
       const onComplete = (err, sid = sessionId) => {
         if (isShutdownSwitchover) {
-          this._shutdownSwitchoverBackoffCalls.delete(sid);
+          this.shutdownSwitchoverBackoffCalls.delete(sid);
         } else {
           this.backoffCalls.delete(sid);
         }
@@ -763,8 +763,8 @@ class MobiusSocket extends EventEmitter {
           this.connecting = this.hasConnectingSockets();
           this.connected = this.hasConnectedSockets();
           this.hasEverConnected = true;
-          this._startTokenRefreshTimer();
-          this._emit(sid, 'online');
+          this.startTokenRefreshTimer();
+          this.emitEvent(sid, 'online');
         }
 
         return resolve();
@@ -778,7 +778,7 @@ class MobiusSocket extends EventEmitter {
           this.logger.info(
             `${MOBIUS_SOCKET_NAMESPACE}: executing ${attemptLogPrefix} attempt ${attemptNum} for ${sessionId}`
           );
-          this._attemptConnection(webSocketUrl, sessionId, callback, attemptOptions);
+          this.attemptConnection(webSocketUrl, sessionId, callback, attemptOptions);
         },
         (err) => onComplete(err, sessionId)
       );
@@ -801,7 +801,7 @@ class MobiusSocket extends EventEmitter {
       // Store the call BEFORE setting up event handlers to prevent race conditions
       // Store backoff call reference BEFORE starting (so it's available in _attemptConnection)
       if (isShutdownSwitchover) {
-        this._shutdownSwitchoverBackoffCalls.set(sessionId, call);
+        this.shutdownSwitchoverBackoffCalls.set(sessionId, call);
       } else {
         this.backoffCalls.set(sessionId, call);
       }
@@ -849,7 +849,7 @@ class MobiusSocket extends EventEmitter {
     });
   }
 
-  _emit(sessionId, eventName, ...args) {
+  private emitEvent(sessionId, eventName, ...args) {
     try {
       if (!sessionId || !eventName) {
         return;
@@ -875,7 +875,7 @@ class MobiusSocket extends EventEmitter {
     }
   }
 
-  _getEventHandlers(eventType) {
+  private getEventHandlers(eventType) {
     if (!eventType) {
       return [];
     }
@@ -898,34 +898,34 @@ class MobiusSocket extends EventEmitter {
     return handlers;
   }
 
-  _startTokenRefreshTimer() {
-    if (this._tokenRefreshTimer || !this.hasConnectedSockets()) {
+  private startTokenRefreshTimer() {
+    if (this.tokenRefreshTimer || !this.hasConnectedSockets()) {
       return;
     }
 
-    this._tokenRefreshTimer = setInterval(() => {
-      this._refreshToken().catch((error) => {
+    this.tokenRefreshTimer = setInterval(() => {
+      this.refreshToken().catch((error) => {
         this.logger.error(`${MOBIUS_SOCKET_NAMESPACE}: periodic token refresh failed`, error);
       });
     }, TOKEN_REFRESH_INTERVAL_MS);
   }
 
-  _stopTokenRefreshTimer() {
-    if (!this._tokenRefreshTimer) {
+  private stopTokenRefreshTimer() {
+    if (!this.tokenRefreshTimer) {
       return;
     }
 
-    clearInterval(this._tokenRefreshTimer);
-    this._tokenRefreshTimer = undefined;
+    clearInterval(this.tokenRefreshTimer);
+    this.tokenRefreshTimer = undefined;
   }
 
-  _refreshToken() {
-    if (this._tokenRefreshInFlight) {
-      return this._tokenRefreshInFlight;
+  private refreshToken() {
+    if (this.tokenRefreshInFlight) {
+      return this.tokenRefreshInFlight;
     }
 
     if (!this.hasConnectedSockets()) {
-      this._stopTokenRefreshTimer();
+      this.stopTokenRefreshTimer();
 
       return Promise.resolve();
     }
@@ -936,7 +936,7 @@ class MobiusSocket extends EventEmitter {
           .then(() => this.webex.credentials.getUserToken())
       : this.webex.credentials.getUserToken();
 
-    this._tokenRefreshInFlight = tokenPromise
+    this.tokenRefreshInFlight = tokenPromise
       .then((token) => {
         if (!token) {
           throw new Error('Mobius token refresh did not return a token');
@@ -960,13 +960,13 @@ class MobiusSocket extends EventEmitter {
         throw error;
       })
       .finally(() => {
-        this._tokenRefreshInFlight = undefined;
+        this.tokenRefreshInFlight = undefined;
       });
 
-    return this._tokenRefreshInFlight;
+    return this.tokenRefreshInFlight;
   }
 
-  _onclose(sessionId, event, sourceSocket) {
+  private onclose(sessionId, event, sourceSocket) {
     // I don't see any way to avoid the complexity or statement count in here.
     /* eslint complexity: [0] */
 
@@ -989,13 +989,13 @@ class MobiusSocket extends EventEmitter {
           if (sessionId === this.defaultSessionId) {
             this.socket = undefined;
           }
-          this._emit(sessionId, 'offline', event);
+          this.emitEvent(sessionId, 'offline', event);
         }
         // Update overall connected status
         this.connecting = this.hasConnectingSockets();
         this.connected = this.hasConnectedSockets();
         if (!this.hasConnectedSockets()) {
-          this._stopTokenRefreshTimer();
+          this.stopTokenRefreshTimer();
         }
       } else {
         // Old socket closed; do not flip connection state
@@ -1014,14 +1014,14 @@ class MobiusSocket extends EventEmitter {
           this.logger.info(
             `${MOBIUS_SOCKET_NAMESPACE}: service rejected last message for ${sessionId}; will not reconnect: ${event.reason}`
           );
-          if (isActiveSocket) this._emit(sessionId, 'offline.permanent', event);
+          if (isActiveSocket) this.emitEvent(sessionId, 'offline.permanent', event);
           break;
         case 4000:
           // metric: disconnect
           this.logger.info(
             `${MOBIUS_SOCKET_NAMESPACE}: socket ${sessionId} replaced; will not reconnect`
           );
-          if (isActiveSocket) this._emit(sessionId, 'offline.replaced', event);
+          if (isActiveSocket) this.emitEvent(sessionId, 'offline.replaced', event);
           // If not active, nothing to do
           break;
         case 4001:
@@ -1033,13 +1033,13 @@ class MobiusSocket extends EventEmitter {
             this.logger.warn(
               `${MOBIUS_SOCKET_NAMESPACE}: active socket closed with 4001; shutdown switchover failed for ${sessionId}`
             );
-            this._emit(sessionId, 'offline.permanent', event);
+            this.emitEvent(sessionId, 'offline.permanent', event);
           } else {
             // Expected: old socket closed after successful switchover
             this.logger.info(
               `${MOBIUS_SOCKET_NAMESPACE}: old socket closed with 4001 (replaced during shutdown); no reconnect needed for ${sessionId}`
             );
-            this._emit(sessionId, 'offline.replaced', event);
+            this.emitEvent(sessionId, 'offline.replaced', event);
           }
           break;
         case 1001:
@@ -1050,11 +1050,11 @@ class MobiusSocket extends EventEmitter {
             `${MOBIUS_SOCKET_NAMESPACE}: socket ${sessionId} disconnected; reconnecting`
           );
           if (isActiveSocket) {
-            this._emit(sessionId, 'offline.transient', event);
+            this.emitEvent(sessionId, 'offline.transient', event);
             this.logger.info(
               `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] reconnecting active socket to recover for ${sessionId}`
             );
-            this._reconnect(socketUrl, sessionId);
+            this.reconnect(socketUrl, sessionId);
           }
           // metric: disconnect
           // if (code == 1011 && reason !== ping error) metric: unexpected disconnect
@@ -1066,11 +1066,11 @@ class MobiusSocket extends EventEmitter {
               `${MOBIUS_SOCKET_NAMESPACE}: socket ${sessionId} disconnected; reconnecting`
             );
             if (isActiveSocket) {
-              this._emit(sessionId, 'offline.transient', event);
+              this.emitEvent(sessionId, 'offline.transient', event);
               this.logger.info(
                 `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] reconnecting due to normal close for ${sessionId}`
               );
-              this._reconnect(socketUrl, sessionId);
+              this.reconnect(socketUrl, sessionId);
             }
             // metric: disconnect
             // if (reason === done forced) metric: force closure
@@ -1078,7 +1078,7 @@ class MobiusSocket extends EventEmitter {
             this.logger.info(
               `${MOBIUS_SOCKET_NAMESPACE}: socket ${sessionId} disconnected; will not reconnect: ${event.reason}`
             );
-            if (isActiveSocket) this._emit(sessionId, 'offline.permanent', event);
+            if (isActiveSocket) this.emitEvent(sessionId, 'offline.permanent', event);
           }
           break;
         default:
@@ -1086,7 +1086,7 @@ class MobiusSocket extends EventEmitter {
             `${MOBIUS_SOCKET_NAMESPACE}: socket ${sessionId} disconnected unexpectedly; will not reconnect`
           );
           // unexpected disconnect
-          if (isActiveSocket) this._emit(sessionId, 'offline.permanent', event);
+          if (isActiveSocket) this.emitEvent(sessionId, 'offline.permanent', event);
       }
     } catch (error) {
       this.logger.error(
@@ -1096,8 +1096,8 @@ class MobiusSocket extends EventEmitter {
     }
   }
 
-  _onmessage(sessionId, event) {
-    this._setTimeOffset(sessionId, event);
+  private onmessage(sessionId, event) {
+    this.setTimeOffset(sessionId, event);
     const envelope = event.data;
 
     if (process.env.ENABLE_MERCURY_LOGGING) {
@@ -1114,38 +1114,38 @@ class MobiusSocket extends EventEmitter {
       this.logger.info(
         `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] imminent shutdown message received for ${sessionId}`
       );
-      this._emit(sessionId, 'event:mercury_shutdown_imminent', envelope);
+      this.emitEvent(sessionId, 'event:mercury_shutdown_imminent', envelope);
 
-      this._handleImminentShutdown(sessionId);
+      this.handleImminentShutdown(sessionId);
 
       return Promise.resolve();
     }
 
-    if (this._trackAsyncEventAndShouldSuppressDuplicate(sessionId, envelope)) {
+    if (this.trackAsyncEventAndShouldSuppressDuplicate(sessionId, envelope)) {
       return Promise.resolve();
     }
 
     // Mobius: emit event:<type> for typed messages (e.g., register.response)
     if (envelope.type) {
-      this._emit(sessionId, `event:${envelope.type}`, envelope);
+      this.emitEvent(sessionId, `event:${envelope.type}`, envelope);
     }
 
     envelope.sessionId = sessionId;
     // Use data/payload if present, otherwise treat the envelope itself as the data (flat format)
     const data = envelope.data || envelope;
 
-    this._applyOverrides(data);
+    this.applyOverrides(data);
 
     // Support both Mercury-enveloped (data.eventType) and flat (eventType) formats
     const eventType = data?.eventType || envelope.eventType;
 
     if (!eventType) {
-      this._emit(sessionId, 'event', envelope);
+      this.emitEvent(sessionId, 'event', envelope);
 
       return Promise.resolve();
     }
 
-    return this._getEventHandlers(eventType)
+    return this.getEventHandlers(eventType)
       .reduce(
         (promise, handler) =>
           promise.then(() => {
@@ -1163,14 +1163,14 @@ class MobiusSocket extends EventEmitter {
         Promise.resolve()
       )
       .then(() => {
-        this._emit(sessionId, 'event', envelope);
+        this.emitEvent(sessionId, 'event', envelope);
         const [namespace] = eventType.split('.');
 
         if (namespace === eventType) {
-          this._emit(sessionId, `event:${namespace}`, envelope);
+          this.emitEvent(sessionId, `event:${namespace}`, envelope);
         } else {
-          this._emit(sessionId, `event:${namespace}`, envelope);
-          this._emit(sessionId, `event:${eventType}`, envelope);
+          this.emitEvent(sessionId, `event:${namespace}`, envelope);
+          this.emitEvent(sessionId, `event:${eventType}`, envelope);
         }
       })
       .catch((reason) => {
@@ -1181,14 +1181,14 @@ class MobiusSocket extends EventEmitter {
       });
   }
 
-  _setTimeOffset(sessionId, event) {
+  private setTimeOffset(sessionId, event) {
     const {wsWriteTimestamp} = event.data;
     if (typeof wsWriteTimestamp === 'number' && wsWriteTimestamp > 0) {
       this.mercuryTimeOffset = Date.now() - wsWriteTimestamp;
     }
   }
 
-  _reconnect(webSocketUrl, sessionId = this.defaultSessionId) {
+  private reconnect(webSocketUrl, sessionId = this.defaultSessionId) {
     this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: reconnecting ${sessionId}`);
 
     return this.connect(webSocketUrl || this.socketUrl, sessionId);

--- a/packages/calling/src/mobius-socket/mobius-socket.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.ts
@@ -22,7 +22,6 @@ import type {
 } from './types';
 
 const normalReconnectReasons = ['idle', 'done (forced)'];
-const DEFAULT_MOBIUS_WEBSOCKET_SESSION = 'mobius-websocket-session';
 const MOBIUS_SOCKET_NAMESPACE = 'MobiusSocket';
 const TOKEN_REFRESH_INTERVAL_MS = 1 * 60 * 60 * 1000; // 1 hour
 
@@ -43,16 +42,14 @@ class MobiusSocket extends EventEmitter {
     this.webex = webex;
     this.config = config;
     this.logger = (webex.logger as unknown as MobiusSocketLogger) || console;
-    this.defaultSessionId = DEFAULT_MOBIUS_WEBSOCKET_SESSION;
     this.connected = false;
     this.connecting = false;
     this.hasEverConnected = false;
     this.socket = undefined;
-    this.sockets = new Map();
-    this.backoffCalls = new Map();
-    this.shutdownSwitchoverBackoffCalls = new Map();
-    this.seenAsyncEventIdsBySession = new Map();
-    this.connectPromises = new Map();
+    this.backoffCall = undefined;
+    this.shutdownSwitchoverBackoffCall = undefined;
+    this.seenAsyncEventIds = new Map();
+    this.connectPromise = undefined;
     this.mercuryTimeOffset = undefined;
     this.tokenRefreshTimer = undefined;
     this.tokenRefreshInFlight = undefined;
@@ -113,89 +110,50 @@ class MobiusSocket extends EventEmitter {
   /**
    * Attach event listeners to a socket.
    * @param {Socket} socket - The socket to attach listeners to
-   * @param {sessionId} sessionId - The socket related session ID
    * @returns {void}
    */
-  private attachSocketEventListeners(socket, sessionId) {
-    socket.on('close', (event) => this.onclose(sessionId, event, socket));
-    socket.on('message', (...args) => this.onmessage(sessionId, ...args));
-    socket.on('pong', (...args) => this.setTimeOffset(sessionId, ...args));
-    socket.on('sequence-mismatch', (...args) =>
-      this.emitEvent(sessionId, 'sequence-mismatch', ...args)
-    );
-    socket.on('ping-pong-latency', (...args) =>
-      this.emitEvent(sessionId, 'ping-pong-latency', ...args)
-    );
-  }
-
-  /**
-   * Returns the per-session cache of seen async_event IDs, creating it on first access.
-   * @param {string} sessionId - The session identifier.
-   * @returns {Map<string, boolean>} Ordered cache of seen event IDs for the session.
-   */
-  private getSeenAsyncEventIds(sessionId) {
-    let seenAsyncEventIds = this.seenAsyncEventIdsBySession.get(sessionId);
-
-    if (!seenAsyncEventIds) {
-      seenAsyncEventIds = new Map();
-      this.seenAsyncEventIdsBySession.set(sessionId, seenAsyncEventIds);
-    }
-
-    return seenAsyncEventIds;
-  }
-
-  /**
-   * Clears the dedup cache for one session or for all sessions when omitted.
-   * @param {string} [sessionId] - Optional session identifier.
-   * @returns {void}
-   */
-  private clearSeenAsyncEventIds(sessionId) {
-    if (sessionId) {
-      this.seenAsyncEventIdsBySession.delete(sessionId);
-
-      return;
-    }
-
-    this.seenAsyncEventIdsBySession.clear();
+  private attachSocketEventListeners(socket) {
+    socket.on('close', (event) => this.onclose(event, socket));
+    socket.on('message', (...args) => this.onmessage(...args));
+    socket.on('pong', (...args) => this.setTimeOffset(...args));
+    socket.on('sequence-mismatch', (...args) => this.emitEvent('sequence-mismatch', ...args));
+    socket.on('ping-pong-latency', (...args) => this.emitEvent('ping-pong-latency', ...args));
   }
 
   /**
    * Tracks a newly seen async_event ID and reports whether a duplicate should be suppressed.
-   * @param {string} sessionId - The session identifier.
    * @param {object} envelope - Parsed websocket message envelope.
-   * @returns {boolean} True when the event has already been seen for this session.
+   * @returns {boolean} True when the event has already been seen.
    */
-  private trackAsyncEventAndShouldSuppressDuplicate(sessionId, envelope) {
+  private trackAsyncEventAndShouldSuppressDuplicate(envelope) {
     if (envelope?.type !== 'async_event' || !envelope.eventId) {
       return false;
     }
 
-    const seenAsyncEventIds = this.getSeenAsyncEventIds(sessionId);
-
-    if (seenAsyncEventIds.has(envelope.eventId)) {
-      const previousValue = seenAsyncEventIds.get(envelope.eventId);
-
+    if (this.seenAsyncEventIds.has(envelope.eventId)) {
       // Refresh recency so frequently retransmitted eventIds stay protected longer.
-      seenAsyncEventIds.delete(envelope.eventId);
-      seenAsyncEventIds.set(envelope.eventId, previousValue);
+      const previousValue = this.seenAsyncEventIds.get(envelope.eventId);
+
+      this.seenAsyncEventIds.delete(envelope.eventId);
+      this.seenAsyncEventIds.set(envelope.eventId, previousValue);
       this.logger.info(
-        `${MOBIUS_SOCKET_NAMESPACE}: duplicate async_event suppressed for ${sessionId}, eventId=${envelope.eventId}`
+        `${MOBIUS_SOCKET_NAMESPACE}: duplicate async_event suppressed, eventId=${envelope.eventId}`
       );
 
       return true;
     }
 
     this.logger.info(
-      `${MOBIUS_SOCKET_NAMESPACE}: tracking async_event for ${sessionId}, eventId=${envelope.eventId}`
+      `${MOBIUS_SOCKET_NAMESPACE}: tracking async_event, eventId=${envelope.eventId}`
     );
-    seenAsyncEventIds.set(envelope.eventId, true);
+    this.seenAsyncEventIds.set(envelope.eventId, true);
 
-    if (seenAsyncEventIds.size > this.config.dedupCacheMaxSize) {
-      const oldestEventId = seenAsyncEventIds.keys().next().value;
+    if (this.seenAsyncEventIds.size > this.config.dedupCacheMaxSize) {
+      const oldestEventId = this.seenAsyncEventIds.keys().next().value;
 
-      seenAsyncEventIds.delete(oldestEventId);
+      this.seenAsyncEventIds.delete(oldestEventId);
       this.logger.info(
-        `${MOBIUS_SOCKET_NAMESPACE}: evicted oldest async_event from dedup cache for ${sessionId}, eventId=${oldestEventId}`
+        `${MOBIUS_SOCKET_NAMESPACE}: evicted oldest async_event from dedup cache, eventId=${oldestEventId}`
       );
     }
 
@@ -206,42 +164,35 @@ class MobiusSocket extends EventEmitter {
    * Handle imminent shutdown by establishing a new connection while keeping
    * the current one alive (make-before-break).
    * Idempotent: will no-op if already in progress.
-   * @param {string} sessionId - The session ID for which the shutdown is imminent
-   * @returns {void}
    */
-  private handleImminentShutdown(sessionId) {
-    const oldSocket = this.sockets.get(sessionId);
+  private handleImminentShutdown() {
+    const oldSocket = this.socket;
 
     try {
-      // Idempotent: if we already have a switchover backoff call for this session,
-      // a switchover is in progress – do nothing.
-      if (this.shutdownSwitchoverBackoffCalls.get(sessionId)) {
-        this.logger.info(
-          `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover already in progress for ${sessionId}`
-        );
+      if (this.shutdownSwitchoverBackoffCall) {
+        this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover already in progress`);
 
         return;
       }
 
-      const switchoverId = `${Date.now()}`;
-      this.logger.info(
-        `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover start, id=${switchoverId} for ${sessionId}`
-      );
+      this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover start`);
 
-      this.connectWithBackoff(undefined, sessionId, {
+      this.connectWithBackoff(undefined, {
         isShutdownSwitchover: true,
         attemptOptions: {
           isShutdownSwitchover: true,
           onSuccess: (newSocket, webSocketUrl) => {
             this.logger.info(
-              `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover connected, url: ${webSocketUrl} for ${sessionId}`
+              `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover connected, url: ${webSocketUrl}`
             );
 
-            // Atomically switch active socket reference
-            this.socket = this.sockets.get(this.defaultSessionId);
-            this.connected = this.hasConnectedSockets(); // remain connected throughout
+            // Promote the new socket now that the switchover succeeded
+            newSocket.connecting = false;
+            newSocket.connected = true;
+            this.socket = newSocket;
+            this.connected = true;
 
-            this.emitEvent(sessionId, 'event:mercury_shutdown_switchover_complete', {
+            this.emitEvent('event:mercury_shutdown_switchover_complete', {
               url: webSocketUrl,
             });
 
@@ -255,84 +206,55 @@ class MobiusSocket extends EventEmitter {
       })
         .then(() => {
           this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover completed successfully for ${sessionId}`
+            `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover completed successfully`
           );
         })
         .catch((err) => {
           this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover exhausted retries; will fall back to normal reconnection for ${sessionId}: `,
+            `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover exhausted retries; will fall back to normal reconnection: `,
             err
           );
-          this.emitEvent(sessionId, 'event:mercury_shutdown_switchover_failed', {reason: err});
-          // Old socket will eventually close with 4001, triggering normal reconnection
+          this.emitEvent('event:mercury_shutdown_switchover_failed', {reason: err});
         });
     } catch (e) {
-      this.logger.error(
-        `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] error during switchover for ${sessionId}`,
-        e
-      );
-      this.shutdownSwitchoverBackoffCalls.delete(sessionId);
-      this.emitEvent(sessionId, 'event:mercury_shutdown_switchover_failed', {reason: e});
+      this.logger.error(`${MOBIUS_SOCKET_NAMESPACE}: [shutdown] error during switchover`, e);
+      this.shutdownSwitchoverBackoffCall = undefined;
+      this.emitEvent('event:mercury_shutdown_switchover_failed', {reason: e});
     }
   }
 
   /**
-   * Get a specific socket by connection ID
-   * @param {string} sessionId - The connection identifier
-   * @returns {Socket|undefined} The socket instance or undefined if not found
-   */
-  public getSocket(sessionId = this.defaultSessionId) {
-    return this.sockets.get(sessionId);
-  }
-
-  /**
-   * Get the websocket URL for a currently connected session.
-   * @param {string} [sessionId=this.defaultSessionId] - The session identifier.
+   * Get the websocket URL for the currently connected socket.
    * @returns {string|undefined} The connected websocket URL, or undefined when not connected.
    */
-  public getConnectedWebSocketUrl(sessionId = this.defaultSessionId): string | undefined {
-    const socket = this.getSocket(sessionId);
-
-    if (!socket?.connected) {
+  public getConnectedWebSocketUrl(): string | undefined {
+    if (!this.socket?.connected) {
       return undefined;
     }
 
-    return socket.url;
+    return this.socket.url;
   }
 
   /**
    * Sends a websocket request and resolves when the matching response arrives.
-   * @param {Object} payload - The websocket request payload.
-   * @param {string|Object} [sessionIdOrRequestOptions=this.defaultSessionId] - Session ID or request options.
-   * @param {Object} [options={}] - Additional request options.
-   * @returns {Promise<Object>}
+   * @param {MobiusSocketRequestPayload} payload - The websocket request payload.
+   * @param {MobiusSocketRequestOptions} [options={}] - Additional request options.
+   * @returns {Promise<SocketResponse>}
    */
   public sendWssRequest(
     payload: MobiusSocketRequestPayload,
-    sessionIdOrRequestOptions: string | MobiusSocketRequestOptions = this.defaultSessionId,
     options: MobiusSocketRequestOptions = {}
   ): Promise<SocketResponse> {
     if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
       return Promise.reject(new Error('`payload` is required'));
     }
 
-    let sessionId = this.defaultSessionId;
-    let requestOptions = options;
-
-    if (typeof sessionIdOrRequestOptions === 'string') {
-      sessionId = sessionIdOrRequestOptions;
-    } else if (sessionIdOrRequestOptions && typeof sessionIdOrRequestOptions === 'object') {
-      requestOptions = sessionIdOrRequestOptions;
+    if (!this.socket || !this.socket.connected) {
+      return Promise.reject(new Error('Mobius socket is not connected'));
     }
 
-    const socket = this.getSocket(sessionId);
-
-    if (!socket || !socket.connected) {
-      return Promise.reject(new Error(`Mobius socket is not connected for session ${sessionId}`));
-    }
-
-    return socket.sendRequest(payload, {
-      timeout: requestOptions.timeout,
+    return this.socket.sendRequest(payload, {
+      timeout: options.timeout,
       matchesResponse: (response, request) =>
         response?.type === 'response_event' &&
         response?.subtype === request.type &&
@@ -355,64 +277,29 @@ class MobiusSocket extends EventEmitter {
   }
 
   /**
-   * Check if the plugin is connected
-   * @returns {boolean} True if connected
+   * Check if the socket is connected.
+   * @returns {boolean} True if connected.
    */
   public isConnected(): boolean {
     return this.connected;
   }
 
   /**
-   * Check if a socket is connected
-   * @param {string} [sessionId] - Optional session identifier
-   * @returns {boolean|undefined} True if the socket is connected
-   */
-  public hasConnectedSockets(sessionId): boolean {
-    if (sessionId) {
-      return Boolean(this.sockets.get(sessionId)?.connected);
-    }
-
-    for (const socket of this.sockets.values()) {
-      if (socket?.connected) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
-   * Check if any sockets are connecting
-   * @param {string} [sessionId=this.defaultSessionId] - The session identifier
-   * @returns {boolean|undefined} True if the socket is connecting
-   */
-  public hasConnectingSockets(sessionId = this.defaultSessionId): boolean {
-    const socket = this.sockets.get(sessionId || this.defaultSessionId);
-
-    return Boolean(socket?.connecting);
-  }
-
-  /**
-   * Connect to Mobius for a specific session.
+   * Connect to Mobius.
    * @param {string} [webSocketUrl] - Optional websocket URL override. Falls back to the device websocket URL.
-   * @param {string} [sessionId=this.defaultSessionId] - The session identifier for this connection.
-   * @returns {Promise<void>} Resolves when connection flow completes for the session.
+   * @returns {Promise<void>} Resolves when connection flow completes.
    */
-  public connect(webSocketUrl?: string, sessionId = this.defaultSessionId): Promise<void> {
-    // First check if there's already a connection promise for this session
-    if (this.connectPromises.has(sessionId)) {
+  public connect(webSocketUrl?: string): Promise<void> {
+    if (this.connectPromise) {
       this.logger.info(
-        `${MOBIUS_SOCKET_NAMESPACE}: connection ${sessionId} already in progress, returning existing promise`
+        `${MOBIUS_SOCKET_NAMESPACE}: connection already in progress, returning existing promise`
       );
 
-      return this.connectPromises.get(sessionId);
+      return this.connectPromise;
     }
 
-    const sessionSocket = this.sockets.get(sessionId);
-    if (sessionSocket?.connected || sessionSocket?.connecting) {
-      this.logger.info(
-        `${MOBIUS_SOCKET_NAMESPACE}: connection ${sessionId} already connected, will not connect again`
-      );
+    if (this.socket?.connected || this.socket?.connecting) {
+      this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: already connected, will not connect again`);
 
       return Promise.resolve();
     }
@@ -432,7 +319,7 @@ class MobiusSocket extends EventEmitter {
     this.connecting = true;
 
     this.logger.info(
-      `${MOBIUS_SOCKET_NAMESPACE}: starting connection attempt for ${sessionId}${
+      `${MOBIUS_SOCKET_NAMESPACE}: starting connection attempt${
         Number(this.config.initialConnectionMaxRetries) === 0 && !this.hasEverConnected
           ? ' (initial retries disabled)'
           : ''
@@ -443,29 +330,25 @@ class MobiusSocket extends EventEmitter {
       this.webex.internal.device.registered || this.webex.internal.device.register()
     )
       .then(() => {
-        this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: connecting ${sessionId}`);
+        this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: connecting`);
 
-        return this.connectWithBackoff(resolvedUrl, sessionId);
+        return this.connectWithBackoff(resolvedUrl);
       })
       .finally(() => {
-        this.connectPromises.delete(sessionId);
+        this.connectPromise = undefined;
       });
 
-    this.connectPromises.set(sessionId, connectPromise);
+    this.connectPromise = connectPromise;
 
     return connectPromise;
   }
 
   /**
-   * Disconnect a Mobius socket for a specific session.
-   * @param {object} [options] - Optional websocket close options (for example: `{code, reason}`).
-   * @param {string} [sessionId=this.defaultSessionId] - The session identifier to disconnect.
-   * @returns {Promise<void>} Resolves after disconnect cleanup and close handling are initiated/completed.
+   * Disconnect the Mobius socket.
+   * @param {MobiusSocketCloseOptions} [options] - Optional websocket close options (code, reason).
+   * @returns {Promise<void>} Resolves after disconnect cleanup and close handling complete.
    */
-  public disconnect(
-    options?: MobiusSocketCloseOptions,
-    sessionId = this.defaultSessionId
-  ): MobiusSocketDisconnectResult {
+  public disconnect(options?: MobiusSocketCloseOptions): MobiusSocketDisconnectResult {
     this.logger.info(
       `${MOBIUS_SOCKET_NAMESPACE}#disconnect: connecting state: ${
         this.connecting
@@ -473,45 +356,35 @@ class MobiusSocket extends EventEmitter {
         .socket}, options: ${JSON.stringify(options)}`
     );
 
-    const backoffCall = this.backoffCalls.get(sessionId);
-    if (backoffCall) {
-      this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: aborting connection ${sessionId}`);
-      backoffCall.abort();
-      this.backoffCalls.delete(sessionId);
+    if (this.backoffCall) {
+      this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: aborting connection`);
+      this.backoffCall.abort();
+      this.backoffCall = undefined;
     }
-    const shutdownSwitchoverBackoffCall = this.shutdownSwitchoverBackoffCalls.get(sessionId);
-    if (shutdownSwitchoverBackoffCall) {
-      this.logger.info(
-        `${MOBIUS_SOCKET_NAMESPACE}: aborting shutdown switchover connection ${sessionId}`
-      );
-      shutdownSwitchoverBackoffCall.abort();
-      this.shutdownSwitchoverBackoffCalls.delete(sessionId);
+    if (this.shutdownSwitchoverBackoffCall) {
+      this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: aborting shutdown switchover connection`);
+      this.shutdownSwitchoverBackoffCall.abort();
+      this.shutdownSwitchoverBackoffCall = undefined;
     }
-    // Clean up any pending connection promises
-    this.connectPromises.delete(sessionId);
+    this.connectPromise = undefined;
 
-    const sessionSocket = this.sockets.get(sessionId);
+    this.seenAsyncEventIds.clear();
 
-    this.clearSeenAsyncEventIds(sessionId);
-
-    if (!sessionSocket) {
-      this.connected = this.hasConnectedSockets();
-      if (!this.hasConnectedSockets()) {
-        this.stopTokenRefreshTimer();
-      }
+    if (!this.socket) {
+      this.connected = false;
+      this.stopTokenRefreshTimer();
 
       return Promise.resolve();
     }
 
-    sessionSocket.removeAllListeners('message');
-    sessionSocket.connecting = false;
-    sessionSocket.connected = false;
+    const currentSocket = this.socket;
+    currentSocket.removeAllListeners('message');
+    currentSocket.connecting = false;
+    currentSocket.connected = false;
 
-    return Promise.resolve(sessionSocket.close(options || undefined)).finally(() => {
-      this.connected = this.hasConnectedSockets();
-      if (!this.hasConnectedSockets()) {
-        this.stopTokenRefreshTimer();
-      }
+    return Promise.resolve(currentSocket.close(options || undefined)).finally(() => {
+      this.connected = false;
+      this.stopTokenRefreshTimer();
     });
   }
 
@@ -554,27 +427,26 @@ class MobiusSocket extends EventEmitter {
     return Promise.resolve(webSocketUrl);
   }
 
-  private attemptConnection(socketUrl, sessionId, callback, options = {}) {
+  private attemptConnection(socketUrl, callback, options = {}) {
     const {isShutdownSwitchover = false, onSuccess = null} = options;
 
     const socket = new Socket();
     socket.connecting = true;
     let newWSUrl;
 
-    this.attachSocketEventListeners(socket, sessionId);
+    this.attachSocketEventListeners(socket);
 
     const backoffCall = isShutdownSwitchover
-      ? this.shutdownSwitchoverBackoffCalls.get(sessionId)
-      : this.backoffCalls.get(sessionId);
+      ? this.shutdownSwitchoverBackoffCall
+      : this.backoffCall;
 
     // Check appropriate backoff call based on connection type
     if (!backoffCall) {
       const mode = isShutdownSwitchover ? 'switchover backoff call' : 'backoffCall';
-      const msg = `${MOBIUS_SOCKET_NAMESPACE}: prevent socket open when ${mode} no longer defined for ${sessionId}`;
+      const msg = `${MOBIUS_SOCKET_NAMESPACE}: prevent socket open when ${mode} no longer defined`;
       const err = new Error(msg);
 
       this.logger.info(msg);
-
       // Call the callback with the error before rejecting
       callback(err);
 
@@ -584,17 +456,17 @@ class MobiusSocket extends EventEmitter {
     // For shutdown switchover, don't set socket yet (make-before-break)
     // For normal connection, set socket before opening to allow disconnect() to close it
     if (!isShutdownSwitchover) {
-      this.sockets.set(sessionId, socket);
+      this.socket = socket;
     }
 
-    return this.prepareAndOpenSocket(socket, socketUrl, sessionId, isShutdownSwitchover)
+    return this.prepareAndOpenSocket(socket, socketUrl, isShutdownSwitchover)
       .then((webSocketUrl) => {
         newWSUrl = webSocketUrl;
 
         this.logger.info(
           `${MOBIUS_SOCKET_NAMESPACE}: ${
             isShutdownSwitchover ? '[shutdown] switchover' : ''
-          } connected to mobius socket, success, action: connected for ${sessionId}, url: ${newWSUrl}`
+          } connected to mobius socket, success, url: ${newWSUrl}`
         );
 
         // Custom success handler for shutdown switchover
@@ -614,35 +486,32 @@ class MobiusSocket extends EventEmitter {
         // For shutdown, simpler error handling - just callback for retry
         if (isShutdownSwitchover) {
           this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover attempt failed for ${sessionId}`,
+            `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] switchover attempt failed`,
             reason
           );
 
           return callback(reason);
         }
 
-        // Normal connection error handling (existing complex logic)
-        const backoffCallNormal = this.backoffCalls.get(sessionId);
-        // Suppress connection errors that appear to be network related. This
-        // may end up suppressing metrics during outages, but we might not care
-        // (especially since many of our outages happen in a way that client
-        // metrics can't be trusted).
+        // Normal connection error handling
+        const backoffCallNormal = this.backoffCall;
+        // Suppress connection errors that appear to be network related (code 1006).
         if (reason.code !== 1006 && backoffCallNormal && backoffCallNormal?.getNumRetries() > 0) {
-          this.emitEvent(sessionId, 'connection_failed', reason, {
-            sessionId,
+          this.emitEvent('connection_failed', reason, {
             retries: backoffCallNormal?.getNumRetries(),
           });
         }
         this.logger.info(
-          `${MOBIUS_SOCKET_NAMESPACE}: connection attempt failed for ${sessionId}`,
+          `${MOBIUS_SOCKET_NAMESPACE}: connection attempt failed`,
           reason,
           backoffCallNormal?.getNumRetries() === 0 ? reason.stack : ''
         );
-        // UnknownResponse is produced by IE for any 4XXX; treated it like a bad
+
+        // UnknownResponse is produced by IE for any 4XXX; treat it like a bad
         // web socket url and let WDM handle the token checking
         if (reason instanceof UnknownResponse) {
           this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: received unknown response code for ${sessionId}, refreshing device registration`
+            `${MOBIUS_SOCKET_NAMESPACE}: received unknown response code, refreshing device registration`
           );
 
           return this.webex.internal.device.refresh().then(() => callback(reason));
@@ -650,16 +519,14 @@ class MobiusSocket extends EventEmitter {
         // NotAuthorized implies expired token
         if (reason instanceof NotAuthorized) {
           this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: received authorization error for ${sessionId}, reauthorizing`
+            `${MOBIUS_SOCKET_NAMESPACE}: received authorization error, reauthorizing`
           );
 
           return this.webex.credentials.refresh({force: true}).then(() => callback(reason));
         }
-        // BadRequest implies current credentials are for a Service Account
-        // Forbidden implies current user is not entitled for Webex
         if (reason instanceof BadRequest || reason instanceof Forbidden) {
           this.logger.warn(
-            `${MOBIUS_SOCKET_NAMESPACE}: received unrecoverable response from ${MOBIUS_SOCKET_NAMESPACE} for ${sessionId}`
+            `${MOBIUS_SOCKET_NAMESPACE}: received unrecoverable response from ${MOBIUS_SOCKET_NAMESPACE}`
           );
           backoffCallNormal?.abort();
 
@@ -670,14 +537,14 @@ class MobiusSocket extends EventEmitter {
       })
       .catch((reason) => {
         this.logger.error(
-          `${MOBIUS_SOCKET_NAMESPACE}: failed to handle connection failure for ${sessionId}`,
+          `${MOBIUS_SOCKET_NAMESPACE}: failed to handle connection failure`,
           reason
         );
         callback(reason);
       });
   }
 
-  private prepareAndOpenSocket(socket, socketUrl, sessionId, isShutdownSwitchover = false) {
+  private prepareAndOpenSocket(socket, socketUrl, isShutdownSwitchover = false) {
     const logPrefix = isShutdownSwitchover ? '[shutdown] switchover' : 'connection';
 
     return Promise.all([this.prepareUrl(socketUrl), this.webex.credentials.getUserToken()]).then(
@@ -685,8 +552,6 @@ class MobiusSocket extends EventEmitter {
         let options = {
           forceCloseDelay: this.config.forceCloseDelay,
           wssResponseTimeout: this.config.wssResponseTimeout,
-          skipAckEventId: this.config.skipAckEventId,
-          skipAckEventType: this.config.skipAckEventType,
           token: normalizeMobiusAuthToken(token.toString()),
           refreshToken: () => this.refreshToken(),
           trackingId: `${this.webex.sessionId}_${Date.now()}`,
@@ -702,25 +567,23 @@ class MobiusSocket extends EventEmitter {
           options = {...options, ...this.webex.config.defaultMobiusSocketOptions};
         }
 
-        // Set the socket before opening it. This allows a disconnect() to close
-        // the socket if it is in the process of being opened.
-        this.sockets.set(sessionId, socket);
-        this.socket = this.sockets.get(this.defaultSessionId);
+        // Only promote the socket reference for normal connections.
+        // Shutdown switchover keeps the old socket active until the new one succeeds.
+        if (!isShutdownSwitchover) {
+          this.socket = socket;
+        }
 
-        this.logger.info(
-          `${MOBIUS_SOCKET_NAMESPACE} ${logPrefix} url for ${sessionId}: ${webSocketUrl}`
-        );
+        this.logger.info(`${MOBIUS_SOCKET_NAMESPACE} ${logPrefix} url: ${webSocketUrl}`);
 
         return socket.open(webSocketUrl, options).then(() => webSocketUrl);
       }
     );
   }
 
-  private connectWithBackoff(webSocketUrl, sessionId, context = {}): Promise<void> {
+  private connectWithBackoff(webSocketUrl, context = {}): Promise<void> {
     const {isShutdownSwitchover = false, attemptOptions = {}} = context;
 
     return new Promise((resolve, reject) => {
-      // eslint gets confused about whether call is actually used
       // eslint-disable-next-line prefer-const
       let call;
       const isInitialConnect = !isShutdownSwitchover && !this.hasEverConnected;
@@ -730,41 +593,42 @@ class MobiusSocket extends EventEmitter {
           : Number(this.config.initialConnectionMaxRetries);
       const isInitialConnectWithoutRetries = isInitialConnect && initialRetryLimit === 0;
 
-      const onComplete = (err, sid = sessionId) => {
+      const onComplete = (err) => {
         if (isShutdownSwitchover) {
-          this.shutdownSwitchoverBackoffCalls.delete(sid);
+          this.shutdownSwitchoverBackoffCall = undefined;
         } else {
-          this.backoffCalls.delete(sid);
+          this.backoffCall = undefined;
         }
-        const sessionSocket = this.sockets.get(sid);
+
         if (err) {
           const msg = isShutdownSwitchover
             ? `[shutdown] switchover failed after ${call.getNumRetries()} retries`
             : `failed to connect after ${call.getNumRetries()} retries`;
 
-          this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: ${msg}; log statement about next retry was inaccurate; ${err}`
-          );
-          if (sessionSocket) {
-            sessionSocket.connecting = false;
-            sessionSocket.connected = false;
+          this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: ${msg}; ${err}`);
+          // Only mutate socket flags for normal connections.
+          // During shutdown switchover, this.socket is the old live socket — don't touch it.
+          if (!isShutdownSwitchover && this.socket) {
+            this.socket.connecting = false;
+            this.socket.connected = false;
           }
 
           return reject(err);
         }
 
-        // Update overall connected status
-        if (sessionSocket) {
-          sessionSocket.connecting = false;
-          sessionSocket.connected = true;
+        // For normal connections, mark the socket as connected.
+        // Shutdown switchover promotion is handled by the onSuccess callback.
+        if (!isShutdownSwitchover && this.socket) {
+          this.socket.connecting = false;
+          this.socket.connected = true;
         }
-        // Default success handling for normal connections
+
         if (!isShutdownSwitchover) {
-          this.connecting = this.hasConnectingSockets();
-          this.connected = this.hasConnectedSockets();
+          this.connecting = false;
+          this.connected = true;
           this.hasEverConnected = true;
           this.startTokenRefreshTimer();
-          this.emitEvent(sid, 'online');
+          this.emitEvent('online');
         }
 
         return resolve();
@@ -776,11 +640,11 @@ class MobiusSocket extends EventEmitter {
           const attemptLogPrefix = isShutdownSwitchover ? '[shutdown] switchover' : 'connection';
 
           this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: executing ${attemptLogPrefix} attempt ${attemptNum} for ${sessionId}`
+            `${MOBIUS_SOCKET_NAMESPACE}: executing ${attemptLogPrefix} attempt ${attemptNum}`
           );
-          this.attemptConnection(webSocketUrl, sessionId, callback, attemptOptions);
+          this.attemptConnection(webSocketUrl, callback, attemptOptions);
         },
-        (err) => onComplete(err, sessionId)
+        (err) => onComplete(err)
       );
 
       call.setStrategy(
@@ -798,28 +662,25 @@ class MobiusSocket extends EventEmitter {
         call.failAfter(this.config.maxRetries);
       }
 
-      // Store the call BEFORE setting up event handlers to prevent race conditions
-      // Store backoff call reference BEFORE starting (so it's available in _attemptConnection)
+      // Store backoff call reference BEFORE starting (so it's available in attemptConnection)
       if (isShutdownSwitchover) {
-        this.shutdownSwitchoverBackoffCalls.set(sessionId, call);
+        this.shutdownSwitchoverBackoffCall = call;
       } else {
-        this.backoffCalls.set(sessionId, call);
+        this.backoffCall = call;
       }
 
       call.on('abort', () => {
         const msg = isShutdownSwitchover ? 'Shutdown Switchover' : 'Connection';
 
-        this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: ${msg} aborted for ${sessionId}`);
-        reject(new Error(`MobiusSocket ${msg} Aborted for ${sessionId}`));
+        this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: ${msg} aborted`);
+        reject(new Error(`MobiusSocket ${msg} Aborted`));
       });
 
       call.on('callback', (err) => {
         if (err) {
           if (isInitialConnectWithoutRetries) {
-            // retryIf(() => false) already disabled retries for this initial connect;
-            // this branch only avoids logging the generic "attempting retry" message.
             this.logger.info(
-              `${MOBIUS_SOCKET_NAMESPACE}: initial connect failed for ${sessionId}; retries already disabled`
+              `${MOBIUS_SOCKET_NAMESPACE}: initial connect failed; retries already disabled`
             );
 
             return;
@@ -833,7 +694,7 @@ class MobiusSocket extends EventEmitter {
           this.logger.info(
             `${MOBIUS_SOCKET_NAMESPACE}: ${callbackLogPrefix} failed to connect; attempting retry ${
               number + 1
-            } in ${delay} ms for ${sessionId}`
+            } in ${delay} ms`
           );
           /* istanbul ignore if */
           if (process.env.NODE_ENV === 'development') {
@@ -842,22 +703,20 @@ class MobiusSocket extends EventEmitter {
 
           return;
         }
-        this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: connected ${sessionId}`);
+        this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: connected`);
       });
 
       call.start();
     });
   }
 
-  private emitEvent(sessionId, eventName, ...args) {
+  private emitEvent(eventName, ...args) {
     try {
-      if (!sessionId || !eventName) {
+      if (!eventName) {
         return;
       }
 
-      const suffix = sessionId === this.defaultSessionId ? '' : `:${sessionId}`;
-
-      this.emit(`${eventName}${suffix}`, ...args);
+      this.emit(eventName, ...args);
     } catch (error) {
       // Safely handle errors without causing additional issues during cleanup
       try {
@@ -865,12 +724,12 @@ class MobiusSocket extends EventEmitter {
           `${MOBIUS_SOCKET_NAMESPACE}: error occurred in event handler:`,
           error,
           ' with args: ',
-          [sessionId, eventName, ...args]
+          [eventName, ...args]
         );
       } catch (logError) {
         // If even logging fails, just ignore to prevent cascading errors during cleanup
         // eslint-disable-next-line no-console
-        console.error('MobiusSocket _emit error handling failed:', logError);
+        console.error('MobiusSocket emitEvent error handling failed:', logError);
       }
     }
   }
@@ -899,7 +758,7 @@ class MobiusSocket extends EventEmitter {
   }
 
   private startTokenRefreshTimer() {
-    if (this.tokenRefreshTimer || !this.hasConnectedSockets()) {
+    if (this.tokenRefreshTimer || !this.connected) {
       return;
     }
 
@@ -924,7 +783,7 @@ class MobiusSocket extends EventEmitter {
       return this.tokenRefreshInFlight;
     }
 
-    if (!this.hasConnectedSockets()) {
+    if (!this.connected) {
       this.stopTokenRefreshTimer();
 
       return Promise.resolve();
@@ -942,19 +801,16 @@ class MobiusSocket extends EventEmitter {
           throw new Error('Mobius token refresh did not return a token');
         }
         const refreshedToken = normalizeMobiusAuthToken(token.toString());
-        const authPayloadPromises = [];
 
-        for (const socket of this.sockets.values()) {
-          if (socket?.connected) {
-            authPayloadPromises.push(socket.refresh(refreshedToken));
-          }
+        if (this.socket?.connected) {
+          return this.socket.refresh(refreshedToken);
         }
 
-        return Promise.all(authPayloadPromises);
+        return undefined;
       })
       .catch((error) => {
         this.logger.error(
-          `${MOBIUS_SOCKET_NAMESPACE}: failed to refresh/re-auth Mobius sockets`,
+          `${MOBIUS_SOCKET_NAMESPACE}: failed to refresh/re-auth Mobius socket`,
           error
         );
         throw error;
@@ -966,41 +822,33 @@ class MobiusSocket extends EventEmitter {
     return this.tokenRefreshInFlight;
   }
 
-  private onclose(sessionId, event, sourceSocket) {
+  private onclose(event, sourceSocket) {
     // I don't see any way to avoid the complexity or statement count in here.
     /* eslint complexity: [0] */
 
     try {
       const reason = event.reason && event.reason.toLowerCase();
-      const sessionSocket = this.sockets.get(sessionId);
       let socketUrl;
-      event.sessionId = sessionId;
 
-      const isActiveSocket = sourceSocket === sessionSocket;
+      const isActiveSocket = sourceSocket === this.socket;
       if (sourceSocket) {
         socketUrl = sourceSocket.url;
       }
-      this.sockets.delete(sessionId);
 
+      // Only tear down state if the currently active socket closed
       if (isActiveSocket) {
-        // Only tear down state if the currently active socket closed
-        if (sessionSocket) {
-          sessionSocket.removeAllListeners();
-          if (sessionId === this.defaultSessionId) {
-            this.socket = undefined;
-          }
-          this.emitEvent(sessionId, 'offline', event);
+        if (this.socket) {
+          this.socket.removeAllListeners();
+          this.socket = undefined;
+          this.emitEvent('offline', event);
         }
-        // Update overall connected status
-        this.connecting = this.hasConnectingSockets();
-        this.connected = this.hasConnectedSockets();
-        if (!this.hasConnectedSockets()) {
-          this.stopTokenRefreshTimer();
-        }
+        this.connecting = false;
+        this.connected = false;
+        this.stopTokenRefreshTimer();
       } else {
         // Old socket closed; do not flip connection state
         this.logger.info(
-          `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] non-active socket closed, code=${event.code} for ${sessionId}`
+          `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] non-active socket closed, code=${event.code}`
         );
         // Clean up listeners from old socket now that it's closed
         if (sourceSocket) {
@@ -1010,127 +858,95 @@ class MobiusSocket extends EventEmitter {
 
       switch (event.code) {
         case 1003:
-          // metric: disconnect
           this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: service rejected last message for ${sessionId}; will not reconnect: ${event.reason}`
+            `${MOBIUS_SOCKET_NAMESPACE}: service rejected last message; will not reconnect: ${event.reason}`
           );
-          if (isActiveSocket) this.emitEvent(sessionId, 'offline.permanent', event);
+          if (isActiveSocket) this.emitEvent('offline.permanent', event);
           break;
         case 4000:
-          // metric: disconnect
-          this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: socket ${sessionId} replaced; will not reconnect`
-          );
-          if (isActiveSocket) this.emitEvent(sessionId, 'offline.replaced', event);
-          // If not active, nothing to do
+          this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: socket replaced; will not reconnect`);
+          if (isActiveSocket) this.emitEvent('offline.replaced', event);
           break;
         case 4001:
           // replaced during shutdown
           if (isActiveSocket) {
             // Server closed active socket with 4001, meaning it expected this connection
-            // to be replaced, but the switchover in _handleImminentShutdown failed.
-            // This is a permanent failure - do not reconnect.
+            // to be replaced, but the switchover in handleImminentShutdown failed.
             this.logger.warn(
-              `${MOBIUS_SOCKET_NAMESPACE}: active socket closed with 4001; shutdown switchover failed for ${sessionId}`
+              `${MOBIUS_SOCKET_NAMESPACE}: active socket closed with 4001; shutdown switchover failed`
             );
-            this.emitEvent(sessionId, 'offline.permanent', event);
+            this.emitEvent('offline.permanent', event);
           } else {
             // Expected: old socket closed after successful switchover
             this.logger.info(
-              `${MOBIUS_SOCKET_NAMESPACE}: old socket closed with 4001 (replaced during shutdown); no reconnect needed for ${sessionId}`
+              `${MOBIUS_SOCKET_NAMESPACE}: old socket closed with 4001 (replaced during shutdown); no reconnect needed`
             );
-            this.emitEvent(sessionId, 'offline.replaced', event);
+            this.emitEvent('offline.replaced', event);
           }
           break;
         case 1001:
         case 1005:
         case 1006:
         case 1011:
-          this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: socket ${sessionId} disconnected; reconnecting`
-          );
+          this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: socket disconnected; reconnecting`);
           if (isActiveSocket) {
-            this.emitEvent(sessionId, 'offline.transient', event);
-            this.logger.info(
-              `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] reconnecting active socket to recover for ${sessionId}`
-            );
-            this.reconnect(socketUrl, sessionId);
+            this.emitEvent('offline.transient', event);
+            this.reconnect(socketUrl);
           }
-          // metric: disconnect
-          // if (code == 1011 && reason !== ping error) metric: unexpected disconnect
           break;
         case 1000:
-        case 3050: // 3050 indicates logout form of closure, default to old behavior, use config reason defined by consumer to proceed with the permanent block
+        case 3050:
           if (normalReconnectReasons.includes(reason)) {
-            this.logger.info(
-              `${MOBIUS_SOCKET_NAMESPACE}: socket ${sessionId} disconnected; reconnecting`
-            );
+            this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: socket disconnected; reconnecting`);
             if (isActiveSocket) {
-              this.emitEvent(sessionId, 'offline.transient', event);
-              this.logger.info(
-                `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] reconnecting due to normal close for ${sessionId}`
-              );
-              this.reconnect(socketUrl, sessionId);
+              this.emitEvent('offline.transient', event);
+              this.reconnect(socketUrl);
             }
-            // metric: disconnect
-            // if (reason === done forced) metric: force closure
           } else {
             this.logger.info(
-              `${MOBIUS_SOCKET_NAMESPACE}: socket ${sessionId} disconnected; will not reconnect: ${event.reason}`
+              `${MOBIUS_SOCKET_NAMESPACE}: socket disconnected; will not reconnect: ${event.reason}`
             );
-            if (isActiveSocket) this.emitEvent(sessionId, 'offline.permanent', event);
+            if (isActiveSocket) this.emitEvent('offline.permanent', event);
           }
           break;
         default:
           this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: socket ${sessionId} disconnected unexpectedly; will not reconnect`
+            `${MOBIUS_SOCKET_NAMESPACE}: socket disconnected unexpectedly; will not reconnect`
           );
-          // unexpected disconnect
-          if (isActiveSocket) this.emitEvent(sessionId, 'offline.permanent', event);
+          if (isActiveSocket) this.emitEvent('offline.permanent', event);
       }
     } catch (error) {
-      this.logger.error(
-        `${MOBIUS_SOCKET_NAMESPACE}: error occurred in close handler for ${sessionId}`,
-        error
-      );
+      this.logger.error(`${MOBIUS_SOCKET_NAMESPACE}: error occurred in close handler`, error);
     }
   }
 
-  private onmessage(sessionId, event) {
-    this.setTimeOffset(sessionId, event);
+  private onmessage(event) {
+    this.setTimeOffset(event);
     const envelope = event.data;
 
     if (process.env.ENABLE_MERCURY_LOGGING) {
-      this.logger.debug(
-        `${MOBIUS_SOCKET_NAMESPACE}: message envelope from ${sessionId}: `,
-        envelope
-      );
+      this.logger.debug(`${MOBIUS_SOCKET_NAMESPACE}: message envelope: `, envelope);
     }
-
-    envelope.sessionId = sessionId;
 
     // Handle shutdown message shape: { type: 'shutdown' }
     if (envelope && envelope.type === 'shutdown') {
-      this.logger.info(
-        `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] imminent shutdown message received for ${sessionId}`
-      );
-      this.emitEvent(sessionId, 'event:mercury_shutdown_imminent', envelope);
+      this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: [shutdown] imminent shutdown message received`);
+      this.emitEvent('event:mercury_shutdown_imminent', envelope);
 
-      this.handleImminentShutdown(sessionId);
+      this.handleImminentShutdown();
 
       return Promise.resolve();
     }
 
-    if (this.trackAsyncEventAndShouldSuppressDuplicate(sessionId, envelope)) {
+    if (this.trackAsyncEventAndShouldSuppressDuplicate(envelope)) {
       return Promise.resolve();
     }
 
-    // Mobius: emit event:<type> for typed messages (e.g., register.response)
+    // Emit event:<type> for typed messages (e.g., register.response)
     if (envelope.type) {
-      this.emitEvent(sessionId, `event:${envelope.type}`, envelope);
+      this.emitEvent(`event:${envelope.type}`, envelope);
     }
 
-    envelope.sessionId = sessionId;
     // Use data/payload if present, otherwise treat the envelope itself as the data (flat format)
     const data = envelope.data || envelope;
 
@@ -1140,7 +956,7 @@ class MobiusSocket extends EventEmitter {
     const eventType = data?.eventType || envelope.eventType;
 
     if (!eventType) {
-      this.emitEvent(sessionId, 'event', envelope);
+      this.emitEvent('event', envelope);
 
       return Promise.resolve();
     }
@@ -1155,7 +971,7 @@ class MobiusSocket extends EventEmitter {
               resolve((this.webex[namespace] || this.webex.internal[namespace])[name](data));
             }).catch((reason) =>
               this.logger.error(
-                `${MOBIUS_SOCKET_NAMESPACE}: error occurred in autowired event handler for ${eventType} from ${sessionId}`,
+                `${MOBIUS_SOCKET_NAMESPACE}: error occurred in autowired event handler for ${eventType}`,
                 reason
               )
             );
@@ -1163,35 +979,35 @@ class MobiusSocket extends EventEmitter {
         Promise.resolve()
       )
       .then(() => {
-        this.emitEvent(sessionId, 'event', envelope);
+        this.emitEvent('event', envelope);
         const [namespace] = eventType.split('.');
 
         if (namespace === eventType) {
-          this.emitEvent(sessionId, `event:${namespace}`, envelope);
+          this.emitEvent(`event:${namespace}`, envelope);
         } else {
-          this.emitEvent(sessionId, `event:${namespace}`, envelope);
-          this.emitEvent(sessionId, `event:${eventType}`, envelope);
+          this.emitEvent(`event:${namespace}`, envelope);
+          this.emitEvent(`event:${eventType}`, envelope);
         }
       })
       .catch((reason) => {
         this.logger.error(
-          `${MOBIUS_SOCKET_NAMESPACE}: error occurred processing socket message from ${sessionId}`,
+          `${MOBIUS_SOCKET_NAMESPACE}: error occurred processing socket message`,
           reason
         );
       });
   }
 
-  private setTimeOffset(sessionId, event) {
+  private setTimeOffset(event) {
     const {wsWriteTimestamp} = event.data;
     if (typeof wsWriteTimestamp === 'number' && wsWriteTimestamp > 0) {
       this.mercuryTimeOffset = Date.now() - wsWriteTimestamp;
     }
   }
 
-  private reconnect(webSocketUrl, sessionId = this.defaultSessionId) {
-    this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: reconnecting ${sessionId}`);
+  private reconnect(webSocketUrl) {
+    this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: reconnecting`);
 
-    return this.connect(webSocketUrl || this.socketUrl, sessionId);
+    return this.connect(webSocketUrl || this.socketUrl);
   }
 }
 

--- a/packages/calling/src/mobius-socket/socket.test.ts
+++ b/packages/calling/src/mobius-socket/socket.test.ts
@@ -765,7 +765,7 @@ describe('plugin-mobius-socket', () => {
       });
 
       it('acknowledges async_event messages only', () => {
-        sinon.spy(socket, '_acknowledge');
+        sinon.spy(socket, 'acknowledge');
         mockWebSocket.emit('message', {
           data: JSON.stringify({
             type: 'async_event',
@@ -773,28 +773,27 @@ describe('plugin-mobius-socket', () => {
             trackingId: 'tracking-123',
           }),
         });
-        assert.called(socket._acknowledge);
+        assert.called(socket.acknowledge);
       });
 
       it('does not acknowledge non-async_event messages', () => {
-        sinon.spy(socket, '_acknowledge');
+        sinon.spy(socket, 'acknowledge');
         mockWebSocket.emit('message', {
           data: JSON.stringify({
             type: 'regular',
             id: 'mockid',
           }),
         });
-        assert.notCalled(socket._acknowledge);
+        assert.notCalled(socket.acknowledge);
       });
     });
 
-    describe('#_acknowledge', () => {
-      it('requires an event', () =>
-        assert.isRejected(socket._acknowledge(), /`event` is required/));
+    describe('#acknowledge', () => {
+      it('requires an event', () => assert.isRejected(socket.acknowledge(), /`event` is required/));
 
       it('acknowledges async events using event_ack and eventId', () =>
         socket
-          ._acknowledge({
+          .acknowledge({
             data: {
               eventId: 'event-123',
               trackingId: 'tracking-123',

--- a/packages/calling/src/mobius-socket/socket.test.ts
+++ b/packages/calling/src/mobius-socket/socket.test.ts
@@ -7,15 +7,9 @@ import {forEach} from 'lodash';
 import {assert} from '@webex/test-helper-chai';
 import MockWebSocket from '@webex/test-helper-mock-web-socket';
 import sinon from 'sinon';
-import {
-  BadRequest,
-  NotAuthorized,
-  Forbidden,
-  // NotFound,
-  config,
-  ConnectionError,
-  Socket,
-} from './index';
+import {BadRequest, NotAuthorized, Forbidden, ConnectionError} from './errors';
+import config from './config';
+import Socket from './socket';
 import {MESSAGE_TYPES} from './socket/constants';
 
 if (!crypto.randomUUID) {
@@ -305,32 +299,6 @@ describe('plugin-mobius-socket', () => {
           });
         });
       });
-
-      // describe(`when connection fails because the websocket registation has expired`, () => {
-      //   it(`rejects with a NotFound`, () => {
-      //     const s = new Socket();
-      //     const promise = s.open(`ws://example.com`, mockoptions);
-      //     mockWebSocket.readyState = 1;
-      //     mockWebSocket.emit(`open`);
-      //
-      //     const firstCallArgs = JSON.parse(mockWebSocket.send.firstCall.args[0]);
-      //     assert.equal(firstCallArgs.type, `authorization`);
-      //
-      //     mockWebSocket.emit(`close`, {
-      //       code: 4404,
-      //       reason: `Expired registration`
-      //     });
-      //
-      //     return assert.isRejected(promise)
-      //       .then((reason) => {
-      //         assert.instanceOf(reason, NotFound);
-      //         assert.match(reason.code, 4404);
-      //         assert.match(reason.reason, /Expired registration/);
-      //         assert.match(reason.message, /Expired registration/);
-      //         return s.close();
-      //       });
-      //   });
-      // });
 
       describe('when connection fails for non-authorization reasons', () => {
         it("rejects with the close event's reason", () => {

--- a/packages/calling/src/mobius-socket/socket/socket-base.ts
+++ b/packages/calling/src/mobius-socket/socket/socket-base.ts
@@ -10,14 +10,7 @@ import {checkRequired} from '@webex/common';
 import {safeSetTimeout} from '@webex/common-timers';
 import {defaults, has, isObject} from 'lodash';
 
-import {
-  BadRequest,
-  ConnectionError,
-  Forbidden,
-  NotAuthorized,
-  UnknownResponse,
-  // NotFound
-} from '../errors';
+import {BadRequest, ConnectionError, Forbidden, NotAuthorized, UnknownResponse} from '../errors';
 import {MESSAGE_TYPES, SOCKET_READY_STATE} from './constants';
 import type {
   SocketCloseEvent,
@@ -48,9 +41,9 @@ const ConnectionErrorCtor = ConnectionError as unknown as new (
  * Generalized socket abstraction
  */
 export default class Socket extends EventEmitter {
-  _domain: string;
+  private domain: string;
 
-  _pendingResponses: Map<string, PendingResponseEntry>;
+  private pendingResponses: Map<string, PendingResponseEntry>;
 
   forceCloseDelay!: number;
 
@@ -68,13 +61,12 @@ export default class Socket extends EventEmitter {
    * constructor
    * @returns {Socket}
    */
-  constructor() {
+  public constructor() {
     super();
-    this._domain = 'unknown-domain';
-    this._pendingResponses = new Map();
+    this.domain = 'unknown-domain';
+    this.pendingResponses = new Map();
     this.onmessage = this.onmessage.bind(this);
     this.onclose = this.onclose.bind(this);
-    // Increase max listeners to avoid memory leak warning in tests
     this.setMaxListeners(10);
   }
 
@@ -82,7 +74,7 @@ export default class Socket extends EventEmitter {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
    * @returns {string}
    */
-  get binaryType() {
+  public get binaryType() {
     return sockets.get(this)!.binaryType;
   }
 
@@ -90,7 +82,7 @@ export default class Socket extends EventEmitter {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
    * @returns {number}
    */
-  get bufferedAmount() {
+  public get bufferedAmount() {
     return sockets.get(this)!.bufferedAmount;
   }
 
@@ -98,7 +90,7 @@ export default class Socket extends EventEmitter {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
    * @returns {string}
    */
-  get extensions() {
+  public get extensions() {
     return sockets.get(this)!.extensions;
   }
 
@@ -106,7 +98,7 @@ export default class Socket extends EventEmitter {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
    * @returns {string}
    */
-  get protocol() {
+  public get protocol() {
     return sockets.get(this)!.protocol;
   }
 
@@ -114,7 +106,7 @@ export default class Socket extends EventEmitter {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
    * @returns {number}
    */
-  get readyState() {
+  public get readyState() {
     return sockets.get(this)!.readyState;
   }
 
@@ -122,7 +114,7 @@ export default class Socket extends EventEmitter {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
    * @returns {string}
    */
-  get url() {
+  public get url() {
     return sockets.get(this)!.url;
   }
 
@@ -131,7 +123,7 @@ export default class Socket extends EventEmitter {
    * WebSocket in browsers)
    * @returns {WebSocket}
    */
-  static getWebSocketConstructor(): unknown {
+  public static getWebSocketConstructor(): unknown {
     throw new Error(
       'Socket.getWebSocketConstructor() must be implemented in an environmentally appropriate way'
     );
@@ -144,7 +136,7 @@ export default class Socket extends EventEmitter {
    * @param {number} options.code
    * @returns {Promise}
    */
-  close(options?: {reason?: string; code?: number}) {
+  public close(options?: {reason?: string; code?: number}) {
     return new Promise<SocketCloseEvent | void>((resolve, reject) => {
       const socket = sockets.get(this);
 
@@ -155,13 +147,13 @@ export default class Socket extends EventEmitter {
         return;
       }
       // logger is defined once open is called
-      this.logger.info(`socket,${this._domain}: closing`);
+      this.logger.info(`socket,${this.domain}: closing`);
 
       if (
         socket.readyState === SOCKET_READY_STATE.CLOSING ||
         socket.readyState === SOCKET_READY_STATE.CLOSED
       ) {
-        this.logger.info(`socket,${this._domain}: already closed`);
+        this.logger.info(`socket,${this.domain}: already closed`);
         resolve();
 
         return;
@@ -187,7 +179,7 @@ export default class Socket extends EventEmitter {
 
       const closeTimer = safeSetTimeout(() => {
         try {
-          this.logger.info(`socket,${this._domain}: no close event received, forcing closure`);
+          this.logger.info(`socket,${this.domain}: no close event received, forcing closure`);
           resolve(
             this.onclose(
               originalCode
@@ -199,12 +191,12 @@ export default class Socket extends EventEmitter {
             )
           );
         } catch (error) {
-          this.logger.warn(`socket,${this._domain}: force-close failed`, error);
+          this.logger.warn(`socket,${this.domain}: force-close failed`, error);
         }
       }, this.forceCloseDelay);
 
       socket.onclose = (event) => {
-        this.logger.info(`socket,${this._domain}: close event fired`, event.code, event.reason);
+        this.logger.info(`socket,${this.domain}: close event fired`, event.code, event.reason);
         clearTimeout(closeTimer);
         this.onclose(event);
         resolve(event);
@@ -214,7 +206,7 @@ export default class Socket extends EventEmitter {
       // because calling close() on a CONNECTING socket may not preserve custom codes
       if (socket.readyState === SOCKET_READY_STATE.CONNECTING) {
         this.logger.info(
-          `socket,${this._domain}: socket still connecting, triggering close manually`
+          `socket,${this.domain}: socket still connecting, triggering close manually`
         );
         clearTimeout(closeTimer);
         const closeEvent: SocketCloseEvent = {
@@ -227,7 +219,7 @@ export default class Socket extends EventEmitter {
           socket.close(resolvedOptions.code, resolvedOptions.reason);
         } catch (error) {
           this.logger.info(
-            `socket,${this._domain}: error while closing CONNECTING socket, likely due to browser incompatibility with custom close codes`,
+            `socket,${this.domain}: error while closing CONNECTING socket, likely due to browser incompatibility with custom close codes`,
             error
           );
         }
@@ -247,11 +239,11 @@ export default class Socket extends EventEmitter {
    * @param {Logger} options.logger (required)
    * @returns {Promise}
    */
-  open(url: string, options?: SocketOpenOptions) {
+  public open(url: string, options?: SocketOpenOptions) {
     try {
-      this._domain = new URL(url).hostname;
+      this.domain = new URL(url).hostname;
     } catch {
-      this._domain = url;
+      this.domain = url;
     }
 
     return new Promise<void>((resolve, reject) => {
@@ -281,15 +273,15 @@ export default class Socket extends EventEmitter {
 
       const WebSocket = Socket.getWebSocketConstructor() as SocketTransportConstructor;
 
-      this.logger.info(`socket,${this._domain}: creating WebSocket`);
+      this.logger.info(`socket,${this.domain}: creating WebSocket`);
       const socket = new WebSocket(url, [], resolvedOptions);
 
       socket.binaryType = 'arraybuffer';
       socket.onmessage = this.onmessage;
 
       socket.onclose = (event) => {
-        event = this._fixCloseCode(event);
-        this.logger.info(`socket,${this._domain}: closed before open`, event.code, event.reason);
+        event = this.fixCloseCode(event);
+        this.logger.info(`socket,${this.domain}: closed before open`, event.code, event.reason);
         switch (event.code) {
           case 1005:
             // IE 11 doesn't seem to allow 4XXX codes, so if we get a 1005, assume
@@ -303,18 +295,16 @@ export default class Socket extends EventEmitter {
             return reject(new NotAuthorizedCtor(event));
           case 4403:
             return reject(new ForbiddenCtor(event));
-          // case 4404:
-          //   return reject(new NotFound(event));
           default:
             return reject(new ConnectionErrorCtor(event));
         }
       };
 
       socket.onopen = () => {
-        this.logger.info(`socket,${this._domain}: connected`);
-        this._authorize(this.token)
+        this.logger.info(`socket,${this.domain}: connected`);
+        this.authorize(this.token)
           .then(() => {
-            this.logger.info(`socket,${this._domain}: authorized`);
+            this.logger.info(`socket,${this.domain}: authorized`);
             socket.onclose = this.onclose;
             resolve();
           })
@@ -322,11 +312,11 @@ export default class Socket extends EventEmitter {
       };
 
       socket.onerror = (event) => {
-        this.logger.warn(`socket,${this._domain}: error event fired`, event);
+        this.logger.warn(`socket,${this.domain}: error event fired`, event);
       };
 
       sockets.set(this, socket);
-      this.logger.info(`socket,${this._domain}: waiting for server`);
+      this.logger.info(`socket,${this.domain}: waiting for server`);
     });
   }
 
@@ -335,11 +325,11 @@ export default class Socket extends EventEmitter {
    * @param {CloseEvent} event
    * @returns {undefined}
    */
-  onclose(event: SocketCloseEvent) {
-    this.logger.info(`socket,${this._domain}: closed`, event.code, event.reason);
+  public onclose(event: SocketCloseEvent) {
+    this.logger.info(`socket,${this.domain}: closed`, event.code, event.reason);
 
-    event = this._fixCloseCode(event);
-    this._rejectPendingResponses(new ConnectionErrorCtor(event));
+    event = this.fixCloseCode(event);
+    this.rejectPendingResponses(new ConnectionErrorCtor(event));
     this.emit('close', event);
 
     // Remove all listeners to (a) avoid reacting to late pongs and (b) ensure
@@ -352,24 +342,24 @@ export default class Socket extends EventEmitter {
    * @param {MessageEvent} event
    * @returns {undefined}
    */
-  onmessage(event: SocketMessageEvent<string>) {
+  public onmessage(event: SocketMessageEvent<string>) {
     try {
       const data = JSON.parse(event.data) as SocketResponse;
       const processedEvent = {data};
 
       if (data.type === 'async_event') {
-        this._acknowledge(processedEvent).catch((error) => {
-          this.logger.warn(`socket,${this._domain}: failed to acknowledge async event`, error);
+        this.acknowledge(processedEvent).catch((error) => {
+          this.logger.warn(`socket,${this.domain}: failed to acknowledge async event`, error);
         });
       }
 
       // Match pending request/response promises before emitting the public message event.
       // The message is still emitted afterward for any external listeners that care about it.
-      this._handlePendingResponse(data);
+      this.handlePendingResponse(data);
       this.emit('message', processedEvent);
     } catch (error) {
       /* istanbul ignore next */
-      this.logger.warn(`socket,${this._domain}: error while receiving WebSocket message`, error);
+      this.logger.warn(`socket,${this.domain}: error while receiving WebSocket message`, error);
     }
   }
 
@@ -378,7 +368,7 @@ export default class Socket extends EventEmitter {
    * @param {mixed} data
    * @returns {Promise}
    */
-  send(data: string | Record<string, unknown>) {
+  public send(data: string | Record<string, unknown>) {
     return new Promise<void>((resolve, reject) => {
       if (this.readyState !== SOCKET_READY_STATE.OPEN) {
         reject(new Error('INVALID_STATE_ERROR'));
@@ -416,13 +406,13 @@ export default class Socket extends EventEmitter {
    * @param {number} [options.timeout]
    * @returns {Promise<Object>}
    */
-  sendRequest(data: SocketResponse, options: SendRequestOptions = {}) {
+  public sendRequest(data: SocketResponse, options: SendRequestOptions = {}) {
     if (!isObject(data)) {
       return Promise.reject(new Error('`data` is required'));
     }
 
     const request = {...data};
-    const trackingId = request.trackingId || this._createTrackingId();
+    const trackingId = request.trackingId || this.createTrackingId();
     const timeout = options.timeout || this.wssResponseTimeout || 10000;
     const matchesResponse =
       options.matchesResponse ||
@@ -443,7 +433,7 @@ export default class Socket extends EventEmitter {
           reason: 'Socket response not received before timeout',
         }));
 
-    if (this._pendingResponses.has(trackingId)) {
+    if (this.pendingResponses.has(trackingId)) {
       return Promise.reject(
         new Error(`socket request already pending for trackingId ${trackingId}`)
       );
@@ -453,29 +443,29 @@ export default class Socket extends EventEmitter {
 
     return new Promise<SocketResponse>((resolve, reject) => {
       const timeoutId = safeSetTimeout(() => {
-        this._clearPendingResponse(trackingId);
+        this.clearPendingResponse(trackingId);
         reject(createTimeoutError(request));
       }, timeout);
 
-      this._pendingResponses.set(trackingId, {
+      this.pendingResponses.set(trackingId, {
         request,
         matchesResponse,
         getStatusCode,
         getStatusMessage,
         createError,
         resolve: (response) => {
-          this._clearPendingResponse(trackingId);
+          this.clearPendingResponse(trackingId);
           resolve(response);
         },
         reject: (error) => {
-          this._clearPendingResponse(trackingId);
+          this.clearPendingResponse(trackingId);
           reject(error);
         },
         timeoutId,
       });
 
       this.send(request).catch((error) => {
-        this._clearPendingResponse(trackingId);
+        this.clearPendingResponse(trackingId);
         reject(error);
       });
     });
@@ -486,7 +476,7 @@ export default class Socket extends EventEmitter {
    * @param {MessageEvent} event
    * @returns {Promise}
    */
-  _acknowledge(event: SocketMessageEvent<SocketResponse>) {
+  private acknowledge(event: SocketMessageEvent<SocketResponse>) {
     if (!event) {
       return Promise.reject(new Error('`event` is required'));
     }
@@ -502,7 +492,7 @@ export default class Socket extends EventEmitter {
 
     return this.send({
       type: MESSAGE_TYPES.EVENT_ACK,
-      trackingId: event.data.trackingId || this._createTrackingId(),
+      trackingId: event.data.trackingId || this.createTrackingId(),
       eventId: event.data.eventId,
     }).catch((error) => {
       if (error.message === 'INVALID_STATE_ERROR') {
@@ -512,7 +502,7 @@ export default class Socket extends EventEmitter {
     });
   }
 
-  refresh(token: string | {toString(): string}) {
+  public refresh(token: string | {toString(): string}) {
     if (!token) {
       return Promise.reject(new Error('`token` is required for Socket#refresh()'));
     }
@@ -527,7 +517,7 @@ export default class Socket extends EventEmitter {
       refreshedToken = String(token);
     }
 
-    return this._authorize(refreshedToken);
+    return this.authorize(refreshedToken);
   }
 
   /**
@@ -535,8 +525,8 @@ export default class Socket extends EventEmitter {
    * @param {string} token
    * @returns {Promise}
    */
-  _authorize(token: string) {
-    this.logger.info(`socket,${this._domain}: authorizing`);
+  private authorize(token: string) {
+    this.logger.info(`socket,${this.domain}: authorizing`);
 
     return this.sendRequest(
       {
@@ -570,7 +560,7 @@ export default class Socket extends EventEmitter {
    * @private
    * @returns {string}
    */
-  _createTrackingId() {
+  private createTrackingId() {
     return `${this.trackingId}_${crypto.randomUUID()}`;
   }
 
@@ -579,14 +569,14 @@ export default class Socket extends EventEmitter {
    * @param {string} trackingId
    * @returns {void}
    */
-  _clearPendingResponse(trackingId: string) {
-    const pendingResponse = this._pendingResponses.get(trackingId);
+  private clearPendingResponse(trackingId: string) {
+    const pendingResponse = this.pendingResponses.get(trackingId);
 
     if (pendingResponse?.timeoutId) {
       clearTimeout(pendingResponse.timeoutId);
     }
 
-    this._pendingResponses.delete(trackingId);
+    this.pendingResponses.delete(trackingId);
   }
 
   /**
@@ -594,12 +584,12 @@ export default class Socket extends EventEmitter {
    * @param {Error} error
    * @returns {void}
    */
-  _rejectPendingResponses(error: unknown) {
-    if (!this._pendingResponses.size) {
+  private rejectPendingResponses(error: unknown) {
+    if (!this.pendingResponses.size) {
       return;
     }
 
-    Array.from(this._pendingResponses.values()).forEach((pendingResponse) => {
+    Array.from(this.pendingResponses.values()).forEach((pendingResponse) => {
       pendingResponse.reject(error);
     });
   }
@@ -609,14 +599,14 @@ export default class Socket extends EventEmitter {
    * @param {Object} response
    * @returns {boolean}
    */
-  _handlePendingResponse(response: SocketResponse) {
+  private handlePendingResponse(response: SocketResponse) {
     if (!response) {
       return false;
     }
 
     // Pending request correlation currently requires trackingId on the response.
     const pendingResponse = response.trackingId
-      ? this._pendingResponses.get(response.trackingId)
+      ? this.pendingResponses.get(response.trackingId)
       : undefined;
 
     if (!pendingResponse) {
@@ -633,11 +623,11 @@ export default class Socket extends EventEmitter {
     if (statusCode === 440 && response?.subtype !== MESSAGE_TYPES.AUTH) {
       if (typeof this.refreshToken === 'function') {
         Promise.resolve(this.refreshToken(response)).catch((error) => {
-          this.logger.warn(`socket,${this._domain}: failed token-expiry re-auth`, error);
+          this.logger.warn(`socket,${this.domain}: failed token-expiry re-auth`, error);
         });
       } else {
         this.logger.warn(
-          `socket,${this._domain}: refreshToken callback is unavailable for statusCode 440`
+          `socket,${this.domain}: refreshToken callback is unavailable for statusCode 440`
         );
       }
     }
@@ -666,12 +656,12 @@ export default class Socket extends EventEmitter {
    * @private
    * @returns {CloseEvent}
    */
-  _fixCloseCode(event: SocketCloseEvent) {
+  private fixCloseCode(event: SocketCloseEvent) {
     if (event.code === 1005 && event.reason) {
       switch (event.reason.toLowerCase()) {
         case 'replaced':
           this.logger.info(
-            `socket,${this._domain}: fixing CloseEvent code for reason: `,
+            `socket,${this.domain}: fixing CloseEvent code for reason: `,
             event.reason
           );
           event.code = 4000;
@@ -679,7 +669,7 @@ export default class Socket extends EventEmitter {
         case 'authentication failed':
         case 'authentication did not happen within the timeout window of 30000 seconds.':
           this.logger.info(
-            `socket,${this._domain}: fixing CloseEvent code for reason: `,
+            `socket,${this.domain}: fixing CloseEvent code for reason: `,
             event.reason
           );
           event.code = 1008;

--- a/packages/calling/src/mobius-socket/socket/socket-base.ts
+++ b/packages/calling/src/mobius-socket/socket/socket-base.ts
@@ -25,17 +25,6 @@ import type {
 } from './types';
 
 const sockets = new WeakMap<Socket, SocketTransport>();
-const UnknownResponseCtor = UnknownResponse as unknown as new (
-  event?: SocketCloseEvent
-) => UnknownResponse;
-const BadRequestCtor = BadRequest as unknown as new (event?: SocketCloseEvent) => BadRequest;
-const NotAuthorizedCtor = NotAuthorized as unknown as new (
-  event?: SocketCloseEvent
-) => NotAuthorized;
-const ForbiddenCtor = Forbidden as unknown as new (event?: SocketCloseEvent) => Forbidden;
-const ConnectionErrorCtor = ConnectionError as unknown as new (
-  event?: SocketCloseEvent
-) => ConnectionError;
 
 /**
  * Generalized socket abstraction
@@ -288,15 +277,15 @@ export default class Socket extends EventEmitter {
             // it's a bad websocket url. That'll trigger a device refresh; if it
             // turns out we had a bad token, the device refresh should 401 and
             // trigger a token refresh.
-            return reject(new UnknownResponseCtor(event));
+            return reject(new UnknownResponse(event));
           case 4400:
-            return reject(new BadRequestCtor(event));
+            return reject(new BadRequest(event));
           case 4401:
-            return reject(new NotAuthorizedCtor(event));
+            return reject(new NotAuthorized(event));
           case 4403:
-            return reject(new ForbiddenCtor(event));
+            return reject(new Forbidden(event));
           default:
-            return reject(new ConnectionErrorCtor(event));
+            return reject(new ConnectionError(event));
         }
       };
 
@@ -329,7 +318,7 @@ export default class Socket extends EventEmitter {
     this.logger.info(`socket,${this.domain}: closed`, event.code, event.reason);
 
     event = this.fixCloseCode(event);
-    this.rejectPendingResponses(new ConnectionErrorCtor(event));
+    this.rejectPendingResponses(new ConnectionError(event));
     this.emit('close', event);
 
     // Remove all listeners to (a) avoid reacting to late pongs and (b) ensure
@@ -422,14 +411,14 @@ export default class Socket extends EventEmitter {
     const createError =
       options.createError ||
       ((response, statusCode, statusMessage) =>
-        new ConnectionErrorCtor({
+        new ConnectionError({
           code: statusCode,
           reason: statusMessage || response?.reason || 'Socket request failed',
         }));
     const createTimeoutError =
       options.createTimeoutError ||
       (() =>
-        new ConnectionErrorCtor({
+        new ConnectionError({
           reason: 'Socket response not received before timeout',
         }));
 
@@ -543,12 +532,12 @@ export default class Socket extends EventEmitter {
         getStatusCode: (response) => response?.statusCode,
         getStatusMessage: (response) => response?.statusMessage,
         createError: (response, statusCode, statusMessage) =>
-          new NotAuthorizedCtor({
+          new NotAuthorized({
             code: statusCode,
             reason: statusMessage || 'Mobius auth failed',
           }),
         createTimeoutError: () =>
-          new NotAuthorizedCtor({
+          new NotAuthorized({
             reason: 'Mobius auth response not received before timeout',
           }),
       }


### PR DESCRIPTION
# COMPLETES #< Part-1: [CAI-7873](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7873) >

## This pull request addresses

This PR continues the Mobius socket cleanup after the TypeScript conversion work. The goal is to reduce unused surface area, remove dead code, and make the Mobius socket internals easier to follow and maintain without changing the higher-level Calling behavior.

## by making the following changes

- Simplifies `mobius-socket/config.ts` by keeping concrete numeric defaults instead of mixed `string | number` config values.
- Removes unused exports and dead code from the Mobius socket entry points and error definitions.
- Refactors `MobiusSocket` and the lower-level socket implementation to use clearer method/property naming and explicit access modifiers instead of underscore-prefixed internals.
- Updates Mobius socket unit tests to follow the cleaned-up API shape and revised cleanup/disconnect paths.

### Change Type

- [x] Internal code refactor

## The following scenarios were tested

- Automated Mobius socket test files were updated to cover the renamed methods and cleanup flows in:
  - `packages/calling/src/mobius-socket/mobius-socket.test.ts`
  - `packages/calling/src/mobius-socket/mobius-socket-events.test.ts`
  - `packages/calling/src/mobius-socket/socket.test.ts`
- Current PR validation is expected to come from CI for this branch.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
  - Codex
- [x] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.