### PR TITLE
fix(calling): bug fixes and error handling

### DIFF
--- a/packages/calling/src/CallingClient/line/index.ts
+++ b/packages/calling/src/CallingClient/line/index.ts
@@ -146,12 +146,12 @@ export default class Line extends Eventing<LineEventTypes> implements ILine {
   /**
    * Wrapper to for device  deregister.
    */
-  public async deregister() {
+  public async deregister(closeMobiusWss = false) {
     log.info(METHOD_START_MESSAGE, {
       file: LINE_FILE,
       method: METHODS.DEREGISTER,
     });
-    await this.registration.deregister();
+    await this.registration.deregister(closeMobiusWss);
     this.registration.setStatus(RegistrationStatus.IDLE);
   }
 

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -1257,16 +1257,16 @@ export class Registration implements IRegistration {
         this.deviceInfo.device?.clientDeviceUri as string
       );
       log.log('Registration successfully deregistered', loggerContext);
-
-      if (closeMobiusWss) {
-        await this.apiRequest.disconnectFromMobiusSocket({
-          code: 3050,
-          reason: 'done (permanent)',
-        });
-        log.log('Mobius socket disconnect complete after deregistration', loggerContext);
-      }
     } catch (err) {
       log.warn(`Delete failed with Mobius: ${JSON.stringify(err)}`, loggerContext);
+    }
+
+    if (closeMobiusWss) {
+      await this.apiRequest.disconnectFromMobiusSocket({
+        code: 3050,
+        reason: 'done (permanent)',
+      });
+      log.log('Mobius socket disconnect complete after deregistration', loggerContext);
     }
 
     this.clearKeepaliveTimer();

--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -305,7 +305,10 @@ export class Registration implements IRegistration {
 
     let abort = false;
 
-    if (this.apiRequest.isSocketEnabled()) {
+    if (
+      this.apiRequest.isSocketEnabled() &&
+      `${this.apiRequest.getConnectedWebSocketUrl()}/` !== this.activeMobiusUrl
+    ) {
       log.info(`Disconnecting from Mobius socket to restore previous registration.`, {
         file: REGISTRATION_FILE,
         method: 'restorePreviousRegistration',
@@ -1239,7 +1242,7 @@ export class Registration implements IRegistration {
     return this.reconnectPending;
   }
 
-  public async deregister() {
+  public async deregister(closeMobiusWss = false) {
     const loggerContext = {
       file: REGISTRATION_FILE,
       method: METHODS.DEREGISTER,
@@ -1254,6 +1257,14 @@ export class Registration implements IRegistration {
         this.deviceInfo.device?.clientDeviceUri as string
       );
       log.log('Registration successfully deregistered', loggerContext);
+
+      if (closeMobiusWss) {
+        await this.apiRequest.disconnectFromMobiusSocket({
+          code: 3050,
+          reason: 'done (permanent)',
+        });
+        log.log('Mobius socket disconnect complete after deregistration', loggerContext);
+      }
     } catch (err) {
       log.warn(`Delete failed with Mobius: ${JSON.stringify(err)}`, loggerContext);
     }

--- a/packages/calling/src/CallingClient/registration/types.ts
+++ b/packages/calling/src/CallingClient/registration/types.ts
@@ -70,7 +70,7 @@ export interface IRegistration {
   /**
    * Deregisters the device.
    */
-  deregister(): void;
+  deregister(closeMobiusWss: boolean): void;
 
   /**
    * Sets the active Mobius server URL to use for registration.

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -159,6 +159,10 @@ export class APIRequest {
     }
   }
 
+  public getConnectedWebSocketUrl() {
+    return this.mobiusSocket.getConnectedWebSocketUrl();
+  }
+
   /**
    * Disconnects the default session from the Mobius WebSocket.
    */

--- a/packages/calling/src/mobius-socket/config.ts
+++ b/packages/calling/src/mobius-socket/config.ts
@@ -24,7 +24,7 @@ const mobiusSocketConfig: MobiusSocketConfig = {
   backoffTimeMax: 32000,
   backoffTimeReset: 1000,
   initialConnectionMaxRetries: 0,
-  maxRetries: 0,
+  maxRetries: 3,
   forceCloseDelay: 2000,
   dedupCacheMaxSize: 1000,
 };

--- a/packages/calling/src/mobius-socket/mobius-socket-events.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket-events.test.ts
@@ -140,6 +140,14 @@ describe('plugin-mobiusSocket', () => {
         });
 
         mobiusSocket = new MobiusSocket(webex, {...mobiusConfig.mobiusSocket});
+
+        (mobiusSocket as any).logger = {
+          debug: jest.fn(),
+          error: jest.fn(),
+          info: jest.fn(),
+          log: jest.fn(),
+          warn: jest.fn(),
+        };
       });
 
       it('removes all listeners for an event when off() is called without a listener', () => {
@@ -292,12 +300,12 @@ describe('plugin-mobiusSocket', () => {
           {
             code: 1000,
             reason: 'idle',
-            action: 'reconnect',
+            action: 'close',
           },
           {
             code: 1000,
             reason: 'done (forced)',
-            action: 'reconnect',
+            action: 'close',
           },
           {
             code: 1000,
@@ -319,7 +327,7 @@ describe('plugin-mobiusSocket', () => {
           },
           {
             code: 1001,
-            action: 'reconnect',
+            action: 'close',
           },
           {
             code: 1005,

--- a/packages/calling/src/mobius-socket/mobius-socket.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.test.ts
@@ -172,6 +172,14 @@ describe('plugin-mobius-socket', () => {
       });
 
       mobiusSocket = new MobiusSocket(webex, {...mobiusConfig.mobiusSocket});
+
+      (mobiusSocket as any).logger = {
+        debug: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn(),
+        log: jest.fn(),
+        warn: jest.fn(),
+      };
     });
 
     afterEach(async () => {

--- a/packages/calling/src/mobius-socket/mobius-socket.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.ts
@@ -767,7 +767,7 @@ class MobiusSocket extends EventEmitter {
     return this.tokenRefreshInFlight;
   }
 
-  private async onclose(event: SocketCloseEvent, sourceSocket: ExtendedSocket): void {
+  private async onclose(event: SocketCloseEvent, sourceSocket: ExtendedSocket): Promise<void> {
     const loggerContext = {
       file: 'mobius-socket.ts',
       method: 'onclose',
@@ -863,14 +863,11 @@ class MobiusSocket extends EventEmitter {
           }
           break;
         case 4401:
-          this.logger.error(`unauthorized, statusCode=${event.code}`, loggerContext);
-          await this.refreshToken();
-          await this.reconnect(this.socket?.url);
-          break;
         case 4403:
         case 4404:
-          this.logger.error(`forbidden, statusCode=${event.code}`, loggerContext);
-          this.reconnect(this.socket?.url);
+          this.logger.error(`onclose, statusCode=${event.code}`, loggerContext);
+          await this.refreshToken();
+          await this.reconnect(this.socket?.url);
           break;
         case 4429:
           // Silently ignore too many requests

--- a/packages/calling/src/mobius-socket/mobius-socket.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.ts
@@ -767,7 +767,7 @@ class MobiusSocket extends EventEmitter {
     return this.tokenRefreshInFlight;
   }
 
-  private onclose(event: SocketCloseEvent, sourceSocket: ExtendedSocket): void {
+  private async onclose(event: SocketCloseEvent, sourceSocket: ExtendedSocket): void {
     const loggerContext = {
       file: 'mobius-socket.ts',
       method: 'onclose',
@@ -864,7 +864,8 @@ class MobiusSocket extends EventEmitter {
           break;
         case 4401:
           this.logger.error(`unauthorized, statusCode=${event.code}`, loggerContext);
-          this.refreshToken();
+          await this.refreshToken();
+          await this.reconnect(this.socket?.url);
           break;
         case 4403:
         case 4404:

--- a/packages/calling/src/mobius-socket/mobius-socket.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.ts
@@ -768,8 +768,10 @@ class MobiusSocket extends EventEmitter {
   }
 
   private onclose(event: SocketCloseEvent, sourceSocket: ExtendedSocket): void {
-    // I don't see any way to avoid the complexity or statement count in here.
-    /* eslint complexity: [0] */
+    const loggerContext = {
+      file: 'mobius-socket.ts',
+      method: 'onclose',
+    };
 
     try {
       const reason = event.reason && event.reason.toLowerCase();
@@ -792,9 +794,7 @@ class MobiusSocket extends EventEmitter {
         this.stopTokenRefreshTimer();
       } else {
         // Old socket closed; do not flip connection state
-        this.logger.info(
-          `${MOBIUS_SOCKET_NAMESPACE}: [shutdown] non-active socket closed, code=${event.code}`
-        );
+        this.logger.info(`[shutdown] non-active socket closed, code=${event.code}`, loggerContext);
         // Clean up listeners from old socket now that it's closed
         if (sourceSocket) {
           sourceSocket.removeAllListeners();
@@ -804,12 +804,13 @@ class MobiusSocket extends EventEmitter {
       switch (event.code) {
         case 1003:
           this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: service rejected last message; will not reconnect: ${event.reason}`
+            `service rejected last message; will not reconnect: ${event.reason}`,
+            loggerContext
           );
           if (isActiveSocket) this.emitEvent('offline.permanent', event);
           break;
         case 4000:
-          this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: socket replaced; will not reconnect`);
+          this.logger.info(`socket replaced; will not reconnect`, loggerContext);
           if (isActiveSocket) this.emitEvent('offline.replaced', event);
           break;
         case 4001:
@@ -818,63 +819,84 @@ class MobiusSocket extends EventEmitter {
             // Server closed active socket with 4001, meaning it expected this connection
             // to be replaced, but the switchover in handleImminentShutdown failed.
             this.logger.warn(
-              `${MOBIUS_SOCKET_NAMESPACE}: active socket closed with 4001; shutdown switchover failed`
+              `active socket closed with 4001; shutdown switchover failed`,
+              loggerContext
             );
             this.emitEvent('offline.permanent', event);
           } else {
             // Expected: old socket closed after successful switchover
             this.logger.info(
-              `${MOBIUS_SOCKET_NAMESPACE}: old socket closed with 4001 (replaced during shutdown); no reconnect needed`
+              `old socket closed with 4001 (replaced during shutdown); no reconnect needed`,
+              loggerContext
             );
             this.emitEvent('offline.replaced', event);
           }
           break;
+        case 1000:
         case 1001:
+          this.logger.info(`socket disconnected; ${event.reason}`, loggerContext);
+          if (isActiveSocket) this.emitEvent('offline.permanent', event);
+          break;
         case 1005:
         case 1006:
         case 1011:
-          this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: socket disconnected; reconnecting`);
+        case 1012:
+          this.logger.info(`socket disconnected; reconnecting`, loggerContext);
           if (isActiveSocket) {
             this.emitEvent('offline.transient', event);
             this.reconnect(socketUrl);
           }
           break;
-        case 1000:
         case 3050:
           if (reason && normalReconnectReasons.includes(reason)) {
-            this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: socket disconnected; reconnecting`);
+            this.logger.info(`socket disconnected; reconnecting`, loggerContext);
             if (isActiveSocket) {
               this.emitEvent('offline.transient', event);
               this.reconnect(socketUrl);
             }
           } else {
             this.logger.info(
-              `${MOBIUS_SOCKET_NAMESPACE}: socket disconnected; will not reconnect: ${event.reason}`
+              `socket disconnected; will not reconnect: ${event.reason}`,
+              loggerContext
             );
             if (isActiveSocket) this.emitEvent('offline.permanent', event);
           }
           break;
+        case 4401:
+          this.logger.error(`unauthorized, statusCode=${event.code}`, loggerContext);
+          this.refreshToken();
+          break;
+        case 4403:
+        case 4404:
+          this.logger.error(`forbidden, statusCode=${event.code}`, loggerContext);
+          this.reconnect(this.socket?.url);
+          break;
+        case 4429:
+          // Silently ignore too many requests
+          this.logger.error(`too many requests, statusCode=${event.code}`, loggerContext);
+          break;
         default:
-          this.logger.info(
-            `${MOBIUS_SOCKET_NAMESPACE}: socket disconnected unexpectedly; will not reconnect`
-          );
+          this.logger.info(`socket disconnected unexpectedly; will not reconnect`, loggerContext);
           if (isActiveSocket) this.emitEvent('offline.permanent', event);
       }
     } catch (error) {
-      this.logger.error(`${MOBIUS_SOCKET_NAMESPACE}: error occurred in close handler`, error);
+      this.logger.error(`error occurred in close handler`, error, loggerContext);
     }
   }
 
   private onmessage(event: SocketMessageEvent<SocketResponse>): Promise<void> {
+    const loggerContext = {
+      file: 'mobius-socket.ts',
+      method: 'onclose',
+    };
+
     const envelope = event.data;
 
-    if (process.env.ENABLE_MOBIUS_LOGGING) {
-      this.logger.debug(`${MOBIUS_SOCKET_NAMESPACE}: message envelope: `, envelope);
-    }
+    this.logger.debug(`message envelope: `, envelope, loggerContext);
 
     // Handle shutdown message shape: { type: 'shutdown' }
     if (envelope && envelope.type === 'shutdown') {
-      this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: [shutdown] imminent shutdown message received`);
+      this.logger.info(`[shutdown] imminent shutdown message received`, loggerContext);
       this.emitEvent('event:mobius_shutdown_imminent', envelope); // This is not yet not implemented, keeping for future support
 
       this.handleImminentShutdown();
@@ -914,17 +936,14 @@ class MobiusSocket extends EventEmitter {
         this.emitEvent(`event:${eventType}`, envelope);
       }
     } catch (reason) {
-      this.logger.error(
-        `${MOBIUS_SOCKET_NAMESPACE}: error occurred processing socket message`,
-        reason
-      );
+      this.logger.error(`error occurred processing socket message`, reason, loggerContext);
     }
 
     return Promise.resolve();
   }
 
   private reconnect(webSocketUrl: string | undefined): Promise<void> {
-    this.logger.info(`${MOBIUS_SOCKET_NAMESPACE}: reconnecting`);
+    this.logger.info(`reconnecting`, {file: 'mobius-socket.ts', method: 'reconnect'});
 
     return this.connect(webSocketUrl || this.socketUrl);
   }

--- a/packages/webex/src/calling.js
+++ b/packages/webex/src/calling.js
@@ -92,7 +92,7 @@ class Calling extends EventEmitter {
 
     for (const line of lines) {
       if (line.getStatus() === 'active') {
-        line.deregister();
+        line.deregister(true); // Close Mobius WSS by passing true
       }
     }
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [CAI-7874](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7874) >

## This pull request addresses

Fixes bugs listed in the linked JIRA

## by making the following changes

- Mobius WSS lifecycle is now driven by the calling SDK's deregister flow, with a guard that prevents redundant socket teardown during URL-stable re-registrations.
- Reconnect policy widened (`maxRetries: 3`, `1012` added) and explicit handling added for `4401/4403/4404/4429`; normal close codes (`1000/1001`) are now treated as permanent.
- Logging cleaned up to use structured `loggerContext`; debug envelope logging is no longer behind an env flag.
- Unit tests updated to reflect the new close-code routing and to fully suppress the package logger so test output stays clean.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Re-registration after page refresh
- On manual deregister, no reconnect
- Error handling for shown code
- Logging improvements

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
