### PR TITLE
fix(task-refactor): add environment to OrgInfo/Profile for dataCenter

### DIFF
--- a/packages/@webex/contact-center/src/services/config/Util.ts
+++ b/packages/@webex/contact-center/src/services/config/Util.ts
@@ -210,6 +210,7 @@ function parseAgentConfigs(profileData: {
     siteId: userData.siteId,
     enterpriseId: orgInfoData.tenantId,
     tenantTimezone: orgInfoData.timezone,
+    environment: orgInfoData.environment,
     privacyShieldVisible: tenantData.privacyShieldVisible,
     organizationIdleCodes: [], // TODO: for supervisor, getOrgFilteredIdleCodes(auxCodes, false),
     idleCodesAccess: agentProfileData.accessIdleCode as 'ALL' | 'SPECIFIC',

--- a/packages/@webex/contact-center/src/services/config/types.ts
+++ b/packages/@webex/contact-center/src/services/config/types.ts
@@ -689,6 +689,8 @@ export type OrgInfo = {
   tenantId: string;
   /** Organization timezone */
   timezone: string;
+  /** Current environment (e.g., 'produs1', 'intgus1') */
+  environment: string;
 };
 
 /**
@@ -1184,6 +1186,8 @@ export type Profile = {
   isAnalyzerEnabled?: boolean;
   /** Tenant timezone */
   tenantTimezone?: string;
+  /** Current environment (e.g., 'produs1', 'intgus1') */
+  environment?: string;
   /** Available voice login options */
   loginVoiceOptions?: LoginOption[];
   /** Current login device type */

--- a/packages/@webex/contact-center/test/unit/spec/services/config/index.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/config/index.ts
@@ -714,6 +714,7 @@ describe('AgentConfigService', () => {
     const mockOrgInfo = {
       tenantId: 'tenant123',
       timezone: 'GMT',
+      environment: 'produs1',
     };
 
     const mockSiteInfo = {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7912

## This pull request addresses

Digital channel tasks (email, chat) not rendering in the task-refactor branch because store.dataCenter was empty after SDK registration, causing the DigitalChannels component to return null.

## by making the following changes

- Added environment field to OrgInfo type to capture the value from the getOrgInfo API response
- Added environment optional field to Profile type so it is available on the register() return value
- Mapped environment: orgInfoData.environment in parseAgentConfigs to include it in the aggregated profile
- Updated unit test mock mockOrgInfo to include the environment field

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
