### PR TITLE
fix(codec): align av1 codec parameters with specification

### DIFF
--- a/packages/@webex/plugin-meetings/src/multistream/codec/constants.ts
+++ b/packages/@webex/plugin-meetings/src/multistream/codec/constants.ts
@@ -6,7 +6,7 @@ export const AV1_CODEC_PARAMETERS: Record<SupportedResolution, AV1EncodingParams
     tier: 0,
     maxWidth: 160,
     maxHeight: 90,
-    maxPicSize: 160 * 90,
+    maxPicSize: 147_456,
     maxDecodeRate: 5_529_600,
   },
   '180p': {
@@ -14,7 +14,7 @@ export const AV1_CODEC_PARAMETERS: Record<SupportedResolution, AV1EncodingParams
     tier: 0,
     maxWidth: 320,
     maxHeight: 180,
-    maxPicSize: 320 * 180,
+    maxPicSize: 147_456,
     maxDecodeRate: 5_529_600,
   },
   '360p': {
@@ -22,7 +22,7 @@ export const AV1_CODEC_PARAMETERS: Record<SupportedResolution, AV1EncodingParams
     tier: 0,
     maxWidth: 640,
     maxHeight: 360,
-    maxPicSize: 640 * 360,
+    maxPicSize: 278_784,
     maxDecodeRate: 10_454_400,
   },
   '540p': {
@@ -30,7 +30,7 @@ export const AV1_CODEC_PARAMETERS: Record<SupportedResolution, AV1EncodingParams
     tier: 0,
     maxWidth: 960,
     maxHeight: 540,
-    maxPicSize: 960 * 540,
+    maxPicSize: 665_856,
     maxDecodeRate: 24_969_600,
   },
   '720p': {
@@ -38,7 +38,7 @@ export const AV1_CODEC_PARAMETERS: Record<SupportedResolution, AV1EncodingParams
     tier: 0,
     maxWidth: 1280,
     maxHeight: 720,
-    maxPicSize: 1280 * 720,
+    maxPicSize: 1_065_024,
     maxDecodeRate: 39_938_400,
   },
   '1080p': {
@@ -46,7 +46,7 @@ export const AV1_CODEC_PARAMETERS: Record<SupportedResolution, AV1EncodingParams
     tier: 0,
     maxWidth: 1920,
     maxHeight: 1080,
-    maxPicSize: 1920 * 1080,
+    maxPicSize: 2_359_296,
     maxDecodeRate: 77_856_768,
   },
 };


### PR DESCRIPTION
# COMPLETES [SPARK-821152](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-821152)

## This pull request addresses

The AV1 codec parameter presets in `plugin-meetings` used raw frame-size-derived `maxPicSize` values for each supported resolution.

Those values should reflect the AV1 spec level limits so the advertised codec parameters align with the selected AV1 levels and correctly cover the intended resolutions.

Spec reference: https://aomediacodec.github.io/av1-spec/av1-spec.pdf

## by making the following changes

Updates `AV1_CODEC_PARAMETERS` in `packages/@webex/plugin-meetings/src/multistream/codec/constants.ts` so each supported resolution uses spec-aligned `maxPicSize` values:

- `90p` and `180p`: `147_456`
- `360p`: `278_784`
- `540p`: `665_856`
- `720p`: `1_065_024`
- `1080p`: `2_359_296`

The existing `levelIdx`, dimensions, tier, and `maxDecodeRate` values are unchanged.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Not run; no local branch test execution was provided or verified during this PR description refresh.
- Diff reviewed for the AV1 parameter updates in `packages/@webex/plugin-meetings/src/multistream/codec/constants.ts`.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify: Cursor
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

Additional GAI usage details: Cursor was used to refresh the PR title and description. No source code changes were made during this PR metadata refresh.

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
