### PR TITLE
fix(task-refactor): epdn flow fixes

### DIFF
--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -691,8 +691,20 @@ export default class TaskManager extends EventEmitter {
         this.wrapupData,
         this.agentId
       );
-      this.setupTaskListeners(task);
       this.taskCollection[payload.interactionId] = task;
+
+      // Transition the new task out of IDLE immediately so UI controls are
+      // computed before TASK_MERGED is emitted. This handles the race where
+      // AgentContactAssigned arrives before ContactMerged and gets dropped.
+      // Send HYDRATE before setupTaskListeners so the emitTaskHydrate action
+      // doesn't bubble up to the Widget (avoids duplicate listener registration).
+      task.sendStateMachineEvent({
+        type: TaskEvent.HYDRATE,
+        taskData,
+        agentId: this.agentId,
+      } as TaskEventPayload);
+
+      this.setupTaskListeners(task);
     }
 
     if (task) {

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -109,7 +109,20 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
                   (p: any) => p?.isConsulted === true && !p?.hasLeft
                 )
             );
-            if (hasJoinedConsultee) updates.consultDestinationAgentJoined = true;
+            const cpd = taskData.interaction?.callProcessingDetails;
+            const backendSaysJoined = cpd?.consultDestinationAgentJoined === 'true';
+            if (hasJoinedConsultee || backendSaysJoined)
+              updates.consultDestinationAgentJoined = true;
+          }
+
+          if (!context.consultDestinationType && !updates.consultDestinationType) {
+            const hasEpDnParticipant = Boolean(
+              taskData.interaction.participants &&
+                Object.values(taskData.interaction.participants).some(
+                  (p: any) => p?.pType === 'EP-DN' && !p?.hasLeft
+                )
+            );
+            if (hasEpDnParticipant) updates.consultDestinationType = 'entryPoint' as any;
           }
 
           const effectiveConsultInitiator = updates.consultInitiator ?? context.consultInitiator;

--- a/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
@@ -100,7 +100,15 @@ export const guards = {
   isInteractionConsulting: ({event}: GuardParams): boolean => {
     const taskData = getTaskDataFromEvent(event);
 
-    return taskData?.interaction?.state === 'consulting';
+    if (taskData?.interaction?.state === 'consulting') return true;
+
+    // EP_DN consulted agent: backend reports state as 'connected' but CPD indicates consult
+    const cpd = taskData?.interaction?.callProcessingDetails;
+    if (cpd?.relationshipType === 'consult' && taskData?.interaction?.state === 'connected') {
+      return true;
+    }
+
+    return false;
   },
 
   isInteractionHeld: ({event}: GuardParams): boolean => {

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -112,9 +112,20 @@ function computeVoiceInteractionUIControls(
   // Note: ownership is used by some controls; keep computations local to those controls
 
   // Context flags (set by state machine actions)
-  const {consultInitiator, consultDestinationAgentJoined, consultCallHeld, consultFromConference} =
-    context;
+  const {
+    consultInitiator,
+    consultDestinationAgentJoined,
+    consultDestinationType,
+    consultCallHeld,
+    consultFromConference,
+  } = context;
   const {recordingControlsAvailable} = context;
+
+  // EP_DN consults are "ready" as soon as the consult is created (EP accepts routing immediately).
+  // Backend sends destinationType as 'EP-DN'; SDK method uses 'entryPoint' — check both.
+  const isEpDnConsult =
+    consultDestinationType === 'entryPoint' || consultDestinationType === ('EP-DN' as any);
+  const isConsultDestinationReady = consultDestinationAgentJoined || isEpDnConsult;
 
   const stateImpliesHeld = state === TaskState.HELD || state === TaskState.RESUME_INITIATING;
   const stateImpliesConnected =
@@ -217,7 +228,9 @@ function computeVoiceInteractionUIControls(
     // End: varies by state; during consulting only on main leg (consult held)
     end: (() => {
       if (!config.isEndTaskEnabled) return DISABLED;
-      if (hasParallelConsultLeg) return VISIBLE_DISABLED;
+      if (hasParallelConsultLeg) {
+        return isConnected && isEpDnConsult ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+      }
 
       if (isConsulting) {
         if (currentLeg === 'consult' && consultCallHeld) return DISABLED;
@@ -248,7 +261,7 @@ function computeVoiceInteractionUIControls(
         if (!consultInitiator) return DISABLED;
         if (consultLegOnHold) return VISIBLE_DISABLED;
 
-        return consultDestinationAgentJoined ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+        return isConsultDestinationReady ? VISIBLE_ENABLED : VISIBLE_DISABLED;
       }
       if (!hasFullControls || inConference) return DISABLED;
       if (state === TaskState.CONNECTED || state === TaskState.HELD) return VISIBLE_ENABLED;
@@ -316,7 +329,7 @@ function computeVoiceInteractionUIControls(
       if (!consultInitiator) return DISABLED;
       if (consultLegOnHold) return VISIBLE_DISABLED;
 
-      return consultDestinationAgentJoined && !maxParticipants ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+      return isConsultDestinationReady && !maxParticipants ? VISIBLE_ENABLED : VISIBLE_DISABLED;
     })(),
 
     // Wrapup: wrapping up state
@@ -337,7 +350,7 @@ function computeVoiceInteractionUIControls(
       if (!inConference || !isConsulting) return DISABLED;
       if (!consultInitiator || isConsulted) return DISABLED;
 
-      return consultDestinationAgentJoined ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+      return isConsultDestinationReady ? VISIBLE_ENABLED : VISIBLE_DISABLED;
     })(),
 
     // MergeToConference: mirrors conference control, enabled on both legs
@@ -345,7 +358,7 @@ function computeVoiceInteractionUIControls(
       if (!isConsulting || !consultInitiator) return DISABLED;
       if (consultLegOnHold) return VISIBLE_DISABLED;
 
-      return consultDestinationAgentJoined && !maxParticipants ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+      return isConsultDestinationReady && !maxParticipants ? VISIBLE_ENABLED : VISIBLE_DISABLED;
     })(),
 
     // Switch: visible only on the currently active leg
@@ -353,11 +366,11 @@ function computeVoiceInteractionUIControls(
       if (currentLeg === 'consult') {
         if (!isConsulting || !consultInitiator || consultCallHeld) return DISABLED;
 
-        return consultDestinationAgentJoined ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+        return isConsultDestinationReady ? VISIBLE_ENABLED : VISIBLE_DISABLED;
       }
 
       if (hasParallelConsultLeg && state === TaskState.CONNECTED) {
-        return consultDestinationAgentJoined ? VISIBLE_ENABLED : VISIBLE_DISABLED;
+        return isConsultDestinationReady ? VISIBLE_ENABLED : VISIBLE_DISABLED;
       }
 
       return DISABLED;


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

EP_DN (Entry Point Dial Number) consult flow issues at both the initiating agent (Agent 1) and the consulted agent (Agent 2) sides. The backend treats EP_DN consults differently from standard agent-to-agent consults — it reports destinationType as 'EP-DN' instead of 'entryPoint', sets isConsulted: false for the consulted agent, and uses interaction.state: 'connected' instead of 'consulting' for the consulted agent's task. These discrepancies caused multiple UI control and state machine hydration failures.

## by making the following changes

1. uiControlsComputer.ts — Enable transfer/switch/merge buttons during EP_DN consult ringing (Agent 1)

- Introduced isEpDnConsult flag to handle backend's 'EP-DN' vs SDK's 'entryPoint' for consultDestinationType
- Created isConsultDestinationReady which treats EP_DN consults as ready even without consultDestinationAgentJoined, enabling transfer/switch/merge/conference buttons during EP_DN ringin
- Fixed the end button to be enabled only for EP_DN consults (not agent-to-agent) when switching to main leg with parallel consult held

2. actions.ts — Hydrate consult context correctly after page refresh (Agent 1)

- Added hydration logic to derive consultDestinationAgentJoined from callProcessingDetails.consultDestinationAgentJoined and participant isConsulted flag
- Added hydration logic to derive consultDestinationType from EP-DN participant's pType for correct EP_DN identification after refresh

3. guards.ts — Recognize EP_DN consulted agent during hydration (Agent 2)

- Enhanced isInteractionConsulting guard to also return true when callProcessingDetails.relationshipType === 'consult' and interaction.state === 'connected' — this handles the EP_DN consulted agent whose task state is reported as 'connected' instead of 'consulting'

4. TaskManager.ts — Initialize merged task state immediately (Agent 2)

- After ContactMerged creates a new task for the parent interaction, immediately send a HYDRATE event to transition it out of IDLE state. This fixes the race condition where AgentContactAssigned could arrive before ContactMerged and get dropped, leaving the task with blank UI controls

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
