### PR TITLE
fix(task-refactor): fixed minor bugs in ui controls

### DIFF
--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -226,7 +226,7 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           // the consulted agent (Agent 2) accepts. Clears the incoming notification.
           [TaskEvent.CONSULT_END]: {
             target: TaskState.TERMINATED,
-            actions: ['updateTaskData', 'clearConsultState', 'emitTaskReject'],
+            actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
           },
         },
       },

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -259,6 +259,17 @@ function computeVoiceInteractionUIControls(
     (isConsulting ||
       taskData?.type === 'AgentConsulting' ||
       selfParticipant?.consultState === 'consulting');
+  const hideExitConferenceOnMainLegForEpDnConsultFromConference =
+    currentLeg === 'main' &&
+    inConference &&
+    consultFromConference &&
+    consultInitiator &&
+    (isConsulting ||
+      consultInProgress ||
+      taskData?.type === 'AgentConsultCreated' ||
+      taskData?.type === 'AgentConsulting' ||
+      selfParticipant?.consultState === 'consultInitiated' ||
+      selfParticipant?.consultState === 'consulting');
   const forceHeldPostConsultControls =
     !hideExitConferenceWhileConsultPending &&
     (postDeclineHeldMainLeg || postConsultCompletedHeldMainLeg);
@@ -308,6 +319,7 @@ function computeVoiceInteractionUIControls(
       if (!isWebrtc) return DISABLED;
       if (isWrappingUp) return DISABLED;
       if (currentLeg === 'consult' && !selfInConsultCall) return DISABLED;
+      if ((isConsulting || hasParallelConsultLeg) && !isCurrentLegActive) return VISIBLE_DISABLED;
       if (isConsulting) return VISIBLE_ENABLED;
 
       if (isConnected || isHeld || isConferencing) {
@@ -469,6 +481,7 @@ function computeVoiceInteractionUIControls(
     // ExitConference: in conference with multiple agents in main call
     exitConference: (() => {
       if (hideExitConferenceWhileConsultPending) return DISABLED;
+      if (hideExitConferenceOnMainLegForEpDnConsultFromConference) return DISABLED;
       if (allowHeldMainLegControlsForNonInitiator) return VISIBLE_ENABLED;
       if (showMainLegConferenceControlsDuringConsult) return VISIBLE_DISABLED;
       if (hideExitConferenceDuringActiveConsultFromConference) return DISABLED;

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
@@ -1,4 +1,4 @@
-import {TASK_CHANNEL_TYPE} from '../../../../../../src/services/task/types';
+import {TASK_CHANNEL_TYPE, VOICE_VARIANT} from '../../../../../../src/services/task/types';
 import {TaskState} from '../../../../../../src/services/task/state-machine/constants';
 import {
   computeUIControls,
@@ -667,6 +667,70 @@ describe('uiControlsComputer consult initiator controls', () => {
     expect(uiControls.consult.endConsult).toEqual({isVisible: true, isEnabled: true});
     expect(uiControls.consult.end).toEqual({isVisible: false, isEnabled: false});
     expect(uiControls.consult.switch).toEqual({isVisible: false, isEnabled: false});
+  });
+
+  it('enables mute only on active leg when main leg is active', () => {
+    const baseTaskData = createConsultTaskData();
+    const taskData = createTaskData({
+      ...baseTaskData,
+      interaction: {
+        ...baseTaskData.interaction,
+        media: {
+          ...baseTaskData.interaction.media,
+          'consult-media': {
+            ...baseTaskData.interaction.media['consult-media'],
+            participants: ['agent-1', 'agent-2'],
+          },
+        },
+      },
+    });
+    const baseContext = createVoiceContext();
+    const context = createVoiceContext({
+      taskData,
+      consultCallHeld: true,
+      uiControlConfig: {
+        ...baseContext.uiControlConfig,
+        voiceVariant: VOICE_VARIANT.WEBRTC,
+      },
+    });
+
+    const uiControls = computeUIControls(TaskState.CONNECTED, context, context.taskData);
+
+    expect(uiControls.activeLeg).toBe('main');
+    expect(uiControls.main.mute).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.consult.mute).toEqual({isVisible: true, isEnabled: false});
+  });
+
+  it('enables mute only on active leg when consult leg is active', () => {
+    const baseTaskData = createConsultTaskData();
+    const taskData = createTaskData({
+      ...baseTaskData,
+      interaction: {
+        ...baseTaskData.interaction,
+        media: {
+          ...baseTaskData.interaction.media,
+          'consult-media': {
+            ...baseTaskData.interaction.media['consult-media'],
+            participants: ['agent-1', 'agent-2'],
+          },
+        },
+      },
+    });
+    const baseContext = createVoiceContext();
+    const context = createVoiceContext({
+      taskData,
+      consultCallHeld: false,
+      uiControlConfig: {
+        ...baseContext.uiControlConfig,
+        voiceVariant: VOICE_VARIANT.WEBRTC,
+      },
+    });
+
+    const uiControls = computeUIControls(TaskState.CONSULTING, context, context.taskData);
+
+    expect(uiControls.activeLeg).toBe('consult');
+    expect(uiControls.main.mute).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.consult.mute).toEqual({isVisible: true, isEnabled: true});
   });
 
   it('hides transfer for the consulted agent during consult', () => {


### PR DESCRIPTION
### Description of changes made (Required)  
Updated task-state and UI controls handling for voice consult/conference edge cases in Contact Center task-refactor flow.

- Fixed consult-end event behavior so `AgentConsultEnded` emits consult-end semantics instead of reject semantics in offered consult path.
- Fixed mute control behavior for split-leg consult flows so mute is enabled only on the active leg and disabled on the inactive leg.
- Fixed conference UI behavior for EP-DN consult from conference so `exitConference` is hidden on the main leg (instead of visible + disabled).

### Associated issue number/tracking link https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7994
Bug bash fixes (no standalone issue link was provided).

### Relevant files (Optional)  
- `packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts`
- `packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts`
- `packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts`

### Bug fix (Required if bug)  
#### Symptom
- `AgentConsultEnded` could surface as task reject behavior in offered consult flow.
- During split-leg consult scenarios, mute could remain enabled on the inactive leg.
- During EP-DN consult while conference is active, main-leg `exitConference` was shown disabled instead of hidden.

#### Root Cause
- Incorrect action mapping in `OFFERED` state for `CONSULT_END`.
- Missing active-leg gating in mute enablement logic for consult/split-leg state.
- Missing EP-DN consult-from-conference condition to hide main-leg `exitConference`.

#### Fix
- Replaced `emitTaskReject` with `emitTaskConsultEnd` for `CONSULT_END` handling in `OFFERED` state.
- Added explicit active-leg checks to disable mute on non-active leg in consult/split-leg scenarios.
- Added targeted condition to hide `exitConference` on main leg for active EP-DN consult from conference.