### PR TITLE
feat(plugin-meetings): added Locus hash trees back-off syncs when LLM is connected

### DIFF
--- a/packages/@webex/plugin-meetings/src/hashTree/constants.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/constants.ts
@@ -17,3 +17,10 @@ export const DataSetNames = {
 // participant object for webinar attendees. If SELF were initialized first, locus.info
 // would not yet be populated and the attendee participant would be skipped.
 export const DATA_SET_INIT_PRIORITY: string[] = [DataSetNames.MAIN, DataSetNames.SELF];
+
+// Data sets for which we normally receive events over LLM connection
+export const LLM_DATASET_NAMES = [
+  DataSetNames.MAIN,
+  DataSetNames.ATD_ACTIVE,
+  DataSetNames.ATD_UNMUTED,
+];

--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -4,10 +4,16 @@ import LoggerProxy from '../common/logs/logger-proxy';
 import Metrics from '../metrics';
 import BEHAVIORAL_METRICS from '../metrics/constants';
 import {Enum, HTTP_VERBS} from '../constants';
-import {DataSetNames, DATA_SET_INIT_PRIORITY, EMPTY_HASH} from './constants';
+import {DataSetNames, DATA_SET_INIT_PRIORITY, EMPTY_HASH, LLM_DATASET_NAMES} from './constants';
 import {ObjectType, HtMeta, HashTreeObject} from './types';
 import {LocusDTO, LocusErrorCodes} from '../locus-info/types';
-import {deleteNestedObjectsWithHtMeta, isMetadata, sortByInitPriority} from './utils';
+import {deleteNestedObjectsWithHtMeta, isMetadata, sleep, sortByInitPriority} from './utils';
+
+export enum SyncAllBackoffType {
+  NONE = 'none',
+  ONLY_LLM = 'onlyLLM',
+  ALL = 'all',
+}
 
 export interface DataSet {
   url: string;
@@ -122,7 +128,10 @@ class HashTreeParser {
   state: 'active' | 'stopped';
   private syncQueue: Array<{dataSetName: string; reason: string; isInitialization?: boolean}> = [];
   private isSyncInProgress = false;
-  private isSyncAllInProgress = false;
+  // tracks whether syncAllDatasets is currently in its backoff delay phase and with what scope
+  private syncAllBackoffType: SyncAllBackoffType = SyncAllBackoffType.NONE;
+  // datasets that received messages during the syncAllDatasets backoff sleep and should be skipped
+  private dataSetsSyncedDuringBackoff: Set<string> = new Set();
   private syncQueueProcessingPromise: Promise<void> = Promise.resolve();
 
   /**
@@ -1342,8 +1351,14 @@ class HashTreeParser {
         // parseMessage() -> cancelPendingSyncsForDataSets() doesn't log a
         // misleading "aborting sync" message for this already-completed sync
         dataSet.syncAbortController = undefined;
+
         // the format of sync response is the same as messages, so we can reuse the same handler
-        this.handleMessage(syncResponse, 'via sync API');
+        this.handleMessage(
+          syncResponse,
+          `via sync API (${
+            isInitialization ? 'init' : `${Object.keys(leavesData).length} mismatched leaves`
+          })`
+        );
       }
     } catch (error) {
       if (!this.handleSyncErrors(error)) {
@@ -1375,6 +1390,13 @@ class HashTreeParser {
           previousLength - this.syncQueue.length
         } entries from sync queue for data sets: ${dataSetNames.join(', ')}`
       );
+    }
+
+    // if we're in the syncAllDatasets backoff sleep, remember these datasets so we skip them after the sleep
+    if (this.syncAllBackoffType !== SyncAllBackoffType.NONE) {
+      for (const name of dataSetNames) {
+        this.dataSetsSyncedDuringBackoff.add(name);
+      }
     }
 
     for (const name of dataSetNames) {
@@ -1453,37 +1475,102 @@ class HashTreeParser {
 
   /**
    * Syncs all data sets that have hash trees, one by one in sequence, using the priority order
-   * provided by sortByInitPriority(). Does nothing if the parser is stopped or if a syncAllDatasets
-   * call is already in progress.
+   * provided by sortByInitPriority().
    *
+   * If a call is already waiting in the backoff delay phase, a new call with a broader scope
+   * (onlyLLM=false) will upgrade the pending scope, and the dataset list will be computed after
+   * the backoff using the upgraded scope. After the backoff, the sync queue handles deduplication
+   * so no guard is needed.
+   *
+   * @param {Object} [options={}] - Options for syncing
+   * @param {boolean} [options.onlyLLM=false] - Whether to sync only LLM based data sets
    * @returns {Promise<void>}
    */
-  public async syncAllDatasets(): Promise<void> {
+  public async syncAllDatasets(options: {onlyLLM?: boolean} = {}): Promise<void> {
+    const {onlyLLM = false} = options;
     if (this.state === 'stopped') return;
-    if (this.isSyncAllInProgress) return;
 
-    this.isSyncAllInProgress = true;
-    try {
-      const dataSetsWithHashTrees = Object.values(this.dataSets)
-        .filter((dataSet) => dataSet?.hashTree)
-        .map((dataSet) => ({name: dataSet.name}));
-
-      const sorted = sortByInitPriority(dataSetsWithHashTrees, DATA_SET_INIT_PRIORITY);
-
-      LoggerProxy.logger.info(
-        `HashTreeParser#syncAllDatasets --> ${this.debugId} syncing datasets: ${sorted
-          .map((ds) => ds.name)
-          .join(', ')}`
-      );
-
-      for (const ds of sorted) {
-        this.enqueueSyncForDataset(ds.name, 'syncAllDatasets');
+    // if we're already in the backoff delay phase, try to upgrade the scope instead of starting a new one
+    if (this.syncAllBackoffType !== SyncAllBackoffType.NONE) {
+      if (!onlyLLM && this.syncAllBackoffType === SyncAllBackoffType.ONLY_LLM) {
+        this.syncAllBackoffType = SyncAllBackoffType.ALL;
+        LoggerProxy.logger.info(
+          `HashTreeParser#syncAllDatasets --> ${this.debugId} upgraded pending syncAll from onlyLLM to all datasets`
+        );
       }
 
-      await this.syncQueueProcessingPromise;
-    } finally {
-      this.isSyncAllInProgress = false;
+      return;
     }
+
+    const dataSetsToSync = this.getSortedDataSetsWithHashTrees(onlyLLM);
+
+    if (dataSetsToSync.length === 0) return;
+
+    this.syncAllBackoffType = onlyLLM ? SyncAllBackoffType.ONLY_LLM : SyncAllBackoffType.ALL;
+
+    const delay = this.getWeightedBackoffTime(dataSetsToSync[0].backoff);
+
+    LoggerProxy.logger.info(
+      `HashTreeParser#syncAllDatasets --> ${this.debugId} starting backoff delay of ${delay}ms (onlyLLM=${onlyLLM})`
+    );
+
+    // delay the start of the syncs - this is a Locus requirement to avoid thundering herd issues
+    await sleep(delay);
+
+    // read the (possibly upgraded) scope and clear the backoff flag
+    const effectiveBackoffType = this.syncAllBackoffType;
+    const skippedDataSets = this.dataSetsSyncedDuringBackoff;
+
+    this.syncAllBackoffType = SyncAllBackoffType.NONE;
+    this.dataSetsSyncedDuringBackoff = new Set();
+
+    if ((this.state as string) === 'stopped') return;
+
+    // re-evaluate the dataset list after the sleep, since the scope may have been upgraded
+    // and exclude datasets that received messages during the backoff sleep
+    const effectiveDataSetsToSync = this.getSortedDataSetsWithHashTrees(
+      effectiveBackoffType === SyncAllBackoffType.ONLY_LLM
+    ).filter((ds) => !skippedDataSets.has(ds.name));
+
+    if (skippedDataSets.size > 0) {
+      LoggerProxy.logger.info(
+        `HashTreeParser#syncAllDatasets --> ${
+          this.debugId
+        } skipping datasets that received messages during backoff: ${[...skippedDataSets].join(
+          ', '
+        )}`
+      );
+    }
+
+    LoggerProxy.logger.info(
+      `HashTreeParser#syncAllDatasets --> ${this.debugId} syncing ${
+        effectiveBackoffType === SyncAllBackoffType.ONLY_LLM ? 'only LLM' : 'all'
+      } datasets: ${effectiveDataSetsToSync.map((ds) => ds.name).join(', ')}`
+    );
+
+    for (const ds of effectiveDataSetsToSync) {
+      this.enqueueSyncForDataset(ds.name, 'syncAllDatasets');
+    }
+
+    await this.syncQueueProcessingPromise;
+  }
+
+  /**
+   * Returns the list of data sets that have hash trees, sorted by the priority order provided by sortByInitPriority().
+   *
+   * @param {boolean} onlyLLM - Whether to include only LLM based data sets
+   * @returns {Array<{name: string, backoff: {maxMs: number, exponent: number}}>} The sorted list of data sets with their backoff configurations
+   */
+  private getSortedDataSetsWithHashTrees(onlyLLM: boolean) {
+    let dataSets = Object.values(this.dataSets)
+      .filter((dataSet) => dataSet?.hashTree)
+      .map((dataSet) => ({name: dataSet.name, backoff: dataSet.backoff}));
+
+    if (onlyLLM) {
+      dataSets = dataSets.filter((ds) => LLM_DATASET_NAMES.includes(ds.name));
+    }
+
+    return sortByInitPriority(dataSets, DATA_SET_INIT_PRIORITY);
   }
 
   /**
@@ -1623,6 +1710,8 @@ class HashTreeParser {
     );
     this.stopAllTimers();
     this.syncQueue = [];
+    this.syncAllBackoffType = SyncAllBackoffType.NONE;
+    this.dataSetsSyncedDuringBackoff = new Set();
     Object.values(this.dataSets).forEach((dataSet) => {
       dataSet.syncAbortController?.abort();
       dataSet.syncAbortController = undefined;

--- a/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/hashTreeParser.ts
@@ -1392,13 +1392,32 @@ class HashTreeParser {
       );
     }
 
-    // if we're in the syncAllDatasets backoff sleep, remember these datasets so we skip them after the sleep
+    this.markDataSetsForSyncAllBackoffSkip(dataSetNames);
+    this.abortInFlightSyncs(dataSetNames);
+  }
+
+  /**
+   * If a syncAllDatasets backoff sleep is in progress, marks the given data sets to be skipped
+   * after the sleep completes.
+   *
+   * @param {string[]} dataSetNames - The names of the data sets to mark
+   * @returns {void}
+   */
+  private markDataSetsForSyncAllBackoffSkip(dataSetNames: string[]): void {
     if (this.syncAllBackoffType !== SyncAllBackoffType.NONE) {
       for (const name of dataSetNames) {
         this.dataSetsSyncedDuringBackoff.add(name);
       }
     }
+  }
 
+  /**
+   * Aborts any in-flight sync HTTP requests for the specified data sets.
+   *
+   * @param {string[]} dataSetNames - The names of the data sets whose syncs should be aborted
+   * @returns {void}
+   */
+  private abortInFlightSyncs(dataSetNames: string[]): void {
     for (const name of dataSetNames) {
       if (this.dataSets[name]?.syncAbortController) {
         LoggerProxy.logger.info(
@@ -1474,6 +1493,38 @@ class HashTreeParser {
   }
 
   /**
+   * sets the backoff type for syncAllDatasets calls, which determines the scope of datasets that will be synced after the backoff delay.
+   *
+   * @param {boolean} onlyLLM - Whether the backoff is for a syncAllDatasets call that is syncing only LLM datasets
+   * @returns {void}
+   */
+  private setSyncAllBackoffType(onlyLLM: boolean): void {
+    this.syncAllBackoffType = onlyLLM ? SyncAllBackoffType.ONLY_LLM : SyncAllBackoffType.ALL;
+  }
+
+  /**
+   * Checks if a syncAll backoff is already in progress. If so, upgrades the scope from
+   * onlyLLM to all datasets when the new call has a broader scope.
+   *
+   * @param {boolean} onlyLLM - Whether the current call is for LLM datasets only
+   * @returns {boolean} true if a backoff is already pending (caller should return early)
+   */
+  private tryUpgradePendingBackoff(onlyLLM: boolean): boolean {
+    if (this.syncAllBackoffType !== SyncAllBackoffType.NONE) {
+      if (!onlyLLM && this.syncAllBackoffType === SyncAllBackoffType.ONLY_LLM) {
+        this.setSyncAllBackoffType(false);
+        LoggerProxy.logger.info(
+          `HashTreeParser#syncAllDatasets --> ${this.debugId} upgraded pending syncAll from onlyLLM to all datasets`
+        );
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
    * Syncs all data sets that have hash trees, one by one in sequence, using the priority order
    * provided by sortByInitPriority().
    *
@@ -1491,14 +1542,7 @@ class HashTreeParser {
     if (this.state === 'stopped') return;
 
     // if we're already in the backoff delay phase, try to upgrade the scope instead of starting a new one
-    if (this.syncAllBackoffType !== SyncAllBackoffType.NONE) {
-      if (!onlyLLM && this.syncAllBackoffType === SyncAllBackoffType.ONLY_LLM) {
-        this.syncAllBackoffType = SyncAllBackoffType.ALL;
-        LoggerProxy.logger.info(
-          `HashTreeParser#syncAllDatasets --> ${this.debugId} upgraded pending syncAll from onlyLLM to all datasets`
-        );
-      }
-
+    if (this.tryUpgradePendingBackoff(onlyLLM)) {
       return;
     }
 
@@ -1506,7 +1550,7 @@ class HashTreeParser {
 
     if (dataSetsToSync.length === 0) return;
 
-    this.syncAllBackoffType = onlyLLM ? SyncAllBackoffType.ONLY_LLM : SyncAllBackoffType.ALL;
+    this.setSyncAllBackoffType(onlyLLM);
 
     const delay = this.getWeightedBackoffTime(dataSetsToSync[0].backoff);
 

--- a/packages/@webex/plugin-meetings/src/hashTree/utils.ts
+++ b/packages/@webex/plugin-meetings/src/hashTree/utils.ts
@@ -77,3 +77,22 @@ export function sortByInitPriority<T extends {name: string}>(items: T[], priorit
 
   return [...prioritized, ...rest];
 }
+
+/**
+ * Sleeps for the specified amount of milliseconds
+ *
+ * @param {number} ms amount of milliseconds to sleep
+ * @returns {Promise<void>} A promise that resolves after the specified delay
+ */
+export function sleep(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    // start a timer that will resolve the promise after the specified delay
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}

--- a/packages/@webex/plugin-meetings/src/locus-info/index.ts
+++ b/packages/@webex/plugin-meetings/src/locus-info/index.ts
@@ -1203,13 +1203,15 @@ export default class LocusInfo extends EventsScope {
    * Triggers a sync of all hash tree datasets for all hash tree parsers associated with this meeting.
    * The syncs are executed sequentially within each parser.
    *
+   * @param {Object} [options={}] - Options for syncing
+   * @param {boolean} [options.onlyLLM=false] - Whether to sync only LLM based data sets
    * @returns {Promise<void>}
    */
-  async syncAllHashTreeDatasets(): Promise<void> {
+  async syncAllHashTreeDatasets(options: {onlyLLM?: boolean} = {}): Promise<void> {
     for (const [, entry] of this.hashTreeParsers) {
       if (entry.parser) {
         // eslint-disable-next-line no-await-in-loop
-        await entry.parser.syncAllDatasets();
+        await entry.parser.syncAllDatasets(options);
       }
     }
   }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6097,6 +6097,7 @@ export default class Meeting extends StatelessWebexPlugin {
    */
   private handleLLMOnline = (): void => {
     this.restoreLLMSubscriptionsIfNeeded();
+    this.locusInfo.syncAllHashTreeDatasets({onlyLLM: true});
 
     Trigger.trigger(
       this,
@@ -6649,6 +6650,7 @@ export default class Meeting extends StatelessWebexPlugin {
     return this.webex.internal.llm
       .registerAndConnect(url, dataChannelUrl, datachannelToken)
       .then((registerAndConnectResult) => {
+        this.locusInfo.syncAllHashTreeDatasets({onlyLLM: true});
         // Record ownership of the default LLM session for this meeting so
         // subsequent cross-meeting `updateLLMConnection` / `cleanupLLMConneciton`
         // calls can detect and skip work that doesn't belong to them.

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/hashTreeParser.ts
@@ -2,6 +2,7 @@ import HashTreeParser, {
   LocusInfoUpdateType,
   MeetingEndedError,
   LocusNotFoundError,
+  SyncAllBackoffType,
 } from '@webex/plugin-meetings/src/hashTree/hashTreeParser';
 import HashTree from '@webex/plugin-meetings/src/hashTree/hashTree';
 import {expect} from '@webex/test-helper-chai';
@@ -4494,8 +4495,8 @@ describe('HashTreeParser', () => {
       );
       expect(mainSyncCallIndex).to.be.lessThan(selfSyncCallIndex);
 
-      // Verify isSyncAllInProgress is reset
-      expect(parser.isSyncAllInProgress).to.be.false;
+      // Verify syncAllBackoffType is reset
+      expect(parser.syncAllBackoffType).to.equal(SyncAllBackoffType.NONE);
     });
 
     it('should return immediately when state is stopped', async () => {
@@ -4558,6 +4559,200 @@ describe('HashTreeParser', () => {
         (args) => args[0]?.method === 'GET' && args[0]?.uri === `${mainUrl}/hashtree`
       );
       expect(getHashtreeCalls).to.have.lengthOf(1);
+    });
+
+    it('should sync only LLM datasets when onlyLLM=true', async () => {
+      const parser = createHashTreeParser();
+
+      const mainUrl = parser.dataSets.main.url;
+      const selfUrl = parser.dataSets.self.url;
+
+      mockGetHashesFromLocusResponse(
+        mainUrl,
+        new Array(16).fill(EMPTY_HASH),
+        createDataSet('main', 16, 1100)
+      );
+
+      const mainSyncDs = createDataSet('main', 16, 1100);
+      mainSyncDs.root = parser.dataSets.main.hashTree.getRootHash();
+      mockSendSyncRequestResponse(mainUrl, {
+        dataSets: [mainSyncDs],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [],
+      });
+
+      await parser.syncAllDatasets({onlyLLM: true});
+
+      // main is an LLM dataset, so it should have been synced
+      assert.calledWith(webexRequest, sinon.match({method: 'GET', uri: `${mainUrl}/hashtree`}));
+
+      // self is NOT an LLM dataset, so it should NOT have been synced
+      assert.neverCalledWith(webexRequest, sinon.match({method: 'POST', uri: `${selfUrl}/sync`}));
+      assert.neverCalledWith(webexRequest, sinon.match({method: 'GET', uri: `${selfUrl}/hashtree`}));
+    });
+
+    it('should upgrade scope from onlyLLM=true to all datasets when onlyLLM=false call arrives during backoff', async () => {
+      // Make Math.random return 1 so backoff = 1^2 * 1000 = 1000ms (non-zero delay for interleaving)
+      mathRandomStub.returns(1);
+
+      const parser = createHashTreeParser();
+
+      const mainUrl = parser.dataSets.main.url;
+      const selfUrl = parser.dataSets.self.url;
+
+      mockGetHashesFromLocusResponse(
+        mainUrl,
+        new Array(16).fill(EMPTY_HASH),
+        createDataSet('main', 16, 1100)
+      );
+
+      const mainSyncDs = createDataSet('main', 16, 1100);
+      mainSyncDs.root = parser.dataSets.main.hashTree.getRootHash();
+      mockSendSyncRequestResponse(mainUrl, {
+        dataSets: [mainSyncDs],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [],
+      });
+
+      const selfSyncDs = createDataSet('self', 1, 2100);
+      selfSyncDs.root = parser.dataSets.self.hashTree.getRootHash();
+      mockSendSyncRequestResponse(selfUrl, {
+        dataSets: [selfSyncDs],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [],
+      });
+
+      // First call with onlyLLM=true starts backoff
+      const promise1 = parser.syncAllDatasets({onlyLLM: true});
+      expect(parser.syncAllBackoffType).to.equal(SyncAllBackoffType.ONLY_LLM);
+
+      // Second call with onlyLLM=false upgrades the scope during backoff
+      const promise2 = parser.syncAllDatasets({onlyLLM: false});
+      expect(parser.syncAllBackoffType).to.equal(SyncAllBackoffType.ALL);
+
+      // Advance clock past the backoff delay (1000ms)
+      await clock.tickAsync(1000);
+
+      await promise1;
+      await promise2;
+
+      // Both main (LLM) and self (non-LLM) should have been synced
+      assert.calledWith(webexRequest, sinon.match({method: 'GET', uri: `${mainUrl}/hashtree`}));
+      assert.calledWith(webexRequest, sinon.match({method: 'POST', uri: `${selfUrl}/sync`}));
+    });
+
+    it('should not downgrade scope from onlyLLM=false when onlyLLM=true call arrives during backoff', async () => {
+      // Make Math.random return 1 so backoff = 1^2 * 1000 = 1000ms (non-zero delay for interleaving)
+      mathRandomStub.returns(1);
+
+      const parser = createHashTreeParser();
+
+      const mainUrl = parser.dataSets.main.url;
+      const selfUrl = parser.dataSets.self.url;
+
+      mockGetHashesFromLocusResponse(
+        mainUrl,
+        new Array(16).fill(EMPTY_HASH),
+        createDataSet('main', 16, 1100)
+      );
+
+      const mainSyncDs = createDataSet('main', 16, 1100);
+      mainSyncDs.root = parser.dataSets.main.hashTree.getRootHash();
+      mockSendSyncRequestResponse(mainUrl, {
+        dataSets: [mainSyncDs],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [],
+      });
+
+      const selfSyncDs = createDataSet('self', 1, 2100);
+      selfSyncDs.root = parser.dataSets.self.hashTree.getRootHash();
+      mockSendSyncRequestResponse(selfUrl, {
+        dataSets: [selfSyncDs],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [],
+      });
+
+      // First call with onlyLLM=false starts backoff with all-datasets scope
+      const promise1 = parser.syncAllDatasets({onlyLLM: false});
+      expect(parser.syncAllBackoffType).to.equal(SyncAllBackoffType.ALL);
+
+      // Second call with onlyLLM=true should NOT downgrade the scope
+      const promise2 = parser.syncAllDatasets({onlyLLM: true});
+      expect(parser.syncAllBackoffType).to.equal(SyncAllBackoffType.ALL);
+
+      // Advance clock past the backoff delay (1000ms)
+      await clock.tickAsync(1000);
+
+      await promise1;
+      await promise2;
+
+      // Both main (LLM) and self (non-LLM) should have been synced (scope was not downgraded)
+      assert.calledWith(webexRequest, sinon.match({method: 'GET', uri: `${mainUrl}/hashtree`}));
+      assert.calledWith(webexRequest, sinon.match({method: 'POST', uri: `${selfUrl}/sync`}));
+    });
+
+    it('should skip datasets that received messages during the backoff sleep', async () => {
+      // Make Math.random return 1 so backoff = 1^2 * 1000 = 1000ms
+      mathRandomStub.returns(1);
+
+      const parser = createHashTreeParser();
+
+      const mainUrl = parser.dataSets.main.url;
+      const selfUrl = parser.dataSets.self.url;
+      const atdUnmutedUrl = parser.dataSets['atd-unmuted'].url;
+
+      // Setup mocks only for self (main and atd-unmuted should be skipped)
+      mockSendSyncRequestResponse(selfUrl, {
+        dataSets: [createDataSet('self', 1, 2100)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [],
+      });
+
+      // Start syncAllDatasets - begins backoff sleep
+      const promise = parser.syncAllDatasets();
+      expect(parser.syncAllBackoffType).to.equal(SyncAllBackoffType.ALL);
+
+      // Simulate a normal message arriving for "main" during the backoff sleep
+      parser.handleMessage({
+        dataSets: [createDataSet('main', 16, 1100)],
+        visibleDataSetsUrl,
+        locusUrl,
+        locusStateElements: [
+          {
+            htMeta: {
+              elementId: {type: 'locus' as const, id: 0, version: 201},
+              dataSetNames: ['main'],
+            },
+            data: {someData: 'value'},
+          },
+        ],
+      });
+
+      // Simulate a heartbeat message arriving for "atd-unmuted" during the backoff sleep
+      parser.handleMessage(
+        createHeartbeatMessage('atd-unmuted', 1, 1100, parser.dataSets['atd-unmuted'].root)
+      );
+
+      // Advance clock past the backoff delay
+      await clock.tickAsync(1000);
+      await promise;
+
+      // main should NOT have been synced (it received a normal message during backoff)
+      assert.neverCalledWith(webexRequest, sinon.match({method: 'GET', uri: `${mainUrl}/hashtree`}));
+      assert.neverCalledWith(webexRequest, sinon.match({method: 'POST', uri: `${mainUrl}/sync`}));
+
+      // atd-unmuted should NOT have been synced (it received a heartbeat during backoff)
+      assert.neverCalledWith(webexRequest, sinon.match({method: 'GET', uri: `${atdUnmutedUrl}/hashtree`}));
+      assert.neverCalledWith(webexRequest, sinon.match({method: 'POST', uri: `${atdUnmutedUrl}/sync`}));
+
+      // self SHOULD have been synced (no messages received for it during backoff)
+      assert.calledWith(webexRequest, sinon.match({method: 'POST', uri: `${selfUrl}/sync`}));
     });
 
     it('should skip datasets that do not have a hash tree', async () => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/hashTree/utils.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/hashTree/utils.ts
@@ -2,9 +2,11 @@ import {HashTreeObject, ObjectType} from '../../../../src/hashTree/types';
 import {
   deleteNestedObjectsWithHtMeta,
   isSelf,
+  sleep,
   sortByInitPriority,
 } from '../../../../src/hashTree/utils';
 import {DataSetNames, DATA_SET_INIT_PRIORITY} from '../../../../src/hashTree/constants';
+import sinon from 'sinon';
 
 import {assert} from '@webex/test-helper-chai';
 
@@ -222,6 +224,41 @@ describe('Hash Tree Utils', () => {
         {name: DataSetNames.SELF, url: 'url2'},
         {name: DataSetNames.ATD_ACTIVE, url: 'url1'},
       ]);
+    });
+  });
+
+  describe('#sleep', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    [0, -1, -100].forEach((ms) => {
+      it(`resolves immediately when ms is ${ms}`, async () => {
+        const result = sleep(ms);
+
+        assert.instanceOf(result, Promise);
+        await result;
+      });
+    });
+
+    it('resolves after the specified delay', async () => {
+      let resolved = false;
+
+      sleep(500).then(() => { resolved = true; });
+
+      assert.isFalse(resolved);
+
+      await clock.tickAsync(499);
+      assert.isFalse(resolved);
+
+      await clock.tickAsync(1);
+      assert.isTrue(resolved);
     });
   });
 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/locus-info/index.js
@@ -3744,6 +3744,18 @@ describe('plugin-meetings', () => {
         assert.calledOnce(parser1.syncAllDatasets);
       });
 
+      it('should forward options to each parser syncAllDatasets', async () => {
+        const parser1 = {syncAllDatasets: sinon.stub().resolves()};
+        const parser2 = {syncAllDatasets: sinon.stub().resolves()};
+        locusInfo.hashTreeParsers.set('url1', {parser: parser1});
+        locusInfo.hashTreeParsers.set('url2', {parser: parser2});
+
+        await locusInfo.syncAllHashTreeDatasets({onlyLLM: true});
+
+        assert.calledOnceWithExactly(parser1.syncAllDatasets, {onlyLLM: true});
+        assert.calledOnceWithExactly(parser2.syncAllDatasets, {onlyLLM: true});
+      });
+
       it('should await each parsers syncAllDatasets sequentially', async () => {
         const callOrder = [];
         const parser1 = {syncAllDatasets: sinon.stub().callsFake(() => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2126,6 +2126,14 @@ describe('plugin-meetings', () => {
 
           assert.notCalled(webex.internal.voicea.updateSubchannelSubscriptions);
         });
+
+        it('calls syncAllHashTreeDatasets on locusInfo', () => {
+          sinon.stub(meeting.locusInfo, 'syncAllHashTreeDatasets').resolves();
+
+          meeting.handleLLMOnline();
+
+          assert.calledOnce(meeting.locusInfo.syncAllHashTreeDatasets);
+        });
       });
 
       describe('#join', () => {
@@ -13599,7 +13607,7 @@ describe('plugin-meetings', () => {
           meeting.joinedWith = {state: 'any other state'};
           webex.internal.llm.getLocusUrl.returns('a url');
 
-          meeting.locusInfo = {url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
+          meeting.locusInfo = {syncAllHashTreeDatasets: sinon.stub().resolves(), url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
 
           const result = await meeting.updateLLMConnection();
 
@@ -13611,6 +13619,7 @@ describe('plugin-meetings', () => {
         it('returns undefined if llm is already connected and the locus url is unchanged', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
             info: {datachannelUrl: 'a datachannel url'},
           };
@@ -13647,7 +13656,7 @@ describe('plugin-meetings', () => {
         });
         it('connects if not already connected', async () => {
           meeting.joinedWith = {state: 'JOINED'};
-          meeting.locusInfo = {url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
+          meeting.locusInfo = {syncAllHashTreeDatasets: sinon.stub().resolves(), url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
 
           const result = await meeting.updateLLMConnection();
 
@@ -13667,6 +13676,7 @@ describe('plugin-meetings', () => {
           webex.internal.llm.getLocusUrl.returns('a url');
 
           meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a different url',
             info: {datachannelUrl: 'a datachannel url'},
             self: {},
@@ -13720,6 +13730,7 @@ describe('plugin-meetings', () => {
           webex.internal.llm.getLocusUrl.returns('a url');
 
           meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
             info: {datachannelUrl: 'a different datachannel url'},
             self: {},
@@ -13771,7 +13782,7 @@ describe('plugin-meetings', () => {
           webex.internal.llm.isConnected.returns(true);
           webex.internal.llm.getLocusUrl.returns('a url');
 
-          meeting.locusInfo = {url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
+          meeting.locusInfo = {syncAllHashTreeDatasets: sinon.stub().resolves(), url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
 
           const result = await meeting.updateLLMConnection();
 
@@ -13794,6 +13805,7 @@ describe('plugin-meetings', () => {
           webex.internal.llm.disconnectLLM.rejects(disconnectError);
 
           meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a different url',
             info: {datachannelUrl: 'a datachannel url'},
             self: {},
@@ -13825,6 +13837,7 @@ describe('plugin-meetings', () => {
         it('still need connect main session data channel when PS started', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
             info: {
               datachannelUrl: 'a datachannel url',
@@ -13845,6 +13858,7 @@ describe('plugin-meetings', () => {
         it('passes dataChannelToken from LLM to registerAndConnect', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
             info: {datachannelUrl: 'a datachannel url'},
           };
@@ -13866,6 +13880,7 @@ describe('plugin-meetings', () => {
         it('passes undefined token when LLM has no token stored', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
             info: {datachannelUrl: 'a datachannel url'},
           };
@@ -13887,6 +13902,7 @@ describe('plugin-meetings', () => {
         it('does not pass token when data channel with jwt token is disabled', async () => {
           meeting.joinedWith = {state: 'JOINED'};
           meeting.locusInfo = {
+            syncAllHashTreeDatasets: sinon.stub().resolves(),
             url: 'a url',
             info: {datachannelUrl: 'a datachannel url'},
           };
@@ -13929,6 +13945,7 @@ describe('plugin-meetings', () => {
             webex.internal.llm.getLocusUrl.returns('owner-locus-url');
             webex.internal.llm.getDatachannelUrl.returns('owner-dc-url');
             meeting.locusInfo = {
+              syncAllHashTreeDatasets: sinon.stub().resolves(),
               url: 'a different url',
               info: {datachannelUrl: 'a different datachannel url'},
               self: {},
@@ -13952,6 +13969,7 @@ describe('plugin-meetings', () => {
             webex.internal.llm.getDatachannelUrl.returns('a datachannel url');
             webex.internal.llm.disconnectLLM.rejects(new Error('disconnect failed'));
             meeting.locusInfo = {
+              syncAllHashTreeDatasets: sinon.stub().resolves(),
               url: 'a different url',
               info: {datachannelUrl: 'a datachannel url'},
               self: {},
@@ -13975,6 +13993,7 @@ describe('plugin-meetings', () => {
             webex.internal.llm.getLocusUrl.returns('a url');
             webex.internal.llm.getDatachannelUrl.returns('a datachannel url');
             meeting.locusInfo = {
+              syncAllHashTreeDatasets: sinon.stub().resolves(),
               url: 'a different url',
               info: {datachannelUrl: 'a datachannel url'},
               self: {},
@@ -14005,7 +14024,7 @@ describe('plugin-meetings', () => {
             meeting.joinedWith = {state: 'JOINED'};
             webex.internal.llm.isConnected.returns(false);
             webex.internal.llm.getOwnerMeetingId.returns(undefined);
-            meeting.locusInfo = {url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
+            meeting.locusInfo = {syncAllHashTreeDatasets: sinon.stub().resolves(), url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
 
             await meeting.updateLLMConnection();
 
@@ -14021,7 +14040,7 @@ describe('plugin-meetings', () => {
             meeting.joinedWith = {state: 'JOINED'};
             webex.internal.llm.isConnected.returns(false);
             webex.internal.llm.getOwnerMeetingId.returns('stale-owner-id');
-            meeting.locusInfo = {url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
+            meeting.locusInfo = {syncAllHashTreeDatasets: sinon.stub().resolves(), url: 'a url', info: {datachannelUrl: 'a datachannel url'}};
 
             await meeting.updateLLMConnection();
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2132,7 +2132,7 @@ describe('plugin-meetings', () => {
 
           meeting.handleLLMOnline();
 
-          assert.calledOnce(meeting.locusInfo.syncAllHashTreeDatasets);
+          assert.calledOnceWithExactly(meeting.locusInfo.syncAllHashTreeDatasets, {onlyLLM: true});
         });
       });
 
@@ -13668,6 +13668,7 @@ describe('plugin-meetings', () => {
             undefined
           );
           assert.equal(result, 'something');
+          assert.calledOnceWithExactly(meeting.locusInfo.syncAllHashTreeDatasets, {onlyLLM: true});
         });
         it('disconnects if the locus url has changed', async () => {
           meeting.joinedWith = {state: 'JOINED'};


### PR DESCRIPTION
# COMPLETES #[SPARK-804241](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-804241)

## This pull request addresses
New requirement from Locus team:
- when we connect a new LLM or after we reconnect LLM/Mercury, we need to do a sync, but we should not do it immediately, we should first wait the back-off period (without idleMs, just the back-off) and then do the sync (so /hashtree and /sync API calls)

## by making the following changes
We already do syncs after Mercury reconnections, but we don't trigger them currently after new LLM connection, so now doing this:
1. calling syncAllDatasets() after new LLM connection is connected or LLM goes online
2. doing a back-off wait before actually starting doing the syncs in HashTreeParser.syncAllDatasets()

We also need to take into account that messages might come in while we're doing the back-off and in that case we need to cancel the sync for those datasets - introduced `dataSetsSyncedDuringBackoff` prop for that.
We also need to distinguish between doing syncAllDatasets() for all datasets or just the ones that are updated over LLM. So far I've been trying to avoid having any knowledge in SDK about which data sets come over LLM vs Mercury, but now there is no way around it, SDK needs to know to only sync LLM based datasets when LLM is connected,



### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests, manual testing with web app and Locus on convergedats

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
