### PR TITLE
feat(meetings): add site preferences API

### DIFF
--- a/packages/@webex/plugin-meetings/src/meetings/index.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/index.ts
@@ -56,9 +56,11 @@ import CaptchaError from '../common/errors/captcha-error';
 import MeetingCollection from './collection';
 import {
   MEETING_KEY,
+  GetSitePreferencesOptions,
   INoiseReductionEffect,
   IVirtualBackgroundEffect,
   MeetingRegistrationStatus,
+  SitePreferencesResponse,
 } from './meetings.types';
 import MeetingsUtil from './util';
 import PermissionError from '../common/errors/permission';
@@ -1403,6 +1405,34 @@ export default class Meetings extends WebexPlugin {
    */
   getPersonalMeetingRoom() {
     return this.personalMeetingRoom;
+  }
+
+  /**
+   * Gets appapi site preferences for a Webex site.
+   *
+   * @param {object} [options]
+   * @param {string} [options.siteUrl] - Webex site URL. Defaults to preferredWebexSite.
+   * @param {string[]|string} [options.select] - Preference sections to fetch.
+   * @param {string} [options.siteName] - Site name query override.
+   * @returns {Promise<SitePreferencesResponse>} site preferences response body
+   * @public
+   * @memberof Meetings
+   * @example
+   * const preferences = await webex.meetings.getSitePreferences();
+   * const canScheduleWebinar = preferences.scheduling?.supportScheduleWebinar;
+   */
+  public getSitePreferences(
+    options: GetSitePreferencesOptions = {}
+  ): Promise<SitePreferencesResponse> {
+    const siteUrl = options.siteUrl || this.preferredWebexSite;
+
+    if (!siteUrl?.trim()) {
+      return Promise.reject(
+        new Error('No site URL available. Call register() first or provide options.siteUrl.')
+      );
+    }
+
+    return this.request.getSitePreferences({...options, siteUrl});
   }
 
   /**

--- a/packages/@webex/plugin-meetings/src/meetings/meetings.types.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/meetings.types.ts
@@ -31,3 +31,22 @@ export type MeetingRegistrationStatus = {
   mercuryConnect: boolean;
   checkH264Support: boolean;
 };
+
+export type SitePreferencesSelect = string[] | string;
+
+export type GetSitePreferencesOptions = {
+  siteUrl?: string;
+  select?: SitePreferencesSelect;
+  siteName?: string;
+};
+
+export type SitePreferencesResponse = {
+  pmr?: Record<string, unknown>;
+  audioVideo?: Record<string, unknown>;
+  scheduling?: {
+    supportScheduleWebinar?: boolean;
+    webinarWebLink?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};

--- a/packages/@webex/plugin-meetings/src/meetings/request.ts
+++ b/packages/@webex/plugin-meetings/src/meetings/request.ts
@@ -3,6 +3,36 @@ import {StatelessWebexPlugin} from '@webex/webex-core';
 
 import LoggerProxy from '../common/logs/logger-proxy';
 import {HTTP_VERBS, API, RESOURCE} from '../constants';
+import type {
+  GetSitePreferencesOptions,
+  SitePreferencesResponse,
+  SitePreferencesSelect,
+} from './meetings.types';
+
+const DEFAULT_SITE_PREFERENCES_SELECT = ['pmr', 'audioVideo', 'scheduling'];
+const WEBEX_SITE_SUFFIX = '.webex.com';
+
+const normalizeSiteUrl = (siteUrl: string) =>
+  siteUrl
+    .trim()
+    .replace(/^(https?:)?\/\//, '')
+    .split(/[/?#]/)[0];
+
+const getSiteName = (siteUrl: string) => {
+  const normalizedSiteUrl = normalizeSiteUrl(siteUrl);
+
+  return normalizedSiteUrl.endsWith(WEBEX_SITE_SUFFIX)
+    ? normalizedSiteUrl.slice(0, -WEBEX_SITE_SUFFIX.length)
+    : normalizedSiteUrl;
+};
+
+const getSelectQuery = (select?: SitePreferencesSelect | null) => {
+  if (!select || (Array.isArray(select) && select.length === 0)) {
+    return DEFAULT_SITE_PREFERENCES_SELECT.join(',');
+  }
+
+  return Array.isArray(select) ? select.join(',') : select;
+};
 
 /**
  * @class MeetingRequest
@@ -43,6 +73,41 @@ export default class MeetingRequest extends StatelessWebexPlugin {
   getMeetingPreferences() {
     // @ts-ignore
     return this.webex.internal.services.getMeetingPreferences();
+  }
+
+  /**
+   * Get appapi site preferences for a Webex site.
+   *
+   * @param {object} options
+   * @param {string} options.siteUrl - Webex site URL, for example "go.webex.com".
+   * @param {string[]|string} [options.select] - Preference sections to fetch.
+   * @param {string} [options.siteName] - Site name query override.
+   * @returns {Promise<SitePreferencesResponse>} site preferences response body
+   * @public
+   * @memberof MeetingRequest
+   */
+  getSitePreferences({
+    siteUrl,
+    select,
+    siteName,
+  }: GetSitePreferencesOptions & {siteUrl: string}): Promise<SitePreferencesResponse> {
+    const normalizedSiteUrl = normalizeSiteUrl(siteUrl);
+
+    if (!normalizedSiteUrl) {
+      return Promise.reject(
+        new Error('No site URL available. Call register() first or provide options.siteUrl.')
+      );
+    }
+
+    // @ts-ignore
+    return this.request({
+      method: HTTP_VERBS.GET,
+      uri: `https://${normalizedSiteUrl}/wbxappapi/v1/users/me/preference`,
+      qs: {
+        select: getSelectQuery(select),
+        siteurl: siteName || getSiteName(normalizedSiteUrl),
+      },
+    }).then((res) => res.body);
   }
 
   // locus federation, determines and populate locus if the responseBody has remote URLs to fetch locus details

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/index.js
@@ -1356,6 +1356,79 @@ describe('plugin-meetings', () => {
             );
           });
         });
+        describe('#getSitePreferences', () => {
+          const sitePreferencesResponse = {
+            scheduling: {
+              supportScheduleWebinar: true,
+              webinarWebLink: 'https://go.webex.com/webappng/sites/go/webinar/scheduler',
+            },
+          };
+
+          beforeEach(() => {
+            webex.meetings.request.getSitePreferences = sinon
+              .stub()
+              .resolves(sitePreferencesResponse);
+          });
+
+          it('should have #getSitePreferences', () => {
+            assert.exists(webex.meetings.getSitePreferences);
+          });
+
+          it('gets site preferences for the preferred Webex site', async () => {
+            webex.meetings.preferredWebexSite = 'go.webex.com';
+
+            const result = await webex.meetings.getSitePreferences();
+
+            assert.deepEqual(result, sitePreferencesResponse);
+            assert.calledOnceWithExactly(webex.meetings.request.getSitePreferences, {
+              siteUrl: 'go.webex.com',
+            });
+          });
+
+          it('gets site preferences for the provided Webex site', async () => {
+            webex.meetings.preferredWebexSite = 'preferred.webex.com';
+
+            await webex.meetings.getSitePreferences({siteUrl: 'go.webex.com'});
+
+            assert.calledOnceWithExactly(webex.meetings.request.getSitePreferences, {
+              siteUrl: 'go.webex.com',
+            });
+          });
+
+          it('forwards site preference options to the request helper', async () => {
+            await webex.meetings.getSitePreferences({
+              siteUrl: 'go.webex.com',
+              select: ['scheduling', 'pmr'],
+              siteName: 'custom-site',
+            });
+
+            assert.calledOnceWithExactly(webex.meetings.request.getSitePreferences, {
+              siteUrl: 'go.webex.com',
+              select: ['scheduling', 'pmr'],
+              siteName: 'custom-site',
+            });
+          });
+
+          it('rejects when no Webex site is available', async () => {
+            webex.meetings.preferredWebexSite = '';
+
+            await assert.isRejected(
+              webex.meetings.getSitePreferences(),
+              'No site URL available. Call register() first or provide options.siteUrl.'
+            );
+            assert.notCalled(webex.meetings.request.getSitePreferences);
+          });
+
+          it('rejects when the configured Webex site is blank', async () => {
+            webex.meetings.preferredWebexSite = '   ';
+
+            await assert.isRejected(
+              webex.meetings.getSitePreferences(),
+              'No site URL available. Call register() first or provide options.siteUrl.'
+            );
+            assert.notCalled(webex.meetings.request.getSitePreferences);
+          });
+        });
         describe('Static shortcut proxy methods', () => {
           describe('MeetingCollection getByKey proxies', () => {
             beforeEach(() => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meetings/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meetings/request.js
@@ -1,0 +1,204 @@
+import 'jsdom-global/register';
+import sinon from 'sinon';
+import {assert} from '@webex/test-helper-chai';
+import MockWebex from '@webex/test-helper-mock-webex';
+import Meetings from '@webex/plugin-meetings';
+import MeetingRequest from '@webex/plugin-meetings/src/meetings/request';
+
+describe('plugin-meetings/meetings/request', () => {
+  let meetingRequest;
+  let request;
+
+  beforeEach(() => {
+    const webex = new MockWebex({
+      children: {
+        meetings: Meetings,
+      },
+    });
+
+    request = sinon.stub().resolves({
+      body: {
+        scheduling: {
+          supportScheduleWebinar: true,
+          webinarWebLink: 'https://go.webex.com/webappng/sites/go/webinar/scheduler',
+        },
+      },
+    });
+
+    meetingRequest = new MeetingRequest(
+      {},
+      {
+        parent: webex,
+      }
+    );
+    meetingRequest.request = request;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('#getSitePreferences', () => {
+    const assertRequest = (expectedOptions) => {
+      assert.calledOnceWithExactly(request, expectedOptions);
+    };
+
+    it('uses default preference sections and derived site name', async () => {
+      const result = await meetingRequest.getSitePreferences({siteUrl: 'go.webex.com'});
+
+      assert.deepEqual(result, {
+        scheduling: {
+          supportScheduleWebinar: true,
+          webinarWebLink: 'https://go.webex.com/webappng/sites/go/webinar/scheduler',
+        },
+      });
+      assertRequest({
+        method: 'GET',
+        uri: 'https://go.webex.com/wbxappapi/v1/users/me/preference',
+        qs: {
+          select: 'pmr,audioVideo,scheduling',
+          siteurl: 'go',
+        },
+      });
+    });
+
+    it('derives the site name for my.webex.com sites', async () => {
+      await meetingRequest.getSitePreferences({siteUrl: 'go.my.webex.com'});
+
+      assertRequest({
+        method: 'GET',
+        uri: 'https://go.my.webex.com/wbxappapi/v1/users/me/preference',
+        qs: {
+          select: 'pmr,audioVideo,scheduling',
+          siteurl: 'go.my',
+        },
+      });
+    });
+
+    it('supports custom preference section arrays', async () => {
+      await meetingRequest.getSitePreferences({
+        siteUrl: 'go.webex.com',
+        select: ['scheduling', 'pmr'],
+      });
+
+      assertRequest({
+        method: 'GET',
+        uri: 'https://go.webex.com/wbxappapi/v1/users/me/preference',
+        qs: {
+          select: 'scheduling,pmr',
+          siteurl: 'go',
+        },
+      });
+    });
+
+    it('supports custom preference section strings', async () => {
+      await meetingRequest.getSitePreferences({
+        siteUrl: 'go.webex.com',
+        select: 'scheduling',
+      });
+
+      assertRequest({
+        method: 'GET',
+        uri: 'https://go.webex.com/wbxappapi/v1/users/me/preference',
+        qs: {
+          select: 'scheduling',
+          siteurl: 'go',
+        },
+      });
+    });
+
+    it('supports custom site name overrides', async () => {
+      await meetingRequest.getSitePreferences({
+        siteUrl: 'go.webex.com',
+        siteName: 'custom-site',
+      });
+
+      assertRequest({
+        method: 'GET',
+        uri: 'https://go.webex.com/wbxappapi/v1/users/me/preference',
+        qs: {
+          select: 'pmr,audioVideo,scheduling',
+          siteurl: 'custom-site',
+        },
+      });
+    });
+
+    it('normalizes site URLs with protocols and paths', async () => {
+      await meetingRequest.getSitePreferences({
+        siteUrl: 'https://go.webex.com/webappng/sites/go/meeting/scheduler',
+      });
+
+      assertRequest({
+        method: 'GET',
+        uri: 'https://go.webex.com/wbxappapi/v1/users/me/preference',
+        qs: {
+          select: 'pmr,audioVideo,scheduling',
+          siteurl: 'go',
+        },
+      });
+    });
+
+    it('normalizes protocol-relative site URLs', async () => {
+      await meetingRequest.getSitePreferences({siteUrl: '//go.webex.com'});
+
+      assertRequest({
+        method: 'GET',
+        uri: 'https://go.webex.com/wbxappapi/v1/users/me/preference',
+        qs: {
+          select: 'pmr,audioVideo,scheduling',
+          siteurl: 'go',
+        },
+      });
+    });
+
+    [
+      {
+        description: 'empty preference section arrays',
+        select: [],
+      },
+      {
+        description: 'empty preference section strings',
+        select: '',
+      },
+      {
+        description: 'null preference sections',
+        select: null,
+      },
+    ].forEach(({description, select}) => {
+      it(`uses default preference sections for ${description}`, async () => {
+        await meetingRequest.getSitePreferences({
+          siteUrl: 'go.webex.com',
+          select,
+        });
+
+        assertRequest({
+          method: 'GET',
+          uri: 'https://go.webex.com/wbxappapi/v1/users/me/preference',
+          qs: {
+            select: 'pmr,audioVideo,scheduling',
+            siteurl: 'go',
+          },
+        });
+      });
+    });
+
+    it('rejects when site URL normalization does not produce a host', async () => {
+      await assert.isRejected(
+        meetingRequest.getSitePreferences({siteUrl: '   '}),
+        'No site URL available. Call register() first or provide options.siteUrl.'
+      );
+      assert.notCalled(request);
+    });
+
+    it('does not suppress request errors', async () => {
+      const error = new Error('site preferences failed');
+
+      request.rejects(error);
+
+      await assert.isRejected(
+        meetingRequest.getSitePreferences({siteUrl: 'go.webex.com'}),
+        'site preferences failed'
+      );
+    });
+  });
+});


### PR DESCRIPTION
# COMPLETES #N/A

No linked SDK issue. This supports the Webex Web Client webinar scheduling work by adding the SDK interface that WWC can consume after this PR ships.

## This pull request addresses

Webex Web Client currently constructs the appapi site-preferences request itself to read `scheduling.supportScheduleWebinar` and `scheduling.webinarWebLink`. The SDK has `getMeetingPreferences()`, but that is the existing Hydra preferred-site flow and does not expose the site-scoped appapi preferences payload.

## by making the following changes

- Adds `webex.meetings.fetchSitePreferencesMeViaSite(selectOptions?)` at the plugin-meetings `Meetings` level.
- Adds `MeetingRequest#fetchSitePreferencesMeViaSite(siteUrl, selectOptions?)` for `GET https://{siteUrl}/wbxappapi/v1/users/me/preference`.
- Defaults `selectOptions` to `['scheduling']`, while allowing callers to pass a different string-array selection.
- Adds `MeetingsUtil.getSiteName()` using the same site-name behavior as WWC, including `.my.` Webex sites.
- Returns the raw appapi response body with a narrow scheduling response type.
- Leaves the existing Hydra-backed `getMeetingPreferences()` preferred-site flow unchanged.
- Adds unit coverage for the meetings public method, request URL construction, custom select options, `.my.webex.com` site-name derivation, request error propagation, `getSiteName`, and the existing preferred-site regression path.

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- `yarn test:unit --packages @webex/plugin-meetings --grep 'fetchSitePreferencesMeViaSite|getSiteName|fetchUserPreferredWebexSite' --no-serve` — 27 passing.
- `yarn run --silent eslint packages/@webex/plugin-meetings/src/meetings/request.ts packages/@webex/plugin-meetings/src/meetings/index.ts packages/@webex/plugin-meetings/src/meetings/meetings.types.ts packages/@webex/plugin-meetings/src/meetings/util.ts` — 0 errors, existing warnings in `meetings/index.ts`.
- `git diff --check` — passed.

Notes:

- `yarn workspace @webex/plugin-meetings build` is currently blocked by an existing unrelated type error in `node_modules/@webex/internal-plugin-metrics/src/call-diagnostic/config.ts` for `LargeScaleWebinar`.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---
> ⚠️ AI Assisted Content 🤖
