### PR TITLE
fix(task-refactor): multi login syncing issues

### DIFF
--- a/packages/@webex/contact-center/src/services/task/Task.ts
+++ b/packages/@webex/contact-center/src/services/task/Task.ts
@@ -589,10 +589,44 @@ export default abstract class Task extends EventEmitter implements ITask {
    */
   public updateTaskData(updatedData: TaskData, shouldOverwrite = false): ITask {
     this.data = shouldOverwrite ? updatedData : this.reconcileData(this.data, updatedData);
+    if (!shouldOverwrite) {
+      this.pruneStaleInteractionMaps(updatedData);
+    }
     this.updateUiControls();
     this.setupAutoWrapupTimer();
 
     return this;
+  }
+
+  /**
+   * The backend sends `interaction.media` and `interaction.participants` as complete snapshots
+   * of the current call state. `reconcileData` deep-merges and never removes keys, so entries the
+   * backend dropped (e.g. a consult leg's media and consultee participant after the consult ends)
+   * linger in `this.data`. That stale data drives incorrect UI controls (e.g. the consult button
+   * staying disabled after the consult leg is gone, until a page refresh re-hydrates cleanly).
+   * Make only these two snapshot maps authoritative to the incoming payload, leaving every other
+   * field on the generic deep-merge path (CAD and other partial updates still merge as before).
+   */
+  private pruneStaleInteractionMaps(incoming: TaskData): void {
+    const incomingInteraction = incoming?.interaction;
+    const currentInteraction = this.data?.interaction;
+    if (!incomingInteraction || !currentInteraction) {
+      return;
+    }
+
+    (['media', 'participants'] as const).forEach((mapKey) => {
+      const incomingMap = incomingInteraction[mapKey] as Record<string, unknown> | undefined;
+      const currentMap = currentInteraction[mapKey] as Record<string, unknown> | undefined;
+      if (!incomingMap || !currentMap || typeof incomingMap !== 'object') {
+        return;
+      }
+
+      Object.keys(currentMap).forEach((id) => {
+        if (!(id in incomingMap)) {
+          delete currentMap[id];
+        }
+      });
+    });
   }
 
   /**

--- a/packages/@webex/contact-center/src/services/task/TaskUtils.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskUtils.ts
@@ -89,10 +89,12 @@ export const getIsConsultInProgressForConferenceControls = (
       if (!p || p.hasLeft) return false;
       if (selfAgentId && participantId === selfAgentId) return false;
 
+      const consultState = p.consultState as string | undefined;
+      const isRonaPendingConsultee = consultState === 'consultReserved' && p.hasJoined === false;
       const consultLegActive =
-        p.consultState === 'consulting' ||
-        p.isConsulted === true ||
-        p.currentState === 'consulting';
+        consultState === 'consulting' ||
+        p.currentState === 'consulting' ||
+        (p.isConsulted === true && consultState !== 'consultCompleted' && !isRonaPendingConsultee);
 
       return consultLegActive && !mainSet.has(participantId);
     });

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -78,6 +78,15 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
       [TaskEvent.HYDRATE]: {
         actions: ['updateTaskData', 'emitTaskHydrate'],
       },
+      // AgentConsultCreated from Stable Prod while already HELD/CONNECTED (external consult).
+      // Child states do not handle CONSULT_CREATED; wire here so updateTaskData + setConsultInitiator run.
+      [TaskEvent.CONSULT_CREATED]: {
+        actions: ['updateTaskData', 'setConsultInitiator'],
+      },
+      // AgentConsultFailed (RONA) while HELD/CONNECTED without passing through CONSULT_INITIATING.
+      [TaskEvent.CONSULT_FAILED]: {
+        actions: ['updateTaskData', 'handleConsultFailed'],
+      },
     },
     states: {
       [TaskState.IDLE]: {
@@ -290,6 +299,24 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           [TaskEvent.TRANSFER_FAILED]: {
             actions: ['updateTaskData'],
           },
+          // AgentConsultEnded from Stable Prod while on connected leg (external end consult).
+          [TaskEvent.CONSULT_END]: [
+            {
+              guard: ({context, event}) => {
+                if (context.consultInitiator !== true) return false;
+                const taskData = getTaskDataFromEvent(event);
+                const mainId = taskData?.interaction?.mainInteractionId || taskData?.interactionId;
+
+                return Boolean(mainId && taskData?.interaction?.media?.[mainId]?.isHold === true);
+              },
+              target: TaskState.HELD,
+              actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+            },
+            {
+              guard: ({context}) => context.consultInitiator === true,
+              actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+            },
+          ],
           // AgentContactEnded Event
           [TaskEvent.CONTACT_ENDED]: [
             {
@@ -370,6 +397,18 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             target: TaskState.CONSULT_INITIATING,
             actions: ['setConsultInitiator', 'setConsultDestination'],
           },
+          // AgentConsulting while main leg is held (Task Refactor / Stable Prod consult accept).
+          [TaskEvent.CONSULTING_ACTIVE]: {
+            target: TaskState.CONSULTING,
+            actions: [
+              'setConsultInitiator',
+              'setConsultDestination',
+              'setConsultAgentJoined',
+              'updateTaskData',
+              'emitTaskConsultAccepted',
+              'emitTaskConsulting',
+            ],
+          },
           // TODO: This may not be a valid transition, need to be removed
           // AgentConsultTransferred / AgentVTeamTransferred / AgentBlindTransferred
           [TaskEvent.TRANSFER_SUCCESS]: [
@@ -402,6 +441,10 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
               actions: ['updateTaskData', 'markEnded', 'emitTaskEnd'],
             },
           ],
+          // AgentConsultEnded from Stable Prod while main leg is held (external end consult).
+          [TaskEvent.CONSULT_END]: {
+            actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+          },
           // TODO: This may not be a valid transition, this needs to be checked as well
           [TaskEvent.TASK_WRAPUP]: {
             target: TaskState.WRAPPING_UP,
@@ -437,6 +480,18 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             target: TaskState.CONSULTING,
             actions: ['updateTaskData', 'setConsultInitiator'],
           },
+          // AgentConsulting (Task Refactor: AgentConsulting event, not CONSULT_SUCCESS)
+          [TaskEvent.CONSULTING_ACTIVE]: {
+            target: TaskState.CONSULTING,
+            actions: [
+              'setConsultInitiator',
+              'setConsultDestination',
+              'setConsultAgentJoined',
+              'updateTaskData',
+              'emitTaskConsultAccepted',
+              'emitTaskConsulting',
+            ],
+          },
           // AgentConsultFailed, API Failures, AgentCtqFailed
           [TaskEvent.CONSULT_FAILED]: [
             {
@@ -465,6 +520,18 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             {
               target: TaskState.CONNECTED,
               actions: ['updateTaskData', 'clearConsultState'],
+            },
+          ],
+          // AgentConsultEnded from Stable Prod during consult initiation (external end consult).
+          [TaskEvent.CONSULT_END]: [
+            {
+              guard: guards.isPrimaryMediaOnHold,
+              target: TaskState.HELD,
+              actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
+            },
+            {
+              target: TaskState.CONNECTED,
+              actions: ['updateTaskData', 'clearConsultState', 'emitTaskConsultEnd'],
             },
           ],
         },
@@ -788,6 +855,20 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
           [TaskEvent.CONSULT]: {
             target: TaskState.CONSULT_INITIATING,
             actions: ['setConsultInitiator', 'setConsultDestination', 'setConsultFromConference'],
+          },
+
+          // AgentConsulting while still in conference (EP-DN/external ordering).
+          [TaskEvent.CONSULTING_ACTIVE]: {
+            target: TaskState.CONSULTING,
+            actions: [
+              'setConsultInitiator',
+              'setConsultDestination',
+              'setConsultFromConference',
+              'setConsultAgentJoined',
+              'updateTaskData',
+              'emitTaskConsultAccepted',
+              'emitTaskConsulting',
+            ],
           },
 
           // Participant leaves - handle conference downgrade scenarios

--- a/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/TaskStateMachine.ts
@@ -549,6 +549,29 @@ export function getTaskStateMachineConfig(uiControlConfig: UIControlConfig) {
             ],
           },
 
+          // AgentConsultFailed (RONA / consultee declined) while the initiator is already in
+          // CONSULTING (AgentConsulting arrived during ringing). Mirror CONSULT_INITIATING so the
+          // initiator returns to their own leg (HELD when main is on hold, else CONNECTED) instead
+          // of staying in CONSULTING. Without this, handleConsultFailed clears consultInitiator but
+          // the machine stays in CONSULTING, so the trailing AgentConsultEnded falls through the
+          // CONSULT_END "consulted agent" branch to TERMINATED and wrongly clears the task.
+          [TaskEvent.CONSULT_FAILED]: [
+            {
+              guard: ({context}) => context.consultFromConference === true,
+              target: TaskState.CONFERENCING,
+              actions: ['updateTaskData', 'handleConsultFailed'],
+            },
+            {
+              guard: guards.isPrimaryMediaOnHold,
+              target: TaskState.HELD,
+              actions: ['updateTaskData', 'handleConsultFailed'],
+            },
+            {
+              target: TaskState.CONNECTED,
+              actions: ['updateTaskData', 'handleConsultFailed'],
+            },
+          ],
+
           // AgentConsultEnded
           [TaskEvent.CONSULT_END]: [
             {

--- a/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/actions.ts
@@ -88,10 +88,20 @@ const isActiveConsultState = (taskData: TaskData | undefined, selfAgentId?: stri
     const hasConsultMedia = Object.values(taskData?.interaction?.media ?? {}).some(
       (media: any) => media?.mType === MEDIA_TYPE_CONSULT
     );
-    const isPendingOrActiveSelfConsult =
-      selfParticipant?.consultState === CONSULT_STATE.CONSULTING ||
-      selfParticipant?.consultState === 'consultInitiated';
-    if (isPendingOrActiveSelfConsult && hasConsultMedia && taskData?.isConsulted === false) {
+    // Pending consult before destination joins stays HELD, not CONSULTING.
+    if (
+      selfParticipant?.consultState === 'consultInitiated' &&
+      !hasJoinedConsultDestination(taskData, selfAgentId) &&
+      hasConsultMedia &&
+      taskData?.isConsulted === false
+    ) {
+      return false;
+    }
+    if (
+      selfParticipant?.consultState === CONSULT_STATE.CONSULTING &&
+      hasConsultMedia &&
+      taskData?.isConsulted === false
+    ) {
       return true;
     }
   }
@@ -119,13 +129,62 @@ const isSelfConsultingOrPending = (
   );
 };
 
-const hasJoinedConsultDestination = (taskData: TaskData | undefined): boolean => {
+const isDnOnConsultMedia = (taskData: TaskData | undefined, selfAgentId?: string): boolean => {
+  if (!taskData?.interaction?.participants) return false;
+
+  const consultMedia: any = taskData.consultMediaResourceId
+    ? taskData.interaction.media?.[taskData.consultMediaResourceId]
+    : Object.values(taskData.interaction.media ?? {}).find(
+        (m: any) => m?.mType === MEDIA_TYPE_CONSULT
+      );
+  const consultParticipantIds = new Set(consultMedia?.participants ?? []);
+  if (consultParticipantIds.size === 0) return false;
+
+  return Object.values(taskData.interaction.participants).some((p: any) => {
+    if (!p || p.hasLeft || p.id === selfAgentId) return false;
+    if (!consultParticipantIds.has(p.id)) return false;
+    const pType = String(p.pType ?? '').toUpperCase();
+
+    return pType === 'DN' || pType === 'EP-DN' || pType === 'EP_DN';
+  });
+};
+
+const mapConsultDestinationType = (
+  destinationType: string | undefined
+): DestinationType | undefined => {
+  if (!destinationType) return undefined;
+  const normalized = String(destinationType).toUpperCase();
+  if (normalized === 'DN' || normalized === 'EP-DN' || normalized === 'EP_DN') {
+    return 'entryPoint' as DestinationType;
+  }
+
+  return destinationType as DestinationType;
+};
+
+const hasJoinedConsultDestination = (
+  taskData: TaskData | undefined,
+  selfAgentId?: string
+): boolean => {
   if (!taskData?.interaction) return false;
   const participants = taskData.interaction.participants as any;
   const cpd = taskData.interaction.callProcessingDetails as any;
   const backendSaysJoined = cpd?.consultDestinationAgentJoined === 'true';
   if (backendSaysJoined) return true;
   if (!participants) return false;
+
+  const effectiveSelfAgentId = selfAgentId ?? taskData.agentId;
+  const selfParticipant = effectiveSelfAgentId
+    ? (participants[effectiveSelfAgentId] as {consultState?: string} | undefined)
+    : undefined;
+
+  if (
+    taskData.type === 'AgentConsulting' &&
+    selfParticipant?.consultState === CONSULT_STATE.CONSULTING &&
+    taskData.isConsulted === false &&
+    isDnOnConsultMedia(taskData, effectiveSelfAgentId)
+  ) {
+    return true;
+  }
 
   return Object.values(participants).some((p: any) => {
     if (!p || p.isConsulted !== true || p.hasLeft) return false;
@@ -154,7 +213,7 @@ const deriveConsultCallHeldFromTaskData = (taskData: TaskData | undefined): bool
   return Boolean(consultMedia.isHold);
 };
 
-const getTaskStateForUiControls = (
+export const getTaskStateForUiControls = (
   taskData: TaskData | undefined,
   selfAgentId: string | undefined
 ): TaskState => {
@@ -214,11 +273,25 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
             updates.consultDestinationAgentId = taskData.destAgentId;
           }
         }
-        if (consultingActive && taskData.destinationType) {
-          updates.consultDestinationType = taskData.destinationType as DestinationType;
+
+        const isConsultTerminalEvent =
+          taskData.type === 'AgentConsultEnded' || taskData.type === 'AgentConsultFailed';
+
+        if (isConsultTerminalEvent) {
+          updates.consultInitiator = false;
+          updates.consultFromConference = false;
+          updates.consultDestinationAgentJoined = false;
+          updates.consultCallHeld = false;
+          updates.consultDestinationType = null;
+          updates.consultDestinationAgentId = null;
+          updates.transferConferenceRequested = false;
         }
 
-        if (!context.consultInitiator) {
+        if (consultingActive && taskData.destinationType) {
+          updates.consultDestinationType = mapConsultDestinationType(taskData.destinationType);
+        }
+
+        if (!isConsultTerminalEvent && !context.consultInitiator) {
           const consultInitiator = determineConsultInitiator(taskData, selfAgentId);
           if (consultInitiator !== undefined) {
             updates.consultInitiator = consultInitiator;
@@ -232,6 +305,7 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
 
         const effectiveConsultInitiator = updates.consultInitiator ?? context.consultInitiator;
         if (
+          !isConsultTerminalEvent &&
           effectiveConsultInitiator &&
           conferenceFromPayload &&
           (consultingActive || selfConsultingOrPending || Boolean(taskData?.consultMediaResourceId))
@@ -239,16 +313,37 @@ const deriveTaskDataUpdates = (context: TaskContext, taskData: TaskData | undefi
           updates.consultFromConference = true;
         }
 
-        if (consultingActive && taskData.interaction) {
-          const joinedConsultee = hasJoinedConsultDestination(taskData);
-          if (joinedConsultee) updates.consultDestinationAgentJoined = true;
+        if (
+          !isConsultTerminalEvent &&
+          (consultingActive || selfConsultingOrPending) &&
+          taskData.interaction
+        ) {
+          const joinedConsultee = hasJoinedConsultDestination(taskData, selfAgentId);
+          const selfParticipant = selfAgentId
+            ? (taskData.interaction.participants?.[selfAgentId] as
+                | {consultState?: string}
+                | undefined)
+            : undefined;
+          const agentConsultingSelfJoined =
+            taskData.type === 'AgentConsulting' &&
+            effectiveConsultInitiator &&
+            selfParticipant?.consultState === CONSULT_STATE.CONSULTING;
+
+          if (joinedConsultee || agentConsultingSelfJoined) {
+            updates.consultDestinationAgentJoined = true;
+          } else if (selfParticipant?.consultState === 'consultInitiated') {
+            updates.consultDestinationAgentJoined = false;
+          }
 
           if (!context.consultDestinationType && !updates.consultDestinationType) {
             const hasEpDnParticipant = Boolean(
               taskData.interaction.participants &&
-                Object.values(taskData.interaction.participants).some(
-                  (p: any) => p?.pType === 'EP-DN' && !p?.hasLeft
-                )
+                Object.values(taskData.interaction.participants).some((p: any) => {
+                  if (p?.hasLeft) return false;
+                  const pType = String(p?.pType ?? '').toUpperCase();
+
+                  return pType === 'EP-DN' || pType === 'EP_DN' || pType === 'DN';
+                })
             );
             if (hasEpDnParticipant) updates.consultDestinationType = 'entryPoint' as any;
           }
@@ -303,7 +398,7 @@ export function createInitialContext(
 
 export function updateUIControls(currentState: TaskState) {
   return assign(({context}: TaskActionArgs) => ({
-    uiControls: computeUIControls(currentState, context),
+    uiControls: computeUIControls(currentState, context, context.taskData ?? undefined),
   }));
 }
 
@@ -349,7 +444,27 @@ export const actions: TaskActionsMap = {
     return {};
   }),
 
-  handleConsultFailed: assign({consultDestinationAgentJoined: false, consultInitiator: false}),
+  handleConsultFailed: assign(({context, event}: TaskActionArgs) => {
+    const taskData = getTaskDataFromEvent(event) ?? context.taskData;
+    const cleared = {
+      consultDestinationType: null,
+      consultDestinationAgentId: null,
+      consultDestinationAgentJoined: false,
+      consultInitiator: false,
+      exitingConference: false,
+      consultCallHeld: false,
+      consultFromConference: false,
+      transferConferenceRequested: false,
+    };
+    const selfAgentId = context.uiControlConfig.agentId ?? taskData?.agentId;
+    const nextContext = {...context, ...cleared, taskData} as TaskContext;
+    const inferredState = getTaskStateForUiControls(taskData, selfAgentId);
+
+    return {
+      ...cleared,
+      uiControls: computeUIControls(inferredState, nextContext, taskData),
+    };
+  }),
   handleConferenceStarted: assign({consultInitiator: false}),
 
   setConsultDestination: assign(({event}: TaskActionArgs) => {
@@ -423,15 +538,26 @@ export const actions: TaskActionsMap = {
     return {};
   }),
 
-  clearConsultState: assign({
-    consultDestinationType: null,
-    consultDestinationAgentId: null,
-    consultDestinationAgentJoined: false,
-    consultInitiator: false,
-    exitingConference: false,
-    consultCallHeld: false,
-    consultFromConference: false,
-    transferConferenceRequested: false,
+  clearConsultState: assign(({context, event}: TaskActionArgs) => {
+    const cleared = {
+      consultDestinationType: null,
+      consultDestinationAgentId: null,
+      consultDestinationAgentJoined: false,
+      consultInitiator: false,
+      exitingConference: false,
+      consultCallHeld: false,
+      consultFromConference: false,
+      transferConferenceRequested: false,
+    };
+    const taskData = context.taskData ?? getTaskDataFromEvent(event);
+    const selfAgentId = context.uiControlConfig.agentId ?? taskData?.agentId;
+    const nextContext = {...context, ...cleared, taskData} as TaskContext;
+    const inferredState = getTaskStateForUiControls(taskData, selfAgentId);
+
+    return {
+      ...cleared,
+      uiControls: computeUIControls(inferredState, nextContext, taskData),
+    };
   }),
 
   setTransferConferenceRequested: assign({transferConferenceRequested: true}),

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -749,9 +749,7 @@ function getVoiceLegState(
     !isConsultEndedForSelf &&
       !interaction?.isTerminated &&
       !isConsultUnansweredFailure &&
-      ((consultOwnedBySelf && !taskData?.isConsulted) ||
-        selfConsultingOnConsultMedia ||
-        selfConsultPendingOnConsultMedia) &&
+      (consultOwnedBySelf || selfConsultingOnConsultMedia || selfConsultPendingOnConsultMedia) &&
       (consultInProgress || isConsultingState || context.consultCallHeld || hasConsultMedia)
   );
 

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -66,6 +66,20 @@ export function getDefaultUIControls(): TaskUIControls {
   );
 }
 
+/** Consult media must exist on the interaction payload, not only as a stale resource id. */
+function hasConsultMediaInInteraction(
+  interaction: TaskData['interaction'] | undefined,
+  consultMediaResourceId?: string
+): boolean {
+  const media = interaction?.media ?? {};
+  const hasConsultLeg = Object.values(media).some((entry: any) => entry?.mType === 'consult');
+
+  if (hasConsultLeg) return true;
+  if (!consultMediaResourceId) return false;
+
+  return Boolean(media[consultMediaResourceId]);
+}
+
 function computeVoiceInteractionUIControls(
   state: TaskState,
   context: TaskContext,
@@ -78,8 +92,8 @@ function computeVoiceInteractionUIControls(
     return getDefaultInteractionUIControls();
   }
 
-  // Essential data
-  const taskData = context.taskData ?? fallbackTaskData ?? null;
+  // Prefer live task.data (fallback) over stale state-machine snapshot during multi-login sync.
+  const taskData = fallbackTaskData ?? context.taskData ?? null;
   const interaction = taskData?.interaction;
   const mainCallId = interaction?.mainInteractionId || taskData?.interactionId;
   const isWebrtc = config.voiceVariant === VOICE_VARIANT.WEBRTC;
@@ -125,7 +139,6 @@ function computeVoiceInteractionUIControls(
   // Backend sends destinationType as 'EP-DN'; SDK method uses 'entryPoint' — check both.
   const isEpDnConsult =
     consultDestinationType === 'entryPoint' || consultDestinationType === ('EP-DN' as any);
-  const isConsultDestinationReady = consultDestinationAgentJoined || isEpDnConsult;
 
   const stateImpliesHeld = state === TaskState.HELD || state === TaskState.RESUME_INITIATING;
   const stateImpliesConnected =
@@ -151,9 +164,32 @@ function computeVoiceInteractionUIControls(
   const selfParticipant = selfAgentId ? interaction?.participants?.[selfAgentId] : null;
   const selfInConsultCall =
     Boolean(selfAgentId) && Boolean(consultMedia?.participants?.includes(selfAgentId as string));
-  const conferenceActive = isConferencing || conferenceFromBackend || consultFromConference;
+  const hasConsultMedia = hasConsultMediaInInteraction(
+    interaction,
+    taskData?.consultMediaResourceId
+  );
+  const isConsultEndedForSelf =
+    taskData?.type === 'AgentConsultEnded' ||
+    taskData?.type === 'AgentConsultFailed' ||
+    (selfParticipant?.consultState === 'consultCompleted' &&
+      !hasConsultMedia &&
+      taskData?.isConsulted === false);
+  const effectiveConsultInitiator = isConsultEndedForSelf ? false : consultInitiator;
+  const effectiveConsultCallHeld = isConsultEndedForSelf ? false : consultCallHeld;
+  const effectiveConsultFromConference = isConsultEndedForSelf ? false : consultFromConference;
+  const effectiveConsultDestinationAgentJoined = isConsultEndedForSelf
+    ? false
+    : consultDestinationAgentJoined;
+  // After a consult ends for self, the backend stops sending consult media but the merged
+  // task.data can still carry the stale consult-media entry (reconcileData never deletes keys).
+  // Treat it as gone so post-consult main-leg controls (consult retry) are not blocked.
+  const effectiveHasConsultMedia = isConsultEndedForSelf ? false : hasConsultMedia;
+  const isConsultDestinationReady = effectiveConsultDestinationAgentJoined || isEpDnConsult;
+  const conferenceActive =
+    isConferencing || conferenceFromBackend || effectiveConsultFromConference;
   // Treat consult initiator as "in conference" even if mainCall participant list lags while consulting.
-  const inConference = conferenceActive && (isConferencing || selfInMainCall || consultInitiator);
+  const inConference =
+    conferenceActive && (isConferencing || selfInMainCall || effectiveConsultInitiator);
 
   // Check if this is a consulted agent (must be after isConsulting is computed).
   const isSoleAgentOnCall =
@@ -162,7 +198,7 @@ function computeVoiceInteractionUIControls(
     inConference || isSoleAgentOnCall
       ? false
       : getIsConsultedAgentForControls(taskData, context, isConsulting) ||
-        (!consultInitiator &&
+        (!effectiveConsultInitiator &&
           (selfParticipant?.isConsulted === true ||
             selfParticipant?.consultState === 'consulting'));
 
@@ -177,13 +213,10 @@ function computeVoiceInteractionUIControls(
 
   // Consulted agents have limited controls until they're in conference or wrapup
   // Use inConference (not isConferencing) so controls remain enabled after state downgrade
-  const hasFullControls = !isConsulted || consultInitiator || inConference || isWrappingUp;
+  const hasFullControls = !isConsulted || effectiveConsultInitiator || inConference || isWrappingUp;
   const consultOwnedBySelf =
-    consultInitiator || (Boolean(selfAgentId) && taskData?.consultingAgentId === selfAgentId);
-  const hasConsultMedia = Boolean(
-    taskData?.consultMediaResourceId ||
-      Object.values(interaction?.media ?? {}).some((media: any) => media?.mType === 'consult')
-  );
+    effectiveConsultInitiator ||
+    (Boolean(selfAgentId) && taskData?.consultingAgentId === selfAgentId);
   const selfConsultPendingOnConsultMedia =
     selfParticipant?.consultState === 'consultInitiated' &&
     !taskData?.isConsulted &&
@@ -207,17 +240,18 @@ function computeVoiceInteractionUIControls(
       })
   );
   const isHydratedConferenceConsultPending =
-    inConference && selfConsultPendingOnConsultMedia && !consultDestinationAgentJoined;
+    inConference && selfConsultPendingOnConsultMedia && !effectiveConsultDestinationAgentJoined;
   const hasParallelConsultLeg =
+    !isConsultEndedForSelf &&
     consultOwnedBySelf &&
     !isConsulting &&
     !isConsulted &&
-    (consultInProgress || consultCallHeld || hasConsultMedia);
-  const activeLegForConferenceConsult = consultCallHeld ? 'main' : 'consult';
+    (consultInProgress || effectiveConsultCallHeld || hasConsultMedia);
+  const activeLegForConferenceConsult = effectiveConsultCallHeld ? 'main' : 'consult';
   const isCurrentLegActive = currentLeg === activeLegForConferenceConsult;
   const isConferenceConsultTransferContext =
-    inConference && consultInitiator && hasConsultMedia && isConsultDestinationReady;
-  const consultLegOnHold = isConsulting && consultCallHeld;
+    inConference && effectiveConsultInitiator && hasConsultMedia && isConsultDestinationReady;
+  const consultLegOnHold = isConsulting && effectiveConsultCallHeld;
   const callProcessingDetails = interaction?.callProcessingDetails as
     | {conferenceHoldParticipant?: boolean | string}
     | undefined;
@@ -280,6 +314,61 @@ function computeVoiceInteractionUIControls(
     currentLeg === 'main' && inConference && consultInProgress && !selfOnConsultLeg;
   const allowHeldMainLegControlsForNonInitiator =
     showMainLegConferenceControlsDuringConsult && !isHydratedConferenceConsultPending;
+  const isConsultRequestedPhase =
+    isConsultPendingBeforeJoin &&
+    !isConsulted &&
+    (consultInitiator ||
+      (Boolean(selfAgentId) &&
+        selfParticipant?.consultState === 'consultInitiated' &&
+        taskData?.agentId === selfAgentId));
+  const isConsultUnansweredFailure =
+    currentLeg === 'main' &&
+    !inConference &&
+    !taskData?.isConsulted &&
+    !effectiveHasConsultMedia &&
+    isHeld &&
+    selfParticipant?.consultState === 'consultCompleted' &&
+    (taskData?.type === 'AgentConsultFailed' ||
+      taskData?.type === 'AgentConsultEnded' ||
+      isConsultEndedForSelf);
+
+  if (isConsultUnansweredFailure) {
+    const recordingControl =
+      recordingControlsAvailable && config.isRecordingEnabled && !inConference
+        ? VISIBLE_ENABLED
+        : DISABLED;
+
+    return {
+      ...getDefaultInteractionUIControls(),
+      hold: VISIBLE_ENABLED,
+      transfer: VISIBLE_ENABLED,
+      consult: VISIBLE_ENABLED,
+      recording: recordingControl,
+      end: VISIBLE_DISABLED,
+    };
+  }
+
+  if (isConsultRequestedPhase) {
+    if (currentLeg === 'main') {
+      return {
+        ...getDefaultInteractionUIControls(),
+        transfer: VISIBLE_DISABLED,
+        conference: VISIBLE_DISABLED,
+        end: VISIBLE_DISABLED,
+      };
+    }
+
+    if (currentLeg === 'consult') {
+      return {
+        ...getDefaultInteractionUIControls(),
+        endConsult: VISIBLE_ENABLED,
+        switch: VISIBLE_DISABLED,
+        transfer: VISIBLE_DISABLED,
+        transferConference: inConference ? VISIBLE_DISABLED : DISABLED,
+        mergeToConference: VISIBLE_DISABLED,
+      };
+    }
+  }
 
   return {
     // Accept/Decline: Voice tasks in offered state
@@ -300,7 +389,10 @@ function computeVoiceInteractionUIControls(
     hold: (() => {
       if (!hasFullControls) return DISABLED;
       if (forceHeldPostConsultControls) return VISIBLE_ENABLED;
-      if (consultOwnedBySelf && (isConsulting || hasParallelConsultLeg || consultCallHeld)) {
+      if (
+        consultOwnedBySelf &&
+        (isConsulting || hasParallelConsultLeg || effectiveConsultCallHeld)
+      ) {
         return DISABLED;
       }
       if (hasParallelConsultLeg) return DISABLED;
@@ -319,7 +411,17 @@ function computeVoiceInteractionUIControls(
       if (!isWebrtc) return DISABLED;
       if (isWrappingUp) return DISABLED;
       if (currentLeg === 'consult' && !selfInConsultCall) return DISABLED;
-      if ((isConsulting || hasParallelConsultLeg) && !isCurrentLegActive) return VISIBLE_DISABLED;
+      // The consulted agent has no separate consult leg; their main leg is the active call, so
+      // mute stays available while they consult (the heuristic below targets the initiator's
+      // inactive leg, not the consultee's only leg).
+      const isConsultedActiveMainLeg = isConsulted && currentLeg === 'main';
+      if (
+        (isConsulting || hasParallelConsultLeg) &&
+        !isCurrentLegActive &&
+        !isConsultedActiveMainLeg
+      ) {
+        return VISIBLE_DISABLED;
+      }
       if (isConsulting) return VISIBLE_ENABLED;
 
       if (isConnected || isHeld || isConferencing) {
@@ -394,6 +496,18 @@ function computeVoiceInteractionUIControls(
     // Consult: connected/held/conference when conditions met
     consult: (() => {
       const isConnectedOrHeld = state === TaskState.CONNECTED || state === TaskState.HELD;
+
+      if (
+        isHeld &&
+        !inConference &&
+        !effectiveHasConsultMedia &&
+        selfParticipant?.consultState === 'consultCompleted' &&
+        !taskData?.isConsulted
+      ) {
+        const canRetryConsult = !maxParticipants && customerPresent && !otherAgentConsultInProgress;
+
+        return {isVisible: true, isEnabled: canRetryConsult};
+      }
 
       if (inConference && nonOwnerPostConsultCompletedHeldMainLeg) return VISIBLE_DISABLED;
       if (hasParallelConsultLeg) return DISABLED;
@@ -591,10 +705,21 @@ function getVoiceLegState(
     };
   }
 
-  const taskData = context.taskData ?? fallbackTaskData ?? null;
+  const taskData = fallbackTaskData ?? context.taskData ?? null;
   const interaction = taskData?.interaction;
   const mainCallId = interaction?.mainInteractionId || taskData?.interactionId;
   const selfAgentId = config.agentId ?? taskData?.agentId;
+  const selfParticipant = selfAgentId ? interaction?.participants?.[selfAgentId] : null;
+  const hasConsultMedia = hasConsultMediaInInteraction(
+    interaction,
+    taskData?.consultMediaResourceId
+  );
+  const isConsultEndedForSelf =
+    taskData?.type === 'AgentConsultEnded' ||
+    taskData?.type === 'AgentConsultFailed' ||
+    (selfParticipant?.consultState === 'consultCompleted' &&
+      !hasConsultMedia &&
+      taskData?.isConsulted === false);
   const consultInProgress = getIsConsultInProgressForConferenceControls(
     interaction,
     mainCallId,
@@ -607,19 +732,23 @@ function getVoiceLegState(
   const consultOwnedBySelf =
     context.consultInitiator ||
     (Boolean(selfAgentId) && taskData?.consultingAgentId === selfAgentId);
-  const hasConsultMedia = Boolean(
-    taskData?.consultMediaResourceId ||
-      Object.values(interaction?.media ?? {}).some((media: any) => media?.mType === 'consult')
-  );
-  const selfParticipant = selfAgentId ? interaction?.participants?.[selfAgentId] : null;
   const selfConsultPendingOnConsultMedia =
     selfParticipant?.consultState === 'consultInitiated' &&
     !taskData?.isConsulted &&
     hasConsultMedia;
   const selfConsultingOnConsultMedia =
     selfParticipant?.consultState === 'consulting' && hasConsultMedia;
+  const isConsultUnansweredFailure =
+    !taskData?.isConsulted &&
+    !hasConsultMedia &&
+    selfParticipant?.consultState === 'consultCompleted' &&
+    Boolean(mainCallId && taskData?.interaction?.media?.[mainCallId]?.isHold === true) &&
+    taskData?.interaction?.state !== 'conference' &&
+    !getIsConferenceInProgress(taskData);
   const hasConsultLeg = Boolean(
-    !interaction?.isTerminated &&
+    !isConsultEndedForSelf &&
+      !interaction?.isTerminated &&
+      !isConsultUnansweredFailure &&
       ((consultOwnedBySelf && !taskData?.isConsulted) ||
         selfConsultingOnConsultMedia ||
         selfConsultPendingOnConsultMedia) &&
@@ -627,10 +756,26 @@ function getVoiceLegState(
   );
 
   if (!hasConsultLeg) {
+    let mainState = currentState;
+    if (isConsultEndedForSelf && taskData?.interaction) {
+      const resolvedMainId = taskData.interaction.mainInteractionId || taskData.interactionId;
+      const isMainHeld = Boolean(
+        resolvedMainId && taskData.interaction.media?.[resolvedMainId]?.isHold === true
+      );
+
+      if (taskData.interaction.state === 'conference' || getIsConferenceInProgress(taskData)) {
+        mainState = TaskState.CONFERENCING;
+      } else if (isMainHeld || taskData.interaction.state === 'hold') {
+        mainState = TaskState.HELD;
+      } else {
+        mainState = TaskState.CONNECTED;
+      }
+    }
+
     return {
       hasConsultLeg: false,
       activeLeg: 'main',
-      mainState: currentState,
+      mainState,
       consultState: TaskState.CONSULTING,
     };
   }

--- a/packages/@webex/contact-center/test/unit/spec/services/task/Task.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/Task.ts
@@ -89,6 +89,67 @@ describe('Task (base class)', () => {
     expect((task.data as any).foo).toBeUndefined();
   });
 
+  it('drops stale interaction.media/participants entries the backend no longer sends (merge keeps other fields)', () => {
+    const withConsult = createTaskData({
+      interaction: {
+        callAssociatedData: {a: {value: 'keep-me'}},
+        media: {
+          main: {mediaResourceId: 'main', mType: 'mainCall', isHold: true},
+          consult: {mediaResourceId: 'consult', mType: 'consult', isHold: false},
+        },
+        participants: {
+          'customer-1': {id: 'customer-1', pType: 'Customer'},
+          'agent-1': {id: 'agent-1', pType: 'Agent'},
+          'agent-2': {id: 'agent-2', pType: 'Agent', consultState: 'consulting'},
+        },
+      } as any,
+    }) as unknown as TaskData;
+    task.updateTaskData(withConsult, true);
+
+    // Backend resume snapshot: consult leg gone (only main media + main participants).
+    const resumeData = createTaskData({
+      interaction: {
+        media: {main: {mediaResourceId: 'main', mType: 'mainCall', isHold: false}},
+        participants: {
+          'customer-1': {id: 'customer-1', pType: 'Customer'},
+          'agent-1': {id: 'agent-1', pType: 'Agent', consultState: null},
+        },
+      } as any,
+    }) as unknown as TaskData;
+    task.updateTaskData(resumeData);
+
+    const interaction = (task.data as any).interaction;
+    // Stale consult media + consultee participant (absent from the resume snapshot) are removed.
+    expect(interaction.media.consult).toBeUndefined();
+    expect(interaction.participants['agent-2']).toBeUndefined();
+    // Entries still present in the incoming snapshot survive and reflect the new values.
+    expect(interaction.media.main).toBeDefined();
+    expect(interaction.media.main.isHold).toBe(false);
+    expect(interaction.participants['agent-1']).toBeDefined();
+    expect(interaction.participants['customer-1']).toBeDefined();
+    // Unrelated merge-able fields (CAD) are preserved.
+    expect(interaction.callAssociatedData.a.value).toBe('keep-me');
+  });
+
+  it('does not touch interaction maps when the incoming payload omits them', () => {
+    const withConsult = createTaskData({
+      interaction: {
+        media: {main: {mediaResourceId: 'main'}, consult: {mediaResourceId: 'consult'}},
+        participants: {'agent-1': {id: 'agent-1'}, 'agent-2': {id: 'agent-2'}},
+      } as any,
+    }) as unknown as TaskData;
+    task.updateTaskData(withConsult, true);
+
+    // A partial update with no interaction maps must not prune existing media/participants.
+    task.updateTaskData({foo: 'changed'} as unknown as TaskData);
+
+    const interaction = (task.data as any).interaction;
+    expect(interaction.media.main).toBeDefined();
+    expect(interaction.media.consult).toBeDefined();
+    expect(interaction.participants['agent-1']).toBeDefined();
+    expect(interaction.participants['agent-2']).toBeDefined();
+  });
+
   it('getUIControls returns default controls shape for idle voice task', () => {
     const controls = task.uiControls;
     const mainControls = controls.main;

--- a/packages/@webex/contact-center/test/unit/spec/services/task/TaskUtils.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/TaskUtils.ts
@@ -13,6 +13,7 @@ import {
   isSecondaryAgent,
   isSecondaryEpDnAgent,
   getConsultMediaResourceId,
+  getIsConsultInProgressForConferenceControls,
 } from '../../../../../src/services/task/TaskUtils';
 import {ITask, Interaction, TaskData} from '../../../../../src/services/task/types';
 import {LoginOption} from '../../../../../src/types';
@@ -569,6 +570,70 @@ describe('TaskUtils', () => {
       } as any;
       const result = getConsultMediaResourceId(interaction, 'direct-id', 'agent1');
       expect(result).toBe('direct-id');
+    });
+  });
+
+  describe('getIsConsultInProgressForConferenceControls', () => {
+    it('returns false when consultee is reserved but has not joined (RONA)', () => {
+      const interaction = {
+        participants: {
+          'agent-1': {id: 'agent-1', pType: 'Agent', hasLeft: false, isConsulted: false},
+          'agent-2': {
+            id: 'agent-2',
+            pType: 'Agent',
+            hasLeft: false,
+            hasJoined: false,
+            isConsulted: true,
+            consultState: 'consultReserved',
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false},
+        },
+        media: {
+          'interaction-1': {
+            mType: 'mainCall',
+            participants: ['customer-1', 'agent-1'],
+          },
+          'consult-media': {
+            mType: 'consult',
+            participants: ['agent-2', 'agent-1'],
+          },
+        },
+      } as any;
+
+      expect(
+        getIsConsultInProgressForConferenceControls(interaction, 'interaction-1', 'agent-1')
+      ).toBe(false);
+    });
+
+    it('returns true when consultee is actively consulting', () => {
+      const interaction = {
+        participants: {
+          'agent-1': {id: 'agent-1', pType: 'Agent', hasLeft: false, isConsulted: false},
+          'agent-2': {
+            id: 'agent-2',
+            pType: 'Agent',
+            hasLeft: false,
+            hasJoined: true,
+            isConsulted: true,
+            consultState: 'consulting',
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false},
+        },
+        media: {
+          'interaction-1': {
+            mType: 'mainCall',
+            participants: ['customer-1', 'agent-1'],
+          },
+          'consult-media': {
+            mType: 'consult',
+            participants: ['agent-2', 'agent-1'],
+          },
+        },
+      } as any;
+
+      expect(
+        getIsConsultInProgressForConferenceControls(interaction, 'interaction-1', 'agent-1')
+      ).toBe(true);
     });
   });
 });

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/TaskStateMachine.ts
@@ -868,6 +868,148 @@ describe('Task state machine', () => {
       });
     });
 
+    it('returns to main leg (HELD) and does not clear the task after AgentConsultFailed then AgentConsultEnded while CONSULTING (RONA)', () => {
+      const service = startMachine();
+      const heldTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        type: 'AgentContactHeld' as any,
+        interaction: {
+          state: 'hold',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          owner: 'agent-1',
+          participants: {
+            'agent-1': {id: 'agent-1', pType: 'Agent', hasLeft: false},
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          } as any,
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              isHold: true,
+              participants: ['customer-1', 'agent-1'],
+            },
+          } as any,
+        } as any,
+      });
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData: heldTaskData});
+      service.send({type: TaskEvent.ASSIGN, taskData: heldTaskData});
+      service.send({type: TaskEvent.HOLD_INITIATED, mediaResourceId: heldTaskData.mediaResourceId});
+      service.send({
+        type: TaskEvent.HOLD_SUCCESS,
+        mediaResourceId: heldTaskData.mediaResourceId,
+        taskData: heldTaskData,
+      });
+      expect(service.getSnapshot().value).toBe(TaskState.HELD);
+
+      // Agent 1 initiates a consult and AgentConsulting arrives during ringing, moving the
+      // initiator into CONSULTING before the consultee answers.
+      service.send({type: TaskEvent.CONSULT, destination: 'agent-2', destinationType: 'agent'});
+      expect(service.getSnapshot().value).toBe(TaskState.CONSULT_INITIATING);
+      service.send({type: TaskEvent.CONSULT_SUCCESS});
+      expect(service.getSnapshot().value).toBe(TaskState.CONSULTING);
+      expect(service.getSnapshot().context.consultInitiator).toBe(true);
+
+      // Consultee RONAs: AgentConsultFailed arrives while still in CONSULTING. Main stays held.
+      const consultFailedTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        consultMediaResourceId: 'consult-media',
+        consultingAgentId: 'agent-1',
+        destAgentId: 'agent-2',
+        isConsulted: false,
+        type: 'AgentConsultFailed' as any,
+        interaction: {
+          state: 'consult',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          owner: 'agent-1',
+          participants: {
+            'agent-1': {
+              id: 'agent-1',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consultCompleted',
+              isConsulted: false,
+            },
+            'agent-2': {
+              id: 'agent-2',
+              pType: 'Agent',
+              hasLeft: false,
+              hasJoined: false,
+              consultState: 'consultReserved',
+              isConsulted: true,
+            },
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          } as any,
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              isHold: true,
+              participants: ['customer-1', 'agent-1'],
+            },
+            'consult-media': {
+              mediaResourceId: 'consult-media',
+              mType: 'consult',
+              participants: ['agent-2', 'agent-1'],
+            },
+          } as any,
+        } as any,
+      });
+      service.send({type: TaskEvent.CONSULT_FAILED, taskData: consultFailedTaskData});
+      // The initiator must leave CONSULTING and fall back to the held main leg (not stay in
+      // CONSULTING, which would let the trailing AgentConsultEnded terminate the task).
+      expect(service.getSnapshot().value).toBe(TaskState.HELD);
+
+      // AgentConsultEnded closes out the consult leg.
+      const consultEndedTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        consultMediaResourceId: 'consult-media',
+        isConsulted: false,
+        type: 'AgentConsultEnded' as any,
+        interaction: {
+          state: 'connected',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          owner: 'agent-1',
+          participants: {
+            'agent-1': {
+              id: 'agent-1',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consultCompleted',
+              isConsulted: false,
+            },
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          } as any,
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              isHold: true,
+              participants: ['customer-1', 'agent-1'],
+            },
+          } as any,
+        } as any,
+      });
+      service.send({type: TaskEvent.CONSULT_END, taskData: consultEndedTaskData});
+
+      const snapshot = service.getSnapshot();
+      // The task must remain on the main leg (HELD) and never reach TERMINATED.
+      expect(snapshot.value).toBe(TaskState.HELD);
+      expect(snapshot.value).not.toBe(TaskState.TERMINATED);
+      expect(snapshot.context.consultInitiator).toBe(false);
+      expect(snapshot.context.uiControls.activeLeg).toBe('main');
+      expect(snapshot.context.uiControls.main.consult).toEqual({
+        isVisible: true,
+        isEnabled: true,
+      });
+    });
+
     it('transitions CONSULT_INITIATING to CONSULTING on CONSULTING_ACTIVE and marks destination joined', () => {
       const service = startMachine();
       const baseTaskData = createTaskData();

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/TaskStateMachine.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/TaskStateMachine.ts
@@ -471,6 +471,464 @@ describe('Task state machine', () => {
       expect(snapshotAfterEnd.context.consultDestinationAgentJoined).toBe(false);
     });
 
+    it('returns to HELD with main-leg controls after AgentConsultEnded from Stable Prod while CONSULTING', () => {
+      const service = startMachine();
+      const baseTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+      });
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData: baseTaskData});
+      service.send({type: TaskEvent.ASSIGN, taskData: baseTaskData});
+      service.send({
+        type: TaskEvent.CONSULT,
+        destination: 'agent-2',
+        destinationType: 'agent',
+      });
+      service.send({type: TaskEvent.CONSULT_SUCCESS});
+      service.send({type: TaskEvent.CONSULTING_ACTIVE, consultDestinationAgentJoined: true});
+      expect(service.getSnapshot().value).toBe(TaskState.CONSULTING);
+
+      const consultEndedTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        type: 'AgentConsultEnded' as any,
+        isConsulted: false,
+        interaction: {
+          state: 'connected',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          owner: 'agent-1',
+          participants: {
+            'agent-1': {
+              id: 'agent-1',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consultCompleted',
+              isConsulted: false,
+            },
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          },
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              isHold: true,
+              participants: ['customer-1', 'agent-1'],
+            },
+          },
+        } as any,
+      });
+
+      service.send({type: TaskEvent.CONSULT_END, taskData: consultEndedTaskData});
+
+      const snapshot = service.getSnapshot();
+      expect(snapshot.value).toBe(TaskState.HELD);
+      expect(snapshot.context.consultInitiator).toBe(false);
+      expect(snapshot.context.consultCallHeld).toBe(false);
+      expect(snapshot.context.consultDestinationAgentJoined).toBe(false);
+      expect(snapshot.context.uiControls.activeLeg).toBe('main');
+      expect(snapshot.context.uiControls.consult.endConsult).toEqual({
+        isVisible: false,
+        isEnabled: false,
+      });
+      expect(snapshot.context.uiControls.main.hold).toEqual({
+        isVisible: true,
+        isEnabled: true,
+      });
+      expect(snapshot.context.uiControls.main.consult).toEqual({
+        isVisible: true,
+        isEnabled: true,
+      });
+      expect(snapshot.context.uiControls.main.transfer).toEqual({
+        isVisible: true,
+        isEnabled: true,
+      });
+      expect(snapshot.context.uiControls.main.recording).toEqual({
+        isVisible: true,
+        isEnabled: true,
+      });
+    });
+
+    it('enables main consult after ending consult before consultee answers (CONSULT_INITIATING -> CONSULT_END)', () => {
+      const service = startMachine();
+      const baseTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+      });
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData: baseTaskData});
+      service.send({type: TaskEvent.ASSIGN, taskData: baseTaskData});
+      service.send({
+        type: TaskEvent.CONSULT,
+        destination: 'agent-2',
+        destinationType: 'agent',
+      });
+      // Consult requested but consultee (agent-2) has not answered yet.
+      expect(service.getSnapshot().value).toBe(TaskState.CONSULT_INITIATING);
+
+      // Agent 1 ends the consult before agent-2 answers. Backend AgentConsultEnded:
+      // main on hold, self consultCompleted, no consult media, consultee not in participants.
+      const consultEndedTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        consultMediaResourceId: 'consult-media',
+        destAgentId: 'agent-2',
+        destinationType: 'Agent',
+        type: 'AgentConsultEnded' as any,
+        isConsulted: false,
+        interaction: {
+          state: 'connected',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          owner: 'agent-1',
+          participants: {
+            'agent-1': {
+              id: 'agent-1',
+              pType: 'Agent',
+              hasLeft: false,
+              hasJoined: true,
+              consultState: 'consultCompleted',
+              isConsulted: false,
+            },
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          },
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              isHold: true,
+              participants: ['customer-1', 'agent-1'],
+            },
+          },
+        } as any,
+      });
+
+      service.send({type: TaskEvent.CONSULT_END, taskData: consultEndedTaskData});
+
+      const snapshot = service.getSnapshot();
+      expect(snapshot.value).toBe(TaskState.HELD);
+      expect(snapshot.context.consultInitiator).toBe(false);
+      expect(snapshot.context.consultDestinationAgentJoined).toBe(false);
+      expect(snapshot.context.uiControls.activeLeg).toBe('main');
+      expect(snapshot.context.uiControls.main.consult).toEqual({
+        isVisible: true,
+        isEnabled: true,
+      });
+      expect(snapshot.context.uiControls.consult.endConsult).toEqual({
+        isVisible: false,
+        isEnabled: false,
+      });
+    });
+
+    it('stays HELD and clears consult UI when AgentConsultEnded arrives on HELD state', () => {
+      const service = startMachine();
+      const heldTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        interaction: {
+          state: 'hold',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          owner: 'agent-1',
+          participants: {
+            'agent-1': {
+              id: 'agent-1',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consulting',
+              isConsulted: false,
+            },
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          },
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              isHold: true,
+              participants: ['customer-1', 'agent-1'],
+            },
+          },
+        } as any,
+      });
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData: heldTaskData});
+      service.send({type: TaskEvent.ASSIGN, taskData: heldTaskData});
+      service.send({
+        type: TaskEvent.HOLD_INITIATED,
+        mediaResourceId: heldTaskData.mediaResourceId,
+      });
+      service.send({
+        type: TaskEvent.HOLD_SUCCESS,
+        mediaResourceId: heldTaskData.mediaResourceId,
+        taskData: heldTaskData,
+      });
+      expect(service.getSnapshot().value).toBe(TaskState.HELD);
+
+      const consultEndedTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        type: 'AgentConsultEnded' as any,
+        isConsulted: false,
+        interaction: {
+          state: 'hold',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          owner: 'agent-1',
+          participants: {
+            'agent-1': {
+              id: 'agent-1',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consultCompleted',
+              isConsulted: false,
+            },
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          },
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              isHold: true,
+              participants: ['customer-1', 'agent-1'],
+            },
+          },
+        } as any,
+      });
+
+      service.send({type: TaskEvent.CONSULT_END, taskData: consultEndedTaskData});
+
+      const snapshot = service.getSnapshot();
+      expect(snapshot.value).toBe(TaskState.HELD);
+      expect(snapshot.context.consultInitiator).toBe(false);
+      expect(snapshot.context.uiControls.activeLeg).toBe('main');
+      expect(snapshot.context.uiControls.main.hold).toEqual({
+        isVisible: true,
+        isEnabled: true,
+      });
+      expect(snapshot.context.uiControls.consult.endConsult).toEqual({
+        isVisible: false,
+        isEnabled: false,
+      });
+    });
+
+    it('keeps main.consult enabled on HELD after AgentConsultFailed then AgentConsultEnded (RONA)', () => {
+      const service = startMachine();
+      const heldTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        type: 'AgentContactHeld' as any,
+        interaction: {
+          state: 'hold',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          owner: 'agent-1',
+          participants: {
+            'agent-1': {id: 'agent-1', pType: 'Agent', hasLeft: false},
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          } as any,
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              isHold: true,
+              participants: ['customer-1', 'agent-1'],
+            },
+          } as any,
+        } as any,
+      });
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData: heldTaskData});
+      service.send({type: TaskEvent.ASSIGN, taskData: heldTaskData});
+      service.send({
+        type: TaskEvent.HOLD_INITIATED,
+        mediaResourceId: heldTaskData.mediaResourceId,
+      });
+      service.send({
+        type: TaskEvent.HOLD_SUCCESS,
+        mediaResourceId: heldTaskData.mediaResourceId,
+        taskData: heldTaskData,
+      });
+      expect(service.getSnapshot().value).toBe(TaskState.HELD);
+
+      const consultCreatedTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        consultMediaResourceId: 'consult-media',
+        consultingAgentId: 'agent-1',
+        destAgentId: 'agent-2',
+        isConsulted: false,
+        type: 'AgentConsultCreated' as any,
+        interaction: {
+          state: 'consult',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          owner: 'agent-1',
+          participants: {
+            'agent-1': {
+              id: 'agent-1',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consultInitiated',
+              isConsulted: false,
+            },
+            'agent-2': {
+              id: 'agent-2',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consultReserved',
+              isConsulted: true,
+            },
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          } as any,
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              isHold: true,
+              participants: ['customer-1', 'agent-1'],
+            },
+            'consult-media': {
+              mediaResourceId: 'consult-media',
+              mType: 'consult',
+              participants: ['agent-2', 'agent-1'],
+            },
+          } as any,
+        } as any,
+      });
+      service.send({type: TaskEvent.CONSULT_CREATED, taskData: consultCreatedTaskData});
+
+      const consultFailedTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        consultMediaResourceId: 'consult-media',
+        consultingAgentId: 'agent-1',
+        destAgentId: 'agent-2',
+        isConsulted: false,
+        type: 'AgentConsultFailed' as any,
+        interaction: {
+          state: 'connected',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          owner: 'agent-1',
+          participants: {
+            'agent-1': {
+              id: 'agent-1',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consultCompleted',
+              isConsulted: false,
+            },
+            'agent-2': {
+              id: 'agent-2',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consultReserved',
+              isConsulted: true,
+            },
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          } as any,
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              isHold: true,
+              participants: ['customer-1', 'agent-1'],
+            },
+          } as any,
+        } as any,
+      });
+      service.send({type: TaskEvent.CONSULT_FAILED, taskData: consultFailedTaskData});
+
+      const consultEndedTaskData = createTaskData({
+        agentId: 'agent-1',
+        mediaResourceId: 'interaction-1',
+        consultMediaResourceId: 'consult-media',
+        isConsulted: false,
+        type: 'AgentConsultEnded' as any,
+        interaction: consultFailedTaskData.interaction,
+      });
+      service.send({type: TaskEvent.CONSULT_END, taskData: consultEndedTaskData});
+
+      const snapshot = service.getSnapshot();
+      expect(snapshot.value).toBe(TaskState.HELD);
+      expect(snapshot.context.consultInitiator).toBe(false);
+      expect(snapshot.context.uiControls.activeLeg).toBe('main');
+      expect(snapshot.context.uiControls.main.consult).toEqual({
+        isVisible: true,
+        isEnabled: true,
+      });
+      expect(snapshot.context.uiControls.main.hold).toEqual({
+        isVisible: true,
+        isEnabled: true,
+      });
+      expect(snapshot.context.uiControls.main.transfer).toEqual({
+        isVisible: true,
+        isEnabled: true,
+      });
+    });
+
+    it('transitions CONSULT_INITIATING to CONSULTING on CONSULTING_ACTIVE and marks destination joined', () => {
+      const service = startMachine();
+      const baseTaskData = createTaskData();
+      const consultingTaskData = createTaskData({
+        agentId: 'agent-1',
+        isConsulted: false,
+        consultMediaResourceId: 'consult-media',
+        interaction: {
+          state: 'consulting',
+          interactionId: 'interaction-1',
+          mainInteractionId: 'interaction-1',
+          participants: {
+            'agent-1': {
+              id: 'agent-1',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consulting',
+              isConsulted: false,
+            },
+            'agent-2': {
+              id: 'agent-2',
+              pType: 'Agent',
+              hasLeft: false,
+              hasJoined: true,
+              consultState: 'consulting',
+              isConsulted: true,
+            },
+          } as any,
+          media: {
+            'interaction-1': {mediaResourceId: 'interaction-1', mType: 'mainCall', isHold: true},
+            'consult-media': {
+              mediaResourceId: 'consult-media',
+              mType: 'consult',
+              participants: ['agent-1', 'agent-2'],
+            },
+          } as any,
+        } as any,
+      });
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData: baseTaskData});
+      service.send({type: TaskEvent.ASSIGN, taskData: baseTaskData});
+      service.send({
+        type: TaskEvent.CONSULT,
+        destination: 'agent-2',
+        destinationType: 'agent',
+      });
+
+      expect(service.getSnapshot().value).toBe(TaskState.CONSULT_INITIATING);
+
+      service.send({
+        type: TaskEvent.CONSULTING_ACTIVE,
+        consultDestinationAgentJoined: true,
+        taskData: consultingTaskData,
+      });
+
+      const snapshot = service.getSnapshot();
+      expect(snapshot.value).toBe(TaskState.CONSULTING);
+      expect(snapshot.context.consultInitiator).toBe(true);
+      expect(snapshot.context.consultDestinationAgentJoined).toBe(true);
+    });
+
     it('keeps consultDestinationAgentJoined false while consultee is only reserved, then sets true on actual join', () => {
       const service = startMachine();
       const pendingTaskData = createTaskData({
@@ -706,6 +1164,82 @@ describe('Task state machine', () => {
 
       service.send({type: TaskEvent.CONSULT_END, taskData: stillConferenceTaskData});
       expect(service.getSnapshot().value).toBe(TaskState.CONFERENCING);
+    });
+
+    it('transitions CONFERENCING to CONSULTING on CONSULTING_ACTIVE and marks DN consult joined', () => {
+      const service = startMachine();
+      const conferenceTaskData = createConferenceConsultTaskData({
+        interactionState: 'conference',
+        includeSecondAgent: true,
+        conferenceHoldParticipant: false,
+      });
+
+      service.send({type: TaskEvent.TASK_INCOMING, taskData: conferenceTaskData});
+      service.send({type: TaskEvent.ASSIGN, taskData: conferenceTaskData});
+      service.send({type: TaskEvent.CONFERENCE_START, taskData: conferenceTaskData});
+      expect(service.getSnapshot().value).toBe(TaskState.CONFERENCING);
+
+      const dnConsultTaskData = createTaskData({
+        type: 'AgentConsulting' as any,
+        agentId: 'agent-1',
+        consultingAgentId: 'agent-1',
+        isConsulted: false,
+        destinationType: 'DN',
+        consultMediaResourceId: 'consult-media-1',
+        interaction: {
+          state: 'conference',
+          mainInteractionId: 'interaction-1',
+          interactionId: 'interaction-1',
+          participants: {
+            'agent-1': {
+              id: 'agent-1',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'consulting',
+              isConsulted: false,
+            },
+            'agent-2': {
+              id: 'agent-2',
+              pType: 'Agent',
+              hasLeft: false,
+              consultState: 'conferencing',
+            },
+            'dn-dest': {
+              id: 'dn-dest',
+              pType: 'DN',
+              hasLeft: false,
+              hasJoined: true,
+            },
+            'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false},
+          },
+          media: {
+            'interaction-1': {
+              mediaResourceId: 'interaction-1',
+              mType: 'mainCall',
+              participants: ['agent-1', 'agent-2', 'customer-1'],
+              isHold: false,
+            },
+            'consult-media-1': {
+              mediaResourceId: 'consult-media-1',
+              mType: 'consult',
+              participants: ['agent-1', 'dn-dest'],
+              isHold: false,
+            },
+          },
+        } as any,
+      });
+
+      service.send({
+        type: TaskEvent.CONSULTING_ACTIVE,
+        consultDestinationAgentJoined: true,
+        taskData: dnConsultTaskData,
+      });
+
+      const snapshot = service.getSnapshot();
+      expect(snapshot.value).toBe(TaskState.CONSULTING);
+      expect(snapshot.context.consultDestinationAgentJoined).toBe(true);
+      expect(snapshot.context.consultFromConference).toBe(true);
+      expect(snapshot.context.consultDestinationType).toBe('entryPoint');
     });
 
     it('transitions to conferencing when merge event is received', () => {

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
@@ -4,6 +4,7 @@ import {
   computeUIControls,
   getDefaultUIControls,
 } from '../../../../../../src/services/task/state-machine/uiControlsComputer';
+import {getTaskStateForUiControls} from '../../../../../../src/services/task/state-machine/actions';
 import {TaskContext} from '../../../../../../src/services/task/state-machine/types';
 import {createTaskData} from '../taskTestUtils';
 
@@ -958,6 +959,80 @@ describe('uiControlsComputer consult initiator controls', () => {
     expect(uiControls.consult.endConsult).toEqual({isVisible: true, isEnabled: true});
   });
 
+  it('enables consult leg controls for conference DN AgentConsulting after destination joined', () => {
+    const taskData = createTaskData({
+      agentId: 'agent-1',
+      consultingAgentId: 'agent-1',
+      consultMediaResourceId: 'consult-media-1',
+      isConsulted: false,
+      destinationType: 'DN',
+      type: 'AgentConsulting' as any,
+      interaction: {
+        state: 'conference',
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        owner: 'agent-1',
+        participants: {
+          'agent-1': {
+            id: 'agent-1',
+            pType: 'Agent',
+            hasLeft: false,
+            consultState: 'consulting',
+            isConsulted: false,
+          },
+          'agent-2': {
+            id: 'agent-2',
+            pType: 'Agent',
+            hasLeft: false,
+            consultState: 'conferencing',
+          },
+          'dn-dest': {
+            id: 'dn-dest',
+            pType: 'DN',
+            hasLeft: false,
+            hasJoined: true,
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false},
+        } as any,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            participants: ['agent-1', 'agent-2', 'customer-1'],
+            isHold: false,
+          },
+          'consult-media-1': {
+            mediaResourceId: 'consult-media-1',
+            mType: 'consult',
+            participants: ['agent-1', 'dn-dest'],
+            isHold: false,
+          },
+        } as any,
+      } as any,
+    });
+    const baseContext = createVoiceContext();
+    const context = createVoiceContext({
+      consultInitiator: true,
+      consultFromConference: true,
+      consultDestinationAgentJoined: true,
+      consultDestinationType: 'entryPoint',
+      consultCallHeld: false,
+      taskData,
+      uiControlConfig: {
+        ...baseContext.uiControlConfig,
+        agentId: 'agent-1',
+      },
+    });
+
+    const uiControls = computeUIControls(TaskState.CONSULTING, context, taskData);
+
+    expect(uiControls.consult.switch).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.consult.transfer).toEqual({isVisible: false, isEnabled: false});
+    expect(uiControls.consult.transferConference).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.consult.mergeToConference).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.consult.endConsult).toEqual({isVisible: true, isEnabled: true});
+  });
+
   it('keeps transferConference visible on consult leg for initiator even when state is conferencing', () => {
     const taskData = createConferenceConsultingInitiatorTaskData();
     const baseContext = createVoiceContext();
@@ -1135,6 +1210,528 @@ describe('uiControlsComputer consult initiator controls', () => {
     const uiControls = computeUIControls(TaskState.CONSULTING, context, taskData);
 
     expect(uiControls.main.exitConference).toEqual({isVisible: false, isEnabled: false});
+  });
+
+  function createSimpleHeldConsultInitiatedTaskData() {
+    return createTaskData({
+      agentId: 'agent-1',
+      mediaResourceId: 'interaction-1',
+      consultMediaResourceId: 'consult-media',
+      destAgentId: 'agent-2',
+      destinationType: 'Agent',
+      isConsulted: false,
+      type: 'AgentConsultCreated' as any,
+      interaction: {
+        state: 'consult',
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        owner: 'agent-1',
+        participants: {
+          'agent-1': {
+            id: 'agent-1',
+            pType: 'Agent',
+            hasLeft: false,
+            consultState: 'consultInitiated',
+            isConsulted: false,
+          },
+          'agent-2': {
+            id: 'agent-2',
+            pType: 'Agent',
+            hasLeft: false,
+            hasJoined: false,
+            consultState: 'consultReserved',
+            isConsulted: true,
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+        } as any,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            isHold: true,
+            participants: ['customer-1', 'agent-1'],
+          },
+          'consult-media': {
+            mediaResourceId: 'consult-media',
+            mType: 'consult',
+            isHold: false,
+            participants: ['agent-2', 'agent-1'],
+          },
+        } as any,
+      } as any,
+    });
+  }
+
+  function createConsultFailedHeldMainTaskData() {
+    return createTaskData({
+      agentId: 'agent-1',
+      mediaResourceId: 'interaction-1',
+      consultMediaResourceId: 'consult-media',
+      destAgentId: 'agent-2',
+      destinationType: 'Agent',
+      isConsulted: false,
+      type: 'AgentConsultFailed' as any,
+      interaction: {
+        state: 'consult',
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        owner: 'agent-1',
+        participants: {
+          'agent-1': {
+            id: 'agent-1',
+            pType: 'Agent',
+            hasLeft: false,
+            consultState: 'consultCompleted',
+            isConsulted: false,
+          },
+          'agent-2': {
+            id: 'agent-2',
+            pType: 'Agent',
+            hasLeft: false,
+            hasJoined: false,
+            consultState: 'consultReserved',
+            isConsulted: true,
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+        } as any,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            isHold: true,
+            participants: ['customer-1', 'agent-1'],
+          },
+          'consult-media': {
+            mediaResourceId: 'consult-media',
+            mType: 'consult',
+            isHold: false,
+            participants: ['agent-2', 'agent-1'],
+          },
+        } as any,
+      } as any,
+    });
+  }
+
+  it('infers HELD (not CONSULTING) while consultee has not joined', () => {
+    const taskData = createSimpleHeldConsultInitiatedTaskData();
+
+    expect(getTaskStateForUiControls(taskData as any, 'agent-1')).toBe(TaskState.HELD);
+  });
+
+  it('matches Stable Prod consult-requested controls for AgentConsultCreated while HELD', () => {
+    const taskData = createSimpleHeldConsultInitiatedTaskData();
+    const context = createVoiceContext({
+      taskData: taskData as any,
+      consultInitiator: true,
+      consultDestinationAgentJoined: false,
+      consultCallHeld: false,
+    });
+
+    const uiControls = computeUIControls(TaskState.HELD, context, taskData as any);
+
+    expect(uiControls.activeLeg).toBe('consult');
+    expect(uiControls.main.transfer).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.main.conference).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.main.end).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.main.hold).toEqual({isVisible: false, isEnabled: false});
+    expect(uiControls.consult.endConsult).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.consult.switch).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.consult.transfer).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.consult.mergeToConference).toEqual({isVisible: true, isEnabled: false});
+  });
+
+  it('clears consult leg and restores HELD main controls after AgentConsultEnded from Stable Prod', () => {
+    const taskData = createTaskData({
+      agentId: 'agent-1',
+      mediaResourceId: 'interaction-1',
+      destAgentId: 'agent-2',
+      destinationType: 'Agent',
+      isConsulted: false,
+      type: 'AgentConsultEnded' as any,
+      interaction: {
+        state: 'connected',
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        owner: 'agent-1',
+        participants: {
+          'agent-1': {
+            id: 'agent-1',
+            pType: 'Agent',
+            hasLeft: false,
+            consultState: 'consultCompleted',
+            isConsulted: false,
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+        } as any,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            isHold: true,
+            holdTimestamp: 1780495564872,
+            participants: ['customer-1', 'agent-1'],
+          },
+        } as any,
+      } as any,
+    });
+    const staleContext = createVoiceContext({
+      taskData: {
+        ...(taskData as any),
+        interaction: {
+          ...(taskData as any).interaction,
+          media: {
+            ...(taskData as any).interaction.media,
+            'consult-media': {
+              mediaResourceId: 'consult-media',
+              mType: 'consult',
+              isHold: false,
+              participants: ['agent-2', 'agent-1'],
+            },
+          },
+        },
+      },
+      consultInitiator: true,
+      consultDestinationAgentJoined: true,
+      consultCallHeld: false,
+    });
+
+    const uiControls = computeUIControls(TaskState.CONSULTING, staleContext, taskData as any);
+
+    expect(uiControls.activeLeg).toBe('main');
+    expect(uiControls.consult.endConsult).toEqual({isVisible: false, isEnabled: false});
+    expect(uiControls.main.hold).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.consult).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.transfer).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.recording).toEqual({isVisible: true, isEnabled: true});
+  });
+
+  it('enables switch, transfer, and merge on consult leg after AgentConsulting accept', () => {
+    const taskData = createTaskData({
+      agentId: 'agent-1',
+      mediaResourceId: 'interaction-1',
+      consultMediaResourceId: 'consult-media',
+      consultingAgentId: 'agent-1',
+      destAgentId: 'agent-2',
+      isConsulted: false,
+      type: 'AgentConsulting' as any,
+      interaction: {
+        state: 'consulting',
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        owner: 'agent-1',
+        participants: {
+          'agent-1': {
+            id: 'agent-1',
+            pType: 'Agent',
+            hasLeft: false,
+            consultState: 'consulting',
+            isConsulted: false,
+          },
+          'agent-2': {
+            id: 'agent-2',
+            pType: 'Agent',
+            hasLeft: false,
+            hasJoined: true,
+            consultState: 'consulting',
+            isConsulted: true,
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+        } as any,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            isHold: true,
+            participants: ['customer-1', 'agent-1'],
+          },
+          'consult-media': {
+            mediaResourceId: 'consult-media',
+            mType: 'consult',
+            isHold: false,
+            participants: ['agent-2', 'agent-1'],
+          },
+        } as any,
+      } as any,
+    });
+    const context = createVoiceContext({
+      taskData: taskData as any,
+      consultInitiator: true,
+      consultDestinationAgentJoined: true,
+      consultCallHeld: false,
+    });
+
+    const uiControls = computeUIControls(TaskState.CONSULTING, context, taskData as any);
+
+    expect(uiControls.activeLeg).toBe('consult');
+    expect(uiControls.consult.switch).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.consult.transfer).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.consult.mergeToConference).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.consult.endConsult).toEqual({isVisible: true, isEnabled: true});
+  });
+
+  it('shows RONA failure controls after AgentConsultFailed while HELD', () => {
+    const taskData = createConsultFailedHeldMainTaskData();
+    const context = createVoiceContext({
+      taskData: taskData as any,
+      consultInitiator: false,
+      consultDestinationAgentJoined: false,
+      consultCallHeld: false,
+    });
+
+    const uiControls = computeUIControls(TaskState.HELD, context, taskData as any);
+
+    expect(uiControls.activeLeg).toBe('main');
+    expect(uiControls.main.hold).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.transfer).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.consult).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.recording).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.end).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.main.conference).toEqual({isVisible: false, isEnabled: false});
+    expect(uiControls.consult.endConsult).toEqual({isVisible: false, isEnabled: false});
+  });
+
+  it('enables main.consult on AgentConsultFailed while consult media remains and destinationJoined is stale', () => {
+    const taskData = createConsultFailedHeldMainTaskData();
+    const context = createVoiceContext({
+      taskData: taskData as any,
+      consultInitiator: true,
+      consultDestinationAgentJoined: true,
+      consultCallHeld: false,
+    });
+
+    const uiControls = computeUIControls(TaskState.HELD, context, taskData as any);
+
+    expect(uiControls.main.consult).toEqual({isVisible: true, isEnabled: true});
+  });
+
+  it('enables main.consult when consultCompleted with stale consultMediaResourceId only (RONA cleanup)', () => {
+    const taskData = createTaskData({
+      agentId: 'agent-1',
+      mediaResourceId: 'interaction-1',
+      consultMediaResourceId: 'consult-media',
+      isConsulted: false,
+      type: 'AgentConsultEnded' as any,
+      interaction: {
+        state: 'connected',
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        owner: 'agent-1',
+        participants: {
+          'agent-1': {
+            id: 'agent-1',
+            pType: 'Agent',
+            hasLeft: false,
+            consultState: 'consultCompleted',
+            isConsulted: false,
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+        } as any,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            isHold: true,
+            participants: ['customer-1', 'agent-1'],
+          },
+        } as any,
+      } as any,
+    });
+    const context = createVoiceContext({
+      taskData: taskData as any,
+      consultInitiator: true,
+      consultDestinationAgentJoined: true,
+      consultCallHeld: false,
+    });
+
+    const uiControls = computeUIControls(TaskState.CONSULT_INITIATING, context, taskData as any);
+
+    expect(uiControls.main.consult).toEqual({isVisible: true, isEnabled: true});
+  });
+
+  it('enables main.consult after AgentConsultFailed then AgentConsultEnded on held main leg (RONA)', () => {
+    const consultEndedTaskData = createTaskData({
+      agentId: 'agent-1',
+      mediaResourceId: 'interaction-1',
+      consultMediaResourceId: 'consult-media',
+      destAgentId: 'agent-2',
+      destinationType: 'Agent',
+      isConsulted: false,
+      type: 'AgentConsultEnded' as any,
+      interaction: {
+        state: 'connected',
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        owner: 'agent-1',
+        participants: {
+          'agent-1': {
+            id: 'agent-1',
+            pType: 'Agent',
+            hasLeft: false,
+            consultState: 'consultCompleted',
+            isConsulted: false,
+          },
+          'agent-2': {
+            id: 'agent-2',
+            pType: 'Agent',
+            hasLeft: false,
+            hasJoined: false,
+            consultState: 'consultReserved',
+            isConsulted: true,
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+        } as any,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            isHold: true,
+            participants: ['customer-1', 'agent-1'],
+          },
+        } as any,
+      } as any,
+    });
+    const staleContext = createVoiceContext({
+      taskData: consultEndedTaskData as any,
+      consultInitiator: true,
+      consultDestinationAgentJoined: false,
+      consultCallHeld: false,
+      consultFromConference: false,
+    });
+
+    const uiControls = computeUIControls(TaskState.HELD, staleContext, consultEndedTaskData as any);
+
+    expect(uiControls.activeLeg).toBe('main');
+    expect(uiControls.main.consult).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.hold).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.transfer).toEqual({isVisible: true, isEnabled: true});
+  });
+
+  it('enables main.consult after AgentConsultEnded when consult ended before consultee answered (held main leg)', () => {
+    // Agent 1 initiates consult to Agent 2 and ends it before Agent 2 answers.
+    // Backend AgentConsultEnded: main on hold, self consultCompleted, no consult media,
+    // and the consultee (destAgent) is not present in the participants map.
+    const consultEndedTaskData = createTaskData({
+      agentId: 'agent-1',
+      mediaResourceId: 'interaction-1',
+      consultMediaResourceId: 'consult-media',
+      destAgentId: 'agent-2',
+      destinationType: 'Agent',
+      isConsulted: false,
+      type: 'AgentConsultEnded' as any,
+      interaction: {
+        state: 'connected',
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        owner: 'agent-1',
+        participants: {
+          'agent-1': {
+            id: 'agent-1',
+            pType: 'Agent',
+            hasLeft: false,
+            hasJoined: true,
+            consultState: 'consultCompleted',
+            isConsulted: false,
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+        } as any,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            isHold: true,
+            participants: ['customer-1', 'agent-1'],
+          },
+        } as any,
+      } as any,
+    });
+    // Stale context from CONSULT_INITIATING: initiator true, consultee never joined.
+    const staleContext = createVoiceContext({
+      taskData: consultEndedTaskData as any,
+      consultInitiator: true,
+      consultDestinationAgentJoined: false,
+      consultCallHeld: false,
+      consultFromConference: false,
+    });
+
+    const uiControls = computeUIControls(TaskState.HELD, staleContext, consultEndedTaskData as any);
+
+    expect(uiControls.activeLeg).toBe('main');
+    expect(uiControls.main.consult).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.hold).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.transfer).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.recording).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.end).toEqual({isVisible: true, isEnabled: false});
+    expect(uiControls.consult.endConsult).toEqual({isVisible: false, isEnabled: false});
+  });
+
+  it('enables main.consult after AgentConsultEnded even when reconciled task.data still carries stale consult media/participant', () => {
+    // Reproduces the real runtime data: Task.reconcileData deep-merges and never deletes keys,
+    // so after AgentConsultEnded the stale consult-media entry and consultee participant from
+    // AgentConsultCreated persist in task.data. The consult button must still be enabled.
+    const consultEndedTaskData = createTaskData({
+      agentId: 'agent-1',
+      mediaResourceId: 'interaction-1',
+      consultMediaResourceId: 'consult-media',
+      destAgentId: 'agent-2',
+      destinationType: 'Agent',
+      isConsulted: false,
+      type: 'AgentConsultEnded' as any,
+      interaction: {
+        state: 'connected',
+        interactionId: 'interaction-1',
+        mainInteractionId: 'interaction-1',
+        owner: 'agent-1',
+        participants: {
+          'agent-1': {
+            id: 'agent-1',
+            pType: 'Agent',
+            hasLeft: false,
+            hasJoined: true,
+            consultState: 'consultCompleted',
+            isConsulted: false,
+          },
+          'customer-1': {id: 'customer-1', pType: 'Customer', hasLeft: false, hasJoined: true},
+          // Stale consultee retained by reconcileData (never joined, consult leg gone).
+          'agent-2': {
+            id: 'agent-2',
+            pType: 'Agent',
+            hasLeft: false,
+            hasJoined: false,
+            consultState: 'consulting',
+            isConsulted: true,
+          },
+        } as any,
+        media: {
+          'interaction-1': {
+            mediaResourceId: 'interaction-1',
+            mType: 'mainCall',
+            isHold: true,
+            participants: ['customer-1', 'agent-1'],
+          },
+          // Stale consult media retained by reconcileData merge.
+          'consult-media': {
+            mediaResourceId: 'consult-media',
+            mType: 'consult',
+            isHold: false,
+            participants: ['agent-1', 'agent-2'],
+          },
+        } as any,
+      } as any,
+    });
+    const staleContext = createVoiceContext({
+      taskData: consultEndedTaskData as any,
+      consultInitiator: true,
+      consultDestinationAgentJoined: false,
+      consultCallHeld: false,
+      consultFromConference: false,
+    });
+
+    const uiControls = computeUIControls(TaskState.HELD, staleContext, consultEndedTaskData as any);
+
+    expect(uiControls.activeLeg).toBe('main');
+    expect(uiControls.main.consult).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.main.hold).toEqual({isVisible: true, isEnabled: true});
+    expect(uiControls.consult.endConsult).toEqual({isVisible: false, isEnabled: false});
   });
 
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Several call-control UI issues in the consult flow where buttons got stuck in the wrong state until a page refresh:

- After Agent 1 ends or RONA-fails a consult before Agent 2 answers, the Consult button stayed disabled on the held main leg, blocking a new consult.
- After the consult ended, resuming the main call (AgentContactUnheld) disabled Consult again. Root cause: Task.reconcileData deep-merges and never deletes keys, so the consult leg's media/participant lingered in task.data and kept being treated as an active consult.
- The Mute button was incorrectly disabled on the consulted agent's main leg while consulting (the consultee has no separate consult leg — their main leg is the active call).

## by making the following changes

- **State machine wiring** (TaskStateMachine.ts, actions.ts): wire CONSULT_END/CONSULT_FAILED on the states the initiator can be in when a consult ends externally (HELD, CONNECTED, CONSULT_INITIATING), reusing the existing clearConsultState/handleConsultFailed actions; clear consult context flags on terminal consult events.
- **Stale consult detection** (TaskUtils.ts): getIsConsultInProgressForConferenceControls ignores RONA-pending consultees (consultReserved + !hasJoined).
- **Authoritative interaction maps** (Task.ts): added pruneStaleInteractionMaps so interaction.media/participants snapshots from the backend become authoritative (drop removed keys) on the merge path, while all other fields keep the existing deep-merge. This is the root-cause fix that stops the consult leg from lingering across subsequent events.
- **UI controls** (uiControlsComputer.ts): treat a consult that has ended for self as having no active consult media (effectiveHasConsultMedia) so the consult button re-enables; keep Mute available on the consulted agent's active main leg.
- **Tests:** added regression coverage in Task, uiControlsComputer, TaskStateMachine, and TaskUtils specs (end-before-answer, RONA cleanup, stale-media-after-resume, consultee mute). Full task suite green — 302 passing.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
