### PR TITLE
fix(calling): fix the url parsing for mobius wss

### DIFF
--- a/packages/calling/src/CallingClient/registration/register.ts
+++ b/packages/calling/src/CallingClient/registration/register.ts
@@ -1311,6 +1311,7 @@ export class Registration implements IRegistration {
 
       if (this.apiRequest.isSocketEnabled()) {
         uri = uri.replace('https://', 'wss://');
+        uri = !uri.endsWith('/') ? `${uri}/` : uri;
       }
 
       this.setActiveMobiusUrl(uri);

--- a/packages/calling/src/CallingClient/utils/mobiusSocketMapper.test.ts
+++ b/packages/calling/src/CallingClient/utils/mobiusSocketMapper.test.ts
@@ -158,6 +158,14 @@ describe('mobiusSocketMapper', () => {
         expect(warnSpy).not.toHaveBeenCalled();
       });
 
+      it('should return DEVICE_STATUS for /status URI without /devices/ segment in path', () => {
+        const uri = '/api/v1/calling/web/status';
+        const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.POST);
+
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.DEVICE_STATUS);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
       it('should return DEVICE_LIST for devices list URI without trailing ID', () => {
         const uri = '/api/v1/calling/web/devices';
         const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.GET);
@@ -216,11 +224,15 @@ describe('mobiusSocketMapper', () => {
         );
       });
 
-      it('should handle URI with /calls/ in path correctly for DEVICE_STATUS (not call-related)', () => {
-        const uri = '/api/v1/calling/web/devices/device-123/status';
+      it('should never return DEVICE_STATUS when /calls/ is present in path ending with /status', () => {
+        // The DEVICE_STATUS check explicitly excludes URIs containing /calls/. Any
+        // call-scoped /status URI must resolve to CALL_STATUS via the earlier branch,
+        // and must never fall through to DEVICE_STATUS even if check ordering changes.
+        const uri = '/api/v1/calling/web/devices/device-123/calls/call-456/status';
         const result = deriveMobiusSocketMessageType(uri, HTTP_METHODS.PATCH);
 
-        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.DEVICE_STATUS);
+        expect(result).toBe(MOBIUS_SOCKET_MESSAGE_TYPE.CALL_STATUS);
+        expect(result).not.toBe(MOBIUS_SOCKET_MESSAGE_TYPE.DEVICE_STATUS);
         expect(warnSpy).not.toHaveBeenCalled();
       });
 

--- a/packages/calling/src/CallingClient/utils/mobiusSocketMapper.ts
+++ b/packages/calling/src/CallingClient/utils/mobiusSocketMapper.ts
@@ -95,7 +95,7 @@ export function deriveMobiusSocketMessageType(
   // --- Device-level operations ---
 
   // Device keepalive: .../devices/{deviceId}/status  (no /calls/ in path)
-  if (uri.includes('/devices/') && uri.endsWith('/status')) {
+  if (!uri.includes('/calls/') && uri.endsWith('/status')) {
     return MOBIUS_SOCKET_MESSAGE_TYPE.DEVICE_STATUS;
   }
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< Ad-hoc >

## This pull request addresses

- Fixes the url parsing for the keepalive
- Add `/` at the end of the base url for mobius wss url coming from error response. This fixes all the ongoing requests after this as we simply utilize `${baseUrl}endpoint` pattern at most of the places

## by making the following changes

- Updates url mapper method
- Add `/` at the end of the base url for mobius wss url coming from error response.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Registration
- Keepalive
- 401 - 101 error causing unregister and then register

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
