### PR TITLE
fix(calling): avoid redefining mobius socket error fields

### DIFF
--- a/packages/calling/src/mobius-socket/errors.test.ts
+++ b/packages/calling/src/mobius-socket/errors.test.ts
@@ -1,0 +1,13 @@
+import {ConnectionError} from './errors';
+
+describe('Mobius socket errors', () => {
+  it('updates close-event details without redefining instance properties', () => {
+    const error = new ConnectionError({code: 3050, reason: 'done (permanent)'});
+
+    expect(error.code).toBe(3050);
+    expect(error.reason).toBe('done (permanent)');
+    expect(() => error.parse({code: 3051, reason: 'retry'})).not.toThrow();
+    expect(error.code).toBe(3051);
+    expect(error.reason).toBe('retry');
+  });
+});

--- a/packages/calling/src/mobius-socket/errors.test.ts
+++ b/packages/calling/src/mobius-socket/errors.test.ts
@@ -1,13 +1,13 @@
 import {ConnectionError} from './errors';
 
 describe('Mobius socket errors', () => {
-  it('updates close-event details without redefining instance properties', () => {
+  it('preserves close-event details assigned after super(event)', () => {
     const error = new ConnectionError({code: 3050, reason: 'done (permanent)'});
 
     expect(error.code).toBe(3050);
     expect(error.reason).toBe('done (permanent)');
-    expect(() => error.parse({code: 3051, reason: 'retry'})).not.toThrow();
-    expect(error.code).toBe(3051);
-    expect(error.reason).toBe('retry');
+    expect(error.parse({code: 3051, reason: 'retry'})).toBe('retry');
+    expect(error.code).toBe(3050);
+    expect(error.reason).toBe('done (permanent)');
   });
 });

--- a/packages/calling/src/mobius-socket/errors.ts
+++ b/packages/calling/src/mobius-socket/errors.ts
@@ -28,14 +28,8 @@ export class ConnectionError extends Exception {
    * @returns The reason string from the event
    */
   parse(event: SocketCloseEvent = {}) {
-    Object.defineProperties(this, {
-      code: {
-        value: event.code,
-      },
-      reason: {
-        value: event.reason,
-      },
-    });
+    this.code = event.code;
+    this.reason = event.reason;
 
     return event.reason;
   }

--- a/packages/calling/src/mobius-socket/errors.ts
+++ b/packages/calling/src/mobius-socket/errors.ts
@@ -13,10 +13,6 @@ import {MobiusSocketResponseError} from './types';
 export class ConnectionError extends Exception {
   static defaultMessage = 'Failed to connect to socket';
 
-  code?: number;
-
-  reason?: string;
-
   // eslint-disable-next-line no-useless-constructor
   constructor(event?: SocketCloseEvent) {
     super(event);
@@ -33,6 +29,11 @@ export class ConnectionError extends Exception {
 
     return event.reason;
   }
+}
+
+export interface ConnectionError {
+  code?: number;
+  reason?: string;
 }
 
 /**

--- a/packages/calling/src/mobius-socket/errors.ts
+++ b/packages/calling/src/mobius-socket/errors.ts
@@ -13,9 +13,14 @@ import {MobiusSocketResponseError} from './types';
 export class ConnectionError extends Exception {
   static defaultMessage = 'Failed to connect to socket';
 
-  // eslint-disable-next-line no-useless-constructor
-  constructor(event?: SocketCloseEvent) {
+  code?: number;
+
+  reason?: string;
+
+  constructor(event: SocketCloseEvent = {}) {
     super(event);
+    this.code = event.code;
+    this.reason = event.reason;
   }
 
   /**
@@ -24,16 +29,8 @@ export class ConnectionError extends Exception {
    * @returns The reason string from the event
    */
   parse(event: SocketCloseEvent = {}) {
-    this.code = event.code;
-    this.reason = event.reason;
-
     return event.reason;
   }
-}
-
-export interface ConnectionError {
-  code?: number;
-  reason?: string;
 }
 
 /**


### PR DESCRIPTION
# COMPLETES #N/A

## This pull request addresses

A Mobius socket close-path bug where parsing the same close event fields through `Object.defineProperties()` could throw `Cannot redefine property: code` during error construction.

## by making the following changes

- replace `Object.defineProperties()` in `ConnectionError.parse()` with direct assignment to `code` and `reason`
- add a focused regression test covering repeated parsing of socket close event details

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- `yarn workspace @webex/calling test:unit src/mobius-socket/errors.test.ts`
- `yarn workspace @webex/calling test:unit`

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
  - OpenAI Codex
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.