### PR TITLE
fix(plugin-meetings): handling of changes to "view participant list" meeting controls

### DIFF
--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -56,11 +56,7 @@ export default class ControlsOptionsManager {
    */
   private mainLocusUrl: string;
 
-  private currentControls: {
-    viewTheParticipantList: {enabled: boolean; panelistEnabled: boolean; attendeeCount: boolean};
-  } = {
-    viewTheParticipantList: {enabled: false, panelistEnabled: false, attendeeCount: false},
-  };
+  private getControls: () => Record<string, any> = () => ({});
 
   /**
    * @param {MeetingRequest} request
@@ -73,6 +69,7 @@ export default class ControlsOptionsManager {
     options?: {
       locusUrl: string;
       displayHints?: Array<string>;
+      getControls: () => Record<string, any>;
     }
   ) {
     this.initialize(request);
@@ -95,7 +92,11 @@ export default class ControlsOptionsManager {
    * @public
    * @memberof ControlsOptionsManager
    */
-  public set(options?: {locusUrl: string; displayHints?: Array<string>}) {
+  public set(options?: {
+    locusUrl: string;
+    displayHints?: Array<string>;
+    getControls?: () => Record<string, any>;
+  }) {
     this.extract(options);
   }
 
@@ -124,22 +125,6 @@ export default class ControlsOptionsManager {
   }
 
   /**
-   * Updates the current viewTheParticipantList state from locus controls.
-   *
-   * @param {Object} state
-   * @returns {void}
-   * @public
-   * @memberof ControlsOptionsManager
-   */
-  public setCurrentViewTheParticipantList(state: {enabled: boolean; panelistEnabled: boolean; attendeeCount: boolean | number}) {
-    this.currentControls.viewTheParticipantList = {
-      enabled: state.enabled,
-      panelistEnabled: state.panelistEnabled,
-      attendeeCount: Boolean(state.attendeeCount),
-    };
-  }
-
-  /**
    * @returns {string}
    * @public
    * @memberof ControlsOptionsManager
@@ -163,9 +148,16 @@ export default class ControlsOptionsManager {
    * @private
    * @memberof ControlsOptionsManager
    */
-  private extract(options?: {locusUrl: string; displayHints?: Array<string>}) {
+  private extract(options?: {
+    locusUrl: string;
+    displayHints?: Array<string>;
+    getControls?: () => Record<string, any>;
+  }) {
     this.setDisplayHints(options?.displayHints);
     this.setLocusUrl(options?.locusUrl);
+    if (options?.getControls) {
+      this.getControls = options.getControls;
+    }
   }
 
   /**
@@ -198,10 +190,11 @@ export default class ControlsOptionsManager {
 
       if (control.scope === Control.viewTheParticipantList) {
         const props = properties as ViewTheParticipantListProperties;
+        const current = this.getControls()?.viewTheParticipantList;
         properties = {
-          enabled: props.enabled ?? this.currentControls.viewTheParticipantList.enabled,
-          panelistEnabled: props.panelistEnabled ?? this.currentControls.viewTheParticipantList.panelistEnabled,
-          attendeeCount: props.attendeeCount ?? this.currentControls.viewTheParticipantList.attendeeCount,
+          enabled: props.enabled ?? current?.enabled ?? false,
+          panelistEnabled: props.panelistEnabled ?? current?.panelistEnabled ?? false,
+          attendeeCount: props.attendeeCount ?? Boolean(current?.attendeeCount) ?? false,
         };
       }
 

--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -4,7 +4,7 @@ import PermissionError from '../common/errors/permission';
 import MeetingRequest from '../meeting/request';
 import LoggerProxy from '../common/logs/logger-proxy';
 import {Control, Setting} from './enums';
-import {ControlConfig} from './types';
+import {ControlConfig, ViewTheParticipantListProperties} from './types';
 import Util from './util';
 import {CAN_SET, CAN_UNSET, ENABLED} from './constants';
 
@@ -55,6 +55,12 @@ export default class ControlsOptionsManager {
    * @memberof ControlsOptionsManager
    */
   private mainLocusUrl: string;
+
+  private currentControls: {
+    viewTheParticipantList: {enabled: boolean; panelistEnabled: boolean; attendeeCount: boolean};
+  } = {
+    viewTheParticipantList: {enabled: false, panelistEnabled: false, attendeeCount: false},
+  };
 
   /**
    * @param {MeetingRequest} request
@@ -118,6 +124,22 @@ export default class ControlsOptionsManager {
   }
 
   /**
+   * Updates the current viewTheParticipantList state from locus controls.
+   *
+   * @param {Object} state
+   * @returns {void}
+   * @public
+   * @memberof ControlsOptionsManager
+   */
+  public setCurrentViewTheParticipantList(state: {enabled: boolean; panelistEnabled: boolean; attendeeCount: boolean | number}) {
+    this.currentControls.viewTheParticipantList = {
+      enabled: state.enabled,
+      panelistEnabled: state.panelistEnabled,
+      attendeeCount: Boolean(state.attendeeCount),
+    };
+  }
+
+  /**
    * @returns {string}
    * @public
    * @memberof ControlsOptionsManager
@@ -172,8 +194,19 @@ export default class ControlsOptionsManager {
         );
       }
 
+      let {properties} = control;
+
+      if (control.scope === Control.viewTheParticipantList) {
+        const props = properties as ViewTheParticipantListProperties;
+        properties = {
+          enabled: props.enabled ?? this.currentControls.viewTheParticipantList.enabled,
+          panelistEnabled: props.panelistEnabled ?? this.currentControls.viewTheParticipantList.panelistEnabled,
+          attendeeCount: props.attendeeCount ?? this.currentControls.viewTheParticipantList.attendeeCount,
+        };
+      }
+
       return {
-        [control.scope]: control.properties,
+        [control.scope]: properties,
       };
     });
 

--- a/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
+++ b/packages/@webex/plugin-meetings/src/controls-options-manager/index.ts
@@ -58,6 +58,8 @@ export default class ControlsOptionsManager {
 
   private getControls: () => Record<string, any> = () => ({});
 
+  private isWebinar: () => boolean = () => false;
+
   /**
    * @param {MeetingRequest} request
    * @param {Object} options
@@ -69,7 +71,8 @@ export default class ControlsOptionsManager {
     options?: {
       locusUrl: string;
       displayHints?: Array<string>;
-      getControls: () => Record<string, any>;
+      getControls?: () => Record<string, any>;
+      isWebinar?: () => boolean;
     }
   ) {
     this.initialize(request);
@@ -96,6 +99,7 @@ export default class ControlsOptionsManager {
     locusUrl: string;
     displayHints?: Array<string>;
     getControls?: () => Record<string, any>;
+    isWebinar?: () => boolean;
   }) {
     this.extract(options);
   }
@@ -152,11 +156,15 @@ export default class ControlsOptionsManager {
     locusUrl: string;
     displayHints?: Array<string>;
     getControls?: () => Record<string, any>;
+    isWebinar?: () => boolean;
   }) {
     this.setDisplayHints(options?.displayHints);
     this.setLocusUrl(options?.locusUrl);
     if (options?.getControls) {
       this.getControls = options.getControls;
+    }
+    if (options?.isWebinar) {
+      this.isWebinar = options.isWebinar;
     }
   }
 
@@ -193,8 +201,10 @@ export default class ControlsOptionsManager {
         const current = this.getControls()?.viewTheParticipantList;
         properties = {
           enabled: props.enabled ?? current?.enabled ?? false,
-          panelistEnabled: props.panelistEnabled ?? current?.panelistEnabled ?? false,
-          attendeeCount: props.attendeeCount ?? Boolean(current?.attendeeCount) ?? false,
+          ...(this.isWebinar() && {
+            panelistEnabled: props.panelistEnabled ?? current?.panelistEnabled ?? false,
+            attendeeCount: props.attendeeCount ?? Boolean(current?.attendeeCount) ?? false,
+          }),
         };
       }
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1567,6 +1567,7 @@ export default class Meeting extends StatelessWebexPlugin {
     this.controlsOptionsManager = new ControlsOptionsManager(this.meetingRequest, {
       locusUrl: this.locusInfo?.url,
       displayHints: [],
+      getControls: () => this.locusInfo?.controls,
     });
 
     this.setUpLocusInfoListeners();
@@ -3027,7 +3028,6 @@ export default class Meeting extends StatelessWebexPlugin {
     });
 
     this.locusInfo.on(LOCUSINFO.EVENTS.CONTROLS_VIEW_THE_PARTICIPANTS_LIST_CHANGED, ({state}) => {
-      this.controlsOptionsManager.setCurrentViewTheParticipantList(state);
       Trigger.trigger(
         this,
         {file: 'meeting/index', function: 'setupLocusControlsListener'},

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -1568,6 +1568,7 @@ export default class Meeting extends StatelessWebexPlugin {
       locusUrl: this.locusInfo?.url,
       displayHints: [],
       getControls: () => this.locusInfo?.controls,
+      isWebinar: () => this.locusInfo?.info?.isWebinar,
     });
 
     this.setUpLocusInfoListeners();

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3027,6 +3027,7 @@ export default class Meeting extends StatelessWebexPlugin {
     });
 
     this.locusInfo.on(LOCUSINFO.EVENTS.CONTROLS_VIEW_THE_PARTICIPANTS_LIST_CHANGED, ({state}) => {
+      this.controlsOptionsManager.setCurrentViewTheParticipantList(state);
       Trigger.trigger(
         this,
         {file: 'meeting/index', function: 'setupLocusControlsListener'},

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
@@ -323,58 +323,102 @@ describe('plugin-meetings', () => {
               describe('viewTheParticipantList fill-in', () => {
                 let restorable;
 
-                beforeEach(() => {
-                  restorable = Util.canUpdate;
-                  Util.canUpdate = sinon.stub().returns(true);
-                  manager.set({
-                    locusUrl: 'test/id',
-                    displayHints: [],
-                    getControls: () => ({viewTheParticipantList: {enabled: true, panelistEnabled: true, attendeeCount: true}}),
-                  });
-                });
-
                 afterEach(() => {
                   Util.canUpdate = restorable;
                 });
 
-                it('should fill in all undefined properties from current state', () => {
-                  const control = {scope: 'viewTheParticipantList', properties: {}};
+                describe('when meeting is a webinar', () => {
+                  beforeEach(() => {
+                    restorable = Util.canUpdate;
+                    Util.canUpdate = sinon.stub().returns(true);
+                    manager.set({
+                      locusUrl: 'test/id',
+                      displayHints: [],
+                      getControls: () => ({viewTheParticipantList: {enabled: true, panelistEnabled: true, attendeeCount: true}}),
+                      isWebinar: () => true,
+                    });
+                  });
 
-                  return manager.update(control).then(() => {
-                    assert.calledOnceWithExactly(request.locusDeltaRequest, {
-                      uri: 'test/id/controls',
-                      body: {
-                        viewTheParticipantList: {enabled: true, panelistEnabled: true, attendeeCount: true},
-                      },
-                      method: HTTP_VERBS.PATCH,
+                  it('should fill in all undefined properties from current state', () => {
+                    const control = {scope: 'viewTheParticipantList', properties: {}};
+
+                    return manager.update(control).then(() => {
+                      assert.calledOnceWithExactly(request.locusDeltaRequest, {
+                        uri: 'test/id/controls',
+                        body: {
+                          viewTheParticipantList: {enabled: true, panelistEnabled: true, attendeeCount: true},
+                        },
+                        method: HTTP_VERBS.PATCH,
+                      });
+                    });
+                  });
+
+                  it('should keep explicitly provided properties and fill in the rest', () => {
+                    const control = {scope: 'viewTheParticipantList', properties: {enabled: false}};
+
+                    return manager.update(control).then(() => {
+                      assert.calledOnceWithExactly(request.locusDeltaRequest, {
+                        uri: 'test/id/controls',
+                        body: {
+                          viewTheParticipantList: {enabled: false, panelistEnabled: true, attendeeCount: true},
+                        },
+                        method: HTTP_VERBS.PATCH,
+                      });
+                    });
+                  });
+
+                  it('should not fill in properties when all are explicitly provided', () => {
+                    const control = {scope: 'viewTheParticipantList', properties: {enabled: false, panelistEnabled: false, attendeeCount: false}};
+
+                    return manager.update(control).then(() => {
+                      assert.calledOnceWithExactly(request.locusDeltaRequest, {
+                        uri: 'test/id/controls',
+                        body: {
+                          viewTheParticipantList: {enabled: false, panelistEnabled: false, attendeeCount: false},
+                        },
+                        method: HTTP_VERBS.PATCH,
+                      });
                     });
                   });
                 });
 
-                it('should keep explicitly provided properties and fill in the rest', () => {
-                  const control = {scope: 'viewTheParticipantList', properties: {enabled: false}};
-
-                  return manager.update(control).then(() => {
-                    assert.calledOnceWithExactly(request.locusDeltaRequest, {
-                      uri: 'test/id/controls',
-                      body: {
-                        viewTheParticipantList: {enabled: false, panelistEnabled: true, attendeeCount: true},
-                      },
-                      method: HTTP_VERBS.PATCH,
+                describe('when meeting is not a webinar', () => {
+                  beforeEach(() => {
+                    restorable = Util.canUpdate;
+                    Util.canUpdate = sinon.stub().returns(true);
+                    manager.set({
+                      locusUrl: 'test/id',
+                      displayHints: [],
+                      getControls: () => ({viewTheParticipantList: {enabled: true, panelistEnabled: true, attendeeCount: true}}),
+                      isWebinar: () => false,
                     });
                   });
-                });
 
-                it('should not fill in properties when all are explicitly provided', () => {
-                  const control = {scope: 'viewTheParticipantList', properties: {enabled: false, panelistEnabled: false, attendeeCount: false}};
+                  it('should only send enabled property', () => {
+                    const control = {scope: 'viewTheParticipantList', properties: {}};
 
-                  return manager.update(control).then(() => {
-                    assert.calledOnceWithExactly(request.locusDeltaRequest, {
-                      uri: 'test/id/controls',
-                      body: {
-                        viewTheParticipantList: {enabled: false, panelistEnabled: false, attendeeCount: false},
-                      },
-                      method: HTTP_VERBS.PATCH,
+                    return manager.update(control).then(() => {
+                      assert.calledOnceWithExactly(request.locusDeltaRequest, {
+                        uri: 'test/id/controls',
+                        body: {
+                          viewTheParticipantList: {enabled: true},
+                        },
+                        method: HTTP_VERBS.PATCH,
+                      });
+                    });
+                  });
+
+                  it('should not include panelistEnabled or attendeeCount even if explicitly provided', () => {
+                    const control = {scope: 'viewTheParticipantList', properties: {enabled: false, panelistEnabled: true, attendeeCount: true}};
+
+                    return manager.update(control).then(() => {
+                      assert.calledOnceWithExactly(request.locusDeltaRequest, {
+                        uri: 'test/id/controls',
+                        body: {
+                          viewTheParticipantList: {enabled: false},
+                        },
+                        method: HTTP_VERBS.PATCH,
+                      });
                     });
                   });
                 });

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
@@ -326,7 +326,11 @@ describe('plugin-meetings', () => {
                 beforeEach(() => {
                   restorable = Util.canUpdate;
                   Util.canUpdate = sinon.stub().returns(true);
-                  manager.setCurrentViewTheParticipantList({enabled: true, panelistEnabled: true, attendeeCount: true});
+                  manager.set({
+                    locusUrl: 'test/id',
+                    displayHints: [],
+                    getControls: () => ({viewTheParticipantList: {enabled: true, panelistEnabled: true, attendeeCount: true}}),
+                  });
                 });
 
                 afterEach(() => {

--- a/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/controls-options-manager/index.js
@@ -319,6 +319,62 @@ describe('plugin-meetings', () => {
                     Util.canUpdate = restorable;
                   });
               });
+
+              describe('viewTheParticipantList fill-in', () => {
+                let restorable;
+
+                beforeEach(() => {
+                  restorable = Util.canUpdate;
+                  Util.canUpdate = sinon.stub().returns(true);
+                  manager.setCurrentViewTheParticipantList({enabled: true, panelistEnabled: true, attendeeCount: true});
+                });
+
+                afterEach(() => {
+                  Util.canUpdate = restorable;
+                });
+
+                it('should fill in all undefined properties from current state', () => {
+                  const control = {scope: 'viewTheParticipantList', properties: {}};
+
+                  return manager.update(control).then(() => {
+                    assert.calledOnceWithExactly(request.locusDeltaRequest, {
+                      uri: 'test/id/controls',
+                      body: {
+                        viewTheParticipantList: {enabled: true, panelistEnabled: true, attendeeCount: true},
+                      },
+                      method: HTTP_VERBS.PATCH,
+                    });
+                  });
+                });
+
+                it('should keep explicitly provided properties and fill in the rest', () => {
+                  const control = {scope: 'viewTheParticipantList', properties: {enabled: false}};
+
+                  return manager.update(control).then(() => {
+                    assert.calledOnceWithExactly(request.locusDeltaRequest, {
+                      uri: 'test/id/controls',
+                      body: {
+                        viewTheParticipantList: {enabled: false, panelistEnabled: true, attendeeCount: true},
+                      },
+                      method: HTTP_VERBS.PATCH,
+                    });
+                  });
+                });
+
+                it('should not fill in properties when all are explicitly provided', () => {
+                  const control = {scope: 'viewTheParticipantList', properties: {enabled: false, panelistEnabled: false, attendeeCount: false}};
+
+                  return manager.update(control).then(() => {
+                    assert.calledOnceWithExactly(request.locusDeltaRequest, {
+                      uri: 'test/id/controls',
+                      body: {
+                        viewTheParticipantList: {enabled: false, panelistEnabled: false, attendeeCount: false},
+                      },
+                      method: HTTP_VERBS.PATCH,
+                    });
+                  });
+                });
+              });
             });
 
             describe('Mute/Unmute All', () => {


### PR DESCRIPTION
# COMPLETES #[SPARK-819661](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-819661)

## This pull request addresses
See the jira description.

## by making the following changes
SDK needs to send current values for the remaining props from viewTheParticipantList control (the ones that client sets to undefined). 
First I've done it by caching the current values in ControlsOptionsManager, this is more inline with other existing code in SDK where we listen for locus info changes in meeting object and update any other objects with the changes - that's the 1st commit. 
Then I decided that I don't really like having the same property values copies in multiple places and changed it to use a callback that gets the values directly from locusInfo.controls - that's the 2nd commit.
Finally, while testing I realised that we should not be sending the 3 props for normal meetings, so now ControlsOptionsManager also needs to know if it's a webinar or not and that also comes from locus info, so I ended up with 1 more callback - see 3rd commit.

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

unit tests, manual testing with web app

## The GAI Coding Policy And Copyright Annotation Best Practices ##
  
- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation
  
### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
