### PR TITLE
fix(internal-plugin-metrics): log call diagnostic milestones

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -390,6 +390,11 @@ export const prepareDiagnosticMetricItem = (webex: any, item: any) => {
 
   item.eventPayload.origin = Object.assign(origin, item.eventPayload.origin);
 
+  // Mark call milestones in logs for easier filtering and analysis
+  if (item.eventPayload.event.name) {
+    webex.logger.log(`Milestone,CallDiagnostic: ${item.eventPayload.event.name}`);
+  }
+
   webex.logger.log(
     `CallDiagnosticLatencies,prepareDiagnosticMetricItem: ${JSON.stringify({
       latencies: Object.fromEntries(cdl.latencyTimestamps),

--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -391,8 +391,8 @@ export const prepareDiagnosticMetricItem = (webex: any, item: any) => {
   item.eventPayload.origin = Object.assign(origin, item.eventPayload.origin);
 
   // Mark call milestones in logs for easier filtering and analysis
-  if (item.eventPayload.event.name) {
-    webex.logger.log(`Milestone,CallDiagnostic: ${item.eventPayload.event.name}`);
+  if (eventName) {
+    webex.logger.log('Milestone,CallDiagnostic', eventName);
   }
 
   webex.logger.log(

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.util.ts
@@ -460,6 +460,33 @@ describe('internal-plugin-metrics', () => {
       });
     });
 
+    it('logs a Milestone entry when event name is present', () => {
+      const logSpy = sinon.spy(webex.logger, 'log');
+      const eventName = 'client.call.initiated';
+      const eventPayload = {event: {name: eventName}};
+
+      prepareDiagnosticMetricItem(webex, {eventPayload, type: ['diagnostic-event']});
+
+      assert.isTrue(
+        logSpy.calledWith('Milestone,CallDiagnostic', eventName),
+        'expected logger.log to be called with Milestone,CallDiagnostic and the event name'
+      );
+      sinon.restore();
+    });
+
+    it('does not log a Milestone entry when event name is absent', () => {
+      const logSpy = sinon.spy(webex.logger, 'log');
+      const eventPayload = {event: {}};
+
+      prepareDiagnosticMetricItem(webex, {eventPayload, type: ['diagnostic-event']});
+
+      assert.isFalse(
+        logSpy.calledWith('Milestone,CallDiagnostic', sinon.match.any),
+        'expected logger.log not to be called with Milestone,CallDiagnostic when event name is absent'
+      );
+      sinon.restore();
+    });
+
     it('sets buildType and upgradeChannel correctly', () => {
       const item: any = {
         eventPayload: {


### PR DESCRIPTION
# COMPLETES SPARK-827015

## This pull request addresses

Without well-known marks (milestones) hard to analyse client logs.

## by making the following changes

This PR uses the call diagnostic events' name as milestones. 
It can be extended later if needed.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request
- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
