### PR TITLE
fix(task-refactor): outdail issue fix

### DIFF
--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -291,7 +291,7 @@ export default class TaskManager extends EventEmitter {
         return {type: TaskEvent.RONA, taskData: payload, reason: payload.reason};
 
       case CC_EVENTS.AGENT_OUTBOUND_FAILED:
-        return {type: TaskEvent.OUTBOUND_FAILED, reason: payload.reason};
+        return {type: TaskEvent.OUTBOUND_FAILED, taskData: payload, reason: payload.reason};
 
       case CC_EVENTS.CONTACT_RECORDING_STARTED:
         return {type: TaskEvent.RECORDING_STARTED, taskData: payload};

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -126,7 +126,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // AgentOutboundFailed can arrive before TASK_INCOMING due to race conditions
           [TaskEvent.OUTBOUND_FAILED]: {
             target: TaskState.TERMINATED,
-            actions: ['updateTaskData', 'markEnded', 'emitTaskOutdialFailed', 'emitTaskReject'],
+            actions: ['updateTaskData', 'markEnded', 'emitTaskOutdialFailed', 'emitTaskEnd'],
           },
 
           // EP-DN split-leg ordering can deliver AgentConsulting before HYDRATE/TASK_INCOMING.
@@ -196,7 +196,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             },
             {
               target: TaskState.TERMINATED,
-              actions: ['updateTaskData', 'markEnded', 'emitTaskOutdialFailed', 'emitTaskReject'],
+              actions: ['updateTaskData', 'markEnded', 'emitTaskOutdialFailed', 'emitTaskEnd'],
             },
           ],
           // AgentConsulting comes for received after the initial consult is accepted

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -123,6 +123,12 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             actions: ['initializeTask', 'emitTaskIncoming'],
           },
 
+          // AgentOutboundFailed can arrive before TASK_INCOMING due to race conditions
+          [TaskEvent.OUTBOUND_FAILED]: {
+            target: TaskState.TERMINATED,
+            actions: ['updateTaskData', 'markEnded', 'emitTaskOutdialFailed', 'emitTaskReject'],
+          },
+
           // EP-DN split-leg ordering can deliver AgentConsulting before HYDRATE/TASK_INCOMING.
           // Do not drop it in IDLE; bootstrap to CONSULTING using event taskData.
           [TaskEvent.CONSULTING_ACTIVE]: {

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -182,16 +182,18 @@ function computeVoiceInteractionUIControls(
 
   return {
     // Accept/Decline: Voice tasks in offered state
-    // For outdial, accept is disabled (auto-answer handles it), decline remains enabled
-    // For Extension mode (non-WebRTC), accept shows as disabled "Ringing" button
+    // Desktop/WebRTC + inbound: accept enabled (agent manually accepts)
+    // Desktop/WebRTC + outdial: accept disabled (auto-answer handles it; Widgets show "Accept" disabled)
+    // Extension mode (non-WebRTC): accept disabled (Widgets show "Ringing...")
     accept:
       state === TaskState.OFFERED && !interaction?.isTerminated
         ? {isVisible: true, isEnabled: isWebrtc && !isOutdial}
         : DISABLED,
-    decline:
-      isWebrtc && state === TaskState.OFFERED && !interaction?.isTerminated
-        ? VISIBLE_ENABLED
-        : DISABLED,
+    decline: (() => {
+      if (!isWebrtc || state !== TaskState.OFFERED || interaction?.isTerminated) return DISABLED;
+
+      return isOutdial ? VISIBLE_DISABLED : VISIBLE_ENABLED;
+    })(),
 
     // Hold: visible in connected/held/conference, disabled in conference/consulting
     hold: (() => {

--- a/packages/@webex/contact-center/src/services/task/voice/Voice.ts
+++ b/packages/@webex/contact-center/src/services/task/voice/Voice.ts
@@ -25,7 +25,7 @@ import Task from '../Task';
 import LoggerProxy from '../../../logger-proxy';
 import MetricsManager from '../../../metrics/MetricsManager';
 import {METRIC_EVENT_NAMES} from '../../../metrics/constants';
-import {TaskState, TaskEvent} from '../state-machine';
+import {TaskState, TaskEvent, TaskActionArgs} from '../state-machine';
 import {WrapupData} from '../../config/types';
 import {getConsultMediaResourceId, getIsConferenceInProgress} from '../TaskUtils';
 
@@ -1247,9 +1247,13 @@ export default class Voice extends Task implements IVoice {
         TASK_EVENTS.TASK_CONFERENCE_TRANSFER_FAILED,
         {updateTaskData: true}
       ),
-      emitTaskOutdialFailed: this.createEmitSelfAction(TASK_EVENTS.TASK_OUTDIAL_FAILED, {
-        updateTaskData: true,
-      }),
+      emitTaskOutdialFailed: ({event}: TaskActionArgs) => {
+        if (event && 'taskData' in event && event.taskData) {
+          this.updateTaskData(event.taskData as TaskData);
+        }
+        const reason = (event as {reason?: string})?.reason || 'Outdial failed';
+        this.emit(TASK_EVENTS.TASK_OUTDIAL_FAILED, reason);
+      },
     };
   }
 }

--- a/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
@@ -1280,6 +1280,32 @@ describe('TaskManager', () => {
     sendStateMachineEventSpy.mockRestore();
   });
 
+  it('should pass taskData in OUTBOUND_FAILED event for shouldWrapUp guard evaluation', () => {
+    const task = taskManager.getTask(taskId);
+    const sendStateMachineEventSpy = jest.spyOn(task, 'sendStateMachineEvent');
+    const payload = {
+      data: {
+        type: CC_EVENTS.AGENT_OUTBOUND_FAILED,
+        interactionId: taskId,
+        reason: 'CUSTOMER_BUSY',
+        agentsPendingWrapUp: ['agent-123'],
+        interaction: {
+          outboundType: 'OUTDIAL',
+          isTerminated: true,
+        },
+      },
+    };
+    webSocketManagerMock.emit('message', JSON.stringify(payload));
+    const stateMachineEvent = expectLastStateMachineEvent(
+      sendStateMachineEventSpy,
+      TaskEvent.OUTBOUND_FAILED
+    );
+    expect(stateMachineEvent?.taskData).toBeDefined();
+    expect(stateMachineEvent?.taskData?.agentsPendingWrapUp).toEqual(['agent-123']);
+    expect(stateMachineEvent?.taskData?.interaction?.outboundType).toBe('OUTDIAL');
+    sendStateMachineEventSpy.mockRestore();
+  });
+
   it('should handle AGENT_OUTBOUND_FAILED gracefully when task is undefined', () => {
     const payload = {
       data: {

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/TaskStateMachine.ts
@@ -573,4 +573,65 @@ describe('Task state machine', () => {
       expect(service.getSnapshot().value).toBe(TaskState.TERMINATED);
     });
   });
+
+  describe('OUTBOUND_FAILED handling', () => {
+    it('transitions from IDLE to TERMINATED on OUTBOUND_FAILED (race condition)', () => {
+      const service = startMachine();
+      expect(service.getSnapshot().value).toBe(TaskState.IDLE);
+
+      const taskData = createTaskData({
+        interaction: {
+          outboundType: 'OUTDIAL',
+          isTerminated: true,
+        } as any,
+      });
+
+      service.send({type: TaskEvent.OUTBOUND_FAILED, taskData, reason: 'CUSTOMER_BUSY'});
+      expect(service.getSnapshot().value).toBe(TaskState.TERMINATED);
+    });
+
+    it('transitions from OFFERED to TERMINATED on OUTBOUND_FAILED without wrapup', () => {
+      const service = startMachine();
+      const offerTaskData = createTaskData({
+        interaction: {
+          outboundType: 'OUTDIAL',
+        } as any,
+      });
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData: offerTaskData});
+      expect(service.getSnapshot().value).toBe(TaskState.OFFERED);
+
+      const failedTaskData = createTaskData({
+        interaction: {
+          outboundType: 'OUTDIAL',
+          isTerminated: true,
+        } as any,
+      });
+      service.send({type: TaskEvent.OUTBOUND_FAILED, taskData: failedTaskData, reason: 'CUSTOMER_BUSY'});
+      expect(service.getSnapshot().value).toBe(TaskState.TERMINATED);
+    });
+
+    it('transitions from OFFERED to WRAPPING_UP on OUTBOUND_FAILED when wrapup is required', () => {
+      const service = startMachine();
+      const offerTaskData = createTaskData({
+        interaction: {
+          outboundType: 'OUTDIAL',
+        } as any,
+      });
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData: offerTaskData});
+      expect(service.getSnapshot().value).toBe(TaskState.OFFERED);
+
+      const failedTaskData = createTaskData({
+        agentId: 'agent-1',
+        agentsPendingWrapUp: ['agent-1'],
+        interaction: {
+          outboundType: 'OUTDIAL',
+          isTerminated: true,
+        } as any,
+      });
+      service.send({type: TaskEvent.OUTBOUND_FAILED, taskData: failedTaskData, reason: 'CUSTOMER_BUSY'});
+      expect(service.getSnapshot().value).toBe(TaskState.WRAPPING_UP);
+    });
+  });
 });

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
@@ -146,6 +146,54 @@ describe('uiControlsComputer consult initiator controls', () => {
   });
 });
 
+describe('uiControlsComputer outdial accept/decline controls', () => {
+  function createOutdialContext(voiceVariant: 'webrtc' | 'pstn' = 'webrtc'): TaskContext {
+    const taskData = createTaskData({
+      interaction: {
+        outboundType: 'OUTDIAL',
+        state: 'new',
+        isTerminated: false,
+      } as any,
+    });
+    return {
+      taskData,
+      consultInitiator: false,
+      exitingConference: false,
+      consultFromConference: false,
+      transferConferenceRequested: false,
+      consultDestinationType: null,
+      consultDestinationAgentId: null,
+      consultDestinationAgentJoined: false,
+      consultCallHeld: false,
+      recordingControlsAvailable: false,
+      recordingInProgress: false,
+      uiControlConfig: {
+        isEndTaskEnabled: true,
+        isEndConsultEnabled: true,
+        channelType: TASK_CHANNEL_TYPE.VOICE,
+        isRecordingEnabled: false,
+        agentId: 'agent-1',
+        voiceVariant,
+      },
+      uiControls: getDefaultUIControls(),
+    };
+  }
+
+  it('accept is visible but disabled for WebRTC outdial in OFFERED state', () => {
+    const context = createOutdialContext('webrtc');
+    const uiControls = computeUIControls(TaskState.OFFERED, context, context.taskData);
+
+    expect(uiControls.main.accept).toEqual({isVisible: true, isEnabled: false});
+  });
+
+  it('decline is visible but disabled for WebRTC outdial in OFFERED state', () => {
+    const context = createOutdialContext('webrtc');
+    const uiControls = computeUIControls(TaskState.OFFERED, context, context.taskData);
+
+    expect(uiControls.main.decline).toEqual({isVisible: true, isEnabled: false});
+  });
+});
+
 describe('uiControlsComputer conference controls', () => {
   function createConferenceTaskData(participantCount: number) {
     const participants: Record<string, any> = {

--- a/packages/@webex/contact-center/test/unit/spec/services/task/voice/Voice.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/voice/Voice.ts
@@ -72,6 +72,30 @@ describe('Voice Task', () => {
     jest.clearAllMocks();
   });
 
+  describe('emitTaskOutdialFailed', () => {
+    it('emits the failure reason string instead of the Task object', () => {
+      const taskData = createBaseData({
+        interaction: {
+          outboundType: 'OUTDIAL',
+        } as any,
+      });
+      const voice = new Voice(dummyContact, taskData, {});
+      const emitSpy = jest.spyOn(voice, 'emit');
+
+      voice.sendStateMachineEvent({
+        type: TaskEvent.OUTBOUND_FAILED,
+        taskData,
+        reason: 'CUSTOMER_BUSY',
+      });
+
+      const outdialFailedCall = emitSpy.mock.calls.find(
+        (call) => call[0] === 'task:outdialFailed'
+      );
+      expect(outdialFailedCall).toBeDefined();
+      expect(outdialFailedCall![1]).toBe('CUSTOMER_BUSY');
+    });
+  });
+
   it('hides end and endConsult when disabled', () => {
     const voice = new Voice(dummyContact, createBaseData(), {
       isEndTaskEnabled: false,


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7940

## This pull request addresses

Outdial flow was broken in multiple ways during the task-refactor work. Agents experienced React crashes, missing wrapup screens, double popups, and incorrect button states when initiating outbound calls.

## by making the following changes

### 1. Fix wrapup screen not showing after outdial failure
- **TaskManager.ts**: Pass `taskData: payload` in the `OUTBOUND_FAILED` event mapping so the `shouldWrapUp` guard can correctly evaluate `agentsPendingWrapUp` from the backend payload.

### 2. Fix React crash on outdial failure
- **Voice.ts**: Override `emitTaskOutdialFailed` to emit the failure `reason` string instead of the entire Task object. The Task object was being rendered as a React child causing "Objects are not valid as a React child" errors.

### 3. Fix race condition — OUTBOUND_FAILED arriving in IDLE state
- **TaskStateMachine.ts**: Added `OUTBOUND_FAILED` handler to the `IDLE` state. `AgentOutboundFailed` can arrive before `AgentOfferContact` due to timing, causing unhandled events.

### 4. Fix double popup (Outdial Failed + Task Rejected)
- **TaskStateMachine.ts**: Replaced `emitTaskReject` with `emitTaskEnd` in `OUTBOUND_FAILED` handlers (both IDLE and OFFERED states). `emitTaskEnd` triggers cleanup without showing a redundant "Task Rejected" notification.

### 5. Fix Accept/Decline button states for outdial
- **uiControlsComputer.ts**: 
  - Accept: `isEnabled: isWebrtc && !isOutdial` — disabled for outdial (auto-answer handles it)
  - Decline: `VISIBLE_DISABLED` for outdial (enabled after `TASK_AUTO_ANSWERED` via Widgets store flag), `VISIBLE_ENABLED` for inbound calls

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
