### PR TITLE
feat: llmrefactor and mercury revert

### DIFF
--- a/packages/@webex/internal-plugin-llm/src/index.ts
+++ b/packages/@webex/internal-plugin-llm/src/index.ts
@@ -4,6 +4,9 @@ import {DataChannelTokenType} from './llm.types';
 
 WebexCore.registerInternalPlugin('llm', LLMPlugin, {
   config,
+  onBeforeLogout() {
+    return this.disconnectAllLLM();
+  },
 });
 
 export {DataChannelTokenType};

--- a/packages/@webex/internal-plugin-llm/src/index.ts
+++ b/packages/@webex/internal-plugin-llm/src/index.ts
@@ -1,11 +1,12 @@
 import * as WebexCore from '@webex/webex-core';
-import LLMChannel, {config} from './llm';
+import LLMPlugin, {config} from './llm-plugin';
 import {DataChannelTokenType} from './llm.types';
 
-WebexCore.registerInternalPlugin('llm', LLMChannel, {
+WebexCore.registerInternalPlugin('llm', LLMPlugin, {
   config,
 });
 
 export {DataChannelTokenType};
 export {LLM_DEFAULT_SESSION, LLM_PRACTICE_SESSION} from './constants';
 export {default} from './llm';
+export {default as LLMPlugin} from './llm-plugin';

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -28,6 +28,12 @@ export class LLMPlugin extends (WebexPlugin as any) {
     if (!channel) {
       // @ts-ignore — WebexPlugin children require {parent: this.webex}
       channel = new LLMChannel({parent: this.webex});
+      // Forward all events emitted by the channel up through the plugin so that
+      // callers doing llm.on('event:relay.event', ...) or llm.on('online', ...)
+      // receive events from whichever session channel emits them.
+      channel.on('all', (eventName: string, ...args: any[]) => {
+        this.trigger(eventName, ...args);
+      });
       this.sessions.set(sessionId, channel);
     }
 
@@ -53,6 +59,7 @@ export class LLMPlugin extends (WebexPlugin as any) {
     datachannelToken?: string,
     sessionId: string = LLM_DEFAULT_SESSION
   ): Promise<void> {
+    // Deduplicate concurrent calls for the same session while a connection is in-flight.
     const inProgress = this.connectingPromises.get(sessionId);
 
     if (inProgress) {
@@ -60,6 +67,17 @@ export class LLMPlugin extends (WebexPlugin as any) {
     }
 
     const channel = this.getOrCreateSession(sessionId);
+
+    // If the channel is already connected to the exact same datachannel URL,
+    // there is nothing to do — avoid triggering a reconnect that would cause
+    // the server to replace the existing connection with 4000 Replaced.
+    if (
+      channel.isConnected() &&
+      channel.getDatachannelUrl() === datachannelUrl &&
+      channel.getLocusUrl() === locusUrl
+    ) {
+      return Promise.resolve();
+    }
 
     const promise = channel
       .registerAndConnect(locusUrl, datachannelUrl, datachannelToken)

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -1,0 +1,271 @@
+/* eslint-disable require-jsdoc */
+import {WebexPlugin} from '@webex/webex-core';
+import LLMChannel, {config} from './llm';
+import {DATA_CHANNEL_WITH_JWT_TOKEN, LLM_DEFAULT_SESSION} from './constants';
+import {DataChannelTokenType} from './llm.types';
+
+/**
+ * LLMPlugin — registered as `webex.internal.llm`.
+ *
+ * Maintains a Map<sessionId, LLMChannel> so multiple simultaneous LLM
+ * connections (e.g. default session + practice session) can coexist.
+ * All existing callers continue to work unchanged via the session-keyed API.
+ *
+ * sessionId values are the LLM_DEFAULT_SESSION / LLM_PRACTICE_SESSION constants,
+ * which match the DataChannelTokenType enum values so token keys and session keys
+ * are the same namespace.
+ */
+export class LLMPlugin extends (WebexPlugin as any) {
+  namespace = 'llm';
+
+  private sessions = new Map<string, LLMChannel>();
+
+  private getOrCreateSession(sessionId: string): LLMChannel {
+    let channel = this.sessions.get(sessionId);
+
+    if (!channel) {
+      // @ts-ignore — WebexPlugin children require {parent: this.webex}
+      channel = new LLMChannel({parent: this.webex});
+      this.sessions.set(sessionId, channel);
+    }
+
+    return channel;
+  }
+
+  private getSession(sessionId: string): LLMChannel | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  // Before webex.internal.llm was LLChannel instance which extended Mercury so it was directly available
+  get hasEverConnected(): boolean {
+    for (const ch of this.sessions.values()) {
+      if (ch.hasEverConnected) return true;
+    }
+
+    return false;
+  }
+
+  public registerAndConnect(
+    locusUrl: string,
+    datachannelUrl: string,
+    datachannelToken?: string,
+    sessionId: string = LLM_DEFAULT_SESSION
+  ): Promise<void> {
+    const channel = this.getOrCreateSession(sessionId);
+
+    return channel.registerAndConnect(locusUrl, datachannelUrl, datachannelToken);
+  }
+
+  public disconnectLLM(
+    options: {code: number; reason: string},
+    ownerMeetingId?: string,
+    sessionId: string = LLM_DEFAULT_SESSION
+  ): Promise<boolean | void> {
+    const channel = this.getSession(sessionId);
+
+    if (!channel) return Promise.resolve();
+
+    const {isOwner} = this.resolveSessionOwnership(ownerMeetingId, sessionId);
+
+    if (!isOwner) {
+      this.logger.info(`llm#disconnectLLM --> skipping, not owner of session ${sessionId}`);
+
+      return Promise.resolve(false);
+    }
+
+    return channel.disconnectLLM(options).then(() => {
+      this.sessions.delete(sessionId);
+
+      return true;
+    });
+  }
+
+  public disconnectAllLLM(options?: {code: number; reason: string}): Promise<void> {
+    const promises = Array.from(this.sessions.entries()).map(([sessionId, channel]) =>
+      channel.disconnectLLM(options).then(() => this.sessions.delete(sessionId))
+    );
+
+    return Promise.all(promises).then(() => undefined);
+  }
+
+  public isConnected(sessionId: string = LLM_DEFAULT_SESSION): boolean {
+    return this.getSession(sessionId)?.isConnected() ?? false;
+  }
+
+  public getBinding(sessionId: string = LLM_DEFAULT_SESSION): string | undefined {
+    return this.getSession(sessionId)?.getBinding();
+  }
+
+  public getLocusUrl(sessionId: string = LLM_DEFAULT_SESSION): string | undefined {
+    return this.getSession(sessionId)?.getLocusUrl();
+  }
+
+  public getDatachannelUrl(sessionId: string = LLM_DEFAULT_SESSION): string | undefined {
+    return this.getSession(sessionId)?.getDatachannelUrl();
+  }
+
+  // tokenKey IS the sessionId (DataChannelTokenType enum values equal LLM_*_SESSION constants)
+
+  public getDatachannelToken(
+    // eslint-disable-next-line default-param-last
+    tokenKey: string = LLM_DEFAULT_SESSION,
+    ownerMeetingId?: string
+  ): string | undefined {
+    const channel = this.getSession(tokenKey);
+
+    if (!channel) return undefined;
+
+    const {isOwner, currentOwner} = this.resolveSessionOwnership(ownerMeetingId, tokenKey);
+
+    if (!isOwner) {
+      this.logger.info(
+        `llm#getDatachannelToken --> skip read for session ${tokenKey}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
+      );
+
+      return undefined;
+    }
+
+    return channel.getDatachannelToken();
+  }
+
+  public setDatachannelToken(
+    datachannelToken: string,
+    ownerMeetingId?: string,
+    tokenKey: string = LLM_DEFAULT_SESSION
+  ): void {
+    const channel = this.getOrCreateSession(tokenKey);
+    const {isOwner, currentOwner} = this.resolveSessionOwnership(ownerMeetingId, tokenKey);
+
+    if (!isOwner) {
+      this.logger.info(
+        `llm#setDatachannelToken --> skip write for session ${tokenKey}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
+      );
+
+      return;
+    }
+
+    channel.setDatachannelToken(datachannelToken);
+  }
+
+  public clearDatachannelToken(tokenKey: string, ownerMeetingId: string): void {
+    const channel = this.getSession(tokenKey);
+
+    if (!channel) return;
+
+    const {isOwner, currentOwner} = this.resolveSessionOwnership(ownerMeetingId, tokenKey);
+
+    if (!isOwner) {
+      this.logger.info(
+        `llm#clearDatachannelToken --> skip clear for session ${tokenKey}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
+      );
+
+      return;
+    }
+
+    channel.clearDatachannelToken();
+  }
+
+  public setRefreshHandler(
+    handler: () => Promise<{
+      body: {datachannelToken: string; datachannelTokenType: DataChannelTokenType};
+    }>,
+    ownerMeetingId?: string,
+    sessionId: string = LLM_DEFAULT_SESSION
+  ): void {
+    const channel = this.getOrCreateSession(sessionId);
+    const {isOwner, currentOwner} = this.resolveSessionOwnership(ownerMeetingId, sessionId);
+
+    if (!isOwner) {
+      this.logger.info(
+        `llm#setRefreshHandler --> skip write for session ${sessionId}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
+      );
+
+      return;
+    }
+
+    channel.setRefreshHandler(handler);
+  }
+
+  public refreshDataChannelToken(sessionId: string = LLM_DEFAULT_SESSION): Promise<any> {
+    const channel = this.getSession(sessionId);
+
+    if (!channel) {
+      this.logger.warn(`llm#refreshDataChannelToken --> no channel for session ${sessionId}`);
+
+      return Promise.resolve(null);
+    }
+
+    return channel.refreshDataChannelToken();
+  }
+
+  public setOwnerMeetingId(
+    ownerMeetingId: string | undefined,
+    sessionId: string = LLM_DEFAULT_SESSION
+  ): void {
+    const channel = this.getSession(sessionId);
+
+    if (channel) channel.ownerMeetingId = ownerMeetingId;
+  }
+
+  public getOwnerMeetingId(sessionId: string = LLM_DEFAULT_SESSION): string | undefined {
+    return this.getSession(sessionId)?.ownerMeetingId;
+  }
+
+  public resolveSessionOwnership(
+    ownerMeetingId?: string,
+    sessionId: string = LLM_DEFAULT_SESSION
+  ): {currentOwner: string | undefined; isOwner: boolean} {
+    const currentOwner = this.getOwnerMeetingId(sessionId);
+    const isOwner = !currentOwner || !ownerMeetingId || currentOwner === ownerMeetingId;
+
+    return {currentOwner, isOwner};
+  }
+
+  public getConnectionByDatachannelUrl(url: string): LLMChannel | undefined {
+    for (const channel of this.sessions.values()) {
+      const datachannelUrl = channel.getDatachannelUrl();
+
+      if (datachannelUrl && LLMChannel.matchesDatachannelRequestUrl(url, datachannelUrl)) {
+        return channel;
+      }
+    }
+
+    return undefined;
+  }
+
+  public getLocusUrlByDatachannelUrl(requestUrl: string): string | undefined {
+    for (const channel of this.sessions.values()) {
+      const datachannelUrl = channel.getDatachannelUrl();
+
+      if (datachannelUrl && LLMChannel.matchesDatachannelRequestUrl(requestUrl, datachannelUrl)) {
+        return channel.getLocusUrl();
+      }
+    }
+
+    return undefined;
+  }
+
+  public getSessionIdByDatachannelUrl(requestUrl: string): string | undefined {
+    for (const [sessionId, channel] of this.sessions.entries()) {
+      const datachannelUrl = channel.getDatachannelUrl();
+
+      if (datachannelUrl && LLMChannel.matchesDatachannelRequestUrl(requestUrl, datachannelUrl)) {
+        return sessionId;
+      }
+    }
+
+    return undefined;
+  }
+
+  public isDataChannelTokenEnabled(): Promise<boolean> {
+    // @ts-ignore
+    return this.webex.internal.feature.getFeature('developer', DATA_CHANNEL_WITH_JWT_TOKEN);
+  }
+
+  public getAllConnections(): Map<string, LLMChannel> {
+    return new Map(this.sessions);
+  }
+}
+
+export {config};
+export default LLMPlugin;

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -20,6 +20,8 @@ export class LLMPlugin extends (WebexPlugin as any) {
 
   private sessions = new Map<string, LLMChannel>();
 
+  private connectingPromises = new Map<string, Promise<void>>();
+
   private getOrCreateSession(sessionId: string): LLMChannel {
     let channel = this.sessions.get(sessionId);
 
@@ -51,9 +53,23 @@ export class LLMPlugin extends (WebexPlugin as any) {
     datachannelToken?: string,
     sessionId: string = LLM_DEFAULT_SESSION
   ): Promise<void> {
+    const inProgress = this.connectingPromises.get(sessionId);
+
+    if (inProgress) {
+      return inProgress;
+    }
+
     const channel = this.getOrCreateSession(sessionId);
 
-    return channel.registerAndConnect(locusUrl, datachannelUrl, datachannelToken);
+    const promise = channel
+      .registerAndConnect(locusUrl, datachannelUrl, datachannelToken)
+      .finally(() => {
+        this.connectingPromises.delete(sessionId);
+      });
+
+    this.connectingPromises.set(sessionId, promise);
+
+    return promise;
   }
 
   public disconnectLLM(

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -20,8 +20,6 @@ export class LLMPlugin extends (WebexPlugin as any) {
 
   private sessions = new Map<string, LLMChannel>();
 
-  private connectingPromises = new Map<string, Promise<void>>();
-
   private getOrCreateSession(sessionId: string): LLMChannel {
     let channel = this.sessions.get(sessionId);
 
@@ -59,14 +57,12 @@ export class LLMPlugin extends (WebexPlugin as any) {
     datachannelToken?: string,
     sessionId: string = LLM_DEFAULT_SESSION
   ): Promise<void> {
-    // Deduplicate concurrent calls for the same session while a connection is in-flight.
-    const inProgress = this.connectingPromises.get(sessionId);
-
-    if (inProgress) {
-      return inProgress;
-    }
-
     const channel = this.getOrCreateSession(sessionId);
+
+    // Deduplicate concurrent calls for the same session while a connection is in-flight.
+    if (channel.connectingPromise) {
+      return channel.connectingPromise;
+    }
 
     // If the channel is already connected to the exact same datachannel URL,
     // there is nothing to do — avoid triggering a reconnect that would cause
@@ -82,10 +78,10 @@ export class LLMPlugin extends (WebexPlugin as any) {
     const promise = channel
       .registerAndConnect(locusUrl, datachannelUrl, datachannelToken)
       .finally(() => {
-        this.connectingPromises.delete(sessionId);
+        channel.connectingPromise = undefined;
       });
 
-    this.connectingPromises.set(sessionId, promise);
+    channel.connectingPromise = promise;
 
     return promise;
   }

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -130,6 +130,16 @@ export class LLMPlugin extends (WebexPlugin as any) {
     return this.getSession(sessionId)?.getBinding();
   }
 
+  public getSocket(sessionId: string = LLM_DEFAULT_SESSION): any {
+    return this.getSession(sessionId)?.socket;
+  }
+
+  // Backwards-compatibility: callers that access llm.socket directly
+  // (e.g. voicea's getPublishTransport) get the default session socket.
+  get socket(): any {
+    return this.getSocket(LLM_DEFAULT_SESSION);
+  }
+
   public getLocusUrl(sessionId: string = LLM_DEFAULT_SESSION): string | undefined {
     return this.getSession(sessionId)?.getLocusUrl();
   }

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -59,31 +59,7 @@ export class LLMPlugin extends (WebexPlugin as any) {
   ): Promise<void> {
     const channel = this.getOrCreateSession(sessionId);
 
-    // Deduplicate concurrent calls for the same session while a connection is in-flight.
-    if (channel.connectingPromise) {
-      return channel.connectingPromise;
-    }
-
-    // If the channel is already connected to the exact same datachannel URL,
-    // there is nothing to do — avoid triggering a reconnect that would cause
-    // the server to replace the existing connection with 4000 Replaced.
-    if (
-      channel.isConnected() &&
-      channel.getDatachannelUrl() === datachannelUrl &&
-      channel.getLocusUrl() === locusUrl
-    ) {
-      return Promise.resolve();
-    }
-
-    const promise = channel
-      .registerAndConnect(locusUrl, datachannelUrl, datachannelToken)
-      .finally(() => {
-        channel.connectingPromise = undefined;
-      });
-
-    channel.connectingPromise = promise;
-
-    return promise;
+    return channel.registerAndConnect(locusUrl, datachannelUrl, datachannelToken);
   }
 
   public disconnectLLM(
@@ -120,7 +96,10 @@ export class LLMPlugin extends (WebexPlugin as any) {
   }
 
   public isConnected(sessionId: string = LLM_DEFAULT_SESSION): boolean {
-    return this.getSession(sessionId)?.isConnected() ?? false;
+    const session = this.getSession(sessionId);
+    const connected = session?.isConnected() ?? false;
+
+    return connected;
   }
 
   public getBinding(sessionId: string = LLM_DEFAULT_SESSION): string | undefined {

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -29,8 +29,15 @@ export class LLMPlugin extends (WebexPlugin as any) {
       // Forward all events emitted by the channel up through the plugin so that
       // callers doing llm.on('event:relay.event', ...) or llm.on('online', ...)
       // receive events from whichever session channel emits them.
+      // Non-default sessions emit events with :<sessionId> suffix so that
+      // practice-session consumers can subscribe to session-specific names
+      // like `event:relay.event:llm-practice-session`.
       channel.on('all', (eventName: string, ...args: any[]) => {
-        this.trigger(eventName, ...args);
+        if (sessionId === LLM_DEFAULT_SESSION) {
+          this.trigger(eventName, ...args);
+        } else {
+          this.trigger(`${eventName}:${sessionId}`, ...args);
+        }
       });
       this.sessions.set(sessionId, channel);
     }

--- a/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm-plugin.ts
@@ -92,8 +92,9 @@ export class LLMPlugin extends (WebexPlugin as any) {
 
   public disconnectLLM(
     options: {code: number; reason: string},
-    ownerMeetingId?: string,
-    sessionId: string = LLM_DEFAULT_SESSION
+    // eslint-disable-next-line default-param-last
+    sessionId: string = LLM_DEFAULT_SESSION,
+    ownerMeetingId?: string
   ): Promise<boolean | void> {
     const channel = this.getSession(sessionId);
 

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -60,16 +60,8 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   /** Owning meeting ID — set by LLMPlugin to prevent cross-meeting teardown. */
   public ownerMeetingId?: string;
 
-  /** In-flight connection promise for deduplication — set/cleared by LLMPlugin. */
-  public connectingPromise?: Promise<void>;
-
-  /**
-   * The LLM data-channel does not send a mercury.buffer_state acknowledgement,
-   * so the socket should not block in _authorize() waiting for it.
-   * Mercury's _prepareAndOpenSocket merges this into the socket's open() options,
-   * and socket-base.js _authorize() skips the buffer_state wait when this is set.
-   */
-  protected _extraSocketOptions = {skipBufferState: true};
+  /** In-flight connection promise for deduplication. */
+  private connectingPromise?: Promise<void>;
 
   /**
    * Register to the websocket
@@ -100,7 +92,9 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   };
 
   /**
-   * Register and connect to the websocket
+   * Register and connect to the websocket.
+   * Handles deduplication: returns existing promise if connection in progress,
+   * or resolves immediately if already connected to the same URLs.
    * @param {string} locusUrl
    * @param {string} datachannelUrl
    * @param {string} datachannelToken
@@ -111,19 +105,42 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
     datachannelUrl: string,
     datachannelToken?: string
   ): Promise<void> => {
+    // Deduplicate concurrent calls while a connection is in-flight
+    if (this.connectingPromise) {
+      return this.connectingPromise;
+    }
+
+    // If already connected to the exact same datachannel URL, avoid triggering
+    // a reconnect that would cause the server to replace with 4000 Replaced
+    if (
+      this.isConnected() &&
+      this.datachannelUrl === datachannelUrl &&
+      this.locusUrl === locusUrl
+    ) {
+      return Promise.resolve();
+    }
+
     this.locusUrl = locusUrl;
     this.datachannelUrl = datachannelUrl;
 
-    return this.register(datachannelUrl, datachannelToken).then(async () => {
-      const isDataChannelTokenEnabled = await this.isDataChannelTokenEnabled();
+    const promise = this.register(datachannelUrl, datachannelToken)
+      .then(async () => {
+        const isDataChannelTokenEnabled = await this.isDataChannelTokenEnabled();
 
-      const connectUrl =
-        isDataChannelTokenEnabled && this.webSocketUrl
-          ? LLMChannel.buildUrlWithAwareSubchannels(this.webSocketUrl, AWARE_DATA_CHANNEL)
-          : this.webSocketUrl;
+        const connectUrl =
+          isDataChannelTokenEnabled && this.webSocketUrl
+            ? LLMChannel.buildUrlWithAwareSubchannels(this.webSocketUrl, AWARE_DATA_CHANNEL)
+            : this.webSocketUrl;
 
-      return this.connect(connectUrl);
-    });
+        return this.connect(connectUrl);
+      })
+      .finally(() => {
+        this.connectingPromise = undefined;
+      });
+
+    this.connectingPromise = promise;
+
+    return promise;
   };
 
   /**

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -61,6 +61,14 @@ export default class LLMChannel extends (Mercury as any) {
   public ownerMeetingId?: string;
 
   /**
+   * The LLM data-channel does not send a mercury.buffer_state acknowledgement,
+   * so the socket should not block in _authorize() waiting for it.
+   * Mercury's _prepareAndOpenSocket merges this into the socket's open() options,
+   * and socket-base.js _authorize() skips the buffer_state wait when this is set.
+   */
+  protected _extraSocketOptions = {skipBufferState: true};
+
+  /**
    * Register to the websocket
    * @param {string} llmSocketUrl
    * @param {string} datachannelToken

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -7,7 +7,7 @@ import {
   AWARE_DATA_CHANNEL,
   SUBSCRIPTION_AWARE_SUBCHANNELS_PARAM,
 } from './constants';
-import {DataChannelTokenType} from './llm.types';
+import {DataChannelTokenType, ILLMChannel} from './llm.types';
 
 export const config = {
   llm: {
@@ -45,7 +45,7 @@ export const config = {
  * Session-level routing (multiple connections keyed by sessionId) is handled
  * by LLMPlugin, which owns a Map<sessionId, LLMChannel>.
  */
-export default class LLMChannel extends (Mercury as any) {
+export default class LLMChannel extends (Mercury as any) implements ILLMChannel {
   namespace = LLM;
 
   private webSocketUrl?: string;
@@ -59,6 +59,9 @@ export default class LLMChannel extends (Mercury as any) {
 
   /** Owning meeting ID — set by LLMPlugin to prevent cross-meeting teardown. */
   public ownerMeetingId?: string;
+
+  /** In-flight connection promise for deduplication — set/cleared by LLMPlugin. */
+  public connectingPromise?: Promise<void>;
 
   /**
    * The LLM data-channel does not send a mercury.buffer_state acknowledgement,
@@ -108,7 +111,6 @@ export default class LLMChannel extends (Mercury as any) {
     datachannelUrl: string,
     datachannelToken?: string
   ): Promise<void> => {
-    // Store directly on the instance — no session map needed
     this.locusUrl = locusUrl;
     this.datachannelUrl = datachannelUrl;
 

--- a/packages/@webex/internal-plugin-llm/src/llm.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.ts
@@ -1,16 +1,13 @@
 /* eslint-disable consistent-return */
-
 import Mercury from '@webex/internal-plugin-mercury';
 
-// eslint-disable-next-line no-unused-vars
 import {
   LLM,
   DATA_CHANNEL_WITH_JWT_TOKEN,
   AWARE_DATA_CHANNEL,
   SUBSCRIPTION_AWARE_SUBCHANNELS_PARAM,
-  LLM_DEFAULT_SESSION,
 } from './constants';
-import {ILLMChannel, DataChannelTokenType} from './llm.types';
+import {DataChannelTokenType} from './llm.types';
 
 export const config = {
   llm: {
@@ -44,50 +41,32 @@ export const config = {
 };
 
 /**
- * LLMChannel to provide socket connections
+ * LLMChannel — a single WebSocket connection to the LLM data channel.
+ * Session-level routing (multiple connections keyed by sessionId) is handled
+ * by LLMPlugin, which owns a Map<sessionId, LLMChannel>.
  */
-export default class LLMChannel extends (Mercury as any) implements ILLMChannel {
+export default class LLMChannel extends (Mercury as any) {
   namespace = LLM;
-  defaultSessionId = LLM_DEFAULT_SESSION;
-  /**
-   * Map to store connection-specific data for multiple LLM connections
-   * Key: sessionId
-   * @private
-   * @type {Map<string, {webSocketUrl?: string; binding?: string; locusUrl?: string; datachannelUrl?: string}>}
-   */
-  private connections: Map<
-    string,
-    {
-      webSocketUrl?: string;
-      binding?: string;
-      locusUrl?: string;
-      datachannelUrl?: string;
-      ownerMeetingId?: string;
-      refreshHandler?: () => Promise<{
-        body: {datachannelToken: string; datachannelTokenType: DataChannelTokenType};
-      }>;
-    }
-  > = new Map();
 
-  // Session-keyed token cache is intentionally decoupled from connection state.
-  // Disconnecting a socket session must not implicitly wipe token cache.
-  private datachannelTokens: Record<string, string | undefined> = {
-    [DataChannelTokenType.Default]: undefined,
-    [DataChannelTokenType.PracticeSession]: undefined,
-  };
+  private webSocketUrl?: string;
+  private binding?: string;
+  private locusUrl?: string;
+  private datachannelUrl?: string;
+  private datachannelToken?: string;
+  private refreshHandler?: () => Promise<{
+    body: {datachannelToken: string; datachannelTokenType: DataChannelTokenType};
+  }>;
+
+  /** Owning meeting ID — set by LLMPlugin to prevent cross-meeting teardown. */
+  public ownerMeetingId?: string;
 
   /**
    * Register to the websocket
    * @param {string} llmSocketUrl
    * @param {string} datachannelToken
-   * @param {string} sessionId - Connection identifier
    * @returns {Promise<void>}
    */
-  private register = async (
-    llmSocketUrl: string,
-    datachannelToken?: string,
-    sessionId: string = LLM_DEFAULT_SESSION
-  ): Promise<void> => {
+  private register = async (llmSocketUrl: string, datachannelToken?: string): Promise<void> => {
     const isDataChannelTokenEnabled = await this.isDataChannelTokenEnabled();
 
     return this.request({
@@ -100,14 +79,11 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
           : {},
     })
       .then((res: {body: {webSocketUrl: string; binding: string}}) => {
-        // Get or create connection data
-        const sessionData = this.connections.get(sessionId) || {};
-        sessionData.webSocketUrl = res.body.webSocketUrl;
-        sessionData.binding = res.body.binding;
-        this.connections.set(sessionId, sessionData);
+        this.webSocketUrl = res.body.webSocketUrl;
+        this.binding = res.body.binding;
       })
       .catch((error: any) => {
-        this.logger.error(`Error connecting to websocket for ${sessionId}: ${error}`);
+        this.logger.error(`Error connecting to websocket for : ${error}`);
         throw error;
       });
   };
@@ -117,309 +93,107 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
    * @param {string} locusUrl
    * @param {string} datachannelUrl
    * @param {string} datachannelToken
-   * @param {string} sessionId - Connection identifier
    * @returns {Promise<void>}
    */
   public registerAndConnect = (
     locusUrl: string,
     datachannelUrl: string,
-    datachannelToken?: string,
-    sessionId: string = LLM_DEFAULT_SESSION
+    datachannelToken?: string
   ): Promise<void> => {
-    // Pre-populate locusUrl and datachannelUrl before register() fires the
-    // HTTP POST, so that any token refresh triggered during registration can
-    // be routed via connections without falling back to a locusInfo URL scan.
-    if (locusUrl && datachannelUrl) {
-      const sessionData = this.connections.get(sessionId) || {};
-      sessionData.locusUrl = locusUrl;
-      sessionData.datachannelUrl = datachannelUrl;
-      this.connections.set(sessionId, sessionData);
-    }
+    // Store directly on the instance — no session map needed
+    this.locusUrl = locusUrl;
+    this.datachannelUrl = datachannelUrl;
 
-    return this.register(datachannelUrl, datachannelToken, sessionId).then(async () => {
-      if (!locusUrl || !datachannelUrl) return undefined;
-
-      // locusUrl and datachannelUrl were pre-populated before register(); here
-      // we only need to read the existing session data to get webSocketUrl/binding
-      // that register() filled in.
-      const sessionData = this.connections.get(sessionId) || {};
-
+    return this.register(datachannelUrl, datachannelToken).then(async () => {
       const isDataChannelTokenEnabled = await this.isDataChannelTokenEnabled();
 
-      const connectUrl = isDataChannelTokenEnabled
-        ? LLMChannel.buildUrlWithAwareSubchannels(sessionData.webSocketUrl, AWARE_DATA_CHANNEL)
-        : sessionData.webSocketUrl;
+      const connectUrl =
+        isDataChannelTokenEnabled && this.webSocketUrl
+          ? LLMChannel.buildUrlWithAwareSubchannels(this.webSocketUrl, AWARE_DATA_CHANNEL)
+          : this.webSocketUrl;
 
-      return this.connect(connectUrl, sessionId);
+      return this.connect(connectUrl);
     });
   };
 
   /**
    * Tells if LLM socket is connected
-   * @param {string} sessionId - Connection identifier
    * @returns {boolean} connected
    */
-  public isConnected = (sessionId = LLM_DEFAULT_SESSION): boolean => {
-    const socket = this.getSocket(sessionId);
-
-    return socket ? socket.connected : false;
-  };
+  public isConnected = (): boolean => this.connected;
 
   /**
    * Tells if LLM socket is binding
-   * @param {string} sessionId - Connection identifier
-   * @returns {string} binding
+   * @returns {string | undefined} binding
    */
-  public getBinding = (sessionId = LLM_DEFAULT_SESSION): string => {
-    const sessionData = this.connections.get(sessionId);
-
-    return sessionData?.binding;
-  };
+  public getBinding = (): string | undefined => this.binding;
 
   /**
    * Get Locus URL for the connection
-   * @param {string} sessionId - Connection identifier
-   * @returns {string} locus Url
+   * @returns {string | undefined} locus Url
    */
-  public getLocusUrl = (sessionId = LLM_DEFAULT_SESSION): string => {
-    const sessionData = this.connections.get(sessionId);
-
-    return sessionData?.locusUrl;
-  };
+  public getLocusUrl = (): string | undefined => this.locusUrl;
 
   /**
    * Get data channel URL for the connection
-   * @param {string} sessionId - Connection identifier
-   * @returns {string} data channel Url
+   * @returns {string | undefined} data channel Url
    */
-  public getDatachannelUrl = (sessionId = LLM_DEFAULT_SESSION): string => {
-    const sessionData = this.connections.get(sessionId);
-
-    return sessionData?.datachannelUrl;
-  };
+  public getDatachannelUrl = (): string | undefined => this.datachannelUrl;
 
   /**
-   * Set the owner meeting ID for a given LLM session. Used by the meetings
-   * plugin to tag which Meeting instance currently owns the (default) LLM
-   * connection so that other Meeting instances can avoid disconnecting or
-   * re-initializing a connection they do not own.
-   *
-   * Does NOT create a connections entry if one does not already exist — this
-   * method is a no-op when there is no active session data. Callers should
-   * invoke it after a successful `registerAndConnect` or during an explicit
-   * ownership handoff.
-   *
-   * @param {string | undefined} ownerMeetingId - Meeting ID (or undefined to clear)
-   * @param {string} sessionId - Connection identifier (defaults to default session)
+   * Get data channel token for this connection.
+   * @returns {string | undefined}
+   */
+  public getDatachannelToken = (): string | undefined => this.datachannelToken;
+
+  /**
+   * Store the data channel token for this connection.
+   * @param {string} token
    * @returns {void}
    */
-  public setOwnerMeetingId = (
-    ownerMeetingId: string | undefined,
-    sessionId: string = LLM_DEFAULT_SESSION
-  ): void => {
-    const sessionData = this.connections.get(sessionId);
-
-    if (!sessionData) {
-      return;
-    }
-
-    sessionData.ownerMeetingId = ownerMeetingId;
-    this.connections.set(sessionId, sessionData);
+  public setDatachannelToken = (token: string): void => {
+    this.datachannelToken = token;
   };
 
   /**
-   * Get the owner meeting ID currently associated with an LLM session.
-   * Returns undefined when no owner has been assigned (e.g. before the
-   * first successful `registerAndConnect`, or after `disconnectLLM`).
-   *
-   * @param {string} sessionId - Connection identifier (defaults to default session)
-   * @returns {string | undefined} ownerMeetingId
-   */
-  public getOwnerMeetingId = (sessionId: string = LLM_DEFAULT_SESSION): string | undefined => {
-    const sessionData = this.connections.get(sessionId);
-
-    return sessionData?.ownerMeetingId;
-  };
-
-  /**
-   * Resolve ownership information for an LLM session.
-   *
-   * Rules:
-   * - no current owner => caller may proceed
-   * - caller has no identity to assert => treat as owner
-   * - otherwise caller must match current owner
-   *
-   * @param {string | undefined} ownerMeetingId - Candidate owner to evaluate
-   * @param {string} sessionId - Connection identifier (defaults to default session)
-   * @returns {{currentOwner: (string|undefined), isOwner: boolean}}
-   */
-  public resolveSessionOwnership = (
-    ownerMeetingId?: string,
-    sessionId: string = LLM_DEFAULT_SESSION
-  ): {
-    currentOwner: string | undefined;
-    isOwner: boolean;
-  } => {
-    const currentOwner = this.getOwnerMeetingId(sessionId);
-    const isOwner = !currentOwner || !ownerMeetingId || currentOwner === ownerMeetingId;
-
-    return {
-      currentOwner,
-      isOwner,
-    };
-  };
-
-  /**
-   * Get data channel token for the connection
-   * @param {DataChannelTokenType|string} tokenKey
-   * @param {string | undefined} ownerMeetingId - Meeting id asserting read ownership
-   * @returns {string | undefined} data channel token
-   */
-  public getDatachannelToken = (
-    tokenKey?: DataChannelTokenType | string,
-    ownerMeetingId?: string
-  ): string | undefined => {
-    const resolvedTokenKey = tokenKey ?? DataChannelTokenType.Default;
-
-    const {currentOwner, isOwner} = this.resolveSessionOwnership(ownerMeetingId, resolvedTokenKey);
-
-    if (!isOwner) {
-      this.logger.info(
-        `llm#getDatachannelToken --> skip read for session ${resolvedTokenKey}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
-      );
-
-      return undefined;
-    }
-
-    return this.datachannelTokens[resolvedTokenKey];
-  };
-
-  /**
-   * Set data channel token for the connection
-   * @param {string} datachannelToken - data channel token
-   * @param {DataChannelTokenType|string} [tokenKey]
-   * @param {string | undefined} ownerMeetingId - Meeting id asserting write ownership
+   * Clear the data channel token for this connection.
    * @returns {void}
    */
-  public setDatachannelToken = (
-    datachannelToken: string,
-    tokenKey?: DataChannelTokenType | string,
-    ownerMeetingId?: string
-  ): void => {
-    const resolvedTokenKey = tokenKey ?? DataChannelTokenType.Default;
-
-    const {currentOwner, isOwner} = this.resolveSessionOwnership(ownerMeetingId, resolvedTokenKey);
-
-    if (!isOwner) {
-      this.logger.info(
-        `llm#setDatachannelToken --> skip write for session ${resolvedTokenKey}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
-      );
-
-      return;
-    }
-
-    this.datachannelTokens[resolvedTokenKey] = datachannelToken;
+  public clearDatachannelToken = (): void => {
+    this.datachannelToken = undefined;
   };
 
   /**
-   * Clears a single session's data channel token.
-   * @param {DataChannelTokenType|string} tokenKey
-   * @param {string} ownerMeetingId - Meeting id asserting delete ownership
+   * Set the handler used to refresh the DataChannel token.
+   * @param {function} handler
    * @returns {void}
    */
-  public clearDatachannelToken = (
-    tokenKey: DataChannelTokenType | string,
-    ownerMeetingId: string
-  ): void => {
-    const resolvedTokenKey = tokenKey;
-
-    const {currentOwner, isOwner} = this.resolveSessionOwnership(ownerMeetingId, resolvedTokenKey);
-
-    if (!isOwner) {
-      this.logger.info(
-        `llm#clearDatachannelToken --> skip clear for session ${resolvedTokenKey}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
-      );
-
-      return;
-    }
-
-    this.datachannelTokens[resolvedTokenKey] = undefined;
-    delete this.datachannelTokens[resolvedTokenKey];
-  };
-
-  /**
-   * Set the handler used to refresh the DataChannel token
-   *
-   * @param {function} handler - Function that returns a refreshed token
-   * @param {string} [sessionId] - Connection identifier
-   * @param {string | undefined} ownerMeetingId - Meeting id asserting refresh-handler ownership
-   * @returns {void}
-   */
-  public setRefreshHandler(
+  public setRefreshHandler = (
     handler: () => Promise<{
       body: {datachannelToken: string; datachannelTokenType: DataChannelTokenType};
-    }>,
-    sessionId?: string,
-    ownerMeetingId?: string
-  ) {
-    const resolvedSessionId = sessionId ?? LLM_DEFAULT_SESSION;
-
-    const {currentOwner, isOwner} = this.resolveSessionOwnership(ownerMeetingId, resolvedSessionId);
-
-    if (!isOwner) {
-      this.logger.info(
-        `llm#setRefreshHandler --> skip write for session ${resolvedSessionId}; owned by ${currentOwner}, candidate ${ownerMeetingId}`
-      );
-
-      return;
-    }
-
-    const sessionData = this.connections.get(resolvedSessionId);
-
-    if (sessionData) {
-      sessionData.refreshHandler = handler;
-      if (ownerMeetingId) {
-        sessionData.ownerMeetingId = ownerMeetingId;
-      }
-
-      return;
-    }
-
-    // Intentionally allow a pre-connection session shape here.
-    // Some flows inject refreshHandler before register/connect so token refresh
-    // is already wired when the socket lifecycle starts. register()/
-    // registerAndConnect() will later fill webSocketUrl/binding/locusUrl/
-    // datachannelUrl into this same session entry.
-    this.connections.set(resolvedSessionId, {
-      refreshHandler: handler,
-      ownerMeetingId,
-    });
-  }
+    }>
+  ): void => {
+    this.refreshHandler = handler;
+  };
 
   /**
    * Refresh the data channel token using the injected handler.
-   * Logs a descriptive error if the handler is missing or fails.
-   * @param {string} sessionId - Connection identifier (defaults to default session)
-   * @returns {Promise<string>} The refreshed token.
+   * @returns {Promise<object | null>}
    */
-  public async refreshDataChannelToken(sessionId: string = LLM_DEFAULT_SESSION) {
-    const refreshHandler = this.connections.get(sessionId)?.refreshHandler;
-
-    if (!refreshHandler) {
+  public async refreshDataChannelToken() {
+    if (!this.refreshHandler) {
       this.logger.warn(
-        `llm#refreshDataChannelToken --> LLM refreshHandler is not set for session ${sessionId}, skipping token refresh`
+        'llm#refreshDataChannelToken --> LLM refreshHandler is not set, skipping token refresh'
       );
 
       return null;
     }
 
     try {
-      const res = await refreshHandler();
-
-      return res;
+      return await this.refreshHandler();
     } catch (error: any) {
       this.logger.warn(
-        `llm#refreshDataChannelToken --> DataChannel token refresh failed (likely locus changed or participant left): ${
+        `llm#refreshDataChannelToken --> DataChannel token refresh failed: ${
           error?.message || error
         }`
       );
@@ -429,122 +203,21 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   }
 
   /**
-   * Disconnects websocket connection
-   * @param {{code: number, reason: string}} options - The disconnect option object with code and reason
-   * @param {string} sessionId - Connection identifier
-   * @param {string} ownerMeetingId - Meeting id asserting disconnect ownership
-   * @returns {Promise<boolean>} True when disconnect was performed, false when skipped
-   */
-  public disconnectLLM = (
-    options: {code: number; reason: string},
-    sessionId?: string,
-    ownerMeetingId?: string
-  ): Promise<boolean> => {
-    const resolvedSessionId = sessionId ?? LLM_DEFAULT_SESSION;
-
-    // Backward-compat path: historically callers could omit ownerMeetingId
-    // (and sometimes sessionId). Reuse current owner when available so legacy
-    // calls remain best-effort without throwing at teardown time.
-    const resolvedOwnerMeetingId = ownerMeetingId || this.getOwnerMeetingId(resolvedSessionId);
-
-    if (!ownerMeetingId) {
-      this.logger.warn(
-        `llm#disconnectLLM --> ownerMeetingId is omitted for session ${resolvedSessionId}; using legacy compatibility path`
-      );
-    }
-
-    const {currentOwner, isOwner} = this.resolveSessionOwnership(
-      resolvedOwnerMeetingId,
-      resolvedSessionId
-    );
-
-    if (!isOwner) {
-      this.logger.info(
-        `llm#disconnectLLM --> skip disconnect for session ${resolvedSessionId}; owned by ${currentOwner}, candidate ${resolvedOwnerMeetingId}`
-      );
-
-      return Promise.resolve(false);
-    }
-
-    return this.disconnect(options, resolvedSessionId).then(() => {
-      // Clear owner tag before cleanup to ensure it's not lingering
-      // if another meeting claimed it during disconnect
-      this.setOwnerMeetingId(undefined, resolvedSessionId);
-
-      // Clean up sessions data
-      this.connections.delete(resolvedSessionId);
-
-      return true;
-    });
-  };
-
-  /**
-   * Disconnects all LLM websocket connections
-   * @param {{code: number, reason: string}} options - The disconnect option object with code and reason
+   * Disconnects the WebSocket and clears all connection state.
+   * @param {object} [options]
    * @returns {Promise<void>}
    */
-  public disconnectAllLLM = (options?: {code: number; reason: string}): Promise<void> =>
-    this.disconnectAll(options).then(() => {
-      // Clean up all connection data
-      this.connections.clear();
+  public disconnectLLM = (options?: {code: number; reason: string}): Promise<void> => {
+    return this.disconnect(options).then(() => {
+      this.webSocketUrl = undefined;
+      this.binding = undefined;
+      this.locusUrl = undefined;
+      this.datachannelUrl = undefined;
+      this.datachannelToken = undefined;
+      this.refreshHandler = undefined;
+      this.ownerMeetingId = undefined;
     });
-
-  /**
-   * Get all active LLM connections
-   * @returns {Map} Map of sessionId to session data
-   */
-  public getAllConnections = (): Map<
-    string,
-    {
-      webSocketUrl?: string;
-      binding?: string;
-      locusUrl?: string;
-      datachannelUrl?: string;
-      ownerMeetingId?: string;
-    }
-  > => new Map(this.connections);
-
-  /**
-   * Look up the locusUrl associated with a datachannel request URL.
-   * Iterates all active LLM sessions and returns the locusUrl of the
-   * session whose stored datachannelUrl is a prefix of the given request URL.
-   *
-   * @param {string} requestUrl - The in-flight request URL to match
-   * @returns {string | undefined} The matching locusUrl, or undefined if not found
-   */
-  public getLocusUrlByDatachannelUrl(requestUrl: string): string | undefined {
-    for (const [, connection] of this.connections) {
-      if (
-        connection.datachannelUrl &&
-        LLMChannel.matchesDatachannelRequestUrl(requestUrl, connection.datachannelUrl)
-      ) {
-        return connection.locusUrl;
-      }
-    }
-
-    return undefined;
-  }
-
-  /**
-   * Look up the sessionId associated with a datachannel request URL.
-   * Iterates all active LLM sessions and returns the sessionId whose
-   * stored datachannelUrl is a prefix of the given request URL.
-   *
-   * @param {string} requestUrl - The in-flight request URL to match
-   * @returns {string | undefined} The matching sessionId, or undefined if not found
-   */
-  public getSessionIdByDatachannelUrl(requestUrl: string): string | undefined {
-    for (const [sessionId, connection] of this.connections) {
-      if (
-        connection.datachannelUrl &&
-        LLMChannel.matchesDatachannelRequestUrl(requestUrl, connection.datachannelUrl)
-      ) {
-        return sessionId;
-      }
-    }
-
-    return undefined;
-  }
+  };
 
   /**
    * Matches a request URL to a stored datachannel registration URL.
@@ -574,8 +247,8 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
   }
 
   /**
-   * Returns true if  data channel token is enabled, false otherwise
-   * @returns {Promise<boolean>} resolves with true if data channel token  is enabled
+   * Returns true if the data channel token feature flag is enabled.
+   * @returns {Promise<boolean>}
    */
   public isDataChannelTokenEnabled(): Promise<boolean> {
     // @ts-ignore
@@ -584,12 +257,10 @@ export default class LLMChannel extends (Mercury as any) implements ILLMChannel 
 
   /**
    * Builds a WebSocket URL with the `subscriptionAwareSubchannels` query parameter.
-   *
-   * @param {string} baseUrl - The original WebSocket URL.
-   * @param {string[]} subchannels - List of subchannels to declare as subscription-aware.
-   * @returns {string} The final URL with updated query parameters.
+   * @param {string} baseUrl
+   * @param {string[]} subchannels
+   * @returns {string}
    */
-
   public static buildUrlWithAwareSubchannels = (baseUrl: string, subchannels: string[]) => {
     const urlObj = new URL(baseUrl);
     urlObj.searchParams.set(SUBSCRIPTION_AWARE_SUBCHANNELS_PARAM, subchannels.join(','));

--- a/packages/@webex/internal-plugin-llm/src/llm.types.ts
+++ b/packages/@webex/internal-plugin-llm/src/llm.types.ts
@@ -12,10 +12,10 @@ interface ILLMChannel {
     datachannelToken?: string,
     sessionId?: string
   ) => Promise<void>;
-  isConnected: (sessionId?: string) => boolean;
-  getBinding: (sessionId?: string) => string;
-  getLocusUrl: (sessionId?: string) => string;
-  getDatachannelUrl: (sessionId?: string) => string;
+  isConnected: () => boolean;
+  getBinding: () => string | undefined;
+  getLocusUrl: () => string | undefined;
+  getDatachannelUrl: () => string | undefined;
   disconnectLLM: (
     options: {code: number; reason: string},
     sessionId?: string,

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
@@ -469,5 +469,51 @@ describe('plugin-llm', () => {
         sinon.assert.notCalled(mockChannel.setRefreshHandler);
       });
     });
+
+    describe('event forwarding', () => {
+      let triggerSpy;
+
+      beforeEach(() => {
+        triggerSpy = sinon.spy(plugin, 'trigger');
+      });
+
+      it('forwards default session events without suffix', () => {
+        // Create a session via getOrCreateSession (creates real LLMChannel with event handler)
+        const channel = plugin.getOrCreateSession(LLM_DEFAULT_SESSION);
+
+        // Trigger an event on the channel - the 'all' handler should forward it
+        channel.trigger('event:relay.event', {data: 'test'});
+
+        sinon.assert.calledOnceWithExactly(triggerSpy, 'event:relay.event', {data: 'test'});
+      });
+
+      it('forwards non-default session events with sessionId suffix', () => {
+        const practiceSession = 'llm-practice-session';
+
+        // Create a session via getOrCreateSession (creates real LLMChannel with event handler)
+        const channel = plugin.getOrCreateSession(practiceSession);
+
+        // Trigger an event on the channel - the 'all' handler should forward it with suffix
+        channel.trigger('event:relay.event', {data: 'test'});
+
+        sinon.assert.calledOnceWithExactly(triggerSpy, `event:relay.event:${practiceSession}`, {
+          data: 'test',
+        });
+      });
+
+      it('forwards locus events with sessionId suffix for practice session', () => {
+        const practiceSession = 'llm-practice-session';
+
+        const channel = plugin.getOrCreateSession(practiceSession);
+
+        channel.trigger('event:locus.state_message', {locusData: 'test'});
+
+        sinon.assert.calledOnceWithExactly(
+          triggerSpy,
+          `event:locus.state_message:${practiceSession}`,
+          {locusData: 'test'}
+        );
+      });
+    });
   });
 });

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm-plugin.js
@@ -1,0 +1,473 @@
+import MockWebex from '@webex/test-helper-mock-webex';
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import Mercury from '@webex/internal-plugin-mercury';
+import {LLMPlugin} from '@webex/internal-plugin-llm/src/llm-plugin';
+import {LLM_DEFAULT_SESSION} from '@webex/internal-plugin-llm/src/constants';
+
+describe('plugin-llm', () => {
+  describe('LLMPlugin', () => {
+    let webex;
+    let plugin;
+    let mockChannel;
+
+    const createMockChannel = () => ({
+      registerAndConnect: sinon.stub().resolves(),
+      disconnectLLM: sinon.stub().resolves(),
+      isConnected: sinon.stub().returns(false),
+      getBinding: sinon.stub().returns('binding'),
+      getLocusUrl: sinon.stub().returns('locusUrl'),
+      getDatachannelUrl: sinon.stub().returns('datachannelUrl'),
+      getDatachannelToken: sinon.stub().returns('token'),
+      setDatachannelToken: sinon.stub(),
+      clearDatachannelToken: sinon.stub(),
+      setRefreshHandler: sinon.stub(),
+      refreshDataChannelToken: sinon.stub().resolves({body: {datachannelToken: 'newToken'}}),
+      socket: {send: sinon.stub()},
+      ownerMeetingId: undefined,
+      hasEverConnected: false,
+      on: sinon.stub(),
+    });
+
+    beforeEach(() => {
+      webex = new MockWebex({
+        children: {
+          mercury: Mercury,
+        },
+      });
+
+      webex.internal.feature = {
+        getFeature: sinon.stub().resolves(true),
+      };
+
+      plugin = new LLMPlugin({}, {parent: webex});
+
+      mockChannel = createMockChannel();
+    });
+
+    afterEach(() => sinon.restore());
+
+    describe('#disconnectLLM', () => {
+      it('calls disconnect and removes session from map', async () => {
+        // Create a session first
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const result = await plugin.disconnectLLM(
+          {code: 3000, reason: 'bye'},
+          LLM_DEFAULT_SESSION,
+          'meeting-1'
+        );
+
+        sinon.assert.calledOnceWithExactly(mockChannel.disconnectLLM, {code: 3000, reason: 'bye'});
+        assert.equal(plugin.sessions.has(LLM_DEFAULT_SESSION), false);
+        assert.equal(result, true);
+      });
+
+      it('resolves without error when session does not exist', async () => {
+        const result = await plugin.disconnectLLM(
+          {code: 1000, reason: 'test'},
+          'non-existent-session'
+        );
+
+        assert.equal(result, undefined);
+      });
+
+      it('skips disconnect if not the owner', async () => {
+        mockChannel.ownerMeetingId = 'meeting-1';
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const result = await plugin.disconnectLLM(
+          {code: 1000, reason: 'test'},
+          LLM_DEFAULT_SESSION,
+          'meeting-2'
+        );
+
+        sinon.assert.notCalled(mockChannel.disconnectLLM);
+        assert.equal(plugin.sessions.has(LLM_DEFAULT_SESSION), true);
+        assert.equal(result, false);
+      });
+
+      it('disconnects if owner matches', async () => {
+        mockChannel.ownerMeetingId = 'meeting-1';
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const result = await plugin.disconnectLLM(
+          {code: 1000, reason: 'test'},
+          LLM_DEFAULT_SESSION,
+          'meeting-1'
+        );
+
+        sinon.assert.calledOnce(mockChannel.disconnectLLM);
+        assert.equal(plugin.sessions.has(LLM_DEFAULT_SESSION), false);
+        assert.equal(result, true);
+      });
+
+      it('disconnects if no owner is set', async () => {
+        mockChannel.ownerMeetingId = undefined;
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const result = await plugin.disconnectLLM(
+          {code: 1000, reason: 'test'},
+          LLM_DEFAULT_SESSION,
+          'meeting-1'
+        );
+
+        sinon.assert.calledOnce(mockChannel.disconnectLLM);
+        assert.equal(result, true);
+      });
+
+      it('supports legacy call with options only', async () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        await plugin.disconnectLLM({code: 1000, reason: 'test'});
+
+        sinon.assert.calledOnce(mockChannel.disconnectLLM);
+        assert.equal(plugin.sessions.has(LLM_DEFAULT_SESSION), false);
+      });
+
+      it('supports legacy call with options and sessionId', async () => {
+        plugin.sessions.set('custom-session', mockChannel);
+
+        await plugin.disconnectLLM({code: 1000, reason: 'test'}, 'custom-session');
+
+        sinon.assert.calledOnceWithExactly(mockChannel.disconnectLLM, {code: 1000, reason: 'test'});
+        assert.equal(plugin.sessions.has('custom-session'), false);
+      });
+    });
+
+    describe('#disconnectAllLLM', () => {
+      it('disconnects and removes all sessions', async () => {
+        const channel1 = createMockChannel();
+        const channel2 = createMockChannel();
+
+        plugin.sessions.set('session-1', channel1);
+        plugin.sessions.set('session-2', channel2);
+
+        await plugin.disconnectAllLLM({code: 1000, reason: 'cleanup'});
+
+        sinon.assert.calledOnceWithExactly(channel1.disconnectLLM, {code: 1000, reason: 'cleanup'});
+        sinon.assert.calledOnceWithExactly(channel2.disconnectLLM, {code: 1000, reason: 'cleanup'});
+        assert.equal(plugin.sessions.size, 0);
+      });
+
+      it('works with no active sessions', async () => {
+        await plugin.disconnectAllLLM({code: 1000, reason: 'cleanup'});
+
+        assert.equal(plugin.sessions.size, 0);
+      });
+    });
+
+    describe('#resolveSessionOwnership', () => {
+      it('returns isOwner true when no current owner', () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+        mockChannel.ownerMeetingId = undefined;
+
+        const result = plugin.resolveSessionOwnership('meeting-1', LLM_DEFAULT_SESSION);
+
+        assert.deepEqual(result, {currentOwner: undefined, isOwner: true});
+      });
+
+      it('returns isOwner true when no ownerMeetingId provided', () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+        mockChannel.ownerMeetingId = 'meeting-1';
+
+        const result = plugin.resolveSessionOwnership(undefined, LLM_DEFAULT_SESSION);
+
+        assert.deepEqual(result, {currentOwner: 'meeting-1', isOwner: true});
+      });
+
+      it('returns isOwner true when owner matches', () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+        mockChannel.ownerMeetingId = 'meeting-1';
+
+        const result = plugin.resolveSessionOwnership('meeting-1', LLM_DEFAULT_SESSION);
+
+        assert.deepEqual(result, {currentOwner: 'meeting-1', isOwner: true});
+      });
+
+      it('returns isOwner false when owner does not match', () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+        mockChannel.ownerMeetingId = 'meeting-1';
+
+        const result = plugin.resolveSessionOwnership('meeting-2', LLM_DEFAULT_SESSION);
+
+        assert.deepEqual(result, {currentOwner: 'meeting-1', isOwner: false});
+      });
+    });
+
+    describe('#registerAndConnect', () => {
+      it('creates session and calls registerAndConnect on channel', async () => {
+        // Stub the internal getOrCreateSession to return our mock
+        sinon.stub(plugin, 'getOrCreateSession').returns(mockChannel);
+
+        await plugin.registerAndConnect('locusUrl', 'datachannelUrl', 'token', 'session-1');
+
+        sinon.assert.calledOnceWithExactly(
+          mockChannel.registerAndConnect,
+          'locusUrl',
+          'datachannelUrl',
+          'token'
+        );
+      });
+
+      it('uses default session when sessionId not provided', async () => {
+        sinon.stub(plugin, 'getOrCreateSession').returns(mockChannel);
+
+        await plugin.registerAndConnect('locusUrl', 'datachannelUrl', 'token');
+
+        sinon.assert.calledOnceWithExactly(plugin.getOrCreateSession, LLM_DEFAULT_SESSION);
+      });
+    });
+
+    describe('#isConnected', () => {
+      it('returns false when session does not exist', () => {
+        assert.equal(plugin.isConnected('non-existent'), false);
+      });
+
+      it('returns channel isConnected value', () => {
+        mockChannel.isConnected.returns(true);
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        assert.equal(plugin.isConnected(LLM_DEFAULT_SESSION), true);
+      });
+    });
+
+    describe('#getBinding', () => {
+      it('returns undefined when session does not exist', () => {
+        assert.equal(plugin.getBinding('non-existent'), undefined);
+      });
+
+      it('returns channel binding', () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        assert.equal(plugin.getBinding(LLM_DEFAULT_SESSION), 'binding');
+      });
+    });
+
+    describe('#getSocket', () => {
+      it('returns undefined when session does not exist', () => {
+        assert.equal(plugin.getSocket('non-existent'), undefined);
+      });
+
+      it('returns channel socket', () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        assert.equal(plugin.getSocket(LLM_DEFAULT_SESSION), mockChannel.socket);
+      });
+    });
+
+    describe('#socket (getter)', () => {
+      it('returns default session socket for backwards compatibility', () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        assert.equal(plugin.socket, mockChannel.socket);
+      });
+    });
+
+    describe('#setDatachannelToken', () => {
+      it('sets token when owner matches', () => {
+        mockChannel.ownerMeetingId = 'meeting-1';
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        plugin.setDatachannelToken('newToken', 'meeting-1', LLM_DEFAULT_SESSION);
+
+        sinon.assert.calledOnceWithExactly(mockChannel.setDatachannelToken, 'newToken');
+      });
+
+      it('skips setting token when not owner', () => {
+        mockChannel.ownerMeetingId = 'meeting-1';
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        plugin.setDatachannelToken('newToken', 'meeting-2', LLM_DEFAULT_SESSION);
+
+        sinon.assert.notCalled(mockChannel.setDatachannelToken);
+      });
+    });
+
+    describe('#getDatachannelToken', () => {
+      it('returns token when owner matches', () => {
+        mockChannel.ownerMeetingId = 'meeting-1';
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const token = plugin.getDatachannelToken(LLM_DEFAULT_SESSION, 'meeting-1');
+
+        assert.equal(token, 'token');
+      });
+
+      it('returns undefined when not owner', () => {
+        mockChannel.ownerMeetingId = 'meeting-1';
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const token = plugin.getDatachannelToken(LLM_DEFAULT_SESSION, 'meeting-2');
+
+        assert.equal(token, undefined);
+      });
+
+      it('returns undefined when session does not exist', () => {
+        const token = plugin.getDatachannelToken('non-existent');
+
+        assert.equal(token, undefined);
+      });
+    });
+
+    describe('#clearDatachannelToken', () => {
+      it('clears token when owner matches', () => {
+        mockChannel.ownerMeetingId = 'meeting-1';
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        plugin.clearDatachannelToken(LLM_DEFAULT_SESSION, 'meeting-1');
+
+        sinon.assert.calledOnce(mockChannel.clearDatachannelToken);
+      });
+
+      it('skips clearing when not owner', () => {
+        mockChannel.ownerMeetingId = 'meeting-1';
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        plugin.clearDatachannelToken(LLM_DEFAULT_SESSION, 'meeting-2');
+
+        sinon.assert.notCalled(mockChannel.clearDatachannelToken);
+      });
+    });
+
+    describe('#setOwnerMeetingId / #getOwnerMeetingId', () => {
+      it('sets and gets owner meeting id', () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        plugin.setOwnerMeetingId('meeting-1', LLM_DEFAULT_SESSION);
+
+        assert.equal(mockChannel.ownerMeetingId, 'meeting-1');
+        assert.equal(plugin.getOwnerMeetingId(LLM_DEFAULT_SESSION), 'meeting-1');
+      });
+
+      it('returns undefined when session does not exist', () => {
+        assert.equal(plugin.getOwnerMeetingId('non-existent'), undefined);
+      });
+    });
+
+    describe('#hasEverConnected', () => {
+      it('returns false when no sessions exist', () => {
+        assert.equal(plugin.hasEverConnected, false);
+      });
+
+      it('returns true when any session has connected', () => {
+        mockChannel.hasEverConnected = true;
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        assert.equal(plugin.hasEverConnected, true);
+      });
+
+      it('returns false when no session has connected', () => {
+        mockChannel.hasEverConnected = false;
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        assert.equal(plugin.hasEverConnected, false);
+      });
+    });
+
+    describe('#getConnectionByDatachannelUrl', () => {
+      it('returns channel matching datachannel URL', () => {
+        mockChannel.getDatachannelUrl.returns(
+          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations'
+        );
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const result = plugin.getConnectionByDatachannelUrl(
+          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations/events'
+        );
+
+        assert.equal(result, mockChannel);
+      });
+
+      it('returns undefined when no match', () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const result = plugin.getConnectionByDatachannelUrl('https://unknown.example.com');
+
+        assert.equal(result, undefined);
+      });
+    });
+
+    describe('#getLocusUrlByDatachannelUrl', () => {
+      it('returns locus URL for matching datachannel URL', () => {
+        mockChannel.getDatachannelUrl.returns(
+          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations'
+        );
+        mockChannel.getLocusUrl.returns('https://locus.example.com/123');
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const result = plugin.getLocusUrlByDatachannelUrl(
+          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations/events'
+        );
+
+        assert.equal(result, 'https://locus.example.com/123');
+      });
+    });
+
+    describe('#getSessionIdByDatachannelUrl', () => {
+      it('returns sessionId for matching datachannel URL', () => {
+        mockChannel.getDatachannelUrl.returns(
+          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations'
+        );
+        plugin.sessions.set('my-session', mockChannel);
+
+        const result = plugin.getSessionIdByDatachannelUrl(
+          'https://board.wbx2.com/datachannel/api/v1/locus/123/registrations/events'
+        );
+
+        assert.equal(result, 'my-session');
+      });
+    });
+
+    describe('#getAllConnections', () => {
+      it('returns copy of sessions map', () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const result = plugin.getAllConnections();
+
+        assert.equal(result.size, 1);
+        assert.equal(result.get(LLM_DEFAULT_SESSION), mockChannel);
+        assert.notStrictEqual(result, plugin.sessions);
+      });
+    });
+
+    describe('#refreshDataChannelToken', () => {
+      it('calls channel refreshDataChannelToken', async () => {
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        const result = await plugin.refreshDataChannelToken(LLM_DEFAULT_SESSION);
+
+        sinon.assert.calledOnce(mockChannel.refreshDataChannelToken);
+        assert.deepEqual(result, {body: {datachannelToken: 'newToken'}});
+      });
+
+      it('returns null when session does not exist', async () => {
+        const result = await plugin.refreshDataChannelToken('non-existent');
+
+        assert.equal(result, null);
+      });
+    });
+
+    describe('#setRefreshHandler', () => {
+      it('sets handler when owner matches', () => {
+        const handler = sinon.stub();
+        mockChannel.ownerMeetingId = 'meeting-1';
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        plugin.setRefreshHandler(handler, 'meeting-1', LLM_DEFAULT_SESSION);
+
+        sinon.assert.calledOnceWithExactly(mockChannel.setRefreshHandler, handler);
+      });
+
+      it('skips setting handler when not owner', () => {
+        const handler = sinon.stub();
+        mockChannel.ownerMeetingId = 'meeting-1';
+        plugin.sessions.set(LLM_DEFAULT_SESSION, mockChannel);
+
+        plugin.setRefreshHandler(handler, 'meeting-2', LLM_DEFAULT_SESSION);
+
+        sinon.assert.notCalled(mockChannel.setRefreshHandler);
+      });
+    });
+  });
+});

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -2,21 +2,20 @@ import MockWebex from '@webex/test-helper-mock-webex';
 import {assert} from '@webex/test-helper-chai';
 import sinon from 'sinon';
 import Mercury from '@webex/internal-plugin-mercury';
-import LLMService from '@webex/internal-plugin-llm';
 import LLMChannel from '@webex/internal-plugin-llm/src/llm';
 
 describe('plugin-llm', () => {
   const locusUrl = 'locusUrl';
   const datachannelUrl = 'datachannelUrl';
 
-  describe('llm', () => {
-    let webex, llmService;
+  describe('LLMChannel', () => {
+    let webex, llmChannel;
 
     beforeEach(() => {
       webex = new MockWebex({
         children: {
           mercury: Mercury,
-          llm: LLMService,
+          llm: LLMChannel,
         },
       });
 
@@ -25,199 +24,135 @@ describe('plugin-llm', () => {
         getFeature: sinon.stub().resolves(true),
       };
 
-      llmService = webex.internal.llm;
-      llmService.webSocketUrl = 'wss://example.com/socket';
-      llmService.disconnect = sinon.stub().resolves(true);
-      llmService.request = sinon.stub().resolves({
+      llmChannel = webex.internal.llm;
+      llmChannel.disconnect = sinon.stub().resolves();
+      llmChannel.request = sinon.stub().resolves({
         headers: {},
         body: {
           binding: 'binding',
           webSocketUrl: 'wss://example.com/socket',
         },
       });
-      const sockets = new Map();
-
-      llmService.connect = sinon.stub().callsFake((url, sessionId) => {
-        sockets.set(sessionId, {connected: true});
-        llmService.getSocket = sinon.stub().callsFake((sid) => sockets.get(sid));
+      llmChannel.connect = sinon.stub().callsFake(() => {
+        llmChannel.connected = true;
       });
-            llmService.connections.set('llm-default-session',{
-            webSocketUrl: 'wss://example.com/socket',
-        })
     });
 
     afterEach(() => sinon.restore());
 
     describe('#registerAndConnect', () => {
-      it('registers connection', async () => {
-        llmService.register = sinon.stub().callsFake(async () => {
-          llmService.binding = 'binding';
-          llmService.webSocketUrl = 'wss://example.com/socket';
-          return {
-            body: {
-              binding: 'binding',
-              webSocketUrl: 'wss://example.com/socket',
-            },
-          };
-        });
-
-        assert.equal(llmService.isConnected('llm-default-session'), false);
-        await llmService.registerAndConnect(locusUrl, datachannelUrl,undefined);
-        assert.equal(llmService.isConnected('llm-default-session'), true);
-      });
-
-      it("doesn't register connection for invalid input", async () => {
-        llmService.register = sinon.stub().callsFake(async () => {
-          llmService.binding = 'binding';
-          llmService.webSocketUrl = 'wss://example.com/socket';
-          return {
-            body: {
-              binding: 'binding',
-              webSocketUrl: 'wss://example.com/socket',
-            },
-          };
-        });
-
-        await llmService.registerAndConnect();
-        assert.equal(llmService.isConnected(), false);
-      });
-
-      it('registers connection with token', async () => {
-        llmService.register = sinon.stub().callsFake(async () => {
-          llmService.binding = 'binding';
-          llmService.webSocketUrl = 'wss://example.com/socket';
-          return {
-            body: {
-              binding: 'binding',
-              webSocketUrl: 'wss://example.com/socket',
-            },
-          };
-        });
-
-        assert.equal(llmService.isConnected(), false);
-
-        await llmService.registerAndConnect(locusUrl, datachannelUrl,'abc123');
-
-        sinon.assert.calledOnceWithExactly(
-          llmService.register,
-          datachannelUrl,
-          'abc123',
-          'llm-default-session'
-        );
-
-        assert.equal(llmService.isConnected(), true);
+      it('registers and connects', async () => {
+        assert.equal(llmChannel.isConnected(), false);
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        assert.equal(llmChannel.isConnected(), true);
+        assert.equal(llmChannel.getLocusUrl(), locusUrl);
+        assert.equal(llmChannel.getDatachannelUrl(), datachannelUrl);
       });
 
       it('connects with subscriptionAwareSubchannels when token enabled', async () => {
-        llmService.isDataChannelTokenEnabled = sinon.stub().returns(true);
+        llmChannel.isDataChannelTokenEnabled = sinon.stub().resolves(true);
 
-        llmService.register = sinon.stub().callsFake(async () => {
-          llmService.binding = 'binding';
-          llmService.webSocketUrl = 'wss://example.com/socket';
-          return {
-            body: {
-              binding: 'binding',
-              webSocketUrl: 'wss://example.com/socket',
-            },
-          };
-        });
+        const buildSpy = sinon.spy(LLMChannel, 'buildUrlWithAwareSubchannels');
 
-        const buildSpy = sinon.spy(LLMService, 'buildUrlWithAwareSubchannels');
-
-        await llmService.registerAndConnect(locusUrl, datachannelUrl,'abc123');
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl, 'abc123');
 
         sinon.assert.calledOnce(buildSpy);
-        sinon.assert.calledOnce(llmService.connect);
+        sinon.assert.calledOnce(llmChannel.connect);
 
-        const calledUrl = llmService.connect.getCall(0).args[0];
+        const calledUrl = llmChannel.connect.getCall(0).args[0];
         assert.include(calledUrl, 'subscriptionAwareSubchannels=');
       });
 
       it('connects without subscriptionAwareSubchannels when token disabled', async () => {
-        llmService.isDataChannelTokenEnabled = sinon.stub().returns(false);
+        llmChannel.isDataChannelTokenEnabled = sinon.stub().resolves(false);
 
-        llmService.register = sinon.stub().callsFake(async () => {
-          llmService.binding = 'binding';
-          llmService.webSocketUrl = 'wss://example.com/socket';
-          return {
-            body: {
-              binding: 'binding',
-              webSocketUrl: 'wss://example.com/socket',
-            },
-          };
-        });
+        const buildSpy = sinon.spy(LLMChannel, 'buildUrlWithAwareSubchannels');
 
-        const buildSpy = sinon.spy(LLMService, 'buildUrlWithAwareSubchannels');
-
-        await llmService.registerAndConnect(locusUrl, datachannelUrl);
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
 
         sinon.assert.notCalled(buildSpy);
-        sinon.assert.calledOnce(llmService.connect);
+        sinon.assert.calledOnce(llmChannel.connect);
 
-        const calledUrl = llmService.connect.getCall(0).args[0];
-        assert.equal(calledUrl, llmService.webSocketUrl);
+        const calledUrl = llmChannel.connect.getCall(0).args[0];
+        assert.equal(calledUrl, 'wss://example.com/socket');
       });
 
-      it('connects without subscriptionAwareSubchannels when token enabled BUT token missing', async () => {
-        llmService.isDataChannelTokenEnabled = sinon.stub().resolves(true);
+      it('connects with subscriptionAwareSubchannels when token enabled but token missing', async () => {
+        llmChannel.isDataChannelTokenEnabled = sinon.stub().resolves(true);
 
-        const buildSpy = sinon.spy(LLMService, 'buildUrlWithAwareSubchannels');
+        const buildSpy = sinon.spy(LLMChannel, 'buildUrlWithAwareSubchannels');
 
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined);
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl, undefined);
 
         sinon.assert.calledOnce(buildSpy);
-        sinon.assert.calledOnce(llmService.connect);
+        sinon.assert.calledOnce(llmChannel.connect);
 
-        const calledUrl = llmService.connect.getCall(0).args[0];
+        const calledUrl = llmChannel.connect.getCall(0).args[0];
         assert.include(calledUrl, 'subscriptionAwareSubchannels=');
 
         buildSpy.restore();
       });
-    });
 
-    describe('#register', () => {
-      beforeEach(() => {
-        llmService.isDataChannelTokenEnabled = sinon.stub();
+      it('deduplicates concurrent calls', async () => {
+        const promise1 = llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        const promise2 = llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+
+        assert.strictEqual(promise1, promise2);
+        await promise1;
       });
 
-      it('registers connection with token header', async () => {
-        llmService.isDataChannelTokenEnabled.resolves(true);
-        await llmService.register(datachannelUrl, 'abc123');
+      it('avoids reconnect if already connected to same URLs', async () => {
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        sinon.assert.calledOnce(llmChannel.connect);
+
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        sinon.assert.calledOnce(llmChannel.connect);
+      });
+    });
+
+    describe('#register (via registerAndConnect)', () => {
+      it('sends request with token header when token enabled and provided', async () => {
+        llmChannel.isDataChannelTokenEnabled = sinon.stub().resolves(true);
+
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl, 'abc123');
 
         sinon.assert.calledOnceWithExactly(
-          llmService.request,
+          llmChannel.request,
           sinon.match({
             method: 'POST',
-            url: `${datachannelUrl}`,
+            url: datachannelUrl,
             body: {deviceUrl: webex.internal.device.url},
             headers: {'Data-Channel-Auth-Token': 'abc123'},
           })
         );
       });
 
-      it('registers connection without token header when none provided', async () => {
-        await llmService.register(datachannelUrl);
+      it('sends request without token header when none provided', async () => {
+        llmChannel.isDataChannelTokenEnabled = sinon.stub().resolves(true);
+
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
 
         sinon.assert.calledOnceWithExactly(
-          llmService.request,
+          llmChannel.request,
           sinon.match({
             method: 'POST',
-            url: `${datachannelUrl}`,
+            url: datachannelUrl,
             body: {deviceUrl: webex.internal.device.url},
             headers: {},
           })
         );
       });
 
-      it('registers connection without token header when toggle disabled', async () => {
-        llmService.isDataChannelTokenEnabled.resolves(false);
+      it('sends request without token header when toggle disabled', async () => {
+        llmChannel.isDataChannelTokenEnabled = sinon.stub().resolves(false);
 
-        await llmService.register(datachannelUrl,'abc123');
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl, 'abc123');
+
         sinon.assert.calledOnceWithExactly(
-          llmService.request,
+          llmChannel.request,
           sinon.match({
             method: 'POST',
-            url: `${datachannelUrl}`,
+            url: datachannelUrl,
             body: {deviceUrl: webex.internal.device.url},
             headers: {},
           })
@@ -227,189 +162,98 @@ describe('plugin-llm', () => {
 
     describe('#getLocusUrl', () => {
       it('gets LocusUrl', async () => {
-        llmService.register = sinon.stub().callsFake(async () => {
-          llmService.binding = 'binding';
-          llmService.webSocketUrl = 'wss://example.com/socket';
-          return {
-            body: {
-              binding: 'binding',
-              webSocketUrl: 'wss://example.com/socket',
-            },
-          };
-        });
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        assert.equal(llmChannel.getLocusUrl(), locusUrl);
+      });
 
-        await llmService.registerAndConnect(locusUrl, datachannelUrl);
-        assert.equal(llmService.getLocusUrl(), locusUrl);
+      it('returns undefined before connection', () => {
+        assert.equal(llmChannel.getLocusUrl(), undefined);
       });
     });
 
     describe('#getDatachannelUrl', () => {
       it('gets dataChannel Url', async () => {
-        llmService.register = sinon.stub().callsFake(async () => {
-          llmService.binding = 'binding';
-          llmService.webSocketUrl = 'wss://example.com/socket';
-          return {
-            body: {
-              binding: 'binding',
-              webSocketUrl: 'wss://example.com/socket',
-            },
-          };
-        });
-        await llmService.registerAndConnect(locusUrl, datachannelUrl);
-        assert.equal(llmService.getDatachannelUrl(), datachannelUrl);
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        assert.equal(llmChannel.getDatachannelUrl(), datachannelUrl);
+      });
+
+      it('returns undefined before connection', () => {
+        assert.equal(llmChannel.getDatachannelUrl(), undefined);
       });
     });
 
-    describe('#disconnect', () => {
-      it('disconnects mercury', async () => {
-        await llmService.disconnect();
-        sinon.assert.calledOnce(llmService.disconnect);
-        assert.equal(llmService.isConnected(), false);
-        assert.equal(llmService.getLocusUrl(), undefined);
-        assert.equal(llmService.getDatachannelUrl(), undefined);
-        assert.equal(llmService.getBinding(), undefined);
+    describe('#getBinding', () => {
+      it('gets binding after connection', async () => {
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        assert.equal(llmChannel.getBinding(), 'binding');
+      });
+
+      it('returns undefined before connection', () => {
+        assert.equal(llmChannel.getBinding(), undefined);
       });
     });
 
     describe('#disconnectLLM', () => {
-      let instance;
+      it('calls disconnect and clears all connection state', async () => {
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        llmChannel.setDatachannelToken('token123');
+        llmChannel.ownerMeetingId = 'meeting-1';
 
-      beforeEach(() => {
-        instance = {
-          disconnect: jest.fn(() => Promise.resolve()),
-          connections: new Map([
-            ['llm-default-session', { foo: 'bar', datachannelToken: 'session-token' }],
-          ]),
+        assert.equal(llmChannel.isConnected(), true);
+        assert.equal(llmChannel.getLocusUrl(), locusUrl);
+        assert.equal(llmChannel.getDatachannelUrl(), datachannelUrl);
+        assert.equal(llmChannel.getBinding(), 'binding');
+        assert.equal(llmChannel.getDatachannelToken(), 'token123');
+        assert.equal(llmChannel.ownerMeetingId, 'meeting-1');
 
-          disconnectLLM: function (
-            options,
-            sessionId = 'llm-default-session',
-            ownerMeetingId = 'meeting-1'
-          ) {
-            if (!ownerMeetingId) {
-              return Promise.reject(new Error('ownerMeetingId is required'));
-            }
+        await llmChannel.disconnectLLM({code: 1000, reason: 'test'});
 
-            return this.disconnect(options, sessionId).then(() => {
-              this.connections.delete(sessionId);
-            });
-          },
-        };
+        sinon.assert.calledOnceWithExactly(llmChannel.disconnect, {code: 1000, reason: 'test'});
+        assert.equal(llmChannel.getLocusUrl(), undefined);
+        assert.equal(llmChannel.getDatachannelUrl(), undefined);
+        assert.equal(llmChannel.getBinding(), undefined);
+        assert.equal(llmChannel.getDatachannelToken(), undefined);
+        assert.equal(llmChannel.ownerMeetingId, undefined);
       });
 
-      it('calls disconnect and clears session connection (including token stored in session)', async () => {
-        await instance.disconnectLLM({ code: 3000, reason: 'bye' }, 'llm-default-session', 'meeting-1');
+      it('works without options', async () => {
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
 
-        expect(instance.disconnect).toHaveBeenCalledWith(
-          { code: 3000, reason: 'bye' },
-          'llm-default-session'
-        );
+        await llmChannel.disconnectLLM();
 
-        expect(instance.connections.has('llm-default-session')).toBe(false);
-      });
-
-      it('disconnectLLM supports legacy call with options only', async () => {
-        llmService.disconnect = sinon.stub().resolves(true);
-
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined, 'llm-default-session');
-
-        const options = {code: 1000, reason: 'legacy'};
-        const disconnected = await llmService.disconnectLLM(options);
-
-        assert.equal(disconnected, true);
-        sinon.assert.calledOnceWithExactly(llmService.disconnect, options, 'llm-default-session');
-        assert.equal(llmService.getAllConnections().has('llm-default-session'), false);
-      });
-
-      it('disconnectLLM supports legacy call with options and sessionId', async () => {
-        llmService.disconnect = sinon.stub().resolves(true);
-
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined, 's1');
-
-        const options = {code: 1000, reason: 'legacy'};
-        const disconnected = await llmService.disconnectLLM(options, 's1');
-
-        assert.equal(disconnected, true);
-        sinon.assert.calledOnceWithExactly(llmService.disconnect, options, 's1');
-        assert.equal(llmService.getAllConnections().has('s1'), false);
-      });
-
-      it('disconnectLLM treats null sessionId as default session', async () => {
-        llmService.disconnect = sinon.stub().resolves(true);
-
-        await llmService.registerAndConnect(
-          locusUrl,
-          datachannelUrl,
-          undefined,
-          'llm-default-session'
-        );
-
-        const options = {code: 1000, reason: 'legacy-null-session'};
-        const disconnected = await llmService.disconnectLLM(options, null);
-
-        assert.equal(disconnected, true);
-        sinon.assert.calledOnceWithExactly(llmService.disconnect, options, 'llm-default-session');
-        assert.equal(llmService.getAllConnections().has('llm-default-session'), false);
+        sinon.assert.calledOnceWithExactly(llmChannel.disconnect, undefined);
       });
 
       it('propagates disconnect errors', async () => {
-        instance.disconnect.mockRejectedValue(new Error('disconnect failed'));
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        llmChannel.disconnect = sinon.stub().rejects(new Error('disconnect failed'));
 
-        await expect(
-          instance.disconnectLLM({ code: 3000, reason: 'bye' }, 'llm-default-session', 'meeting-1')
-        ).rejects.toThrow('disconnect failed');
+        try {
+          await llmChannel.disconnectLLM({code: 1000, reason: 'test'});
+          assert.fail('should have thrown');
+        } catch (error) {
+          assert.equal(error.message, 'disconnect failed');
+        }
       });
     });
 
     describe('#setRefreshHandler', () => {
-      beforeEach(() => {
-        llmService.setRefreshHandler = LLMChannel.prototype.setRefreshHandler.bind(llmService);
-        llmService.refreshDataChannelToken = LLMChannel.prototype.refreshDataChannelToken.bind(llmService);
-      });
+      it('stores the provided handler', async () => {
+        const handler = sinon.stub().resolves({body: {datachannelToken: 'newToken'}});
+        llmChannel.setRefreshHandler(handler);
 
-      it('defaults to llm-default-session when sessionId is omitted', () => {
-        const handler = sinon.stub().resolves({ body: { datachannelToken: 'legacyToken' } });
+        const result = await llmChannel.refreshDataChannelToken();
 
-        llmService.setRefreshHandler(handler);
-
-        return llmService.refreshDataChannelToken().then((result) => {
-          assert.equal(result.body.datachannelToken, 'legacyToken');
-          sinon.assert.calledOnce(handler);
-        });
-      });
-
-      it('stores the provided handler', () => {
-        const handler = sinon.stub().resolves({ body: { datachannelToken: 'newToken' } });
-        llmService.setRefreshHandler(handler, 'llm-default-session');
-
-        return llmService.refreshDataChannelToken().then((result) => {
-          assert.equal(result.body.datachannelToken, 'newToken');
-          sinon.assert.calledOnce(handler);
-        });
-      });
-
-      it('stores handlers per session id', () => {
-        const handlerS1 = sinon.stub().resolves({ body: { datachannelToken: 'token-s1' } });
-        const handlerS2 = sinon.stub().resolves({ body: { datachannelToken: 'token-s2' } });
-
-        llmService.setRefreshHandler(handlerS1, 's1');
-        llmService.setRefreshHandler(handlerS2, 's2');
-
-        return Promise.all([
-          llmService.refreshDataChannelToken('s1'),
-          llmService.refreshDataChannelToken('s2'),
-        ]).then(([resultS1, resultS2]) => {
-          assert.equal(resultS1.body.datachannelToken, 'token-s1');
-          assert.equal(resultS2.body.datachannelToken, 'token-s2');
-        });
+        assert.equal(result.body.datachannelToken, 'newToken');
+        sinon.assert.calledOnce(handler);
       });
     });
 
     describe('#isDataChannelTokenEnabled', () => {
-      it('works correctly', async () => {
-        webex.internal.feature.getFeature.returns(true);
+      it('returns value from feature toggle', async () => {
+        webex.internal.feature.getFeature.resolves(true);
 
-        const result = await llmService.isDataChannelTokenEnabled();
+        const result = await llmChannel.isDataChannelTokenEnabled();
 
         sinon.assert.calledOnceWithExactly(
           webex.internal.feature.getFeature,
@@ -422,44 +266,24 @@ describe('plugin-llm', () => {
     });
 
     describe('#refreshDataChannelToken', () => {
-      beforeEach(() => {
-        llmService.setRefreshHandler = LLMChannel.prototype.setRefreshHandler.bind(llmService);
-        llmService.refreshDataChannelToken = LLMChannel.prototype.refreshDataChannelToken.bind(llmService);
-      });
-
       it('returns null and logs warn if no handler is set', async () => {
-        const warnSpy = llmService.logger.warn
+        const warnSpy = llmChannel.logger.warn;
 
-        const result = await llmService.refreshDataChannelToken();
+        const result = await llmChannel.refreshDataChannelToken();
 
         assert.equal(result, null);
 
         sinon.assert.calledOnce(warnSpy);
-        sinon.assert.calledWithMatch(
-          warnSpy,
-          sinon.match('LLM refreshHandler is not set for session')
-        );
+        sinon.assert.calledWithMatch(warnSpy, sinon.match('LLM refreshHandler is not set'));
       });
 
       it('returns token when handler resolves', async () => {
-        const mockToken = { body: { datachannelToken: 'newToken', isPracticeSession: false } };
+        const mockToken = {body: {datachannelToken: 'newToken', datachannelTokenType: 'default'}};
         const handler = sinon.stub().resolves(mockToken);
 
-        llmService.setRefreshHandler(handler, 'llm-default-session');
+        llmChannel.setRefreshHandler(handler);
 
-        const token = await llmService.refreshDataChannelToken();
-
-        assert.equal(token, mockToken);
-        sinon.assert.calledOnce(handler);
-      });
-
-      it('uses the handler for the provided session id', async () => {
-        const mockToken = { body: { datachannelToken: 'session-token', isPracticeSession: true } };
-        const handler = sinon.stub().resolves(mockToken);
-
-        llmService.setRefreshHandler(handler, 's2');
-
-        const token = await llmService.refreshDataChannelToken('s2');
+        const token = await llmChannel.refreshDataChannelToken();
 
         assert.equal(token, mockToken);
         sinon.assert.calledOnce(handler);
@@ -467,247 +291,134 @@ describe('plugin-llm', () => {
 
       it('logs warn and returns null when handler rejects', async () => {
         const handler = sinon.stub().rejects(new Error('throw error'));
-        llmService.setRefreshHandler(handler, 'llm-default-session');
+        llmChannel.setRefreshHandler(handler);
 
-        const warnSpy = llmService.logger.warn
+        const warnSpy = llmChannel.logger.warn;
 
-        const result = await llmService.refreshDataChannelToken();
+        const result = await llmChannel.refreshDataChannelToken();
 
         assert.equal(result, null);
 
         sinon.assert.calledOnce(warnSpy);
-        sinon.assert.calledWithMatch(
-          warnSpy,
-          sinon.match('DataChannel token refresh failed'),
-        );
+        sinon.assert.calledWithMatch(warnSpy, sinon.match('DataChannel token refresh failed'));
       });
     });
 
-    describe('#getDatachannelToken / #setDatachannelToken', () => {
+    describe('#getDatachannelToken / #setDatachannelToken / #clearDatachannelToken', () => {
       it('sets and gets datachannel token', () => {
-        llmService.setDatachannelToken('abc123','llm-default-session');
-        assert.equal(llmService.getDatachannelToken('llm-default-session'), 'abc123');
-        llmService.setDatachannelToken('123abc','llm-practice-session');
-        assert.equal(llmService.getDatachannelToken('llm-practice-session'), '123abc');
+        llmChannel.setDatachannelToken('abc123');
+        assert.equal(llmChannel.getDatachannelToken(), 'abc123');
       });
 
-      it('supports arbitrary session id token keys', () => {
-        llmService.setDatachannelToken('token-s1', 'session-custom-1');
-
-        assert.equal(llmService.getDatachannelToken('session-custom-1'), 'token-s1');
+      it('returns undefined when no token is set', () => {
+        assert.equal(llmChannel.getDatachannelToken(), undefined);
       });
 
-    });
+      it('clears datachannel token', () => {
+        llmChannel.setDatachannelToken('abc123');
+        assert.equal(llmChannel.getDatachannelToken(), 'abc123');
 
-    describe('#setOwnerMeetingId / #getOwnerMeetingId', () => {
-      it('stores and returns the owner meeting id for the default session', () => {
-        // beforeEach seeds connections with the default session entry
-        llmService.setOwnerMeetingId('meeting-1');
-
-        assert.equal(llmService.getOwnerMeetingId(), 'meeting-1');
-      });
-
-      it('returns undefined when no owner has been set yet', () => {
-        assert.equal(llmService.getOwnerMeetingId(), undefined);
-      });
-
-      it('is a no-op when there is no session data for the given sessionId', () => {
-        // Default session exists (seeded in beforeEach), but an arbitrary
-        // session id does not — setOwnerMeetingId must not create entries.
-        llmService.setOwnerMeetingId('meeting-1', 'unknown-session');
-
-        assert.equal(llmService.getOwnerMeetingId('unknown-session'), undefined);
-      });
-
-      it('allows clearing ownership by passing undefined', () => {
-        llmService.setOwnerMeetingId('meeting-1');
-        assert.equal(llmService.getOwnerMeetingId(), 'meeting-1');
-
-        llmService.setOwnerMeetingId(undefined);
-
-        assert.equal(llmService.getOwnerMeetingId(), undefined);
-      });
-
-      it('tracks ownership per session id', () => {
-        llmService.connections.set('session-A', {webSocketUrl: 'wss://a'});
-        llmService.connections.set('session-B', {webSocketUrl: 'wss://b'});
-
-        llmService.setOwnerMeetingId('meeting-A', 'session-A');
-        llmService.setOwnerMeetingId('meeting-B', 'session-B');
-
-        assert.equal(llmService.getOwnerMeetingId('session-A'), 'meeting-A');
-        assert.equal(llmService.getOwnerMeetingId('session-B'), 'meeting-B');
-      });
-
-      it('clears ownerMeetingId naturally when disconnectLLM deletes the session entry', async () => {
-        llmService.register = sinon.stub().callsFake(async () => ({
-          body: {binding: 'binding', webSocketUrl: 'wss://example.com/socket'},
-        }));
-
-        await llmService.registerAndConnect(locusUrl, datachannelUrl);
-        llmService.setOwnerMeetingId('meeting-1');
-        assert.equal(llmService.getOwnerMeetingId(), 'meeting-1');
-
-        await llmService.disconnectLLM(
-          {code: 3050, reason: 'done (permanent)'},
-          'llm-default-session',
-          'meeting-1'
-        );
-
-        // Session entry was deleted, so ownerMeetingId is gone.
-        assert.equal(llmService.getOwnerMeetingId(), undefined);
+        llmChannel.clearDatachannelToken();
+        assert.equal(llmChannel.getDatachannelToken(), undefined);
       });
     });
 
-    describe('multi-connection logic', () => {
-      const locusUrl2 = 'locusUrl2';
-      const datachannelUrl2 = 'datachannelUrl2';
+    describe('#ownerMeetingId', () => {
+      it('stores and returns the owner meeting id', () => {
+        llmChannel.ownerMeetingId = 'meeting-1';
 
-      it('tracks multiple sessions independently', async () => {
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined, 's1');
-        await llmService.registerAndConnect(locusUrl2, datachannelUrl2, undefined, 's2');
-
-        assert.equal(llmService.isConnected('s1'), true);
-        assert.equal(llmService.isConnected('s2'), true);
-        assert.equal(llmService.getLocusUrl('s1'), locusUrl);
-        assert.equal(llmService.getLocusUrl('s2'), locusUrl2);
-        assert.equal(llmService.getDatachannelUrl('s1'), datachannelUrl);
-        assert.equal(llmService.getDatachannelUrl('s2'), datachannelUrl2);
-
-        const all = llmService.getAllConnections();
-        assert.equal(all.has('s1'), true);
-        assert.equal(all.has('s2'), true);
+        assert.equal(llmChannel.ownerMeetingId, 'meeting-1');
       });
 
-      it('disconnectLLM clears only the targeted session', async () => {
-        llmService.disconnect = sinon.stub().resolves(true);
-
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined, 's1');
-        await llmService.registerAndConnect(locusUrl2, datachannelUrl2, undefined, 's2');
-
-        const options = {code: 1000, reason: 'test'};
-        const disconnected = await llmService.disconnectLLM(options, 's1', 'meeting-1');
-
-        assert.equal(disconnected, true);
-        sinon.assert.calledOnceWithExactly(llmService.disconnect, options, 's1');
-
-        const all = llmService.getAllConnections();
-        assert.equal(all.has('s1'), false);
-        assert.equal(all.has('s2'), true);
-        assert.equal(llmService.getDatachannelToken('s1'), undefined);
+      it('returns undefined when no owner has been set', () => {
+        assert.equal(llmChannel.ownerMeetingId, undefined);
       });
 
-      it('disconnectLLM skips disconnect when ownerMeetingId does not match', async () => {
-        llmService.disconnect = sinon.stub().resolves(true);
+      it('allows clearing ownership by setting undefined', () => {
+        llmChannel.ownerMeetingId = 'meeting-1';
+        assert.equal(llmChannel.ownerMeetingId, 'meeting-1');
 
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined, 's1');
-        llmService.setOwnerMeetingId('meeting-1', 's1');
+        llmChannel.ownerMeetingId = undefined;
 
-        const options = {code: 1000, reason: 'test'};
-        const disconnected = await llmService.disconnectLLM(options, 's1', 'meeting-2');
-
-        assert.equal(disconnected, false);
-        sinon.assert.notCalled(llmService.disconnect);
-        assert.equal(llmService.getAllConnections().has('s1'), true);
+        assert.equal(llmChannel.ownerMeetingId, undefined);
       });
 
-      it('disconnectAllLLM clears all sessions', async () => {
-        llmService.disconnectAll = sinon.stub().resolves(true);
+      it('is cleared by disconnectLLM', async () => {
+        await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+        llmChannel.ownerMeetingId = 'meeting-1';
+        assert.equal(llmChannel.ownerMeetingId, 'meeting-1');
 
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined, 's1');
-        await llmService.registerAndConnect(locusUrl2, datachannelUrl2, undefined, 's2');
+        await llmChannel.disconnectLLM({code: 1000, reason: 'test'});
 
-        await llmService.disconnectAllLLM({code: 1000, reason: 'all'});
-
-        sinon.assert.calledOnce(llmService.disconnectAll);
-        assert.equal(llmService.getAllConnections().size, 0);
+        assert.equal(llmChannel.ownerMeetingId, undefined);
       });
     });
 
-    describe('#getLocusUrlByDatachannelUrl', () => {
-      const locusUrl2 = 'https://locus-b.wbx2.com/locus/api/v1/loci/456';
-      const datachannelUrl2 = 'https://board-b.wbx2.com/datachannel/api/v1/locus/ps-encoded/registrations';
+    describe('.matchesDatachannelRequestUrl', () => {
+      it('returns true when request URL starts with registration URL', () => {
+        const registrationUrl =
+          'https://board.wbx2.com/datachannel/api/v1/locus/ps-encoded/registrations';
+        const requestUrl = registrationUrl + '/some-path';
 
-      // Ampersand State.extend() does not always propagate prototype methods
-      // added to child classes, so we bind the method from the class prototype
-      // directly onto the test instance.
-      beforeEach(() => {
-        llmService.getLocusUrlByDatachannelUrl = LLMChannel.prototype.getLocusUrlByDatachannelUrl.bind(llmService);
+        const result = LLMChannel.matchesDatachannelRequestUrl(requestUrl, registrationUrl);
+
+        assert.equal(result, true);
       });
 
-      it('returns locusUrl when request URL matches a session datachannelUrl', async () => {
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined, 's1');
-        await llmService.registerAndConnect(locusUrl2, datachannelUrl2, undefined, 's2');
+      it('returns false when URLs do not match', () => {
+        const registrationUrl =
+          'https://board.wbx2.com/datachannel/api/v1/locus/ps-encoded/registrations';
+        const requestUrl = 'https://unknown.example.com/path';
 
-        const result = llmService.getLocusUrlByDatachannelUrl(datachannelUrl2 + '/some-path');
+        const result = LLMChannel.matchesDatachannelRequestUrl(requestUrl, registrationUrl);
 
-        assert.equal(result, locusUrl2);
+        assert.equal(result, false);
       });
 
-      it('returns undefined when no session matches the request URL', async () => {
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined, 's1');
-
-        const result = llmService.getLocusUrlByDatachannelUrl('https://unknown.example.com/path');
-
-        assert.equal(result, undefined);
-      });
-
-      it('matches locusUrl when request host is rewritten but pathname matches', async () => {
-        await llmService.registerAndConnect(locusUrl2, datachannelUrl2, undefined, 's2');
-
-        const rewrittenHostRequestUrl =
+      it('returns true when request host is rewritten but pathname matches', () => {
+        const registrationUrl =
+          'https://board-b.wbx2.com/datachannel/api/v1/locus/ps-encoded/registrations';
+        const requestUrl =
           'https://hostmap-rewritten.example.com/datachannel/api/v1/locus/ps-encoded/registrations/events';
-        const result = llmService.getLocusUrlByDatachannelUrl(rewrittenHostRequestUrl);
 
-        assert.equal(result, locusUrl2);
+        const result = LLMChannel.matchesDatachannelRequestUrl(requestUrl, registrationUrl);
+
+        assert.equal(result, true);
       });
 
-      it('returns undefined when no connections exist', () => {
-        const result = llmService.getLocusUrlByDatachannelUrl(datachannelUrl);
-
-        assert.equal(result, undefined);
-      });
-    });
-
-    describe('#getSessionIdByDatachannelUrl', () => {
-      const datachannelUrl2 = 'https://board-b.wbx2.com/datachannel/api/v1/locus/ps-encoded/registrations';
-
-      beforeEach(() => {
-        llmService.getSessionIdByDatachannelUrl = LLMChannel.prototype.getSessionIdByDatachannelUrl.bind(llmService);
+      it('returns false for empty or null URLs', () => {
+        assert.equal(LLMChannel.matchesDatachannelRequestUrl('', 'https://example.com'), false);
+        assert.equal(LLMChannel.matchesDatachannelRequestUrl('https://example.com', ''), false);
+        assert.equal(LLMChannel.matchesDatachannelRequestUrl(null, 'https://example.com'), false);
+        assert.equal(LLMChannel.matchesDatachannelRequestUrl('https://example.com', null), false);
       });
 
-      it('returns sessionId when request URL matches a session datachannelUrl', async () => {
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined, 's1');
-        await llmService.registerAndConnect('https://locus-b.wbx2.com/locus/api/v1/loci/456', datachannelUrl2, undefined, 's2');
+      it('returns false for invalid URLs', () => {
+        const result = LLMChannel.matchesDatachannelRequestUrl('not-a-url', 'also-not-a-url');
 
-        const result = llmService.getSessionIdByDatachannelUrl(datachannelUrl2 + '/some-path');
-
-        assert.equal(result, 's2');
-      });
-
-      it('returns undefined when no session matches the request URL', async () => {
-        await llmService.registerAndConnect(locusUrl, datachannelUrl, undefined, 's1');
-
-        const result = llmService.getSessionIdByDatachannelUrl('https://unknown.example.com/path');
-
-        assert.equal(result, undefined);
-      });
-
-      it('matches sessionId when request host is rewritten but pathname matches', async () => {
-        await llmService.registerAndConnect(
-          'https://locus-b.wbx2.com/locus/api/v1/loci/456',
-          datachannelUrl2,
-          undefined,
-          's2'
-        );
-
-        const rewrittenHostRequestUrl =
-          'https://hostmap-rewritten.example.com/datachannel/api/v1/locus/ps-encoded/registrations/messages';
-        const result = llmService.getSessionIdByDatachannelUrl(rewrittenHostRequestUrl);
-
-        assert.equal(result, 's2');
+        assert.equal(result, false);
       });
     });
 
+    describe('.buildUrlWithAwareSubchannels', () => {
+      it('adds subscriptionAwareSubchannels query param', () => {
+        const baseUrl = 'wss://example.com/socket';
+        const subchannels = ['channel1', 'channel2'];
+
+        const result = LLMChannel.buildUrlWithAwareSubchannels(baseUrl, subchannels);
+
+        assert.include(result, 'subscriptionAwareSubchannels=channel1%2Cchannel2');
+      });
+
+      it('preserves existing query params', () => {
+        const baseUrl = 'wss://example.com/socket?existing=param';
+        const subchannels = ['channel1'];
+
+        const result = LLMChannel.buildUrlWithAwareSubchannels(baseUrl, subchannels);
+
+        assert.include(result, 'existing=param');
+        assert.include(result, 'subscriptionAwareSubchannels=channel1');
+      });
+    });
   });
 });

--- a/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
+++ b/packages/@webex/internal-plugin-llm/test/unit/spec/llm.js
@@ -108,6 +108,20 @@ describe('plugin-llm', () => {
         await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
         sinon.assert.calledOnce(llmChannel.connect);
       });
+
+      it('propagates error when registration request fails', async () => {
+        const error = new Error('Network failure');
+        llmChannel.request = sinon.stub().rejects(error);
+
+        try {
+          await llmChannel.registerAndConnect(locusUrl, datachannelUrl);
+          assert.fail('should have thrown');
+        } catch (e) {
+          assert.equal(e.message, 'Network failure');
+        }
+
+        sinon.assert.notCalled(llmChannel.connect);
+      });
     });
 
     describe('#register (via registerAndConnect)', () => {

--- a/packages/@webex/internal-plugin-mercury/src/index.js
+++ b/packages/@webex/internal-plugin-mercury/src/index.js
@@ -8,10 +8,10 @@ import '@webex/internal-plugin-metrics';
 
 import {registerInternalPlugin} from '@webex/webex-core';
 
-import MercuryPlugin from './mercury-plugin';
+import Mercury from './mercury';
 import config from './config';
 
-registerInternalPlugin('mercury', MercuryPlugin, {
+registerInternalPlugin('mercury', Mercury, {
   config,
   onBeforeLogout() {
     return this.logout();
@@ -20,7 +20,6 @@ registerInternalPlugin('mercury', MercuryPlugin, {
 
 export {default} from './mercury';
 export {default as Mercury} from './mercury';
-export {MercuryPlugin} from './mercury-plugin';
 export {default as Socket} from './socket';
 export {default as config} from './config';
 export {

--- a/packages/@webex/internal-plugin-mercury/src/index.js
+++ b/packages/@webex/internal-plugin-mercury/src/index.js
@@ -8,10 +8,10 @@ import '@webex/internal-plugin-metrics';
 
 import {registerInternalPlugin} from '@webex/webex-core';
 
-import Mercury from './mercury';
+import MercuryPlugin from './mercury-plugin';
 import config from './config';
 
-registerInternalPlugin('mercury', Mercury, {
+registerInternalPlugin('mercury', MercuryPlugin, {
   config,
   onBeforeLogout() {
     return this.logout();
@@ -20,6 +20,7 @@ registerInternalPlugin('mercury', Mercury, {
 
 export {default} from './mercury';
 export {default as Mercury} from './mercury';
+export {MercuryPlugin} from './mercury-plugin';
 export {default as Socket} from './socket';
 export {default as config} from './config';
 export {

--- a/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
+++ b/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
@@ -44,6 +44,10 @@ export class MercuryPlugin extends (WebexPlugin as any) {
     return this._mercury?.getLastError();
   }
 
+  get hasEverConnected(): boolean {
+    return this._mercury?.hasEverConnected ?? false;
+  }
+
   connect(webSocketUrl?: string): Promise<void> {
     return this._mercury.connect(webSocketUrl);
   }

--- a/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
+++ b/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
@@ -40,6 +40,11 @@ export class MercuryPlugin extends (WebexPlugin as any) {
     return this._mercury?.socket;
   }
 
+  /** Cluster service URLs received from registration status event. */
+  get localClusterServiceUrls(): any {
+    return this._mercury?.localClusterServiceUrls;
+  }
+
   getLastError(): any {
     return this._mercury?.getLastError();
   }

--- a/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
+++ b/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
@@ -9,7 +9,7 @@ import {WebexPlugin} from '@webex/webex-core';
 import config from './config';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const Mercury = require('./mercury');
+const Mercury = require('./mercury').default;
 
 /**
  * MercuryPlugin is the plugin registered as `this.webex.internal.mercury`.

--- a/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
+++ b/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
@@ -5,33 +5,22 @@
 
 // @ts-ignore
 import {WebexPlugin} from '@webex/webex-core';
-// @ts-ignore
+
 import config from './config';
+
+// Since mercury-plugin.ts is a .ts file, the TS language server tries to parse mercury.js and chokes on the @deprecated decorator.
+// using a require() call instead of import to avoid TS parsing the file:
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const Mercury = require('./mercury').default;
 
-/**
- * MercuryPlugin is the plugin registered as `this.webex.internal.mercury`.
- *
- * It wraps a single {@link Mercury} instance and delegates all public methods
- * and property reads to it, while transparently proxying all events so that
- * existing consumers — which subscribe via `this.webex.internal.mercury.on(...)` —
- * continue to work without any changes.
- *
- * The wrapped Mercury instance handles session-multiplexed connections
- * (including the session-suffix event convention used by multi-connection
- * scenarios), keepalive backoff, and all low-level WebSocket management.
- */
 export class MercuryPlugin extends (WebexPlugin as any) {
   namespace = 'Mercury';
 
-  /** The wrapped Mercury connection manager. */
   private _mercury: any;
 
-  initialize(...args: any[]) {
-    super.initialize?.(...args);
-
+  constructor(...args: any[]) {
+    super(...args);
     this._mercury = new (Mercury as any)({parent: (this as any).webex});
 
     // Re-emit every event from Mercury on this plugin so listeners attached to

--- a/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
+++ b/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
@@ -56,12 +56,13 @@ export class MercuryPlugin extends (WebexPlugin as any) {
     return this._mercury.disconnect(options);
   }
 
-  disconnectAll(options?: any): Promise<void> {
-    return this._mercury.disconnectAll(options);
-  }
-
   logout(): Promise<void> {
-    return this._mercury.logout();
+    const normalReconnectReasons = ['idle', 'done (forced)', 'pong not received', 'pong mismatch'];
+    const reason = this.config.beforeLogoutOptionsCloseReason;
+    const options =
+      reason && !normalReconnectReasons.includes(reason) ? {code: 3050, reason} : undefined;
+
+    return this._mercury.disconnect(options);
   }
 
   processRegistrationStatusEvent(message: any): void {

--- a/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
+++ b/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
@@ -40,6 +40,10 @@ export class MercuryPlugin extends (WebexPlugin as any) {
     return this._mercury?.socket;
   }
 
+  getLastError(): any {
+    return this._mercury?.getLastError();
+  }
+
   connect(webSocketUrl?: string): Promise<void> {
     return this._mercury.connect(webSocketUrl);
   }

--- a/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
+++ b/packages/@webex/internal-plugin-mercury/src/mercury-plugin.ts
@@ -1,0 +1,76 @@
+/* eslint-disable require-jsdoc */
+/*!
+ * Copyright (c) 2015-2024 Cisco Systems, Inc. See LICENSE file.
+ */
+
+// @ts-ignore
+import {WebexPlugin} from '@webex/webex-core';
+// @ts-ignore
+import config from './config';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Mercury = require('./mercury');
+
+/**
+ * MercuryPlugin is the plugin registered as `this.webex.internal.mercury`.
+ *
+ * It wraps a single {@link Mercury} instance and delegates all public methods
+ * and property reads to it, while transparently proxying all events so that
+ * existing consumers — which subscribe via `this.webex.internal.mercury.on(...)` —
+ * continue to work without any changes.
+ *
+ * The wrapped Mercury instance handles session-multiplexed connections
+ * (including the session-suffix event convention used by multi-connection
+ * scenarios), keepalive backoff, and all low-level WebSocket management.
+ */
+export class MercuryPlugin extends (WebexPlugin as any) {
+  namespace = 'Mercury';
+
+  /** The wrapped Mercury connection manager. */
+  private _mercury: any;
+
+  initialize(...args: any[]) {
+    super.initialize?.(...args);
+
+    this._mercury = new (Mercury as any)({parent: (this as any).webex});
+
+    // Re-emit every event from Mercury on this plugin so listeners attached to
+    // `this.webex.internal.mercury` continue to work.
+    this._mercury.on('all', (eventName: string, ...rest: any[]) => {
+      (this as any).trigger(eventName, ...rest);
+    });
+  }
+
+  /** True when the primary Mercury socket is connected. */
+  get connected(): boolean {
+    return this._mercury?.connected ?? false;
+  }
+
+  /** The primary socket, if connected. */
+  get socket(): any {
+    return this._mercury?.socket;
+  }
+
+  connect(webSocketUrl?: string): Promise<void> {
+    return this._mercury.connect(webSocketUrl);
+  }
+
+  disconnect(options?: any): Promise<void> {
+    return this._mercury.disconnect(options);
+  }
+
+  disconnectAll(options?: any): Promise<void> {
+    return this._mercury.disconnectAll(options);
+  }
+
+  logout(): Promise<void> {
+    return this._mercury.logout();
+  }
+
+  processRegistrationStatusEvent(message: any): void {
+    return this._mercury.processRegistrationStatusEvent(message);
+  }
+}
+
+export {config};
+export default MercuryPlugin;

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -360,6 +360,7 @@ const Mercury = WebexPlugin.extend({
       // Call the callback with the error before rejecting
       callback(err);
 
+      // eslint-disable-next-line no-unreachable
       return Promise.reject(err);
     }
 

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -649,6 +649,10 @@ const Mercury = WebexPlugin.extend({
   },
 
   _getEventHandlers(eventType) {
+    if (!eventType) {
+      return [];
+    }
+
     const [namespace, name] = eventType.split('.');
     const handlers = [];
 
@@ -796,9 +800,15 @@ const Mercury = WebexPlugin.extend({
 
     const {data} = envelope;
 
+    if (!data || !data.eventType) {
+      this._emit('event', envelope);
+
+      return Promise.resolve();
+    }
+
     this._applyOverrides(data);
 
-    return this._getEventHandlers(data.eventType || '')
+    return this._getEventHandlers(data.eventType)
       .reduce(
         (promise, handler) =>
           promise.then(() => {

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -500,6 +500,11 @@ const Mercury = WebexPlugin.extend({
           options = {...options, ...this.webex.config.defaultMercuryOptions};
         }
 
+        // Allow subclasses to inject extra socket options (e.g. skipBufferState for LLM)
+        if (this._extraSocketOptions) {
+          options = {...options, ...this._extraSocketOptions};
+        }
+
         this.logger.info(`${this.namespace}: ${logPrefix} url: ${webSocketUrl}`);
 
         return socket.open(webSocketUrl, options).then(() => webSocketUrl);

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -198,17 +198,6 @@ const Mercury = WebexPlugin.extend({
     });
   },
 
-  logout() {
-    this.logger.info(`${this.namespace}: logout() called`);
-
-    return this.disconnect(
-      this.config.beforeLogoutOptionsCloseReason &&
-        !normalReconnectReasons.includes(this.config.beforeLogoutOptionsCloseReason)
-        ? {code: 3050, reason: this.config.beforeLogoutOptionsCloseReason}
-        : undefined
-    );
-  },
-
   disconnect(options) {
     this.logger.info(
       `${this.namespace}#disconnect: connecting state: ${this.connecting}, connected state: ${

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -45,6 +45,14 @@ const Mercury = WebexPlugin.extend({
       default: undefined,
       type: 'number',
     },
+    backoffCall: 'object',
+    _connectPromise: 'object',
+    _shutdownSwitchoverBackoffCall: 'object',
+    _shutdownSwitchoverInProgress: {
+      default: false,
+      type: 'boolean',
+    },
+    _shutdownSwitchoverId: 'string',
   },
 
   derived: {
@@ -116,6 +124,8 @@ const Mercury = WebexPlugin.extend({
    * @returns {void}
    */
   _handleImminentShutdown() {
+    const oldSocket = this.socket;
+
     try {
       if (this._shutdownSwitchoverInProgress) {
         this.logger.info(`${this.namespace}: [shutdown] switchover already in progress`);
@@ -137,7 +147,6 @@ const Mercury = WebexPlugin.extend({
               `${this.namespace}: [shutdown] switchover connected, url: ${webSocketUrl}`
             );
 
-            const oldSocket = this.socket;
             // Atomically switch active socket reference
             this.socket = newSocket;
             this.connected = true; // remain connected throughout
@@ -185,17 +194,32 @@ const Mercury = WebexPlugin.extend({
       return Promise.resolve();
     }
 
+    // If already connecting, return the existing promise so callers can await it
+    if (this._connectPromise) {
+      this.logger.info(
+        `${this.namespace}: connection already in progress, returning existing promise`
+      );
+
+      return this._connectPromise;
+    }
+
     this.connecting = true;
 
     this.logger.info(`${this.namespace}: starting connection attempt`);
 
-    return Promise.resolve(
+    this._connectPromise = Promise.resolve(
       this.webex.internal.device.registered || this.webex.internal.device.register()
-    ).then(() => {
-      this.logger.info(`${this.namespace}: connecting`);
+    )
+      .then(() => {
+        this.logger.info(`${this.namespace}: connecting`);
 
-      return this._connectWithBackoff(webSocketUrl);
-    });
+        return this._connectWithBackoff(webSocketUrl);
+      })
+      .finally(() => {
+        this._connectPromise = null;
+      });
+
+    return this._connectPromise;
   },
 
   disconnect(options) {
@@ -219,7 +243,9 @@ const Mercury = WebexPlugin.extend({
       if (this.socket) {
         this.socket.removeAllListeners('message');
         this.once('offline', resolve);
-        resolve(this.socket.close(options || undefined));
+        this.socket.close(options || undefined);
+
+        return;
       }
 
       resolve();
@@ -314,6 +340,8 @@ const Mercury = WebexPlugin.extend({
         }
 
         webSocketUrl.query.clientTimestamp = Date.now();
+
+        delete webSocketUrl.search;
 
         return url.format(webSocketUrl);
       });
@@ -489,11 +517,6 @@ const Mercury = WebexPlugin.extend({
           options = {...options, ...this.webex.config.defaultMercuryOptions};
         }
 
-        // Allow subclasses to inject extra socket options (e.g. skipBufferState for LLM)
-        if (this._extraSocketOptions) {
-          options = {...options, ...this._extraSocketOptions};
-        }
-
         this.logger.info(`${this.namespace}: ${logPrefix} url: ${webSocketUrl}`);
 
         return socket.open(webSocketUrl, options).then(() => webSocketUrl);
@@ -610,12 +633,18 @@ const Mercury = WebexPlugin.extend({
     try {
       this.trigger(...args);
     } catch (error) {
-      this.logger.error(
-        `${this.namespace}: error occurred in event handler:`,
-        error,
-        ' with args: ',
-        args
-      );
+      try {
+        this.logger.error(
+          `${this.namespace}: error occurred in event handler:`,
+          error,
+          ' with args: ',
+          args
+        );
+      } catch (logError) {
+        // If even logging fails, just ignore to prevent cascading errors during cleanup
+        // eslint-disable-next-line no-console
+        console.error('Mercury _emit error handling failed:', logError);
+      }
     }
   },
 
@@ -648,11 +677,7 @@ const Mercury = WebexPlugin.extend({
       const reason = event.reason && event.reason.toLowerCase();
 
       let socketUrl;
-      if (isActiveSocket && this.socket) {
-        // Active socket closed - get URL from current socket reference
-        socketUrl = this.socket.url;
-      } else if (sourceSocket) {
-        // Old socket closed - get URL from the closed socket
+      if (sourceSocket) {
         socketUrl = sourceSocket.url;
       }
 

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -25,7 +25,6 @@ const normalReconnectReasons = ['idle', 'done (forced)', 'pong not received', 'p
 const Mercury = WebexPlugin.extend({
   namespace: 'Mercury',
   lastError: undefined,
-  defaultSessionId: 'mercury-default-session',
 
   session: {
     connected: {
@@ -40,18 +39,7 @@ const Mercury = WebexPlugin.extend({
       default: false,
       type: 'boolean',
     },
-    sockets: {
-      default: () => new Map(),
-      type: 'object',
-    },
-    backoffCalls: {
-      default: () => new Map(),
-      type: 'object',
-    },
-    _shutdownSwitchoverBackoffCalls: {
-      default: () => new Map(),
-      type: 'object',
-    },
+    socket: 'object',
     localClusterServiceUrls: 'object',
     mercuryTimeOffset: {
       default: undefined,
@@ -111,63 +99,50 @@ const Mercury = WebexPlugin.extend({
   /**
    * Attach event listeners to a socket.
    * @param {Socket} socket - The socket to attach listeners to
-   * @param {sessionId} sessionId - The socket related session ID
    * @returns {void}
    */
-  _attachSocketEventListeners(socket, sessionId) {
-    socket.on('close', (event) => this._onclose(sessionId, event, socket));
-    socket.on('message', (...args) => this._onmessage(sessionId, ...args));
-    socket.on('pong', (...args) => this._setTimeOffset(sessionId, ...args));
-    socket.on('sequence-mismatch', (...args) =>
-      this._emit(sessionId, 'sequence-mismatch', ...args)
-    );
-    socket.on('ping-pong-latency', (...args) =>
-      this._emit(sessionId, 'ping-pong-latency', ...args)
-    );
+  _attachSocketEventListeners(socket) {
+    socket.on('close', (event) => this._onclose(event, socket));
+    socket.on('message', (...args) => this._onmessage(...args));
+    socket.on('pong', (...args) => this._setTimeOffset(...args));
+    socket.on('sequence-mismatch', (...args) => this._emit('sequence-mismatch', ...args));
+    socket.on('ping-pong-latency', (...args) => this._emit('ping-pong-latency', ...args));
   },
 
   /**
    * Handle imminent shutdown by establishing a new connection while keeping
    * the current one alive (make-before-break).
    * Idempotent: will no-op if already in progress.
-   * @param {string} sessionId - The session ID for which the shutdown is imminent
    * @returns {void}
    */
-  _handleImminentShutdown(sessionId) {
-    const oldSocket = this.sockets.get(sessionId);
-
+  _handleImminentShutdown() {
     try {
-      // Idempotent: if we already have a switchover backoff call for this session,
-      // a switchover is in progress – do nothing.
-      if (this._shutdownSwitchoverBackoffCalls.get(sessionId)) {
-        this.logger.info(
-          `${this.namespace}: [shutdown] switchover already in progress for ${sessionId}`
-        );
+      if (this._shutdownSwitchoverInProgress) {
+        this.logger.info(`${this.namespace}: [shutdown] switchover already in progress`);
 
         return;
       }
-
+      this._shutdownSwitchoverInProgress = true;
       this._shutdownSwitchoverId = `${Date.now()}`;
       this.logger.info(
-        `${this.namespace}: [shutdown] switchover start, id=${this._shutdownSwitchoverId} for ${sessionId}`
+        `${this.namespace}: [shutdown] switchover start, id=${this._shutdownSwitchoverId}`
       );
 
-      this._connectWithBackoff(undefined, sessionId, {
+      this._connectWithBackoff(undefined, {
         isShutdownSwitchover: true,
         attemptOptions: {
           isShutdownSwitchover: true,
           onSuccess: (newSocket, webSocketUrl) => {
             this.logger.info(
-              `${this.namespace}: [shutdown] switchover connected, url: ${webSocketUrl} for ${sessionId}`
+              `${this.namespace}: [shutdown] switchover connected, url: ${webSocketUrl}`
             );
 
+            const oldSocket = this.socket;
             // Atomically switch active socket reference
-            this.socket = this.sockets.get(this.defaultSessionId);
-            this.connected = this.hasConnectedSockets(); // remain connected throughout
+            this.socket = newSocket;
+            this.connected = true; // remain connected throughout
 
-            this._emit(sessionId, 'event:mercury_shutdown_switchover_complete', {
-              url: webSocketUrl,
-            });
+            this._emit('event:mercury_shutdown_switchover_complete', {url: webSocketUrl});
 
             if (oldSocket) {
               this.logger.info(
@@ -178,25 +153,20 @@ const Mercury = WebexPlugin.extend({
         },
       })
         .then(() => {
-          this.logger.info(
-            `${this.namespace}: [shutdown] switchover completed successfully for ${sessionId}`
-          );
+          this.logger.info(`${this.namespace}: [shutdown] switchover completed successfully`);
         })
         .catch((err) => {
           this.logger.info(
-            `${this.namespace}: [shutdown] switchover exhausted retries; will fall back to normal reconnection for ${sessionId}: `,
+            `${this.namespace}: [shutdown] switchover exhausted retries; will fall back to normal reconnection`,
             err
           );
-          this._emit(sessionId, 'event:mercury_shutdown_switchover_failed', {reason: err});
+          this._emit('event:mercury_shutdown_switchover_failed', {reason: err});
           // Old socket will eventually close with 4001, triggering normal reconnection
         });
     } catch (e) {
-      this.logger.error(
-        `${this.namespace}: [shutdown] error during switchover for ${sessionId}`,
-        e
-      );
-      this._shutdownSwitchoverBackoffCalls.delete(sessionId);
-      this._emit(sessionId, 'event:mercury_shutdown_switchover_failed', {reason: e});
+      this.logger.error(`${this.namespace}: [shutdown] error during switchover`, e);
+      this._shutdownSwitchoverInProgress = false;
+      this._emit('event:mercury_shutdown_switchover_failed', {reason: e});
     }
   },
 
@@ -208,105 +178,30 @@ const Mercury = WebexPlugin.extend({
     return this.lastError;
   },
 
-  /**
-   * Get all active socket connections
-   * @returns {Map} Map of sessionId to socket instances
-   */
-  getSockets() {
-    return this.sockets;
-  },
-
-  /**
-   * Get a specific socket by connection ID
-   * @param {string} sessionId - The connection identifier
-   * @returns {Socket|undefined} The socket instance or undefined if not found
-   */
-  getSocket(sessionId = this.defaultSessionId) {
-    return this.sockets.get(sessionId);
-  },
-
-  /**
-   * Check if a socket is connected
-   * @param {string} [sessionId=this.defaultSessionId] - The session identifier
-   * @returns {boolean|undefined} True if the socket is connected
-   */
-  hasConnectedSockets(sessionId = this.defaultSessionId) {
-    const socket = this.sockets.get(sessionId || this.defaultSessionId);
-
-    return socket?.connected;
-  },
-
-  /**
-   * Check if any sockets are connecting
-   * @param {string} [sessionId=this.defaultSessionId] - The session identifier
-   * @returns {boolean|undefined} True if the socket is connecting
-   */
-  hasConnectingSockets(sessionId = this.defaultSessionId) {
-    const socket = this.sockets.get(sessionId || this.defaultSessionId);
-
-    return socket?.connecting;
-  },
-
-  /**
-   * Connect to Mercury for a specific session.
-   * @param {string} [webSocketUrl] - Optional websocket URL override. Falls back to the device websocket URL.
-   * @param {string} [sessionId=this.defaultSessionId] - The session identifier for this connection.
-   * @returns {Promise<void>} Resolves when connection flow completes for the session.
-   */
-  connect(webSocketUrl, sessionId = this.defaultSessionId) {
-    if (!this._connectPromises) this._connectPromises = new Map();
-
-    // First check if there's already a connection promise for this session
-    if (this._connectPromises.has(sessionId)) {
-      this.logger.info(
-        `${this.namespace}: connection ${sessionId} already in progress, returning existing promise`
-      );
-
-      return this._connectPromises.get(sessionId);
-    }
-
-    const sessionSocket = this.sockets.get(sessionId);
-    if (sessionSocket?.connected || sessionSocket?.connecting) {
-      this.logger.info(
-        `${this.namespace}: connection ${sessionId} already connected, will not connect again`
-      );
+  connect(webSocketUrl) {
+    if (this.connected) {
+      this.logger.info(`${this.namespace}: already connected, will not connect again`);
 
       return Promise.resolve();
     }
 
     this.connecting = true;
 
-    this.logger.info(`${this.namespace}: starting connection attempt for ${sessionId}`);
-    this.logger.info(
-      `${this.namespace}: debug_mercury_logging stack: `,
-      new Error('debug_mercury_logging').stack
-    );
+    this.logger.info(`${this.namespace}: starting connection attempt`);
 
-    const connectPromise = Promise.resolve(
+    return Promise.resolve(
       this.webex.internal.device.registered || this.webex.internal.device.register()
-    )
-      .then(() => {
-        this.logger.info(`${this.namespace}: connecting ${sessionId}`);
+    ).then(() => {
+      this.logger.info(`${this.namespace}: connecting`);
 
-        return this._connectWithBackoff(webSocketUrl, sessionId);
-      })
-      .finally(() => {
-        this._connectPromises.delete(sessionId);
-      });
-
-    this._connectPromises.set(sessionId, connectPromise);
-
-    return connectPromise;
+      return this._connectWithBackoff(webSocketUrl);
+    });
   },
 
   logout() {
     this.logger.info(`${this.namespace}: logout() called`);
-    this.logger.info(
-      `${this.namespace}: debug_mercury_logging stack: `,
-      new Error('debug_mercury_logging').stack
-    );
 
-    return this.disconnectAll(
+    return this.disconnect(
       this.config.beforeLogoutOptionsCloseReason &&
         !normalReconnectReasons.includes(this.config.beforeLogoutOptionsCloseReason)
         ? {code: 3050, reason: this.config.beforeLogoutOptionsCloseReason}
@@ -314,13 +209,7 @@ const Mercury = WebexPlugin.extend({
     );
   },
 
-  /**
-   * Disconnect a Mercury socket for a specific session.
-   * @param {object} [options] - Optional websocket close options (for example: `{code, reason}`).
-   * @param {string} [sessionId=this.defaultSessionId] - The session identifier to disconnect.
-   * @returns {Promise<void>} Resolves after disconnect cleanup and close handling are initiated/completed.
-   */
-  disconnect(options, sessionId = this.defaultSessionId) {
+  disconnect(options) {
     this.logger.info(
       `${this.namespace}#disconnect: connecting state: ${this.connecting}, connected state: ${
         this.connected
@@ -328,60 +217,23 @@ const Mercury = WebexPlugin.extend({
     );
 
     return new Promise((resolve) => {
-      const backoffCall = this.backoffCalls.get(sessionId);
-      if (backoffCall) {
-        this.logger.info(`${this.namespace}: aborting connection ${sessionId}`);
-        backoffCall.abort();
-        this.backoffCalls.delete(sessionId);
-      }
-      const shutdownSwitchoverBackoffCall = this._shutdownSwitchoverBackoffCalls.get(sessionId);
-      if (shutdownSwitchoverBackoffCall) {
-        this.logger.info(`${this.namespace}: aborting shutdown switchover connection ${sessionId}`);
-        shutdownSwitchoverBackoffCall.abort();
-        this._shutdownSwitchoverBackoffCalls.delete(sessionId);
-      }
-      // Clean up any pending connection promises
-      if (this._connectPromises) {
-        this._connectPromises.delete(sessionId);
+      if (this.backoffCall) {
+        this.logger.info(`${this.namespace}: aborting connection`);
+        this.backoffCall.abort();
       }
 
-      const sessionSocket = this.sockets.get(sessionId);
-      const suffix = sessionId === this.defaultSessionId ? '' : `:${sessionId}`;
-
-      if (sessionSocket) {
-        sessionSocket.removeAllListeners('message');
-        sessionSocket.connecting = false;
-        sessionSocket.connected = false;
-        this.once(sessionId === this.defaultSessionId ? 'offline' : `offline${suffix}`, resolve);
-        resolve(sessionSocket.close(options || undefined));
+      if (this._shutdownSwitchoverBackoffCall) {
+        this.logger.info(`${this.namespace}: aborting shutdown switchover`);
+        this._shutdownSwitchoverBackoffCall.abort();
       }
+
+      if (this.socket) {
+        this.socket.removeAllListeners('message');
+        this.once('offline', resolve);
+        resolve(this.socket.close(options || undefined));
+      }
+
       resolve();
-
-      // Update overall connected status
-      this.connected = this.hasConnectedSockets();
-    });
-  },
-
-  /**
-   * Disconnect all socket connections
-   * @param {object} options - Close options
-   * @returns {Promise} Promise that resolves when all connections are closed
-   */
-  disconnectAll(options) {
-    const disconnectPromises = [];
-
-    for (const sessionId of this.sockets.keys()) {
-      disconnectPromises.push(this.disconnect(options, sessionId));
-    }
-
-    return Promise.all(disconnectPromises).then(() => {
-      this.connected = false;
-      this.sockets.clear();
-      this.backoffCalls.clear();
-      // Clear connection promises to prevent stale promises
-      if (this._connectPromises) {
-        this._connectPromises.clear();
-      }
     });
   },
 
@@ -473,29 +325,34 @@ const Mercury = WebexPlugin.extend({
         }
 
         webSocketUrl.query.clientTimestamp = Date.now();
-        delete webSocketUrl.search;
 
         return url.format(webSocketUrl);
       });
   },
 
-  _attemptConnection(socketUrl, sessionId, callback, options = {}) {
+  _attemptConnection(socketUrl, callback, options = {}) {
     const {isShutdownSwitchover = false, onSuccess = null} = options;
 
     const socket = new Socket();
-    socket.connecting = true;
     let newWSUrl;
 
-    this._attachSocketEventListeners(socket, sessionId);
-
-    const backoffCall = isShutdownSwitchover
-      ? this._shutdownSwitchoverBackoffCalls.get(sessionId)
-      : this.backoffCalls.get(sessionId);
+    this._attachSocketEventListeners(socket);
 
     // Check appropriate backoff call based on connection type
-    if (!backoffCall) {
-      const mode = isShutdownSwitchover ? 'switchover backoff call' : 'backoffCall';
-      const msg = `${this.namespace}: prevent socket open when ${mode} no longer defined for ${sessionId}`;
+    if (isShutdownSwitchover && !this._shutdownSwitchoverBackoffCall) {
+      const msg = `${this.namespace}: prevent socket open when switchover backoff call no longer defined`;
+      const err = new Error(msg);
+
+      this.logger.info(msg);
+
+      // Call the callback with the error before rejecting
+      callback(err);
+
+      return Promise.reject(err);
+    }
+
+    if (!isShutdownSwitchover && !this.backoffCall) {
+      const msg = `${this.namespace}: prevent socket open when backoffCall no longer defined`;
       const err = new Error(msg);
 
       this.logger.info(msg);
@@ -509,17 +366,16 @@ const Mercury = WebexPlugin.extend({
     // For shutdown switchover, don't set socket yet (make-before-break)
     // For normal connection, set socket before opening to allow disconnect() to close it
     if (!isShutdownSwitchover) {
-      this.sockets.set(sessionId, socket);
+      this.socket = socket;
     }
 
-    return this._prepareAndOpenSocket(socket, socketUrl, sessionId, isShutdownSwitchover)
+    return this._prepareAndOpenSocket(socket, socketUrl, isShutdownSwitchover)
       .then((webSocketUrl) => {
         newWSUrl = webSocketUrl;
-
         this.logger.info(
           `${this.namespace}: ${
             isShutdownSwitchover ? '[shutdown] switchover' : ''
-          } connected to mercury, success, action: connected for ${sessionId}, url: ${newWSUrl}`
+          } connected to mercury, success, action: connected, url: ${newWSUrl}`
         );
 
         // Custom success handler for shutdown switchover
@@ -546,10 +402,7 @@ const Mercury = WebexPlugin.extend({
       .catch((reason) => {
         // For shutdown, simpler error handling - just callback for retry
         if (isShutdownSwitchover) {
-          this.logger.info(
-            `${this.namespace}: [shutdown] switchover attempt failed for ${sessionId}`,
-            reason
-          );
+          this.logger.info(`${this.namespace}: [shutdown] switchover attempt failed`, reason);
 
           return callback(reason);
         }
@@ -557,36 +410,30 @@ const Mercury = WebexPlugin.extend({
         // Normal connection error handling (existing complex logic)
         this.lastError = reason; // remember the last error
 
-        const backoffCallNormal = this.backoffCalls.get(sessionId);
         // Suppress connection errors that appear to be network related. This
         // may end up suppressing metrics during outages, but we might not care
         // (especially since many of our outages happen in a way that client
         // metrics can't be trusted).
-        if (reason.code !== 1006 && backoffCallNormal && backoffCallNormal?.getNumRetries() > 0) {
-          this._emit(sessionId, 'connection_failed', reason, {
-            sessionId,
-            retries: backoffCallNormal?.getNumRetries(),
-          });
+        if (reason.code !== 1006 && this.backoffCall && this.backoffCall?.getNumRetries() > 0) {
+          this._emit('connection_failed', reason, {retries: this.backoffCall?.getNumRetries()});
         }
         this.logger.info(
-          `${this.namespace}: connection attempt failed for ${sessionId}`,
+          `${this.namespace}: connection attempt failed`,
           reason,
-          backoffCallNormal?.getNumRetries() === 0 ? reason.stack : ''
+          this.backoffCall?.getNumRetries() === 0 ? reason.stack : ''
         );
         // UnknownResponse is produced by IE for any 4XXX; treated it like a bad
         // web socket url and let WDM handle the token checking
         if (reason instanceof UnknownResponse) {
           this.logger.info(
-            `${this.namespace}: received unknown response code for ${sessionId}, refreshing device registration`
+            `${this.namespace}: received unknown response code, refreshing device registration`
           );
 
           return this.webex.internal.device.refresh().then(() => callback(reason));
         }
         // NotAuthorized implies expired token
         if (reason instanceof NotAuthorized) {
-          this.logger.info(
-            `${this.namespace}: received authorization error for ${sessionId}, reauthorizing`
-          );
+          this.logger.info(`${this.namespace}: received authorization error, reauthorizing`);
 
           return this.webex.credentials.refresh({force: true}).then(() => callback(reason));
         }
@@ -599,10 +446,8 @@ const Mercury = WebexPlugin.extend({
         // BadRequest implies current credentials are for a Service Account
         // Forbidden implies current user is not entitle for Webex
         if (reason instanceof BadRequest || reason instanceof Forbidden) {
-          this.logger.warn(
-            `${this.namespace}: received unrecoverable response from mercury for ${sessionId}`
-          );
-          backoffCallNormal?.abort();
+          this.logger.warn(`${this.namespace}: received unrecoverable response from mercury`);
+          this.backoffCall.abort();
 
           return callback(reason);
         }
@@ -612,7 +457,7 @@ const Mercury = WebexPlugin.extend({
             .then((haMessagingEnabled) => {
               if (haMessagingEnabled) {
                 this.logger.info(
-                  `${this.namespace}: received a generic connection error for ${sessionId}, will try to connect to another datacenter. failed, action: 'failed', url: ${newWSUrl} error: ${reason.message}`
+                  `${this.namespace}: received a generic connection error, will try to connect to another datacenter. failed, action: 'failed', url: ${newWSUrl} error: ${reason.message}`
                 );
 
                 return this.webex.internal.services.markFailedUrl(newWSUrl);
@@ -626,15 +471,12 @@ const Mercury = WebexPlugin.extend({
         return callback(reason);
       })
       .catch((reason) => {
-        this.logger.error(
-          `${this.namespace}: failed to handle connection failure for ${sessionId}`,
-          reason
-        );
+        this.logger.error(`${this.namespace}: failed to handle connection failure`, reason);
         callback(reason);
       });
   },
 
-  _prepareAndOpenSocket(socket, socketUrl, sessionId, isShutdownSwitchover = false) {
+  _prepareAndOpenSocket(socket, socketUrl, isShutdownSwitchover = false) {
     const logPrefix = isShutdownSwitchover ? '[shutdown] switchover' : 'connection';
 
     return Promise.all([this._prepareUrl(socketUrl), this.webex.credentials.getUserToken()]).then(
@@ -657,32 +499,30 @@ const Mercury = WebexPlugin.extend({
           options = {...options, ...this.webex.config.defaultMercuryOptions};
         }
 
-        // Set the socket before opening it. This allows a disconnect() to close
-        // the socket if it is in the process of being opened.
-        this.sockets.set(sessionId, socket);
-        this.socket = this.sockets.get(this.defaultSessionId);
-
-        this.logger.info(`${this.namespace} ${logPrefix} url for ${sessionId}: ${webSocketUrl}`);
+        this.logger.info(`${this.namespace}: ${logPrefix} url: ${webSocketUrl}`);
 
         return socket.open(webSocketUrl, options).then(() => webSocketUrl);
       }
     );
   },
 
-  _connectWithBackoff(webSocketUrl, sessionId, context = {}) {
+  _connectWithBackoff(webSocketUrl, context = {}) {
     const {isShutdownSwitchover = false, attemptOptions = {}} = context;
 
     return new Promise((resolve, reject) => {
-      // eslint gets confused about whether call is actually used
+      // eslint gets confused about whether or not call is actually used
       // eslint-disable-next-line prefer-const
       let call;
-      const onComplete = (err, sid = sessionId) => {
+      const onComplete = (err) => {
+        // Clear state flags based on connection type
         if (isShutdownSwitchover) {
-          this._shutdownSwitchoverBackoffCalls.delete(sid);
+          this._shutdownSwitchoverInProgress = false;
+          this._shutdownSwitchoverBackoffCall = undefined;
         } else {
-          this.backoffCalls.delete(sid);
+          this.connecting = false;
+          this.backoffCall = undefined;
         }
-        const sessionSocket = this.sockets.get(sid);
+
         if (err) {
           const msg = isShutdownSwitchover
             ? `[shutdown] switchover failed after ${call.getNumRetries()} retries`
@@ -691,45 +531,29 @@ const Mercury = WebexPlugin.extend({
           this.logger.info(
             `${this.namespace}: ${msg}; log statement about next retry was inaccurate; ${err}`
           );
-          if (sessionSocket) {
-            sessionSocket.connecting = false;
-            sessionSocket.connected = false;
-          }
 
           return reject(err);
         }
 
-        // Update overall connected status
-        if (sessionSocket) {
-          sessionSocket.connecting = false;
-          sessionSocket.connected = true;
-        }
         // Default success handling for normal connections
         if (!isShutdownSwitchover) {
-          this.connecting = this.hasConnectingSockets();
-          this.connected = this.hasConnectedSockets();
+          this.connected = true;
           this.hasEverConnected = true;
-          this._emit(sid, 'online');
-          if (this.connected) {
-            this.webex.internal.newMetrics.callDiagnosticMetrics.setMercuryConnectedStatus(true);
-          }
+          this._emit('online');
+          this.webex.internal.newMetrics.callDiagnosticMetrics.setMercuryConnectedStatus(true);
         }
 
         return resolve();
       };
-      // eslint-disable-next-line prefer-reflect
-      call = backoff.call(
-        (callback) => {
-          const attemptNum = call.getNumRetries();
-          const logPrefix = isShutdownSwitchover ? '[shutdown] switchover' : 'connection';
 
-          this.logger.info(
-            `${this.namespace}: executing ${logPrefix} attempt ${attemptNum} for ${sessionId}`
-          );
-          this._attemptConnection(webSocketUrl, sessionId, callback, attemptOptions);
-        },
-        (err) => onComplete(err, sessionId)
-      );
+      // eslint-disable-next-line prefer-reflect
+      call = backoff.call((callback) => {
+        const attemptNum = call.getNumRetries();
+        const logPrefix = isShutdownSwitchover ? '[shutdown] switchover' : 'connection';
+
+        this.logger.info(`${this.namespace}: executing ${logPrefix} attempt ${attemptNum}`);
+        this._attemptConnection(webSocketUrl, callback, attemptOptions);
+      }, onComplete);
 
       call.setStrategy(
         new backoff.ExponentialStrategy({
@@ -748,32 +572,23 @@ const Mercury = WebexPlugin.extend({
         call.failAfter(this.config.maxRetries);
       }
 
-      // Store the call BEFORE setting up event handlers to prevent race conditions
-      // Store backoff call reference BEFORE starting (so it's available in _attemptConnection)
-      if (isShutdownSwitchover) {
-        this._shutdownSwitchoverBackoffCalls.set(sessionId, call);
-      } else {
-        this.backoffCalls.set(sessionId, call);
-      }
-
       call.on('abort', () => {
         const msg = isShutdownSwitchover ? 'Shutdown Switchover' : 'Connection';
 
-        this.logger.info(`${this.namespace}: ${msg} aborted for ${sessionId}`);
-        reject(new Error(`Mercury ${msg} Aborted for ${sessionId}`));
+        this.logger.info(`${this.namespace}: ${msg} aborted`);
+        reject(new Error(`Mercury ${msg} Aborted`));
       });
 
       call.on('callback', (err) => {
         if (err) {
           const number = call.getNumRetries();
           const delay = Math.min(call.strategy_.nextBackoffDelay_, this.config.backoffTimeMax);
-
           const logPrefix = isShutdownSwitchover ? '[shutdown] switchover' : '';
 
           this.logger.info(
             `${this.namespace}: ${logPrefix} failed to connect; attempting retry ${
               number + 1
-            } in ${delay} ms for ${sessionId}`
+            } in ${delay} ms`
           );
           /* istanbul ignore if */
           if (process.env.NODE_ENV === 'development') {
@@ -782,8 +597,15 @@ const Mercury = WebexPlugin.extend({
 
           return;
         }
-        this.logger.info(`${this.namespace}: connected ${sessionId}`);
+        this.logger.info(`${this.namespace}: connected`);
       });
+
+      // Store backoff call reference BEFORE starting (so it's available in _attemptConnection)
+      if (isShutdownSwitchover) {
+        this._shutdownSwitchoverBackoffCall = call;
+      } else {
+        this.backoffCall = call;
+      }
 
       call.start();
     });
@@ -791,46 +613,18 @@ const Mercury = WebexPlugin.extend({
 
   _emit(...args) {
     try {
-      if (!args || args.length === 0) {
-        return;
-      }
-
-      // New signature: _emit(sessionId, eventName, ...rest)
-      // Backwards compatibility: if the first arg isn't a known sessionId (or defaultSessionId),
-      // treat the call as the old signature and forward directly to trigger(...)
-      const [first, second, ...rest] = args;
-
-      if (typeof first === 'string' && typeof second === 'string') {
-        const sessionId = first;
-        const eventName = second;
-        const suffix = sessionId === this.defaultSessionId ? '' : `:${sessionId}`;
-
-        this.trigger(`${eventName}${suffix}`, ...rest);
-      } else {
-        // Old usage: _emit(eventName, ...args)
-        this.trigger(...args);
-      }
+      this.trigger(...args);
     } catch (error) {
-      // Safely handle errors without causing additional issues during cleanup
-      try {
-        this.logger.error(
-          `${this.namespace}: error occurred in event handler:`,
-          error,
-          ' with args: ',
-          args
-        );
-      } catch (logError) {
-        // If even logging fails, just ignore to prevent cascading errors during cleanup
-        // eslint-disable-next-line no-console
-        console.error('Mercury _emit error handling failed:', logError);
-      }
+      this.logger.error(
+        `${this.namespace}: error occurred in event handler:`,
+        error,
+        ' with args: ',
+        args
+      );
     }
   },
 
   _getEventHandlers(eventType) {
-    if (!eventType) {
-      return [];
-    }
     const [namespace, name] = eventType.split('.');
     const handlers = [];
 
@@ -850,40 +644,36 @@ const Mercury = WebexPlugin.extend({
     return handlers;
   },
 
-  _onclose(sessionId, event, sourceSocket) {
+  _onclose(event, sourceSocket) {
     // I don't see any way to avoid the complexity or statement count in here.
     /* eslint complexity: [0] */
 
     try {
+      const isActiveSocket = sourceSocket === this.socket;
       const reason = event.reason && event.reason.toLowerCase();
-      const sessionSocket = this.sockets.get(sessionId);
-      let socketUrl;
-      event.sessionId = sessionId;
 
-      const isActiveSocket = sourceSocket === sessionSocket;
-      if (sourceSocket) {
+      let socketUrl;
+      if (isActiveSocket && this.socket) {
+        // Active socket closed - get URL from current socket reference
+        socketUrl = this.socket.url;
+      } else if (sourceSocket) {
+        // Old socket closed - get URL from the closed socket
         socketUrl = sourceSocket.url;
       }
-      this.sockets.delete(sessionId);
 
       if (isActiveSocket) {
         // Only tear down state if the currently active socket closed
-        if (sessionSocket) {
-          sessionSocket.removeAllListeners();
-          if (sessionId === this.defaultSessionId) this.unset('socket');
-          this._emit(sessionId, 'offline', event);
+        if (this.socket) {
+          this.socket.removeAllListeners();
         }
-        // Update overall connected status
-        this.connecting = this.hasConnectingSockets();
-        this.connected = this.hasConnectedSockets();
-
-        if (!this.connected) {
-          this.webex.internal.newMetrics.callDiagnosticMetrics.setMercuryConnectedStatus(false);
-        }
+        this.unset('socket');
+        this.connected = false;
+        this._emit('offline', event);
+        this.webex.internal.newMetrics.callDiagnosticMetrics.setMercuryConnectedStatus(false);
       } else {
         // Old socket closed; do not flip connection state
         this.logger.info(
-          `${this.namespace}: [shutdown] non-active socket closed, code=${event.code} for ${sessionId}`
+          `${this.namespace}: [shutdown] non-active socket closed, code=${event.code}`
         );
         // Clean up listeners from old socket now that it's closed
         if (sourceSocket) {
@@ -895,14 +685,14 @@ const Mercury = WebexPlugin.extend({
         case 1003:
           // metric: disconnect
           this.logger.info(
-            `${this.namespace}: Mercury service rejected last message for ${sessionId}; will not reconnect: ${event.reason}`
+            `${this.namespace}: Mercury service rejected last message; will not reconnect: ${event.reason}`
           );
-          if (isActiveSocket) this._emit(sessionId, 'offline.permanent', event);
+          if (isActiveSocket) this._emit('offline.permanent', event);
           break;
         case 4000:
           // metric: disconnect
-          this.logger.info(`${this.namespace}: socket ${sessionId} replaced; will not reconnect`);
-          if (isActiveSocket) this._emit(sessionId, 'offline.replaced', event);
+          this.logger.info(`${this.namespace}: socket replaced; will not reconnect`);
+          if (isActiveSocket) this._emit('offline.replaced', event);
           // If not active, nothing to do
           break;
         case 4001:
@@ -912,28 +702,26 @@ const Mercury = WebexPlugin.extend({
             // to be replaced, but the switchover in _handleImminentShutdown failed.
             // This is a permanent failure - do not reconnect.
             this.logger.warn(
-              `${this.namespace}: active socket closed with 4001; shutdown switchover failed for ${sessionId}`
+              `${this.namespace}: active socket closed with 4001; shutdown switchover failed`
             );
-            this._emit(sessionId, 'offline.permanent', event);
+            this._emit('offline.permanent', event);
           } else {
             // Expected: old socket closed after successful switchover
             this.logger.info(
-              `${this.namespace}: old socket closed with 4001 (replaced during shutdown); no reconnect needed for ${sessionId}`
+              `${this.namespace}: old socket closed with 4001 (replaced during shutdown); no reconnect needed`
             );
-            this._emit(sessionId, 'offline.replaced', event);
+            this._emit('offline.replaced', event);
           }
           break;
         case 1001:
         case 1005:
         case 1006:
         case 1011:
-          this.logger.info(`${this.namespace}: socket ${sessionId} disconnected; reconnecting`);
+          this.logger.info(`${this.namespace}: socket disconnected; reconnecting`);
           if (isActiveSocket) {
-            this._emit(sessionId, 'offline.transient', event);
-            this.logger.info(
-              `${this.namespace}: [shutdown] reconnecting active socket to recover for ${sessionId}`
-            );
-            this._reconnect(socketUrl, sessionId);
+            this._emit('offline.transient', event);
+            this.logger.info(`${this.namespace}: [shutdown] reconnecting active socket to recover`);
+            this._reconnect(socketUrl);
           }
           // metric: disconnect
           // if (code == 1011 && reason !== ping error) metric: unexpected disconnect
@@ -941,70 +729,54 @@ const Mercury = WebexPlugin.extend({
         case 1000:
         case 3050: // 3050 indicates logout form of closure, default to old behavior, use config reason defined by consumer to proceed with the permanent block
           if (normalReconnectReasons.includes(reason)) {
-            this.logger.info(`${this.namespace}: socket ${sessionId} disconnected; reconnecting`);
+            this.logger.info(`${this.namespace}: socket disconnected; reconnecting`);
             if (isActiveSocket) {
-              this._emit(sessionId, 'offline.transient', event);
-              this.logger.info(
-                `${this.namespace}: [shutdown] reconnecting due to normal close for ${sessionId}`
-              );
-              this._reconnect(socketUrl, sessionId);
+              this._emit('offline.transient', event);
+              this.logger.info(`${this.namespace}: [shutdown] reconnecting due to normal close`);
+              this._reconnect(socketUrl);
             }
             // metric: disconnect
             // if (reason === done forced) metric: force closure
           } else {
             this.logger.info(
-              `${this.namespace}: socket ${sessionId} disconnected; will not reconnect: ${event.reason}`
+              `${this.namespace}: socket disconnected; will not reconnect: ${event.reason}`
             );
-            if (isActiveSocket) this._emit(sessionId, 'offline.permanent', event);
+            if (isActiveSocket) this._emit('offline.permanent', event);
           }
           break;
         default:
           this.logger.info(
-            `${this.namespace}: socket ${sessionId} disconnected unexpectedly; will not reconnect`
+            `${this.namespace}: socket disconnected unexpectedly; will not reconnect`
           );
           // unexpected disconnect
-          if (isActiveSocket) this._emit(sessionId, 'offline.permanent', event);
+          if (isActiveSocket) this._emit('offline.permanent', event);
       }
     } catch (error) {
-      this.logger.error(
-        `${this.namespace}: error occurred in close handler for ${sessionId}`,
-        error
-      );
+      this.logger.error(`${this.namespace}: error occurred in close handler`, error);
     }
   },
 
-  _onmessage(sessionId, event) {
-    this._setTimeOffset(sessionId, event);
+  _onmessage(event) {
+    this._setTimeOffset(event);
     const envelope = event.data;
 
     if (process.env.ENABLE_MERCURY_LOGGING) {
-      this.logger.debug(`${this.namespace}: message envelope from ${sessionId}: `, envelope);
+      this.logger.debug(`${this.namespace}: message envelope: `, envelope);
     }
-
-    envelope.sessionId = sessionId;
 
     // Handle shutdown message shape: { type: 'shutdown' }
     if (envelope && envelope.type === 'shutdown') {
-      this.logger.info(
-        `${this.namespace}: [shutdown] imminent shutdown message received for ${sessionId}`
-      );
-      this._emit(sessionId, 'event:mercury_shutdown_imminent', envelope);
+      this.logger.info(`${this.namespace}: [shutdown] imminent shutdown message received`);
+      this._emit('event:mercury_shutdown_imminent', envelope);
 
-      this._handleImminentShutdown(sessionId);
+      this._handleImminentShutdown();
 
       return Promise.resolve();
     }
 
-    envelope.sessionId = sessionId;
     const {data} = envelope;
 
     this._applyOverrides(data);
-
-    if (!data || !data.eventType) {
-      this._emit(sessionId, 'event', envelope);
-
-      return Promise.resolve();
-    }
 
     return this._getEventHandlers(data.eventType)
       .reduce(
@@ -1016,7 +788,7 @@ const Mercury = WebexPlugin.extend({
               resolve((this.webex[namespace] || this.webex.internal[namespace])[name](data))
             ).catch((reason) =>
               this.logger.error(
-                `${this.namespace}: error occurred in autowired event handler for ${data.eventType} from ${sessionId}`,
+                `${this.namespace}: error occurred in autowired event handler for ${data.eventType}`,
                 reason
               )
             );
@@ -1024,35 +796,32 @@ const Mercury = WebexPlugin.extend({
         Promise.resolve()
       )
       .then(() => {
-        this._emit(sessionId, 'event', envelope);
+        this._emit('event', event.data);
         const [namespace] = data.eventType.split('.');
 
         if (namespace === data.eventType) {
-          this._emit(sessionId, `event:${namespace}`, envelope);
+          this._emit(`event:${namespace}`, envelope);
         } else {
-          this._emit(sessionId, `event:${namespace}`, envelope);
-          this._emit(sessionId, `event:${data.eventType}`, envelope);
+          this._emit(`event:${namespace}`, envelope);
+          this._emit(`event:${data.eventType}`, envelope);
         }
       })
       .catch((reason) => {
-        this.logger.error(
-          `${this.namespace}: error occurred processing socket message from ${sessionId}`,
-          reason
-        );
+        this.logger.error(`${this.namespace}: error occurred processing socket message`, reason);
       });
   },
 
-  _setTimeOffset(sessionId, event) {
+  _setTimeOffset(event) {
     const {wsWriteTimestamp} = event.data;
     if (typeof wsWriteTimestamp === 'number' && wsWriteTimestamp > 0) {
       this.mercuryTimeOffset = Date.now() - wsWriteTimestamp;
     }
   },
 
-  _reconnect(webSocketUrl, sessionId = this.defaultSessionId) {
-    this.logger.info(`${this.namespace}: reconnecting ${sessionId}`);
+  _reconnect(webSocketUrl) {
+    this.logger.info(`${this.namespace}: reconnecting`);
 
-    return this.connect(webSocketUrl, sessionId);
+    return this.connect(webSocketUrl);
   },
 });
 

--- a/packages/@webex/internal-plugin-mercury/src/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/src/mercury.js
@@ -784,7 +784,7 @@ const Mercury = WebexPlugin.extend({
 
     this._applyOverrides(data);
 
-    return this._getEventHandlers(data.eventType)
+    return this._getEventHandlers(data.eventType || '')
       .reduce(
         (promise, handler) =>
           promise.then(() => {
@@ -803,7 +803,7 @@ const Mercury = WebexPlugin.extend({
       )
       .then(() => {
         this._emit('event', event.data);
-        const [namespace] = data.eventType.split('.');
+        const [namespace] = data.eventType ? data.eventType.split('.') : [];
 
         if (namespace === data.eventType) {
           this._emit(`event:${namespace}`, envelope);

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -315,7 +315,11 @@ export default class Socket extends EventEmitter {
    */
   onmessage(event) {
     try {
-      const data = JSON.parse(event.data);
+      const rawData =
+        event.data instanceof ArrayBuffer
+          ? new TextDecoder('utf-8').decode(event.data)
+          : event.data;
+      const data = JSON.parse(rawData);
       const sequenceNumber = parseInt(data.sequenceNumber, 10);
 
       this.logger.debug(`socket,${this._domain}: sequence number: `, sequenceNumber);
@@ -431,7 +435,10 @@ export default class Socket extends EventEmitter {
         }
       };
 
-      this.once('message', waitForBufferState);
+      // Use 'on' (not 'once') so we keep listening even if a relay event
+      // arrives before mercury.buffer_state — which happens for LLM data-channel
+      // WebSockets that send relay events before sending buffer_state.
+      this.on('message', waitForBufferState);
     });
   }
 

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -315,11 +315,7 @@ export default class Socket extends EventEmitter {
    */
   onmessage(event) {
     try {
-      const rawData =
-        event.data instanceof ArrayBuffer
-          ? new TextDecoder('utf-8').decode(event.data)
-          : event.data;
-      const data = JSON.parse(rawData);
+      const data = JSON.parse(event.data);
       const sequenceNumber = parseInt(data.sequenceNumber, 10);
 
       this.logger.debug(`socket,${this._domain}: sequence number: `, sequenceNumber);

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -442,10 +442,7 @@ export default class Socket extends EventEmitter {
           }
         };
 
-        // Use 'on' (not 'once') so we keep listening even if a relay event
-        // arrives before mercury.buffer_state — which happens for LLM data-channel
-        // WebSockets that send relay events before sending buffer_state.
-        this.on('message', waitForBufferState);
+        this.once('message', waitForBufferState);
       }
     });
   }

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -423,22 +423,30 @@ export default class Socket extends EventEmitter {
         logLevelToken: this.logLevelToken,
       });
 
-      const waitForBufferState = (event) => {
-        if (
-          !event.data.type &&
-          (event.data.data.eventType === 'mercury.buffer_state' ||
-            event.data.data.eventType === 'mercury.registration_status')
-        ) {
-          this.removeListener('message', waitForBufferState);
-          this._ping();
-          resolve();
-        }
-      };
+      // Some channels (e.g. LLM data-channel) never send mercury.buffer_state.
+      // For those, the socket signals skipBufferState: true via open() options,
+      // so we start ping/pong and resolve immediately after sending auth.
+      if (this.skipBufferState) {
+        this._ping();
+        resolve();
+      } else {
+        const waitForBufferState = (event) => {
+          if (
+            !event.data.type &&
+            (event.data.data.eventType === 'mercury.buffer_state' ||
+              event.data.data.eventType === 'mercury.registration_status')
+          ) {
+            this.removeListener('message', waitForBufferState);
+            this._ping();
+            resolve();
+          }
+        };
 
-      // Use 'on' (not 'once') so we keep listening even if a relay event
-      // arrives before mercury.buffer_state — which happens for LLM data-channel
-      // WebSockets that send relay events before sending buffer_state.
-      this.on('message', waitForBufferState);
+        // Use 'on' (not 'once') so we keep listening even if a relay event
+        // arrives before mercury.buffer_state — which happens for LLM data-channel
+        // WebSockets that send relay events before sending buffer_state.
+        this.on('message', waitForBufferState);
+      }
     });
   }
 

--- a/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
+++ b/packages/@webex/internal-plugin-mercury/src/socket/socket-base.js
@@ -419,27 +419,19 @@ export default class Socket extends EventEmitter {
         logLevelToken: this.logLevelToken,
       });
 
-      // Some channels (e.g. LLM data-channel) never send mercury.buffer_state.
-      // For those, the socket signals skipBufferState: true via open() options,
-      // so we start ping/pong and resolve immediately after sending auth.
-      if (this.skipBufferState) {
-        this._ping();
-        resolve();
-      } else {
-        const waitForBufferState = (event) => {
-          if (
-            !event.data.type &&
-            (event.data.data.eventType === 'mercury.buffer_state' ||
-              event.data.data.eventType === 'mercury.registration_status')
-          ) {
-            this.removeListener('message', waitForBufferState);
-            this._ping();
-            resolve();
-          }
-        };
+      const waitForBufferState = (event) => {
+        if (
+          !event.data.type &&
+          (event.data.data.eventType === 'mercury.buffer_state' ||
+            event.data.data.eventType === 'mercury.registration_status')
+        ) {
+          this.removeListener('message', waitForBufferState);
+          this._ping();
+          resolve();
+        }
+      };
 
-        this.once('message', waitForBufferState);
-      }
+      this.once('message', waitForBufferState);
     });
   }
 

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury-events.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury-events.js
@@ -38,7 +38,6 @@ describe('plugin-mercury', () => {
         },
         timestamp: Date.now(),
         trackingId: `suffix_${uuid.v4()}_${Date.now()}`,
-        sessionId: 'mercury-default-session',
       };
 
       beforeEach(() => {
@@ -93,7 +92,6 @@ describe('plugin-mercury', () => {
         });
 
         mercury = webex.internal.mercury;
-        mercury.defaultSessionId = 'mercury-default-session';
       });
 
       afterEach(() => {
@@ -319,7 +317,7 @@ describe('plugin-mercury', () => {
                 })
                 .then(() => {
                   assert.called(offlineSpy);
-                  assert.calledWith(offlineSpy, {code, reason, sessionId: 'mercury-default-session'});
+                  assert.calledWith(offlineSpy, {code, reason});
                   switch (action) {
                     case 'close':
                       assert.called(permanentSpy);

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury-plugin.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury-plugin.js
@@ -1,0 +1,263 @@
+/*!
+ * Copyright (c) 2015-2024 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {assert} from '@webex/test-helper-chai';
+import sinon from 'sinon';
+import MockWebex from '@webex/test-helper-mock-webex';
+import {MercuryPlugin, config as mercuryConfig} from '@webex/internal-plugin-mercury';
+
+describe('plugin-mercury', () => {
+  describe('MercuryPlugin', () => {
+    let webex, mercuryPlugin;
+
+    beforeEach(() => {
+      webex = new MockWebex({
+        children: {
+          mercury: MercuryPlugin,
+        },
+      });
+
+      webex.internal.feature = {
+        getFeature: sinon.stub().resolves(false),
+      };
+
+      webex.credentials = {
+        refresh: sinon.stub().resolves(),
+        getUserToken: sinon.stub().resolves({
+          toString() {
+            return 'Bearer FAKE';
+          },
+        }),
+      };
+
+      webex.internal.device = {
+        register: sinon.stub().resolves(),
+        refresh: sinon.stub().resolves(),
+        webSocketUrl: 'ws://example.com',
+        registered: true,
+      };
+
+      webex.internal.services = {
+        convertUrlToPriorityHostUrl: sinon.stub().returns('ws://example.com'),
+        markFailedUrl: sinon.stub().resolves(),
+        isValidHost: sinon.stub().returns(true),
+      };
+
+      webex.internal.newMetrics = {
+        callDiagnosticMetrics: {
+          setMercuryConnectedStatus: sinon.stub(),
+        },
+      };
+
+      webex.config.mercury = mercuryConfig.mercury;
+
+      mercuryPlugin = webex.internal.mercury;
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    describe('#constructor()', () => {
+      it('creates an instance with namespace Mercury', () => {
+        assert.equal(mercuryPlugin.namespace, 'Mercury');
+      });
+
+      it('has an internal Mercury instance', () => {
+        assert.isDefined(mercuryPlugin._mercury);
+      });
+    });
+
+    describe('#connected', () => {
+      it('returns false when Mercury is not connected', () => {
+        assert.equal(mercuryPlugin.connected, false);
+      });
+
+      it('returns true when Mercury is connected', () => {
+        mercuryPlugin._mercury.connected = true;
+        assert.equal(mercuryPlugin.connected, true);
+      });
+
+      it('returns false when _mercury is undefined', () => {
+        mercuryPlugin._mercury = undefined;
+        assert.equal(mercuryPlugin.connected, false);
+      });
+    });
+
+    describe('#socket', () => {
+      it('returns undefined when no socket exists', () => {
+        assert.isUndefined(mercuryPlugin.socket);
+      });
+
+      it('returns the socket when connected', () => {
+        const mockSocket = {url: 'ws://test.com'};
+        mercuryPlugin._mercury.socket = mockSocket;
+        assert.equal(mercuryPlugin.socket, mockSocket);
+      });
+    });
+
+    describe('#getLastError()', () => {
+      it('returns undefined when no error occurred', () => {
+        assert.isUndefined(mercuryPlugin.getLastError());
+      });
+
+      it('returns the last error when one occurred', () => {
+        const error = new Error('test error');
+        mercuryPlugin._mercury.lastError = error;
+        assert.equal(mercuryPlugin.getLastError(), error);
+      });
+    });
+
+    describe('#hasEverConnected', () => {
+      it('returns false when never connected', () => {
+        assert.equal(mercuryPlugin.hasEverConnected, false);
+      });
+
+      it('returns true when has connected before', () => {
+        mercuryPlugin._mercury.hasEverConnected = true;
+        assert.equal(mercuryPlugin.hasEverConnected, true);
+      });
+
+      it('returns false when _mercury is undefined', () => {
+        mercuryPlugin._mercury = undefined;
+        assert.equal(mercuryPlugin.hasEverConnected, false);
+      });
+    });
+
+    describe('#connect()', () => {
+      it('delegates to Mercury.connect()', () => {
+        const connectStub = sinon.stub(mercuryPlugin._mercury, 'connect').resolves();
+        const webSocketUrl = 'ws://custom.com';
+
+        mercuryPlugin.connect(webSocketUrl);
+
+        sinon.assert.calledOnceWithExactly(connectStub, webSocketUrl);
+      });
+
+      it('calls connect without URL when none provided', () => {
+        const connectStub = sinon.stub(mercuryPlugin._mercury, 'connect').resolves();
+
+        mercuryPlugin.connect();
+
+        sinon.assert.calledOnceWithExactly(connectStub, undefined);
+      });
+    });
+
+    describe('#disconnect()', () => {
+      it('delegates to Mercury.disconnect()', () => {
+        const disconnectStub = sinon.stub(mercuryPlugin._mercury, 'disconnect').resolves();
+        const options = {code: 1000, reason: 'test'};
+
+        mercuryPlugin.disconnect(options);
+
+        sinon.assert.calledOnceWithExactly(disconnectStub, options);
+      });
+
+      it('calls disconnect without options when none provided', () => {
+        const disconnectStub = sinon.stub(mercuryPlugin._mercury, 'disconnect').resolves();
+
+        mercuryPlugin.disconnect();
+
+        sinon.assert.calledOnceWithExactly(disconnectStub, undefined);
+      });
+    });
+
+    describe('#logout()', () => {
+      it('calls disconnect with code 3050 when reason is not a normal reconnect reason', () => {
+        const disconnectStub = sinon.stub(mercuryPlugin._mercury, 'disconnect').resolves();
+        mercuryPlugin.config.beforeLogoutOptionsCloseReason = 'done (permanent)';
+
+        mercuryPlugin.logout();
+
+        sinon.assert.calledOnceWithExactly(disconnectStub, {
+          code: 3050,
+          reason: 'done (permanent)',
+        });
+      });
+
+      it('calls disconnect with undefined when reason is a normal reconnect reason', () => {
+        const disconnectStub = sinon.stub(mercuryPlugin._mercury, 'disconnect').resolves();
+        mercuryPlugin.config.beforeLogoutOptionsCloseReason = 'idle';
+
+        mercuryPlugin.logout();
+
+        sinon.assert.calledOnceWithExactly(disconnectStub, undefined);
+      });
+
+      it('calls disconnect with undefined when no reason configured', () => {
+        const disconnectStub = sinon.stub(mercuryPlugin._mercury, 'disconnect').resolves();
+        mercuryPlugin.config.beforeLogoutOptionsCloseReason = undefined;
+
+        mercuryPlugin.logout();
+
+        sinon.assert.calledOnceWithExactly(disconnectStub, undefined);
+      });
+
+      [
+        {reason: 'idle', expectUndefined: true},
+        {reason: 'done (forced)', expectUndefined: true},
+        {reason: 'pong not received', expectUndefined: true},
+        {reason: 'pong mismatch', expectUndefined: true},
+        {reason: 'custom reason', expectUndefined: false},
+        {reason: 'done (permanent)', expectUndefined: false},
+      ].forEach(({reason, expectUndefined}) => {
+        it(`calls disconnect with ${expectUndefined ? 'undefined' : 'code 3050'} for reason "${reason}"`, () => {
+          const disconnectStub = sinon.stub(mercuryPlugin._mercury, 'disconnect').resolves();
+          mercuryPlugin.config.beforeLogoutOptionsCloseReason = reason;
+
+          mercuryPlugin.logout();
+
+          if (expectUndefined) {
+            sinon.assert.calledOnceWithExactly(disconnectStub, undefined);
+          } else {
+            sinon.assert.calledOnceWithExactly(disconnectStub, {code: 3050, reason});
+          }
+        });
+      });
+    });
+
+    describe('#processRegistrationStatusEvent()', () => {
+      it('delegates to Mercury.processRegistrationStatusEvent()', () => {
+        const processStub = sinon
+          .stub(mercuryPlugin._mercury, 'processRegistrationStatusEvent')
+          .returns();
+        const message = {localClusterServiceUrls: {test: 'url'}};
+
+        mercuryPlugin.processRegistrationStatusEvent(message);
+
+        sinon.assert.calledOnceWithExactly(processStub, message);
+      });
+    });
+
+    describe('event re-emission', () => {
+      it('re-emits events from Mercury to the plugin', (done) => {
+        const testData = {test: 'data'};
+
+        mercuryPlugin.on('event:test', (data) => {
+          assert.deepEqual(data, testData);
+          done();
+        });
+
+        mercuryPlugin._mercury.trigger('event:test', testData);
+      });
+
+      it('re-emits online event', (done) => {
+        mercuryPlugin.on('online', () => {
+          done();
+        });
+
+        mercuryPlugin._mercury.trigger('online');
+      });
+
+      it('re-emits offline event', (done) => {
+        mercuryPlugin.on('offline', (event) => {
+          assert.deepEqual(event, {code: 1000, reason: 'test'});
+          done();
+        });
+
+        mercuryPlugin._mercury.trigger('offline', {code: 1000, reason: 'test'});
+      });
+    });
+  });
+});

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury-plugin.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury-plugin.js
@@ -97,6 +97,23 @@ describe('plugin-mercury', () => {
       });
     });
 
+    describe('#localClusterServiceUrls', () => {
+      it('returns undefined when not set', () => {
+        assert.isUndefined(mercuryPlugin.localClusterServiceUrls);
+      });
+
+      it('returns the localClusterServiceUrls when set', () => {
+        const urls = {mercuryConnectionServiceClusterUrl: 'https://mercury.example.com'};
+        mercuryPlugin._mercury.localClusterServiceUrls = urls;
+        assert.deepEqual(mercuryPlugin.localClusterServiceUrls, urls);
+      });
+
+      it('returns undefined when _mercury is undefined', () => {
+        mercuryPlugin._mercury = undefined;
+        assert.isUndefined(mercuryPlugin.localClusterServiceUrls);
+      });
+    });
+
     describe('#getLastError()', () => {
       it('returns undefined when no error occurred', () => {
         assert.isUndefined(mercuryPlugin.getLastError());

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -107,14 +107,12 @@ describe('plugin-mercury', () => {
       // Clean up Mercury connections and internal state
       if (mercury) {
         try {
-          await mercury.disconnectAll();
+          await mercury.disconnect();
         } catch (e) {
           // Ignore cleanup errors
         }
-        // Clear any remaining connection promises
-        if (mercury._connectPromises) {
-          mercury._connectPromises.clear();
-        }
+        // Clear any remaining connection promise
+        mercury._connectPromise = null;
       }
 
       // Ensure mock socket is properly closed

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -1146,23 +1146,28 @@ describe('plugin-mercury', () => {
           mercury._applyOverrides.restore();
         });
 
-        it('should throw when envelope.data (nested) is undefined', () => {
+        it('should emit generic event and return early when envelope.data (nested) is undefined', async () => {
           const event = {
             data: {
               type: 'someType',
-              // no nested data property - will cause TypeError when accessing data.eventType
+              // no nested data property
             },
           };
 
-          assert.throws(() => mercury._onmessage(event), TypeError);
+          const result = mercury._onmessage(event);
+
+          assert.instanceOf(result, Promise);
+          await result;
+          assert.calledOnceWithExactly(mercury._emit, 'event', event.data);
+          assert.notCalled(mercury._applyOverrides);
         });
 
-        it('should handle when data.eventType is undefined', async () => {
+        it('should emit generic event and return early when data.eventType is undefined', async () => {
           const event = {
             data: {
               type: 'someType',
               data: {
-                // no eventType property - will use empty string fallback
+                // no eventType property
                 someField: 'value',
               },
             },
@@ -1172,7 +1177,8 @@ describe('plugin-mercury', () => {
 
           assert.instanceOf(result, Promise);
           await result;
-          assert.calledWith(mercury._emit, 'event', event.data);
+          assert.calledOnceWithExactly(mercury._emit, 'event', event.data);
+          assert.notCalled(mercury._applyOverrides);
         });
 
         it('should emit generic event for messages without eventType (e.g. subscription responses)', async () => {
@@ -1190,7 +1196,8 @@ describe('plugin-mercury', () => {
 
           assert.instanceOf(result, Promise);
           await result;
-          assert.calledWith(mercury._emit, 'event', event.data);
+          assert.calledOnceWithExactly(mercury._emit, 'event', event.data);
+          assert.notCalled(mercury._applyOverrides);
         });
 
         it('should still process messages with a valid eventType', async () => {
@@ -1212,12 +1219,16 @@ describe('plugin-mercury', () => {
       });
 
       describe('#_getEventHandlers()', () => {
-        it('should throw when eventType is undefined', () => {
-          assert.throws(() => mercury._getEventHandlers(undefined), TypeError);
+        it('should return an empty array when eventType is undefined', () => {
+          const result = mercury._getEventHandlers(undefined);
+
+          assert.deepEqual(result, []);
         });
 
-        it('should throw when eventType is null', () => {
-          assert.throws(() => mercury._getEventHandlers(null), TypeError);
+        it('should return an empty array when eventType is null', () => {
+          const result = mercury._getEventHandlers(null);
+
+          assert.deepEqual(result, []);
         });
 
         it('should return an empty array when eventType is an empty string', () => {

--- a/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/@webex/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -100,19 +100,39 @@ describe('plugin-mercury', () => {
       });
 
       mercury = webex.internal.mercury;
-      mercury.defaultSessionId = 'mercury-default-session';
     });
 
-    afterEach(async () => {
-      // Clean up Mercury connections and internal state
+    afterEach(() => {
+      // Clean up Mercury connections and internal state synchronously
+      // to avoid issues with fake timers
       if (mercury) {
-        try {
-          await mercury.disconnect();
-        } catch (e) {
-          // Ignore cleanup errors
+        // Abort any pending backoff calls first
+        if (mercury.backoffCall) {
+          mercury.backoffCall.abort();
+          mercury.backoffCall = undefined;
         }
+        if (mercury._shutdownSwitchoverBackoffCall) {
+          mercury._shutdownSwitchoverBackoffCall.abort();
+          mercury._shutdownSwitchoverBackoffCall = undefined;
+        }
+
+        // Close socket directly without waiting for offline event
+        if (mercury.socket) {
+          if (typeof mercury.socket.removeAllListeners === 'function') {
+            mercury.socket.removeAllListeners();
+          }
+          try {
+            mercury.socket.close();
+          } catch (e) {
+            // Ignore cleanup errors
+          }
+          mercury.socket = undefined;
+        }
+
         // Clear any remaining connection promise
         mercury._connectPromise = null;
+        mercury.connected = false;
+        mercury.connecting = false;
       }
 
       // Ensure mock socket is properly closed
@@ -131,9 +151,6 @@ describe('plugin-mercury', () => {
       if (Socket.getWebSocketConstructor.restore) {
         Socket.getWebSocketConstructor.restore();
       }
-
-      // Small delay to ensure all async operations complete
-      await new Promise(resolve => setTimeout(resolve, 10));
     });
 
     describe('#listen()', () => {
@@ -612,44 +629,6 @@ describe('plugin-mercury', () => {
       });
     });
 
-    describe('#logout()', () => {
-      it('calls disconnectAll and logs', () => {
-        sinon.stub(mercury.logger, 'info');
-        sinon.stub(mercury, 'disconnectAll');
-        mercury.logout();
-        assert.called(mercury.disconnectAll);
-        assert.calledTwice(mercury.logger.info);
-
-        assert.calledWith(mercury.logger.info.getCall(0), 'Mercury: logout() called');
-        assert.isTrue(
-          mercury.logger.info
-            .getCall(1)
-            .args[0].startsWith('Mercury: debug_mercury_logging stack: ')
-        );
-      });
-
-      it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send code 3050 for logout', () => {
-        sinon.stub(mercury, 'disconnectAll');
-        mercury.config.beforeLogoutOptionsCloseReason = 'done (permanent)';
-        mercury.logout();
-        assert.calledWith(mercury.disconnectAll, {code: 3050, reason: 'done (permanent)'});
-      });
-
-      it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send code 3050 for logout if the reason is different than standard', () => {
-        sinon.stub(mercury, 'disconnectAll');
-        mercury.config.beforeLogoutOptionsCloseReason = 'test';
-        mercury.logout();
-        assert.calledWith(mercury.disconnectAll, {code: 3050, reason: 'test'});
-      });
-
-      it('uses the config.beforeLogoutOptionsCloseReason to disconnect and will send undefined for logout if the reason is same as standard', () => {
-        sinon.stub(mercury, 'disconnectAll');
-        mercury.config.beforeLogoutOptionsCloseReason = 'done (forced)';
-        mercury.logout();
-        assert.calledWith(mercury.disconnectAll, undefined);
-      });
-    });
-
     describe('#disconnect()', () => {
       it('disconnects the WebSocket', () =>
         mercury
@@ -752,12 +731,12 @@ describe('plugin-mercury', () => {
           return promiseTick(webex.internal.mercury.config.backoffTimeReset).then(() => {
             // By this time backoffCall and mercury socket should be defined by the
             // 'connect' call
-            assert.isDefined(mercury.backoffCalls.get('mercury-default-session'), 'Mercury backoffCall is not defined');
+            assert.isDefined(mercury.backoffCall, 'Mercury backoffCall is not defined');
             assert.isDefined(mercury.socket, 'Mercury socket is not defined');
             // Calling disconnect will abort the backoffCall, close the socket, and
             // reject the connect
             mercury.disconnect();
-            assert.isUndefined(mercury.backoffCalls.get('mercury-default-session'), 'Mercury backoffCall is still defined');
+            assert.notOk(mercury.backoffCall, 'Mercury backoffCall is still defined');
             // The socket will never be unset (which seems bad)
             assert.isDefined(mercury.socket, 'Mercury socket is not defined');
 
@@ -775,20 +754,16 @@ describe('plugin-mercury', () => {
 
           let reason;
 
-          mercury.backoffCalls.clear();
+          mercury.backoffCall = undefined;
 
-          const promise = mercury._attemptConnection(
-            'ws://example.com',
-            'mercury-default-session',
-            (_reason) => {
-              reason = _reason;
-            }
-          );
+          const promise = mercury._attemptConnection('ws://example.com', (_reason) => {
+            reason = _reason;
+          });
 
           return promiseTick(webex.internal.mercury.config.backoffTimeReset).then(() => {
             assert.equal(
               reason.message,
-              `Mercury: prevent socket open when backoffCall no longer defined for ${mercury.defaultSessionId}`
+              'Mercury: prevent socket open when backoffCall no longer defined'
             );
 
             // Ensure the promise was actually rejected (short-circuited)
@@ -813,7 +788,7 @@ describe('plugin-mercury', () => {
             return assert.isRejected(promise).then((error) => {
               const lastError = mercury.getLastError();
 
-              assert.equal(error.message, `Mercury Connection Aborted for ${mercury.defaultSessionId}`);
+              assert.equal(error.message, 'Mercury Connection Aborted');
               assert.isDefined(lastError);
               assert.equal(lastError, realError);
             });
@@ -907,7 +882,7 @@ describe('plugin-mercury', () => {
           },
         };
         assert.isUndefined(mercury.mercuryTimeOffset);
-        mercury._setTimeOffset('mercury-default-session', event);
+        mercury._setTimeOffset(event);
         assert.isDefined(mercury.mercuryTimeOffset);
         assert.isTrue(mercury.mercuryTimeOffset > 0);
       });
@@ -917,7 +892,7 @@ describe('plugin-mercury', () => {
             wsWriteTimestamp: Date.now() + 60000,
           },
         };
-        mercury._setTimeOffset('mercury-default-session', event);
+        mercury._setTimeOffset(event);
         assert.isTrue(mercury.mercuryTimeOffset < 0);
       });
       it('handles invalid wsWriteTimestamp', () => {
@@ -928,7 +903,7 @@ describe('plugin-mercury', () => {
               wsWriteTimestamp: invalidTimestamp,
             },
           };
-          mercury._setTimeOffset('mercury-default-session', event);
+          mercury._setTimeOffset(event);
           assert.isUndefined(mercury.mercuryTimeOffset);
         });
       });
@@ -1035,15 +1010,13 @@ describe('plugin-mercury', () => {
     describe('shutdown protocol', () => {
       describe('#_handleImminentShutdown()', () => {
         let connectWithBackoffStub;
-        const sessionId = 'mercury-default-session';
 
         beforeEach(() => {
           mercury.connected = true;
-          mercury.sockets.set(sessionId, {
+          mercury.socket = {
             url: 'ws://old-socket.com',
             removeAllListeners: sinon.stub(),
-          });
-          mercury.socket = mercury.sockets.get(sessionId);
+          };
           connectWithBackoffStub = sinon.stub(mercury, '_connectWithBackoff');
           connectWithBackoffStub.returns(Promise.resolve());
           sinon.stub(mercury, '_emit');
@@ -1052,47 +1025,42 @@ describe('plugin-mercury', () => {
         afterEach(() => {
           connectWithBackoffStub.restore();
           mercury._emit.restore();
-          mercury.sockets.clear();
         });
 
         it('should be idempotent - no-op if already in progress', () => {
-          // Simulate an existing switchover in progress by seeding the backoff map
-          mercury._shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
+          // Simulate an existing switchover in progress
+          mercury._shutdownSwitchoverInProgress = true;
 
-          mercury._handleImminentShutdown(sessionId);
+          mercury._handleImminentShutdown();
 
           assert.notCalled(connectWithBackoffStub);
         });
 
         it('should set switchover flags when called', () => {
-          mercury._handleImminentShutdown(sessionId);
+          mercury._handleImminentShutdown();
 
-          // With _connectWithBackoff stubbed, the backoff map entry may not be created here.
-          // Assert that switchover initiation state was set and a shutdown switchover connect was requested.
           assert.isDefined(mercury._shutdownSwitchoverId);
 
           assert.calledOnce(connectWithBackoffStub);
           const callArgs = connectWithBackoffStub.firstCall.args;
           assert.isUndefined(callArgs[0]); // webSocketUrl
-          assert.equal(callArgs[1], sessionId); // sessionId
-          assert.isObject(callArgs[2]); // context
-          assert.isTrue(callArgs[2].isShutdownSwitchover);
-          assert.isObject(callArgs[2].attemptOptions);
-          assert.isTrue(callArgs[2].attemptOptions.isShutdownSwitchover);
+          assert.isObject(callArgs[1]); // context
+          assert.isTrue(callArgs[1].isShutdownSwitchover);
+          assert.isObject(callArgs[1].attemptOptions);
+          assert.isTrue(callArgs[1].attemptOptions.isShutdownSwitchover);
         });
 
         it('should call _connectWithBackoff with correct parameters', (done) => {
-          mercury._handleImminentShutdown(sessionId);
+          mercury._handleImminentShutdown();
 
           process.nextTick(() => {
             assert.calledOnce(connectWithBackoffStub);
             const callArgs = connectWithBackoffStub.firstCall.args;
             assert.isUndefined(callArgs[0]); // webSocketUrl
-            assert.equal(callArgs[1], sessionId); // sessionId
-            assert.isObject(callArgs[2]); // context
-            assert.isTrue(callArgs[2].isShutdownSwitchover);
-            assert.isObject(callArgs[2].attemptOptions);
-            assert.isTrue(callArgs[2].attemptOptions.isShutdownSwitchover);
+            assert.isObject(callArgs[1]); // context
+            assert.isTrue(callArgs[1].isShutdownSwitchover);
+            assert.isObject(callArgs[1].attemptOptions);
+            assert.isTrue(callArgs[1].attemptOptions.isShutdownSwitchover);
             done();
           });
         });
@@ -1101,12 +1069,10 @@ describe('plugin-mercury', () => {
           connectWithBackoffStub.restore();
           sinon.stub(mercury, '_connectWithBackoff').throws(new Error('Connection failed'));
 
-          mercury._handleImminentShutdown(sessionId);
+          mercury._handleImminentShutdown();
 
-          // When an exception happens synchronously, the placeholder entry
-          // should be removed from the map.
-          const switchoverCall = mercury._shutdownSwitchoverBackoffCalls.get(sessionId);
-          assert.isUndefined(switchoverCall);
+          // When an exception happens synchronously, the in-progress flag should be cleared
+          assert.isFalse(mercury._shutdownSwitchoverInProgress);
           mercury._connectWithBackoff.restore();
         });
       });
@@ -1132,15 +1098,10 @@ describe('plugin-mercury', () => {
             },
           };
 
-          const result = mercury._onmessage(mercury.defaultSessionId, shutdownEvent);
+          const result = mercury._onmessage(shutdownEvent);
 
           assert.calledOnce(mercury._handleImminentShutdown);
-          assert.calledWith(
-            mercury._emit,
-            mercury.defaultSessionId,
-            'event:mercury_shutdown_imminent',
-            shutdownEvent.data
-          );
+          assert.calledWith(mercury._emit, 'event:mercury_shutdown_imminent', shutdownEvent.data);
           assert.instanceOf(result, Promise);
         });
 
@@ -1151,7 +1112,7 @@ describe('plugin-mercury', () => {
             },
           };
 
-          mercury._onmessage(mercury.defaultSessionId, shutdownEvent);
+          mercury._onmessage(shutdownEvent);
 
           assert.calledOnce(mercury._handleImminentShutdown);
         });
@@ -1166,7 +1127,7 @@ describe('plugin-mercury', () => {
             },
           };
 
-          mercury._onmessage(mercury.defaultSessionId, regularEvent);
+          mercury._onmessage(regularEvent);
 
           assert.notCalled(mercury._handleImminentShutdown);
         });
@@ -1185,38 +1146,36 @@ describe('plugin-mercury', () => {
           mercury._applyOverrides.restore();
         });
 
-        it('should not throw when envelope.data is undefined', () => {
+        it('should throw when envelope.data (nested) is undefined', () => {
           const event = {
             data: {
               type: 'someType',
-              // no nested data property
+              // no nested data property - will cause TypeError when accessing data.eventType
             },
           };
 
-          const result = mercury._onmessage(mercury.defaultSessionId, event);
-
-          assert.instanceOf(result, Promise);
-          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'event', event.data);
+          assert.throws(() => mercury._onmessage(event), TypeError);
         });
 
-        it('should not throw when data.eventType is undefined', () => {
+        it('should handle when data.eventType is undefined', async () => {
           const event = {
             data: {
               type: 'someType',
               data: {
-                // no eventType property
+                // no eventType property - will use empty string fallback
                 someField: 'value',
               },
             },
           };
 
-          const result = mercury._onmessage(mercury.defaultSessionId, event);
+          const result = mercury._onmessage(event);
 
           assert.instanceOf(result, Promise);
-          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'event', event.data);
+          await result;
+          assert.calledWith(mercury._emit, 'event', event.data);
         });
 
-        it('should emit generic event for messages without eventType (e.g. subscription responses)', () => {
+        it('should emit generic event for messages without eventType (e.g. subscription responses)', async () => {
           const event = {
             data: {
               id: 'msg-123',
@@ -1227,11 +1186,11 @@ describe('plugin-mercury', () => {
             },
           };
 
-          const result = mercury._onmessage(mercury.defaultSessionId, event);
+          const result = mercury._onmessage(event);
 
           assert.instanceOf(result, Promise);
-          assert.calledOnce(mercury._emit);
-          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'event', event.data);
+          await result;
+          assert.calledWith(mercury._emit, 'event', event.data);
         });
 
         it('should still process messages with a valid eventType', async () => {
@@ -1243,26 +1202,22 @@ describe('plugin-mercury', () => {
             },
           };
 
-          await mercury._onmessage(mercury.defaultSessionId, event);
+          await mercury._onmessage(event);
 
           // Normal flow emits namespace-specific events after processing handlers.
           // The early-return guard only emits 'event', so asserting these proves the normal path was taken.
-          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'event:conversation', event.data);
-          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'event:conversation.activity', event.data);
+          assert.calledWith(mercury._emit, 'event:conversation', event.data);
+          assert.calledWith(mercury._emit, 'event:conversation.activity', event.data);
         });
       });
 
       describe('#_getEventHandlers()', () => {
-        it('should return an empty array when eventType is undefined', () => {
-          const result = mercury._getEventHandlers(undefined);
-
-          assert.deepEqual(result, []);
+        it('should throw when eventType is undefined', () => {
+          assert.throws(() => mercury._getEventHandlers(undefined), TypeError);
         });
 
-        it('should return an empty array when eventType is null', () => {
-          const result = mercury._getEventHandlers(null);
-
-          assert.deepEqual(result, []);
+        it('should throw when eventType is null', () => {
+          assert.throws(() => mercury._getEventHandlers(null), TypeError);
         });
 
         it('should return an empty array when eventType is an empty string', () => {
@@ -1291,7 +1246,6 @@ describe('plugin-mercury', () => {
             removeAllListeners: sinon.stub(),
           };
           mercury.socket = mockSocket;
-          mercury.sockets.set(mercury.defaultSessionId, mockSocket);
           mercury.connected = true;
           sinon.stub(mercury, '_emit');
           sinon.stub(mercury, '_reconnect');
@@ -1310,9 +1264,9 @@ describe('plugin-mercury', () => {
             reason: 'replaced during shutdown',
           };
 
-          mercury._onclose(mercury.defaultSessionId, closeEvent, mockSocket);
+          mercury._onclose(closeEvent, mockSocket);
 
-          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'offline.permanent', closeEvent);
+          assert.calledWith(mercury._emit, 'offline.permanent', closeEvent);
           assert.notCalled(mercury._reconnect); // No reconnect for 4001 on active socket
           assert.isFalse(mercury.connected);
         });
@@ -1323,9 +1277,9 @@ describe('plugin-mercury', () => {
             reason: 'replaced during shutdown',
           };
 
-          mercury._onclose(mercury.defaultSessionId, closeEvent, anotherSocket);
+          mercury._onclose(closeEvent, anotherSocket);
 
-          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'offline.replaced', closeEvent);
+          assert.calledWith(mercury._emit, 'offline.replaced', closeEvent);
           assert.notCalled(mercury._reconnect);
           assert.isTrue(mercury.connected); // Should remain connected
           assert.notCalled(mercury.unset);
@@ -1338,16 +1292,15 @@ describe('plugin-mercury', () => {
           };
 
           // Test non-active socket
-          mercury._onclose(mercury.defaultSessionId, closeEvent, anotherSocket);
-          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'offline.replaced', closeEvent);
+          mercury._onclose(closeEvent, anotherSocket);
+          assert.calledWith(mercury._emit, 'offline.replaced', closeEvent);
 
           // Reset the spy call history
           mercury._emit.resetHistory();
 
           // Test active socket
-          mercury.sockets.set(mercury.defaultSessionId, mockSocket);
-          mercury._onclose(mercury.defaultSessionId, closeEvent, mockSocket);
-          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'offline.permanent', closeEvent);
+          mercury._onclose(closeEvent, mockSocket);
+          assert.calledWith(mercury._emit, 'offline.permanent', closeEvent);
         });
 
         it('should handle missing sourceSocket parameter (treats as non-active)', () => {
@@ -1356,10 +1309,10 @@ describe('plugin-mercury', () => {
             reason: 'replaced during shutdown',
           };
 
-          mercury._onclose(mercury.defaultSessionId, closeEvent); // No sourceSocket parameter
+          mercury._onclose(closeEvent); // No sourceSocket parameter
 
           // With simplified logic, undefined !== this.socket, so isActiveSocket = false
-          assert.calledWith(mercury._emit, mercury.defaultSessionId, 'offline.replaced', closeEvent);
+          assert.calledWith(mercury._emit, 'offline.replaced', closeEvent);
           assert.notCalled(mercury._reconnect);
         });
 
@@ -1370,11 +1323,9 @@ describe('plugin-mercury', () => {
           };
 
           // Close non-active socket (not the active one)
-          mercury._onclose(mercury.defaultSessionId, closeEvent, anotherSocket);
+          mercury._onclose(closeEvent, anotherSocket);
 
           // Verify listeners were removed from the old socket
-          // The _onclose method checks if sourceSocket !== this.socket (non-active)
-          // and then calls removeAllListeners in the else branch
           assert.calledOnce(anotherSocket.removeAllListeners);
         });
 
@@ -1385,7 +1336,7 @@ describe('plugin-mercury', () => {
           };
 
           // Close active socket
-          mercury._onclose(mercury.defaultSessionId, closeEvent, mockSocket);
+          mercury._onclose(closeEvent, mockSocket);
 
           // Verify listeners were removed from active socket
           assert.calledOnce(mockSocket.removeAllListeners);
@@ -1394,15 +1345,13 @@ describe('plugin-mercury', () => {
 
       describe('shutdown switchover with retry logic', () => {
         let connectWithBackoffStub;
-        const sessionId = 'mercury-default-session';
 
         beforeEach(() => {
           mercury.connected = true;
-          mercury.sockets.set(sessionId, {
+          mercury.socket = {
             url: 'ws://old-socket.com',
             removeAllListeners: sinon.stub(),
-          });
-          mercury.socket = mercury.sockets.get(sessionId);
+          };
           connectWithBackoffStub = sinon.stub(mercury, '_connectWithBackoff');
           sinon.stub(mercury, '_emit');
         });
@@ -1410,46 +1359,42 @@ describe('plugin-mercury', () => {
         afterEach(() => {
           connectWithBackoffStub.restore();
           mercury._emit.restore();
-          mercury.sockets.clear();
         });
 
         it('should call _connectWithBackoff with shutdown switchover context', (done) => {
           connectWithBackoffStub.returns(Promise.resolve());
 
-          mercury._handleImminentShutdown(sessionId);
+          mercury._handleImminentShutdown();
 
           process.nextTick(() => {
             assert.calledOnce(connectWithBackoffStub);
             const callArgs = connectWithBackoffStub.firstCall.args;
 
             assert.isUndefined(callArgs[0]); // webSocketUrl
-            assert.equal(callArgs[1], sessionId);
-            assert.isObject(callArgs[2]);
-            assert.isTrue(callArgs[2].isShutdownSwitchover);
-            assert.isObject(callArgs[2].attemptOptions);
-            assert.isTrue(callArgs[2].attemptOptions.isShutdownSwitchover);
+            assert.isObject(callArgs[1]);
+            assert.isTrue(callArgs[1].isShutdownSwitchover);
+            assert.isObject(callArgs[1].attemptOptions);
+            assert.isTrue(callArgs[1].attemptOptions.isShutdownSwitchover);
             done();
           });
         });
 
         it('should set _shutdownSwitchoverInProgress flag during switchover', () => {
-          // With the new behavior, "in progress" is represented by the presence
-          // of an entry in _shutdownSwitchoverBackoffCalls.
-          // Since _connectWithBackoff is stubbed in this suite, simulate its side-effect
-          // of seeding the backoff-call map entry.
+          // Since _connectWithBackoff is stubbed, we can just check that
+          // _handleImminentShutdown sets the flag
           connectWithBackoffStub.callsFake(() => {
-            mercury._shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
             return new Promise(() => {}); // Never resolves
           });
 
-          mercury._handleImminentShutdown(sessionId);
+          mercury._handleImminentShutdown();
 
-          const switchoverBackoffCall = mercury._shutdownSwitchoverBackoffCalls.get(sessionId);
-          assert.isOk(switchoverBackoffCall);
+          // The flag is set to true initially when switchover starts
+          // (but then gets cleared in finally if the promise rejects)
+          assert.isDefined(mercury._shutdownSwitchoverId);
         });
 
         it('should emit success event when switchover completes', async () => {
-          connectWithBackoffStub.callsFake((url, sid, context) => {
+          connectWithBackoffStub.callsFake((url, context) => {
             if (context && context.attemptOptions && context.attemptOptions.onSuccess) {
               const mockSocket = {url: 'ws://new-socket.com'};
               context.attemptOptions.onSuccess(mockSocket, 'ws://new-socket.com');
@@ -1457,15 +1402,13 @@ describe('plugin-mercury', () => {
             return Promise.resolve();
           });
 
-          mercury._handleImminentShutdown(sessionId);
+          mercury._handleImminentShutdown();
 
           await promiseTick(50);
 
           const emitCalls = mercury._emit.getCalls();
           const hasCompleteEvent = emitCalls.some(
-            (call) =>
-              call.args[0] === sessionId &&
-              call.args[1] === 'event:mercury_shutdown_switchover_complete'
+            (call) => call.args[0] === 'event:mercury_shutdown_switchover_complete'
           );
 
           assert.isTrue(hasCompleteEvent, 'Should emit switchover complete event');
@@ -1474,27 +1417,26 @@ describe('plugin-mercury', () => {
         it('should emit failure event when switchover exhausts retries', async () => {
           const testError = new Error('Connection failed');
 
-          connectWithBackoffStub.returns(Promise.reject(testError));
+          connectWithBackoffStub.callsFake(() => Promise.reject(testError));
 
-          mercury._handleImminentShutdown(sessionId);
+          mercury._handleImminentShutdown();
           await promiseTick(50);
 
           const emitCalls = mercury._emit.getCalls();
           const hasFailureEvent = emitCalls.some(
             (call) =>
-              call.args[0] === sessionId &&
-              call.args[1] === 'event:mercury_shutdown_switchover_failed' &&
-              call.args[2] &&
-              call.args[2].reason === testError
+              call.args[0] === 'event:mercury_shutdown_switchover_failed' &&
+              call.args[1] &&
+              call.args[1].reason === testError
           );
 
           assert.isTrue(hasFailureEvent, 'Should emit switchover failed event');
         });
 
         it('should allow old socket to be closed by server after switchover failure', async () => {
-          connectWithBackoffStub.returns(Promise.reject(new Error('Failed')));
+          connectWithBackoffStub.callsFake(() => Promise.reject(new Error('Failed')));
 
-          mercury._handleImminentShutdown(sessionId);
+          mercury._handleImminentShutdown();
           await promiseTick(50);
 
           assert.equal(mercury.socket.removeAllListeners.callCount, 0);
@@ -1594,14 +1536,13 @@ describe('plugin-mercury', () => {
 
       describe('#_attemptConnection() with shutdown switchover', () => {
         let prepareAndOpenSocketStub, callback;
-        const sessionId = 'mercury-default-session';
 
         beforeEach(() => {
           prepareAndOpenSocketStub = sinon
             .stub(mercury, '_prepareAndOpenSocket')
             .returns(Promise.resolve('ws://new-socket.com'));
           callback = sinon.stub();
-          mercury._shutdownSwitchoverBackoffCalls.set(sessionId, {abort: sinon.stub()});
+          mercury._shutdownSwitchoverBackoffCall = {abort: sinon.stub()};
           mercury.socket = {url: 'ws://test.com'};
           mercury.connected = true;
           sinon.stub(mercury, '_emit');
@@ -1612,13 +1553,13 @@ describe('plugin-mercury', () => {
           prepareAndOpenSocketStub.restore();
           mercury._emit.restore();
           mercury._attachSocketEventListeners.restore();
-          mercury._shutdownSwitchoverBackoffCalls.clear();
+          mercury._shutdownSwitchoverBackoffCall = undefined;
         });
 
         it('should not set socket reference before opening for shutdown switchover', async () => {
           const originalSocket = mercury.socket;
 
-          await mercury._attemptConnection('ws://test.com', sessionId, callback, {
+          await mercury._attemptConnection('ws://test.com', callback, {
             isShutdownSwitchover: true,
             onSuccess: (newSocket, url) => {
               assert.equal(mercury.socket, originalSocket);
@@ -1631,7 +1572,7 @@ describe('plugin-mercury', () => {
         it('should call onSuccess callback with new socket and URL for shutdown', async () => {
           const onSuccessStub = sinon.stub();
 
-          await mercury._attemptConnection('ws://test.com', sessionId, callback, {
+          await mercury._attemptConnection('ws://test.com', callback, {
             isShutdownSwitchover: true,
             onSuccess: onSuccessStub,
           });
@@ -1641,22 +1582,17 @@ describe('plugin-mercury', () => {
         });
 
         it('should emit shutdown switchover complete event', async () => {
-          await mercury._attemptConnection('ws://test.com', sessionId, callback, {
+          await mercury._attemptConnection('ws://test.com', callback, {
             isShutdownSwitchover: true,
             onSuccess: (newSocket, url) => {
               mercury.socket = newSocket;
               mercury.connected = true;
-              mercury._emit(
-                sessionId,
-                'event:mercury_shutdown_switchover_complete',
-                {url}
-              );
+              mercury._emit('event:mercury_shutdown_switchover_complete', {url});
             },
           });
 
           assert.calledWith(
             mercury._emit,
-            sessionId,
             'event:mercury_shutdown_switchover_complete',
             sinon.match.has('url', 'ws://new-socket.com')
           );
@@ -1666,7 +1602,7 @@ describe('plugin-mercury', () => {
           prepareAndOpenSocketStub.returns(Promise.reject(new Error('Connection failed')));
 
           await mercury
-            ._attemptConnection('ws://test.com', sessionId, callback, {
+            ._attemptConnection('ws://test.com', callback, {
               isShutdownSwitchover: true,
             })
             .catch(() => {});
@@ -1676,14 +1612,11 @@ describe('plugin-mercury', () => {
         });
 
         it('should check _shutdownSwitchoverBackoffCall for shutdown connections', () => {
-          mercury._shutdownSwitchoverBackoffCalls.clear();
+          mercury._shutdownSwitchoverBackoffCall = undefined;
 
-          const result = mercury._attemptConnection(
-            'ws://test.com',
-            sessionId,
-            callback,
-            {isShutdownSwitchover: true}
-          );
+          const result = mercury._attemptConnection('ws://test.com', callback, {
+            isShutdownSwitchover: true,
+          });
 
           return result.catch((err) => {
             assert.instanceOf(err, Error);
@@ -1693,27 +1626,25 @@ describe('plugin-mercury', () => {
       });
 
       describe('#_connectWithBackoff() with shutdown switchover', () => {
-        const sessionId = 'mercury-default-session';
-
         it('should use shutdown-specific parameters when called', () => {
           const connectWithBackoffStub = sinon
             .stub(mercury, '_connectWithBackoff')
             .returns(Promise.resolve());
 
-          mercury._handleImminentShutdown(sessionId);
+          mercury._handleImminentShutdown();
 
           assert.calledOnce(connectWithBackoffStub);
           const callArgs = connectWithBackoffStub.firstCall.args;
-          assert.equal(callArgs[1], sessionId);
-          assert.isObject(callArgs[2]);
-          assert.isTrue(callArgs[2].isShutdownSwitchover);
+          // First arg is the URL, second is the context object
+          assert.isObject(callArgs[1]);
+          assert.isTrue(callArgs[1].isShutdownSwitchover);
 
           connectWithBackoffStub.restore();
         });
 
         it('should pass shutdown switchover options to _attemptConnection', () => {
           const attemptStub = sinon.stub(mercury, '_attemptConnection');
-          attemptStub.callsFake((url, sid, cb) => cb());
+          attemptStub.callsFake((url, cb) => cb());
 
           const context = {
             isShutdownSwitchover: true,
@@ -1723,30 +1654,29 @@ describe('plugin-mercury', () => {
             },
           };
 
-          const promise = mercury._connectWithBackoff(undefined, sessionId, context);
+          const promise = mercury._connectWithBackoff(undefined, context);
 
           return promise.then(() => {
             assert.calledOnce(attemptStub);
             const callArgs = attemptStub.firstCall.args;
-            assert.equal(callArgs[1], sessionId);
-            assert.isObject(callArgs[3]);
-            assert.isTrue(callArgs[3].isShutdownSwitchover);
+            assert.isObject(callArgs[2]);
+            assert.isTrue(callArgs[2].isShutdownSwitchover);
             attemptStub.restore();
           });
         });
 
         it('should set and clear state flags appropriately', () => {
-          sinon.stub(mercury, '_attemptConnection').callsFake((url, sid, cb) => cb());
+          sinon.stub(mercury, '_attemptConnection').callsFake((url, cb) => cb());
 
-          mercury._shutdownSwitchoverBackoffCalls.set(sessionId, {placeholder: true});
+          mercury._shutdownSwitchoverInProgress = true;
 
-          const promise = mercury._connectWithBackoff(undefined, sessionId, {
+          const promise = mercury._connectWithBackoff(undefined, {
             isShutdownSwitchover: true,
             attemptOptions: {isShutdownSwitchover: true, onSuccess: () => {}},
           });
 
           return promise.then(() => {
-            assert.isUndefined(mercury._shutdownSwitchoverBackoffCalls.get(sessionId));
+            assert.isFalse(mercury._shutdownSwitchoverInProgress);
             mercury._attemptConnection.restore();
           });
         });
@@ -1754,30 +1684,30 @@ describe('plugin-mercury', () => {
 
       describe('#disconnect() with shutdown switchover in progress', () => {
         let abortStub;
-        const sessionId = 'mercury-default-session';
 
         beforeEach(() => {
-          mercury.sockets.clear();
-          mercury.sockets.set(sessionId, {
-            close: sinon.stub().returns(Promise.resolve()),
-            removeAllListeners: sinon.stub(),
-          });
           abortStub = sinon.stub();
-          mercury._shutdownSwitchoverBackoffCalls.set(sessionId, {abort: abortStub});
+          mercury._shutdownSwitchoverBackoffCall = {abort: abortStub};
         });
 
-        it('should abort shutdown switchover backoff call on disconnect', async () => {
-          await mercury.disconnect(undefined, sessionId);
+        it('should abort shutdown switchover backoff call on disconnect', () => {
+          // Don't set up socket so disconnect resolves immediately
+          mercury.socket = undefined;
 
-          assert.calledOnce(abortStub);
+          return mercury.disconnect().then(() => {
+            assert.calledOnce(abortStub);
+          });
         });
 
-        it('should handle disconnect when no switchover is in progress', async () => {
-          mercury._shutdownSwitchoverBackoffCalls.clear();
+        it('should handle disconnect when no switchover is in progress', () => {
+          mercury._shutdownSwitchoverBackoffCall = undefined;
+          // Don't set up socket so disconnect resolves immediately
+          mercury.socket = undefined;
 
-          await mercury.disconnect(undefined, sessionId);
-
-          assert.calledOnce(mercury.sockets.get(sessionId).close);
+          return mercury.disconnect().then(() => {
+            // If we get here, disconnect completed without error
+            assert.notOk(mercury._shutdownSwitchoverBackoffCall);
+          });
         });
       });
     });

--- a/packages/@webex/plugin-meetings/src/interceptors/dataChannelAuthToken.ts
+++ b/packages/@webex/plugin-meetings/src/interceptors/dataChannelAuthToken.ts
@@ -124,7 +124,7 @@ export default class DataChannelAuthTokenInterceptor extends Interceptor {
           // @ts-ignore
           meeting?.id || this.internal.llm.getOwnerMeetingId?.(tokenStoreKey);
         // @ts-ignore
-        this.internal.llm.setDatachannelToken(datachannelToken, tokenStoreKey, ownerMeetingId);
+        this.internal.llm.setDatachannelToken(datachannelToken, ownerMeetingId, tokenStoreKey);
 
         return datachannelToken;
       },

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6615,15 +6615,15 @@ export default class Meeting extends StatelessWebexPlugin {
 
     if (datachannelToken) {
       // @ts-ignore
-      this.webex.internal.llm.setDatachannelToken(datachannelToken, LLM_DEFAULT_SESSION, this.id);
+      this.webex.internal.llm.setDatachannelToken(datachannelToken, this.id, LLM_DEFAULT_SESSION);
     }
 
     if (practiceSessionDatachannelToken) {
       // @ts-ignore
       this.webex.internal.llm.setDatachannelToken(
         practiceSessionDatachannelToken,
-        LLM_PRACTICE_SESSION,
-        this.id
+        this.id,
+        LLM_PRACTICE_SESSION
       );
     }
   }
@@ -6661,8 +6661,8 @@ export default class Meeting extends StatelessWebexPlugin {
       // @ts-ignore
       this.webex.internal.llm.setDatachannelToken(
         fetchedDatachannelToken,
-        LLM_DEFAULT_SESSION,
-        this.id
+        this.id,
+        LLM_DEFAULT_SESSION
       );
 
       return true;

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -3822,7 +3822,6 @@ export default class Meeting extends StatelessWebexPlugin {
           }`
         );
       }
-
       this.updateLLMConnection();
     });
 
@@ -6046,9 +6045,10 @@ export default class Meeting extends StatelessWebexPlugin {
     }
     switch (e.data.relayType) {
       case REACTION_RELAY_TYPES.REACTION:
+        // @ts-ignore - config coming from registerPlugin
         if (
           // @ts-ignore - config coming from registerPlugin
-          (this.config.receiveReactions || options.receiveReactions) &&
+          this.config.receiveReactions &&
           this.isReactionsSupported()
         ) {
           const member = this.members.membersCollection.get(e.data.sender.participantId);
@@ -6771,6 +6771,23 @@ export default class Meeting extends StatelessWebexPlugin {
       refreshHandlerOwnerMeetingId
     );
 
+    // Register event listeners BEFORE calling registerAndConnect.
+    // The LLM data-channel server does not follow the standard Mercury
+    // buffer_state handshake, so Mercury.connect() / _authorize() may never
+    // resolve. Registering here ensures relay events (e.g. reactions) are
+    // handled immediately regardless of whether the connect() promise settles.
+    // @ts-ignore - Fix type
+    this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);
+    // @ts-ignore - Fix type
+    this.webex.internal.llm.on('event:relay.event', this.processRelayEvent);
+    // @ts-ignore - Fix type
+    this.webex.internal.llm.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
+    // @ts-ignore - Fix type
+    this.webex.internal.llm.on(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
+    LoggerProxy.logger.info(
+      'Meeting:index#updateLLMConnection --> enabled to receive relay events (pre-registered)!'
+    );
+
     // @ts-ignore - Fix type
     return this.webex.internal.llm
       .registerAndConnect(url, dataChannelUrl, datachannelToken)
@@ -6807,6 +6824,9 @@ export default class Meeting extends StatelessWebexPlugin {
             );
           }
         }
+        // Listeners were already registered before registerAndConnect (see above).
+        // Re-register them here too in case connect() did eventually resolve
+        // (e.g. after mercury.buffer_state arrives) to ensure a clean state.
         // @ts-ignore - Fix type
         this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);
         // @ts-ignore - Fix type
@@ -6818,10 +6838,12 @@ export default class Meeting extends StatelessWebexPlugin {
         LoggerProxy.logger.info(
           'Meeting:index#updateLLMConnection --> enabled to receive relay events!'
         );
-
         this.startLLMHealthCheckTimer();
 
         return Promise.resolve(registerAndConnectResult);
+      })
+      .catch((error) => {
+        throw error;
       });
   }
 

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6771,11 +6771,8 @@ export default class Meeting extends StatelessWebexPlugin {
       refreshHandlerOwnerMeetingId
     );
 
-    // Register event listeners BEFORE calling registerAndConnect.
-    // The LLM data-channel server does not follow the standard Mercury
-    // buffer_state handshake, so Mercury.connect() / _authorize() may never
-    // resolve. Registering here ensures relay events (e.g. reactions) are
-    // handled immediately regardless of whether the connect() promise settles.
+    // Register event listeners before calling registerAndConnect so relay
+    // events (e.g. reactions) are handled even if connect() is slow to resolve.
     // @ts-ignore - Fix type
     this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);
     // @ts-ignore - Fix type
@@ -6784,9 +6781,6 @@ export default class Meeting extends StatelessWebexPlugin {
     this.webex.internal.llm.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
     // @ts-ignore - Fix type
     this.webex.internal.llm.on(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
-    LoggerProxy.logger.info(
-      'Meeting:index#updateLLMConnection --> enabled to receive relay events (pre-registered)!'
-    );
 
     // @ts-ignore - Fix type
     return this.webex.internal.llm
@@ -6824,9 +6818,6 @@ export default class Meeting extends StatelessWebexPlugin {
             );
           }
         }
-        // Listeners were already registered before registerAndConnect (see above).
-        // Re-register them here too in case connect() did eventually resolve
-        // (e.g. after mercury.buffer_state arrives) to ensure a clean state.
         // @ts-ignore - Fix type
         this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);
         // @ts-ignore - Fix type

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6771,17 +6771,6 @@ export default class Meeting extends StatelessWebexPlugin {
       refreshHandlerOwnerMeetingId
     );
 
-    // Register event listeners before calling registerAndConnect so relay
-    // events (e.g. reactions) are handled even if connect() is slow to resolve.
-    // @ts-ignore - Fix type
-    this.webex.internal.llm.off('event:relay.event', this.processRelayEvent);
-    // @ts-ignore - Fix type
-    this.webex.internal.llm.on('event:relay.event', this.processRelayEvent);
-    // @ts-ignore - Fix type
-    this.webex.internal.llm.off(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
-    // @ts-ignore - Fix type
-    this.webex.internal.llm.on(LOCUS_LLM_EVENT, this.processLocusLLMEvent);
-
     // @ts-ignore - Fix type
     return this.webex.internal.llm
       .registerAndConnect(url, dataChannelUrl, datachannelToken)

--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6767,8 +6767,8 @@ export default class Meeting extends StatelessWebexPlugin {
     // @ts-ignore - Fix type
     this.webex.internal.llm.setRefreshHandler(
       () => this.refreshDataChannelToken(),
-      LLM_DEFAULT_SESSION,
-      refreshHandlerOwnerMeetingId
+      refreshHandlerOwnerMeetingId,
+      LLM_DEFAULT_SESSION
     );
 
     // @ts-ignore - Fix type
@@ -6802,8 +6802,8 @@ export default class Meeting extends StatelessWebexPlugin {
             // @ts-ignore - Fix type
             this.webex.internal.llm.setRefreshHandler(
               () => this.refreshDataChannelToken(),
-              LLM_DEFAULT_SESSION,
-              this.id
+              this.id,
+              LLM_DEFAULT_SESSION
             );
           }
         }

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -427,8 +427,8 @@ const Webinar = WebexPlugin.extend({
     // @ts-ignore - Fix type
     this.webex.internal.llm.setRefreshHandler(
       () => meeting.refreshDataChannelToken(),
-      LLM_PRACTICE_SESSION,
-      this.meetingId
+      this.meetingId,
+      LLM_PRACTICE_SESSION
     );
     // @ts-ignore - Fix type
     this.webex.internal.llm.setOwnerMeetingId?.(this.meetingId, LLM_PRACTICE_SESSION);

--- a/packages/@webex/plugin-meetings/src/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/src/webinar/index.ts
@@ -277,8 +277,8 @@ const Webinar = WebexPlugin.extend({
       // @ts-ignore
       this.webex.internal.llm.setDatachannelToken(
         datachannelToken,
-        dataChannelTokenType || LLM_PRACTICE_SESSION,
-        this.meetingId
+        this.meetingId,
+        dataChannelTokenType || LLM_PRACTICE_SESSION
       );
 
       return datachannelToken;

--- a/packages/@webex/plugin-meetings/test/unit/spec/interceptors/dataChannelAuthToken.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/interceptors/dataChannelAuthToken.ts
@@ -293,8 +293,8 @@ describe('plugin-meetings', () => {
           sinon.assert.calledOnceWithExactly(
             llmMock.setDatachannelToken,
             'token-from-ps-session',
-            'llm-practice-session',
-            undefined
+            undefined,
+            'llm-practice-session'
           );
         });
 
@@ -316,8 +316,8 @@ describe('plugin-meetings', () => {
           sinon.assert.calledOnceWithExactly(
             llmMock.setDatachannelToken,
             'token-from-default-session',
-            'llm-default-session',
-            undefined
+            undefined,
+            'llm-default-session'
           );
         });
 
@@ -338,8 +338,8 @@ describe('plugin-meetings', () => {
           sinon.assert.calledOnceWithExactly(
             llmMock.setDatachannelToken,
             'token-from-default-fallback',
-            'llm-default-session',
-            undefined
+            undefined,
+            'llm-default-session'
           );
         });
 
@@ -356,8 +356,8 @@ describe('plugin-meetings', () => {
           sinon.assert.calledOnceWithExactly(
             llmMock.setDatachannelToken,
             'token-from-meeting-a',
-            'llm-practice-session',
-            'meeting-a'
+            'meeting-a',
+            'llm-practice-session'
           );
         });
 
@@ -384,8 +384,8 @@ describe('plugin-meetings', () => {
           sinon.assert.calledOnceWithExactly(
             llmMock.setDatachannelToken,
             'token-from-meeting-a',
-            'llm-practice-session',
-            'meeting-a'
+            'meeting-a',
+            'llm-practice-session'
           );
         });
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -14197,8 +14197,8 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(
             webex.internal.llm.setRefreshHandler,
             sinon.match.func,
-            'llm-default-session',
-            meeting.id
+            meeting.id,
+            'llm-default-session'
           );
           assert.equal(result, 'something');
           assert.calledOnceWithExactly(meeting.locusInfo.syncAllHashTreeDatasets, {onlyLLM: true});
@@ -14593,8 +14593,8 @@ describe('plugin-meetings', () => {
             assert.calledOnceWithExactly(
               webex.internal.llm.setRefreshHandler,
               sinon.match.func,
-              'llm-default-session',
-              meeting.id
+              meeting.id,
+              'llm-default-session'
             );
             assert.calledOnceWithExactly(webex.internal.llm.setOwnerMeetingId, meeting.id);
           });
@@ -14632,15 +14632,15 @@ describe('plugin-meetings', () => {
             assert.calledWithExactly(
               webex.internal.llm.setRefreshHandler.firstCall,
               sinon.match.func,
-              'llm-default-session',
-              undefined
+              undefined,
+              'llm-default-session'
             );
             assert.calledTwice(webex.internal.llm.setRefreshHandler);
             assert.calledWithExactly(
               webex.internal.llm.setRefreshHandler.secondCall,
               sinon.match.func,
-              'llm-default-session',
-              meeting.id
+              meeting.id,
+              'llm-default-session'
             );
             assert.calledOnceWithExactly(webex.internal.llm.setOwnerMeetingId, meeting.id);
           });

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2891,6 +2891,7 @@ describe('plugin-meetings', () => {
                 }
               });
               meeting.webex.internal.llm.off = sinon.stub();
+              sinon.stub(meeting.webex.internal.llm, 'registerAndConnect').resolves({});
 
               meeting.updateLLMConnection.restore();
 
@@ -14008,8 +14009,8 @@ describe('plugin-meetings', () => {
           assert.calledWithExactly(
             webex.internal.llm.setDatachannelToken,
             'default-token',
-            'llm-default-session',
-            meeting.id
+            meeting.id,
+            'llm-default-session'
           );
         });
 
@@ -14023,8 +14024,8 @@ describe('plugin-meetings', () => {
           assert.calledWithExactly(
             webex.internal.llm.setDatachannelToken,
             'ps-token',
-            'llm-practice-session',
-            meeting.id
+            meeting.id,
+            'llm-practice-session'
           );
         });
 
@@ -14042,14 +14043,14 @@ describe('plugin-meetings', () => {
           assert.calledWithExactly(
             webex.internal.llm.setDatachannelToken,
             'default-token',
-            'llm-default-session',
-            meeting.id
+            meeting.id,
+            'llm-default-session'
           );
           assert.calledWithExactly(
             webex.internal.llm.setDatachannelToken,
             'ps-token',
-            'llm-practice-session',
-            meeting.id
+            meeting.id,
+            'llm-practice-session'
           );
         });
 
@@ -14081,8 +14082,8 @@ describe('plugin-meetings', () => {
           assert.calledOnceWithExactly(
             webex.internal.llm.setDatachannelToken,
             'default-token',
-            'llm-default-session',
-            meeting.id
+            meeting.id,
+            'llm-default-session'
           );
         });
       });

--- a/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
+++ b/packages/@webex/plugin-meetings/test/unit/spec/webinar/index.ts
@@ -433,8 +433,8 @@ describe('plugin-meetings', () => {
         assert.calledWithExactly(
           webex.internal.llm.setDatachannelToken,
           'ps-token-from-refresh',
-          DataChannelTokenType.PracticeSession,
-          'meeting-id'
+          'meeting-id',
+          DataChannelTokenType.PracticeSession
         );
         assert.calledWith(
           webex.internal.llm.registerAndConnect,


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

This PR refactors the LLM, adds LLM and Mercury plugins to support multiple simultaneous LLM sessions (default + practice session) and wraps Mercury in a plugin pattern for consistency.



## by making the following changes

< DESCRIBE YOUR CHANGES >
Created LLMPlugin wrapper that maintains Map<sessionId, LLMChannel>

Refactored llm.ts: 
- Simplified to single-session LLMChannel class
- Moved multi-session management to plugin layer
- Each channel has its own connectingPromise

Added mercury-plugin.ts:
- Wraps existing Mercury class in plugin pattern
- Exposes: connected, socket, localClusterServiceUrls, hasEverConnected
- Methods: connect(), disconnect(), logout(), processRegistrationStatusEvent()
- Event re-emission from internal _mercury to plugin

Reverted: mercury.js
- Removed session-id changes that were causing issues
- Back to single Mercury connection model

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
