### PR TITLE
[CAI-7881 T1] Suggested Responses payload contract

### DIFF
--- a/packages/@webex/contact-center/src/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/src/services/ApiAiAssistant.ts
@@ -88,7 +88,9 @@ export class ApiAIAssistant {
     action?: TranscriptAction,
     context?: string,
     languageCode?: string,
-    trackingId?: string
+    trackingId?: string,
+    actionTimeStamp?: number,
+    conversationId?: string
   ): Promise<Record<string, unknown>> {
     LoggerProxy.info('Sending event', {
       module: CC_FILE,
@@ -116,9 +118,10 @@ export class ApiAIAssistant {
           eventDetails: {
             data: {
               interactionId,
+              ...(conversationId !== undefined ? {conversationId} : {}),
               action,
               context,
-              actionTimeStamp: String(Date.now()),
+              actionTimeStamp: String(actionTimeStamp ?? Date.now()),
               languageCode,
               trackingId,
             },
@@ -159,10 +162,11 @@ export class ApiAIAssistant {
    * @public
    */
   public async getSuggestedResponse(params: SuggestedResponseParams): Promise<any> {
-    const {agentId, interactionId, context} = params;
+    const {agentId, interactionId, actionTimeStamp, context} = params;
     const trimmedContext = context?.trim();
     const languageCode = params.languageCode ?? 'en';
     const trackingId = `WX_CC_SDK_${uuidv4()}`;
+    const conversationId = interactionId;
     const eventName = trimmedContext
       ? AIAssistantEventName.ADD_SUGGESTIONS_EXTRA_CONTEXT
       : AIAssistantEventName.GET_SUGGESTIONS;
@@ -202,7 +206,9 @@ export class ApiAIAssistant {
         undefined,
         trimmedContext,
         languageCode,
-        trackingId
+        trackingId,
+        actionTimeStamp,
+        conversationId
       );
 
       this.metricsManager.trackEvent(

--- a/packages/@webex/contact-center/src/types.ts
+++ b/packages/@webex/contact-center/src/types.ts
@@ -863,6 +863,8 @@ export type SuggestedResponseParams = {
   agentId: string;
   /** Interaction identifier for which suggestion should be generated */
   interactionId: string;
+  /** Consumer-provided client timestamp for the request (ms epoch) */
+  actionTimeStamp?: number;
   /** Optional additional context that should refine the suggestion */
   context?: string;
   /** Optional language code for suggestions (for example, 'en'). Defaults to 'en'. */

--- a/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
+++ b/packages/@webex/contact-center/test/unit/spec/services/ApiAiAssistant.ts
@@ -92,7 +92,7 @@ describe('ApiAIAssistant', () => {
     expect(result).toEqual(responseBody as any);
   });
 
-  it('should request suggested response without extra context using sendEvent', async () => {
+  it('AC-3 / spec 3: should request suggested response without extra context using sendEvent', async () => {
     const sendEventSpy = jest.spyOn(apiAIAssistant, 'sendEvent').mockResolvedValue({ok: true});
     apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: true}} as any);
 
@@ -117,7 +117,60 @@ describe('ApiAIAssistant', () => {
     expect(result).toEqual({ok: true});
   });
 
-  it('should request suggested response with extra context using sendEvent', async () => {
+  it('AC-1 / AC-2 / spec 3,5,6: getSuggestedResponse forwards actionTimeStamp and derived conversationId into sendEvent', async () => {
+    const sendEventSpy = jest.spyOn(apiAIAssistant, 'sendEvent').mockResolvedValue({ok: true});
+    apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: true}} as any);
+
+    await apiAIAssistant.getSuggestedResponse({
+      agentId: 'test-agent-id',
+      interactionId: 'interaction-1',
+      actionTimeStamp: 1777479641173,
+    });
+
+    expect(sendEventSpy).toHaveBeenCalledTimes(1);
+    expect(sendEventSpy.mock.calls[0][8]).toBe(1777479641173);
+    expect(sendEventSpy.mock.calls[0][9]).toBe('interaction-1');
+  });
+
+  it('AC-2 / spec 3,5,6: sendEvent includes conversationId derived from interactionId in the request body', async () => {
+    (mockWebex.request as jest.Mock).mockResolvedValue({body: {ok: true}});
+
+    await apiAIAssistant.sendEvent(
+      'test-agent-id',
+      'interaction-1',
+      'CUSTOM_EVENT',
+      'GET_SUGGESTIONS',
+      undefined,
+      undefined,
+      'en',
+      'WX_CC_SDK_test',
+      1777479641173,
+      'interaction-1'
+    );
+
+    const requestArgs = (mockWebex.request as jest.Mock).mock.calls[0][0];
+
+    expect(requestArgs.body.eventDetails.data.actionTimeStamp).toBe('1777479641173');
+    expect(requestArgs.body.eventDetails.data.conversationId).toBe('interaction-1');
+  });
+
+  it('AC-1 / spec 7: sendEvent falls back to Date.now when actionTimeStamp is omitted', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1777479641174);
+    (mockWebex.request as jest.Mock).mockResolvedValue({body: {ok: true}});
+
+    await apiAIAssistant.sendEvent(
+      'test-agent-id',
+      'interaction-1',
+      'CUSTOM_EVENT',
+      'GET_SUGGESTIONS'
+    );
+
+    const requestArgs = (mockWebex.request as jest.Mock).mock.calls[0][0];
+
+    expect(requestArgs.body.eventDetails.data.actionTimeStamp).toBe('1777479641174');
+  });
+
+  it('AC-3 / spec 3: should request suggested response with extra context using sendEvent', async () => {
     const sendEventSpy = jest.spyOn(apiAIAssistant, 'sendEvent').mockResolvedValue({ok: true});
     apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: true}} as any);
 
@@ -143,7 +196,7 @@ describe('ApiAIAssistant', () => {
     expect(result).toEqual({ok: true});
   });
 
-  it('should treat whitespace-only context as GET_SUGGESTIONS', async () => {
+  it('AC-3 / spec 3: should treat whitespace-only context as GET_SUGGESTIONS', async () => {
     const sendEventSpy = jest.spyOn(apiAIAssistant, 'sendEvent').mockResolvedValue({ok: true});
     apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: true}} as any);
 
@@ -202,7 +255,8 @@ describe('ApiAIAssistant', () => {
     expect(errorMessage).toBe('Error while performing fetchHistoricTranscripts');
   });
 
-  it('should fail when suggested responses feature is disabled', async () => {
+  it('AC-4 / spec 7: should fail when suggested responses feature is disabled', async () => {
+    const sendEventSpy = jest.spyOn(apiAIAssistant, 'sendEvent');
     apiAIAssistant.setAIFeatureFlags({suggestedResponses: {enable: false}} as any);
     let errorMessage = '';
 
@@ -216,5 +270,7 @@ describe('ApiAIAssistant', () => {
     }
 
     expect(errorMessage).toBe('Error while performing getSuggestedResponse');
+    expect(sendEventSpy).not.toHaveBeenCalled();
+    expect(mockWebex.request).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Implements CAI-7881 T1 for the Suggested Responses payload contract:

- Adds optional `actionTimeStamp` to `SuggestedResponseParams`.
- Forwards consumer-provided `actionTimeStamp` into AI Assistant event payloads, with existing `Date.now()` fallback when omitted.
- Adds `conversationId` to outbound `eventDetails.data`, derived from `interactionId`.
- Preserves event-name selection, feature-flag gating, metrics, logging, and the T2 return-type scope.

## Spec-delta

spec-delta: none
reason: T1 implements the approved spec exactly; no implementation-time contract change was introduced.

## Validation

- `node .yarn/releases/yarn-3.4.1.cjs workspace @webex/contact-center test:unit` — pass, 31 suites / 650 tests.
- `node .yarn/releases/yarn-3.4.1.cjs workspace @webex/contact-center test:style` — pass with existing warnings.
- `node .yarn/releases/yarn-3.4.1.cjs workspace @webex/contact-center build:src` — pass.
- `pr-size.sh /Users/balaored/Documents/GitHub/WebJS/webex-js-sdk task-refactor` — pass, 80 changed lines / 3 files.
- `tdd-commit-order.sh /Users/balaored/Documents/GitHub/WebJS/webex-js-sdk task-refactor T1` — pass.
- `secret-scan.sh --diff /Users/balaored/Documents/GitHub/WebJS/webex-js-sdk task-refactor` — pass.

## Cross-verification summary

Reviewer subagent Aquinas re-checked amended commit `6447872677` and reported T1 cross-verification green.

- Previous AC-4 coverage blocker resolved: disabled feature flag now asserts both `sendEvent` and `mockWebex.request` are not called.
- Timestamp fallback coverage added: `Date.now()` is mocked and the request body asserts fallback `actionTimeStamp` when omitted.
- No remaining blocking findings from re-check.

## MCP / fallback matrix

| Capability | Status | Fallback |
|---|---|---|
| Jira MCP | Available | Not needed for code implementation. |
| GitHub MCP | Not exposed | Local `git` / `gh` CLI. |
| Playwright / E2E | Not applicable for this fixture | E2E skipped: no UI/sample flow change. |
| Figma / Postman / Vidcast | Not applicable | Spec artifacts used. |

## Sequencing

This is the sequenced T1 PR. T2 must wait until this PR reaches the configured `advance_on` gate (`approved_or_merged`) before opening the stacked return-type PR.
