### PR TITLE
feat(calling): add mobius socket switch on samples page

### DIFF
--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -170,6 +170,12 @@ if (localStorage.getItem('date') > new Date().getTime()) {
   localStorage.removeItem('access-token');
 }
 
+// Initialize Mobius WSS checkbox from localStorage
+const mobiusWssCheckbox = document.getElementById('mobius-wss');
+if (localStorage.getItem('mobius-wss-enabled') === 'true') {
+  mobiusWssCheckbox.checked = true;
+}
+
 tokenElm.addEventListener('change', (event) => {
   localStorage.setItem('access-token', event.target.value);
   localStorage.setItem('date', new Date().getTime() + 12 * 60 * 60 * 1000);
@@ -178,6 +184,16 @@ tokenElm.addEventListener('change', (event) => {
 function changeEnv() {
   enableProd = !enableProd;
   enableProduction.innerHTML = enableProd ? 'In Production' : 'In Integration';
+}
+
+function toggleMobiusWss() {
+  if (mobiusWssCheckbox.checked) {
+    localStorage.setItem('mobius-wss-enabled', 'true');
+    console.log('Mobius WebSocket enabled via samples page');
+  } else {
+    localStorage.removeItem('mobius-wss-enabled');
+    console.log('Mobius WebSocket disabled via samples page');
+  }
 }
 
 // Guest access token via Service App - Logic deployed on the AWS Lambda

--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -170,10 +170,15 @@ if (localStorage.getItem('date') > new Date().getTime()) {
   localStorage.removeItem('access-token');
 }
 
-// Initialize Mobius WSS checkbox from localStorage
+// Initialize Mobius WSS dropdown from localStorage
 const mobiusWssCheckbox = document.getElementById('mobius-wss');
-if (localStorage.getItem('mobius-wss-enabled') === 'true') {
-  mobiusWssCheckbox.checked = true;
+const storedMobiusWss = localStorage.getItem('mobius-wss-enabled');
+if (storedMobiusWss === 'true') {
+  mobiusWssCheckbox.value = 'true';
+} else if (storedMobiusWss === 'false') {
+  mobiusWssCheckbox.value = 'false';
+} else {
+  mobiusWssCheckbox.value = 'default';
 }
 
 tokenElm.addEventListener('change', (event) => {
@@ -187,12 +192,16 @@ function changeEnv() {
 }
 
 function toggleMobiusWss() {
-  if (mobiusWssCheckbox.checked) {
+  const value = mobiusWssCheckbox.value;
+  if (value === 'true') {
     localStorage.setItem('mobius-wss-enabled', 'true');
-    console.log('Mobius WebSocket enabled via samples page');
+    console.log('Mobius WebSocket force-enabled via samples page');
+  } else if (value === 'false') {
+    localStorage.setItem('mobius-wss-enabled', 'false');
+    console.log('Mobius WebSocket force-disabled via samples page');
   } else {
     localStorage.removeItem('mobius-wss-enabled');
-    console.log('Mobius WebSocket disabled via samples page');
+    console.log('Mobius WebSocket using backend flag (override cleared)');
   }
 }
 

--- a/docs/samples/calling/index.html
+++ b/docs/samples/calling/index.html
@@ -39,6 +39,7 @@
                     require token with spark:calls_write scope.</p>
                   <button id="enableProduction" type="button" class="btn-code" onclick=changeEnv()>In Production</button><span class="text-color"> ( Click to change the environment )</span>
                   <input id="fedramp" type="checkbox"> Enable FedRAMP
+                  <input id="mobius-wss" type="checkbox" onchange="toggleMobiusWss()"> Enable Mobius WebSocket
                   <input id="access-token" name="accessToken" placeholder="Access Token" value="" type="text" style="margin: 1rem 0 0.5rem 0;" required>
 
                   <div id="guest-container" class="hidden">

--- a/docs/samples/calling/index.html
+++ b/docs/samples/calling/index.html
@@ -39,7 +39,13 @@
                     require token with spark:calls_write scope.</p>
                   <button id="enableProduction" type="button" class="btn-code" onclick=changeEnv()>In Production</button><span class="text-color"> ( Click to change the environment )</span>
                   <input id="fedramp" type="checkbox"> Enable FedRAMP
-                  <input id="mobius-wss" type="checkbox" onchange="toggleMobiusWss()"> Enable Mobius WebSocket
+                  <label style="margin-left: 1rem;">Mobius WebSocket:
+                    <select id="mobius-wss" onchange="toggleMobiusWss()">
+                      <option value="default">Use Backend Flag</option>
+                      <option value="true">Force Enable</option>
+                      <option value="false">Force Disable</option>
+                    </select>
+                  </label>
                   <input id="access-token" name="accessToken" placeholder="Access Token" value="" type="text" style="margin: 1rem 0 0.5rem 0;" required>
 
                   <div id="guest-container" class="hidden">

--- a/packages/calling/src/CallingClient/utils/wsFeatureFlag.test.ts
+++ b/packages/calling/src/CallingClient/utils/wsFeatureFlag.test.ts
@@ -33,7 +33,7 @@ describe('wsFeatureFlag', () => {
         WEBRTC_CALLING_OVER_WS_FEATURE_KEY
       );
       expect(traceSpy).toHaveBeenCalledWith(
-        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: true`,
+        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: true (backend: true, localStorage: null)`,
         {
           file: 'wsFeatureFlag',
           method: 'isMobiusWssEnabled',
@@ -48,7 +48,7 @@ describe('wsFeatureFlag', () => {
 
       expect(result).toBe(false);
       expect(traceSpy).toHaveBeenCalledWith(
-        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: false`,
+        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: false (backend: false, localStorage: null)`,
         {
           file: 'wsFeatureFlag',
           method: 'isMobiusWssEnabled',
@@ -63,7 +63,7 @@ describe('wsFeatureFlag', () => {
 
       expect(result).toBe(false);
       expect(traceSpy).toHaveBeenCalledWith(
-        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: false`,
+        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: false (backend: false, localStorage: null)`,
         {
           file: 'wsFeatureFlag',
           method: 'isMobiusWssEnabled',
@@ -86,7 +86,7 @@ describe('wsFeatureFlag', () => {
 
       expect(result).toBe(false);
       expect(traceSpy).toHaveBeenCalledWith(
-        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: false`,
+        `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: false (backend: false, localStorage: null)`,
         {
           file: 'wsFeatureFlag',
           method: 'isMobiusWssEnabled',

--- a/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
+++ b/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
@@ -8,26 +8,44 @@ export const WEBRTC_CALLING_OVER_WS_FEATURE_KEY = 'webrtc-calling-over-ws-CALL-2
 /** Allowed origins for samples page localStorage override */
 const ALLOWED_ORIGINS = ['localhost', '127.0.0.1', 'web-sdk.webex.com'];
 
-function samplesPageToggleValue() {
-  // Check for samples page localStorage override on allowed origins
-  let localStorageOverride = false;
-
-  if (typeof window !== 'undefined' && window.localStorage) {
-    const hostname = window.location.hostname;
-    const isAllowedOrigin = ALLOWED_ORIGINS.some(
-      (origin) => hostname === origin || hostname.endsWith(`.${origin}`)
-    );
-
-    if (isAllowedOrigin && localStorage.getItem('mobius-wss-enabled') === 'true') {
-      localStorageOverride = true;
-      log.trace(`Mobius WSS enabled via samples page localStorage override on ${hostname}`, {
-        file: WS_FEATURE_FLAG_FILE,
-        method: METHODS.IS_MOBIUS_WSS_ENABLED,
-      });
-    }
+/**
+ * Returns tri-state localStorage override: true (force-enable), false (force-disable), or null (defer to backend).
+ */
+function samplesPageToggleValue(): boolean | null {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null;
   }
 
-  return localStorageOverride;
+  const hostname = window.location.hostname;
+  const isAllowedOrigin = ALLOWED_ORIGINS.some(
+    (origin) => hostname === origin || hostname.endsWith(`.${origin}`)
+  );
+
+  if (!isAllowedOrigin) {
+    return null;
+  }
+
+  const localStorageValue = localStorage.getItem('mobius-wss-enabled');
+
+  if (localStorageValue === 'true') {
+    log.trace(`Mobius WSS force-enabled via samples page localStorage override on ${hostname}`, {
+      file: WS_FEATURE_FLAG_FILE,
+      method: METHODS.IS_MOBIUS_WSS_ENABLED,
+    });
+
+    return true;
+  }
+
+  if (localStorageValue === 'false') {
+    log.trace(`Mobius WSS force-disabled via samples page localStorage override on ${hostname}`, {
+      file: WS_FEATURE_FLAG_FILE,
+      method: METHODS.IS_MOBIUS_WSS_ENABLED,
+    });
+
+    return false;
+  }
+
+  return null;
 }
 
 /**
@@ -37,6 +55,7 @@ function samplesPageToggleValue() {
  *
  * Additionally checks browser localStorage for 'mobius-wss-enabled' flag on allowed origins
  * (localhost, 127.0.0.1, web-sdk.webex.com) to enable testing via samples page.
+ * localStorage can force-enable ('true'), force-disable ('false'), or defer to backend (null/unset).
  */
 export function isMobiusWssEnabled(webex: WebexSDK): boolean {
   const enabled =
@@ -44,10 +63,10 @@ export function isMobiusWssEnabled(webex: WebexSDK): boolean {
     true;
 
   const localStorageOverride = samplesPageToggleValue();
-  const finalValue = localStorageOverride || enabled;
+  const finalValue = localStorageOverride !== null ? localStorageOverride : enabled;
 
   log.trace(
-    `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: ${enabled}`,
+    `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: ${finalValue} (backend: ${enabled}, localStorage: ${localStorageOverride})`,
     {
       file: WS_FEATURE_FLAG_FILE,
       method: METHODS.IS_MOBIUS_WSS_ENABLED,

--- a/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
+++ b/packages/calling/src/CallingClient/utils/wsFeatureFlag.ts
@@ -4,15 +4,47 @@ import {METHODS, WS_FEATURE_FLAG_FILE} from '../constants';
 
 /** WDM device-settings key for routing Mobius traffic over WebSocket. */
 export const WEBRTC_CALLING_OVER_WS_FEATURE_KEY = 'webrtc-calling-over-ws-CALL-219562';
+
+/** Allowed origins for samples page localStorage override */
+const ALLOWED_ORIGINS = ['localhost', '127.0.0.1', 'web-sdk.webex.com'];
+
+function samplesPageToggleValue() {
+  // Check for samples page localStorage override on allowed origins
+  let localStorageOverride = false;
+
+  if (typeof window !== 'undefined' && window.localStorage) {
+    const hostname = window.location.hostname;
+    const isAllowedOrigin = ALLOWED_ORIGINS.some(
+      (origin) => hostname === origin || hostname.endsWith(`.${origin}`)
+    );
+
+    if (isAllowedOrigin && localStorage.getItem('mobius-wss-enabled') === 'true') {
+      localStorageOverride = true;
+      log.trace(`Mobius WSS enabled via samples page localStorage override on ${hostname}`, {
+        file: WS_FEATURE_FLAG_FILE,
+        method: METHODS.IS_MOBIUS_WSS_ENABLED,
+      });
+    }
+  }
+
+  return localStorageOverride;
+}
+
 /**
  * Whether Webex Calling should use the Mobius WebSocket transport for API requests.
  * Reads WDM `webex.internal.device.settings['webrtc-calling-over-ws'].value`; must be
  * strictly `true` to enable WebSocket—otherwise use HTTP.
+ *
+ * Additionally checks browser localStorage for 'mobius-wss-enabled' flag on allowed origins
+ * (localhost, 127.0.0.1, web-sdk.webex.com) to enable testing via samples page.
  */
 export function isMobiusWssEnabled(webex: WebexSDK): boolean {
   const enabled =
     webex.internal?.device?.features?.developer?.get(WEBRTC_CALLING_OVER_WS_FEATURE_KEY)?.value ===
     true;
+
+  const localStorageOverride = samplesPageToggleValue();
+  const finalValue = localStorageOverride || enabled;
 
   log.trace(
     `Mobius WSS feature flag '${WEBRTC_CALLING_OVER_WS_FEATURE_KEY}' resolved to: ${enabled}`,
@@ -22,5 +54,5 @@ export function isMobiusWssEnabled(webex: WebexSDK): boolean {
     }
   );
 
-  return enabled;
+  return finalValue;
 }


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< Ad-hoc >

## This pull request addresses

- Adds dropdown on the calling samples page to enable/disable the mobius-socket flow. 
- This bypasses the feature flag
- Only works on the localhost, 127.0.0.1 and web-sdk.webex.com

## by making the following changes

Updated samples page and feature flag method

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

<img width="1194" height="464" alt="Screenshot 2026-05-12 at 12 42 02 PM" src="https://github.com/user-attachments/assets/e395eb9d-17a3-4fe2-9bd4-43b55106d356" />
<img width="1171" height="706" alt="Screenshot 2026-05-12 at 12 42 12 PM" src="https://github.com/user-attachments/assets/c8158294-860e-4ce9-bfa6-bc3bf8699434" />


## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
