### PR TITLE
feat(plugin-meetings): include isMultistream and isInLobby in media i…

### DIFF
--- a/packages/@webex/plugin-meetings/src/media/properties.ts
+++ b/packages/@webex/plugin-meetings/src/media/properties.ts
@@ -455,10 +455,14 @@ export default class MediaProperties {
    *
    * @param {string} issueType
    * @param {string} issueSubType
-   * @param {string} correlationId
+   * @param {Object} metadata - static-per-meeting context included in the metric payload
    * @returns {void}
    */
-  public sendMediaIssueMetric(issueType: string, issueSubType: string, correlationId) {
+  public sendMediaIssueMetric(
+    issueType: string,
+    issueSubType: string,
+    metadata: {correlationId: string; isMultistream: boolean; isInLobby: boolean}
+  ) {
     const key = `${issueType}_${issueSubType}`;
 
     const count = (this.mediaIssueCounters[key] || 0) + 1;
@@ -466,7 +470,7 @@ export default class MediaProperties {
     this.mediaIssueCounters[key] = count;
 
     this.throttledSendMediaIssueMetric({
-      correlationId,
+      ...metadata,
       ...this.mediaIssueCounters,
     });
   }

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -8020,11 +8020,11 @@ export default class Meeting extends StatelessWebexPlugin {
         });
 
         if (atLeastOneUnmutedOtherMember) {
-          this.mediaProperties.sendMediaIssueMetric(
-            'inbound_audio',
-            data.issueSubType,
-            this.correlationId
-          );
+          this.mediaProperties.sendMediaIssueMetric('inbound_audio', data.issueSubType, {
+            correlationId: this.correlationId,
+            isMultistream: this.isMultistream,
+            isInLobby: !!this.isUserUnadmitted,
+          });
 
           Trigger.trigger(
             this,

--- a/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/media/properties.ts
@@ -419,33 +419,39 @@ describe('MediaProperties', () => {
     it('should send a behavioral metric with correct parameters', () => {
       const issueType = 'audio';
       const issueSubType = 'packet-loss';
-      const correlationId = 'test-correlation-id-123';
+      const metadata = {correlationId: 'test-correlation-id-123', isMultistream: true, isInLobby: false};
 
-      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, correlationId);
+      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, metadata);
 
-      assert.calledOnce(sendBehavioralMetricStub);
-      assert.calledWith(sendBehavioralMetricStub, BEHAVIORAL_METRICS.MEDIA_ISSUE_DETECTED, {
-        correlationId,
-        'audio_packet-loss': 1,
-      });
+      assert.calledOnceWithExactly(
+        sendBehavioralMetricStub,
+        BEHAVIORAL_METRICS.MEDIA_ISSUE_DETECTED,
+        {
+          ...metadata,
+          'audio_packet-loss': 1,
+        }
+      );
     });
 
     it('should increment count while being throttled and reset it once metric goes out', () => {
       const issueType = 'video';
       const issueSubType = 'freeze';
-      const correlationId = 'test-correlation-id';
+      const metadata = {correlationId: 'test-correlation-id', isMultistream: false, isInLobby: true};
 
       // Call multiple times with same issue type/subtype
-      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, correlationId);
-      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, correlationId);
-      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, correlationId);
+      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, metadata);
+      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, metadata);
+      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, metadata);
 
       // First call should go through immediately, subsequent calls are throttled
-      assert.calledOnce(sendBehavioralMetricStub);
-      assert.calledWith(sendBehavioralMetricStub, BEHAVIORAL_METRICS.MEDIA_ISSUE_DETECTED, {
-        correlationId,
-        video_freeze: 1, // Only the first call goes through due to throttling
-      });
+      assert.calledOnceWithExactly(
+        sendBehavioralMetricStub,
+        BEHAVIORAL_METRICS.MEDIA_ISSUE_DETECTED,
+        {
+          ...metadata,
+          video_freeze: 1, // Only the first call goes through due to throttling
+        }
+      );
       sendBehavioralMetricStub.resetHistory();
 
       assert.equal(mediaProperties.mediaIssueCounters['video_freeze'], 2); // counter should be reset after the first metric goes out, hence only 2 not 3 here
@@ -456,29 +462,29 @@ describe('MediaProperties', () => {
         sendBehavioralMetricStub,
         BEHAVIORAL_METRICS.MEDIA_ISSUE_DETECTED,
         {
-          correlationId,
+          ...metadata,
           video_freeze: 2,
         }
       );
     });
 
     it('should track different issue types separately in counters', () => {
-      const correlationId = 'test-correlation-id';
+      const metadata = {correlationId: 'test-correlation-id', isMultistream: true, isInLobby: false};
 
       // Send different issue types
-      mediaProperties.sendMediaIssueMetric('audio', 'packet-loss', correlationId);
-      mediaProperties.sendMediaIssueMetric('video', 'freeze', correlationId);
-      mediaProperties.sendMediaIssueMetric('audio', 'packet-loss', correlationId);
-      mediaProperties.sendMediaIssueMetric('audio', 'packet-loss', correlationId);
-      mediaProperties.sendMediaIssueMetric('audio', 'packet-loss', correlationId);
-      mediaProperties.sendMediaIssueMetric('video', 'freeze', correlationId);
+      mediaProperties.sendMediaIssueMetric('audio', 'packet-loss', metadata);
+      mediaProperties.sendMediaIssueMetric('video', 'freeze', metadata);
+      mediaProperties.sendMediaIssueMetric('audio', 'packet-loss', metadata);
+      mediaProperties.sendMediaIssueMetric('audio', 'packet-loss', metadata);
+      mediaProperties.sendMediaIssueMetric('audio', 'packet-loss', metadata);
+      mediaProperties.sendMediaIssueMetric('video', 'freeze', metadata);
 
       // First call should go through immediately, subsequent calls are throttled
       assert.calledOnceWithExactly(
         sendBehavioralMetricStub,
         BEHAVIORAL_METRICS.MEDIA_ISSUE_DETECTED,
         {
-          correlationId,
+          ...metadata,
           'audio_packet-loss': 1,
         }
       );
@@ -495,7 +501,7 @@ describe('MediaProperties', () => {
         sendBehavioralMetricStub,
         BEHAVIORAL_METRICS.MEDIA_ISSUE_DETECTED,
         {
-          correlationId,
+          ...metadata,
           video_freeze: 2,
           'audio_packet-loss': 3,
         }
@@ -505,18 +511,18 @@ describe('MediaProperties', () => {
     it('should flush throttled metrics when unsetPeerConnection is called', () => {
       const issueType = 'share';
       const issueSubType = 'connection-lost';
-      const correlationId = 'test-correlation-id';
+      const metadata = {correlationId: 'test-correlation-id', isMultistream: false, isInLobby: true};
 
       // Send metrics multiple times
-      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, correlationId);
-      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, correlationId);
+      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, metadata);
+      mediaProperties.sendMediaIssueMetric(issueType, issueSubType, metadata);
 
       // First call should go through immediately
       assert.calledOnceWithExactly(
         sendBehavioralMetricStub,
         BEHAVIORAL_METRICS.MEDIA_ISSUE_DETECTED,
         {
-          correlationId,
+          ...metadata,
           'share_connection-lost': 1,
         }
       );
@@ -529,7 +535,7 @@ describe('MediaProperties', () => {
         sendBehavioralMetricStub,
         BEHAVIORAL_METRICS.MEDIA_ISSUE_DETECTED,
         {
-          correlationId,
+          ...metadata,
           'share_connection-lost': 1,
         }
       );

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -5219,7 +5219,11 @@ describe('plugin-meetings', () => {
                 meeting.mediaProperties.sendMediaIssueMetric,
                 'inbound_audio',
                 fakeEventData.issueSubType,
-                meeting.correlationId
+                {
+                  correlationId: meeting.correlationId,
+                  isMultistream: meeting.isMultistream,
+                  isInLobby: !!meeting.isUserUnadmitted,
+                }
               );
             });
           });


### PR DESCRIPTION
## This pull request addresses

The `js_sdk_media_issue_detected` behavioral metric only carried `correlationId` plus per-issue counts. When triaging inbound audio issues we couldn't tell from the metric alone whether the affected client was in a multistream meeting or whether it was still sitting in the lobby — both of which significantly change the expected media behavior and the set of plausible root causes.

## by making the following changes

- Refactored `MediaProperties.sendMediaIssueMetric` to take a single `metadata` object instead of a positional `correlationId`, so future static-per-meeting context can be added without further signature churn.
- Extended the metadata with `isMultistream` and `isInLobby` (sourced from `meeting.isMultistream` and `!!meeting.isUserUnadmitted` respectively).
- Updated the only call site in `meeting/index.ts` (inbound audio issue handler) to pass the new metadata object.
- Updated unit tests in `media/properties.ts` and `meeting/index.js` to cover the new payload shape and tightened a couple of assertions to `calledOnceWithExactly`.

No behavioral change beyond additional fields in the emitted metric; throttling, counter accumulation, and reset semantics are unchanged.

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Ran `yarn workspace @webex/plugin-meetings test:unit --targets media/properties.ts` — all 30 tests pass, including the four `sendMediaIssueMetric` cases that now assert `isMultistream` and `isInLobby` in the emitted payload.
- Ran the relevant `meeting/index.js` unit tests covering the inbound audio issue handler to confirm the new metadata is forwarded with `correlationId`, `isMultistream`, and `isInLobby`.

## The GAI Coding Policy And Copyright Annotation Best Practices

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly