### PR TITLE
feat(auth): add helpers for new oauth flows

### DIFF
--- a/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/src/authorization.js
@@ -344,6 +344,59 @@ const Authorization = WebexPlugin.extend({
   },
 
   /**
+   * Initiates third-party (social provider) login by redirecting the user
+   * to IdBroker's `/idb/ThirdPartyLogin` endpoint.
+   *
+   * Mirrors `initiateLogin`'s role for the standard `/authorize` flow.
+   * Delegates to `initiateThirdPartyLoginRedirect` so any pre-redirect
+   * security plumbing (CSRF / `state`) can be added here without changing
+   * the navigation method, which the web client overrides for
+   * `targetOrigin` / postMessage handling in iframed contexts.
+   *
+   * @instance
+   * @memberof AuthorizationBrowserFirstParty
+   * @param {Object} options
+   * @param {string} options.oauth2provider
+   * @param {string} options.returnURL
+   * @returns {Promise<void>}
+   */
+  initiateThirdPartyLogin(options = {}) {
+    return this.initiateThirdPartyLoginRedirect(options);
+  },
+
+  /**
+   * Performs the navigation step of the third-party login flow. Builds the
+   * IdBroker URL via `Credentials#buildThirdPartyLoginUrl` and assigns it
+   * to `getWindow().location`.
+   *
+   * Mirrors `initiateAuthorizationCodeGrant` for the `/authorize` flow. The
+   * web client overrides this method to add `targetOrigin`/postMessage
+   * branching for iframed (crosslauncher / MJP) contexts.
+   *
+   * Note: intentionally not decorated with `@whileInFlight('isAuthorizing')`
+   * the way `initiateAuthorizationCodeGrant` is. That decorator just toggles
+   * an observable boolean on the instance while the returned promise is
+   * pending; this method resolves synchronously before the navigation
+   * actually happens, so the flag would flip true→false within the same
+   * tick and provide no useful signal.
+   *
+   * @instance
+   * @memberof AuthorizationBrowserFirstParty
+   * @param {Object} options
+   * @param {string} options.oauth2provider
+   * @param {string} options.returnURL
+   * @returns {Promise<void>}
+   */
+  initiateThirdPartyLoginRedirect(options = {}) {
+    this.logger.info('authorization: initiating third-party login redirect');
+    const url = this.webex.credentials.buildThirdPartyLoginUrl(options);
+
+    this.webex.getWindow().location = url;
+
+    return Promise.resolve();
+  },
+
+  /**
    * Called by {@link WebexCore#logout()}.
    * Constructs logout URL and (unless suppressed) navigates away to ensure
    * server-side session termination.

--- a/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
+++ b/packages/@webex/plugin-authorization-browser-first-party/test/unit/spec/authorization.js
@@ -560,6 +560,72 @@ describe('plugin-authorization-browser-first-party', () => {
       });
     });
 
+    describe('#initiateThirdPartyLogin()', () => {
+      it('delegates to #initiateThirdPartyLoginRedirect with the same options', () => {
+        const webex = makeWebex();
+        const stub = sinon
+          .stub(webex.authorization, 'initiateThirdPartyLoginRedirect')
+          .returns(Promise.resolve());
+        const options = {
+          oauth2provider: 'google',
+          returnURL: 'https://web.webex.com',
+        };
+
+        return webex.authorization.initiateThirdPartyLogin(options).then(() => {
+          assert.calledOnceWithExactly(stub, options);
+        });
+      });
+
+      it('returns the promise from #initiateThirdPartyLoginRedirect', () => {
+        const webex = makeWebex();
+        const expected = Promise.resolve();
+        sinon.stub(webex.authorization, 'initiateThirdPartyLoginRedirect').returns(expected);
+
+        assert.equal(
+          webex.authorization.initiateThirdPartyLogin({
+            oauth2provider: 'google',
+            returnURL: 'https://web.webex.com',
+          }),
+          expected
+        );
+      });
+    });
+
+    describe('#initiateThirdPartyLoginRedirect()', () => {
+      it('builds the third-party login URL and assigns it to getWindow().location', () => {
+        const webex = makeWebex();
+        const builtUrl =
+          'https://idbroker.webex.com/idb/ThirdPartyLogin?oauth2provider=google&returnURL=https%3A%2F%2Fweb.webex.com';
+        sinon.stub(webex.credentials, 'buildThirdPartyLoginUrl').returns(builtUrl);
+
+        return webex.authorization
+          .initiateThirdPartyLoginRedirect({
+            oauth2provider: 'google',
+            returnURL: 'https://web.webex.com',
+          })
+          .then(() => {
+            assert.calledOnceWithExactly(webex.credentials.buildThirdPartyLoginUrl, {
+              oauth2provider: 'google',
+              returnURL: 'https://web.webex.com',
+            });
+            assert.equal(webex.getWindow().location, builtUrl);
+          });
+      });
+
+      it('returns a Promise', () => {
+        const webex = makeWebex();
+        sinon.stub(webex.credentials, 'buildThirdPartyLoginUrl').returns('https://example.com');
+
+        const result = webex.authorization.initiateThirdPartyLoginRedirect({
+          oauth2provider: 'apple',
+          returnURL: 'https://web.webex.com',
+        });
+
+        assert.instanceOf(result, Promise);
+        return result;
+      });
+    });
+
     describe('#_generateQRCodeVerificationUrl()', () => {
       it('should generate a QR code URL when a userCode is present', () => {
         const verificationUrl = 'https://example.com/verify?userCode=123456';

--- a/packages/@webex/webex-core/src/lib/credentials/credentials.js
+++ b/packages/@webex/webex-core/src/lib/credentials/credentials.js
@@ -213,6 +213,48 @@ const Credentials = WebexPlugin.extend({
   },
 
   /**
+   * Generates a Third-Party Login URL pointing at IdBroker's
+   * `/idb/ThirdPartyLogin` endpoint. Used by the social-provider sign-in
+   * flow (Google / Microsoft / Apple / ...).
+   *
+   * Mirrors `buildLoginUrl` / `buildLogoutUrl` — pure URL construction, no
+   * navigation side effects. The base URL is read from the `idbroker`
+   * service in the services plugin catalog rather than from
+   * `this.config.authorizeUrl`, because the third-party endpoint always
+   * lives on IdBroker (no hydra proxy).
+   *
+   * @instance
+   * @memberof Credentials
+   * @param {Object} options
+   * @param {string} options.oauth2provider - Provider name (`google`,
+   *   `microsoft`, `apple`, ...). Required.
+   * @param {string} options.returnURL - URL IdBroker should send the user
+   *   back to after the third-party hand-off. Required.
+   * @returns {string}
+   */
+  buildThirdPartyLoginUrl({oauth2provider, returnURL} = {}) {
+    if (!oauth2provider) {
+      throw new Error('`options.oauth2provider` is required');
+    }
+    if (!returnURL) {
+      throw new Error('`options.returnURL` is required');
+    }
+
+    const baseUrl = this.webex.internal.services.get('idbroker');
+
+    if (!baseUrl) {
+      throw new Error('idbroker service is not available');
+    }
+
+    const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+
+    return `${normalizedBase}idb/ThirdPartyLogin?${querystring.stringify({
+      oauth2provider,
+      returnURL,
+    })}`;
+  },
+
+  /**
    * Generates a Logout URL
    * @instance
    * @memberof Credentials

--- a/packages/@webex/webex-core/src/lib/credentials/credentials.js
+++ b/packages/@webex/webex-core/src/lib/credentials/credentials.js
@@ -219,9 +219,12 @@ const Credentials = WebexPlugin.extend({
    *
    * Mirrors `buildLoginUrl` / `buildLogoutUrl` — pure URL construction, no
    * navigation side effects. The base URL is read from the `idbroker`
-   * service in the services plugin catalog rather than from
-   * `this.config.authorizeUrl`, because the third-party endpoint always
-   * lives on IdBroker (no hydra proxy).
+   * service in the services plugin catalog when available, falling back
+   * to `this.config.idbroker.url` (which itself defaults to
+   * `https://idbroker.webex.com` or `IDBROKER_BASE_URL`). This matches
+   * the pattern used by sibling derived URLs (`activationUrl`,
+   * `tokenUrl`, `logoutUrl`, ...) and avoids a race where this helper
+   * could be called before the services catalog has populated.
    *
    * @instance
    * @memberof Credentials
@@ -240,11 +243,7 @@ const Credentials = WebexPlugin.extend({
       throw new Error('`options.returnURL` is required');
     }
 
-    const baseUrl = this.webex.internal.services.get('idbroker');
-
-    if (!baseUrl) {
-      throw new Error('idbroker service is not available');
-    }
+    const baseUrl = this.webex.internal.services.get('idbroker') || this.config.idbroker.url;
 
     const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
 

--- a/packages/@webex/webex-core/test/unit/spec/credentials/credentials.js
+++ b/packages/@webex/webex-core/test/unit/spec/credentials/credentials.js
@@ -232,6 +232,76 @@ describe('webex-core', () => {
       });
     });
 
+    describe('#buildThirdPartyLoginUrl()', () => {
+      function makeWebexWithIdbroker(idbrokerUrl) {
+        const webex = new MockWebex({
+          children: {
+            credentials: Credentials,
+          },
+        });
+
+        webex.internal = webex.internal || {};
+        webex.internal.services = {
+          get: sinon.stub().withArgs('idbroker').returns(idbrokerUrl),
+        };
+        webex.trigger('change:config');
+
+        return webex;
+      }
+
+      it('throws if `oauth2provider` is missing', () => {
+        const webex = makeWebexWithIdbroker('https://idbroker.webex.com/');
+
+        assert.throws(() => {
+          webex.credentials.buildThirdPartyLoginUrl({returnURL: 'https://web.webex.com'});
+        }, /`options.oauth2provider` is required/);
+      });
+
+      it('throws if `returnURL` is missing', () => {
+        const webex = makeWebexWithIdbroker('https://idbroker.webex.com/');
+
+        assert.throws(() => {
+          webex.credentials.buildThirdPartyLoginUrl({oauth2provider: 'google'});
+        }, /`options.returnURL` is required/);
+      });
+
+      it('throws if the idbroker service is not available', () => {
+        const webex = makeWebexWithIdbroker(undefined);
+
+        assert.throws(() => {
+          webex.credentials.buildThirdPartyLoginUrl({
+            oauth2provider: 'google',
+            returnURL: 'https://web.webex.com',
+          });
+        }, /idbroker service is not available/);
+      });
+
+      it('builds the URL with provider and returnURL query params', () => {
+        const webex = makeWebexWithIdbroker('https://idbroker.webex.com/');
+
+        const url = webex.credentials.buildThirdPartyLoginUrl({
+          oauth2provider: 'google',
+          returnURL: 'https://web.webex.com',
+        });
+
+        assert.equal(
+          url,
+          'https://idbroker.webex.com/idb/ThirdPartyLogin?oauth2provider=google&returnURL=https%3A%2F%2Fweb.webex.com'
+        );
+      });
+
+      it('normalizes idbroker base URL without trailing slash', () => {
+        const webex = makeWebexWithIdbroker('https://idbroker.webex.com');
+
+        const url = webex.credentials.buildThirdPartyLoginUrl({
+          oauth2provider: 'google',
+          returnURL: 'https://web.webex.com',
+        });
+
+        assert.match(url, /^https:\/\/idbroker\.webex\.com\/idb\/ThirdPartyLogin\?/);
+      });
+    });
+
     describe('#buildLogoutUrl()', () => {
       skipInBrowser(it)('generates the logout url', () => {
         const webex = new MockWebex();

--- a/packages/@webex/webex-core/test/unit/spec/credentials/credentials.js
+++ b/packages/@webex/webex-core/test/unit/spec/credentials/credentials.js
@@ -265,15 +265,20 @@ describe('webex-core', () => {
         }, /`options.returnURL` is required/);
       });
 
-      it('throws if the idbroker service is not available', () => {
+      it('falls back to config.idbroker.url when the idbroker service is unavailable', () => {
         const webex = makeWebexWithIdbroker(undefined);
 
-        assert.throws(() => {
-          webex.credentials.buildThirdPartyLoginUrl({
-            oauth2provider: 'google',
-            returnURL: 'https://web.webex.com',
-          });
-        }, /idbroker service is not available/);
+        const url = webex.credentials.buildThirdPartyLoginUrl({
+          oauth2provider: 'google',
+          returnURL: 'https://web.webex.com',
+        });
+
+        assert.equal(
+          url,
+          `${
+            process.env.IDBROKER_BASE_URL || 'https://idbroker.webex.com'
+          }/idb/ThirdPartyLogin?oauth2provider=google&returnURL=https%3A%2F%2Fweb.webex.com`
+        );
       });
 
       it('builds the URL with provider and returnURL query params', () => {


### PR DESCRIPTION
## This pull request addresses
new SSO OAuth helper functions

## by making the following changes
Adds Credentials.prototype.buildThirdPartyLoginUrl({oauth2provider, returnURL}) which constructs the IdBroker /idb/ThirdPartyLogin URL (mirrors the existing buildLoginUrl/buildLogoutUrl style). Adds Authorization.prototype.initiateThirdPartyLogin and initiateThirdPartyLoginRedirect to wrap the URL build + window.location assignment, mirroring initiateAuthorizationCodeGrant's shape so the web client can override initiateThirdPartyLoginRedirect for iframed targetOrigin/postMessage handling. Behaviour-preserving lift of logic that today lives in webex-web-client's createThirdPartyLoginURI; no consumers wired up yet.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
