### PR TITLE
feat(meetingInfo): SPARK-813765-add meeting info unique query endpoint

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
+++ b/packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts
@@ -809,4 +809,63 @@ export default class MeetingInfoV2 {
         throw err;
       });
   }
+
+  /**
+   * Fetches detailed meeting info using the `/wbxappapi/v1/meetingInfo/uniqueQuery` endpoint.
+   *
+   * @param {String} meetingUrl meeting link used both as the body identifier
+   * @returns {Promise} the meeting info response
+   * @public
+   * @memberof MeetingInfo
+   */
+  async fetchMeetingDetailInfo(meetingUrl: string) {
+    if (!meetingUrl) {
+      const err = new Error('meetingUrl is required to fetch meeting detail info');
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.FETCH_MEETING_DETAIL_INFO_FAILURE, {
+        reason: err.message,
+      });
+      throw err;
+    }
+
+    let host: string;
+    try {
+      host = new URL(meetingUrl).host;
+    } catch {
+      host = '';
+    }
+    if (!host) {
+      const err = new Error(`Invalid meetingUrl: ${meetingUrl}`);
+      Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.FETCH_MEETING_DETAIL_INFO_FAILURE, {
+        reason: err.message,
+      });
+      throw err;
+    }
+
+    const body = {
+      meetingUrl,
+    };
+
+    const uri = `https://${host}/wbxappapi/v1/meetingInfo/uniqueQuery`;
+
+    return this.webex
+      .request({
+        method: HTTP_VERBS.POST,
+        uri,
+        body,
+      })
+      .then((response) => {
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.FETCH_MEETING_DETAIL_INFO_SUCCESS);
+
+        return response;
+      })
+      .catch((err) => {
+        Metrics.sendBehavioralMetric(BEHAVIORAL_METRICS.FETCH_MEETING_DETAIL_INFO_FAILURE, {
+          reason: err?.message,
+          statusCode: err?.statusCode,
+          code: err?.body?.code,
+          stack: err?.stack,
+        });
+        throw err;
+      });
+  }
 }

--- a/packages/@webex/plugin-meetings/src/metrics/constants.ts
+++ b/packages/@webex/plugin-meetings/src/metrics/constants.ts
@@ -53,6 +53,8 @@ const BEHAVIORAL_METRICS = {
   STATIC_MEETING_LINK_ALREADY_EXISTS_ERROR: 'js_sdk_static_meeting_link_already_exists_error',
   FETCH_MEETING_INFO_V1_SUCCESS: 'js_sdk_fetch_meeting_info_v1_success',
   FETCH_MEETING_INFO_V1_FAILURE: 'js_sdk_fetch_meeting_info_v1_failure',
+  FETCH_MEETING_DETAIL_INFO_SUCCESS: 'js_sdk_fetch_meeting_detail_info_success',
+  FETCH_MEETING_DETAIL_INFO_FAILURE: 'js_sdk_fetch_meeting_detail_info_failure',
   ENABLE_STATIC_METTING_LINK_SUCCESS: 'js_sdk_enable_static_meeting_link_success',
   ENABLE_STATIC_METTING_LINK_FAILURE: 'js_sdk_enable_static_meeting_link_failure',
   DISABLE_STATIC_MEETING_LINK_SUCCESS: 'js_sdk_disable_static_meeting_link_success',

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js
@@ -1352,5 +1352,87 @@ describe('plugin-meetings', () => {
         });
       });
     });
+
+    describe('#fetchMeetingDetailInfo', () => {
+      const meetingUrl = 'https://example.webex.com/example/j.php?MTID=abc';
+      const requestResponse = {
+        statusCode: 200,
+        body: {meetingKey: '1234323'},
+      };
+
+      it('POSTs to /wbxappapi/v1/meetingInfo/uniqueQuery on the host derived from meetingUrl', async () => {
+        webex.request.resolves(requestResponse);
+
+        const result = await meetingInfo.fetchMeetingDetailInfo(meetingUrl);
+
+        assert.calledOnceWithExactly(webex.request, {
+          method: 'POST',
+          uri: 'https://example.webex.com/wbxappapi/v1/meetingInfo/uniqueQuery',
+          body: {meetingUrl},
+        });
+        assert.deepEqual(result, requestResponse);
+        assert.calledWith(
+          Metrics.sendBehavioralMetric,
+          BEHAVIORAL_METRICS.FETCH_MEETING_DETAIL_INFO_SUCCESS
+        );
+      });
+
+      it('throws and reports a failure metric when meetingUrl is missing', async () => {
+        try {
+          await meetingInfo.fetchMeetingDetailInfo(undefined);
+          assert.fail('fetchMeetingDetailInfo did not throw');
+        } catch (err) {
+          assert.equal(err.message, 'meetingUrl is required to fetch meeting detail info');
+          assert.calledWith(
+            Metrics.sendBehavioralMetric,
+            BEHAVIORAL_METRICS.FETCH_MEETING_DETAIL_INFO_FAILURE,
+            {reason: err.message}
+          );
+          assert.notCalled(webex.request);
+        }
+      });
+
+      it('throws and reports a failure metric when meetingUrl is unparseable', async () => {
+        try {
+          await meetingInfo.fetchMeetingDetailInfo('not a url');
+          assert.fail('fetchMeetingDetailInfo did not throw');
+        } catch (err) {
+          assert.equal(err.message, 'Invalid meetingUrl: not a url');
+          assert.calledWith(
+            Metrics.sendBehavioralMetric,
+            BEHAVIORAL_METRICS.FETCH_MEETING_DETAIL_INFO_FAILURE,
+            {reason: err.message}
+          );
+          assert.notCalled(webex.request);
+        }
+      });
+
+      it('rethrows the request error verbatim and reports a failure metric', async () => {
+        const rawErr = {
+          statusCode: 500,
+          body: {code: 500001, message: 'a message'},
+          message: 'a message',
+          stack: 'stack-trace',
+        };
+        webex.request = sinon.stub().rejects(rawErr);
+
+        try {
+          await meetingInfo.fetchMeetingDetailInfo(meetingUrl);
+          assert.fail('expected the original error to be re-thrown');
+        } catch (err) {
+          assert.equal(err, rawErr);
+          assert.calledWith(
+            Metrics.sendBehavioralMetric,
+            BEHAVIORAL_METRICS.FETCH_MEETING_DETAIL_INFO_FAILURE,
+            {
+              reason: 'a message',
+              statusCode: 500,
+              code: 500001,
+              stack: 'stack-trace',
+            }
+          );
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-813765 >

## This pull request addresses

A defect reported by the TestDevLab team:

**Precondition**
- User opens `web.webex.com` and signs in as a **free (panelist) user**.
- The calendar contains a webinar hosted on `co.webex.com`, scheduled with `convergedats.webex.com` as the Webex default site.
- The host has not yet started the webinar.

**Steps**
1. The user clicks the webinar in the Meetings tab to open its details popover.

**Expected**
All webinar join details are displayed (webinar number, password, panelist password, "join from a video system or application", webinar password for video system, "join by phone", access code, webinar password for audio, global call-in numbers link, toll-free calling restrictions link).

**Actual**
Only the webinar link is displayed; every other join detail is missing.

### Root cause

The popover in the Web Client fetches meeting info through the existing `fetchMeetingInfo` plugin method, which calls the `meetingInfo` AppApi endpoint. In the bug's scenario, that endpoint responds with **HTTP 403 / `"Meeting is not allow to access since not reach JBH time"`** — i.e. join-before-host time has not been reached, so the join-flow endpoint refuses to return any details to a panelist. The Web Client treats this failure as "nothing to show" and falls back to rendering only the webinar link from the calendar entry, which is why every other field (number, passwords, dial-in, etc.) goes missing.

The native client does not hit this fallback because it uses a different AppApi endpoint — `wbxappapi/v1/meetingInfo/uniqueQuery` — for read-only detail lookups. That endpoint is not gated by the JBH-time check, so it returns the full set of webinar details to a panelist even before the host has started the meeting.

After confirming with the AppApi team that the Web Client is allowed to use the same endpoint, the fix is to expose `uniqueQuery` from the SDK so the Web Client can call it from the Calendar popover.

## by making the following changes

Added a new SDK method `MeetingInfoV2#fetchMeetingDetailInfo(meetingUrl: string)` in [`packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts`](packages/@webex/plugin-meetings/src/meeting-info/meeting-info-v2.ts).

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

**Unit tests** — added to `packages/@webex/plugin-meetings/test/unit/spec/meeting-info/meetinginfov2.js` under `#fetchMeetingDetailInfo`:

1. POSTs to `/wbxappapi/v1/meetingInfo/uniqueQuery` on the host derived from `meetingUrl`, with body `{meetingUrl}`, returns the response, and reports `FETCH_MEETING_DETAIL_INFO_SUCCESS`.
2. Missing `meetingUrl` throws early, reports `FETCH_MEETING_DETAIL_INFO_FAILURE`, and never calls `webex.request`.
3. Unparseable `meetingUrl` throws early, reports `FETCH_MEETING_DETAIL_INFO_FAILURE`, and never calls `webex.request`.
4. Request errors are rethrown verbatim with a single `FETCH_MEETING_DETAIL_INFO_FAILURE` metric (no join-flow mapping).

**Manual validation** — repro of the original defect against the Web Client wired to this SDK build:

| Step | Before | After |
| --- | --- | --- |
| Free panelist opens the cross-site webinar popover from the Meetings tab | Only the webinar link is shown | All join details are displayed (webinar number, password, panelist password, video system join URL/password, dial-in access code & audio password, global call-in / toll-free links) |

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
