### PR TITLE
fix: participant updates are not visible in a webinar 5k practice session

### DIFF
--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -14,6 +14,7 @@ import {
   SHARE_STATUS,
   DEFAULT_LARGE_SCALE_WEBINAR_ATTENDEE_SEARCH_LIMIT,
   LLM_PRACTICE_SESSION,
+  LOCUS_LLM_EVENT,
 } from '../constants';
 
 import WebinarCollection from './collection';
@@ -194,6 +195,14 @@ const Webinar = WebexPlugin.extend({
       );
       this._practiceSessionRelayListener = null;
     }
+    if (this._practiceSessionLocusLLMListener) {
+      // @ts-ignore - Fix type
+      this.webex.internal.llm.off(
+        `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
+        this._practiceSessionLocusLLMListener
+      );
+      this._practiceSessionLocusLLMListener = null;
+    }
   },
 
   /**
@@ -356,7 +365,7 @@ const Webinar = WebexPlugin.extend({
         LLM_PRACTICE_SESSION
       )
       .then((registerAndConnectResult) => {
-        // Track the exact listener reference so cleanupPSDataChannel can
+        // Track the exact listener references so cleanupPSDataChannel can
         // unsubscribe deterministically, even if the meeting can no longer
         // be resolved at cleanup time.
         if (this._practiceSessionRelayListener) {
@@ -371,6 +380,19 @@ const Webinar = WebexPlugin.extend({
         this.webex.internal.llm.on(
           `event:relay.event:${LLM_PRACTICE_SESSION}`,
           this._practiceSessionRelayListener
+        );
+        if (this._practiceSessionLocusLLMListener) {
+          // @ts-ignore - Fix type
+          this.webex.internal.llm.off(
+            `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
+            this._practiceSessionLocusLLMListener
+          );
+        }
+        this._practiceSessionLocusLLMListener = meeting?.processLocusLLMEvent;
+        // @ts-ignore - Fix type
+        this.webex.internal.llm.on(
+          `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
+          this._practiceSessionLocusLLMListener
         );
         // @ts-ignore - Fix type
         this.webex.internal.voicea?.announce?.();

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -22,6 +22,19 @@ import LoggerProxy from '../common/logs/logger-proxy';
 import MeetingUtil from '../meeting/util';
 import {sanitizeParams} from './utils';
 
+const PS_LLM_EVENTS = [
+  {
+    event: `event:relay.event:${LLM_PRACTICE_SESSION}`,
+    listenerKey: 'relay',
+    handlerKey: 'processRelayEvent',
+  },
+  {
+    event: `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
+    listenerKey: 'locusLLM',
+    handlerKey: 'processLocusLLMEvent',
+  },
+];
+
 /**
  * @class Webinar
  */
@@ -172,6 +185,8 @@ const Webinar = WebexPlugin.extend({
    * @returns {Promise<void>}
    */
   async cleanupPSDataChannel() {
+    this.llmListeners = this.llmListeners || {};
+
     if (this._pendingOnlineListener) {
       // @ts-ignore - Fix type
       this.webex.internal.llm.off('online', this._pendingOnlineListener);
@@ -187,21 +202,12 @@ const Webinar = WebexPlugin.extend({
       LLM_PRACTICE_SESSION
     );
 
-    if (this._practiceSessionRelayListener) {
-      // @ts-ignore - Fix type
-      this.webex.internal.llm.off(
-        `event:relay.event:${LLM_PRACTICE_SESSION}`,
-        this._practiceSessionRelayListener
-      );
-      this._practiceSessionRelayListener = null;
-    }
-    if (this._practiceSessionLocusLLMListener) {
-      // @ts-ignore - Fix type
-      this.webex.internal.llm.off(
-        `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
-        this._practiceSessionLocusLLMListener
-      );
-      this._practiceSessionLocusLLMListener = null;
+    for (const {event, listenerKey} of PS_LLM_EVENTS) {
+      if (this.llmListeners[listenerKey]) {
+        // @ts-ignore - Fix type
+        this.webex.internal.llm.off(event, this.llmListeners[listenerKey]);
+        this.llmListeners[listenerKey] = null;
+      }
     }
   },
 
@@ -261,6 +267,8 @@ const Webinar = WebexPlugin.extend({
    * @returns {Promise}
    */
   async updatePSDataChannel() {
+    this.llmListeners = this.llmListeners || {};
+
     this._updatePSDataChannelSequence = (this._updatePSDataChannelSequence || 0) + 1;
     const invocationSequence = this._updatePSDataChannelSequence;
 
@@ -368,32 +376,15 @@ const Webinar = WebexPlugin.extend({
         // Track the exact listener references so cleanupPSDataChannel can
         // unsubscribe deterministically, even if the meeting can no longer
         // be resolved at cleanup time.
-        if (this._practiceSessionRelayListener) {
+        for (const {event, listenerKey, handlerKey} of PS_LLM_EVENTS) {
+          if (this.llmListeners[listenerKey]) {
+            // @ts-ignore - Fix type
+            this.webex.internal.llm.off(event, this.llmListeners[listenerKey]);
+          }
+          this.llmListeners[listenerKey] = meeting?.[handlerKey];
           // @ts-ignore - Fix type
-          this.webex.internal.llm.off(
-            `event:relay.event:${LLM_PRACTICE_SESSION}`,
-            this._practiceSessionRelayListener
-          );
+          this.webex.internal.llm.on(event, this.llmListeners[listenerKey]);
         }
-        this._practiceSessionRelayListener = meeting?.processRelayEvent;
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.on(
-          `event:relay.event:${LLM_PRACTICE_SESSION}`,
-          this._practiceSessionRelayListener
-        );
-        if (this._practiceSessionLocusLLMListener) {
-          // @ts-ignore - Fix type
-          this.webex.internal.llm.off(
-            `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
-            this._practiceSessionLocusLLMListener
-          );
-        }
-        this._practiceSessionLocusLLMListener = meeting?.processLocusLLMEvent;
-        // @ts-ignore - Fix type
-        this.webex.internal.llm.on(
-          `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
-          this._practiceSessionLocusLLMListener
-        );
         // @ts-ignore - Fix type
         this.webex.internal.voicea?.announce?.();
         if (isCaptionBoxOn) {

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -5,7 +5,7 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import uuid from 'uuid';
 import sinon from 'sinon';
 import {DataChannelTokenType} from '@webex/internal-plugin-llm';
-import {LLM_PRACTICE_SESSION, SHARE_STATUS} from '@webex/plugin-meetings/src/constants';
+import {LLM_PRACTICE_SESSION, LOCUS_LLM_EVENT, SHARE_STATUS} from '@webex/plugin-meetings/src/constants';
 
 describe('plugin-meetings', () => {
     describe('Webinar', () => {
@@ -227,7 +227,7 @@ describe('plugin-meetings', () => {
 
       beforeEach(() => {
         relayListener = sinon.stub();
-        webinar._practiceSessionRelayListener = relayListener;
+        webinar.llmListeners = {relay: relayListener, locusLLM: null};
       });
 
       it('disconnects the practice session channel and removes the tracked relay listener', async () => {
@@ -238,16 +238,16 @@ describe('plugin-meetings', () => {
           {code: 3050, reason: 'done (permanent)'},
           LLM_PRACTICE_SESSION
         );
-        assert.calledOnceWithExactly(
+        assert.calledWithExactly(
           webex.internal.llm.off,
           `event:relay.event:${LLM_PRACTICE_SESSION}`,
           relayListener
         );
-        assert.isNull(webinar._practiceSessionRelayListener);
+        assert.isNull(webinar.llmListeners.relay);
       });
 
       it('skips relay listener removal when no listener has been tracked', async () => {
-        webinar._practiceSessionRelayListener = null;
+        webinar.llmListeners.relay = null;
 
         await webinar.cleanupPSDataChannel();
 
@@ -255,6 +255,31 @@ describe('plugin-meetings', () => {
           ([event]) => event === `event:relay.event:${LLM_PRACTICE_SESSION}`
         );
         assert.equal(relayOffCalls.length, 0);
+      });
+
+      it('disconnects and removes the tracked locusLLM listener', async () => {
+        const locusLLMListener = sinon.stub();
+        webinar.llmListeners.locusLLM = locusLLMListener;
+
+        await webinar.cleanupPSDataChannel();
+
+        assert.calledWithExactly(
+          webex.internal.llm.off,
+          `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
+          locusLLMListener
+        );
+        assert.isNull(webinar.llmListeners.locusLLM);
+      });
+
+      it('skips locusLLM listener removal when no listener has been tracked', async () => {
+        webinar.llmListeners.locusLLM = null;
+
+        await webinar.cleanupPSDataChannel();
+
+        const locusLLMOffCalls = webex.internal.llm.off.args.filter(
+          ([event]) => event === `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`
+        );
+        assert.equal(locusLLMOffCalls.length, 0);
       });
 
       it('does not consult the meeting collection during cleanup', async () => {
@@ -289,13 +314,16 @@ describe('plugin-meetings', () => {
     describe('#updatePSDataChannel', () => {
       let meeting;
       let processRelayEvent;
+      let processLocusLLMEvent;
 
       beforeEach(() => {
         processRelayEvent = sinon.stub();
+        processLocusLLMEvent = sinon.stub();
         meeting = {
           locusUrl: 'locusUrl',
           isJoined: sinon.stub().returns(true),
           processRelayEvent,
+          processLocusLLMEvent,
           locusInfo: {
             url: 'locus-url',
             info: {practiceSessionDatachannelUrl: 'dc-url'},
@@ -476,7 +504,7 @@ describe('plugin-meetings', () => {
         await webinar.updatePSDataChannel();
 
         // Stores the exact listener reference for deterministic cleanup
-        assert.equal(webinar._practiceSessionRelayListener, processRelayEvent);
+        assert.equal(webinar.llmListeners.relay, processRelayEvent);
         assert.calledWith(
           webex.internal.llm.on,
           `event:relay.event:${LLM_PRACTICE_SESSION}`,
@@ -486,7 +514,7 @@ describe('plugin-meetings', () => {
 
       it('removes a previously tracked relay listener before re-binding on reconnect', async () => {
         const previousListener = sinon.stub();
-        webinar._practiceSessionRelayListener = previousListener;
+        webinar.llmListeners = {relay: previousListener, locusLLM: null};
 
         await webinar.updatePSDataChannel();
 
@@ -495,7 +523,32 @@ describe('plugin-meetings', () => {
           `event:relay.event:${LLM_PRACTICE_SESSION}`,
           previousListener
         );
-        assert.equal(webinar._practiceSessionRelayListener, processRelayEvent);
+        assert.equal(webinar.llmListeners.relay, processRelayEvent);
+      });
+
+      it('tracks and binds the locusLLM listener after successful connect', async () => {
+        await webinar.updatePSDataChannel();
+
+        assert.equal(webinar.llmListeners.locusLLM, processLocusLLMEvent);
+        assert.calledWith(
+          webex.internal.llm.on,
+          `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
+          processLocusLLMEvent
+        );
+      });
+
+      it('removes a previously tracked locusLLM listener before re-binding on reconnect', async () => {
+        const previousListener = sinon.stub();
+        webinar.llmListeners = {relay: null, locusLLM: previousListener};
+
+        await webinar.updatePSDataChannel();
+
+        assert.calledWith(
+          webex.internal.llm.off,
+          `${LOCUS_LLM_EVENT}:${LLM_PRACTICE_SESSION}`,
+          previousListener
+        );
+        assert.equal(webinar.llmListeners.locusLLM, processLocusLLMEvent);
       });
 
       it('subscribes to transcription when caption intent is enabled', async () => {


### PR DESCRIPTION
# COMPLETES #[SPARK-814970](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-814970)

## This pull request addresses
updates that arrive over LLM where not being handled at all if we were in a webinar practice session

## by making the following changes
to receive the events, we need to register them with a ":llm-practice-session" suffix, so I've added the missing code for the Locus events (1st commit). The code was quite repetitive and almost the same as for the relay events so I've refactored it slightly (2nd commit).

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
