### PR TITLE
fix(meeting join): fail better when we can't find locus join meeting url

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/request.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/request.ts
@@ -1,5 +1,5 @@
 import uuid from 'uuid';
-import {debounce} from 'lodash';
+import {debounce, isEmpty} from 'lodash';
 // @ts-ignore
 import {StatelessWebexPlugin} from '@webex/webex-core';
 // @ts-ignore
@@ -258,6 +258,13 @@ export default class MeetingRequest extends StatelessWebexPlugin {
         );
         throw e;
       }
+    }
+
+    if (isEmpty(url)) {
+      LoggerProxy.logger.error(
+        'Meeting:request#joinMeeting Error: Locus join meeting URL is empty'
+      );
+      throw new Error('Locus join meeting URL is empty');
     }
 
     // TODO: -- this will be resolved in SDK request

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/request.js
@@ -115,7 +115,6 @@ describe('plugin-meetings', () => {
     });
 
     describe('#changeVideoLayout', () => {
-
       const locusUrl = 'locusURL';
       const deviceUrl = 'deviceUrl';
       const layoutType = 'Equal';
@@ -322,6 +321,7 @@ describe('plugin-meetings', () => {
 
       it('adds deviceCapabilities to request when breakouts are supported', async () => {
         await meetingsRequest.joinMeeting({
+          locusUrl: 'locusUrl',
           breakoutsSupported: true,
         });
         const requestParams = meetingsRequest.request.getCall(0).args[0];
@@ -331,6 +331,7 @@ describe('plugin-meetings', () => {
 
       it('adds deviceCapabilities to request when live annotation are supported', async () => {
         await meetingsRequest.joinMeeting({
+          locusUrl: 'locusUrl',
           liveAnnotationSupported: true,
         });
         const requestParams = meetingsRequest.request.getCall(0).args[0];
@@ -338,6 +339,7 @@ describe('plugin-meetings', () => {
       });
       it('adds deviceCapabilities to request when breakouts and live annotation are supported', async () => {
         await meetingsRequest.joinMeeting({
+          locusUrl: 'locusUrl',
           liveAnnotationSupported: true,
           breakoutsSupported: true,
         });
@@ -348,7 +350,7 @@ describe('plugin-meetings', () => {
         ]);
       });
       it('does not add deviceCapabilities to request when breakouts and live annotation are not supported', async () => {
-        await meetingsRequest.joinMeeting({});
+        await meetingsRequest.joinMeeting({locusUrl: 'locusUrl'});
 
         const requestParams = meetingsRequest.request.getCall(0).args[0];
 
@@ -357,6 +359,7 @@ describe('plugin-meetings', () => {
 
       it('adds deviceCapabilities and locale to request when they are provided', async () => {
         await meetingsRequest.joinMeeting({
+          locusUrl: 'locusUrl',
           locale: 'en_UK',
           deviceCapabilities: ['SERVER_AUDIO_ANNOUNCEMENT_SUPPORTED'],
         });
@@ -369,7 +372,7 @@ describe('plugin-meetings', () => {
       });
 
       it('does not add deviceCapabilities and locale to request when they are not provided', async () => {
-        await meetingsRequest.joinMeeting({});
+        await meetingsRequest.joinMeeting({locusUrl: 'locusUrl'});
         const requestParams = meetingsRequest.request.getCall(0).args[0];
 
         assert.deepEqual(requestParams.body.deviceCapabilities, undefined);
@@ -378,6 +381,7 @@ describe('plugin-meetings', () => {
 
       it('adds alias to request when they are provided', async () => {
         await meetingsRequest.joinMeeting({
+          locusUrl: 'locusUrl',
           alias: 'assigned name',
         });
         const requestParams = meetingsRequest.request.getCall(0).args[0];
@@ -386,10 +390,18 @@ describe('plugin-meetings', () => {
       });
 
       it('does not add alias to request when they are not provided', async () => {
-        await meetingsRequest.joinMeeting({});
+        await meetingsRequest.joinMeeting({locusUrl: 'locusUrl'});
         const requestParams = meetingsRequest.request.getCall(0).args[0];
 
         assert.deepEqual(requestParams.body.alias, undefined);
+      });
+
+      it('throws when locusUrl, inviteeAddress, and meetingNumber are all absent', async () => {
+        await assert.isRejected(
+          meetingsRequest.joinMeeting({deviceUrl: 'deviceUrl', correlationId: 'random-uuid'}),
+          'Locus join meeting URL is empty'
+        );
+        assert.notCalled(meetingsRequest.request);
       });
     });
 
@@ -915,7 +927,7 @@ describe('plugin-meetings', () => {
         },
         headers: {
           locusId,
-        }
+        },
       });
     });
   });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # jira-eng-gpk2.cisco.com/jira/browse/SPARK-813470

## This pull request addresses

There was a particular scenario where we were not getting enough information to make a locus join meeting url
We ended up using the url "?alternateRedirect=true" which made a POST to the current URL instead of Locus, and the failure reason was unclear.

## by making the following changes

Throw an error if the locus join meeting url is empty. The actual bug is fixed in web client.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
