### PR TITLE
[codex] feat(contact-center): add ai handoff summary gate

### DIFF
--- a/packages/@webex/contact-center/src/constants.ts
+++ b/packages/@webex/contact-center/src/constants.ts
@@ -55,4 +55,5 @@ export const METHODS = {
   GET_BASE_URL: 'getBaseUrl',
   SEND_EVENT: 'sendEvent',
   FETCH_HISTORIC_TRANSCRIPTS: 'fetchHistoricTranscripts',
+  REQUEST_HANDOFF_SUMMARY: 'requestHandoffSummary',
 };

--- a/packages/@webex/contact-center/src/index.ts
+++ b/packages/@webex/contact-center/src/index.ts
@@ -82,6 +82,13 @@ export {CC_AGENT_EVENTS} from './services/config/types';
 export {CC_EVENTS} from './services/config/types';
 export type {CC_EVENTS as ContactCenterEvents} from './services/config/types';
 
+export {
+  AIAssistantEventAction,
+  AIAssistantEventName,
+  AIAssistantEventType,
+  HandoffSummaryRequestDisabledReason,
+} from './types';
+
 // Interfaces
 /** Main types and interfaces for Contact Center functionality */
 export type {
@@ -120,6 +127,13 @@ export type {
   GenericError,
   /** Set state response */
   SetStateResponse,
+  HandoffSummaryRequestAction,
+  HandoffSummaryRequestParams,
+  HandoffSummaryRequestResult,
+  HandoffSummaryResponseAction,
+  HistoricTranscriptsResponse,
+  TranscriptAction,
+  TranscriptMessage,
 } from './types';
 
 /** Task related types */
@@ -213,6 +227,10 @@ export type {
   DialPlan,
   /** Auxiliary code type (IDLE_CODE or WRAP_UP_CODE) */
   AuxCodeType,
+  /** AI feature flags */
+  AIFeatureFlags,
+  /** AI feature flags list response */
+  AIFeatureFlagsResponse,
 } from './services/config/types';
 
 // Constants

--- a/packages/@webex/contact-center/src/metrics/constants.ts
+++ b/packages/@webex/contact-center/src/metrics/constants.ts
@@ -168,12 +168,15 @@ export const METRIC_EVENT_NAMES = {
   CAMPAIGN_PREVIEW_REMOVE_SUCCESS: 'Campaign Preview Remove Success',
   CAMPAIGN_PREVIEW_REMOVE_FAILED: 'Campaign Preview Remove Failed',
 
-  // AI Assistant transcript events
+  // AI Assistant events
   AI_ASSISTANT_SEND_EVENT_SUCCESS: 'AI Assistant Send Event Success',
   AI_ASSISTANT_SEND_EVENT_FAILED: 'AI Assistant Send Event Failed',
   AI_ASSISTANT_FETCH_HISTORIC_TRANSCRIPTS_SUCCESS:
     'AI Assistant Fetch Historic Transcripts Success',
   AI_ASSISTANT_FETCH_HISTORIC_TRANSCRIPTS_FAILED: 'AI Assistant Fetch Historic Transcripts Failed',
+  AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_SUCCESS: 'AI Assistant Handoff Summary Request Success',
+  AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_FAILED: 'AI Assistant Handoff Summary Request Failed',
+  AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_DISABLED: 'AI Assistant Handoff Summary Request Disabled',
 } as const;
 
 /**

--- a/packages/@webex/contact-center/src/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/src/services/ApiAiAssistant.ts
@@ -3,39 +3,46 @@ import MetricsManager from '../metrics/MetricsManager';
 import {METRIC_EVENT_NAMES} from '../metrics/constants';
 import {CC_FILE, METHODS} from '../constants';
 import {
-  HTTP_METHODS,
-  WebexSDK,
-  IHttpResponse,
-  TranscriptAction,
-  AIAssistantEventType,
+  AIAssistantEventAction,
   AIAssistantEventName,
+  AIAssistantEventType,
+  HandoffSummaryRequestDisabledReason,
+  HandoffSummaryRequestParams,
+  HandoffSummaryRequestResult,
   HistoricTranscriptsResponse,
+  HTTP_METHODS,
+  IHttpResponse,
+  WebexSDK,
 } from '../types';
 import {getErrorDetails} from './core/Utils';
 import {
+  AI_ASSISTANT_API_URLS,
   AI_ASSISTANT_BASE_URL_TEMPLATE,
   AI_ASSISTANT_ENV_MAP,
-  AI_ASSISTANT_API_URLS,
   WCC_API_GATEWAY,
 } from './constants';
 import {AIFeatureFlags} from './config/types';
 
 /**
- * ApiAIAssistant provides AI Assistant APIs for transcript controls.
+ * ApiAIAssistant provides AI Assistant APIs for transcript and handoff-summary controls.
  * @public
  */
 export class ApiAIAssistant {
   private webex: WebexSDK;
   private metricsManager: MetricsManager;
-  public aiFeature: AIFeatureFlags;
+  public aiFeature?: AIFeatureFlags;
 
   constructor(webex: WebexSDK) {
     this.webex = webex;
     this.metricsManager = MetricsManager.getInstance({webex});
   }
 
-  public setAIFeatureFlags(aiFeature: AIFeatureFlags): void {
+  public setAIFeatureFlags(aiFeature?: AIFeatureFlags): void {
     this.aiFeature = aiFeature;
+  }
+
+  public isHandoffSummaryEnabled(): boolean {
+    return this.aiFeature?.generatedSummaries?.consultTransferSummariesEnabled === true;
   }
 
   private getBaseUrl(): string {
@@ -70,20 +77,28 @@ export class ApiAIAssistant {
     return AI_ASSISTANT_BASE_URL_TEMPLATE.replace('%s', resolvedEnv);
   }
 
+  private static getSanitizedError(error: unknown): string {
+    if (error instanceof Error) {
+      return error.name || 'Error';
+    }
+
+    return typeof error;
+  }
+
   /**
    * Sends an event to the AI Assistant service.
    * @param agentId - agent identifier
    * @param interactionId - interaction/conversation identifier
-   * @param eventType - the type of event (e.g. 'CUSTOM_EVENT')
-   * @param eventName - the name of the event (e.g. 'GET_TRANSCRIPTS')
-   * @param action - action within eventDetails (e.g. 'START' or 'STOP')
+   * @param eventType - the type of event
+   * @param eventName - the name of the event
+   * @param action - action within eventDetails
    */
   public async sendEvent(
     agentId: string,
     interactionId: string,
     eventType: AIAssistantEventType,
     eventName: AIAssistantEventName,
-    action: TranscriptAction
+    action: AIAssistantEventAction
   ): Promise<Record<string, unknown>> {
     LoggerProxy.info('Sending event', {
       module: CC_FILE,
@@ -133,13 +148,89 @@ export class ApiAIAssistant {
           eventType,
           eventName,
           action,
-          error: error instanceof Error ? error.message : String(error),
+          error: ApiAIAssistant.getSanitizedError(error),
         },
         ['operational']
       );
 
       const {error: detailedError} = getErrorDetails(error, METHODS.SEND_EVENT, CC_FILE);
       throw detailedError;
+    }
+  }
+
+  public async requestHandoffSummary(
+    params: HandoffSummaryRequestParams
+  ): Promise<HandoffSummaryRequestResult> {
+    const {agentId, interactionId} = params;
+    const eventName = AIAssistantEventName.GET_MID_CALL_SUMMARY;
+    const action = AIAssistantEventAction.REQUEST;
+
+    LoggerProxy.info('Requesting handoff summary', {
+      module: CC_FILE,
+      method: METHODS.REQUEST_HANDOFF_SUMMARY,
+      interactionId,
+      data: {eventName, enabled: this.isHandoffSummaryEnabled()},
+    });
+
+    if (!this.isHandoffSummaryEnabled()) {
+      this.metricsManager.trackEvent(
+        METRIC_EVENT_NAMES.AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_DISABLED,
+        {
+          agentId,
+          interactionId,
+          eventName,
+        },
+        ['operational']
+      );
+
+      return {
+        enabled: false,
+        reason: HandoffSummaryRequestDisabledReason.CONSULT_TRANSFER_SUMMARIES_DISABLED,
+      };
+    }
+
+    try {
+      const response = await this.sendEvent(
+        agentId,
+        interactionId,
+        AIAssistantEventType.CUSTOM_EVENT,
+        eventName,
+        action
+      );
+
+      this.metricsManager.trackEvent(
+        METRIC_EVENT_NAMES.AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_SUCCESS,
+        {
+          agentId,
+          interactionId,
+          eventName,
+          action,
+        },
+        ['operational']
+      );
+
+      return {enabled: true, response};
+    } catch (error) {
+      this.metricsManager.trackEvent(
+        METRIC_EVENT_NAMES.AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_FAILED,
+        {
+          agentId,
+          interactionId,
+          eventName,
+          action,
+          error: ApiAIAssistant.getSanitizedError(error),
+        },
+        ['operational']
+      );
+
+      LoggerProxy.error('Handoff summary request failed', {
+        module: CC_FILE,
+        method: METHODS.REQUEST_HANDOFF_SUMMARY,
+        interactionId,
+        data: {eventName, action, error: ApiAIAssistant.getSanitizedError(error)},
+      });
+
+      throw error;
     }
   }
 
@@ -197,7 +288,7 @@ export class ApiAIAssistant {
         METRIC_EVENT_NAMES.AI_ASSISTANT_FETCH_HISTORIC_TRANSCRIPTS_FAILED,
         {
           interactionId,
-          error: error instanceof Error ? error.message : String(error),
+          error: ApiAIAssistant.getSanitizedError(error),
         },
         ['operational']
       );

--- a/packages/@webex/contact-center/src/services/ai-docs/ai-assistant-overview.md
+++ b/packages/@webex/contact-center/src/services/ai-docs/ai-assistant-overview.md
@@ -1,0 +1,59 @@
+# AI Assistant - overview
+
+> Deep design: [`ai-assistant-spec.md`](./ai-assistant-spec.md).
+
+## Metadata
+| Field | Value |
+|---|---|
+| Module id | `ai-assistant` |
+| Source path(s) | `src/services/ApiAiAssistant.ts`, `src/types.ts`, `src/services/config/index.ts`, `src/metrics/constants.ts` |
+| Doc kind | Module overview / HLD |
+| Updated at | 2026-06-25 |
+
+## Purpose / Responsibility
+`ApiAIAssistant` owns Contact Center SDK calls to the AI Assistant backend. It provides:
+
+- a generic event transport for AI Assistant custom events;
+- historic transcript retrieval when real-time transcripts are enabled;
+- the Task 1 handoff-summary request gate and event send path.
+
+The service does not fetch its own feature flags. `ContactCenter` loads `agentConfig.aiFeature` through `AgentConfigService` during registration and injects those flags into `ApiAIAssistant` with `setAIFeatureFlags`.
+
+## Key Files
+| File | Holds |
+|---|---|
+| `src/services/ApiAiAssistant.ts` | AI Assistant base URL resolution, event transport, transcript fetch, handoff summary request gate. |
+| `src/services/config/index.ts` | AI feature flag fetch and fail-closed fallback during agent config aggregation. |
+| `src/types.ts` | AI Assistant event/action enums and handoff summary request/result types. |
+| `src/metrics/constants.ts` | Operational metric names for AI Assistant event and handoff summary request outcomes. |
+
+## Public Surface
+`ApiAIAssistant` is exported from `src/index.ts`. The handoff summary request accepts `{agentId, interactionId}` and returns either:
+
+- `{enabled: false, reason: CONSULT_TRANSFER_SUMMARIES_DISABLED}` when the gate is disabled or unavailable;
+- `{enabled: true, response}` when the AI Assistant event request succeeds.
+
+## Feature Gate
+The handoff summary request is enabled only when:
+
+```ts
+agentConfig.aiFeature?.generatedSummaries?.consultTransferSummariesEnabled === true
+```
+
+Any other value, including missing config, missing `generatedSummaries`, or failed AI feature fetch, disables the request and prevents any `/event` call.
+
+## Runtime Flow
+```mermaid
+flowchart LR
+  Config[AgentConfigService] -->|aiFeature| CC[ContactCenter]
+  CC -->|setAIFeatureFlags| AI[ApiAIAssistant]
+  Consumer -->|requestHandoffSummary| AI
+  AI -->|gate true| Event[AI Assistant /event]
+  AI --> Metrics[MetricsManager]
+  AI --> Logs[LoggerProxy]
+```
+
+## Non-Goals
+- This module does not route WebSocket summary responses.
+- This module does not add public `Task` or `Voice` helper APIs.
+- This module does not log or metric generated summary body text.

--- a/packages/@webex/contact-center/src/services/ai-docs/ai-assistant-spec.md
+++ b/packages/@webex/contact-center/src/services/ai-docs/ai-assistant-spec.md
@@ -1,0 +1,104 @@
+# AI Assistant - SPEC
+
+> Overview: [`ai-assistant-overview.md`](./ai-assistant-overview.md).
+
+## Metadata
+| Field | Value |
+|---|---|
+| Module id | `ai-assistant` |
+| Source path(s) | `src/services/ApiAiAssistant.ts`, `src/types.ts`, `src/services/config/index.ts`, `src/metrics/constants.ts` |
+| Doc kind | Module spec / LLD |
+| Updated at | 2026-06-25 |
+
+## Design Overview
+`ApiAIAssistant` is a thin service wrapper over the AI Assistant HTTP APIs. It resolves the AI Assistant base URL from the configured WCC API gateway host, sends typed event payloads through `/event`, fetches historic transcripts through `/transcripts/list`, and owns the enable-gated handoff summary request path.
+
+The handoff summary flow intentionally fails closed. The SDK must not call AI Assistant for handoff summaries unless `generatedSummaries.consultTransferSummariesEnabled` is exactly `true`.
+
+## Requirements
+| ID | WHAT | WHY | Source Evidence | Test Evidence |
+|---|---|---|---|---|
+| AIA-R-001 | Resolve the AI Assistant base URL from the WCC API gateway host and fail if no mapping exists. | AI Assistant endpoints are environment-specific. | `ApiAiAssistant.getBaseUrl` | `ApiAiAssistant` unit test for unknown host failure. |
+| AIA-R-002 | `sendEvent` must POST an authenticated `/event` request with `agentId`, `orgId`, `eventType`, `eventName`, `interactionId`, `action`, and `actionTimeStamp`. | AI Assistant custom events require this transport contract. | `ApiAIAssistant.sendEvent` | `should send transcript start event successfully`; handoff summary enabled test. |
+| AIA-R-003 | Handoff summary requests must be disabled unless `consultTransferSummariesEnabled === true`. | Missing or false feature config must not trigger generated-summary requests. | `isHandoffSummaryEnabled`, `requestHandoffSummary` | Disabled gate and missing gate tests. |
+| AIA-R-004 | Enabled handoff summary requests must send `CUSTOM_EVENT` / `GET_MID_CALL_SUMMARY` / `REQUEST`. | Backend uses the mid-call summary event contract for handoff summaries. | `requestHandoffSummary` | Enabled handoff summary test. |
+| AIA-R-005 | Failure metrics and logs must not include summary body text or raw error messages. | Generated summaries can contain sensitive conversation content. | `getSanitizedError`, failure branch in `requestHandoffSummary` | Sanitized failure test. |
+| AIA-R-006 | Agent config aggregation must continue with AI features disabled when the AI feature API is unavailable. | Registration should not fail just because optional AI feature resources are unavailable. | `AgentConfigService.getAgentConfig` AI feature catch fallback | Config fail-closed test. |
+
+## Handoff Summary Data Flow
+```mermaid
+sequenceDiagram
+  participant Config as AgentConfigService
+  participant CC as ContactCenter
+  participant AI as ApiAIAssistant
+  participant API as AI Assistant /event
+  participant Metrics as MetricsManager
+
+  Config-->>CC: Profile.aiFeature
+  CC->>AI: setAIFeatureFlags(aiFeature)
+  CC->>AI: requestHandoffSummary({agentId, interactionId})
+  alt consultTransferSummariesEnabled is true
+    AI->>API: POST CUSTOM_EVENT GET_MID_CALL_SUMMARY REQUEST
+    API-->>AI: response body
+    AI->>Metrics: HANDOFF_SUMMARY_REQUEST_SUCCESS
+    AI-->>CC: {enabled: true, response}
+  else disabled, missing, or unavailable
+    AI->>Metrics: HANDOFF_SUMMARY_REQUEST_DISABLED
+    AI-->>CC: {enabled: false, reason}
+  end
+```
+
+## Event Payload
+Enabled handoff summary requests use the generic event transport:
+
+```json
+{
+  "eventType": "CUSTOM_EVENT",
+  "eventName": "GET_MID_CALL_SUMMARY",
+  "eventDetails": {
+    "data": {
+      "interactionId": "<interaction-id>",
+      "action": "REQUEST",
+      "actionTimeStamp": "<epoch-ms-string>"
+    }
+  }
+}
+```
+
+`agentId` and `orgId` are included at the top level of the request body.
+
+## Metrics
+| Metric | When emitted |
+|---|---|
+| `AI_ASSISTANT_SEND_EVENT_SUCCESS` | Generic `/event` request succeeds. |
+| `AI_ASSISTANT_SEND_EVENT_FAILED` | Generic `/event` request fails. |
+| `AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_SUCCESS` | Enabled handoff summary request succeeds. |
+| `AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_FAILED` | Enabled handoff summary request fails. |
+| `AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_DISABLED` | Gate is disabled or unavailable. |
+
+All handoff summary metrics are operational metrics.
+
+## Error Handling
+| Condition | Behavior |
+|---|---|
+| Missing WCC gateway mapping | Throw detailed `getBaseUrl` error. |
+| `consultTransferSummariesEnabled` is missing or false | Do not call `/event`; return disabled result. |
+| AI feature API fails during config aggregation | Use `{data: []}` so `Profile.aiFeature` is absent and downstream gates fail closed. |
+| `/event` request fails | Emit sanitized failure metric/log context and rethrow the detailed send-event error. |
+
+## Test Strategy
+Focused unit coverage lives in:
+
+- `test/unit/spec/services/ApiAiAssistant.ts`
+- `test/unit/spec/services/config/index.ts`
+
+Required coverage for this feature:
+
+- enabled gate sends `GET_MID_CALL_SUMMARY` with `REQUEST`;
+- false gate prevents AI Assistant calls;
+- missing gate prevents AI Assistant calls;
+- event failures emit sanitized metrics/logs;
+- config aggregation fails closed when the AI feature API rejects.
+
+## Boundaries
+This spec covers Task 1 only. WebSocket summary response routing and public `Task`/`Voice` helper APIs belong to later tasks and should be documented separately when implemented.

--- a/packages/@webex/contact-center/src/services/config/index.ts
+++ b/packages/@webex/contact-center/src/services/config/index.ts
@@ -62,7 +62,14 @@ export default class AgentConfigService {
       const orgSettingsPromise = this.getOrganizationSetting(orgId);
       const tenantDataPromise = this.getTenantData(orgId);
       const urlMappingPromise = this.getURLMapping(orgId);
-      const aiFeatureFlagsPromise = this.getAIFeatureFlags(orgId);
+      const aiFeatureFlagsPromise = this.getAIFeatureFlags(orgId).catch(() => {
+        LoggerProxy.info('AI feature resources unavailable; continuing with AI features disabled', {
+          module: CONFIG_FILE_NAME,
+          method: METHODS.GET_AI_FEATURE_FLAGS,
+        });
+
+        return {data: []} as AIFeatureFlagsResponse;
+      });
       const auxCodesPromise = this.getAllAuxCodes(
         orgId,
         DEFAULT_PAGE_SIZE,
@@ -656,10 +663,10 @@ export default class AgentConfigService {
   }
 
   /**
-   * Fetches AI feature resources for the organization.
+   * Fetches AI feature resources for the given orgId.
    * @ignore
    * @param {string} orgId - organization ID for which AI feature resources are to be fetched.
-   * @returns {Promise<AIFeatureFlagsResponse>} - AI feature resources response.
+   * @returns {Promise<AIFeatureFlagsResponse>} - A promise that resolves to AI feature resources.
    * @throws {Error} - Throws an error if the API call fails or if the response status is not 200.
    * @private
    */
@@ -668,6 +675,7 @@ export default class AgentConfigService {
       module: CONFIG_FILE_NAME,
       method: METHODS.GET_AI_FEATURE_FLAGS,
     });
+
     try {
       const resource = endPointMap.aiFeature(orgId);
       const response = await this.webexReq.request({

--- a/packages/@webex/contact-center/src/types.ts
+++ b/packages/@webex/contact-center/src/types.ts
@@ -823,7 +823,24 @@ export type BuddyAgentsResponse = Agent.BuddyAgentsSuccess | Error;
  */
 export type UpdateDeviceTypeResponse = Agent.DeviceTypeUpdateSuccess | Error;
 
-export type TranscriptAction = 'START' | 'STOP';
+export const AIAssistantEventAction = {
+  START: 'START',
+  STOP: 'STOP',
+  REQUEST: 'REQUEST',
+  CANCEL: 'CANCEL',
+  CONSULT: 'CONSULT',
+  TRANSFER: 'TRANSFER',
+} as const;
+
+export type AIAssistantEventAction = Enum<typeof AIAssistantEventAction>;
+export type TranscriptAction =
+  | typeof AIAssistantEventAction.START
+  | typeof AIAssistantEventAction.STOP;
+export type HandoffSummaryRequestAction = typeof AIAssistantEventAction.REQUEST;
+export type HandoffSummaryResponseAction =
+  | typeof AIAssistantEventAction.CANCEL
+  | typeof AIAssistantEventAction.CONSULT
+  | typeof AIAssistantEventAction.TRANSFER;
 
 export const AIAssistantEventType = {
   CUSTOM_EVENT: 'CUSTOM_EVENT',
@@ -842,6 +859,27 @@ export const AIAssistantEventName = {
 } as const;
 
 export type AIAssistantEventName = Enum<typeof AIAssistantEventName>;
+
+export type HandoffSummaryRequestParams = {
+  agentId: string;
+  interactionId: string;
+};
+
+export const HandoffSummaryRequestDisabledReason = {
+  CONSULT_TRANSFER_SUMMARIES_DISABLED: 'CONSULT_TRANSFER_SUMMARIES_DISABLED',
+} as const;
+
+export type HandoffSummaryRequestDisabledReason = Enum<typeof HandoffSummaryRequestDisabledReason>;
+
+export type HandoffSummaryRequestResult =
+  | {
+      enabled: false;
+      reason: HandoffSummaryRequestDisabledReason;
+    }
+  | {
+      enabled: true;
+      response: Record<string, unknown>;
+    };
 
 export type TranscriptMessage = {
   role: string;

--- a/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
@@ -1,22 +1,44 @@
 import ApiAIAssistant from '../../../../src/services/ApiAiAssistant';
 import MetricsManager from '../../../../src/metrics/MetricsManager';
+import {METRIC_EVENT_NAMES} from '../../../../src/metrics/constants';
 import LoggerProxy from '../../../../src/logger-proxy';
-import {HTTP_METHODS, WebexSDK} from '../../../../src/types';
+import WebexRequest from '../../../../src/services/core/WebexRequest';
+import {
+  AIAssistantEventAction,
+  AIAssistantEventName,
+  AIAssistantEventType,
+  HandoffSummaryRequestDisabledReason,
+  HTTP_METHODS,
+  WebexSDK,
+} from '../../../../src/types';
 
 jest.mock('../../../../src/metrics/MetricsManager');
-jest.mock('../../../../src/logger-proxy');
+jest.mock('../../../../src/logger-proxy', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    initialize: jest.fn(),
+  },
+}));
 
 describe('ApiAIAssistant', () => {
   let apiAIAssistant: ApiAIAssistant;
   let mockWebex: WebexSDK;
   let mockMetricsManager: jest.Mocked<MetricsManager>;
+  let mockUploadLogs: jest.Mock;
+
+  const agentId = 'agent-123';
+  const interactionId = 'interaction-456';
+  const orgId = 'org-789';
 
   beforeEach(() => {
     jest.clearAllMocks();
 
     mockWebex = {
       credentials: {
-        getOrgId: jest.fn().mockReturnValue('test-org-id'),
+        getOrgId: jest.fn().mockReturnValue(orgId),
       },
       request: jest.fn(),
       internal: {
@@ -39,7 +61,16 @@ describe('ApiAIAssistant', () => {
     } as unknown as jest.Mocked<MetricsManager>;
     (MetricsManager.getInstance as jest.Mock).mockReturnValue(mockMetricsManager);
 
+    mockUploadLogs = jest.fn();
+    jest.spyOn(WebexRequest, 'getInstance').mockReturnValue({
+      uploadLogs: mockUploadLogs,
+    } as unknown as WebexRequest);
+
     apiAIAssistant = new ApiAIAssistant(mockWebex);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('should send transcript start event successfully', async () => {
@@ -48,9 +79,9 @@ describe('ApiAIAssistant', () => {
     const result = await apiAIAssistant.sendEvent(
       'test-agent-id',
       'interaction-1',
-      'CUSTOM_EVENT',
-      'GET_TRANSCRIPTS',
-      'START'
+      AIAssistantEventType.CUSTOM_EVENT,
+      AIAssistantEventName.GET_TRANSCRIPTS,
+      AIAssistantEventAction.START
     );
 
     expect(mockWebex.request).toHaveBeenCalledWith({
@@ -59,13 +90,13 @@ describe('ApiAIAssistant', () => {
       addAuthHeader: true,
       body: {
         agentId: 'test-agent-id',
-        orgId: 'test-org-id',
-        eventType: 'CUSTOM_EVENT',
-        eventName: 'GET_TRANSCRIPTS',
+        orgId,
+        eventType: AIAssistantEventType.CUSTOM_EVENT,
+        eventName: AIAssistantEventName.GET_TRANSCRIPTS,
         eventDetails: {
           data: expect.objectContaining({
             interactionId: 'interaction-1',
-            action: 'START',
+            action: AIAssistantEventAction.START,
           }),
         },
       },
@@ -86,7 +117,7 @@ describe('ApiAIAssistant', () => {
       addAuthHeader: true,
       body: {
         agentId: 'test-agent-id',
-        orgId: 'test-org-id',
+        orgId,
         interactionId: 'interaction-1',
       },
     });
@@ -101,15 +132,152 @@ describe('ApiAIAssistant', () => {
       await apiAIAssistant.sendEvent(
         'test-agent-id',
         'interaction-1',
-        'CUSTOM_EVENT',
-        'GET_TRANSCRIPTS',
-        'STOP'
+        AIAssistantEventType.CUSTOM_EVENT,
+        AIAssistantEventName.GET_TRANSCRIPTS,
+        AIAssistantEventAction.STOP
       );
     } catch (_error) {
       failed = true;
     }
 
     expect(failed).toBe(true);
-    expect(LoggerProxy.error).toHaveBeenCalled();
+    expect(mockMetricsManager.trackEvent).toHaveBeenCalledWith(
+      METRIC_EVENT_NAMES.AI_ASSISTANT_SEND_EVENT_FAILED,
+      expect.objectContaining({
+        interactionId: 'interaction-1',
+        eventType: AIAssistantEventType.CUSTOM_EVENT,
+        eventName: AIAssistantEventName.GET_TRANSCRIPTS,
+        action: AIAssistantEventAction.STOP,
+        error: 'Error',
+      }),
+      ['operational']
+    );
+  });
+
+  it('requests a handoff summary through the AI Assistant event transport when enabled', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+    (mockWebex.request as jest.Mock).mockResolvedValue({
+      statusCode: 202,
+      body: {accepted: true},
+    });
+    apiAIAssistant.setAIFeatureFlags({
+      id: 'feature-1',
+      generatedSummaries: {
+        consultTransferSummariesEnabled: true,
+      },
+    });
+
+    const result = await apiAIAssistant.requestHandoffSummary({agentId, interactionId});
+
+    expect(result).toEqual({enabled: true, response: {accepted: true}});
+    expect(mockWebex.request).toHaveBeenCalledWith({
+      uri: 'https://api-ai-assistant.produs1.ciscoccservice.com/event',
+      method: HTTP_METHODS.POST,
+      addAuthHeader: true,
+      body: {
+        agentId,
+        orgId,
+        eventType: AIAssistantEventType.CUSTOM_EVENT,
+        eventName: AIAssistantEventName.GET_MID_CALL_SUMMARY,
+        eventDetails: {
+          data: {
+            interactionId,
+            action: AIAssistantEventAction.REQUEST,
+            actionTimeStamp: '1700000000000',
+          },
+        },
+      },
+    });
+    expect(mockMetricsManager.timeEvent).toHaveBeenCalledWith([
+      METRIC_EVENT_NAMES.AI_ASSISTANT_SEND_EVENT_SUCCESS,
+      METRIC_EVENT_NAMES.AI_ASSISTANT_SEND_EVENT_FAILED,
+    ]);
+    expect(mockMetricsManager.trackEvent).toHaveBeenCalledWith(
+      METRIC_EVENT_NAMES.AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_SUCCESS,
+      {
+        agentId,
+        interactionId,
+        eventName: AIAssistantEventName.GET_MID_CALL_SUMMARY,
+        action: AIAssistantEventAction.REQUEST,
+      },
+      ['operational']
+    );
+  });
+
+  it('does not call AI Assistant when consult transfer summaries are disabled', async () => {
+    apiAIAssistant.setAIFeatureFlags({
+      id: 'feature-1',
+      generatedSummaries: {
+        consultTransferSummariesEnabled: false,
+      },
+    });
+
+    const result = await apiAIAssistant.requestHandoffSummary({agentId, interactionId});
+
+    expect(result).toEqual({
+      enabled: false,
+      reason: HandoffSummaryRequestDisabledReason.CONSULT_TRANSFER_SUMMARIES_DISABLED,
+    });
+    expect(mockWebex.request).not.toHaveBeenCalled();
+    expect(mockMetricsManager.trackEvent).toHaveBeenCalledWith(
+      METRIC_EVENT_NAMES.AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_DISABLED,
+      {
+        agentId,
+        interactionId,
+        eventName: AIAssistantEventName.GET_MID_CALL_SUMMARY,
+      },
+      ['operational']
+    );
+  });
+
+  it('does not call AI Assistant when the summary gate is missing', async () => {
+    const result = await apiAIAssistant.requestHandoffSummary({agentId, interactionId});
+
+    expect(result).toEqual({
+      enabled: false,
+      reason: HandoffSummaryRequestDisabledReason.CONSULT_TRANSFER_SUMMARIES_DISABLED,
+    });
+    expect(mockWebex.request).not.toHaveBeenCalled();
+  });
+
+  it('logs and metrics request failures without logging summary content', async () => {
+    const sensitiveText = 'Sensitive summary body should not be logged';
+    apiAIAssistant.setAIFeatureFlags({
+      id: 'feature-1',
+      generatedSummaries: {
+        consultTransferSummariesEnabled: true,
+      },
+    });
+    (mockWebex.request as jest.Mock).mockRejectedValue(new Error(sensitiveText));
+
+    await expect(
+      apiAIAssistant.requestHandoffSummary({agentId, interactionId})
+    ).rejects.toThrow('Error while performing sendEvent');
+
+    expect(mockMetricsManager.trackEvent).toHaveBeenCalledWith(
+      METRIC_EVENT_NAMES.AI_ASSISTANT_HANDOFF_SUMMARY_REQUEST_FAILED,
+      {
+        agentId,
+        interactionId,
+        eventName: AIAssistantEventName.GET_MID_CALL_SUMMARY,
+        action: AIAssistantEventAction.REQUEST,
+        error: 'Error',
+      },
+      ['operational']
+    );
+    expect(LoggerProxy.error).toHaveBeenCalledWith('Handoff summary request failed', {
+      module: 'cc',
+      method: 'requestHandoffSummary',
+      interactionId,
+      data: {
+        eventName: AIAssistantEventName.GET_MID_CALL_SUMMARY,
+        action: AIAssistantEventAction.REQUEST,
+        error: 'Error',
+      },
+    });
+    expect(JSON.stringify((LoggerProxy.error as jest.Mock).mock.calls)).not.toContain(
+      sensitiveText
+    );
+    expect(JSON.stringify(mockMetricsManager.trackEvent.mock.calls)).not.toContain(sensitiveText);
   });
 });

--- a/packages/@webex/contact-center/test/unit/spec/services/config/index.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/config/index.ts
@@ -495,12 +495,25 @@ describe('AgentConfigService', () => {
       const mockResponse = {
         statusCode: 200,
         body: {
-          realtimeTranscripts: {enable: true},
+          data: [
+            {
+              id: 'ai-feature-1',
+              generatedSummaries: {
+                consultTransferSummariesEnabled: true,
+              },
+            },
+          ],
         },
       };
       mockWebexRequest.request.mockResolvedValue(mockResponse);
 
       const result = await agentConfigService.getAIFeatureFlags(mockOrgId);
+
+      expect(mockWebexRequest.request).toHaveBeenCalledWith({
+        service: mockWccAPIURL,
+        resource: `organization/${mockOrgId}/v2/ai-feature?page=0&pageSize=100`,
+        method: 'GET',
+      });
       expect(result).toEqual(mockResponse.body);
       expect(LoggerProxy.log).toHaveBeenCalledWith('getAIFeatureFlags api success.', {
         module: CONFIG_FILE_NAME,
@@ -508,7 +521,7 @@ describe('AgentConfigService', () => {
       });
     });
 
-    it('should throw an error if API call returns non-200 status code', async () => {
+    it('should throw an error if AI feature flags API returns non-200 status code', async () => {
       const mockError = {statusCode: 500};
       mockWebexRequest.request.mockResolvedValue(mockError);
 
@@ -794,14 +807,21 @@ describe('AgentConfigService', () => {
         {key: 'ACQUEON_CONSOLE_URL', url: 'https://console.example.com'},
       ];
 
+      const mockAiFeatureFlags = {
+        data: [
+          {
+            id: 'ai-feature-1',
+            generatedSummaries: {
+              consultTransferSummariesEnabled: true,
+            },
+          },
+        ],
+      };
+
       const mockAuxCodes = [
         {id: 'aux1', type: 'WRAP_UP_CODE', name: 'Wrap Up Code 1', isDefault: true},
         {id: 'aux2', type: 'IDLE_CODE', name: 'Idle Code 1', isDefault: true},
       ];
-      const mockAIFeatureFlags = {
-        data: [{realtimeTranscripts: {enable: true}}],
-      };
-
       const parseAgentConfigsSpy = jest.spyOn(util, 'parseAgentConfigs');
       agentConfigService.getUserUsingCI = jest.fn().mockResolvedValue(mockUserConfig);
       agentConfigService.getOrgInfo = jest.fn().mockResolvedValue(mockOrgInfo);
@@ -809,7 +829,7 @@ describe('AgentConfigService', () => {
       agentConfigService.getSiteInfo = jest.fn().mockResolvedValue(mockSiteInfo);
       agentConfigService.getTenantData = jest.fn().mockResolvedValue(mockTenantData);
       agentConfigService.getURLMapping = jest.fn().mockResolvedValue(mockURLMapping);
-      agentConfigService.getAIFeatureFlags = jest.fn().mockResolvedValue(mockAIFeatureFlags);
+      agentConfigService.getAIFeatureFlags = jest.fn().mockResolvedValue(mockAiFeatureFlags);
       agentConfigService.getAllAuxCodes = jest.fn().mockResolvedValue(mockAuxCodes);
       agentConfigService.getDesktopProfileById = jest.fn().mockResolvedValue(mockAgentProfile);
       agentConfigService.getDialPlanData = jest.fn().mockResolvedValue(mockDialPlanData);
@@ -817,6 +837,7 @@ describe('AgentConfigService', () => {
 
       const result = await agentConfigService.getAgentConfig(mockOrgId, mockAgentId);
 
+      expect(result.aiFeature).toEqual(mockAiFeatureFlags.data[0]);
       expect(LoggerProxy.info).toHaveBeenCalledWith(
         `Fetched user data, userId: ${mockUserConfig.ciUserId}`,
         {
@@ -849,7 +870,7 @@ describe('AgentConfigService', () => {
         dialPlanData: mockDialPlanData,
         urlMapping: mockURLMapping,
         multimediaProfileId: mockSiteInfo.multimediaProfileId,
-        aiFeatureFlags: mockAIFeatureFlags,
+        aiFeatureFlags: mockAiFeatureFlags,
       });
     });
 
@@ -940,14 +961,21 @@ describe('AgentConfigService', () => {
         {key: 'ACQUEON_CONSOLE_URL', url: 'https://console.example.com'},
       ];
 
+      const mockAiFeatureFlags = {
+        data: [
+          {
+            id: 'ai-feature-2',
+            generatedSummaries: {
+              consultTransferSummariesEnabled: false,
+            },
+          },
+        ],
+      };
+
       const mockAuxCodes = [
         {id: 'aux1', type: 'WRAP_UP_CODE', name: 'Wrap Up Code 1'},
         {id: 'aux2', type: 'IDLE_CODE', name: 'Idle Code 1'},
       ];
-      const mockAIFeatureFlags = {
-        data: [{realtimeTranscripts: {enable: true}}],
-      };
-
       const parseAgentConfigsSpy = jest.spyOn(util, 'parseAgentConfigs');
       agentConfigService.getUserUsingCI = jest.fn().mockResolvedValue(mockUserConfig);
       agentConfigService.getOrgInfo = jest.fn().mockResolvedValue(mockOrgInfo);
@@ -955,7 +983,7 @@ describe('AgentConfigService', () => {
       agentConfigService.getSiteInfo = jest.fn().mockResolvedValue(mockSiteInfo);
       agentConfigService.getTenantData = jest.fn().mockResolvedValue(mockTenantData);
       agentConfigService.getURLMapping = jest.fn().mockResolvedValue(mockURLMapping);
-      agentConfigService.getAIFeatureFlags = jest.fn().mockResolvedValue(mockAIFeatureFlags);
+      agentConfigService.getAIFeatureFlags = jest.fn().mockResolvedValue(mockAiFeatureFlags);
       agentConfigService.getAllAuxCodes = jest.fn().mockResolvedValue(mockAuxCodes);
       agentConfigService.getDesktopProfileById = jest.fn().mockResolvedValue(mockAgentProfile);
       agentConfigService.getDialPlanData = jest.fn().mockResolvedValue(mockDialPlanData);
@@ -963,6 +991,7 @@ describe('AgentConfigService', () => {
 
       const result = await agentConfigService.getAgentConfig(mockOrgId, mockAgentId);
 
+      expect(result.aiFeature).toEqual(mockAiFeatureFlags.data[0]);
       expect(LoggerProxy.info).toHaveBeenCalledWith(
         `Fetched user data, userId: ${mockUserConfig.ciUserId}`,
         {
@@ -995,7 +1024,7 @@ describe('AgentConfigService', () => {
         dialPlanData: mockDialPlanData,
         urlMapping: mockURLMapping,
         multimediaProfileId: mockSiteInfo.multimediaProfileId,
-        aiFeatureFlags: mockAIFeatureFlags,
+        aiFeatureFlags: mockAiFeatureFlags,
       });
     });
 
@@ -1016,6 +1045,53 @@ describe('AgentConfigService', () => {
       await expect(agentConfigService.getAgentConfig(mockOrgId, mockAgentId)).rejects.toThrow(
         'API call failed'
       );
+    });
+
+    it('should continue with AI features disabled if AI feature flags fail to load', async () => {
+      const mockProfile = {aiFeature: undefined};
+      const parseAgentConfigsSpy = jest
+        .spyOn(util, 'parseAgentConfigs')
+        .mockReturnValue(mockProfile as any);
+
+      agentConfigService.getUserUsingCI = jest.fn().mockResolvedValue({
+        ciUserId: 'agent001',
+        agentProfileId: 'profile123',
+        siteId: 'site789',
+        teamIds: [],
+      });
+      agentConfigService.getOrgInfo = jest.fn().mockResolvedValue({});
+      agentConfigService.getOrganizationSetting = jest.fn().mockResolvedValue({});
+      agentConfigService.getTenantData = jest.fn().mockResolvedValue({});
+      agentConfigService.getURLMapping = jest.fn().mockResolvedValue([]);
+      agentConfigService.getAIFeatureFlags = jest
+        .fn()
+        .mockRejectedValue(new Error('AI feature unavailable'));
+      agentConfigService.getAllAuxCodes = jest.fn().mockResolvedValue([]);
+      agentConfigService.getDesktopProfileById = jest.fn().mockResolvedValue({
+        dialPlanEnabled: false,
+      });
+      agentConfigService.getSiteInfo = jest.fn().mockResolvedValue({
+        multimediaProfileId: 'multimedia-profile-1',
+      });
+      agentConfigService.getAllTeams = jest.fn().mockResolvedValue([]);
+
+      const result = await agentConfigService.getAgentConfig(mockOrgId, mockAgentId);
+
+      expect(result).toEqual(mockProfile);
+      expect(parseAgentConfigsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aiFeatureFlags: {data: []},
+        })
+      );
+      expect(LoggerProxy.info).toHaveBeenCalledWith(
+        'AI feature resources unavailable; continuing with AI features disabled',
+        {
+          module: CONFIG_FILE_NAME,
+          method: 'getAIFeatureFlags',
+        }
+      );
+
+      parseAgentConfigsSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `ApiAIAssistant.requestHandoffSummary` gated by `agentConfig.aiFeature.generatedSummaries.consultTransferSummariesEnabled === true`.
- Send the enabled `GET_MID_CALL_SUMMARY` request through the existing AI Assistant event transport with sanitized failure logging/metrics.
- Fail closed when AI feature flags are missing or unavailable, and add focused unit coverage for enabled, disabled, missing, and failure paths.
- Add module-specific `ai-docs` for the AI Assistant handoff summary gate and event contract.

## Scope
- Implements Task 1 code and module docs only.
- Stops before Task 2 WebSocket summary routing and Task 3 public Task/Voice helper APIs.

## Validation
- `yarn jest --config packages/@webex/contact-center/jest.config.js --runTestsByPath packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts packages/@webex/contact-center/test/unit/spec/services/config/index.ts --coverage=false`
- `yarn workspace @webex/contact-center run test:style`
- `yarn workspace @webex/contact-center exec tsc --pretty false --noEmit --declaration false --emitDeclarationOnly false`
- `git diff --cached --check` for the docs commit