### PR TITLE
feat(plugin-metrics): added webexSubServiceType in MQEs

### DIFF
--- a/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/src/call-diagnostic/call-diagnostic-metrics.ts
@@ -607,6 +607,7 @@ export default class CallDiagnosticMetrics extends StatelessWebexPlugin {
           mediaEngineSoftwareVersion: getOSVersion() || 'unknown',
           startTime: new Date().toISOString(),
         },
+        webexSubServiceType: this.getSubServiceType(meeting),
       };
 
       // merge any new properties, or override existing ones

--- a/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
+++ b/packages/@webex/internal-plugin-metrics/test/unit/spec/call-diagnostic/call-diagnostic-metrics.ts
@@ -3154,6 +3154,7 @@ describe('internal-plugin-metrics', () => {
               mediaEngineSoftwareVersion: getOSVersion() || 'unknown',
               startTime: now.toISOString(),
             },
+            webexSubServiceType: undefined,
           },
           options
         );
@@ -3194,6 +3195,7 @@ describe('internal-plugin-metrics', () => {
                 mediaEngineSoftwareVersion: getOSVersion() || 'unknown',
                 startTime: now.toISOString(),
               },
+              webexSubServiceType: undefined,
             },
           },
         });
@@ -3232,8 +3234,46 @@ describe('internal-plugin-metrics', () => {
               mediaEngineSoftwareVersion: getOSVersion() || 'unknown',
               startTime: now.toISOString(),
             },
+            webexSubServiceType: undefined,
           },
         });
+      });
+
+      it('includes webexSubServiceType in the media quality event payload', () => {
+        const meeting = {
+          ...fakeMeeting,
+          meetingInfo: {
+            enableConvergedArchitecture: true,
+            enableEvent: true,
+            enableConvergedWebinarLargeScale: true,
+          },
+        };
+        const prepareDiagnosticEventSpy = sinon.spy(cd, 'prepareDiagnosticEvent');
+        sinon.stub(cd, 'getOrigin').returns({origin: 'fake-origin'});
+        webex.meetings.getBasicMeetingInformation = sinon.stub().returns(meeting);
+
+        const options = {
+          networkType: 'wifi' as const,
+          meetingId: fakeMeeting.id,
+        };
+
+        cd.submitMQE({
+          name: 'client.mediaquality.event',
+          payload: {
+            //@ts-ignore
+            intervals: [{}],
+          },
+          options,
+        });
+
+        assert.calledOnceWithExactly(
+          prepareDiagnosticEventSpy,
+          sinon.match({
+            name: 'client.mediaquality.event',
+            webexSubServiceType: 'LargeScaleWebinar',
+          }),
+          options
+        );
       });
 
       it('throws if meeting id not provided', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

#  Added webexSubServiceType in MQEs

## This pull request addresses
`webexSubServiceType` was sent for CA events, but not for MQE events, so add it

## by making the following changes
Added `webexSubServiceType` field in MQEs in `submitMQE`

**Result:**
<img width="1333" height="554" alt="image" src="https://github.com/user-attachments/assets/585135fe-ed1f-4486-8ad3-f5b3a03297ea" />

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### I certified that

- [ ] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [ ] I discussed changes with code owners prior to submitting this pull request
- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
