### PR TITLE
[CAI-7881 T1] Suggested Responses payload contract (actionTimeStamp + conversationId)

### DIFF
--- a/packages/@webex/contact-center/src/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/src/services/ApiAiAssistant.ts
@@ -79,6 +79,8 @@ export class ApiAIAssistant {
    * @param eventType - the type of event (e.g. 'CUSTOM_EVENT')
    * @param eventName - the name of the event (e.g. 'GET_TRANSCRIPTS')
    * @param action - action within eventDetails (e.g. 'START' or 'STOP')
+   * @param actionTimeStamp - consumer-provided client timestamp for the request
+   * @param conversationId - conversation identifier derived from the interaction
    */
   public async sendEvent(
     agentId: string,
@@ -88,7 +90,9 @@ export class ApiAIAssistant {
     action?: TranscriptAction,
     context?: string,
     languageCode?: string,
-    trackingId?: string
+    trackingId?: string,
+    actionTimeStamp?: number,
+    conversationId?: string
   ): Promise<Record<string, unknown>> {
     LoggerProxy.info('Sending event', {
       module: CC_FILE,
@@ -116,9 +120,10 @@ export class ApiAIAssistant {
           eventDetails: {
             data: {
               interactionId,
+              conversationId,
               action,
               context,
-              actionTimeStamp: String(Date.now()),
+              actionTimeStamp: String(actionTimeStamp ?? Date.now()),
               languageCode,
               trackingId,
             },
@@ -159,8 +164,9 @@ export class ApiAIAssistant {
    * @public
    */
   public async getSuggestedResponse(params: SuggestedResponseParams): Promise<any> {
-    const {agentId, interactionId, context} = params;
+    const {agentId, interactionId, actionTimeStamp, context} = params;
     const trimmedContext = context?.trim();
+    const conversationId = interactionId;
     const languageCode = params.languageCode ?? 'en';
     const trackingId = `WX_CC_SDK_${uuidv4()}`;
     const eventName = trimmedContext
@@ -184,12 +190,12 @@ export class ApiAIAssistant {
 
     try {
       if (!this.aiFeature?.suggestedResponses?.enable) {
-        const {error: detailedError} = getErrorDetails(
-          new Error('SUGGESTED_RESPONSES_NOT_ENABLED'),
-          METHODS.GET_SUGGESTED_RESPONSE,
-          CC_FILE
-        );
-        throw detailedError;
+        const featureFlagError = new Error('SUGGESTED_RESPONSES_NOT_ENABLED') as Error & {
+          details: {data: {reason: string}};
+        };
+        featureFlagError.details = {data: {reason: 'SUGGESTED_RESPONSES_NOT_ENABLED'}};
+
+        throw featureFlagError;
       }
 
       const orgId = this.webex.credentials.getOrgId();
@@ -202,7 +208,9 @@ export class ApiAIAssistant {
         undefined,
         trimmedContext,
         languageCode,
-        trackingId
+        trackingId,
+        actionTimeStamp,
+        conversationId
       );
 
       this.metricsManager.trackEvent(

--- a/packages/@webex/contact-center/src/types.ts
+++ b/packages/@webex/contact-center/src/types.ts
@@ -863,6 +863,8 @@ export type SuggestedResponseParams = {
   agentId: string;
   /** Interaction identifier for which suggestion should be generated */
   interactionId: string;
+  /** Consumer-provided client timestamp for the request in milliseconds since epoch */
+  actionTimeStamp?: number;
   /** Optional additional context that should refine the suggestion */
   context?: string;
   /** Optional language code for suggestions (for example, 'en'). Defaults to 'en'. */

--- a/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
@@ -92,7 +92,38 @@ describe('ApiAIAssistant', () => {
     expect(result).toEqual(responseBody as any);
   });
 
-  it('should request suggested response without extra context using sendEvent', async () => {
+  it('AC-1 / spec 3,5,6: getSuggestedResponse forwards consumer actionTimeStamp into the request body', async () => {
+    const actionTimeStamp = 1777479641173;
+
+    (mockWebex.request as jest.Mock).mockResolvedValue({body: {ok: true}});
+    apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: true}} as any);
+
+    await apiAIAssistant.getSuggestedResponse({
+      agentId: 'test-agent-id',
+      interactionId: 'interaction-1',
+      actionTimeStamp,
+    } as any);
+
+    const requestArgs = (mockWebex.request as jest.Mock).mock.calls[0][0];
+
+    expect(requestArgs.body.eventDetails.data.actionTimeStamp).toBe(String(actionTimeStamp));
+  });
+
+  it('AC-2 / spec 3,5,6: getSuggestedResponse derives conversationId from interactionId in the outbound payload', async () => {
+    (mockWebex.request as jest.Mock).mockResolvedValue({body: {ok: true}});
+    apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: true}} as any);
+
+    await apiAIAssistant.getSuggestedResponse({
+      agentId: 'test-agent-id',
+      interactionId: 'interaction-1',
+    });
+
+    const requestArgs = (mockWebex.request as jest.Mock).mock.calls[0][0];
+
+    expect(requestArgs.body.eventDetails.data.conversationId).toBe('interaction-1');
+  });
+
+  it('AC-3 / spec 3: getSuggestedResponse sends GET_SUGGESTIONS without context', async () => {
     const sendEventSpy = jest.spyOn(apiAIAssistant, 'sendEvent').mockResolvedValue({ok: true});
     apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: true}} as any);
 
@@ -117,7 +148,7 @@ describe('ApiAIAssistant', () => {
     expect(result).toEqual({ok: true});
   });
 
-  it('should request suggested response with extra context using sendEvent', async () => {
+  it('AC-3 / spec 3: getSuggestedResponse sends ADD_SUGGESTIONS_EXTRA_CONTEXT with context', async () => {
     const sendEventSpy = jest.spyOn(apiAIAssistant, 'sendEvent').mockResolvedValue({ok: true});
     apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: true}} as any);
 
@@ -202,7 +233,8 @@ describe('ApiAIAssistant', () => {
     expect(errorMessage).toBe('Error while performing fetchHistoricTranscripts');
   });
 
-  it('should fail when suggested responses feature is disabled', async () => {
+  it('AC-4 / spec 7: getSuggestedResponse throws SUGGESTED_RESPONSES_NOT_ENABLED and skips sendEvent when disabled', async () => {
+    const sendEventSpy = jest.spyOn(apiAIAssistant, 'sendEvent');
     apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: false}} as any);
     let errorMessage = '';
 
@@ -215,6 +247,7 @@ describe('ApiAIAssistant', () => {
       errorMessage = (error as Error)?.message || '';
     }
 
-    expect(errorMessage).toBe('Error while performing getSuggestedResponse');
+    expect(errorMessage).toBe('SUGGESTED_RESPONSES_NOT_ENABLED');
+    expect(sendEventSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# CAI-7881 T1 - Suggested Responses Payload Contract

## Summary
- Add optional `actionTimeStamp` to `SuggestedResponseParams`.
- Forward consumer `actionTimeStamp` through `getSuggestedResponse` and `sendEvent`, falling back to `Date.now()` when omitted.
- Include `conversationId` derived from `interactionId` in the outbound AI Assistant event payload.
- Preserve event-name selection and return the specific `SUGGESTED_RESPONSES_NOT_ENABLED` error when the feature flag is disabled.

## Motivation
- JIRA: https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7881
- Spec: `/Users/balaored/Documents/GitHub/WebJS/webex-js-sdk/cypher/CAI-7881/CAI-7881-suggested-responses-spec.md`
- Task: T1 - Suggested Responses payload contract (actionTimeStamp + conversationId)

## Spec-delta
spec-delta: none
reason: This PR implements the pre-approved CAI-7881 spec without changing the contract.

## SDK Surface Changes
- `SuggestedResponseParams` now accepts `actionTimeStamp?: number`.
- `getSuggestedResponse(...)` passes `actionTimeStamp` and `conversationId` to the event API.
- `sendEvent(...)` accepts appended optional params, preserving existing call sites.

## Risk & Rollback
- Risk is low and bounded to `@webex/contact-center` AI Assistant suggested responses.
- Rollback is reverting this PR; the change is additive and guarded by the existing `suggestedResponses` feature flag.

## Behavioural Risk & Rollback
- Existing no-context and context event-name selection is preserved.
- Disabled feature flag behavior is now more specific: callers receive `SUGGESTED_RESPONSES_NOT_ENABLED`.

## Testing Evidence
- Targeted red states observed:
  - AC-1 failed before implementation because `actionTimeStamp` used `Date.now()`.
  - AC-2 failed before implementation because `conversationId` was absent.
  - AC-4 failed before review fix because the disabled-flag error was generic.
- Targeted Jest: `ApiAiAssistant.ts` passed 11/11.
- Unit suite: `node .yarn/releases/yarn-3.4.1.cjs workspace @webex/contact-center test:unit` passed 31 suites / 650 tests.
- Style: `node .yarn/releases/yarn-3.4.1.cjs workspace @webex/contact-center test:style` passed with 0 errors and existing warnings.
- Type check: `node .yarn/releases/yarn-3.4.1.cjs workspace @webex/contact-center exec tsc -p tsconfig.json --emitDeclarationOnly false --noEmit` passed.
- Playwright E2E: skipped. The fixture is SDK-only, with samples app and Playwright files explicitly out of scope.

## New Operational Surface
- Runbook: N/A, SDK API-contract fixture only.
- Beta plan: N/A.
- TAC TOI: N/A.
- Blog: N/A.
- Dev Portal Changelog: N/A for this fixture.

## Updated Operational Surface
- No operational dashboards, alerts, or runbooks changed.

## Cross-verification Summary
- Reviewer runtime: gpt-5.4 / Ampere.
- Final verdict: PASS with zero Blocking findings.
- Confirmed ownership boundaries: only `ApiAiAssistant.ts`, `types.ts`, and `ApiAiAssistant` unit tests changed.
- Confirmed no `must_not_touch` paths changed.
- Confirmed E2E skip is justified by the approved fixture scope.

## Test Plan (for the reviewer)
- [ ] Review `getSuggestedResponse` payload mapping for `actionTimeStamp` and `conversationId`.
- [ ] Review disabled feature-flag behavior for `SUGGESTED_RESPONSES_NOT_ENABLED`.
- [ ] Run targeted ApiAIAssistant Jest or the full contact-center unit suite.
