### PR TITLE
fix(cc): add desktop multi-login support

### DIFF
--- a/docs/samples/contact-center/app.js
+++ b/docs/samples/contact-center/app.js
@@ -105,6 +105,7 @@ const aiAssistantRawToggleBtn = document.querySelector('#assistant-raw-output-to
 const aiAssistantRawOutputPanelElm = document.querySelector('#assistant-raw-output-panel');
 const aiAssistantRawOutputContentElm = document.querySelector('#assistant-raw-output-content');
 const multiLoginCheckbox = document.querySelector('#multiLoginFlag');
+const disableWebRTCRegistrationCheckbox = document.querySelector('#disableWebRTCRegistrationFlag');
 deregisterBtn.style.backgroundColor = 'red';
 
 let isMultiLoginEnabled = localStorage.getItem('isMultiLoginEnabled') === 'true';
@@ -112,9 +113,20 @@ if (multiLoginCheckbox) {
   multiLoginCheckbox.checked = isMultiLoginEnabled;
 }
 
+let isWebRTCRegistrationDisabled =
+  localStorage.getItem('isWebRTCRegistrationDisabled') === 'true';
+if (disableWebRTCRegistrationCheckbox) {
+  disableWebRTCRegistrationCheckbox.checked = isWebRTCRegistrationDisabled;
+}
+
 function toggleMultiLogin() {
   isMultiLoginEnabled = multiLoginCheckbox.checked;
   localStorage.setItem('isMultiLoginEnabled', String(isMultiLoginEnabled));
+}
+
+function toggleWebRTCRegistration() {
+  isWebRTCRegistrationDisabled = disableWebRTCRegistrationCheckbox.checked;
+  localStorage.setItem('isWebRTCRegistrationDisabled', String(isWebRTCRegistrationDisabled));
 }
 
 const transcriptEntries = [];
@@ -2213,6 +2225,7 @@ function generateWebexConfig({credentials}) {
     },
     cc: {
       allowMultiLogin: isMultiLoginEnabled,
+      disableWebRTCRegistration: isWebRTCRegistrationDisabled,
     },
     credentials,
   };

--- a/docs/samples/contact-center/index.html
+++ b/docs/samples/contact-center/index.html
@@ -51,6 +51,10 @@
             <input type="checkbox" id="multiLoginFlag" onchange="toggleMultiLogin()">
             Enable Multi Login
           </label>
+          <label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer; margin-top: 8px;">
+            <input type="checkbox" id="disableWebRTCRegistrationFlag" onchange="toggleWebRTCRegistration()">
+            Disable WebRTC Registration
+          </label>
           <p class="note" style="margin-top: 5px;">
             NOTE: Toggle before initializing SDK. Persisted across page reloads.
           </p>

--- a/packages/@webex/contact-center/src/cc.ts
+++ b/packages/@webex/contact-center/src/cc.ts
@@ -351,6 +351,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     this.$webex.once(READY, () => {
       // @ts-ignore
       this.$config = this.config;
+      this.validatePluginConfig();
 
       /**
        * This is used for handling the async requests by sending webex.request and wait for corresponding websocket event.
@@ -407,6 +408,16 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   };
 
   /**
+   * Handles multi-login hydrate events for SDK instances without Mobius registration
+   * @private
+   * @param {ITask} task The task object associated with the multi-login hydrate
+   */
+  private handleTaskMultiLoginHydrate = (task: ITask) => {
+    // @ts-ignore
+    this.trigger(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, task);
+  };
+
+  /**
    * Handles task merged events when tasks are combined eg: EPDN merge/transfer
    * @private
    * @param {ITask} task The task object that has been merged
@@ -424,6 +435,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   private incomingTaskListener() {
     this.taskManager.on(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
     this.taskManager.on(TASK_EVENTS.TASK_HYDRATE, this.handleTaskHydrate);
+    this.taskManager.on(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, this.handleTaskMultiLoginHydrate);
     this.taskManager.on(TASK_EVENTS.TASK_MERGED, this.handleTaskMerged);
   }
 
@@ -553,6 +565,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
 
       this.taskManager.off(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
       this.taskManager.off(TASK_EVENTS.TASK_HYDRATE, this.handleTaskHydrate);
+      this.taskManager.off(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, this.handleTaskMultiLoginHydrate);
       this.taskManager.unregisterIncomingCallEvent();
 
       this.services.webSocketManager.off('message', this.handleWebsocketMessage);
@@ -769,7 +782,8 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
           }
           if (
             this.agentConfig.webRtcEnabled &&
-            this.agentConfig.loginVoiceOptions.includes(LoginOption.BROWSER)
+            this.agentConfig.loginVoiceOptions.includes(LoginOption.BROWSER) &&
+            !this.isWebRTCRegistrationDisabled()
           ) {
             this.$webex.internal.mercury
               .connect()
@@ -785,6 +799,14 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
                   method: METHODS.CONNECT_WEBSOCKET,
                 });
               });
+          } else if (this.isWebRTCRegistrationDisabled()) {
+            LoggerProxy.info(
+              'Skipping Mobius registration because disableWebRTCRegistration is enabled',
+              {
+                module: CC_FILE,
+                method: METHODS.CONNECT_WEBSOCKET,
+              }
+            );
           }
           if (this.$config && this.$config.allowAutomatedRelogin) {
             await this.silentRelogin();
@@ -868,8 +890,24 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
         },
       });
 
-      if (this.agentConfig.webRtcEnabled && data.loginOption === LoginOption.BROWSER) {
+      if (
+        this.agentConfig.webRtcEnabled &&
+        data.loginOption === LoginOption.BROWSER &&
+        !this.isWebRTCRegistrationDisabled()
+      ) {
         await this.webCallingService.registerWebCallingLine();
+      } else if (
+        this.agentConfig.webRtcEnabled &&
+        data.loginOption === LoginOption.BROWSER &&
+        this.isWebRTCRegistrationDisabled()
+      ) {
+        LoggerProxy.info(
+          'Skipping web calling line registration because disableWebRTCRegistration is enabled',
+          {
+            module: CC_FILE,
+            method: METHODS.STATION_LOGIN,
+          }
+        );
       }
 
       const resp = await loginResponse;
@@ -1236,6 +1274,30 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
   };
 
   /**
+   * Checks whether Mobius/WebRTC registration should be skipped by config
+   * @returns {boolean} True when browser WebRTC registration is disabled
+   * @private
+   */
+  private isWebRTCRegistrationDisabled(): boolean {
+    return this.$config?.disableWebRTCRegistration === true;
+  }
+
+  /**
+   * Validates contact-center plugin configuration before service initialization
+   * @private
+   */
+  private validatePluginConfig(): void {
+    if (
+      this.$config?.disableWebRTCRegistration === true &&
+      this.$config?.allowMultiLogin === false
+    ) {
+      throw new Error(
+        'Invalid Contact Center configuration: disableWebRTCRegistration cannot be true when allowMultiLogin is false. Enable allowMultiLogin or allow WebRTC registration so an SDK instance can receive Mobius events.'
+      );
+    }
+  }
+
+  /**
    * Initializes event listeners for the Contact Center service
    * Sets up handlers for connection state changes and other core events
    * @private
@@ -1380,6 +1442,16 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
     this.agentConfig.deviceType = deviceType;
     switch (deviceType) {
       case LoginOption.BROWSER:
+        if (this.isWebRTCRegistrationDisabled()) {
+          LoggerProxy.info(
+            'Skipping web calling line registration because disableWebRTCRegistration is enabled',
+            {
+              module: CC_FILE,
+              method: METHODS.HANDLE_DEVICE_TYPE,
+            }
+          );
+          break;
+        }
         try {
           await this.webCallingService.registerWebCallingLine();
         } catch (error) {

--- a/packages/@webex/contact-center/src/cc.ts
+++ b/packages/@webex/contact-center/src/cc.ts
@@ -1292,7 +1292,7 @@ export default class ContactCenter extends WebexPlugin implements IContactCenter
       this.$config?.allowMultiLogin === false
     ) {
       throw new Error(
-        'Invalid Contact Center configuration: disableWebRTCRegistration cannot be true when allowMultiLogin is false. Enable allowMultiLogin or allow WebRTC registration so an SDK instance can receive Mobius events.'
+        'Invalid Contact Center configuration: disableWebRTCRegistration cannot be true when allowMultiLogin is false. Enable allowMultiLogin or allow WebRTC registration so an SDK instance can receive Mobius/WebRTC task events.'
       );
     }
   }

--- a/packages/@webex/contact-center/src/config.ts
+++ b/packages/@webex/contact-center/src/config.ts
@@ -26,6 +26,12 @@ export default {
      */
     allowAutomatedRelogin: true,
     /**
+     * Whether to skip Mobius/WebRTC registration for browser login flows.
+     * @type {boolean}
+     * @default false
+     */
+    disableWebRTCRegistration: false,
+    /**
      * The type of client making the connection.
      * @type {string}
      * @default 'WebexCCSDK'

--- a/packages/@webex/contact-center/src/services/task/Task.ts
+++ b/packages/@webex/contact-center/src/services/task/Task.ts
@@ -278,7 +278,9 @@ export default abstract class Task extends EventEmitter implements ITask {
     const currentState = snapshot.value as TaskState;
     const context = snapshot.context as TaskContext;
 
-    return computeUIControls(currentState, context, this.data);
+    const uiControls = computeUIControls(currentState, context, this.data);
+
+    return uiControls;
   }
 
   /**
@@ -418,9 +420,11 @@ export default abstract class Task extends EventEmitter implements ITask {
       emitTaskOfferContact: this.createEmitSelfAction(TASK_EVENTS.TASK_OFFER_CONTACT, {
         updateTaskData: true,
       }),
-      emitTaskAssigned: this.createEmitSelfAction(TASK_EVENTS.TASK_ASSIGNED, {
-        updateTaskData: true,
-      }),
+      emitTaskAssigned: ({event}: TaskActionArgs) => {
+        this.updateTaskFromEvent(event);
+        this.emit(TASK_EVENTS.TASK_ASSIGNED, this);
+        this.emit(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, this);
+      },
       emitTaskEnd: this.createEmitSelfAction(TASK_EVENTS.TASK_END, {updateTaskData: true}),
       emitTaskOfferConsult: this.createEmitSelfAction(TASK_EVENTS.TASK_OFFER_CONSULT, {
         updateTaskData: true,
@@ -435,6 +439,7 @@ export default abstract class Task extends EventEmitter implements ITask {
         } else {
           this.emit(TASK_EVENTS.TASK_CONSULTING, this);
         }
+        this.emit(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, this);
       },
       emitTaskConsultAccepted: this.createEmitSelfAction(TASK_EVENTS.TASK_CONSULT_ACCEPTED),
       emitTaskConsultEnd: this.createEmitSelfAction(TASK_EVENTS.TASK_CONSULT_END, {

--- a/packages/@webex/contact-center/src/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/src/services/task/TaskManager.ts
@@ -630,6 +630,10 @@ export default class TaskManager extends EventEmitter {
       this.emit(TASK_EVENTS.TASK_HYDRATE, t);
     });
 
+    task.on(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, (t: ITask) => {
+      this.emit(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, t);
+    });
+
     // Listen for internal cleanup signal emitted by the state machine
     task.on(TASK_EVENTS.TASK_CLEANUP, (t: ITask, options?: {removeFromCollection?: boolean}) => {
       this.handleTaskCleanup(t);

--- a/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/src/services/task/state-machine/uiControlsComputer.ts
@@ -438,7 +438,7 @@ function computeVoiceInteractionUIControls(
       if (allowHeldMainLegControlsForNonInitiator) return VISIBLE_ENABLED;
       if (showMainLegConferenceControlsDuringConsult) return VISIBLE_DISABLED;
       if (isHydratedConferenceConsultPending && currentLeg === 'main') return VISIBLE_DISABLED;
-      if (!config.isEndTaskEnabled) return DISABLED;
+      if (!config.isEndTaskEnabled && !isWebrtc) return DISABLED;
       if (hasParallelConsultLeg) {
         return isConnected && isEpDnConsult ? VISIBLE_ENABLED : VISIBLE_DISABLED;
       }

--- a/packages/@webex/contact-center/src/services/task/types.ts
+++ b/packages/@webex/contact-center/src/services/task/types.ts
@@ -628,6 +628,17 @@ export enum TASK_EVENTS {
    * ```
    */
   TASK_POST_CALL_ACTIVITY = 'task:postCallActivity',
+
+  /**
+   * Triggered when a multi-login task update should hydrate SDK instances without Mobius registration.
+   * @example
+   * ```typescript
+   * task.on(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, (task: ITask) => {
+   *   console.log('Multi-login hydrate:', task.data.interactionId);
+   * });
+   * ```
+   */
+  TASK_MULTI_LOGIN_HYDRATE = 'task:multiLoginHydrate',
 }
 
 /**

--- a/packages/@webex/contact-center/src/types.ts
+++ b/packages/@webex/contact-center/src/types.ts
@@ -156,6 +156,8 @@ export interface CCPluginConfig {
   };
   /** Configuration for the calling client */
   callingClientConfig: CallingClientConfig;
+  /** Whether to skip Mobius/WebRTC registration for browser login flows */
+  disableWebRTCRegistration?: boolean;
 }
 
 /**

--- a/packages/@webex/contact-center/test/unit/spec/cc.ts
+++ b/packages/@webex/contact-center/test/unit/spec/cc.ts
@@ -195,6 +195,35 @@ describe('webex.cc', () => {
     webex.emit('ready');
   });
 
+  it('should throw when WebRTC registration is disabled without multi-login', () => {
+    const invalidWebex = MockWebex({
+      children: {
+        mercury: Mercury,
+      },
+      logger: {
+        log: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn(),
+      },
+      credentials: {
+        getOrgId: jest.fn(() => 'mockOrgId'),
+      },
+      config: {
+        ...config,
+        cc: {
+          ...config.cc,
+          allowMultiLogin: false,
+          disableWebRTCRegistration: true,
+        },
+      },
+      once: jest.fn((event, callback) => callback()),
+    }) as unknown as WebexSDK;
+
+    expect(() => new ContactCenter({parent: invalidWebex})).toThrow(
+      'Invalid Contact Center configuration: disableWebRTCRegistration cannot be true when allowMultiLogin is false. Enable allowMultiLogin or allow WebRTC registration so an SDK instance can receive Mobius/WebRTC task events.'
+    );
+  });
+
   describe('cc.getDeviceId', () => {
     it('should return dialNumber when loginOption is EXTENSION', () => {
       const loginOption = LoginOption.EXTENSION;
@@ -326,6 +355,10 @@ describe('webex.cc', () => {
       );
       expect(mockTaskManager.on).toHaveBeenCalledWith(
         TASK_EVENTS.TASK_HYDRATE,
+        expect.any(Function)
+      );
+      expect(mockTaskManager.on).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE,
         expect.any(Function)
       );
       expect(mockWebSocketManager.on).toHaveBeenCalledWith('message', expect.any(Function));
@@ -475,6 +508,10 @@ describe('webex.cc', () => {
         TASK_EVENTS.TASK_HYDRATE,
         expect.any(Function)
       );
+      expect(mockTaskManager.on).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE,
+        expect.any(Function)
+      );
       expect(mockWebSocketManager.on).toHaveBeenCalledWith('message', expect.any(Function));
 
       expect(configSpy).toHaveBeenCalled();
@@ -483,6 +520,36 @@ describe('webex.cc', () => {
         method: 'connectWebsocket',
       });
       expect(reloadSpy).toHaveBeenCalled();
+      expect(result).toEqual(mockAgentProfile);
+    });
+
+    it('should skip mercury connection when disableWebRTCRegistration is enabled', async () => {
+      webex.cc.$config = {
+        ...webex.cc.$config,
+        allowAutomatedRelogin: false,
+        disableWebRTCRegistration: true,
+      };
+      mockAgentProfile.webRtcEnabled = true;
+      const mercurySpy = jest.spyOn(webex.internal.mercury, 'connect');
+      const connectWebsocketSpy = jest.spyOn(webex.cc, 'connectWebsocket');
+      const setupEventListenersSpy = jest.spyOn(webex.cc, 'setupEventListeners');
+      jest.spyOn(webex.cc.services.config, 'getAgentConfig').mockResolvedValue(mockAgentProfile);
+      mockWebSocketManager.initWebSocket.mockResolvedValue({
+        agentId: 'agent123',
+      });
+
+      const result = await webex.cc.register();
+
+      expect(connectWebsocketSpy).toHaveBeenCalled();
+      expect(setupEventListenersSpy).toHaveBeenCalled();
+      expect(mercurySpy).not.toHaveBeenCalled();
+      expect(LoggerProxy.info).toHaveBeenCalledWith(
+        'Skipping Mobius registration because disableWebRTCRegistration is enabled',
+        {
+          module: CC_FILE,
+          method: 'connectWebsocket',
+        }
+      );
       expect(result).toEqual(mockAgentProfile);
     });
 
@@ -655,6 +722,59 @@ describe('webex.cc', () => {
       expect(ccEmitSpy).toHaveBeenCalledWith(
         AGENT_EVENTS.AGENT_MULTI_LOGIN,
         agentMultiLoginEventData.data
+      );
+    });
+
+    it('should skip web calling line registration when disableWebRTCRegistration is enabled', async () => {
+      const options = {
+        teamId: 'teamId',
+        loginOption: LoginOption.BROWSER,
+      };
+
+      webex.cc.$config = {
+        ...webex.cc.$config,
+        disableWebRTCRegistration: true,
+      };
+      webex.cc.agentConfig = {
+        agentId: 'agentId',
+        webRtcEnabled: true,
+        loginVoiceOptions: ['BROWSER', 'EXTENSION', 'AGENT_DN'],
+      };
+
+      const registerWebCallingLineSpy = jest.spyOn(
+        webex.cc.webCallingService,
+        'registerWebCallingLine'
+      );
+
+      jest.spyOn(webex.cc.services.agent, 'stationLogin').mockResolvedValue({
+        data: {
+          loginOption: LoginOption.BROWSER,
+          agentId: 'agentId',
+          teamId: 'teamId',
+          siteId: 'siteId',
+          roles: [AGENT],
+          channelsMap: {
+            chat: [],
+            email: [],
+            social: [],
+            telephony: [],
+          },
+        },
+        trackingId: 'notifs_52628',
+        orgId: 'orgId',
+        type: 'StationLoginSuccess',
+        eventType: 'STATION_LOGIN',
+      } as unknown as StationLoginSuccess);
+
+      await webex.cc.stationLogin(options);
+
+      expect(registerWebCallingLineSpy).not.toHaveBeenCalled();
+      expect(LoggerProxy.info).toHaveBeenCalledWith(
+        'Skipping web calling line registration because disableWebRTCRegistration is enabled',
+        {
+          module: CC_FILE,
+          method: 'stationLogin',
+        }
       );
     });
 
@@ -1568,6 +1688,10 @@ describe('webex.cc', () => {
         TASK_EVENTS.TASK_HYDRATE,
         expect.any(Function)
       );
+      expect(mockTaskManager.off).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE,
+        expect.any(Function)
+      );
       expect(mockWebSocketManager.off).toHaveBeenCalledWith('message', expect.any(Function));
       expect(webex.cc.services.connectionService.off).toHaveBeenCalledWith(
         'connectionLost',
@@ -1617,6 +1741,13 @@ describe('webex.cc', () => {
       const [, hydrateCallback] = hydrateCalls[0];
       expect(hydrateCallback).toBe(webex.cc['handleTaskHydrate']);
 
+      const multiLoginHydrateCalls = mockTaskManager.off.mock.calls.filter(
+        ([evt]) => evt === TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE
+      );
+      expect(multiLoginHydrateCalls).toHaveLength(1);
+      const [, multiLoginHydrateCallback] = multiLoginHydrateCalls[0];
+      expect(multiLoginHydrateCallback).toBe(webex.cc['handleTaskMultiLoginHydrate']);
+
       const messageCalls = mockWebSocketManager.off.mock.calls.filter(([evt]) => evt === 'message');
       expect(messageCalls).toHaveLength(1);
       const [, messageCallback] = messageCalls[0];
@@ -1640,6 +1771,10 @@ describe('webex.cc', () => {
       );
       expect(mockTaskManager.off).toHaveBeenCalledWith(
         TASK_EVENTS.TASK_HYDRATE,
+        expect.any(Function)
+      );
+      expect(mockTaskManager.off).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE,
         expect.any(Function)
       );
       expect(mockWebSocketManager.off).toHaveBeenCalledWith('message', expect.any(Function));
@@ -1685,6 +1820,10 @@ describe('webex.cc', () => {
       );
       expect(mockTaskManager.off).toHaveBeenCalledWith(
         TASK_EVENTS.TASK_HYDRATE,
+        expect.any(Function)
+      );
+      expect(mockTaskManager.off).toHaveBeenCalledWith(
+        TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE,
         expect.any(Function)
       );
 

--- a/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/TaskManager.ts
@@ -92,6 +92,10 @@ describe('TaskManager', () => {
         }
       }
 
+      if ([TaskEvent.ASSIGN, TaskEvent.CONSULTING_ACTIVE].includes(event.type as TaskEvent)) {
+        task.emit(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, task);
+      }
+
       // Auto-answer is now handled at the Task layer (triggered by state machine actions)
       if (
         [TaskEvent.TASK_OFFERED, TaskEvent.OFFER_CONSULT].includes(event.type as TaskEvent) &&
@@ -494,11 +498,16 @@ describe('TaskManager', () => {
       taskManager.getTask(payload.data.interactionId),
       'emit'
     );
+    const taskManagerEmitSpy = jest.spyOn(taskManager, 'emit');
 
     webSocketManagerMock.emit('message', JSON.stringify(assignedPayload));
 
     expect(currentTaskAssignedSpy).toHaveBeenCalledWith(
       TASK_EVENTS.TASK_ASSIGNED,
+      taskManager.getTask(taskId)
+    );
+    expect(taskManagerEmitSpy).toHaveBeenCalledWith(
+      TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE,
       taskManager.getTask(taskId)
     );
   });
@@ -1837,6 +1846,7 @@ describe('TaskManager', () => {
     taskManager.getTask(taskId).data.isConsulted = false;
     const task = taskManager.getTask(taskId);
     const sendStateMachineEventSpy = jest.spyOn(task, 'sendStateMachineEvent');
+    const taskManagerEmitSpy = jest.spyOn(taskManager, 'emit');
     const consultingPayload = {
       data: {
         ...initalPayload.data,
@@ -1846,6 +1856,10 @@ describe('TaskManager', () => {
     };
     webSocketManagerMock.emit('message', JSON.stringify(consultingPayload));
     expectLastStateMachineEvent(sendStateMachineEventSpy, TaskEvent.CONSULTING_ACTIVE);
+    expect(taskManagerEmitSpy).toHaveBeenCalledWith(
+      TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE,
+      taskManager.getTask(taskId)
+    );
     sendStateMachineEventSpy.mockRestore();
   });
 

--- a/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/task/state-machine/uiControlsComputer.ts
@@ -1784,6 +1784,53 @@ describe('uiControlsComputer outdial accept/decline controls', () => {
   });
 });
 
+describe('uiControlsComputer WebRTC call-control end button', () => {
+  function createConnectedContext(voiceVariant: 'webrtc' | 'pstn'): TaskContext {
+    const taskData = createTaskData({
+      interaction: {
+        state: 'connected',
+      } as any,
+    });
+
+    return {
+      taskData,
+      consultInitiator: false,
+      exitingConference: false,
+      consultFromConference: false,
+      transferConferenceRequested: false,
+      consultDestinationType: null,
+      consultDestinationAgentId: null,
+      consultDestinationAgentJoined: false,
+      consultCallHeld: false,
+      recordingControlsAvailable: true,
+      recordingInProgress: true,
+      uiControlConfig: {
+        isEndTaskEnabled: false,
+        isEndConsultEnabled: true,
+        channelType: TASK_CHANNEL_TYPE.VOICE,
+        isRecordingEnabled: true,
+        agentId: taskData.agentId,
+        voiceVariant,
+      },
+      uiControls: getDefaultUIControls(),
+    };
+  }
+
+  it('shows main end for connected WebRTC call-control tasks even when end task is disabled', () => {
+    const context = createConnectedContext('webrtc');
+    const uiControls = computeUIControls(TaskState.CONNECTED, context, context.taskData);
+
+    expect(uiControls.main.end).toEqual({isVisible: true, isEnabled: true});
+  });
+
+  it('keeps main end hidden for non-WebRTC voice tasks when end task is disabled', () => {
+    const context = createConnectedContext('pstn');
+    const uiControls = computeUIControls(TaskState.CONNECTED, context, context.taskData);
+
+    expect(uiControls.main.end).toEqual({isVisible: false, isEnabled: false});
+  });
+});
+
 describe('uiControlsComputer conference controls', () => {
   function createConferenceTaskData(participantCount: number) {
     const participants: Record<string, any> = {


### PR DESCRIPTION
# COMPLETES # https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7899

## This pull request addresses

Desktop multi-login scenarios where an SDK instance skips Mobius/WebRTC registration while another SDK instance owns the registration. Without explicit task hydration and WebRTC-aware controls, secondary instances can miss task updates or render incomplete call controls.

## by making the following changes

- Adds contact-center configuration support for disabling Mobius/WebRTC registration in browser flows.
- Propagates multi-login task hydration events through `Task`, `TaskManager`, and `ContactCenter`.
- Updates WebRTC task UI control logic so the end-call control remains available for active WebRTC calls.
- Updates the contact-center sample app to expose the WebRTC registration toggle.
- Adds unit coverage for skipped registration, multi-login hydration propagation, and WebRTC end-call controls.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- `yarn workspace @webex/contact-center test:unit test/unit/spec/cc.ts test/unit/spec/services/task/state-machine/uiControlsComputer.ts`
- Verified the focused contact-center unit run passed with 31 suites and 647 tests.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify: Cursor
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.

Made with [Cursor](https://cursor.com)