### PR TITLE
fix(task-refactor): consult flow bug bash fixes

### DIFF
--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -661,8 +661,7 @@ export default class TaskManager extends EventEmitter {
     const {payload} = context;
     let task = context.task;
 
-    if (payload.childInteractionId) {
-      // remove the child task from collection
+    if (payload.childInteractionId && this.taskCollection[payload.childInteractionId]) {
       this.removeTaskFromCollection(this.taskCollection[payload.childInteractionId]);
     }
 

--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -307,6 +307,7 @@ export default class TaskManager extends EventEmitter {
 
       // Conference events - these trigger state machine transition to CONFERENCING
       case CC_EVENTS.AGENT_CONSULT_CONFERENCED:
+      case CC_EVENTS.AGENT_CONSULT_CONFERENCING:
       case CC_EVENTS.PARTICIPANT_JOINED_CONFERENCE:
         return {type: TaskEvent.CONFERENCE_START, taskData: payload};
 

--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -375,6 +375,12 @@ export default class TaskManager extends EventEmitter {
         task.sendStateMachineEvent(stateMachineEvent);
       }
 
+      // Emit TASK_POST_CALL_ACTIVITY for ParticipantPostCallActivity events so
+      // consumers (Widgets) can detect the interaction state change to post_call.
+      if (eventContext.eventType === CC_EVENTS.PARTICIPANT_POST_CALL_ACTIVITY) {
+        task.emit(TASK_EVENTS.TASK_POST_CALL_ACTIVITY, task);
+      }
+
       // Send transcript start/stop events for relevant CC events
       this.requestRealTimeTranscripts(eventContext.eventType, payload.interactionId);
     });

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -619,7 +619,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
 
       [TaskState.CONF_INITIATING]: {
         on: {
-          // AgentConsultConferenced, ParticipantJoinedConference
+          // AgentConsultConferenced, AgentConsultConferencing, ParticipantJoinedConference
           [TaskEvent.CONFERENCE_START]: {
             target: TaskState.CONFERENCING,
             actions: [
@@ -633,6 +633,37 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           [TaskEvent.CONFERENCE_FAILED]: {
             target: TaskState.CONSULTING,
             actions: ['handleConferenceFailed', 'emitTaskConferenceFailed'],
+          },
+          // AgentConsultEnded while conference is initiating (end call before conference completes)
+          [TaskEvent.CONSULT_END]: [
+            {
+              guard: ({event}) => {
+                const taskData = getTaskDataFromEvent(event);
+
+                return taskData?.interaction?.isTerminated === true;
+              },
+              target: TaskState.WRAPPING_UP,
+              actions: ['updateTaskData', 'markEnded', 'clearConsultState', 'emitTaskWrapup'],
+            },
+            {
+              target: TaskState.CONNECTED,
+              actions: ['updateTaskData', 'clearConsultState'],
+            },
+          ],
+          // ContactEnded while conference is initiating
+          [TaskEvent.CONTACT_ENDED]: {
+            target: TaskState.WRAPPING_UP,
+            actions: [
+              'updateTaskData',
+              'markEnded',
+              'clearConsultState',
+              'emitTaskWrapup',
+              'requestCleanup',
+            ],
+          },
+          [TaskEvent.TASK_WRAPUP]: {
+            target: TaskState.WRAPPING_UP,
+            actions: ['updateTaskData', 'markEnded', 'clearConsultState', 'emitTaskWrapup'],
           },
         },
       },
@@ -660,9 +691,23 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           ],
 
           // Needed as all agents in conference get this event, hence we need to clear the consult state
-          [TaskEvent.CONSULT_END]: {
-            actions: ['updateTaskData', 'clearConsultState'],
-          },
+          [TaskEvent.CONSULT_END]: [
+            {
+              guard: ({context, event}) => {
+                const taskData = getTaskDataFromEvent(event);
+
+                return (
+                  taskData?.interaction?.isTerminated === true &&
+                  shouldWrapUpForThisAgent(context, taskData)
+                );
+              },
+              target: TaskState.WRAPPING_UP,
+              actions: ['updateTaskData', 'markEnded', 'clearConsultState', 'emitTaskWrapup'],
+            },
+            {
+              actions: ['updateTaskData', 'clearConsultState'],
+            },
+          ],
 
           [TaskEvent.HOLD_SUCCESS]: {
             actions: ['updateTaskData', 'setHoldState', 'emitTaskHold'],

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -12,7 +12,7 @@ import {setup} from 'xstate';
 import {TaskContext, TaskEventPayload, UIControlConfig, TaskActionsMap} from './types';
 import {TaskState, TaskEvent} from './constants';
 import {actions, createInitialContext} from './actions';
-import {guards} from './guards';
+import {guards, shouldWrapUpForThisAgent, getTaskDataFromEvent} from './guards';
 import {getIsCustomerInCall} from '../TaskUtils';
 
 type TaskActionConfigMap = {[K in keyof typeof actions]: undefined};
@@ -466,6 +466,26 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
                 context.consultInitiator === true && context.consultCallHeld === true,
               target: TaskState.CONNECTED,
               actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+            },
+            {
+              // Interaction terminated during consult (customer left) → WRAPPING_UP
+              guard: ({context, event}) => {
+                if (context.consultInitiator !== true) return false;
+                const taskData = getTaskDataFromEvent(event);
+
+                return (
+                  taskData?.interaction?.isTerminated === true &&
+                  shouldWrapUpForThisAgent(context, taskData)
+                );
+              },
+              target: TaskState.WRAPPING_UP,
+              actions: [
+                'updateTaskData',
+                'markEnded',
+                'clearConsultState',
+                'emitTaskWrapup',
+                'requestCleanup',
+              ],
             },
             {
               // Initiator (no conference) → HELD

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -607,7 +607,12 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // AgentConsultConferenced, ParticipantJoinedConference
           [TaskEvent.CONFERENCE_START]: {
             target: TaskState.CONFERENCING,
-            actions: ['handleConferenceStarted', 'clearConsultState'],
+            actions: [
+              'updateTaskData',
+              'syncTaskDataFromEvent',
+              'handleConferenceStarted',
+              'clearConsultState',
+            ],
           },
         },
       },
@@ -617,7 +622,12 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // AgentConsultConferenced, ParticipantJoinedConference
           [TaskEvent.CONFERENCE_START]: {
             target: TaskState.CONFERENCING,
-            actions: ['handleConferenceStarted'],
+            actions: [
+              'updateTaskData',
+              'syncTaskDataFromEvent',
+              'handleConferenceStarted',
+              'clearConsultState',
+            ],
           },
           // AgentConsultConferenceFailed
           [TaskEvent.CONFERENCE_FAILED]: {
@@ -630,7 +640,12 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
       [TaskState.CONFERENCING]: {
         on: {
           [TaskEvent.CONFERENCE_START]: {
-            actions: ['updateTaskData', 'clearConsultState', 'emitTaskConferenceStarted'],
+            actions: [
+              'updateTaskData',
+              'syncTaskDataFromEvent',
+              'clearConsultState',
+              'emitTaskConferenceStarted',
+            ],
           },
           [TaskEvent.EXIT_CONFERENCE_SUCCESS]: [
             {
@@ -653,7 +668,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             actions: ['updateTaskData', 'setHoldState', 'emitTaskHold'],
           },
           [TaskEvent.UNHOLD_SUCCESS]: {
-            actions: ['updateTaskData', 'setHoldState', 'emitTaskResume'],
+            actions: ['updateTaskData', 'syncTaskDataFromEvent', 'setHoldState', 'emitTaskResume'],
           },
 
           // Start a new consult from within an active conference

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -468,15 +468,12 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
               actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
             },
             {
-              // Interaction terminated during consult (customer left) → WRAPPING_UP
+              // Customer left during consult → WRAPPING_UP
               guard: ({context, event}) => {
                 if (context.consultInitiator !== true) return false;
                 const taskData = getTaskDataFromEvent(event);
 
-                return (
-                  taskData?.interaction?.isTerminated === true &&
-                  shouldWrapUpForThisAgent(context, taskData)
-                );
+                return shouldWrapUpForThisAgent(context, taskData, {requireCustomerLeft: true});
               },
               target: TaskState.WRAPPING_UP,
               actions: [

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -470,10 +470,11 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             {
               // Customer left during consult → WRAPPING_UP
               guard: ({context, event}) => {
-                if (context.consultInitiator !== true) return false;
                 const taskData = getTaskDataFromEvent(event);
+                const cpd = taskData?.interaction?.callProcessingDetails;
+                if (cpd?.hasCustomerLeft !== 'true') return false;
 
-                return shouldWrapUpForThisAgent(context, taskData, {requireCustomerLeft: true});
+                return shouldWrapUpForThisAgent(context, taskData);
               },
               target: TaskState.WRAPPING_UP,
               actions: [
@@ -647,21 +648,6 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
               actions: ['updateTaskData', 'clearConsultState'],
             },
           ],
-          // ContactEnded while conference is initiating
-          [TaskEvent.CONTACT_ENDED]: {
-            target: TaskState.WRAPPING_UP,
-            actions: [
-              'updateTaskData',
-              'markEnded',
-              'clearConsultState',
-              'emitTaskWrapup',
-              'requestCleanup',
-            ],
-          },
-          [TaskEvent.TASK_WRAPUP]: {
-            target: TaskState.WRAPPING_UP,
-            actions: ['updateTaskData', 'markEnded', 'clearConsultState', 'emitTaskWrapup'],
-          },
         },
       },
 

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -74,12 +74,6 @@ const deriveRecordingState = (taskData?: TaskData | null): RecordingStateUpdate 
   return update;
 };
 
-const isActiveConsultState = (taskData: TaskData | undefined, selfAgentId?: string): boolean => {
-  if (taskData?.interaction?.state === INTERACTION_STATE.CONSULTING) return true;
-
-  return hasActiveConsultInPostCall(taskData, selfAgentId);
-};
-
 const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefined) =>
   taskData
     ? (() => {
@@ -89,7 +83,9 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
         };
 
         const selfAgentId = context.uiControlConfig.agentId ?? taskData?.agentId;
-        const consultingActive = isActiveConsultState(taskData, selfAgentId);
+        const consultingActive =
+          taskData?.interaction?.state === INTERACTION_STATE.CONSULTING ||
+          hasActiveConsultInPostCall(taskData, selfAgentId);
 
         if (taskData.destAgentId) {
           const isEpDnWithStoredId =

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -11,15 +11,10 @@ import {
   TaskActionArgs,
   RecordingStateUpdate,
 } from './types';
-import {
-  TaskEvent,
-  TaskState,
-  INTERACTION_STATE,
-  CONSULT_STATE,
-  MEDIA_TYPE_CONSULT,
-} from './constants';
+import {TaskEvent, TaskState, INTERACTION_STATE} from './constants';
 import {DestinationType, TaskData} from '../types';
 import {computeUIControls, getDefaultUIControls} from './uiControlsComputer';
+import {hasActiveConsultInPostCall} from './guards';
 
 const determineConsultInitiator = (
   taskData: TaskData | undefined,
@@ -81,15 +76,8 @@ const deriveRecordingState = (taskData?: TaskData | null): RecordingStateUpdate 
 
 const isActiveConsultState = (taskData: TaskData | undefined, selfAgentId?: string): boolean => {
   if (taskData?.interaction?.state === INTERACTION_STATE.CONSULTING) return true;
-  if (taskData?.interaction?.state === INTERACTION_STATE.POST_CALL && selfAgentId) {
-    const selfParticipant = taskData.interaction?.participants?.[selfAgentId];
-    const hasConsultMedia = Object.values(taskData.interaction?.media ?? {}).some(
-      (media) => (media as {mType?: string})?.mType === MEDIA_TYPE_CONSULT
-    );
-    if (selfParticipant?.consultState === CONSULT_STATE.CONSULTING && hasConsultMedia) return true;
-  }
 
-  return false;
+  return hasActiveConsultInPostCall(taskData, selfAgentId);
 };
 
 const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefined) =>

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -98,7 +98,11 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
         const consultingActive = isActiveConsultState(taskData, selfAgentId);
 
         if (taskData.destAgentId) {
-          updates.consultDestinationAgentId = taskData.destAgentId;
+          const isEpDnWithStoredId =
+            context.consultDestinationType === 'entryPoint' && context.consultDestinationAgentId;
+          if (!isEpDnWithStoredId) {
+            updates.consultDestinationAgentId = taskData.destAgentId;
+          }
         }
         if (consultingActive && taskData.destinationType) {
           updates.consultDestinationType = taskData.destinationType as DestinationType;
@@ -242,7 +246,10 @@ export const actions: TaskActionsMap = {
     const taskData = getTaskDataFromEvent(event);
     const consultDestinationType =
       'destinationType' in event ? event.destinationType ?? null : null;
-    const consultDestinationAgentId = 'destAgentId' in event ? event.destAgentId ?? null : null;
+    const consultDestinationAgentId =
+      ('destAgentId' in event ? event.destAgentId : null) ??
+      ('destination' in event ? (event as any).destination : null) ??
+      null;
 
     return {
       consultDestinationType,

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -11,7 +11,13 @@ import {
   TaskActionArgs,
   RecordingStateUpdate,
 } from './types';
-import {TaskEvent, TaskState} from './constants';
+import {
+  TaskEvent,
+  TaskState,
+  INTERACTION_STATE,
+  CONSULT_STATE,
+  MEDIA_TYPE_CONSULT,
+} from './constants';
 import {DestinationType, TaskData} from '../types';
 import {computeUIControls, getDefaultUIControls} from './uiControlsComputer';
 
@@ -74,13 +80,13 @@ const deriveRecordingState = (taskData?: TaskData | null): RecordingStateUpdate 
 };
 
 const isActiveConsultState = (taskData: TaskData | undefined, selfAgentId?: string): boolean => {
-  if (taskData?.interaction?.state === 'consulting') return true;
-  if (taskData?.interaction?.state === 'post_call' && selfAgentId) {
+  if (taskData?.interaction?.state === INTERACTION_STATE.CONSULTING) return true;
+  if (taskData?.interaction?.state === INTERACTION_STATE.POST_CALL && selfAgentId) {
     const selfParticipant = taskData.interaction?.participants?.[selfAgentId] as any;
     const hasConsultMedia = Object.values(taskData.interaction?.media ?? {}).some(
-      (media: any) => media?.mType === 'consult'
+      (media: any) => media?.mType === MEDIA_TYPE_CONSULT
     );
-    if (selfParticipant?.consultState === 'consulting' && hasConsultMedia) return true;
+    if (selfParticipant?.consultState === CONSULT_STATE.CONSULTING && hasConsultMedia) return true;
   }
 
   return false;

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -82,9 +82,9 @@ const deriveRecordingState = (taskData?: TaskData | null): RecordingStateUpdate 
 const isActiveConsultState = (taskData: TaskData | undefined, selfAgentId?: string): boolean => {
   if (taskData?.interaction?.state === INTERACTION_STATE.CONSULTING) return true;
   if (taskData?.interaction?.state === INTERACTION_STATE.POST_CALL && selfAgentId) {
-    const selfParticipant = taskData.interaction?.participants?.[selfAgentId] as any;
+    const selfParticipant = taskData.interaction?.participants?.[selfAgentId];
     const hasConsultMedia = Object.values(taskData.interaction?.media ?? {}).some(
-      (media: any) => media?.mType === MEDIA_TYPE_CONSULT
+      (media) => (media as {mType?: string})?.mType === MEDIA_TYPE_CONSULT
     );
     if (selfParticipant?.consultState === CONSULT_STATE.CONSULTING && hasConsultMedia) return true;
   }

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -73,6 +73,19 @@ const deriveRecordingState = (taskData?: TaskData | null): RecordingStateUpdate 
   return update;
 };
 
+const isActiveConsultState = (taskData: TaskData | undefined, selfAgentId?: string): boolean => {
+  if (taskData?.interaction?.state === 'consulting') return true;
+  if (taskData?.interaction?.state === 'post_call' && selfAgentId) {
+    const selfParticipant = taskData.interaction?.participants?.[selfAgentId] as any;
+    const hasConsultMedia = Object.values(taskData.interaction?.media ?? {}).some(
+      (media: any) => media?.mType === 'consult'
+    );
+    if (selfParticipant?.consultState === 'consulting' && hasConsultMedia) return true;
+  }
+
+  return false;
+};
+
 const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefined) =>
   taskData
     ? (() => {
@@ -81,27 +94,26 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
           ...deriveRecordingState(taskData),
         };
 
+        const selfAgentId = context.uiControlConfig.agentId ?? taskData?.agentId;
+        const consultingActive = isActiveConsultState(taskData, selfAgentId);
+
         if (taskData.destAgentId) {
           updates.consultDestinationAgentId = taskData.destAgentId;
         }
-        if (taskData.interaction?.state === 'consulting' && taskData.destinationType) {
+        if (consultingActive && taskData.destinationType) {
           updates.consultDestinationType = taskData.destinationType as DestinationType;
         }
 
         if (!context.consultInitiator) {
-          const selfAgentId = context.uiControlConfig.agentId ?? taskData?.agentId;
           const consultInitiator = determineConsultInitiator(taskData, selfAgentId);
           if (consultInitiator !== undefined) {
             updates.consultInitiator = consultInitiator;
-          } else if (
-            taskData.interaction?.state === 'consulting' &&
-            taskData.isConsulted === false
-          ) {
+          } else if (consultingActive && taskData.isConsulted === false) {
             updates.consultInitiator = true;
           }
         }
 
-        if (taskData.interaction?.state === 'consulting') {
+        if (consultingActive && taskData.interaction) {
           if (!context.consultDestinationAgentJoined) {
             const hasJoinedConsultee = Boolean(
               taskData.interaction.participants &&

--- a/packages/@webex/contact-center/src/services/task/state-machine/constants.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/constants.ts
@@ -37,6 +37,25 @@ export const MEDIA_TYPE_CONSULT = 'consult';
 export const MEDIA_TYPE_MAIN_CALL = 'mainCall';
 
 // ============================================
+// Backend Interaction State Constants
+// ============================================
+
+/** Backend interaction state values (from server payloads) */
+export const INTERACTION_STATE = {
+  CONSULTING: 'consulting',
+  POST_CALL: 'post_call',
+  CONFERENCE: 'conference',
+  CONNECTED: 'connected',
+  NEW: 'new',
+} as const;
+
+/** Backend participant consultState values */
+export const CONSULT_STATE = {
+  CONSULTING: 'consulting',
+  CONFERENCING: 'conferencing',
+} as const;
+
+// ============================================
 // State Machine Enums
 // ============================================
 

--- a/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
@@ -97,7 +97,7 @@ export const guards = {
     return false;
   },
 
-  isInteractionConsulting: ({event}: GuardParams): boolean => {
+  isInteractionConsulting: ({event, context}: GuardParams): boolean => {
     const taskData = getTaskDataFromEvent(event);
 
     if (taskData?.interaction?.state === 'consulting') return true;
@@ -106,6 +106,21 @@ export const guards = {
     const cpd = taskData?.interaction?.callProcessingDetails;
     if (cpd?.relationshipType === 'consult' && taskData?.interaction?.state === 'connected') {
       return true;
+    }
+
+    // Customer left during consult: interaction state is "post_call" but consult
+    // between agents is still active. Detect via agent's consultState + consult media.
+    if (taskData?.interaction?.state === 'post_call') {
+      const selfAgentId = getSelfAgentId(context, taskData);
+      const selfParticipant = selfAgentId
+        ? taskData?.interaction?.participants?.[selfAgentId]
+        : null;
+      const hasConsultMedia = Object.values(taskData?.interaction?.media ?? {}).some(
+        (media: any) => media?.mType === 'consult'
+      );
+      if (selfParticipant?.consultState === 'consulting' && hasConsultMedia) {
+        return true;
+      }
     }
 
     return false;

--- a/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
@@ -119,7 +119,7 @@ export const guards = {
         ? taskData?.interaction?.participants?.[selfAgentId]
         : null;
       const hasConsultMedia = Object.values(taskData?.interaction?.media ?? {}).some(
-        (media: any) => media?.mType === MEDIA_TYPE_CONSULT
+        (media) => (media as {mType?: string})?.mType === MEDIA_TYPE_CONSULT
       );
       if (selfParticipant?.consultState === CONSULT_STATE.CONSULTING && hasConsultMedia) {
         return true;

--- a/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
@@ -45,6 +45,24 @@ export const isSelfConsultingAgent = (context: TaskContext, taskData?: TaskData)
 };
 
 /**
+ * Detects an active consult during post_call state (customer left but agents still consulting).
+ * Shared by hydration guard (isInteractionConsulting) and action (deriveTaskDataUpdates).
+ */
+export const hasActiveConsultInPostCall = (
+  taskData: TaskData | undefined,
+  selfAgentId?: string
+): boolean => {
+  if (taskData?.interaction?.state !== INTERACTION_STATE.POST_CALL || !selfAgentId) return false;
+
+  const selfParticipant = taskData.interaction?.participants?.[selfAgentId];
+  const hasConsultMedia = Object.values(taskData.interaction?.media ?? {}).some(
+    (media) => (media as {mType?: string})?.mType === MEDIA_TYPE_CONSULT
+  );
+
+  return selfParticipant?.consultState === CONSULT_STATE.CONSULTING && hasConsultMedia;
+};
+
+/**
  * Determines if this agent should enter WRAPPING_UP state.
  * Priority: agentsPendingWrapUp > wrapUpRequired / participant.isWrapUp > ownership > !isConsulted
  */
@@ -113,17 +131,8 @@ export const guards = {
 
     // Customer left during consult: interaction state is "post_call" but consult
     // between agents is still active. Detect via agent's consultState + consult media.
-    if (taskData?.interaction?.state === INTERACTION_STATE.POST_CALL) {
-      const selfAgentId = getSelfAgentId(context, taskData);
-      const selfParticipant = selfAgentId
-        ? taskData?.interaction?.participants?.[selfAgentId]
-        : null;
-      const hasConsultMedia = Object.values(taskData?.interaction?.media ?? {}).some(
-        (media) => (media as {mType?: string})?.mType === MEDIA_TYPE_CONSULT
-      );
-      if (selfParticipant?.consultState === CONSULT_STATE.CONSULTING && hasConsultMedia) {
-        return true;
-      }
+    if (hasActiveConsultInPostCall(taskData, getSelfAgentId(context, taskData))) {
+      return true;
     }
 
     return false;

--- a/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
@@ -27,7 +27,7 @@ import {
   getConferenceParticipantsCount,
   getIsConferenceInProgress,
 } from '../TaskUtils';
-import {TaskEvent} from './constants';
+import {TaskEvent, INTERACTION_STATE, CONSULT_STATE, MEDIA_TYPE_CONSULT} from './constants';
 
 export const getTaskDataFromEvent = (event?: TaskEventPayload): TaskData | undefined =>
   event && typeof event === 'object' && 'taskData' in event
@@ -100,25 +100,28 @@ export const guards = {
   isInteractionConsulting: ({event, context}: GuardParams): boolean => {
     const taskData = getTaskDataFromEvent(event);
 
-    if (taskData?.interaction?.state === 'consulting') return true;
+    if (taskData?.interaction?.state === INTERACTION_STATE.CONSULTING) return true;
 
     // EP_DN consulted agent: backend reports state as 'connected' but CPD indicates consult
     const cpd = taskData?.interaction?.callProcessingDetails;
-    if (cpd?.relationshipType === 'consult' && taskData?.interaction?.state === 'connected') {
+    if (
+      cpd?.relationshipType === 'consult' &&
+      taskData?.interaction?.state === INTERACTION_STATE.CONNECTED
+    ) {
       return true;
     }
 
     // Customer left during consult: interaction state is "post_call" but consult
     // between agents is still active. Detect via agent's consultState + consult media.
-    if (taskData?.interaction?.state === 'post_call') {
+    if (taskData?.interaction?.state === INTERACTION_STATE.POST_CALL) {
       const selfAgentId = getSelfAgentId(context, taskData);
       const selfParticipant = selfAgentId
         ? taskData?.interaction?.participants?.[selfAgentId]
         : null;
       const hasConsultMedia = Object.values(taskData?.interaction?.media ?? {}).some(
-        (media: any) => media?.mType === 'consult'
+        (media: any) => media?.mType === MEDIA_TYPE_CONSULT
       );
-      if (selfParticipant?.consultState === 'consulting' && hasConsultMedia) {
+      if (selfParticipant?.consultState === CONSULT_STATE.CONSULTING && hasConsultMedia) {
         return true;
       }
     }
@@ -142,7 +145,7 @@ export const guards = {
   isInteractionConnected: ({event}: GuardParams): boolean => {
     const taskData = getTaskDataFromEvent(event);
 
-    return taskData?.interaction?.state === 'connected';
+    return taskData?.interaction?.state === INTERACTION_STATE.CONNECTED;
   },
 
   isConferencingByParticipants: ({event}: GuardParams): boolean => {
@@ -191,7 +194,7 @@ export const guards = {
     if (!mainCallId) return false;
 
     // Don't downgrade while backend still reports conference.
-    if (taskData.interaction.state === 'conference') return false;
+    if (taskData.interaction.state === INTERACTION_STATE.CONFERENCE) return false;
 
     const agentParticipantsCount = getConferenceParticipantsCount(taskData.interaction, mainCallId);
     if (agentParticipantsCount >= 2) return false;
@@ -233,7 +236,7 @@ export const guards = {
     return (
       taskData.isConsulted === true ||
       relationshipType === 'consult' ||
-      taskData.interaction?.state === 'consulting'
+      taskData.interaction?.state === INTERACTION_STATE.CONSULTING
     );
   },
 

--- a/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
@@ -66,18 +66,9 @@ export const hasActiveConsultInPostCall = (
  * Determines if this agent should enter WRAPPING_UP state.
  * Priority: agentsPendingWrapUp > wrapUpRequired / participant.isWrapUp > ownership > !isConsulted
  */
-export const shouldWrapUpForThisAgent = (
-  context: TaskContext,
-  taskData: TaskData,
-  options?: {requireCustomerLeft?: boolean}
-): boolean => {
+export const shouldWrapUpForThisAgent = (context: TaskContext, taskData: TaskData): boolean => {
   const selfAgentId = getSelfAgentId(context, taskData);
   if (!selfAgentId) return false;
-
-  if (options?.requireCustomerLeft) {
-    const cpd = taskData?.interaction?.callProcessingDetails;
-    if (cpd?.hasCustomerLeft !== 'true') return false;
-  }
 
   const pending = taskData?.agentsPendingWrapUp;
   if (Array.isArray(pending) && pending.length > 0) {

--- a/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/guards.ts
@@ -66,9 +66,18 @@ export const hasActiveConsultInPostCall = (
  * Determines if this agent should enter WRAPPING_UP state.
  * Priority: agentsPendingWrapUp > wrapUpRequired / participant.isWrapUp > ownership > !isConsulted
  */
-export const shouldWrapUpForThisAgent = (context: TaskContext, taskData: TaskData): boolean => {
+export const shouldWrapUpForThisAgent = (
+  context: TaskContext,
+  taskData: TaskData,
+  options?: {requireCustomerLeft?: boolean}
+): boolean => {
   const selfAgentId = getSelfAgentId(context, taskData);
   if (!selfAgentId) return false;
+
+  if (options?.requireCustomerLeft) {
+    const cpd = taskData?.interaction?.callProcessingDetails;
+    if (cpd?.hasCustomerLeft !== 'true') return false;
+  }
 
   const pending = taskData?.agentsPendingWrapUp;
   if (Array.isArray(pending) && pending.length > 0) {

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -251,7 +251,7 @@ function computeVoiceInteractionUIControls(
       return DISABLED;
     })(),
 
-    // Transfer: connected/held, not in conference
+    // Transfer: connected/held/conference
     transfer: (() => {
       if (hasParallelConsultLeg) {
         if (!customerPresent) return DISABLED;
@@ -265,7 +265,12 @@ function computeVoiceInteractionUIControls(
 
         return isConsultDestinationReady ? VISIBLE_ENABLED : VISIBLE_DISABLED;
       }
-      if (!hasFullControls || inConference) return DISABLED;
+      if (!hasFullControls) return DISABLED;
+      if (inConference) {
+        // Real conference (multiple agents): transfer is hidden
+        // Pending conference (only self agent): transfer remains available
+        return participantCount > 1 ? DISABLED : VISIBLE_ENABLED;
+      }
       if (state === TaskState.CONNECTED || state === TaskState.HELD) return VISIBLE_ENABLED;
 
       return DISABLED;
@@ -280,15 +285,22 @@ function computeVoiceInteractionUIControls(
         return DISABLED;
       }
 
-      // Enabled conditions differ by state
+      // In conference: behavior depends on whether it's a real multi-agent conference
+      if (inConference) {
+        // Pending conference (only self agent): consult disabled
+        if (participantCount <= 1) return VISIBLE_DISABLED;
+        // Real conference: consult enabled if conditions met
+        const canFromConference =
+          !maxParticipants && customerPresent && !consultInProgress && !isConsulting;
+
+        return {isVisible: true, isEnabled: canFromConference};
+      }
+
+      // Enabled conditions for connected/held
       const canFromConnected =
         !maxParticipants && customerPresent && !consultInProgress && !isConsulted;
-      const canFromConference =
-        !maxParticipants && customerPresent && !consultInProgress && !isConsulting;
 
-      const isEnabled = inConference ? canFromConference : canFromConnected;
-
-      return {isVisible: true, isEnabled};
+      return {isVisible: true, isEnabled: canFromConnected};
     })(),
 
     // ConsultTransfer: always hidden (use transfer button)
@@ -305,10 +317,15 @@ function computeVoiceInteractionUIControls(
       return {isVisible: true, isEnabled: consultInitiator || config.isEndConsultEnabled};
     })(),
 
-    // Recording: connected/held only, not in consult/conference
+    // Recording: connected/held, hidden in real conference, visible in pending conference
     recording: (() => {
       if (!recordingControlsAvailable || !config.isRecordingEnabled) return DISABLED;
-      if (!hasFullControls || isConsulting || inConference) return DISABLED;
+      if (!hasFullControls || isConsulting) return DISABLED;
+      if (inConference) {
+        // Real conference (multiple agents): recording hidden
+        // Pending conference (only self agent): recording available
+        return participantCount > 1 ? DISABLED : VISIBLE_ENABLED;
+      }
       if (hasParallelConsultLeg && !customerPresent) return DISABLED;
       if (state === TaskState.CONNECTED || state === TaskState.HELD) {
         return VISIBLE_ENABLED;
@@ -340,10 +357,11 @@ function computeVoiceInteractionUIControls(
     // Wrapup: wrapping up state
     wrapup: isWrappingUp ? VISIBLE_ENABLED : DISABLED,
 
-    // ExitConference: in conference, not consulting from conference
+    // ExitConference: in conference with multiple agents in main call
     exitConference: (() => {
       if (isConsulted && !isConferencing) return DISABLED;
       if (!inConference) return DISABLED;
+      if (participantCount <= 1) return DISABLED;
       const consultingFromConference = consultInitiator && isConsulting && conferenceFromBackend;
 
       return consultingFromConference ? VISIBLE_DISABLED : VISIBLE_ENABLED;

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -254,11 +254,13 @@ function computeVoiceInteractionUIControls(
     // Transfer: connected/held, not in conference
     transfer: (() => {
       if (hasParallelConsultLeg) {
+        if (!customerPresent) return DISABLED;
         if (state === TaskState.CONNECTED) return VISIBLE_ENABLED;
         if (state === TaskState.HELD) return VISIBLE_DISABLED;
       }
       if (isConsulting) {
         if (!consultInitiator) return DISABLED;
+        if (!customerPresent) return VISIBLE_DISABLED;
         if (consultLegOnHold) return VISIBLE_DISABLED;
 
         return isConsultDestinationReady ? VISIBLE_ENABLED : VISIBLE_DISABLED;
@@ -307,6 +309,7 @@ function computeVoiceInteractionUIControls(
     recording: (() => {
       if (!recordingControlsAvailable || !config.isRecordingEnabled) return DISABLED;
       if (!hasFullControls || isConsulting || inConference) return DISABLED;
+      if (hasParallelConsultLeg && !customerPresent) return DISABLED;
       if (state === TaskState.CONNECTED || state === TaskState.HELD) {
         return VISIBLE_ENABLED;
       }
@@ -318,6 +321,7 @@ function computeVoiceInteractionUIControls(
     // Label changes based on leg: "Conference" on main leg, "Merge" on consult leg
     conference: (() => {
       if (hasParallelConsultLeg) {
+        if (!customerPresent) return DISABLED;
         if (state === TaskState.CONNECTED) {
           return maxParticipants ? VISIBLE_DISABLED : VISIBLE_ENABLED;
         }
@@ -327,6 +331,7 @@ function computeVoiceInteractionUIControls(
       }
       if (!hasFullControls || !isConsulting) return DISABLED;
       if (!consultInitiator) return DISABLED;
+      if (!customerPresent) return VISIBLE_DISABLED;
       if (consultLegOnHold) return VISIBLE_DISABLED;
 
       return isConsultDestinationReady && !maxParticipants ? VISIBLE_ENABLED : VISIBLE_DISABLED;
@@ -356,6 +361,7 @@ function computeVoiceInteractionUIControls(
     // MergeToConference: mirrors conference control, enabled on both legs
     mergeToConference: (() => {
       if (!isConsulting || !consultInitiator) return DISABLED;
+      if (!customerPresent) return VISIBLE_DISABLED;
       if (consultLegOnHold) return VISIBLE_DISABLED;
 
       return isConsultDestinationReady && !maxParticipants ? VISIBLE_ENABLED : VISIBLE_DISABLED;
@@ -363,8 +369,10 @@ function computeVoiceInteractionUIControls(
 
     // Switch: visible only on the currently active leg
     switch: (() => {
+      if (!customerPresent && hasParallelConsultLeg) return DISABLED;
       if (currentLeg === 'consult') {
         if (!isConsulting || !consultInitiator || consultCallHeld) return DISABLED;
+        if (!customerPresent) return VISIBLE_DISABLED;
 
         return isConsultDestinationReady ? VISIBLE_ENABLED : VISIBLE_DISABLED;
       }

--- a/packages/@webex/contact-center/src/services/task/types.ts
+++ b/packages/@webex/contact-center/src/services/task/types.ts
@@ -935,6 +935,8 @@ export type Interaction = {
     fcDesktopView?: string;
     /** Agent ID who initiated the outdial call */
     outdialAgentId?: string;
+    /** Indicates if the customer has left the call during an active consult */
+    hasCustomerLeft?: string;
   };
   /** Main interaction identifier for related interactions */
   mainInteractionId?: string;

--- a/packages/@webex/contact-center/src/services/task/voice/Voice.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/Voice.ts
@@ -710,17 +710,22 @@ export default class Voice extends Task implements IVoice {
         ? calculateDestType(this.data.interaction, this.data.agentId)
         : '';
 
+    // derivedDestType is most reliable as it inspects live interaction participants
+    const resolvedDestinationType =
+      derivedDestType ||
+      this.getStateMachineSnapshot()?.context?.consultDestinationType ||
+      this.data.destinationType ||
+      'agent';
+
     const consultationData: consultConferencePayloadData = {
       agentId: this.data.agentId,
-      destinationType:
-        this.getStateMachineSnapshot()?.context?.consultDestinationType ||
-        this.data.destinationType ||
-        derivedDestType ||
-        'agent',
+      destinationType: resolvedDestinationType,
+      // derivedDestAgentId is most reliable as it resolves epId for EP_DN
+      // and agent ID for regular agents from live interaction data
       destAgentId:
+        derivedDestAgentId ||
         this.getStateMachineSnapshot()?.context?.consultDestinationAgentId ||
-        this.data.destAgentId ||
-        derivedDestAgentId,
+        this.data.destAgentId,
     };
 
     // Send state machine event to transition to CONF_INITIATING

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/TaskStateMachine.ts
@@ -444,6 +444,146 @@ describe('Task state machine', () => {
     });
   });
 
+  describe('CONF_INITIATING state event handlers', () => {
+    it('transitions to CONFERENCING on CONFERENCE_START', () => {
+      const service = startMachine();
+      const taskData = createTaskData({consultingAgentId: 'agent-1'});
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData});
+      service.send({type: TaskEvent.ASSIGN, taskData});
+      service.send({
+        type: TaskEvent.CONSULT,
+        destination: 'agent-42',
+        destinationType: 'agent',
+      });
+      service.send({type: TaskEvent.CONSULT_SUCCESS, taskData});
+      service.send({type: TaskEvent.MERGE_TO_CONFERENCE});
+      expect(service.getSnapshot().value).toBe(TaskState.CONF_INITIATING);
+
+      service.send({type: TaskEvent.CONFERENCE_START, taskData});
+      expect(service.getSnapshot().value).toBe(TaskState.CONFERENCING);
+    });
+
+    it('transitions to WRAPPING_UP on CONSULT_END with isTerminated during CONF_INITIATING', () => {
+      const service = startMachine();
+      const taskData = createTaskData({consultingAgentId: 'agent-1'});
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData});
+      service.send({type: TaskEvent.ASSIGN, taskData});
+      service.send({
+        type: TaskEvent.CONSULT,
+        destination: 'agent-42',
+        destinationType: 'agent',
+      });
+      service.send({type: TaskEvent.CONSULT_SUCCESS, taskData});
+      service.send({type: TaskEvent.MERGE_TO_CONFERENCE});
+      expect(service.getSnapshot().value).toBe(TaskState.CONF_INITIATING);
+
+      const terminatedTaskData = createTaskData({
+        consultingAgentId: 'agent-1',
+        interaction: {
+          isTerminated: true,
+          owner: 'agent-1',
+        } as any,
+      });
+      service.send({type: TaskEvent.CONSULT_END, taskData: terminatedTaskData});
+      expect(service.getSnapshot().value).toBe(TaskState.WRAPPING_UP);
+    });
+
+    it('transitions to CONNECTED on CONSULT_END without isTerminated during CONF_INITIATING', () => {
+      const service = startMachine();
+      const taskData = createTaskData({consultingAgentId: 'agent-1'});
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData});
+      service.send({type: TaskEvent.ASSIGN, taskData});
+      service.send({
+        type: TaskEvent.CONSULT,
+        destination: 'agent-42',
+        destinationType: 'agent',
+      });
+      service.send({type: TaskEvent.CONSULT_SUCCESS, taskData});
+      service.send({type: TaskEvent.MERGE_TO_CONFERENCE});
+      expect(service.getSnapshot().value).toBe(TaskState.CONF_INITIATING);
+
+      service.send({type: TaskEvent.CONSULT_END, taskData});
+      expect(service.getSnapshot().value).toBe(TaskState.CONNECTED);
+    });
+
+    it('transitions to WRAPPING_UP on CONTACT_ENDED during CONF_INITIATING', () => {
+      const service = startMachine();
+      const taskData = createTaskData({consultingAgentId: 'agent-1'});
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData});
+      service.send({type: TaskEvent.ASSIGN, taskData});
+      service.send({
+        type: TaskEvent.CONSULT,
+        destination: 'agent-42',
+        destinationType: 'agent',
+      });
+      service.send({type: TaskEvent.CONSULT_SUCCESS, taskData});
+      service.send({type: TaskEvent.MERGE_TO_CONFERENCE});
+      expect(service.getSnapshot().value).toBe(TaskState.CONF_INITIATING);
+
+      service.send({type: TaskEvent.CONTACT_ENDED, taskData});
+      expect(service.getSnapshot().value).toBe(TaskState.WRAPPING_UP);
+    });
+
+    it('transitions to WRAPPING_UP on TASK_WRAPUP during CONF_INITIATING', () => {
+      const service = startMachine();
+      const taskData = createTaskData({consultingAgentId: 'agent-1'});
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData});
+      service.send({type: TaskEvent.ASSIGN, taskData});
+      service.send({
+        type: TaskEvent.CONSULT,
+        destination: 'agent-42',
+        destinationType: 'agent',
+      });
+      service.send({type: TaskEvent.CONSULT_SUCCESS, taskData});
+      service.send({type: TaskEvent.MERGE_TO_CONFERENCE});
+      expect(service.getSnapshot().value).toBe(TaskState.CONF_INITIATING);
+
+      service.send({type: TaskEvent.TASK_WRAPUP});
+      expect(service.getSnapshot().value).toBe(TaskState.WRAPPING_UP);
+    });
+  });
+
+  describe('CONFERENCING state CONSULT_END with terminated interaction', () => {
+    it('transitions to WRAPPING_UP when CONSULT_END arrives with isTerminated in CONFERENCING', () => {
+      const service = startMachine();
+      const taskData = createTaskData({
+        consultingAgentId: 'agent-1',
+        interaction: {
+          owner: 'agent-1',
+          state: 'conference',
+        } as any,
+      });
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData});
+      service.send({type: TaskEvent.ASSIGN, taskData});
+      service.send({
+        type: TaskEvent.CONSULT,
+        destination: 'agent-42',
+        destinationType: 'agent',
+      });
+      service.send({type: TaskEvent.CONSULT_SUCCESS, taskData});
+      service.send({type: TaskEvent.MERGE_TO_CONFERENCE});
+      service.send({type: TaskEvent.CONFERENCE_START, taskData});
+      expect(service.getSnapshot().value).toBe(TaskState.CONFERENCING);
+
+      const terminatedTaskData = createTaskData({
+        consultingAgentId: 'agent-1',
+        interaction: {
+          isTerminated: true,
+          owner: 'agent-1',
+          state: 'conference',
+        } as any,
+      });
+      service.send({type: TaskEvent.CONSULT_END, taskData: terminatedTaskData});
+      expect(service.getSnapshot().value).toBe(TaskState.WRAPPING_UP);
+    });
+  });
+
   describe('OFFERED state event handlers', () => {
     it('transitions to TERMINATED when customer disconnects before agent answers', () => {
       const service = startMachine();

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/TaskStateMachine.ts
@@ -509,43 +509,6 @@ describe('Task state machine', () => {
       expect(service.getSnapshot().value).toBe(TaskState.CONNECTED);
     });
 
-    it('transitions to WRAPPING_UP on CONTACT_ENDED during CONF_INITIATING', () => {
-      const service = startMachine();
-      const taskData = createTaskData({consultingAgentId: 'agent-1'});
-
-      service.send({type: TaskEvent.TASK_INCOMING, taskData});
-      service.send({type: TaskEvent.ASSIGN, taskData});
-      service.send({
-        type: TaskEvent.CONSULT,
-        destination: 'agent-42',
-        destinationType: 'agent',
-      });
-      service.send({type: TaskEvent.CONSULT_SUCCESS, taskData});
-      service.send({type: TaskEvent.MERGE_TO_CONFERENCE});
-      expect(service.getSnapshot().value).toBe(TaskState.CONF_INITIATING);
-
-      service.send({type: TaskEvent.CONTACT_ENDED, taskData});
-      expect(service.getSnapshot().value).toBe(TaskState.WRAPPING_UP);
-    });
-
-    it('transitions to WRAPPING_UP on TASK_WRAPUP during CONF_INITIATING', () => {
-      const service = startMachine();
-      const taskData = createTaskData({consultingAgentId: 'agent-1'});
-
-      service.send({type: TaskEvent.TASK_INCOMING, taskData});
-      service.send({type: TaskEvent.ASSIGN, taskData});
-      service.send({
-        type: TaskEvent.CONSULT,
-        destination: 'agent-42',
-        destinationType: 'agent',
-      });
-      service.send({type: TaskEvent.CONSULT_SUCCESS, taskData});
-      service.send({type: TaskEvent.MERGE_TO_CONFERENCE});
-      expect(service.getSnapshot().value).toBe(TaskState.CONF_INITIATING);
-
-      service.send({type: TaskEvent.TASK_WRAPUP});
-      expect(service.getSnapshot().value).toBe(TaskState.WRAPPING_UP);
-    });
   });
 
   describe('CONFERENCING state CONSULT_END with terminated interaction', () => {

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/guards.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/guards.ts
@@ -238,6 +238,109 @@ describe('State Machine Guards', () => {
     });
   });
 
+  describe('Hydration Guards - isInteractionConsulting', () => {
+    it('returns true when interaction state is consulting', () => {
+      const ctx = createContext();
+      const taskData = createTaskData({
+        interaction: {
+          ...createTaskData().interaction,
+          state: 'consulting',
+        },
+      });
+      expect(
+        guards.isInteractionConsulting(createParams(ctx, createEventWithTaskData(taskData)))
+      ).toBe(true);
+    });
+
+    it('returns true for EP_DN consulted agent (state=connected, CPD relationshipType=consult)', () => {
+      const ctx = createContext();
+      const taskData = createTaskData({
+        interaction: {
+          ...createTaskData().interaction,
+          state: 'connected',
+          callProcessingDetails: {
+            ...createTaskData().interaction!.callProcessingDetails,
+            relationshipType: 'consult',
+          },
+        },
+      });
+      expect(
+        guards.isInteractionConsulting(createParams(ctx, createEventWithTaskData(taskData)))
+      ).toBe(true);
+    });
+
+    it('returns true when post_call with active consult (consultState=consulting + consult media)', () => {
+      const ctx = createContext();
+      const taskData = createTaskData({
+        interaction: {
+          ...createTaskData().interaction,
+          state: 'post_call',
+          participants: {
+            'agent-123': {
+              ...createParticipant('agent-123', 'Agent'),
+              consultState: 'consulting',
+            },
+          },
+          media: {
+            [INTERACTION_ID]: {
+              mediaResourceId: INTERACTION_ID,
+              mediaType: 'telephony',
+              mediaMgr: 'media-mgr',
+              participants: ['agent-123'],
+              mType: 'mainCall',
+              isHold: false,
+              holdTimestamp: null,
+            },
+            'consult-media': {
+              mediaResourceId: 'consult-media',
+              mediaType: 'telephony',
+              mediaMgr: 'media-mgr',
+              participants: ['agent-123', 'agent-2'],
+              mType: 'consult',
+              isHold: false,
+              holdTimestamp: null,
+            },
+          },
+        },
+      });
+      expect(
+        guards.isInteractionConsulting(createParams(ctx, createEventWithTaskData(taskData)))
+      ).toBe(true);
+    });
+
+    it('returns false for post_call without consult media', () => {
+      const ctx = createContext();
+      const taskData = createTaskData({
+        interaction: {
+          ...createTaskData().interaction,
+          state: 'post_call',
+          participants: {
+            'agent-123': {
+              ...createParticipant('agent-123', 'Agent'),
+              consultState: undefined,
+            },
+          },
+        },
+      });
+      expect(
+        guards.isInteractionConsulting(createParams(ctx, createEventWithTaskData(taskData)))
+      ).toBe(false);
+    });
+
+    it('returns false for plain connected state without consult CPD', () => {
+      const ctx = createContext();
+      const taskData = createTaskData({
+        interaction: {
+          ...createTaskData().interaction,
+          state: 'connected',
+        },
+      });
+      expect(
+        guards.isInteractionConsulting(createParams(ctx, createEventWithTaskData(taskData)))
+      ).toBe(false);
+    });
+  });
+
   describe('Server State Guards', () => {
     it('isPrimaryMediaOnHold returns true when media isHold is true', () => {
       const ctx = createContext();

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
@@ -27,7 +27,7 @@ function createConsultTaskData() {
           currentState: 'consulting',
           isConsulted: true,
         },
-        'customer-1': {id: 'customer-1', pType: 'CUSTOMER', hasLeft: false},
+        'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false},
       } as any,
       media: {
         'interaction-1': {

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
@@ -145,3 +145,191 @@ describe('uiControlsComputer consult initiator controls', () => {
     expect(uiControls.consult).toEqual(getDefaultUIControls().consult);
   });
 });
+
+describe('uiControlsComputer conference controls', () => {
+  function createConferenceTaskData(participantCount: number) {
+    const participants: Record<string, any> = {
+      'customer-1': {id: 'customer-1', pType: 'Customer', hasJoined: true, hasLeft: false},
+      'agent-1': {
+        id: 'agent-1',
+        pType: 'Agent',
+        hasJoined: true,
+        hasLeft: false,
+        consultState: 'conferencing',
+      },
+    };
+    const mainCallParticipants = ['customer-1', 'agent-1'];
+
+    if (participantCount > 1) {
+      participants['agent-2'] = {
+        id: 'agent-2',
+        pType: 'Agent',
+        hasJoined: true,
+        hasLeft: false,
+        consultState: 'conferencing',
+      };
+      mainCallParticipants.push('agent-2');
+    }
+
+    return createTaskData({
+      agentId: 'agent-1',
+      mediaResourceId: 'interaction-1',
+      consultMediaResourceId: '' as any,
+      interaction: {
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        state: 'conference',
+        participants,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            isHold: false,
+            participants: mainCallParticipants,
+          },
+        },
+      } as any,
+    });
+  }
+
+  function createConferenceContext(participantCount: number, overrides: Partial<TaskContext> = {}): TaskContext {
+    return {
+      taskData: createConferenceTaskData(participantCount),
+      consultInitiator: true,
+      exitingConference: false,
+      consultFromConference: false,
+      transferConferenceRequested: false,
+      consultDestinationType: null,
+      consultDestinationAgentId: null,
+      consultDestinationAgentJoined: false,
+      consultCallHeld: false,
+      recordingControlsAvailable: true,
+      recordingInProgress: true,
+      uiControlConfig: {
+        isEndTaskEnabled: true,
+        isEndConsultEnabled: true,
+        channelType: TASK_CHANNEL_TYPE.VOICE,
+        isRecordingEnabled: true,
+        agentId: 'agent-1',
+      },
+      uiControls: getDefaultUIControls(),
+      ...overrides,
+    };
+  }
+
+  it('pending conference (participantCount <= 1): transfer/recording enabled, consult disabled, exitConference hidden', () => {
+    const context = createConferenceContext(1);
+
+    const uiControls = computeUIControls(TaskState.CONFERENCING, context, context.taskData);
+
+    expect(uiControls.main.transfer).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.recording).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.consult).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.main.exitConference).toEqual({isVisible: false, isEnabled: false});
+    expect(uiControls.main.end).toEqual({isVisible: true, isEnabled: true});
+  });
+
+  it('real conference (participantCount > 1): transfer/recording hidden, consult enabled, exitConference visible', () => {
+    const context = createConferenceContext(2);
+
+    const uiControls = computeUIControls(TaskState.CONFERENCING, context, context.taskData);
+
+    expect(uiControls.main.transfer).toEqual({isVisible: false, isEnabled: false});
+    expect(uiControls.main.recording).toEqual({isVisible: false, isEnabled: false});
+    expect(uiControls.main.consult).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.exitConference).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.end).toEqual({isVisible: true, isEnabled: true});
+  });
+
+  it('hold button shows visible but disabled in conference', () => {
+    const context = createConferenceContext(2);
+
+    const uiControls = computeUIControls(TaskState.CONFERENCING, context, context.taskData);
+
+    expect(uiControls.main.hold).toEqual({isVisible: true, isEnabled: false});
+  });
+});
+
+describe('uiControlsComputer post-call consult controls (customer left)', () => {
+  function createPostCallConsultTaskData() {
+    return createTaskData({
+      agentId: 'agent-1',
+      mediaResourceId: 'interaction-1',
+      consultMediaResourceId: 'consult-media',
+      consultingAgentId: 'agent-1',
+      destAgentId: 'agent-2',
+      interaction: {
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        state: 'post_call',
+        isTerminated: false,
+        participants: {
+          'agent-1': {
+            id: 'agent-1',
+            pType: 'Agent',
+            hasJoined: true,
+            hasLeft: false,
+            consultState: 'consulting',
+          },
+          'agent-2': {
+            id: 'agent-2',
+            pType: 'Agent',
+            hasLeft: false,
+            consultState: 'consulting',
+            isConsulted: true,
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasJoined: true, hasLeft: true},
+        } as any,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            isHold: false,
+            participants: ['agent-1'],
+          },
+          'consult-media': {
+            mediaResourceId: 'consult-media',
+            mType: 'consult',
+            isHold: false,
+            participants: ['agent-1', 'agent-2'],
+          },
+        } as any,
+      } as any,
+    });
+  }
+
+  it('consult controls are visible but disabled when customer has left', () => {
+    const taskData = createPostCallConsultTaskData();
+    const context: TaskContext = {
+      taskData,
+      consultInitiator: true,
+      exitingConference: false,
+      consultFromConference: false,
+      transferConferenceRequested: false,
+      consultDestinationType: null,
+      consultDestinationAgentId: null,
+      consultDestinationAgentJoined: true,
+      consultCallHeld: false,
+      recordingControlsAvailable: true,
+      recordingInProgress: true,
+      uiControlConfig: {
+        isEndTaskEnabled: true,
+        isEndConsultEnabled: true,
+        channelType: TASK_CHANNEL_TYPE.VOICE,
+        isRecordingEnabled: true,
+        agentId: 'agent-1',
+      },
+      uiControls: getDefaultUIControls(),
+    };
+
+    const uiControls = computeUIControls(TaskState.CONSULTING, context, context.taskData);
+
+    // Consult leg: transfer/conference/merge/switch should be visible but disabled
+    expect(uiControls.consult.transfer).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.consult.conference).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.consult.switch).toEqual({isVisible: true, isEnabled: false});
+
+    // Main leg end should be visible but disabled
+    expect(uiControls.main.end).toEqual({isVisible: true, isEnabled: false});
+  });
+});


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #<https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7897>

## This pull request addresses

Issues in the contact center SDK task-refactor state machine related to the consult flow lifecycle and 3-party conference controls. The uiControlsComputer, state machine guards, actions, task manager, and voice service did not correctly handle: (1) post-call lifecycle when the customer leaves a 3-way consult interaction, (2) conference UI controls during and after merge, (3) EP_DN conference API payload resolution, and (4) pending vs real conference state distinction.

## by making the following changes

**1. Fix extra controls visible after customer ends call (uiControlsComputer.ts)**

- When `customerPresent` is false during an active consult, `transfer`, `conference`, `mergeToConference`, and `switch` controls now return `VISIBLE_DISABLED` on the consult leg and `DISABLED` (hidden) on the main leg.
- The `recording` control on the main leg returns `DISABLED` when `hasParallelConsultLeg && !customerPresent`.

**2. Emit post-call activity event to Widgets (TaskManager.ts)**

- When `CC_EVENTS.PARTICIPANT_POST_CALL_ACTIVITY` is received, the task manager now explicitly emits `TASK_EVENTS.TASK_POST_CALL_ACTIVITY` on the task object so Widgets can render the "Post Call" timer label.
- Added null check before `removeTaskFromCollection` in `handleContactMergedEvent` to prevent `cancelAutoWrapupTimer` TypeError.

**3. Fix hydration failure during post-call state (guards.ts, actions.ts)**

- Enhanced `isInteractionConsulting` guard to return true when `interaction.state === 'post_call'` if self-agent's `consultState === 'consulting'` and consult media exists.
- Introduced `isActiveConsultState` helper to correctly gate hydration of consult context fields during post-call refresh.

**4. Fix incorrect wrap-up transition and conference state actions (TaskStateMachine.ts)**

- Added guarded transition: when `consultInitiator === true`, `interaction.isTerminated === true`, and `shouldWrapUpForThisAgent` is true, transitions directly from `CONSULTING → WRAPPING_UP`.
- Added `updateTaskData`/`syncTaskDataFromEvent` actions to `CONFERENCE_START` and `UNHOLD_SUCCESS` transitions to ensure task data is current when entering conference.
- Added `clearConsultState` action to `CONF_INITIATING → CONFERENCING` transition to reset stale consult context.

**5. Fix conference Exit Conference button for pending state (uiControlsComputer.ts)**

- `exitConference` returns `DISABLED` when `participantCount <= 1` (pending conference where only initiating agent is present).

**6. Fix EP_DN conference 400 Bad Request (Voice.ts)**

- Reordered resolution priority in `consultConference()` to use `derivedDestAgentId`/`derivedDestType` (computed from live interaction data via `calculateDestAgentId`/`calculateDestType`) as highest priority, ensuring EP_ID UUID is used instead of phone number.

**7. Fix conference controls for pending vs real conference (uiControlsComputer.ts)**

- Uses `participantCount` to distinguish pending conference (only self agent in mainCall) vs real multi-agent conference:
  - **Pending (participantCount <= 1):** Transfer/Recording enabled, Consult disabled, Exit Conference hidden
  - **Real (participantCount > 1):** Transfer/Recording hidden, Consult enabled, Exit Conference visible

**8. Fix missing wrapup screen after end call from pending conference (TaskManager.ts, TaskStateMachine.ts)**

- Added `AgentConsultConferencing` to the `CONFERENCE_START` event mapping in TaskManager so the state machine correctly transitions from `CONF_INITIATING` to `CONFERENCING` when Agent 1 merges before Agent 2 accepts.
- Added `CONSULT_END`, `CONTACT_ENDED`, and `TASK_WRAPUP` handlers to the `CONF_INITIATING` state for defense-in-depth, ensuring wrapup transitions are never dropped.
- Enhanced the `CONFERENCING` state's `CONSULT_END` handler to transition to `WRAPPING_UP` when `isTerminated === true`.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
