### PR TITLE
feat(calling): emit connect and disconnect event for mobius socket

### DIFF
--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -366,8 +366,9 @@ async function initCalling(e) {
       registerElm.disabled = false;
 
       if(window.callingClient === undefined && calling.callingClient !== undefined) {
-      callingClient = window.callingClient = calling.callingClient;
-    }
+        callingClient = window.callingClient = calling.callingClient;
+        monitorMobiusSocket();
+      }
 
       if (window.contacts === undefined) {
         contacts = window.contacts = calling.contactClient;
@@ -432,6 +433,18 @@ function userSession() {
   callingClient.on('callingClient:user_recent_sessions', (sessionData) => {
     console.log('Users recent session data : ', sessionData.data.userSessions.userSessions[0]);
     userSessionData.innerText = `${JSON.stringify(sessionData.data.userSessions.userSessions[0])}`;
+  });
+}
+
+function monitorMobiusSocket() {
+  if (!callingClient) return;
+
+  callingClient.on('callingClient:mobius_socket_connected', () => {
+    console.log('Mobius socket connected');
+  });
+
+  callingClient.on('callingClient:mobius_socket_disconnected', (event) => {
+    console.log('Mobius socket disconnected, reason: ', event.reason);
   });
 }
 

--- a/docs/samples/calling/app.js
+++ b/docs/samples/calling/app.js
@@ -446,6 +446,12 @@ function monitorMobiusSocket() {
   callingClient.on('callingClient:mobius_socket_disconnected', (event) => {
     console.log('Mobius socket disconnected, reason: ', event.reason);
   });
+
+  // The connected event is emitted during client init, before this listener is
+  // attached, so reconcile the current state to avoid missing the initial connection.
+  if (callingClient.isMobiusSocketConnected()) {
+    console.log('Mobius socket connected');
+  }
 }
 
 function createDevice() {

--- a/packages/calling/src/CallingClient/CallingClient.test.ts
+++ b/packages/calling/src/CallingClient/CallingClient.test.ts
@@ -67,6 +67,7 @@ jest.mock('../mobius-socket', () => ({
   getMobiusSocketInstance: jest.fn().mockReturnValue({
     sendWssRequest: jest.fn(),
     connect: jest.fn(),
+    isConnected: jest.fn().mockReturnValue(false),
     on: jest.fn(),
     off: jest.fn(),
   }),
@@ -933,9 +934,11 @@ describe('CallingClient Tests', () => {
       ).getMobiusSocketInstance(webex) as {
         on: jest.Mock;
         off: jest.Mock;
+        isConnected: jest.Mock;
       };
       (mobiusSocketMock.on as jest.Mock).mockClear();
       (mobiusSocketMock.off as jest.Mock).mockClear();
+      (mobiusSocketMock.isConnected as jest.Mock).mockReturnValue(false);
 
       callingClient = await createClient(webex, {
         logger: {level: LOGGER.INFO},
@@ -971,6 +974,15 @@ describe('CallingClient Tests', () => {
 
         expect(listener).toHaveBeenCalledTimes(1);
         expect(listener).toHaveBeenCalledWith({reason});
+      }
+    );
+
+    it.each([true, false])(
+      'isMobiusSocketConnected() reflects the underlying socket state (%s) when WSS is enabled',
+      (connected) => {
+        (mobiusSocketMock.isConnected as jest.Mock).mockReturnValue(connected);
+
+        expect(callingClient.isMobiusSocketConnected()).toBe(connected);
       }
     );
   });

--- a/packages/calling/src/CallingClient/CallingClient.test.ts
+++ b/packages/calling/src/CallingClient/CallingClient.test.ts
@@ -15,7 +15,12 @@ import {
   WebexRequestPayload,
 } from '../common/types';
 /* eslint-disable dot-notation */
-import {CALLING_CLIENT_EVENT_KEYS, CallSessionEvent, MOBIUS_EVENT_KEYS} from '../Events/types';
+import {
+  CALLING_CLIENT_EVENT_KEYS,
+  CallSessionEvent,
+  MOBIUS_EVENT_KEYS,
+  MOBIUS_SOCKET_DISCONNECT_REASON,
+} from '../Events/types';
 import log from '../Logger';
 import {CallingClient, createClient} from './CallingClient';
 import {ICallingClient} from './types';
@@ -902,6 +907,72 @@ describe('CallingClient Tests', () => {
         })
       );
     });
+  });
+
+  describe('Mobius socket connection events', () => {
+    let callingClient: ICallingClient;
+    let mobiusSocketMock;
+
+    const getSocketHandlerFor = (eventName: string) => {
+      const onCall = (mobiusSocketMock.on as jest.Mock).mock.calls.find(
+        (call) => call[0] === eventName
+      );
+
+      return onCall[1];
+    };
+
+    beforeEach(async () => {
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue({value: true});
+      APIRequest.resetInstance();
+      APIRequest.getInstance({webex});
+
+      mobiusSocketMock = (
+        jest.requireMock('../mobius-socket') as {
+          getMobiusSocketInstance: (w: unknown) => unknown;
+        }
+      ).getMobiusSocketInstance(webex) as {
+        on: jest.Mock;
+        off: jest.Mock;
+      };
+      (mobiusSocketMock.on as jest.Mock).mockClear();
+      (mobiusSocketMock.off as jest.Mock).mockClear();
+
+      callingClient = await createClient(webex, {
+        logger: {level: LOGGER.INFO},
+      });
+    });
+
+    afterEach(() => {
+      callingClient.removeAllListeners();
+      callManager.removeAllListeners();
+      webex.internal.device.features.developer.get = jest.fn().mockReturnValue({value: false});
+    });
+
+    it('emits MOBIUS_SOCKET_CONNECTED when the socket comes online', () => {
+      const listener = jest.fn();
+      callingClient.on(CALLING_CLIENT_EVENT_KEYS.MOBIUS_SOCKET_CONNECTED, listener);
+
+      getSocketHandlerFor('online')();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['offline.permanent', MOBIUS_SOCKET_DISCONNECT_REASON.PERMANENT],
+      ['offline.transient', MOBIUS_SOCKET_DISCONNECT_REASON.TRANSIENT],
+      ['offline.replaced', MOBIUS_SOCKET_DISCONNECT_REASON.REPLACED],
+    ])(
+      'emits MOBIUS_SOCKET_DISCONNECTED with the matching reason when %s fires',
+      (eventName, reason) => {
+        const listener = jest.fn();
+        callingClient.on(CALLING_CLIENT_EVENT_KEYS.MOBIUS_SOCKET_DISCONNECTED, listener);
+
+        getSocketHandlerFor(eventName as string)();
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener).toHaveBeenCalledWith({reason});
+      }
+    );
   });
 
   describe('getDevices', () => {

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -228,6 +228,11 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
 
     await this.getMobiusServers();
     if (this.apiRequest.isSocketEnabled()) {
+      this.apiRequest.registerMobiusSocketConnectionListener({
+        onConnected: () => this.emit(CALLING_CLIENT_EVENT_KEYS.MOBIUS_SOCKET_CONNECTED),
+        onDisconnected: (reason) =>
+          this.emit(CALLING_CLIENT_EVENT_KEYS.MOBIUS_SOCKET_DISCONNECTED, {reason}),
+      });
       await this.connectToMobiusSocket();
       this.apiRequest.registerMobiusSocketListener(this.handleMobiusAsyncEvent);
     }

--- a/packages/calling/src/CallingClient/CallingClient.ts
+++ b/packages/calling/src/CallingClient/CallingClient.ts
@@ -1039,6 +1039,17 @@ export class CallingClient extends Eventing<CallingClientEventTypes> implements 
   }
 
   /**
+   * Indicates whether the Mobius WebSocket transport is currently connected.
+   *
+   * The `MOBIUS_SOCKET_CONNECTED` event is emitted during `init()`, so consumers that
+   * subscribe afterwards may miss it; this lets them reconcile the current state. Returns
+   * `false` when the WebSocket transport is not enabled.
+   */
+  public isMobiusSocketConnected(): boolean {
+    return this.apiRequest.isSocketEnabled() && this.apiRequest.isSocketConnected();
+  }
+
+  /**
    * Uploads logs to help troubleshoot SDK issues.
    *
    * This method collects the current SDK logs including network requests, WebSocket

--- a/packages/calling/src/CallingClient/ai-docs/AGENTS.md
+++ b/packages/calling/src/CallingClient/ai-docs/AGENTS.md
@@ -61,6 +61,7 @@ The following methods are defined on the `ICallingClient` interface and are the 
 | `getDevices`       | `(userId?: string): Promise<DeviceType[]>` | Fetches devices from Mobius for the user        |
 | `getActiveCalls`   | `(): Record<string, ICall[]>`              | Returns active calls grouped by lineId          |
 | `getConnectedCall` | `(): ICall \| undefined`                   | Returns the currently connected (non-held) call |
+| `isMobiusSocketConnected` | `(): boolean`                       | Whether the Mobius WebSocket transport is currently connected. Lets consumers that subscribe to `mobius_socket_connected` after `init()` reconcile the initial state. `false` when WSS transport is not in use. |
 | `mediaEngine`      | `typeof Media`                             | The `@webex/internal-media-core` engine         |
 
 ### CallingClient Class Methods (not on ICallingClient interface)

--- a/packages/calling/src/CallingClient/ai-docs/AGENTS.md
+++ b/packages/calling/src/CallingClient/ai-docs/AGENTS.md
@@ -77,6 +77,8 @@ The following methods are defined on the `ICallingClient` interface and are the 
 | `callingClient:outgoing_call`        | `CALLING_CLIENT_EVENT_KEYS.OUTGOING_CALL`     | `string` (callId)    | Outbound call initiated      |
 | `callingClient:user_recent_sessions` | `CALLING_CLIENT_EVENT_KEYS.USER_SESSION_INFO` | `CallSessionEvent`   | User session info from Janus |
 | `callingClient:all_calls_cleared`    | `CALLING_CLIENT_EVENT_KEYS.ALL_CALLS_CLEARED` | _(none)_             | All active calls have ended  |
+| `callingClient:mobius_socket_connected`    | `CALLING_CLIENT_EVENT_KEYS.MOBIUS_SOCKET_CONNECTED` | _(none)_             | Mobius WebSocket (re)connected (WSS transport only) |
+| `callingClient:mobius_socket_disconnected` | `CALLING_CLIENT_EVENT_KEYS.MOBIUS_SOCKET_DISCONNECTED` | `MobiusSocketDisconnectedEvent` (`{reason}`) | Mobius WebSocket disconnected; `reason` is `permanent` / `transient` / `replaced` (WSS transport only) |
 
 ---
 

--- a/packages/calling/src/CallingClient/constants.ts
+++ b/packages/calling/src/CallingClient/constants.ts
@@ -240,6 +240,8 @@ export const METHODS = {
   CONNECT_TO_MOBIUS_SOCKET: 'connectToMobiusSocket',
   REGISTER_MOBIUS_SOCKET_LISTENER: 'registerMobiusSocketListener',
   UNREGISTER_MOBIUS_SOCKET_LISTENER: 'unregisterMobiusSocketListener',
+  REGISTER_MOBIUS_SOCKET_CONNECTION_LISTENER: 'registerMobiusSocketConnectionListener',
+  UNREGISTER_MOBIUS_SOCKET_CONNECTION_LISTENER: 'unregisterMobiusSocketConnectionListener',
   HANDLE_MOBIUS_ASYNC_EVENT: 'handleMobiusAsyncEvent',
   HANDLE_REGISTRATION_DOWN_EVENT: 'handleRegistrationDownEvent',
   DISCONNECT_FROM_MOBIUS_SOCKET: 'disconnectFromMobiusSocket',

--- a/packages/calling/src/CallingClient/types.ts
+++ b/packages/calling/src/CallingClient/types.ts
@@ -128,4 +128,22 @@ export interface ICallingClient extends Eventing<CallingClientEventTypes> {
    * The `connectedCall` object will be the Call object of the connected call with the client
    */
   getConnectedCall(): ICall | undefined;
+
+  /**
+   * Indicates whether the Mobius WebSocket transport is currently connected.
+   *
+   * The `callingClient:mobius_socket_connected` event is emitted during client
+   * initialization, so consumers that subscribe afterwards may miss it. This method
+   * lets them reconcile the current connection state right after subscribing. Returns
+   * `false` when the WebSocket transport is not in use.
+   *
+   * @example
+   * ```typescript
+   * callingClient.on(CALLING_CLIENT_EVENT_KEYS.MOBIUS_SOCKET_CONNECTED, onConnected);
+   * if (callingClient.isMobiusSocketConnected()) {
+   *   onConnected();
+   * }
+   * ```
+   */
+  isMobiusSocketConnected(): boolean;
 }

--- a/packages/calling/src/CallingClient/utils/constants.ts
+++ b/packages/calling/src/CallingClient/utils/constants.ts
@@ -39,3 +39,15 @@ export enum MOBIUS_SOCKET_MESSAGE_TYPE {
   CALL_DELETE = 'call_delete',
   CALL_DELETE_RESPONSE = 'call_delete.response',
 }
+
+/**
+ * Reason describing why the Mobius WebSocket disconnected.
+ * - `PERMANENT`: socket closed and will not be reconnected automatically.
+ * - `TRANSIENT`: socket closed and a reconnect attempt is in progress.
+ * - `REPLACED`: socket was replaced by a newer connection.
+ */
+export enum MOBIUS_SOCKET_DISCONNECT_REASON {
+  PERMANENT = 'permanent',
+  TRANSIENT = 'transient',
+  REPLACED = 'replaced',
+}

--- a/packages/calling/src/CallingClient/utils/request.test.ts
+++ b/packages/calling/src/CallingClient/utils/request.test.ts
@@ -161,6 +161,19 @@ describe('APIRequest', () => {
     });
   });
 
+  describe('isSocketConnected', () => {
+    it.each([true, false])(
+      'should delegate to the Mobius socket isConnected() and return %s',
+      (connected) => {
+        mockMobiusSocket.isConnected.mockReturnValue(connected);
+        const apiRequest = APIRequest.getInstance({webex});
+
+        expect(apiRequest.isSocketConnected()).toBe(connected);
+        expect(mockMobiusSocket.isConnected).toHaveBeenCalled();
+      }
+    );
+  });
+
   describe('connectToMobiusSocket', () => {
     it('should return immediately if socket is already connected', async () => {
       mockMobiusSocket.isConnected.mockReturnValue(true);

--- a/packages/calling/src/CallingClient/utils/request.test.ts
+++ b/packages/calling/src/CallingClient/utils/request.test.ts
@@ -7,7 +7,7 @@ import {getMobiusSocketInstance} from '../../mobius-socket';
 import {getMetricManager} from '../../Metrics';
 import {METRIC_EVENT, METRIC_TYPE, MOBIUS_SOCKET_ACTION} from '../../Metrics/types';
 import {isMobiusWssEnabled} from './wsFeatureFlag';
-import {MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
+import {MOBIUS_SOCKET_DISCONNECT_REASON, MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
 import {MobiusSocketResponse, MobiusAsyncEvent} from './types';
 
 // Mock dependencies
@@ -676,6 +676,90 @@ describe('APIRequest', () => {
         MOBIUS_SOCKET_ACTION.LISTENER_UNREGISTERED,
         METRIC_TYPE.BEHAVIORAL
       );
+    });
+  });
+
+  describe('registerMobiusSocketConnectionListener', () => {
+    const getHandlerFor = (eventName: string): ((...args: unknown[]) => void) => {
+      const call = mockMobiusSocket.on.mock.calls.find(([name]: [string]) => name === eventName);
+
+      return call[1];
+    };
+
+    it('should attach listeners to online and offline.* socket events', () => {
+      const apiRequest = APIRequest.getInstance({webex});
+
+      apiRequest.registerMobiusSocketConnectionListener({
+        onConnected: jest.fn(),
+        onDisconnected: jest.fn(),
+      });
+
+      expect(mockMobiusSocket.on).toHaveBeenCalledWith('online', expect.any(Function));
+      expect(mockMobiusSocket.on).toHaveBeenCalledWith('offline.permanent', expect.any(Function));
+      expect(mockMobiusSocket.on).toHaveBeenCalledWith('offline.transient', expect.any(Function));
+      expect(mockMobiusSocket.on).toHaveBeenCalledWith('offline.replaced', expect.any(Function));
+      expect(infoSpy).toHaveBeenCalledWith('Attaching Mobius socket connection listener', {
+        file: 'REQUEST',
+        method: 'registerMobiusSocketConnectionListener',
+      });
+      expect(logSpy).toHaveBeenCalledWith('Mobius socket connection listener attached', {
+        file: 'REQUEST',
+        method: 'registerMobiusSocketConnectionListener',
+      });
+    });
+
+    it('should invoke onConnected when the online event fires', () => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const onConnected = jest.fn();
+
+      apiRequest.registerMobiusSocketConnectionListener({
+        onConnected,
+        onDisconnected: jest.fn(),
+      });
+
+      getHandlerFor('online')();
+
+      expect(onConnected).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['offline.permanent', MOBIUS_SOCKET_DISCONNECT_REASON.PERMANENT],
+      ['offline.transient', MOBIUS_SOCKET_DISCONNECT_REASON.TRANSIENT],
+      ['offline.replaced', MOBIUS_SOCKET_DISCONNECT_REASON.REPLACED],
+    ])('should invoke onDisconnected with %s reason when %s fires', (eventName, reason) => {
+      const apiRequest = APIRequest.getInstance({webex});
+      const onDisconnected = jest.fn();
+
+      apiRequest.registerMobiusSocketConnectionListener({
+        onConnected: jest.fn(),
+        onDisconnected,
+      });
+
+      getHandlerFor(eventName as string)();
+
+      expect(onDisconnected).toHaveBeenCalledTimes(1);
+      expect(onDisconnected).toHaveBeenCalledWith(reason);
+    });
+  });
+
+  describe('unregisterMobiusSocketConnectionListener', () => {
+    it('should detach listeners from online and offline.* socket events', () => {
+      const apiRequest = APIRequest.getInstance({webex});
+
+      apiRequest.unregisterMobiusSocketConnectionListener();
+
+      expect(mockMobiusSocket.off).toHaveBeenCalledWith('online');
+      expect(mockMobiusSocket.off).toHaveBeenCalledWith('offline.permanent');
+      expect(mockMobiusSocket.off).toHaveBeenCalledWith('offline.transient');
+      expect(mockMobiusSocket.off).toHaveBeenCalledWith('offline.replaced');
+      expect(infoSpy).toHaveBeenCalledWith('Detaching Mobius socket connection listener', {
+        file: 'REQUEST',
+        method: 'unregisterMobiusSocketConnectionListener',
+      });
+      expect(logSpy).toHaveBeenCalledWith('Mobius socket connection listener detached', {
+        file: 'REQUEST',
+        method: 'unregisterMobiusSocketConnectionListener',
+      });
     });
   });
 });

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -3,12 +3,18 @@ import {getMobiusSocketInstance} from '../../mobius-socket';
 import {WebexRequestPayload} from '../../common/types';
 import {WebexSDK} from '../../SDKConnector/types';
 import log from '../../Logger';
-import {APIRequestConfig, APIRequestOptions, MobiusAsyncEvent, MobiusSocketResponse} from './types';
+import {
+  APIRequestConfig,
+  APIRequestOptions,
+  MobiusAsyncEvent,
+  MobiusSocketConnectionListener,
+  MobiusSocketResponse,
+} from './types';
 import {
   deriveMobiusSocketMessageType,
   isSupplementaryServiceMessageType,
 } from './mobiusSocketMapper';
-import {MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
+import {MOBIUS_SOCKET_DISCONNECT_REASON, MOBIUS_SOCKET_MESSAGE_TYPE} from './constants';
 import {isMobiusWssEnabled} from './wsFeatureFlag';
 import {CALLING_USER_AGENT, METHODS, REQUEST_FILE} from '../constants';
 import {getMetricManager} from '../../Metrics';
@@ -303,6 +309,58 @@ export class APIRequest {
       MOBIUS_SOCKET_ACTION.LISTENER_UNREGISTERED,
       METRIC_TYPE.BEHAVIORAL
     );
+  }
+
+  /**
+   * Bridges the underlying Mobius socket connect/disconnect lifecycle to the caller.
+   * The socket emits `online` on every successful (re)connect and `offline.*` on close,
+   * where the suffix distinguishes the disconnect reason.
+   *
+   * @param listener - Callbacks invoked on connect and disconnect transitions.
+   */
+  public registerMobiusSocketConnectionListener(listener: MobiusSocketConnectionListener): void {
+    const logContext = {
+      file: REQUEST_FILE,
+      method: METHODS.REGISTER_MOBIUS_SOCKET_CONNECTION_LISTENER,
+    };
+
+    log.info('Attaching Mobius socket connection listener', logContext);
+
+    this.mobiusSocket.on('online', () => {
+      log.log('Mobius socket connected', logContext);
+      listener.onConnected();
+    });
+
+    this.mobiusSocket.on('offline.permanent', () => {
+      log.log('Mobius socket disconnected (permanent)', logContext);
+      listener.onDisconnected(MOBIUS_SOCKET_DISCONNECT_REASON.PERMANENT);
+    });
+
+    this.mobiusSocket.on('offline.transient', () => {
+      log.log('Mobius socket disconnected (transient)', logContext);
+      listener.onDisconnected(MOBIUS_SOCKET_DISCONNECT_REASON.TRANSIENT);
+    });
+
+    this.mobiusSocket.on('offline.replaced', () => {
+      log.log('Mobius socket disconnected (replaced)', logContext);
+      listener.onDisconnected(MOBIUS_SOCKET_DISCONNECT_REASON.REPLACED);
+    });
+
+    log.log('Mobius socket connection listener attached', logContext);
+  }
+
+  public unregisterMobiusSocketConnectionListener(): void {
+    const logContext = {
+      file: REQUEST_FILE,
+      method: METHODS.UNREGISTER_MOBIUS_SOCKET_CONNECTION_LISTENER,
+    };
+
+    log.info('Detaching Mobius socket connection listener', logContext);
+    this.mobiusSocket.off('online');
+    this.mobiusSocket.off('offline.permanent');
+    this.mobiusSocket.off('offline.transient');
+    this.mobiusSocket.off('offline.replaced');
+    log.log('Mobius socket connection listener detached', logContext);
   }
 }
 

--- a/packages/calling/src/CallingClient/utils/request.ts
+++ b/packages/calling/src/CallingClient/utils/request.ts
@@ -349,6 +349,17 @@ export class APIRequest {
     log.log('Mobius socket connection listener attached', logContext);
   }
 
+  /**
+   * Whether the underlying Mobius WebSocket is currently connected.
+   *
+   * Useful for consumers that subscribe to connection events after the socket may
+   * already be up (the socket only emits `online` on a fresh (re)connect), so they
+   * can reconcile the initial connected state instead of waiting for the next event.
+   */
+  public isSocketConnected(): boolean {
+    return this.mobiusSocket.isConnected();
+  }
+
   public unregisterMobiusSocketConnectionListener(): void {
     const logContext = {
       file: REQUEST_FILE,

--- a/packages/calling/src/CallingClient/utils/types.ts
+++ b/packages/calling/src/CallingClient/utils/types.ts
@@ -1,6 +1,7 @@
 import {MobiusCallData, MobiusRegistrationDownData} from '../calling/types';
 import {WebexRequestPayload} from '../../common/types';
 import {WebexSDK} from '../../SDKConnector/types';
+import {MOBIUS_SOCKET_DISCONNECT_REASON} from './constants';
 
 /**
  * Configuration for APIRequest class
@@ -55,4 +56,12 @@ export type MobiusAsyncEvent = {
   eventId: string;
   trackingId: string;
   data: MobiusCallData | MobiusRegistrationDownData;
+};
+
+/**
+ * Callbacks invoked when the Mobius WebSocket connects or disconnects.
+ */
+export type MobiusSocketConnectionListener = {
+  onConnected: () => void;
+  onDisconnected: (reason: MOBIUS_SOCKET_DISCONNECT_REASON) => void;
 };

--- a/packages/calling/src/Events/types.ts
+++ b/packages/calling/src/Events/types.ts
@@ -4,6 +4,9 @@ import {LINE_EVENTS} from '../CallingClient/line/types';
 import type {ICall} from '../CallingClient/calling/types';
 import {CallId, DisplayInformation} from '../common/types';
 import {CallError, CallingClientError, LineError} from '../Errors';
+import {MOBIUS_SOCKET_DISCONNECT_REASON} from '../CallingClient/utils/constants';
+
+export {MOBIUS_SOCKET_DISCONNECT_REASON};
 
 /** External Eventing Start */
 export enum COMMON_EVENT_KEYS {
@@ -22,7 +25,13 @@ export enum CALLING_CLIENT_EVENT_KEYS {
   OUTGOING_CALL = 'callingClient:outgoing_call',
   USER_SESSION_INFO = 'callingClient:user_recent_sessions',
   ALL_CALLS_CLEARED = 'callingClient:all_calls_cleared',
+  MOBIUS_SOCKET_CONNECTED = 'callingClient:mobius_socket_connected',
+  MOBIUS_SOCKET_DISCONNECTED = 'callingClient:mobius_socket_disconnected',
 }
+
+export type MobiusSocketDisconnectedEvent = {
+  reason: MOBIUS_SOCKET_DISCONNECT_REASON;
+};
 
 export enum CALL_EVENT_KEYS {
   ALERTING = 'alerting',
@@ -231,6 +240,10 @@ export type CallingClientEventTypes = {
   [CALLING_CLIENT_EVENT_KEYS.USER_SESSION_INFO]: (event: CallSessionEvent) => void;
   [CALLING_CLIENT_EVENT_KEYS.OUTGOING_CALL]: (callId: string) => void;
   [CALLING_CLIENT_EVENT_KEYS.ALL_CALLS_CLEARED]: () => void;
+  [CALLING_CLIENT_EVENT_KEYS.MOBIUS_SOCKET_CONNECTED]: () => void;
+  [CALLING_CLIENT_EVENT_KEYS.MOBIUS_SOCKET_DISCONNECTED]: (
+    event: MobiusSocketDisconnectedEvent
+  ) => void;
 };
 
 export type CallHistoryEventTypes = {

--- a/packages/calling/src/index.ts
+++ b/packages/calling/src/index.ts
@@ -38,6 +38,8 @@ export {
   Disposition,
   LINE_EVENT_KEYS,
   COMMON_EVENT_KEYS,
+  MOBIUS_SOCKET_DISCONNECT_REASON,
+  MobiusSocketDisconnectedEvent,
   UserSession,
 } from './Events/types';
 export {

--- a/packages/calling/src/mobius-socket/mobius-socket.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.test.ts
@@ -1399,6 +1399,61 @@ describe('plugin-mobius-socket', () => {
         });
       });
 
+      describe('#_onclose() with code 4429 (too many requests)', () => {
+        let mockSocket;
+        let anotherSocket;
+
+        beforeEach(() => {
+          mockSocket = {
+            url: 'ws://active-socket.com',
+            removeAllListeners: sinon.stub(),
+          };
+          anotherSocket = {
+            url: 'ws://old-socket.com',
+            removeAllListeners: sinon.stub(),
+          };
+          mobiusSocket.socket = mockSocket;
+          mobiusSocket.connected = true;
+          sinon.stub(mobiusSocket, 'emitEvent');
+          sinon.stub(mobiusSocket, 'reconnect');
+        });
+
+        afterEach(() => {
+          mobiusSocket.emitEvent.restore();
+          mobiusSocket.reconnect.restore();
+        });
+
+        it('should emit offline.permanent and tear down state on active socket close, without reconnecting', () => {
+          const closeEvent = {
+            code: 4429,
+            reason: 'too many requests',
+          };
+
+          mobiusSocket.onclose(closeEvent, mockSocket);
+
+          assert.calledWith(mobiusSocket.emitEvent, 'offline', closeEvent);
+          // 4429 tears down without auto-reconnect, so lifecycle listeners must be notified.
+          assert.calledWith(mobiusSocket.emitEvent, 'offline.permanent', closeEvent);
+          assert.notCalled(mobiusSocket.reconnect);
+          assert.isFalse(mobiusSocket.connected);
+        });
+
+        it('should not emit offline.permanent for a non-active socket close', () => {
+          const closeEvent = {
+            code: 4429,
+            reason: 'too many requests',
+          };
+
+          mobiusSocket.onclose(closeEvent, anotherSocket);
+
+          assert.neverCalledWith(mobiusSocket.emitEvent, 'offline', closeEvent);
+          assert.neverCalledWith(mobiusSocket.emitEvent, 'offline.permanent', closeEvent);
+          assert.notCalled(mobiusSocket.reconnect);
+          assert.isTrue(mobiusSocket.connected);
+          assert.strictEqual(mobiusSocket.socket, mockSocket);
+        });
+      });
+
       describe('shutdown switchover with retry logic', () => {
         let connectWithBackoffStub;
 

--- a/packages/calling/src/mobius-socket/mobius-socket.test.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.test.ts
@@ -1306,7 +1306,7 @@ describe('plugin-mobius-socket', () => {
           mobiusSocket.reconnect.restore();
         });
 
-        it('should handle active socket close with 4001 - emits registration.down and tears down state', () => {
+        it('should handle active socket close with 4001 - emits registration.down, offline.permanent, and tears down state', () => {
           const closeEvent = {
             code: 4001,
             reason: 'replaced during shutdown',
@@ -1316,7 +1316,9 @@ describe('plugin-mobius-socket', () => {
 
           assert.calledWith(mobiusSocket.emitEvent, 'offline', closeEvent);
           assert.calledWith(mobiusSocket.emitEvent, 'event:async_event', MOBIUS_SOCKET_4001_EVENT);
-          assert.neverCalledWith(mobiusSocket.emitEvent, 'offline.permanent', closeEvent);
+          // 4001 will not reconnect, so connection-lifecycle listeners must be notified
+          // via the suffixed offline.permanent event in addition to registration.down.
+          assert.calledWith(mobiusSocket.emitEvent, 'offline.permanent', closeEvent);
           assert.notCalled(mobiusSocket.reconnect);
           assert.isFalse(mobiusSocket.connected);
         });
@@ -1332,6 +1334,8 @@ describe('plugin-mobius-socket', () => {
           assert.calledWith(mobiusSocket.emitEvent, 'event:async_event', MOBIUS_SOCKET_4001_EVENT);
           assert.neverCalledWith(mobiusSocket.emitEvent, 'offline.replaced', closeEvent);
           assert.neverCalledWith(mobiusSocket.emitEvent, 'offline', closeEvent);
+          // Non-active socket close must not surface a disconnect to lifecycle listeners.
+          assert.neverCalledWith(mobiusSocket.emitEvent, 'offline.permanent', closeEvent);
           assert.notCalled(mobiusSocket.reconnect);
           assert.isTrue(mobiusSocket.connected);
           assert.strictEqual(mobiusSocket.socket, mockSocket);
@@ -1343,17 +1347,19 @@ describe('plugin-mobius-socket', () => {
             reason: 'replaced during shutdown',
           };
 
-          // Non-active socket: only registration.down is emitted (no 'offline')
+          // Non-active socket: only registration.down is emitted (no 'offline' / 'offline.permanent')
           mobiusSocket.onclose(closeEvent, anotherSocket);
           assert.calledWith(mobiusSocket.emitEvent, 'event:async_event', MOBIUS_SOCKET_4001_EVENT);
           assert.neverCalledWith(mobiusSocket.emitEvent, 'offline', closeEvent);
+          assert.neverCalledWith(mobiusSocket.emitEvent, 'offline.permanent', closeEvent);
 
           mobiusSocket.emitEvent.resetHistory();
 
-          // Active socket: 'offline' is emitted alongside registration.down
+          // Active socket: 'offline' and 'offline.permanent' are emitted alongside registration.down
           mobiusSocket.onclose(closeEvent, mockSocket);
           assert.calledWith(mobiusSocket.emitEvent, 'offline', closeEvent);
           assert.calledWith(mobiusSocket.emitEvent, 'event:async_event', MOBIUS_SOCKET_4001_EVENT);
+          assert.calledWith(mobiusSocket.emitEvent, 'offline.permanent', closeEvent);
         });
 
         it('should handle missing sourceSocket parameter (treats as non-active)', () => {
@@ -1366,6 +1372,7 @@ describe('plugin-mobius-socket', () => {
 
           assert.calledWith(mobiusSocket.emitEvent, 'event:async_event', MOBIUS_SOCKET_4001_EVENT);
           assert.neverCalledWith(mobiusSocket.emitEvent, 'offline.replaced', closeEvent);
+          assert.neverCalledWith(mobiusSocket.emitEvent, 'offline.permanent', closeEvent);
           assert.notCalled(mobiusSocket.reconnect);
         });
 

--- a/packages/calling/src/mobius-socket/mobius-socket.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.ts
@@ -863,8 +863,12 @@ class MobiusSocket extends EventEmitter {
           await this.reconnect(this.socket?.url);
           break;
         case 4429:
-          // Silently ignore too many requests
+          // Too many requests: the socket is torn down and not auto-reconnected, so surface
+          // a permanent disconnect to connection-lifecycle listeners (which only observe the
+          // suffixed offline.* events) instead of leaving them unaware of the close.
+          // Silently ignore (do not attempt reconnect)
           this.logger.error(`too many requests, statusCode=${event.code}`, loggerContext);
+          if (isActiveSocket) this.emitEvent('offline.permanent', event);
           break;
         default:
           this.logger.info(`socket disconnected unexpectedly; will not reconnect`, loggerContext);

--- a/packages/calling/src/mobius-socket/mobius-socket.ts
+++ b/packages/calling/src/mobius-socket/mobius-socket.ts
@@ -818,6 +818,10 @@ class MobiusSocket extends EventEmitter {
           // Handle the same way we do for registration.down event from Mobius.
           this.logger.info(`socket closed with 4001; will not reconnect`, loggerContext);
           this.emitEvent('event:async_event', MOBIUS_SOCKET_4001_EVENT);
+          // 4001 means the socket is offline and will not reconnect, so surface a
+          // permanent disconnect to connection-lifecycle listeners (which only observe
+          // the suffixed offline.* events) in addition to the registration.down signal.
+          if (isActiveSocket) this.emitEvent('offline.permanent', event);
           break;
         case 1000:
         case 1001:


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [CAI-7968](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7968) >

## This pull request addresses

Adds code to emit events for mobius connection status which could be listened as follows:

```js
  callingClient.on('callingClient:mobius_socket_connected', () => {
    console.log('Mobius socket connected');
  });

  callingClient.on('callingClient:mobius_socket_disconnected', (event) => {
    console.log('Mobius socket disconnected, reason: ', event.reason);
  });

 // The connected event is emitted during client init, before this listener is
 // attached, so reconcile the current state to avoid missing the initial connection. 
 if (callingClient.isMobiusSocketConnected()) {
    console.log('Mobius socket connected');
  }
```

**Note**: This feature is being provided solely for the logging purpose in the consuming application such as Agent Desktop.

## by making the following changes

Exposed listener from the APIRequest file and registered inside the CallingClient which re-emits the event for end application.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

Tested the event being listened in the sample app.

~~One caveat is that application using the `Calling.Init()` of `calling.js` will not get the `connected` event for very first connection if they don't provide the **webex** object to the `Calling.Init()`. Agent Desktop provides this value so, it should work fine there.~~ Updated the example code

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Cursor with opus 4.8
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
